### PR TITLE
Update build scripts to do wasm target installation before compilation.

### DIFF
--- a/apps/kv-store/build.sh
+++ b/apps/kv-store/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-rustup target add wasm32-unknown-unknown
-
 cd "$(dirname $0)"
 
 TARGET="${CARGO_TARGET_DIR:-../../target}"
+
+rustup target add wasm32-unknown-unknown
 
 cargo build --target wasm32-unknown-unknown --profile app-release
 

--- a/apps/only-peers/build.sh
+++ b/apps/only-peers/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-rustup target add wasm32-unknown-unknown
-
 cd "$(dirname $0)"
 
 TARGET="${CARGO_TARGET_DIR:-../../target}"
+
+rustup target add wasm32-unknown-unknown
 
 cargo build --target wasm32-unknown-unknown --profile app-release
 


### PR DESCRIPTION
## Summary:

Add `rustup target add wasm32-unknown-unknown` to build scripts to stop getting compilation errors.

## Test plan:
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration. Add screenshots or videos for changes in the user-interface.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added a test plan that prove my fix is effective or that my feature works
- [ ] I squashed all commits and provided a meaningful commit message
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
