### PR TITLE
fix(admin-ui + admin-api) : listing applications

### DIFF
--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -467,6 +467,14 @@ struct ApplicationListResult {
 async fn fetch_application_handler(
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
+
+    if(!&state.service.application_dir.exists()){
+        return ApiResponse {
+            payload: ApplicationListResult { apps: HashMap::new() },
+        }
+        .into_response();
+    }
+
     if let Ok(entries) = fs::read_dir(&state.service.application_dir) {
         let mut applications: HashMap<String, String> = HashMap::new();
 

--- a/node-ui/src/api/dataSource/AppsDataSource.js
+++ b/node-ui/src/api/dataSource/AppsDataSource.js
@@ -8,7 +8,7 @@ export class AppsDataSource {
   async getInstalledAplications() {
     try {
       const response = await this.client.get("/admin-api/applications");
-      if (response?.apps?.length) {
+      if (response?.apps) {
         return Object.keys(response.apps);
       } else {
         return [];

--- a/node-ui/src/hooks/useNear.js
+++ b/node-ui/src/hooks/useNear.js
@@ -32,7 +32,7 @@ export function useRPC() {
       method_name: "get_package",
       args_base64: btoa(
         JSON.stringify({
-          name: id,
+          id,
         })
       ),
       finality: "final",

--- a/node-ui/src/pages/Applications.jsx
+++ b/node-ui/src/pages/Applications.jsx
@@ -45,7 +45,7 @@ export default function Applications() {
       }
     };
     setApps();
-  }, []);
+  }, [swithInstall]);
 
   return (
     <FlexLayout>


### PR DESCRIPTION
# fix(admin-ui + admin-api) : listing applications
 
## Summary:
First issue was with api returning "Failed to read application directory" when no applications were installed as the "apps" folder did not exist. Now there is a check for "apps" folder existence and it returns empty hash map if no applications are installed yet 

The check "response?.apps?.length" was not working as there is no length for KV object in javascript without using Object.keys. Changing the response to have different key like "apps2" (img2) throws no errors and just returns empty array. 

## Test plan:


