### PR TITLE
feat(calimero-sdk): export wallet type from sdk

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@calimero-is-near/calimero-p2p-sdk",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "Javascript library to interact with Calimero P2P node",
     "type": "module",
     "main": "lib/index.js",

--- a/packages/calimero-sdk/src/index.ts
+++ b/packages/calimero-sdk/src/index.ts
@@ -9,3 +9,4 @@ export * from "./wallets/MetamaskLogin/LoginWithMetamask";
 export * from "./wallets/MetamaskLogin/MetamaskWrapper";
 export * from "./wallets/LoginSelector";
 export * from "./setup/SetupModal";
+export * from "./nodeApi";


### PR DESCRIPTION
# feat(calimero-sdk): export wallet type from sdk

## Summary
So it can be used in auth headers on all applications without the need to redefine types and interfaces for walletType


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the version number of `@calimero-is-near/calimero-p2p-sdk` package from "0.0.17" to "0.0.18".
  - Added an export statement for a module named `nodeApi` in the `index.ts` file within the `calimero-sdk` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->