### PR TITLE
chore(sdk): fmt

### DIFF
--- a/crates/sdk/macros/src/event.rs
+++ b/crates/sdk/macros/src/event.rs
@@ -53,7 +53,7 @@ impl<'a> ToTokens for EventImpl<'a> {
                     }
                 }
             }
-            
+
             impl #impl_generics ::calimero_sdk::event::AppEventExt for #ident #ty_generics #where_clause {}
         }
         .to_tokens(tokens)
@@ -78,32 +78,42 @@ impl<'a> TryFrom<EventImplInput<'a>> for EventImpl<'a> {
         match vis {
             syn::Visibility::Public(_) => {}
             syn::Visibility::Inherited => {
-                return Err(errors.finish(syn::Error::new_spanned(ident, errors::ParseError::NoPrivateEvent)));
+                return Err(errors.finish(syn::Error::new_spanned(
+                    ident,
+                    errors::ParseError::NoPrivateEvent,
+                )));
             }
             syn::Visibility::Restricted(spec) => {
-                return Err(errors.finish(syn::Error::new_spanned(spec, errors::ParseError::NoComplexVisibility)));
+                return Err(errors.finish(syn::Error::new_spanned(
+                    spec,
+                    errors::ParseError::NoComplexVisibility,
+                )));
             }
         }
 
         if ident == &*reserved::idents::input() {
-            errors.subsume(syn::Error::new_spanned(&ident, errors::ParseError::UseOfReservedIdent));
+            errors.subsume(syn::Error::new_spanned(
+                &ident,
+                errors::ParseError::UseOfReservedIdent,
+            ));
         }
 
         for generic in &generics.params {
             match generic {
                 syn::GenericParam::Lifetime(params) => {
                     if params.lifetime == *reserved::lifetimes::input() {
-                        errors.subsume(
-                            syn::Error::new(
-                                params.lifetime.span(),
-                                errors::ParseError::UseOfReservedLifetime
-                            )
-                        );
+                        errors.subsume(syn::Error::new(
+                            params.lifetime.span(),
+                            errors::ParseError::UseOfReservedLifetime,
+                        ));
                     }
                 }
                 syn::GenericParam::Type(params) => {
                     if params.ident == *reserved::idents::input() {
-                        errors.subsume(syn::Error::new_spanned(&params.ident, errors::ParseError::UseOfReservedIdent));
+                        errors.subsume(syn::Error::new_spanned(
+                            &params.ident,
+                            errors::ParseError::UseOfReservedIdent,
+                        ));
                     }
                 }
                 syn::GenericParam::Const(_) => {}
@@ -111,7 +121,7 @@ impl<'a> TryFrom<EventImplInput<'a>> for EventImpl<'a> {
         }
 
         errors.check()?;
-        
+
         Ok(EventImpl {
             ident,
             generics,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,6 +1,4 @@
-pub use borsh;
-pub use serde;
-pub use serde_json;
+pub use {borsh, serde, serde_json};
 
 pub mod env;
 pub mod event;


### PR DESCRIPTION
`cargo +nightly fmt` on code introduced in #102 to clean up #258 & #253.