### PR TITLE
fix: pass version to the release step

### DIFF
--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -103,6 +103,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" | jq -r '.url')
           if [[ "$RELEASE_URL" != "null" ]]; then
             echo "exists=true" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
@@ -113,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(grep '^version' Cargo.toml | head -1 | awk -F\" '{print $2}')
-          gh release create "v$VERSION" --title "Release v$VERSION" --notes "Release for version $VERSION"
+          gh release create "v${{ steps.check_release.outputs.version }}" --title "Release v${{ steps.check_release.outputs.version }}" --notes "Release for version ${{ steps.check_release.outputs.version }}"
 
       - name: Upload artifact to release
         if: steps.check_release.outputs.exists == 'false'


### PR DESCRIPTION
Macos release step didn't have access to the version. To fix that the version is added in the build step output and accessed from the release step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added output of the version to a file for easier tracking.
    - Modified release creation command to use the version from a previous step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->