### PR TITLE
chore: build once, exec N in script

### DIFF
--- a/crates/node/gen_localnet_configs.sh
+++ b/crates/node/gen_localnet_configs.sh
@@ -13,13 +13,13 @@ cargo build --bin calimero-node
 
 # Iterate in a loop N times
 for ((i = 1; i <= N; i++)); do
-  node_home="~/.calimero/node$i"
+  node_home="$HOME/.calimero/node$i"
   echo "\x1b[1;36m(i)\x1b[39m Initializing Node $i at \x1b[33m$node_home\x1b[0m"
   rm -rf "$node_home"
   mkdir -p "$node_home"
   ./target/debug/calimero-node --home "$node_home" \
       init --swarm-port $((2427 + $i)) --server-port $((2527 + $i)) \
-    | sed 's/^/ \x1b[36m|\x1b[0m  /'
+    | sed 's/^/ \x1b[1;36m|\x1b[0m  /'
   if [ $? -ne 0 ]; then
     echo " \x1b[1;31m✖\x1b[39m \x1b[33mNode $i\x1b[39m initialization failed, ensure that the node is not already running.\x1b[0m"
     exit 1


### PR DESCRIPTION
#### Before

![CleanShot 2024-03-06 at 15 18 33@2x](https://github.com/calimero-is-near/cali2.0-experimental/assets/16881812/165e03cf-ddc1-48de-8154-ac2d21e4ad83)

#### After

![CleanShot 2024-03-06 at 15 20 37@2x](https://github.com/calimero-is-near/cali2.0-experimental/assets/16881812/9aada7ed-ad7b-45cb-bd80-808b40686354)

##### If the node is already running, it also presents an informative error

![CleanShot 2024-03-06 at 15 21 16@2x](https://github.com/calimero-is-near/cali2.0-experimental/assets/16881812/d888e3a7-aae2-4b5f-9159-4760c2fb71c6)

We may need to introduce a `calimero-node clean` subcommand so it guards against forceful deletion of the db, which is what causes this `Bus error` above. But we'll leave that for later.