### PR TITLE
refactor(docs): remove generated category in contribute and resources

### DIFF
--- a/docs/docs/04-Contribute/01-github.mdx
+++ b/docs/docs/04-Contribute/01-github.mdx
@@ -1,5 +1,6 @@
 ---
 id: github
 title: Github
-slug: /github
 ---
+
+- instructions how to contribute on github

--- a/docs/docs/04-Contribute/02-hackathons.mdx
+++ b/docs/docs/04-Contribute/02-hackathons.mdx
@@ -1,5 +1,4 @@
 ---
 id: hackathons
 title: Hackathons
-slug: /hackathons
 ---

--- a/docs/docs/04-Contribute/03-bounty-program.mdx
+++ b/docs/docs/04-Contribute/03-bounty-program.mdx
@@ -1,5 +1,4 @@
 ---
 id: bounty-program
 title: Bounty Program
-slug: /bounty-program
 ---

--- a/docs/docs/04-Contribute/_category_.json
+++ b/docs/docs/04-Contribute/_category_.json
@@ -1,7 +1,3 @@
 {
-  "label": "Contribute",
-  "link": {
-    "type": "generated-index",
-    "description": "description"
-  }
+  "label": "Contribute"
 }

--- a/docs/docs/05-Resources/01-community.mdx
+++ b/docs/docs/05-Resources/01-community.mdx
@@ -1,8 +1,9 @@
 ---
 id: community
 title: Community
-slug: /community
 ---
+
+## Community
 
 - Discord - https://discord.gg/bp7uKv9kBv
 - Twitter - "https://twitter.com/CalimeroNetwork

--- a/docs/docs/05-Resources/02-support.mdx
+++ b/docs/docs/05-Resources/02-support.mdx
@@ -1,7 +1,6 @@
 ---
 id: support
 title: Support
-slug: /support
 ---
 
 - Website - https://www.calimero.network

--- a/docs/docs/05-Resources/_category_.json
+++ b/docs/docs/05-Resources/_category_.json
@@ -1,7 +1,3 @@
 {
-  "label": "Resources",
-  "link": {
-    "type": "generated-index",
-    "description": "description"
-  }
+  "label": "Resources"
 }

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -79,12 +79,12 @@ const config: Config = {
           label: "Build",
         },
         {
-          to: "/category/contribute",
+          to: "/contribute/github",
           position: "left",
           label: "Contribute",
         },
         {
-          to: "/category/resources",
+          to: "/resources/community",
           position: "left",
           label: "Resources",
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions on how to contribute on GitHub.
  - Updated "Community" section with a new heading and fixed URLs for Discord, Twitter, and Telegram.
  - Removed `slug` fields from "Hackathons," "Bounty Program," and "Support" documents.
  - Simplified category metadata for "Contribute" and "Resources."

- **Navigation**
  - Updated navigation links: "Contribute" now points to `/contribute/github` and "Resources" to `/resources/community`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->