### PR TITLE
fix: support multi-value server host

### DIFF
--- a/crates/node/src/cli/init.rs
+++ b/crates/node/src/cli/init.rs
@@ -41,6 +41,7 @@ pub struct InitCommand {
     /// Host to listen on for RPC
     #[clap(long, value_name = "HOST")]
     #[clap(default_value = "127.0.0.1,::1")]
+    #[clap(use_value_delimiter = true)]
     pub server_host: Vec<IpAddr>,
 
     /// Port to listen on for RPC


### PR DESCRIPTION
```console
error: invalid value '127.0.0.1,::1' for '--server-host <HOST>': invalid IP address syntax
```