### PR TITLE
fix: app path

### DIFF
--- a/crates/node/src/application_manager.rs
+++ b/crates/node/src/application_manager.rs
@@ -54,7 +54,6 @@ impl ApplicationManager {
         application_id: &calimero_primitives::application::ApplicationId,
     ) -> Option<String> {
         let application_base_path = self.application_dir.join(application_id.to_string());
-
         if let Ok(entries) = fs::read_dir(&application_base_path) {
             // Collect version folders that contain binary.wasm into a vector
             let mut versions_with_binary = entries
@@ -68,7 +67,7 @@ impl ApplicationManager {
                     };
 
                     let binary_path = entry_path.join("binary.wasm");
-                    binary_path.exists().then_some((version, entry_path))
+                    binary_path.exists().then_some((version, binary_path))
                 })
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
Initial error
```
2024-04-23T11:29:04.290036Z ERROR calimero_node: Failed to execute transaction: Is a directory (os error 21)
2024-04-23T11:29:04.290538Z ERROR calimero_server::jsonrpc: Failed to execute JSON RPC method err=HandlerError(Object {"ExecutionError": Object {"message": String("channel closed")}})
```

App path didn't include file name.

Error after fix, probably not related
Flow:
Application is installed through admin ui to node 1. Then copied to node2 and coordinator. 
Coordinator, node 1 and node 2 are up and running with the same app. 
Open only-peers frontend and create new post with node 1. Error appears. 

```
2024-04-23T11:34:13.947392Z ERROR calimero_node: Failed to send transaction: No connected peers to send message to.
2024-04-23T11:34:13.947500Z ERROR calimero_server::jsonrpc: Failed to execute JSON RPC method err=HandlerError(Object {"ExecutionError": Object {"message": String("channel closed")}})
```

