### PR TITLE
feat: add app wasm path to config

### DIFF
--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -35,6 +35,7 @@ pub struct Config {
     pub discovery: DiscoveryConfig,
     #[serde(default)]
     pub endpoint: EndpointConfig,
+    pub app: AppConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -82,6 +83,11 @@ impl Default for EndpointConfig {
             port: DEFAULT_RPC_PORT,
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub wasm_path: String,
 }
 
 impl Config {

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -4,7 +4,9 @@ use color_eyre::eyre::{self, Context};
 use libp2p::{identity, Multiaddr};
 use tracing::{info, warn};
 
-use crate::config::{BootstrapConfig, Config, DiscoveryConfig, EndpointConfig, SwarmConfig};
+use crate::config::{
+    AppConfig, BootstrapConfig, Config, DiscoveryConfig, EndpointConfig, SwarmConfig,
+};
 use crate::{cli, config};
 
 pub async fn run(args: cli::RootArgs, init: cli::InitCommand) -> eyre::Result<()> {
@@ -66,6 +68,9 @@ pub async fn run(args: cli::RootArgs, init: cli::InitCommand) -> eyre::Result<()
         endpoint: EndpointConfig {
             host: init.rpc_host,
             port: init.rpc_port,
+        },
+        app: AppConfig {
+            wasm_path: "".to_string(),
         },
     };
 

--- a/crates/node/src/network/mod.rs
+++ b/crates/node/src/network/mod.rs
@@ -93,6 +93,8 @@ pub async fn run(args: cli::RootArgs) -> eyre::Result<()> {
     let (mut client, mut event_receiver, event_loop) = init(peer_id, &config).await?;
     tokio::spawn(event_loop.run());
 
+    info!("App wasm path {:?}", config.app.wasm_path);
+
     for addr in &config.swarm.listen {
         client.listen_on(addr.clone()).await?;
     }


### PR DESCRIPTION
Enable setup of the wasm path through the config file. 

tbd: Connect with runtime


config:

```
[identity]
PeerID = "12D3KooWRqX2NS3kHKY9HJQevEG1X65yKDubc5HJT5GVnLkJrowG"
PrivKey = "23jhTddKp3F7Pmowank6AAZzgjMKyXzKYghSnWJAqGVnLd8UWUNs9NDr6MoXVcpbfJhaYh6rhNhWSfcndpF2NBPvTK55L"

[swarm]
listen = [
    "/ip4/0.0.0.0/tcp/2331",
    "/ip4/0.0.0.0/udp/2331/quic-v1",
    "/ip6/::/tcp/2331",
    "/ip6/::/udp/2331/quic-v1",
]

[bootstrap]
nodes = []

[discovery]
mdns = true

[endpoint]
host = "127.0.0.1"
port = 3031

[app]
wasm_path = "./app.wasm"
```
