### PR TITLE
chore: update localnet build script

### DIFF
--- a/crates/meroctl/gen_localnet_configs.sh
+++ b/crates/meroctl/gen_localnet_configs.sh
@@ -2,6 +2,9 @@
 
 set -o pipefail
 
+# Set default NODE_HOME 
+: ${NODE_HOME:="$HOME/.calimero"}
+
 # Check if an argument was provided
 if [ $# -eq 0 ]; then
   echo "Please provide the number of local nodes argument."
@@ -19,7 +22,7 @@ for ((i = 1; i <= N; i++)); do
   echo "\x1b[1;36m(i)\x1b[39m Initializing Node $i at \x1b[33m$node_home\x1b[0m"
   rm -rf "$node_home"
   mkdir -p "$node_home"
-  ./target/debug/meroctl --home "$HOME/.calimero" --node-name "node$i" \
+  ./target/debug/meroctl --home "$NODE_HOME" --node-name "node$i" \
       init --swarm-port $((2427 + $i)) --server-port $((2527 + $i)) \
     | sed 's/^/ \x1b[1;36m|\x1b[0m  /'
   if [ $? -ne 0 ]; then

--- a/crates/meroctl/gen_localnet_configs.sh
+++ b/crates/meroctl/gen_localnet_configs.sh
@@ -11,7 +11,7 @@ fi
 # Get the first command line argument
 N=$1
 
-cargo build --bin calimero-node
+cargo build --bin meroctl
 
 # Iterate in a loop N times
 for ((i = 1; i <= N; i++)); do
@@ -19,7 +19,7 @@ for ((i = 1; i <= N; i++)); do
   echo "\x1b[1;36m(i)\x1b[39m Initializing Node $i at \x1b[33m$node_home\x1b[0m"
   rm -rf "$node_home"
   mkdir -p "$node_home"
-  ./target/debug/calimero-node --home "$node_home" \
+  ./target/debug/meroctl --home "$HOME/.calimero" --node-name "node$i" \
       init --swarm-port $((2427 + $i)) --server-port $((2527 + $i)) \
     | sed 's/^/ \x1b[1;36m|\x1b[0m  /'
   if [ $? -ne 0 ]; then

--- a/crates/meroctl/src/defaults.rs
+++ b/crates/meroctl/src/defaults.rs
@@ -1,4 +1,4 @@
-pub(crate) const DEFAULT_CALIMERO_HOME: &str = "data";
+pub(crate) const DEFAULT_CALIMERO_HOME: &str = ".calimero";
 
 pub fn default_node_dir() -> camino::Utf8PathBuf {
     if let Some(home) = dirs::home_dir() {


### PR DESCRIPTION
# Update default dir and move build script

This solves #450 and #451 


## Summary

The build script is updated so it builds the new `meroctl` binary, and uses new initialization methods. 
Also default directory for `meroctl` changed from `/data` to `/.calimero`


## Test plan

running `./crates/meroctl/gen_localnet_configs.sh 3` from the root of this repository creates three nodes (`node1`, `node2`, `node3`) in the `~./calimero` directory