### PR TITLE
chore: remove `context_id` from `ContextTransaction`

### DIFF
--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -77,7 +77,6 @@ impl PredefinedEntry for key::ContextIdentity {
 
 #[derive(Eq, Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct ContextTransaction {
-    pub context_id: [u8; 32],
     pub method: Box<str>,
     pub payload: Box<[u8]>,
     pub prior_hash: TransactionHash,


### PR DESCRIPTION
#445 made me realized this is here, when it shouldn't be