### PR TITLE
ci(calimero-node): run build and release workflow only when path matches

### DIFF
--- a/.github/workflows/calimero_node_linux.yml
+++ b/.github/workflows/calimero_node_linux.yml
@@ -3,7 +3,11 @@ name: Build and Upload Binary for Linux
 on:
   push:
     branches:
-      - '**'
+      - "**"
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - "crates/**"
   pull_request:
     types: [closed]
 

--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -3,7 +3,11 @@ name: Build and Upload Binary for MacOS
 on:
   push:
     branches:
-      - '**'
+      - "**"
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - "crates/**"
   pull_request:
     types: [closed]
 
@@ -74,7 +78,7 @@ jobs:
           key: build-artifact-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             build-artifact-${{ matrix.target }}
-      
+
       - name: Sanitize ref name
         id: sanitize
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added specific paths related to Cargo for triggering workflows in Linux and MacOS environments.
	- Updated event triggers for workflow in MacOS to include paths and adjust steps for sanitizing ref names.
	- Adjusted command for uploading release artifact in MacOS workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->