### PR TITLE
build: add macos workflows

### DIFF
--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/master' }}
 
     steps:
       - name: Restore build artifact
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
-    if: ${{ github.ref == 'refs/heads/main' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') }}
+    if: ${{ github.ref == 'refs/heads/master' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master') }}
 
     steps:
       - name: Setup gh CLI


### PR DESCRIPTION
This workflow builds, compresses, caches, and uploads binaries for `calimero-node` for `x86_64-apple-darwin` and `aarch64-apple-darwin` targets. The shared job `build` runs on every push and closed pull request to handle the building and caching of the binaries.

When a push occurs on any branch that is not `main`, the `upload_branch_artifact` job runs. This job restores the cached build artifact and uploads it with a retention period of two days.

When changes are pushed to `main` or a pull request is merged into `main`, the `release` job is triggered. This job also restores the cached build artifact, checks if a release for the current version exists, and if not, creates a new release and uploads the artifact.

<img width="1443" alt="Screenshot 2024-06-13 at 3 33 04 PM" src="https://github.com/calimero-network/core/assets/2929173/a537416a-c581-4903-b72f-c62d91a9c658">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GitHub Actions workflow for building and uploading a binary for the `calimero-node` project on macOS. 
  - The workflow triggers on pushes and pull requests to the `main` branch, includes steps for setting up Rust, installing the target architecture, caching dependencies, building the crate, compressing the artifact using gzip, and uploading the binary as an artifact. 
  - Additional steps involve checking the existence of a release, creating a new release if it doesn't exist, and uploading artifacts to the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->