### PR TITLE
refactor: remove hardcoded application id

### DIFF
--- a/crates/server/src/admin/handlers/add_client_key.rs
+++ b/crates/server/src/admin/handlers/add_client_key.rs
@@ -14,7 +14,6 @@ use tracing::info;
 use crate::admin::service::{ApiError, ApiResponse};
 use crate::admin::storage::root_key::{get_root_key, RootKey};
 use crate::verifysignature::verify_near_signature;
-use crate::APPLICATION_ID;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -284,15 +283,12 @@ fn validate_root_key_exists(
     req: AddClientKeyRequest,
     store: Store,
 ) -> Result<AddClientKeyRequest, ApiError> {
-    //TODO extract from request
-    let application_id = ApplicationId(APPLICATION_ID.to_string());
-
     //Check if root key exists
     let root_key = RootKey {
         signing_key: req.wallet_metadata.signing_key.clone(),
     };
 
-    let existing_root_key = match get_root_key(application_id, &store, &root_key).map_err(|e| {
+    let existing_root_key = match get_root_key(&store, &root_key).map_err(|e| {
         info!("Error getting root key: {}", e);
         ApiError {
             status_code: StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/server/src/admin/handlers/fetch_did.rs
+++ b/crates/server/src/admin/handlers/fetch_did.rs
@@ -1,6 +1,5 @@
 use axum::extract::State;
 use axum::response::IntoResponse;
-use calimero_primitives::application::ApplicationId;
 use calimero_store::Store;
 use serde::Serialize;
 use tower_sessions::Session;
@@ -8,7 +7,6 @@ use tower_sessions::Session;
 use super::add_client_key::parse_api_error;
 use crate::admin::service::ApiResponse;
 use crate::admin::storage::did::{get_or_create_did, Did};
-use crate::APPLICATION_ID;
 
 #[derive(Debug, Serialize)]
 struct DidResponse {
@@ -16,9 +14,7 @@ struct DidResponse {
 }
 
 pub async fn fetch_did_handler(_session: Session, State(store): State<Store>) -> impl IntoResponse {
-    let application_id = ApplicationId(APPLICATION_ID.to_string());
-
-    let did = get_or_create_did(application_id, &store).map_err(|err| parse_api_error(err));
+    let did = get_or_create_did(&store).map_err(|err| parse_api_error(err));
 
     return match did {
         Ok(did) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -11,7 +11,6 @@ use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
-use calimero_primitives::application::ApplicationId;
 use calimero_store::Store;
 use near_jsonrpc_client::{methods, JsonRpcClient};
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
@@ -29,7 +28,7 @@ use tracing::{error, info};
 use super::handlers::add_client_key::{add_client_key_handler, parse_api_error};
 use super::handlers::fetch_did::fetch_did_handler;
 use super::storage::root_key::{add_root_key, RootKey};
-use crate::{verifysignature, APPLICATION_ID};
+use crate::verifysignature;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AdminConfig {
@@ -194,9 +193,6 @@ async fn create_root_key_handler(
     let message = "helloworld";
     let app = "me";
 
-    //TODO extract from request
-    let application_id = ApplicationId(APPLICATION_ID.to_string());
-
     match session.get::<String>(CHALLENGE_KEY).await.ok().flatten() {
         Some(challenge) => {
             if verifysignature::verify_near_signature(
@@ -208,7 +204,6 @@ async fn create_root_key_handler(
                 &req.public_key,
             ) {
                 let result = add_root_key(
-                    application_id,
                     &store,
                     RootKey {
                         signing_key: req.public_key.clone(),

--- a/crates/server/src/admin/storage/did.rs
+++ b/crates/server/src/admin/storage/did.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use super::root_key::RootKey;
 
-pub const DID_KEY: &str = "did:cali";
+const DID_KEY: &str = "did:cali";
+const NODE_STORE_KEY: &str = "node";
 
 //TODO extract this to identity where suitable
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -13,8 +14,9 @@ pub struct Did {
     pub(crate) root_keys: Vec<RootKey>,
 }
 
-pub fn create_did(application_id: ApplicationId, store: &Store) -> eyre::Result<Did> {
-    let mut storage = calimero_store::TemporalStore::new(application_id, &store);
+pub fn create_did(store: &Store) -> eyre::Result<Did> {
+    let mut storage =
+        calimero_store::TemporalStore::new(ApplicationId(NODE_STORE_KEY.to_string()), &store);
 
     let did_document = Did {
         id: DID_KEY.to_string(),
@@ -30,22 +32,24 @@ pub fn create_did(application_id: ApplicationId, store: &Store) -> eyre::Result<
     Ok(did_document)
 }
 
-pub fn get_or_create_did(application_id: ApplicationId, store: &Store) -> eyre::Result<Did> {
-    let mut storage = calimero_store::ReadOnlyStore::new(application_id.clone(), &store);
+pub fn get_or_create_did(store: &Store) -> eyre::Result<Did> {
+    let mut storage =
+        calimero_store::ReadOnlyStore::new(ApplicationId(NODE_STORE_KEY.to_string()), &store);
 
     let did_vec = storage.get(&DID_KEY.as_bytes().to_vec())?;
     match did_vec {
         Some(bytes) => serde_json::from_slice(&bytes)
             .map_err(|e| eyre::Report::new(e).wrap_err("Deserialization error")),
-        None => create_did(application_id, store),
+        None => create_did(store),
     }
 }
 
-pub fn update_did(application_id: ApplicationId, store: &Store, did: Did) -> eyre::Result<()> {
+pub fn update_did(store: &Store, did: Did) -> eyre::Result<()> {
     let did_document_vec = serde_json::to_vec(&did)
         .map_err(|e| eyre::Report::new(e).wrap_err("Serialization error"))?;
 
-    let mut storage = calimero_store::TemporalStore::new(application_id, store);
+    let mut storage =
+        calimero_store::TemporalStore::new(ApplicationId(NODE_STORE_KEY.to_string()), store);
     storage.put(DID_KEY.as_bytes().to_owned(), did_document_vec);
     storage.commit()?;
     Ok(())

--- a/crates/server/src/admin/storage/root_key.rs
+++ b/crates/server/src/admin/storage/root_key.rs
@@ -1,4 +1,3 @@
-use calimero_primitives::application::ApplicationId;
 use calimero_store::Store;
 use serde::{Deserialize, Serialize};
 
@@ -9,12 +8,8 @@ pub(crate) struct RootKey {
     pub(crate) signing_key: String,
 }
 
-pub fn add_root_key(
-    application_id: ApplicationId,
-    store: &Store,
-    root_key: RootKey,
-) -> eyre::Result<bool> {
-    let mut did_document = get_or_create_did(application_id.clone(), store)?;
+pub fn add_root_key(store: &Store, root_key: RootKey) -> eyre::Result<bool> {
+    let mut did_document = get_or_create_did(store)?;
 
     if !did_document
         .root_keys
@@ -22,19 +17,13 @@ pub fn add_root_key(
         .any(|k| k.signing_key == root_key.signing_key)
     {
         did_document.root_keys.push(root_key);
-        update_did(application_id, store, did_document)?;
+        update_did(store, did_document)?;
     }
     Ok(true)
 }
 
-pub fn get_root_key(
-    application_id: ApplicationId,
-    store: &Store,
-    root_key: &RootKey,
-) -> eyre::Result<Option<RootKey>> {
-    let mut storage = calimero_store::ReadOnlyStore::new(application_id.clone(), &store);
-
-    let did = get_or_create_did(application_id.clone(), store)?;
+pub fn get_root_key(store: &Store, root_key: &RootKey) -> eyre::Result<Option<RootKey>> {
+    let did = get_or_create_did(store)?;
     Ok(did
         .root_keys
         .into_iter()


### PR DESCRIPTION
Node identity (root key and did) does not rely on application id as it is used on node level. 