### PR TITLE
chore: enable manual sdk publish

### DIFF
--- a/.github/workflows/calimero_sdk_publish.yml
+++ b/.github/workflows/calimero_sdk_publish.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - "packages/calimero-sdk/**"
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Enable manual publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added a manual trigger option for the GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->