### PR TITLE
fix: add headers to constructor

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@calimero-is-near/calimero-p2p-sdk",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "Javascript library to interact with Calimero P2P node",
     "type": "module",
     "main": "lib/index.js",

--- a/packages/calimero-sdk/src/rpc/jsonrpc.ts
+++ b/packages/calimero-sdk/src/rpc/jsonrpc.ts
@@ -1,112 +1,138 @@
-
 import {
-    RpcRequestId,
-    RpcClient,
-    RpcQueryResponse,
-    RpcMutateResponse,
-    RpcQueryParams,
-    RpcMutateParams,
-    RequestConfig,
-    RpcResult,
+  RpcRequestId,
+  RpcClient,
+  RpcQueryResponse,
+  RpcMutateResponse,
+  RpcQueryParams,
+  RpcMutateParams,
+  RequestConfig,
+  RpcResult,
 } from "../rpc";
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosHeaders, AxiosInstance } from "axios";
 
-type JsonRpcVersion = '2.0'
+type JsonRpcVersion = "2.0";
 
 interface JsonRpcRequest<Params> {
-    jsonrpc: JsonRpcVersion;
-    id: RpcRequestId | null;
-    method: string;
-    params: Params;
+  jsonrpc: JsonRpcVersion;
+  id: RpcRequestId | null;
+  method: string;
+  params: Params;
 }
 
 interface JsonRpcResponse<Result> {
-    jsonrpc: JsonRpcVersion;
-    id: RpcRequestId | null;
-    result?: Result;
-    error?: any; // TODO define error types
+  jsonrpc: JsonRpcVersion;
+  id: RpcRequestId | null;
+  result?: Result;
+  error?: any; // TODO define error types
 }
 
 export class JsonRpcClient implements RpcClient {
-    readonly path: string;
-    readonly axiosInstance: AxiosInstance;
+  readonly path: string;
+  readonly axiosInstance: AxiosInstance;
 
-    public constructor(baseUrl: string, path: string, defaultTimeout: number = 1000) {
-        this.path = path;
-        this.axiosInstance = axios.create({
-            baseURL: baseUrl,
-            timeout: defaultTimeout,
-        });
-    }
+  public constructor(
+    baseUrl: string,
+    path: string,
+    defaultTimeout: number = 1000,
+    headers: AxiosHeaders
+  ) {
+    this.path = path;
+    this.axiosInstance = axios.create({
+      baseURL: baseUrl,
+      timeout: defaultTimeout,
+      headers: headers,
+    });
+  }
 
-    public async query<Args, Output>(params: RpcQueryParams<Args>, config?: RequestConfig): Promise<RpcResult<RpcQueryResponse<Output>>> {
-        return await this.request<RpcQueryParams<Args>, RpcQueryResponse<Output>>('query', params, config);
-    }
+  public async query<Args, Output>(
+    params: RpcQueryParams<Args>,
+    config?: RequestConfig
+  ): Promise<RpcResult<RpcQueryResponse<Output>>> {
+    return await this.request<RpcQueryParams<Args>, RpcQueryResponse<Output>>(
+      "query",
+      params,
+      config
+    );
+  }
 
-    public async mutate<Args, Output>(params: RpcMutateParams<Args>, config?: RequestConfig): Promise<RpcResult<RpcMutateResponse<Output>>> {
-        return await this.request<RpcMutateParams<Args>, RpcMutateResponse<Output>>('mutate', params, config);
-    }
+  public async mutate<Args, Output>(
+    params: RpcMutateParams<Args>,
+    config?: RequestConfig
+  ): Promise<RpcResult<RpcMutateResponse<Output>>> {
+    return await this.request<RpcMutateParams<Args>, RpcMutateResponse<Output>>(
+      "mutate",
+      params,
+      config
+    );
+  }
 
-    async request<Params, Result>(method: string, params: Params, config?: RequestConfig): Promise<RpcResult<Result>> {
-        const requestId = this.getRandomRequestId()
-        const data: JsonRpcRequest<Params> = {
-            jsonrpc: '2.0',
-            id: requestId,
-            method,
-            params,
-        };
+  async request<Params, Result>(
+    method: string,
+    params: Params,
+    config?: RequestConfig
+  ): Promise<RpcResult<Result>> {
+    const requestId = this.getRandomRequestId();
+    const data: JsonRpcRequest<Params> = {
+      jsonrpc: "2.0",
+      id: requestId,
+      method,
+      params,
+    };
 
-        try {
-            const response = await this.axiosInstance.post<JsonRpcResponse<Result>>(this.path, data, config);
-            if (response.status === 200) {
-                if (response.data.id !== requestId) {
-                    return {
-                        result: null,
-                        error: {
-                            type: 'MissmatchedRequestIdError',
-                            expected: requestId,
-                            got: response.data.id,
-                        },
-                    };
-                }
-
-                if (response.data.error) {
-                    return {
-                        result: null,
-                        error: {
-                            type: 'RpcExecutionError',
-                            inner: response.data.error,
-                        },
-                    };
-                }
-
-                return {
-                    result: response.data.result,
-                    error: null,
-                };
-            } else {
-
-                return {
-                    result: null,
-                    error: {
-                        type: 'InvalidRequestError',
-                        data: response.data,
-                        code: response.status,
-                    },
-                };
-            }
-        } catch (error: any) {
-            return {
-                result: null,
-                error: {
-                    type: 'UnknownServerError',
-                    inner: error,
-                },
-            };
+    try {
+      const response = await this.axiosInstance.post<JsonRpcResponse<Result>>(
+        this.path,
+        data,
+        config
+      );
+      if (response.status === 200) {
+        if (response.data.id !== requestId) {
+          return {
+            result: null,
+            error: {
+              type: "MissmatchedRequestIdError",
+              expected: requestId,
+              got: response.data.id,
+            },
+          };
         }
-    }
 
-    getRandomRequestId(): number {
-        return Math.floor(Math.random() * Math.pow(2, 32));
+        if (response.data.error) {
+          return {
+            result: null,
+            error: {
+              type: "RpcExecutionError",
+              inner: response.data.error,
+            },
+          };
+        }
+
+        return {
+          result: response.data.result,
+          error: null,
+        };
+      } else {
+        return {
+          result: null,
+          error: {
+            type: "InvalidRequestError",
+            data: response.data,
+            code: response.status,
+          },
+        };
+      }
+    } catch (error: any) {
+      return {
+        result: null,
+        error: {
+          type: "UnknownServerError",
+          inner: error,
+        },
+      };
     }
+  }
+
+  getRandomRequestId(): number {
+    return Math.floor(Math.random() * Math.pow(2, 32));
+  }
 }


### PR DESCRIPTION
Pass headers to axios.

Tested with auth headers and postman
```
{
  "content-type": "application/json",
  "challenge": "dasd",
  "wallet_type": "wallet_type",
  "signing_key": "signing_key",
  "signature": "signature",
  "user-agent": "PostmanRuntime/7.37.0",
  "accept": "*/*",
  "cache-control": "no-cache",
  "postman-token": "ed5c86bb-3394-45ed-9c8b-d423a188011c",
  "host": "localhost:2428",
  "accept-encoding": "gzip, deflate, br",
  "connection": "keep-alive",
  "content-length": "337"
}
```