### PR TITLE
feat(sdk+vm): all panics are contextually addressed

### DIFF
--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -2,12 +2,12 @@ use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
-use super::{HostError, PanicContext, VMLogic};
+use super::{HostError, Location, PanicContext, VMLogic};
 
 thread_local! {
     // https://open.spotify.com/track/7DPUuTaTZCtQ6o4Xx00qzT
     static HOOKER: Once = Once::new();
-    static PAYLOAD: RefCell<Option<String>> = RefCell::new(None);
+    static PAYLOAD: RefCell<Option<(String, Location)>> = RefCell::new(None);
     static HOST_CTX: AtomicBool = AtomicBool::new(false);
 }
 
@@ -17,8 +17,8 @@ impl<'a> VMLogic<'a> {
             store;
             logic: self;
 
-            fn panic();
-            fn panic_utf8(len: u64, ptr: u64);
+            fn panic(file_len: u64, file_ptr: u64, line: u32, column: u32);
+            fn panic_utf8(msg_len: u64, msg_ptr: u64, file_len: u64, file_ptr: u64, line: u32, column: u32);
 
             // todo! custom memory injection
             fn register_len(register_id: u64) -> u64;
@@ -63,8 +63,8 @@ macro_rules! _imports {
                             };
 
                             *payload.borrow_mut() = Some(match info.location() {
-                                Some(location) => format!("panicked at {}: {}", location, message),
-                                None => format!("fatal: panicked at unknown location: {}", message),
+                                Some(location) => (message.to_owned(), Location::from(location)),
+                                None => (message.to_owned(), Location::Unknown),
                             });
                         });
 
@@ -109,18 +109,24 @@ macro_rules! _imports {
                         let data = unsafe { &mut *(*data.get_mut() as *mut VMLogic) };
 
                         data.host_functions(store).$func($($arg),*)
-                    })).unwrap_or_else(|_| Err(HostError::Panic {
-                        context: PanicContext::Host,
-                        message: PAYLOAD.with(|payload| {
-                            payload.borrow_mut().take().unwrap_or_else(|| "<no message>".to_string())
-                        })
-                    }.into()));
+                    })).unwrap_or_else(|_| {
+                        let (message, location) = PAYLOAD.with(|payload| {
+                            payload.borrow_mut().take().unwrap_or_else(|| ("<no message>".to_owned(), Location::Unknown))
+                        });
+
+                        Err(HostError::Panic {
+                            context: PanicContext::Host,
+                            message,
+                            location,
+                        }.into())
+                    });
                     HOST_CTX.with(|ctx| ctx.store(false, Ordering::Relaxed));
 
-                    #[cfg(feature = "host-traces")] {
+                    #[cfg(feature = "host-traces")]
+                    {
                         #[allow(unused_mut, unused_assignments)]
-                        let mut return_ty = "()".to_string();
-                        $( return_ty = stringify!($returns).to_string(); )?
+                        let mut return_ty = "()";
+                        $( return_ty = stringify!($returns); )?
                         println!(
                             " ⇲ {}(..) -> {} = {res:?}",
                             stringify!($func).fg_rgb::<166, 226, 46>(),

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -6,8 +6,8 @@ mod types;
 pub use types::*;
 
 extern "C" {
-    pub fn panic() -> !;
-    pub fn panic_utf8(msg: Buffer) -> !;
+    pub fn panic(loc: Location) -> !;
+    pub fn panic_utf8(msg: Buffer, loc: Location) -> !;
     // --
     pub fn register_len(register_id: RegisterId) -> PtrSized<Integer>;
     pub fn read_register(register_id: RegisterId, ptr: PtrSized<Pointer<&mut u8>>);

--- a/crates/sdk/src/sys/types.rs
+++ b/crates/sdk/src/sys/types.rs
@@ -1,10 +1,12 @@
 mod bool;
 mod buffer;
+mod location;
 mod pointer;
 mod register;
 
 pub use bool::*;
 pub use buffer::*;
+pub use location::*;
 pub use pointer::*;
 pub use register::*;
 

--- a/crates/sdk/src/sys/types/buffer.rs
+++ b/crates/sdk/src/sys/types/buffer.rs
@@ -19,6 +19,10 @@ impl<'a> Buffer<'a> {
     pub fn ptr(&self) -> *const u8 {
         self.ptr.into()
     }
+
+    pub fn empty() -> Self {
+        Self::new(0, PtrSized::null())
+    }
 }
 
 impl From<&[u8]> for Buffer<'_> {
@@ -27,8 +31,22 @@ impl From<&[u8]> for Buffer<'_> {
     }
 }
 
+impl From<Buffer<'_>> for &[u8] {
+    fn from(buffer: Buffer<'_>) -> Self {
+        unsafe { std::slice::from_raw_parts(buffer.ptr(), buffer.len()) }
+    }
+}
+
 impl From<&str> for Buffer<'_> {
     fn from(string: &str) -> Self {
         Self::from(string.as_bytes())
+    }
+}
+
+impl TryFrom<Buffer<'_>> for &str {
+    type Error = std::str::Utf8Error;
+
+    fn try_from(buffer: Buffer<'_>) -> Result<Self, Self::Error> {
+        std::str::from_utf8(buffer.into())
     }
 }

--- a/crates/sdk/src/sys/types/location.rs
+++ b/crates/sdk/src/sys/types/location.rs
@@ -1,0 +1,53 @@
+use super::Buffer;
+
+#[repr(C)]
+pub struct Location<'a> {
+    file: Buffer<'a>,
+    line: u32,
+    column: u32,
+}
+
+impl<'a> Location<'a> {
+    pub fn unknown() -> Self {
+        Location {
+            file: Buffer::empty(),
+            line: 0,
+            column: 0,
+        }
+    }
+
+    #[track_caller]
+    pub fn caller() -> Self {
+        std::panic::Location::caller().into()
+    }
+
+    pub fn file(&self) -> &str {
+        self.file
+            .try_into()
+            .expect("this should always be a valid utf8 string") // todo! test if this pulls in format code
+    }
+
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+
+    pub fn column(&self) -> u32 {
+        self.column
+    }
+}
+
+impl From<&std::panic::Location<'_>> for Location<'_> {
+    fn from(location: &std::panic::Location<'_>) -> Self {
+        Location {
+            file: Buffer::from(location.file()),
+            line: location.line(),
+            column: location.column(),
+        }
+    }
+}
+
+impl From<Option<&std::panic::Location<'_>>> for Location<'_> {
+    fn from(location: Option<&std::panic::Location<'_>>) -> Self {
+        location.map_or_else(Location::unknown, Location::from)
+    }
+}

--- a/crates/sdk/src/sys/types/pointer.rs
+++ b/crates/sdk/src/sys/types/pointer.rs
@@ -26,6 +26,10 @@ impl<T> PtrSized<Pointer<&T>> {
             _phantom: PhantomData,
         }
     }
+
+    pub fn null() -> Self {
+        Self::new(std::ptr::null())
+    }
 }
 
 impl<T> PtrSized<Pointer<&mut T>> {


### PR DESCRIPTION
All panics, from the host or guest are correctly addressed in all situations.

### Guest

```rust
env::panic();
```

```console
[crates/runtime/examples/demo.rs:37] set_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Guest,
                message: "explicit panic",
                location: At {
                    file: "apps/kv-store/src/lib.rs",
                    line: 15,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
env::panic_str("hello world")
```

```console
[crates/runtime/examples/demo.rs:37] set_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Guest,
                message: "hello world",
                location: At {
                    file: "apps/kv-store/src/lib.rs",
                    line: 16,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
panic!("at the disco")
```

```console
[crates/runtime/examples/demo.rs:37] set_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Guest,
                message: "at the disco",
                location: At {
                    file: "apps/kv-store/src/lib.rs",
                    line: 17,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
0u8 - 1
```

```console
[crates/runtime/examples/demo.rs:37] set_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Guest,
                message: "attempt to subtract with overflow",
                location: At {
                    file: "apps/kv-store/src/lib.rs",
                    line: 19,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
None::<()>.unwrap()
```

```console
[crates/runtime/examples/demo.rs:37] set_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Guest,
                message: "called `Option::unwrap()` on a `None` value",
                location: At {
                    file: "apps/kv-store/src/lib.rs",
                    line: 18,
                    column: 20,
                },
            },
        ),
    ),
    logs: [],
}
```

### Host

```rust
panic!();
```

```console
[crates/runtime/examples/demo.rs:28] get_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Host,
                message: "explicit panic",
                location: At {
                    file: "crates/runtime/src/logic.rs",
                    line: 172,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
panic!("hello world")
```

```console
[crates/runtime/examples/demo.rs:61] get_unchecked_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Host,
                message: "hello world",
                location: At {
                    file: "crates/runtime/src/logic.rs",
                    line: 172,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
0u8 - 1
```

```console
[crates/runtime/examples/demo.rs:53] get_result_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Host,
                message: "attempt to subtract with overflow",
                location: At {
                    file: "crates/runtime/src/logic.rs",
                    line: 174,
                    column: 9,
                },
            },
        ),
    ),
    logs: [],
}
```

---

```rust
None::<()>.unwrap()
```

```console
[crates/runtime/examples/demo.rs:45] get_outcome = Outcome {
    returns: Err(
        HostError(
            Panic {
                context: Host,
                message: "called `Option::unwrap()` on a `None` value",
                location: At {
                    file: "crates/runtime/src/logic.rs",
                    line: 172,
                    column: 20,
                },
            },
        ),
    ),
    logs: [],
}
```