### PR TITLE
fix: sanitize branch artifact names 

### DIFF
--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Sanitize ref name
         id: sanitize
         run: |
-          sanitized_ref_name=$(echo "${GITHUB_REF_NAME}" | tr '":<>|*?\\/\r\n' '-')
+          sanitized_ref_name=$(echo "${GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9_-]/-/g; s/^-*//; s/-*$//')
           echo "sanitized_ref_name=${sanitized_ref_name}" >> $GITHUB_OUTPUT
 
       - name: Upload binary as artifact


### PR DESCRIPTION
The GH action resposible of creating the branch artifact was not considering invalid characters coming from the branch name. This PR adds an aditional step to sanitize the branch name before renaming the artifact.

sanitize steps uses the following command:
 `sed 's/[^a-zA-Z0-9_-]/-/g; s/^-*//; s/-*$//'`
 
 * Converts any character that is not a letter, digit, hyphen, or underscore into a hyphen.
 * Eliminates hyphens at the beginning of the string.
 * Eliminates hyphens at the end of the string.

TEST PLAN

* Create a new branch with invalid characters and push the code: e.g. fix/sanitize_branch_artifact_name
* Verify that the build artifacts are named correctly

<img width="1467" alt="Screenshot 2024-06-18 at 8 24 10 AM" src="https://github.com/calimero-network/core/assets/2929173/6679aa53-6f9f-40c4-b5c4-281bc878f97a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added workflow for building and uploading binaries for Linux and MacOS.
    - Implemented steps for setting up the build environment, installing dependencies, building the crate for different architectures, extracting version, compressing artifact, caching, and uploading artifacts in the workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->