### PR TITLE
fix(admin-ui): page wrapper css

### DIFF
--- a/node-ui/src/components/common/ContentCard.tsx
+++ b/node-ui/src/components/common/ContentCard.tsx
@@ -12,7 +12,7 @@ const Container = styled.div<{isOverflow: boolean}>`
   border-radius: 0.5rem;
   background-color: #212325;
   color: #fff;
-  ${(props) => props.isOverflow && "height: 100%;"}
+  ${(props) => props.isOverflow ? "" : "height: 100%;"}
 
   .header-back {
     display: flex;


### PR DESCRIPTION
# fix(admin-ui): page wrapper css

## Summary
 Update css display issue mentioned in previous PR's - content card was in the middle of the screen and not taking full screen h + w 

Fixes # C20-83



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified conditional styling for container height based on the `isOverflow` prop in `ContentCard.tsx`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->