### PR TITLE
fix(admin-ui): environment variables import error

### DIFF
--- a/node-ui/package.json
+++ b/node-ui/package.json
@@ -37,8 +37,7 @@
     "react-router-dom": "^6.22.3",
     "react-tooltip": "^5.26.3",
     "styled-components": "^6.1.8",
-    "typescript": "^5.4.5",
-    "vite-plugin-environment": "^1.1.3"
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.79",

--- a/node-ui/src/pages/AddRelease.tsx
+++ b/node-ui/src/pages/AddRelease.tsx
@@ -83,7 +83,7 @@ export default function AddRelease() {
 
   const addWalletAccount = async () => {
     const selector = await setupWalletSelector({
-      network: process.env["VITE_NEAR_ENVIRONMENT"] as NetworkId ?? "testnet",
+      network: import.meta.env["VITE_NEAR_ENVIRONMENT"] as NetworkId ?? "testnet",
       modules: [setupMyNearWallet()],
     });
     const wallet: BrowserWallet = await selector.wallet("my-near-wallet");

--- a/node-ui/src/pages/Near.tsx
+++ b/node-ui/src/pages/Near.tsx
@@ -6,8 +6,7 @@ import ContentWrapper from "../components/login/ContentWrapper";
 
 import "@near-wallet-selector/modal-ui/styles.css";
 
-// @ts-expect-error
-const environment = import.meta.env.VITE_NEAR_ENVIRONMENT ?? "testnet";
+const environment = import.meta.env["VITE_NEAR_ENVIRONMENT"] ?? "testnet";
 
 export default function Near() {
   const navigate = useNavigate();

--- a/node-ui/src/pages/PublishApplication.tsx
+++ b/node-ui/src/pages/PublishApplication.tsx
@@ -99,7 +99,7 @@ export default function PublishApplication() {
 
   const addWalletAccount = async () => {
     const selector = await setupWalletSelector({
-      network: process.env["VITE_NEAR_ENVIRONMENT"] as NetworkId ?? "testnet",
+      network: import.meta.env["VITE_NEAR_ENVIRONMENT"] as NetworkId ?? "testnet",
       modules: [setupMyNearWallet()],
     });
     const wallet: BrowserWallet = await selector.wallet("my-near-wallet");

--- a/node-ui/src/vite-env.d.ts
+++ b/node-ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/node-ui/tsconfig.json
+++ b/node-ui/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "compilerOptions": {
     "jsx": "react",
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["vite/client", "vite-plugin-svgr/client", "node"],
+    "module": "esnext",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "resolveJsonModule": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "alwaysStrict": true,

--- a/node-ui/vite.config.js
+++ b/node-ui/vite.config.js
@@ -1,12 +1,10 @@
 import { defineConfig } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
-import EnvironmentPlugin from 'vite-plugin-environment';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/admin/',
   plugins: [
     nodePolyfills(),
-    EnvironmentPlugin('all')
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
-      vite-plugin-environment:
-        specifier: ^1.1.3
-        version: 1.1.3(vite@5.2.12(@types/node@18.19.34)(sass@1.77.4)(terser@5.31.0))
     devDependencies:
       '@types/react':
         specifier: ^18.2.79
@@ -10305,11 +10302,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  vite-plugin-environment@1.1.3:
-    resolution: {integrity: sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==}
-    peerDependencies:
-      vite: '>= 2.7'
 
   vite-plugin-node-polyfills@0.21.0:
     resolution: {integrity: sha512-Sk4DiKnmxN8E0vhgEhzLudfJQfaT8k4/gJ25xvUPG54KjLJ6HAmDKbr4rzDD/QWEY+Lwg80KE85fGYBQihEPQA==}
@@ -24908,10 +24900,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
       - zod
-
-  vite-plugin-environment@1.1.3(vite@5.2.12(@types/node@18.19.34)(sass@1.77.4)(terser@5.31.0)):
-    dependencies:
-      vite: 5.2.12(@types/node@18.19.34)(sass@1.77.4)(terser@5.31.0)
 
   vite-plugin-node-polyfills@0.21.0(rollup@4.18.0)(vite@4.5.3(@types/node@18.19.34)(sass@1.77.4)(terser@5.31.0)):
     dependencies:


### PR DESCRIPTION
# fix(admin-ui): environment variables import error

## Summary
When using "pnpm build" and using page through node it was working while using "pnpm dev" it was throwing error in img which is now fixed.

<img width="477" alt="Screenshot 2024-06-05 at 15 07 20" src="https://github.com/calimero-network/core/assets/93442516/5c974421-18c0-4f35-a45e-3b909381c536">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated access to environment variables in various files for improved functionality:
    - `AddRelease.tsx`
    - `Near.tsx`
    - `PublishApplication.tsx`
- **Refactor**
  - Removed `vite-plugin-environment` dependency from `package.json`
  - Updated `vite.config.js` to remove `EnvironmentPlugin`
- **Documentation**
  - Added `vite/client` types reference in `vite-env.d.ts`
- **Chores**
  - Updated `tsconfig.json` with various changes for better compatibility and module resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->