### PR TITLE
feat(admin-ui): root key adding status

### DIFF
--- a/node-ui/src/components/confirmWallet/RootKeyContainer.jsx
+++ b/node-ui/src/components/confirmWallet/RootKeyContainer.jsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import CalimeroLogo from "../../assets/calimero-logo.svg";
 import styled from "styled-components";
+import StatusModal from "../common/StatusModal";
 import translations from "../../constants/en.global.json";
 
 const Container = styled.div`
@@ -119,14 +121,35 @@ const Container = styled.div`
         padding-top: 12px;
         width: 100%;
       }
+
+      .back-button {
+        color: rgb(255, 255, 255, 0.7);
+        font-size: 16px;
+        text-decoration: none;
+      }
+
+      .back-button:hover {
+        color: #fff;
+      }
     }
   }
 `;
 
-export function RootKeyContainer({ params, submitRootKeyRequest }) {
+export function RootKeyContainer({
+  params,
+  submitRootKeyRequest,
+  showStatusModal,
+  closeStatusModal,
+  addRootKeyStatus,
+}) {
   const t = translations.confirmWallet;
   return (
     <Container>
+      <StatusModal
+        show={showStatusModal}
+        closeModal={closeStatusModal}
+        modalContent={addRootKeyStatus}
+      />
       <div className="navbar">
         <div className="logo-container">
           <img
@@ -151,6 +174,11 @@ export function RootKeyContainer({ params, submitRootKeyRequest }) {
               {t.submitButtonText}
             </button>
           </div>
+          <div className="flex-container">
+          <Link to="/" className="back-button">
+              {t.backButtonText}
+            </Link>
+          </div>
         </div>
       </div>
     </Container>
@@ -167,4 +195,7 @@ const renderParam = (label, value) => (
 RootKeyContainer.propTypes = {
   params: PropTypes.object.isRequired,
   submitRootKeyRequest: PropTypes.func.isRequired,
+  showStatusModal: PropTypes.bool.isRequired,
+  closeStatusModal: PropTypes.func.isRequired,
+  addRootKeyStatus: PropTypes.object.isRequired,
 };

--- a/node-ui/src/constants/en.global.json
+++ b/node-ui/src/constants/en.global.json
@@ -41,7 +41,8 @@
         "signatureText": "Signature",
         "publicKeyText": "PublicKey",
         "callbackUrlText": "Callback Url",
-        "submitButtonText": "Submit Request"
+        "submitButtonText": "Submit Request",
+        "backButtonText": "Back to login"
     },
     "identityTable": {
         "title": "Identity",

--- a/node-ui/src/pages/ConfirmWallet.jsx
+++ b/node-ui/src/pages/ConfirmWallet.jsx
@@ -1,31 +1,58 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { RootKeyContainer } from "../components/confirmWallet/RootKeyContainer";
-import { useEffect, useState } from "react";
-import {
-  getParams,
-  submitRootKeyRequest,
-  isRootKeyAdded,
-} from "../utils/rootkey";
+import { useState } from "react";
+import { getParams, submitRootKeyRequest } from "../utils/rootkey";
 
 export default function ConfirmWallet() {
   const location = useLocation();
   const navigate = useNavigate();
   const params = getParams(location);
-  const [rootkeyAdded, setRootKeyAdded] = useState(false);
-
-  useEffect(() => {
-    if (isRootKeyAdded() || rootkeyAdded) {
-      navigate("/identity");
-    }
-  }, [rootkeyAdded, navigate]);
+  const [showStatusModal, setShowStatusModal] = useState(false);
+  const [addRootKeyStatus, setAddRootKeyStatus] = useState({
+    title: "",
+    message: "",
+    error: false,
+  });
 
   const addRootKey = async () => {
-    let data = await submitRootKeyRequest(params);
-    if (data) {
-      setRootKeyAdded(true);
+    let addRootKeyResponse = await submitRootKeyRequest(params);
+
+    if (addRootKeyResponse.error) {
+      setAddRootKeyStatus({
+        title: "Failed to add root key",
+        message: addRootKeyResponse.error,
+        error: true,
+      });
+    } else {
+      setAddRootKeyStatus({
+        title: "Success",
+        message: addRootKeyResponse.data,
+        error: false,
+      });
+    }
+    setShowStatusModal(true);
+  };
+
+  const closeStatusModal = () => {
+    setShowStatusModal(false);
+    setAddRootKeyStatus({
+      title: "",
+      message: "",
+      error: false,
+    });
+    if (!addRootKeyStatus.error) {
+      navigate("/identity");
     }
   };
 
-  return <RootKeyContainer params={params} submitRootKeyRequest={addRootKey} />;
+  return (
+    <RootKeyContainer
+      params={params}
+      submitRootKeyRequest={addRootKey}
+      showStatusModal={showStatusModal}
+      closeStatusModal={closeStatusModal}
+      addRootKeyStatus={addRootKeyStatus}
+    />
+  );
 }

--- a/node-ui/src/utils/rootkey.js
+++ b/node-ui/src/utils/rootkey.js
@@ -14,14 +14,13 @@ export const getParams = (location) => {
 export const submitRootKeyRequest = async (params) => {
   try {
     const response = await axios.post("/admin-api/root-key", params);
-    const data = response.data;
-    console.log("Response received:", data);
+    const message = response.data;
     localStorage.setItem(ROOT_KEY, true);
     localStorage.setItem(PUBLIC_KEY, params.publicKey);
-    return data;
-  } catch (e) {
-    console.error("Failed to submit root key request:", e);
-    return false;
+    return { data: message };
+  } catch (error) {
+    console.error("Failed to submit root key request:", error);
+    return { error: error.message };
   }
 };
 


### PR DESCRIPTION
# feat(admin-ui): root key adding status
 
## Summary:
Added status popup for verify wallet page, where on success response it redirects you to dashboard (/identity) and if its an error ,after closing the popup, you stay on the same page.
Also added a new button on the page that lets you get back to login or index page.

Removed the logic that was redirecting from page if the root key was already in the local storage (the useEffect part removed). This prevented the action of adding multiple root keys.

Fixes # [C20-57](https://calimero.atlassian.net/browse/C20-57)



