### PR TITLE
fix: ignore git check in the publish workflow

### DIFF
--- a/.github/workflows/calimero_sdk_publish.yml
+++ b/.github/workflows/calimero_sdk_publish.yml
@@ -44,5 +44,5 @@ jobs:
         run: pnpm buildSdk
 
       - name: Publish Calimero SDK
-        run: pnpm publish --access public
+        run: pnpm publish --access public --no-git-checks
         working-directory: ./packages/calimero-sdk


### PR DESCRIPTION
The lockfile in the repository is not compatible with the ci arch. For that reason the lockfile is regenerated in the workflow triggering an error while publishing the package. This PR is a temporary solution until we discuss which lockfile should be committed during the engineering sync.

<img width="1344" alt="Screenshot 2024-06-10 at 1 36 33 PM" src="https://github.com/calimero-network/core/assets/2929173/ff1317b7-5792-4f8b-b59c-8e6408b7362c">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `--no-git-checks` flag to the Calimero SDK publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->