### PR TITLE
chore: fix typed unreachable

### DIFF
--- a/apps/only-peers/src/lib.rs
+++ b/apps/only-peers/src/lib.rs
@@ -49,7 +49,10 @@ impl OnlyPeers {
             comments: Vec::new(),
         });
 
-        self.posts.last().unwrap_or_else(env::unreachable)
+        match self.posts.last() {
+            Some(post) => post,
+            None => env::unreachable(),
+        }
     }
 
     pub fn create_comment(


### PR DESCRIPTION
`rustc` does type resolution before figuring out that `env::unreachable` never returns, so we have to break these apart