### PR TITLE
chore: add slack notif when gh actions fail

### DIFF
--- a/.github/workflows/docusaurus_deploy.yml
+++ b/.github/workflows/docusaurus_deploy.yml
@@ -34,3 +34,18 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build
+
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    needs: [build-and-deploy]
+    if: failure()
+    steps:
+      - name: Notify failure
+        uses: "ravsamhq/notify-slack-action@2.5.0"
+        with:
+          status: failure
+          notification_title: "Docusaurus Deploy failed on ${{ github.ref_name }} - <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Failure>"
+          message_format: ":fire: *Deploy Core Documentation to Pages* in <${{ github.server_url }}/${{ github.repository }}/${{ github.ref_name }}|${{ github.repository }}>"
+          footer: "Linked Repo <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Failure>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_FAIL_SLACK }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a Slack notification on deployment failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->