### PR TITLE
chore(network): use only required features from libp2p dependecy

### DIFF
--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -10,7 +10,23 @@ license.workspace = true
 bytes.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
-libp2p = { workspace = true, features = ["full"] }
+libp2p = { workspace = true, features = [
+    "dcutr",
+    "gossipsub",
+    "identify",
+    "kad",
+    "macros",
+    "mdns",
+    "noise",
+    "ping",
+    "quic",
+    "rendezvous",
+    "relay",
+    "tokio",
+    "tcp",
+    "tls",
+    "yamux",
+] }
 libp2p-stream.workspace = true
 multiaddr.workspace = true
 owo-colors.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Updated `libp2p` dependency in `Cargo.toml` to include additional features such as `dcutr`, `gossipsub`, `identify`, `kad`, `mdns`, `noise`, `ping`, `quic`, `rendezvous`, `relay`, `tokio`, `tcp`, `tls`, and `yamux`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->