### PR TITLE
fix: update repo name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Calimero Limited <info@calimero.network>"]
 edition = "2021"
-repository = "https://github.com/calimero-is-near/cali2.0-experimental"
+repository = "https://github.com/calimero-network/core"
 license = "MIT OR Apache-2.0"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 [![Discord](https://dcbadge.vercel.app/api/server/urJeMtRRMu?style=flat&theme=default-inverted)](https://discord.gg/urJeMtRRMu)
 [![Telegram Group](https://img.shields.io/badge/Join-Telegram%20Group-blue.svg?logo=telegram)](https://t.me/+_6h-gJlnXO83OGVk)
-[![Build Status](https://github.com/calimero-is-near/cali2.0-experimental/actions/workflows/docusaurus_deploy.yml/badge.svg)](https://github.com/calimero-is-near/cali2.0-experimental/actions/workflows/docusaurus_deploy.yml)
+[![Build Status](https://github.com/calimero-network/core/actions/workflows/docusaurus_deploy.yml/badge.svg)](https://github.com/calimero-network/core/actions/workflows/docusaurus_deploy.yml)
 [![License](https://img.shields.io/badge/License-Apache--2.0-blue)](#license)
-[![Issues - calimero](https://img.shields.io/github/issues/calimero-is-near/cali2.0-experimental)](https://github.com/calimero-is-near/cali2.0-experimental/issues)
+[![Issues - calimero](https://img.shields.io/github/issues/calimero-network/core)](https://github.com/calimero-network/core/issues)
 
 <div align="center">
   <picture>

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Follow these steps to get started with the documentation:
 1. Clone the repository (if you haven't already):
 
    ```bash
-   git clone https://github.com/calimero-is-near/cali2.0-experimental.git
+   git clone https://github.com/calimero-network/core.git
    cd yourproject/docs
    ```
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,10 +7,10 @@ const config: Config = {
   tagline: 'Dinosaurs are cool',
   favicon: 'img/favicon.ico',
 
-  url: 'https://calimero-is-near.github.io',
-  baseUrl: '/cali2.0-experimental/',
-  organizationName: 'calimero-is-near',
-  projectName: 'cali2.0-experimental',
+  url: 'https://calimero-network.github.io',
+  baseUrl: '/core/',
+  organizationName: 'calimero-network',
+  projectName: 'core',
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -66,7 +66,7 @@ const config: Config = {
         },
         {to: '/blog', label: 'Blog', position: 'left'},
         {
-          href: 'https://github.com/calimero-is-near/cali2.0-experimental',
+          href: 'https://github.com/calimero-network/core',
           label: 'GitHub',
           position: 'right',
         },
@@ -114,7 +114,7 @@ const config: Config = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/calimero-is-near/cali2.0-experimental',
+              href: 'https://github.com/calimero-network/core',
             },
           ],
         },


### PR DESCRIPTION
After changing the organization and repo name some files are outdated. This PR replaces the old repo with the new one.