### PR TITLE
fix(calimero-sdk): styled component error

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@calimero-is-near/calimero-p2p-sdk",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "description": "Javascript library to interact with Calimero P2P node",
     "type": "module",
     "main": "lib/index.js",

--- a/packages/calimero-sdk/src/components/loader/Spinner.tsx
+++ b/packages/calimero-sdk/src/components/loader/Spinner.tsx
@@ -1,42 +1,43 @@
 import React from "react";
-import styled, { keyframes } from "styled-components";
 
-const SpinnerContainer = styled.div`
-  display: flex;
-  width: 100%;
-  justify-content: center;
-  align-items: center;
-`;
+const SpinnerContainerStyle = {
+  display: 'flex',
+  width: '100%',
+  justifyContent: 'center',
+  alignItems: 'center',
+};
 
-const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-`;
+const SvgStyle = {
+  width: '2.5rem',
+  height: '2.5rem',
+  color: '#b67352',
+  animation: 'spin 1s linear infinite',
+  fill: '#ecb159',
+};
 
-const Svg = styled.svg`
-  width: 2.5rem; // equivalent to w-10
-  height: 2.5rem; // equivalent to h-10
-  color: #b67352;
-  animation: ${spin} 1s linear infinite;
-  fill: #ecb159;
-
-  @media (prefers-color-scheme: dark) {
-    color: #4b5563; // dark:text-gray-600
+const spinKeyframes = `
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
   }
 `;
+
+const styleSheet = document.styleSheets[0];
+styleSheet.insertRule(spinKeyframes, styleSheet.cssRules.length);
 
 export default function Spinner() {
   return (
-    <SpinnerContainer role="status">
-      <Svg
+    <div style={SpinnerContainerStyle} role="status">
+      <svg
         aria-hidden="true"
         viewBox="0 0 100 101"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        style={SvgStyle}
       >
         <path
           d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
@@ -46,7 +47,7 @@ export default function Spinner() {
           d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
           fill="currentFill"
         />
-      </Svg>
-    </SpinnerContainer>
+      </svg>
+    </div>
   );
 }


### PR DESCRIPTION
# fix(calimero-sdk): styled component error

## Summary
When using Spinner in the set node url component issue from image is shown, removing styled components and using pure css solves this issue.


![Screenshot 2024-06-11 at 15 01 08](https://github.com/calimero-network/core/assets/93442516/67d82552-ce6e-403f-9880-01f641148513)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Refactored the styling approach for the spinner animation in the `Spinner` component.
- **Chores**
	- Updated the version of `@calimero-is-near/calimero-p2p-sdk` in the `package.json` from "0.0.18" to "0.0.19".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->