### PR TITLE
feat(runtime): wrap mutable buffers

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -167,10 +167,13 @@ impl<'a> VMHostFunctions<'a> {
             .unwrap_or(u64::MAX))
     }
 
-    pub fn read_register(&mut self, register_id: u64, ptr: u64) -> Result<()> {
+    pub fn read_register(&mut self, register_id: u64, ptr: u64, len: u64) -> Result<u32> {
         let data = self.borrow_logic().registers.get(register_id)?;
+        if data.len() != len as usize {
+            return Ok(0);
+        }
         self.borrow_memory().write(ptr, data)?;
-        Ok(())
+        Ok(1)
     }
 
     pub fn input(&mut self, register_id: u64) -> Result<()> {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -29,7 +29,7 @@ impl<'a> VMLogic<'a> {
 
             // todo! custom memory injection
             fn register_len(register_id: u64) -> u64;
-            fn read_register(register_id: u64, ptr: u64);
+            fn read_register(register_id: u64, ptr: u64, len: u64) -> u32;
 
             fn input(register_id: u64);
             fn value_return(tag: u64, value_ptr: u64, value_len: u64);

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -10,7 +10,7 @@ extern "C" {
     pub fn panic_utf8(msg: Buffer, loc: Location) -> !;
     // --
     pub fn register_len(register_id: RegisterId) -> PtrSized<Integer>;
-    pub fn read_register(register_id: RegisterId, ptr: PtrSized<Pointer<&mut u8>>);
+    pub fn read_register(register_id: RegisterId, buf: BufferMut) -> Bool;
     // --
     pub fn input(register_id: RegisterId);
     pub fn value_return(value: ValueReturn);

--- a/crates/sdk/src/sys/types/pointer.rs
+++ b/crates/sdk/src/sys/types/pointer.rs
@@ -19,6 +19,15 @@ impl<T> PtrSized<T> {
     };
 }
 
+impl<T> PtrSized<Pointer<T>> {
+    pub fn null() -> Self {
+        Self {
+            value: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
 impl<T> PtrSized<Pointer<&T>> {
     pub fn new(ptr: *const T) -> Self {
         Self {
@@ -27,8 +36,8 @@ impl<T> PtrSized<Pointer<&T>> {
         }
     }
 
-    pub fn null() -> Self {
-        Self::new(std::ptr::null())
+    pub fn as_ptr(&self) -> *const T {
+        self.value as _
     }
 }
 
@@ -39,17 +48,13 @@ impl<T> PtrSized<Pointer<&mut T>> {
             _phantom: PhantomData,
         }
     }
-}
 
-impl<T> From<PtrSized<Pointer<&T>>> for *const T {
-    fn from(ptr: PtrSized<Pointer<&T>>) -> Self {
-        ptr.value as _
+    pub fn as_ptr(&self) -> *const T {
+        self.value as _
     }
-}
 
-impl<T> From<PtrSized<Pointer<&mut T>>> for *mut T {
-    fn from(ptr: PtrSized<Pointer<&mut T>>) -> Self {
-        ptr.value as _
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.value as _
     }
 }
 
@@ -84,11 +89,5 @@ impl PtrSized<Integer> {
 impl From<usize> for PtrSized<Integer> {
     fn from(value: usize) -> Self {
         Self::new(value)
-    }
-}
-
-impl From<PtrSized<Integer>> for usize {
-    fn from(ptr: PtrSized<Integer>) -> Self {
-        ptr.value as _
     }
 }


### PR DESCRIPTION
To read some data from a register:

`sys::register_len` to see how big it is, you allocate a buffer with that capacity, pass a pointer to the VM which will do a secondary check for the capacity at which point, it writes to that section of memory and returns a bool if it was a good fit or not.