### PR TITLE
chore(sdk+runtime): abstract out the FFI interface

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -120,30 +120,6 @@ impl<'a> VMHostFunctions<'a> {
 }
 
 impl<'a> VMHostFunctions<'a> {
-    pub fn read_register(&mut self, register_id: u64, ptr: u64) -> Result<()> {
-        let data = self.borrow_logic().registers.get(register_id)?;
-        self.borrow_memory().write(ptr, data)?;
-        Ok(())
-    }
-
-    pub fn register_len(&self, register_id: u64) -> Result<u64> {
-        Ok(self
-            .borrow_logic()
-            .registers
-            .get_len(register_id)
-            .unwrap_or(u64::MAX))
-    }
-
-    pub fn input(&mut self, register_id: u64) -> Result<()> {
-        self.with_logic_mut(|logic| {
-            logic
-                .registers
-                .set(&logic.limits, register_id, &logic.context.input[..])
-        })?;
-
-        Ok(())
-    }
-
     pub fn panic(&self) -> Result<()> {
         Err(HostError::Panic {
             context: PanicContext::Guest,
@@ -160,6 +136,30 @@ impl<'a> VMHostFunctions<'a> {
             message,
         }
         .into())
+    }
+
+    pub fn register_len(&self, register_id: u64) -> Result<u64> {
+        Ok(self
+            .borrow_logic()
+            .registers
+            .get_len(register_id)
+            .unwrap_or(u64::MAX))
+    }
+
+    pub fn read_register(&mut self, register_id: u64, ptr: u64) -> Result<()> {
+        let data = self.borrow_logic().registers.get(register_id)?;
+        self.borrow_memory().write(ptr, data)?;
+        Ok(())
+    }
+
+    pub fn input(&mut self, register_id: u64) -> Result<()> {
+        self.with_logic_mut(|logic| {
+            logic
+                .registers
+                .set(&logic.limits, register_id, &logic.context.input[..])
+        })?;
+
+        Ok(())
     }
 
     pub fn value_return(&mut self, len: u64, ptr: u64) -> Result<()> {
@@ -184,6 +184,24 @@ impl<'a> VMHostFunctions<'a> {
         Ok(())
     }
 
+    pub fn storage_read(&mut self, key_len: u64, key_ptr: u64, register_id: u64) -> Result<u32> {
+        let logic = self.borrow_logic();
+
+        if key_len > logic.limits.max_storage_key_size.get() {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
+
+        let key = self.read_guest_memory(key_len, key_ptr)?;
+
+        if let Some(value) = logic.storage.get(&key) {
+            self.with_logic_mut(|logic| logic.registers.set(&logic.limits, register_id, value))?;
+
+            return Ok(1);
+        }
+
+        Ok(0)
+    }
+
     pub fn storage_write(
         &mut self,
         key_len: u64,
@@ -191,7 +209,7 @@ impl<'a> VMHostFunctions<'a> {
         value_len: u64,
         value_ptr: u64,
         register_id: u64,
-    ) -> Result<u64> {
+    ) -> Result<u32> {
         let logic = self.borrow_logic();
 
         if key_len > logic.limits.max_storage_key_size.get() {
@@ -212,24 +230,6 @@ impl<'a> VMHostFunctions<'a> {
 
             return Ok(1);
         };
-
-        Ok(0)
-    }
-
-    pub fn storage_read(&mut self, key_len: u64, key_ptr: u64, register_id: u64) -> Result<u64> {
-        let logic = self.borrow_logic();
-
-        if key_len > logic.limits.max_storage_key_size.get() {
-            return Err(HostError::KeyLengthOverflow.into());
-        }
-
-        let key = self.read_guest_memory(key_len, key_ptr)?;
-
-        if let Some(value) = logic.storage.get(&key) {
-            self.with_logic_mut(|logic| logic.registers.set(&logic.limits, register_id, value))?;
-
-            return Ok(1);
-        }
 
         Ok(0)
     }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -17,14 +17,14 @@ impl<'a> VMLogic<'a> {
             store;
             logic: self;
 
-            // todo! custom memory injection
-            fn read_register(register_id: u64, ptr: u64);
-            fn register_len(register_id: u64) -> u64;
-
-            fn input(register_id: u64);
-
             fn panic();
             fn panic_utf8(len: u64, ptr: u64);
+
+            // todo! custom memory injection
+            fn register_len(register_id: u64) -> u64;
+            fn read_register(register_id: u64, ptr: u64);
+
+            fn input(register_id: u64);
             fn value_return(value_len: u64, value_ptr: u64);
             fn log_utf8(len: u64, ptr: u64);
 
@@ -34,8 +34,8 @@ impl<'a> VMLogic<'a> {
                 value_len: u64,
                 value_ptr: u64,
                 register_id: u64,
-            ) -> u64;
-            fn storage_read(key_len: u64, key_ptr: u64, register_id: u64) -> u64;
+            ) -> u32;
+            fn storage_read(key_len: u64, key_ptr: u64, register_id: u64) -> u32;
         }
     }
 }
@@ -117,8 +117,16 @@ macro_rules! _imports {
                     }.into()));
                     HOST_CTX.with(|ctx| ctx.store(false, Ordering::Relaxed));
 
-                    #[cfg(feature = "host-traces")]
-                    println!(" ⇲ {}(..) -> {:?}", stringify!($func).fg_rgb::<166, 226, 46>(), res);
+                    #[cfg(feature = "host-traces")] {
+                        #[allow(unused_mut, unused_assignments)]
+                        let mut return_ty = "()".to_string();
+                        $( return_ty = stringify!($returns).to_string(); )?
+                        println!(
+                            " ⇲ {}(..) -> {} = {res:?}",
+                            stringify!($func).fg_rgb::<166, 226, 46>(),
+                            return_ty.fg_rgb::<102, 217, 239>()
+                        );
+                    }
 
                     res.map_err(|err| wasmer::RuntimeError::user(Box::new(err)))
                 }

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -1,29 +1,21 @@
 #![allow(dead_code)]
 
-#[cfg(not(target_arch = "wasm32"))]
-const _: () = {
-    compile_error!(
-        "Incompatible target architecture, no polyfill available, only wasm32 is supported."
-    );
-};
+mod guard;
+mod types;
+
+pub use types::*;
 
 extern "C" {
-    pub fn read_register(register_id: u64, ptr: u64);
-    pub fn register_len(register_id: u64) -> u64;
-    // --
-    pub fn input(register_id: u64);
-    // --
     pub fn panic() -> !;
-    pub fn panic_utf8(len: u64, ptr: u64) -> !;
-    pub fn value_return(value_len: u64, value_ptr: u64);
-    pub fn log_utf8(len: u64, ptr: u64);
+    pub fn panic_utf8(msg: Buffer) -> !;
     // --
-    pub fn storage_write(
-        key_len: u64,
-        key_ptr: u64,
-        value_len: u64,
-        value_ptr: u64,
-        register_id: u64,
-    ) -> u64;
-    pub fn storage_read(key_len: u64, key_ptr: u64, register_id: u64) -> u64;
+    pub fn register_len(register_id: RegisterId) -> PtrSized<Integer>;
+    pub fn read_register(register_id: RegisterId, ptr: PtrSized<Pointer<&mut u8>>);
+    // --
+    pub fn input(register_id: RegisterId);
+    pub fn value_return(value: Buffer);
+    pub fn log_utf8(msg: Buffer);
+    // --
+    pub fn storage_read(key: Buffer, register_id: RegisterId) -> Bool;
+    pub fn storage_write(key: Buffer, value: Buffer, register_id: RegisterId) -> Bool;
 }

--- a/crates/sdk/src/sys/guard.rs
+++ b/crates/sdk/src/sys/guard.rs
@@ -1,0 +1,6 @@
+#[cfg(not(target_arch = "wasm32"))]
+const _: () = {
+    compile_error!(
+        "Incompatible target architecture, no polyfill available, only wasm32 is supported."
+    );
+};

--- a/crates/sdk/src/sys/types.rs
+++ b/crates/sdk/src/sys/types.rs
@@ -1,0 +1,9 @@
+mod bool;
+mod buffer;
+mod pointer;
+mod register;
+
+pub use bool::*;
+pub use buffer::*;
+pub use pointer::*;
+pub use register::*;

--- a/crates/sdk/src/sys/types/bool.rs
+++ b/crates/sdk/src/sys/types/bool.rs
@@ -1,0 +1,13 @@
+#[repr(C)]
+#[derive(Eq, Ord, Copy, Hash, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Bool(u8);
+
+impl Bool {
+    pub const fn as_bool(self) -> Option<bool> {
+        match self {
+            Self(0) => Some(false),
+            Self(1) => Some(true),
+            _ => None,
+        }
+    }
+}

--- a/crates/sdk/src/sys/types/buffer.rs
+++ b/crates/sdk/src/sys/types/buffer.rs
@@ -1,0 +1,34 @@
+use super::{Pointer, PtrSized};
+
+#[repr(C)]
+#[derive(Eq, Copy, Clone, Debug, PartialEq)]
+pub struct Buffer<'a> {
+    len: u64,
+    ptr: PtrSized<Pointer<&'a u8>>,
+}
+
+impl<'a> Buffer<'a> {
+    pub fn new(len: usize, ptr: PtrSized<Pointer<&'a u8>>) -> Self {
+        Self { len: len as _, ptr }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len as _
+    }
+
+    pub fn ptr(&self) -> *const u8 {
+        self.ptr.into()
+    }
+}
+
+impl From<&[u8]> for Buffer<'_> {
+    fn from(slice: &[u8]) -> Self {
+        Self::new(slice.len(), slice.as_ptr().into())
+    }
+}
+
+impl From<&str> for Buffer<'_> {
+    fn from(string: &str) -> Self {
+        Self::from(string.as_bytes())
+    }
+}

--- a/crates/sdk/src/sys/types/pointer.rs
+++ b/crates/sdk/src/sys/types/pointer.rs
@@ -1,0 +1,90 @@
+use std::marker::PhantomData;
+
+#[repr(C)]
+#[derive(Eq, Ord, Copy, Hash, Clone, Debug, PartialEq, PartialOrd)]
+
+pub struct PtrSized<T> {
+    value: u64,
+    _phantom: PhantomData<T>,
+}
+
+#[repr(C)]
+#[derive(Eq, Ord, Copy, Hash, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Pointer<T>(PhantomData<T>);
+
+impl<T> PtrSized<T> {
+    pub const MAX: Self = Self {
+        value: u64::MAX,
+        _phantom: PhantomData,
+    };
+}
+
+impl<T> PtrSized<Pointer<&T>> {
+    pub fn new(ptr: *const T) -> Self {
+        Self {
+            value: ptr as _,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> PtrSized<Pointer<&mut T>> {
+    pub fn new(ptr: *mut T) -> Self {
+        Self {
+            value: ptr as _,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> From<PtrSized<Pointer<&T>>> for *const T {
+    fn from(ptr: PtrSized<Pointer<&T>>) -> Self {
+        ptr.value as _
+    }
+}
+
+impl<T> From<PtrSized<Pointer<&mut T>>> for *mut T {
+    fn from(ptr: PtrSized<Pointer<&mut T>>) -> Self {
+        ptr.value as _
+    }
+}
+
+impl<T> From<*const T> for PtrSized<Pointer<&T>> {
+    fn from(ptr: *const T) -> Self {
+        Self::new(ptr)
+    }
+}
+
+impl<T> From<*mut T> for PtrSized<Pointer<&mut T>> {
+    fn from(ptr: *mut T) -> Self {
+        Self::new(ptr)
+    }
+}
+
+#[derive(Eq, Ord, Copy, Hash, Clone, Debug, PartialEq, PartialOrd)]
+pub enum Integer {}
+
+impl PtrSized<Integer> {
+    pub const fn new(value: usize) -> Self {
+        Self {
+            value: value as _,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub const fn as_usize(self) -> usize {
+        self.value as _
+    }
+}
+
+impl From<usize> for PtrSized<Integer> {
+    fn from(value: usize) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<PtrSized<Integer>> for usize {
+    fn from(ptr: PtrSized<Integer>) -> Self {
+        ptr.value as _
+    }
+}

--- a/crates/sdk/src/sys/types/register.rs
+++ b/crates/sdk/src/sys/types/register.rs
@@ -1,0 +1,17 @@
+use super::{Integer, PtrSized};
+
+#[repr(C)]
+#[derive(Eq, Ord, Copy, Hash, Clone, Debug, PartialEq, PartialOrd)]
+pub struct RegisterId(PtrSized<Integer>);
+
+impl RegisterId {
+    pub const fn new(value: usize) -> Self {
+        Self(PtrSized::<Integer>::new(value))
+    }
+}
+
+impl From<usize> for RegisterId {
+    fn from(value: usize) -> Self {
+        Self::new(value)
+    }
+}


### PR DESCRIPTION
First a couple of PRs, abstracts out intricacies of the FFI interface since it's part of the public API