### PR TITLE
refactor: styled import

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/components/loader/Spinner.tsx
+++ b/packages/calimero-sdk/src/components/loader/Spinner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
+import { styled, keyframes } from 'styled-components';
 
 const SpinnerContainer = styled.div`
   display: flex;

--- a/packages/calimero-sdk/src/setup/SetupModal.tsx
+++ b/packages/calimero-sdk/src/setup/SetupModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import apiClient from '../api';
 import React from 'react';
 import Spinner from '../components/loader/Spinner';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 export interface SetupModalProps {
   successRoute: () => void;


### PR DESCRIPTION
Fix  `Collecting page data  ...TypeError: styled.div `is not a function for nextjs clients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated `@calimero-is-near/calimero-p2p-sdk` package version from "0.0.19" to "0.0.20".
- **Style**
  - Modified import statements in `Spinner.tsx` and `SetupModal.tsx` for `styled-components`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->