### PR TITLE
fix(admin-api): cors delete method not allowed

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -106,7 +106,7 @@ pub async fn start(
         cors::CorsLayer::new()
             .allow_origin(cors::Any)
             .allow_headers(cors::Any)
-            .allow_methods([http::Method::POST]),
+            .allow_methods([http::Method::POST, http::Method::GET, http::Method::DELETE, http::Method::PUT, http::Method::OPTIONS]),
     );
 
     let mut set = tokio::task::JoinSet::new();


### PR DESCRIPTION
# fix(admin-api): cors delete method not allowed

## Summary
Fixing this issue, occuring when trying to delete context (axios.DELETE method)

<img width="449" alt="Screenshot 2024-06-24 at 15 48 13" src="https://github.com/calimero-network/core/assets/93442516/552955e1-5876-43a3-ad4d-5d5e905c0a37">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced `cors` configuration in the `server` crate to allow additional HTTP methods (`GET`, `DELETE`, `PUT`, `OPTIONS`) for improved API functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->