### PR TITLE
fix(admin-api): update install app handler return type

### DIFF
--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -182,6 +182,11 @@ async fn health_check_handler() -> impl IntoResponse {
     .into_response()
 }
 
+#[derive(Debug, Serialize)]
+struct InstallApplicationResponse {
+    data: bool,
+}
+
 async fn install_application_handler(
     Extension(state): Extension<Arc<AdminState>>,
     Json(req): Json<calimero_server_primitives::admin::InstallApplicationRequest>,
@@ -191,7 +196,10 @@ async fn install_application_handler(
         .install_application(req.application, &req.version)
         .await
     {
-        Ok(()) => ApiResponse { payload: () }.into_response(),
+        Ok(()) => ApiResponse {
+            payload: InstallApplicationResponse { data: true },
+        }
+        .into_response(),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     }
 }


### PR DESCRIPTION
# fix: update install app handler return type

## Summary
Added that install application handler return data: true if installation was successful. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of successful application installations with structured response.
- **Refactor**
	- Updated `install_application_handler` function to return `InstallApplicationResponse` for successful installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->