### PR TITLE
feat(sdk): no wrapped exchange

### DIFF
--- a/crates/sdk/src/sys/types/bool.rs
+++ b/crates/sdk/src/sys/types/bool.rs
@@ -1,13 +1,15 @@
 #[repr(C)]
 #[derive(Eq, Ord, Copy, Hash, Clone, Debug, PartialEq, PartialOrd)]
-pub struct Bool(u8);
+pub struct Bool(u32);
 
-impl Bool {
-    pub const fn as_bool(self) -> Option<bool> {
-        match self {
-            Self(0) => Some(false),
-            Self(1) => Some(true),
-            _ => None,
+impl TryFrom<Bool> for bool {
+    type Error = u32;
+
+    fn try_from(value: Bool) -> Result<Self, Self::Error> {
+        match value {
+            Bool(0) => Ok(false),
+            Bool(1) => Ok(true),
+            Bool(x) => Err(x),
         }
     }
 }


### PR DESCRIPTION
`u8` gets represented as the wasm `i32` type in the ABI. The host could pass a larger range of values to the guest and the guest would treat those bytes as u8, wrapped.

This patch takes all 32-bits, and only then tests them to be more precise.