### PR TITLE
ci(calimero-js-sdk): build and release only if package doesn't exist in the registry

### DIFF
--- a/.github/workflows/calimero_sdk_publish.yml
+++ b/.github/workflows/calimero_sdk_publish.yml
@@ -1,4 +1,4 @@
-name: Publish Calimero SDK
+name: Publish Calimero JavaScript SDK
 
 on:
   push:
@@ -9,8 +9,38 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  metadata:
+    name: Get package metadata
     runs-on: ubuntu-latest
+    outputs:
+      package_exists: ${{ steps.check_release.outputs.exists }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@calimero-is-near"
+
+      - name: Check if release exists
+        id: check_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/calimero-sdk/package.json').version")
+          REGISTRY_VERSION=$(npm view @calimero-is-near/calimero-p2p-sdk@$VERSION version)
+          if [[ "$PACKAGE_VERSION" == "$REGISTRY_VERSION" ]]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+  publish:
+    name: Build and release
+    runs-on: ubuntu-latest
+    needs: metadata
+    if: needs.metadata.outputs.package_exists == 'false'
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Updated workflow name from "Publish Calimero SDK" to "Publish Calimero JavaScript SDK" in GitHub Actions.
    - Added a new job step to check for existing releases before building and releasing the package.
    - Renamed job step to "Build and release" in the GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->