### PR TITLE
feat(sdk): define inline directives for sdk methods

### DIFF
--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -5,18 +5,21 @@ const DATA_REGISTER: sys::RegisterId = sys::RegisterId::new(sys::PtrSizedInt::MA
 const STATE_KEY: &[u8] = b"STATE";
 
 #[track_caller]
-fn expected_register<T>() -> T {
-    panic_str("Expected a register to be set, but it was not.");
-}
-
-#[track_caller]
+#[inline]
 pub fn panic() -> ! {
     unsafe { sys::panic(sys::Location::caller()) }
 }
 
 #[track_caller]
+#[inline]
 pub fn panic_str(message: &str) -> ! {
     unsafe { sys::panic_utf8(sys::Buffer::from(message), sys::Location::caller()) }
+}
+
+#[track_caller]
+#[inline]
+fn expected_register<T>() -> T {
+    panic_str("Expected a register to be set, but it was not.");
 }
 
 pub fn setup_panic_hook() {
@@ -47,6 +50,7 @@ pub fn unreachable() -> ! {
     unreachable!()
 }
 
+#[inline(always)]
 pub fn register_len(register_id: sys::RegisterId) -> Option<usize> {
     let len = unsafe { sys::register_len(register_id) };
 
@@ -57,6 +61,7 @@ pub fn register_len(register_id: sys::RegisterId) -> Option<usize> {
     Some(len.as_usize())
 }
 
+#[inline]
 pub fn read_register(register_id: sys::RegisterId) -> Option<Vec<u8>> {
     let len = register_len(register_id)?;
 
@@ -75,11 +80,13 @@ pub fn read_register(register_id: sys::RegisterId) -> Option<Vec<u8>> {
     Some(buffer)
 }
 
+#[inline]
 pub fn input() -> Option<Vec<u8>> {
     unsafe { sys::input(DATA_REGISTER) };
     read_register(DATA_REGISTER)
 }
 
+#[inline]
 pub fn value_return<T, E>(result: Result<T, E>)
 where
     T: AsRef<[u8]>,
@@ -88,10 +95,12 @@ where
     unsafe { sys::value_return(sys::ValueReturn::from(result.as_ref())) }
 }
 
+#[inline]
 pub fn log(message: &str) {
     unsafe { sys::log_utf8(sys::Buffer::from(message)) }
 }
 
+#[inline]
 pub fn emit<T: crate::event::AppEvent>(event: T) {
     let kind = event.kind();
     let data = event.data();
@@ -99,6 +108,7 @@ pub fn emit<T: crate::event::AppEvent>(event: T) {
     unsafe { sys::emit(sys::Event::new(&kind, &data)) }
 }
 
+#[inline]
 pub fn storage_read(key: &[u8]) -> Option<Vec<u8>> {
     match unsafe { sys::storage_read(sys::Buffer::from(key), DATA_REGISTER) }.try_into() {
         Ok(false) => None,
@@ -115,6 +125,7 @@ pub fn state_read<T: crate::state::AppState>() -> Option<T> {
     }
 }
 
+#[inline]
 pub fn storage_write(key: &[u8], value: &[u8]) -> bool {
     unsafe {
         sys::storage_write(

--- a/crates/sdk/src/event.rs
+++ b/crates/sdk/src/event.rs
@@ -18,6 +18,7 @@ thread_local! {
 }
 
 #[track_caller]
+#[inline(never)]
 fn handler<E: AppEvent + AppEventExt>(event: Box<dyn AppEventExt>) {
     if let Ok(event) = E::downcast(event) {
         env::emit(event);

--- a/crates/sdk/src/returns.rs
+++ b/crates/sdk/src/returns.rs
@@ -18,6 +18,7 @@ where
     T: Serialize,
     E: Serialize,
 {
+    #[inline]
     pub fn to_json(self) -> serde_json::Result<Result<Vec<u8>, Vec<u8>>> {
         Ok(match self {
             ReturnsResult(Ok(ok)) => Ok(serde_json::to_vec(&ok)?),
@@ -29,12 +30,14 @@ where
 pub struct WrappedReturn<T>(T);
 
 impl<T> WrappedReturn<T> {
+    #[inline(always)]
     pub fn new(value: T) -> Self {
         WrappedReturn(value)
     }
 }
 
 impl<T, E> WrappedReturn<Result<T, E>> {
+    #[inline(always)]
     pub fn into_result(self) -> ReturnsResult<T, E> {
         let WrappedReturn(value) = self;
         ReturnsResult(value)
@@ -52,6 +55,7 @@ where
     type Ok = T;
     type Err = Infallible;
 
+    #[inline(always)]
     fn into_result(self) -> ReturnsResult<Self::Ok, Self::Err> {
         let WrappedReturn(value) = self;
         ReturnsResult(Ok(value))

--- a/crates/sdk/src/sys/types.rs
+++ b/crates/sdk/src/sys/types.rs
@@ -24,6 +24,7 @@ where
     T: AsRef<[u8]>,
     E: AsRef<[u8]>,
 {
+    #[inline]
     fn from(result: Result<&'a T, &'a E>) -> Self {
         match result {
             Ok(value) => ValueReturn::Ok(Buffer::new(value)),

--- a/crates/sdk/src/sys/types/bool.rs
+++ b/crates/sdk/src/sys/types/bool.rs
@@ -5,6 +5,7 @@ pub struct Bool(u32);
 impl TryFrom<Bool> for bool {
     type Error = u32;
 
+    #[inline(always)]
     fn try_from(value: Bool) -> Result<Self, Self::Error> {
         match value {
             Bool(0) => Ok(false),

--- a/crates/sdk/src/sys/types/buffer.rs
+++ b/crates/sdk/src/sys/types/buffer.rs
@@ -11,6 +11,7 @@ pub struct Slice<'a, T> {
 }
 
 impl<'a, T> Slice<'a, T> {
+    #[inline]
     pub fn new<U: AsRef<[T]> + 'a>(value: U) -> Self {
         let slice = value.as_ref();
         Self {
@@ -20,6 +21,7 @@ impl<'a, T> Slice<'a, T> {
         }
     }
 
+    #[inline(always)]
     pub fn empty() -> Self {
         Self {
             ptr: Pointer::null(),
@@ -28,38 +30,45 @@ impl<'a, T> Slice<'a, T> {
         }
     }
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.len as _
     }
 
+    #[inline]
     fn as_slice(&self) -> &'a [T] {
         unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 
+    #[inline]
     fn as_mut_slice(&mut self) -> &'a mut [T] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr.as_mut_ptr(), self.len()) }
     }
 }
 
 impl<'a, T> AsRef<[T]> for Slice<'a, T> {
-    fn as_ref(&self) -> &[T] {
+    #[inline]
+    fn as_ref(&self) -> &'a [T] {
         self.as_slice()
     }
 }
 
 impl<'a, T> AsMut<[T]> for Slice<'a, T> {
-    fn as_mut(&mut self) -> &mut [T] {
+    #[inline]
+    fn as_mut(&mut self) -> &'a mut [T] {
         self.as_mut_slice()
     }
 }
 
 impl<'a, T> From<&'a [T]> for Slice<'a, T> {
+    #[inline]
     fn from(buf: &'a [T]) -> Self {
         Self::new(buf)
     }
 }
 
 impl<'a, T> From<&'a mut [T]> for Slice<'a, T> {
+    #[inline]
     fn from(buf: &'a mut [T]) -> Self {
         Self::new(buf)
     }
@@ -68,13 +77,15 @@ impl<'a, T> From<&'a mut [T]> for Slice<'a, T> {
 impl<'a, T> std::ops::Deref for Slice<'a, T> {
     type Target = [T];
 
-    fn deref(&self) -> &Self::Target {
+    #[inline]
+    fn deref(&self) -> &'a Self::Target {
         self.as_slice()
     }
 }
 
 impl<'a, T> std::ops::DerefMut for Slice<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    #[inline]
+    fn deref_mut(&mut self) -> &'a mut Self::Target {
         self.as_mut_slice()
     }
 }
@@ -83,6 +94,7 @@ pub type Buffer<'a> = Slice<'a, u8>;
 pub type BufferMut<'a> = Buffer<'a>;
 
 impl<'a> From<&'a str> for Buffer<'a> {
+    #[inline]
     fn from(buf: &'a str) -> Self {
         Self::new(buf)
     }

--- a/crates/sdk/src/sys/types/event.rs
+++ b/crates/sdk/src/sys/types/event.rs
@@ -7,6 +7,7 @@ pub struct Event<'a> {
 }
 
 impl<'a> Event<'a> {
+    #[inline(always)]
     pub fn new(kind: &'a str, data: &'a [u8]) -> Self {
         Event {
             kind: Buffer::new(kind),
@@ -14,12 +15,14 @@ impl<'a> Event<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn kind(&self) -> &str {
         self.kind
             .try_into()
             .expect("this should always be a valid utf8 string") // todo! test if this pulls in format code
     }
 
+    #[inline(always)]
     pub fn data(&self) -> &[u8] {
         &self.data
     }

--- a/crates/sdk/src/sys/types/location.rs
+++ b/crates/sdk/src/sys/types/location.rs
@@ -8,6 +8,7 @@ pub struct Location<'a> {
 }
 
 impl<'a> Location<'a> {
+    #[inline(always)]
     pub fn unknown() -> Self {
         Location {
             file: Buffer::empty(),
@@ -17,26 +18,31 @@ impl<'a> Location<'a> {
     }
 
     #[track_caller]
+    #[inline]
     pub fn caller() -> Self {
         std::panic::Location::caller().into()
     }
 
+    #[inline]
     pub fn file(&self) -> &str {
         self.file
             .try_into()
             .expect("this should always be a valid utf8 string") // todo! test if this pulls in format code
     }
 
+    #[inline(always)]
     pub fn line(&self) -> u32 {
         self.line
     }
 
+    #[inline(always)]
     pub fn column(&self) -> u32 {
         self.column
     }
 }
 
 impl<'a> From<&'a std::panic::Location<'_>> for Location<'a> {
+    #[inline]
     fn from(location: &'a std::panic::Location<'_>) -> Self {
         Location {
             file: Buffer::from(location.file()),
@@ -47,6 +53,7 @@ impl<'a> From<&'a std::panic::Location<'_>> for Location<'a> {
 }
 
 impl<'a> From<Option<&'a std::panic::Location<'_>>> for Location<'a> {
+    #[inline]
     fn from(location: Option<&'a std::panic::Location<'_>>) -> Self {
         location.map_or_else(Location::unknown, Location::from)
     }

--- a/crates/sdk/src/sys/types/pointer.rs
+++ b/crates/sdk/src/sys/types/pointer.rs
@@ -10,16 +10,19 @@ pub struct PtrSizedInt {
 impl PtrSizedInt {
     pub const MAX: Self = Self { value: u64::MAX };
 
+    #[inline(always)]
     pub const fn new(value: usize) -> Self {
         Self { value: value as _ }
     }
 
+    #[inline(always)]
     pub const fn as_usize(self) -> usize {
         self.value as _
     }
 }
 
 impl From<usize> for PtrSizedInt {
+    #[inline(always)]
     fn from(value: usize) -> Self {
         Self::new(value)
     }
@@ -33,6 +36,7 @@ pub struct Pointer<T> {
 }
 
 impl<T> Pointer<T> {
+    #[inline(always)]
     pub fn new(ptr: *const T) -> Self {
         Self {
             value: PtrSizedInt::new(ptr as _),
@@ -40,26 +44,31 @@ impl<T> Pointer<T> {
         }
     }
 
+    #[inline(always)]
     pub fn null() -> Self {
         Self::new(std::ptr::null())
     }
 
+    #[inline(always)]
     pub fn as_ptr(&self) -> *const T {
         self.value.as_usize() as _
     }
 
+    #[inline(always)]
     pub fn as_mut_ptr(&self) -> *mut T {
         self.value.as_usize() as _
     }
 }
 
 impl<T> From<*const T> for Pointer<T> {
+    #[inline(always)]
     fn from(ptr: *const T) -> Self {
         Self::new(ptr)
     }
 }
 
 impl<T> From<*mut T> for Pointer<T> {
+    #[inline(always)]
     fn from(ptr: *mut T) -> Self {
         Self::new(ptr)
     }

--- a/crates/sdk/src/sys/types/register.rs
+++ b/crates/sdk/src/sys/types/register.rs
@@ -5,12 +5,14 @@ use super::PtrSizedInt;
 pub struct RegisterId(PtrSizedInt);
 
 impl RegisterId {
+    #[inline(always)]
     pub const fn new(value: usize) -> Self {
         Self(PtrSizedInt::new(value))
     }
 }
 
 impl From<usize> for RegisterId {
+    #[inline(always)]
     fn from(value: usize) -> Self {
         Self::new(value)
     }


### PR DESCRIPTION
slap inline directives for some optimization wins

```console
$ git checkout miraclx/sdk-optim
$ ./apps/kv-store/build.sh
   Compiling calimero-sdk-macros v0.1.0 (/Users/miraclx/git/calimero-is-near/cali2.0-experimental/crates/sdk/macros)
   Compiling calimero-sdk v0.1.0 (/Users/miraclx/git/calimero-is-near/cali2.0-experimental/crates/sdk)
   Compiling kv-store v0.1.0 (/Users/miraclx/git/calimero-is-near/cali2.0-experimental/apps/kv-store)
    Finished app-release [optimized] target(s) in 2.45s
$ wc -c apps/kv-store/res/kv_store.wasm
237577 apps/kv-store/res/kv_store.wasm
```

```console
$ git checkout master
$ ./apps/kv-store/build.sh
   Compiling calimero-sdk v0.1.0 (/Users/miraclx/git/calimero-is-near/cali2.0-experimental/crates/sdk)
   Compiling kv-store v0.1.0 (/Users/miraclx/git/calimero-is-near/cali2.0-experimental/apps/kv-store)
    Finished app-release [optimized] target(s) in 1.40s
$ wc -c apps/kv-store/res/kv_store.wasm
237673 apps/kv-store/res/kv_store.wasm
```

through further investigation, we should be able to cut down the binary size much more