### PR TITLE
chore(contracts): cleanup code-generated methods

### DIFF
--- a/apps/kv-store/src/code_generated_from_calimero_sdk_macros.rs
+++ b/apps/kv-store/src/code_generated_from_calimero_sdk_macros.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 use super::KvStore;
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn set() {
     env::setup_panic_hook();
@@ -25,6 +26,7 @@ pub extern "C" fn set() {
     env::state_write(&app);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn entries() {
     env::setup_panic_hook();
@@ -46,6 +48,7 @@ pub extern "C" fn entries() {
     env::value_return(&output);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn get() {
     env::setup_panic_hook();
@@ -69,6 +72,7 @@ pub extern "C" fn get() {
     env::value_return(&output);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn get_unchecked() {
     env::setup_panic_hook();
@@ -92,6 +96,7 @@ pub extern "C" fn get_unchecked() {
     env::value_return(&output);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn remove() {
     env::setup_panic_hook();
@@ -113,6 +118,7 @@ pub extern "C" fn remove() {
     env::state_write(&app);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn clear() {
     env::setup_panic_hook();

--- a/apps/only-peers/src/code_generated_from_calimero_sdk_macros.rs
+++ b/apps/only-peers/src/code_generated_from_calimero_sdk_macros.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 use super::OnlyPeers;
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn post() {
     env::setup_panic_hook();
@@ -26,6 +27,7 @@ pub extern "C" fn post() {
     env::value_return(&output);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn posts() {
     env::setup_panic_hook();
@@ -47,6 +49,7 @@ pub extern "C" fn posts() {
     env::value_return(&output);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn create_post() {
     env::setup_panic_hook();
@@ -73,6 +76,7 @@ pub extern "C" fn create_post() {
     env::state_write(&app);
 }
 
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn create_comment() {
     env::setup_panic_hook();


### PR DESCRIPTION
Remove the `Serialize` impl for the code-generated `Input` type.

Guarantee only the wasm32 targets get the code generated methods.