### PR TITLE
fix(sdk): disallow non-wasm targets for now

### DIFF
--- a/crates/sdk/build.rs
+++ b/crates/sdk/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH is not set") != "wasm32"
+    {
+        panic!(
+            "\x1b[1;31merror\x1b[0m: Incompatible target architecture, no polyfill available, only \x1b[1mwasm32\x1b[0m is supported."
+        );
+    }
+}


### PR DESCRIPTION
In the future we should add a polyfill that mocks the host functions

But for now, we report a more descriptive error when attempting to build apps for a non-WASM arch

### Before

![CleanShot 2024-02-26 at 16 37 38@2x](https://github.com/calimero-is-near/cali2.0-experimental/assets/16881812/c0b79428-8166-40de-b94c-2a20e7c2bd1a)

### After

![CleanShot 2024-02-26 at 16 38 17@2x](https://github.com/calimero-is-near/cali2.0-experimental/assets/16881812/7ae3fb39-7915-4061-8a34-8e64be33dae8)
