### PR TITLE
feat: add nodes script

### DIFF
--- a/start-nodes.sh
+++ b/start-nodes.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+show_usage() {
+    echo "Usage: $0 delete-and-start || start"
+    exit 1
+}
+
+current_dir=$(pwd)
+
+if [ $# -ne 1 ]; then
+    show_usage
+fi
+
+case "$1" in
+    delete-and-start)
+        rm -rf "$current_dir/data"
+        mkdir -p "$current_dir/data"
+        osascript <<EOF
+tell application "Terminal"
+    activate
+    do script "cd '$current_dir' && cargo run -p calimero-node -- --home data/coordinator init --server-port 2427 --swarm-port 2527 && cargo run -p calimero-node -- --home data/coordinator run --node-type coordinator"
+    delay 1
+    tell application "System Events" to keystroke "t" using command down
+    delay 1
+    do script "cd '$current_dir' && cargo run -p calimero-node -- --home data/node1 init --server-port 2428 --swarm-port 2528 && cargo run -p calimero-node -- --home data/node1 run" in selected tab of the front window
+    delay 1
+    tell application "System Events" to keystroke "t" using command down
+    delay 1
+    do script "cd '$current_dir' && cargo run -p calimero-node -- --home data/node2 init --server-port 2420 --swarm-port 2529 && cargo run -p calimero-node -- --home data/node2 run" in selected tab of the front window
+end tell
+EOF
+        ;;
+    start)
+        osascript <<EOF
+tell application "Terminal"
+    activate
+    do script "cd '$current_dir' && cargo run -p calimero-node -- --home data/coordinator run --node-type coordinator"
+    delay 1
+    tell application "System Events" to keystroke "t" using command down
+    delay 1
+    do script "cd '$current_dir' && cargo run -p calimero-node -- --home data/node1 run" in selected tab of the front window
+    delay 1
+    tell application "System Events" to keystroke "t" using command down
+    delay 1
+    do script "cd '$current_dir' && cargo run -p calimero-node -- --home data/node2 run" in selected tab of the front window
+end tell
+EOF
+        ;;
+    *)
+        show_usage
+        ;;
+esac


### PR DESCRIPTION
# feat: add nodes script

## Summary
Shell script for starting nodes and has 2 options:
1. delete-and-start - deletes the data folder and recreates all the files : coordinator, node1, node2
2. start - starts the nodes + coordinator with existing files in data folder.

Video: 

https://github.com/calimero-network/core/assets/93442516/6bae697f-2715-40b6-9efe-a2b61166b34f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added functionality to manage the initialization and running of multiple nodes using Cargo.
    - Options to delete and start nodes or simply start them were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->