### PR TITLE
chore: revise ptr-len order

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -113,7 +113,7 @@ pub struct VMHostFunctions<'a> {
 }
 
 impl<'a> VMHostFunctions<'a> {
-    fn read_guest_memory(&self, len: u64, ptr: u64) -> Result<Vec<u8>> {
+    fn read_guest_memory(&self, ptr: u64, len: u64) -> Result<Vec<u8>> {
         let mut buf = vec![0; len as usize];
 
         self.borrow_memory().read(ptr, &mut buf)?;
@@ -121,16 +121,16 @@ impl<'a> VMHostFunctions<'a> {
         Ok(buf)
     }
 
-    fn get_string(&self, len: u64, ptr: u64) -> Result<String> {
-        let buf = self.read_guest_memory(len, ptr)?;
+    fn get_string(&self, ptr: u64, len: u64) -> Result<String> {
+        let buf = self.read_guest_memory(ptr, len)?;
 
         String::from_utf8(buf).map_err(|_| HostError::BadUTF8.into())
     }
 }
 
 impl<'a> VMHostFunctions<'a> {
-    pub fn panic(&self, file_len: u64, file_ptr: u64, line: u32, column: u32) -> Result<()> {
-        let file = self.get_string(file_len, file_ptr)?;
+    pub fn panic(&self, file_ptr: u64, file_len: u64, line: u32, column: u32) -> Result<()> {
+        let file = self.get_string(file_ptr, file_len)?;
         Err(HostError::Panic {
             context: PanicContext::Guest,
             message: "explicit panic".to_owned(),
@@ -141,15 +141,15 @@ impl<'a> VMHostFunctions<'a> {
 
     pub fn panic_utf8(
         &self,
-        msg_len: u64,
         msg_ptr: u64,
-        file_len: u64,
+        msg_len: u64,
         file_ptr: u64,
+        file_len: u64,
         line: u32,
         column: u32,
     ) -> Result<()> {
-        let message = self.get_string(msg_len, msg_ptr)?;
-        let file = self.get_string(file_len, file_ptr)?;
+        let message = self.get_string(msg_ptr, msg_len)?;
+        let file = self.get_string(file_ptr, file_len)?;
 
         Err(HostError::Panic {
             context: PanicContext::Guest,
@@ -183,8 +183,8 @@ impl<'a> VMHostFunctions<'a> {
         Ok(())
     }
 
-    pub fn value_return(&mut self, tag: u64, len: u64, ptr: u64) -> Result<()> {
-        let buf = self.read_guest_memory(len, ptr)?;
+    pub fn value_return(&mut self, tag: u64, ptr: u64, len: u64) -> Result<()> {
+        let buf = self.read_guest_memory(ptr, len)?;
 
         let result = match tag {
             0 => Ok(buf),
@@ -197,28 +197,28 @@ impl<'a> VMHostFunctions<'a> {
         Ok(())
     }
 
-    pub fn log_utf8(&mut self, len: u64, ptr: u64) -> Result<()> {
+    pub fn log_utf8(&mut self, ptr: u64, len: u64) -> Result<()> {
         let logic = self.borrow_logic();
 
         if logic.logs.len() >= logic.limits.max_logs as usize {
             return Err(HostError::LogsOverflow.into());
         }
 
-        let message = self.get_string(len, ptr)?;
+        let message = self.get_string(ptr, len)?;
 
         self.with_logic_mut(|logic| logic.logs.push(message));
 
         Ok(())
     }
 
-    pub fn storage_read(&mut self, key_len: u64, key_ptr: u64, register_id: u64) -> Result<u32> {
+    pub fn storage_read(&mut self, key_ptr: u64, key_len: u64, register_id: u64) -> Result<u32> {
         let logic = self.borrow_logic();
 
         if key_len > logic.limits.max_storage_key_size.get() {
             return Err(HostError::KeyLengthOverflow.into());
         }
 
-        let key = self.read_guest_memory(key_len, key_ptr)?;
+        let key = self.read_guest_memory(key_ptr, key_len)?;
 
         if let Some(value) = logic.storage.get(&key) {
             self.with_logic_mut(|logic| logic.registers.set(&logic.limits, register_id, value))?;
@@ -231,10 +231,10 @@ impl<'a> VMHostFunctions<'a> {
 
     pub fn storage_write(
         &mut self,
-        key_len: u64,
         key_ptr: u64,
-        value_len: u64,
+        key_len: u64,
         value_ptr: u64,
+        value_len: u64,
         register_id: u64,
     ) -> Result<u32> {
         let logic = self.borrow_logic();
@@ -247,8 +247,8 @@ impl<'a> VMHostFunctions<'a> {
             return Err(HostError::ValueLengthOverflow.into());
         }
 
-        let key = self.read_guest_memory(key_len, key_ptr)?;
-        let value = self.read_guest_memory(value_len, value_ptr)?;
+        let key = self.read_guest_memory(key_ptr, key_len)?;
+        let value = self.read_guest_memory(value_ptr, value_len)?;
 
         let evicted = self.with_logic_mut(|logic| logic.storage.set(key, value));
 

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -17,25 +17,32 @@ impl<'a> VMLogic<'a> {
             store;
             logic: self;
 
-            fn panic(file_len: u64, file_ptr: u64, line: u32, column: u32);
-            fn panic_utf8(msg_len: u64, msg_ptr: u64, file_len: u64, file_ptr: u64, line: u32, column: u32);
+            fn panic(file_ptr: u64, file_len: u64, line: u32, column: u32);
+            fn panic_utf8(
+                msg_ptr: u64,
+                msg_len: u64,
+                file_ptr: u64,
+                file_len: u64,
+                line: u32,
+                column: u32
+            );
 
             // todo! custom memory injection
             fn register_len(register_id: u64) -> u64;
             fn read_register(register_id: u64, ptr: u64);
 
             fn input(register_id: u64);
-            fn value_return(tag: u64, value_len: u64, value_ptr: u64);
-            fn log_utf8(len: u64, ptr: u64);
+            fn value_return(tag: u64, value_ptr: u64, value_len: u64);
+            fn log_utf8(ptr: u64, len: u64);
 
             fn storage_write(
-                key_len: u64,
                 key_ptr: u64,
-                value_len: u64,
+                key_len: u64,
                 value_ptr: u64,
+                value_len: u64,
                 register_id: u64,
             ) -> u32;
-            fn storage_read(key_len: u64, key_ptr: u64, register_id: u64) -> u32;
+            fn storage_read(key_ptr: u64, key_len: u64, register_id: u64) -> u32;
         }
     }
 }

--- a/crates/sdk/src/sys/types/buffer.rs
+++ b/crates/sdk/src/sys/types/buffer.rs
@@ -3,13 +3,13 @@ use super::{Pointer, PtrSized};
 #[repr(C)]
 #[derive(Eq, Copy, Clone, Debug, PartialEq)]
 pub struct Buffer<'a> {
-    len: u64,
     ptr: PtrSized<Pointer<&'a u8>>,
+    len: u64,
 }
 
 impl<'a> Buffer<'a> {
-    pub fn new(len: usize, ptr: PtrSized<Pointer<&'a u8>>) -> Self {
-        Self { len: len as _, ptr }
+    pub fn new(ptr: PtrSized<Pointer<&'a u8>>, len: usize) -> Self {
+        Self { ptr, len: len as _ }
     }
 
     pub fn len(&self) -> usize {
@@ -21,13 +21,13 @@ impl<'a> Buffer<'a> {
     }
 
     pub fn empty() -> Self {
-        Self::new(0, PtrSized::null())
+        Self::new(PtrSized::null(), 0)
     }
 }
 
 impl From<&[u8]> for Buffer<'_> {
     fn from(slice: &[u8]) -> Self {
-        Self::new(slice.len(), slice.as_ptr().into())
+        Self::new(slice.as_ptr().into(), slice.len())
     }
 }
 


### PR DESCRIPTION
Taking a leaf from the Rust std's design (which itself borrows [from the C std](https://en.cppreference.com/w/c/string/byte/memcpy)) the pattern is (what we're addressing, how large it is):

- https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts
- https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html
- https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html
- https://doc.rust-lang.org/std/ptr/fn.slice_from_raw_parts.html