### PR TITLE
fix: set inital value with use effects

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/setup/SetupModal.tsx
+++ b/packages/calimero-sdk/src/setup/SetupModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import apiClient from '../api';
 import React from 'react';
 import Spinner from '../components/loader/Spinner';
@@ -87,8 +87,12 @@ export const SetupModal: React.FC<SetupModalProps> = (
 ) => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [url, setUrl] = useState<string | null>(props.getNodeUrl());
+  const [url, setUrl] = useState<string | null>(null);
   const MINIMUM_LOADING_TIME_MS = 1000;
+
+  useEffect(() => {
+    setUrl(props.getNodeUrl());
+  }, [props]);
 
   function validateUrl(value: string): boolean {
     try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `@calimero-is-near/calimero-p2p-sdk` from version `0.0.20` to `0.0.21`.
	- Improved `SetupModal` component in `SetupModal.tsx` to dynamically set URL using `useEffect` hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->