### PR TITLE
chore(docs): throw for broken links

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   baseUrl: "/core/",
   organizationName: "calimero-network",
   projectName: "core",
-  onBrokenLinks: "warn",
+  onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   i18n: {
     defaultLocale: "en",


### PR DESCRIPTION
Fixed broken links -> returning throw instead of warn

Git didn’t noticed changes in folder structure naming: e.g. Learn -> learn so it didn’t push new name which resulted in having broken links as they are constructed from folders and files name..



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated settings to enforce stricter handling of broken links, changing the behavior from warning to throwing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->