### PR TITLE
Moved structs to server-primitives

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -208,12 +208,6 @@ impl ContextManager {
     ) -> eyre::Result<()> {
         self.link_release(&application_id, version, &path)?;
 
-        let topic_hash = self
-            .network_client
-            .subscribe(calimero_network::types::IdentTopic::new(application_id))
-            .await?;
-
-        info!(%topic_hash, "Subscribed to network topic");
         Ok(())
     }
 

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -1,8 +1,3 @@
-use calimero_primitives::application::ApplicationId;
-use calimero_server_primitives::admin::{
-    CreateContextRequest, CreateContextResponse, InstallDevApplicationRequest,
-    ListApplicationsResponse,
-};
 use camino::Utf8PathBuf;
 use clap::{Args, Parser};
 use libp2p::Multiaddr;
@@ -91,14 +86,15 @@ async fn create_context(
     }
 
     let url = multiaddr_to_url(base_multiaddr, "admin-api/dev/contexts")?;
-    let request = CreateContextRequest {
+    let request = calimero_server_primitives::admin::CreateContextRequest {
         application_id: calimero_primitives::application::ApplicationId(application_id),
     };
 
     let response = client.post(url).json(&request).send().await?;
 
     if response.status().is_success() {
-        let context_response: CreateContextResponse = response.json().await?;
+        let context_response: calimero_server_primitives::admin::CreateContextResponse =
+            response.json().await?;
         let context = context_response.data;
 
         println!("Context created successfully:");
@@ -128,7 +124,8 @@ async fn app_installed(
         eyre::bail!("Request failed with status: {}", response.status())
     }
 
-    let api_response: ListApplicationsResponse = response.json().await?;
+    let api_response: calimero_server_primitives::admin::ListApplicationsResponse =
+        response.json().await?;
     let app_list = api_response.data.apps;
     let is_installed = app_list.iter().any(|app| app.id.as_ref() == application_id);
 
@@ -148,8 +145,8 @@ async fn link_local_app(
     hasher.update(id.as_bytes());
     let application_id = hex::encode(hasher.finalize());
 
-    let install_request = InstallDevApplicationRequest {
-        application_id: ApplicationId(application_id.clone()),
+    let install_request = calimero_server_primitives::admin::InstallDevApplicationRequest {
+        application_id: calimero_primitives::application::ApplicationId(application_id.clone()),
         version: version,
         path,
     };

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -1,39 +1,19 @@
 use calimero_primitives::application::ApplicationId;
-use calimero_primitives::context::Context;
-use calimero_server_primitives::admin::{ApplicationListResult, InstallDevApplicationRequest};
+use calimero_server_primitives::admin::{
+    CreateContextRequest, CreateContextResponse, InstallDevApplicationRequest,
+    ListApplicationsResponse,
+};
 use camino::Utf8PathBuf;
 use clap::{Args, Parser};
 use libp2p::Multiaddr;
 use reqwest::Client;
 use semver::Version;
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::info;
 
 use crate::cli::context::common::multiaddr_to_url;
 use crate::cli::RootArgs;
 use crate::config_file::ConfigFile;
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CreateContextRequest {
-    application_id: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CreateContextResponse {
-    data: ContextResponse,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ContextResponse {
-    context: Context,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ListApplicationsResponse {
-    data: ApplicationListResult,
-}
 
 #[derive(Debug, Parser)]
 pub struct CreateCommand {
@@ -111,7 +91,9 @@ async fn create_context(
     }
 
     let url = multiaddr_to_url(base_multiaddr, "admin-api/dev/contexts")?;
-    let request = CreateContextRequest { application_id };
+    let request = CreateContextRequest {
+        application_id: calimero_primitives::application::ApplicationId(application_id),
+    };
 
     let response = client.post(url).json(&request).send().await?;
 

--- a/crates/meroctl/src/cli/context/list.rs
+++ b/crates/meroctl/src/cli/context/list.rs
@@ -1,4 +1,3 @@
-use calimero_server_primitives::admin::GetContextsResponse;
 use clap::Parser;
 use reqwest::Client;
 
@@ -27,7 +26,8 @@ impl ListCommand {
         let response = client.get(url).send().await?;
 
         if response.status().is_success() {
-            let api_response: GetContextsResponse = response.json().await?;
+            let api_response: calimero_server_primitives::admin::GetContextsResponse =
+                response.json().await?;
             let contexts = api_response.data.contexts;
 
             for context in contexts {

--- a/crates/meroctl/src/cli/context/list.rs
+++ b/crates/meroctl/src/cli/context/list.rs
@@ -1,21 +1,10 @@
-use calimero_primitives::context::Context;
+use calimero_server_primitives::admin::GetContextsResponse;
 use clap::Parser;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
 
 use crate::cli::context::common::multiaddr_to_url;
 use crate::cli::RootArgs;
 use crate::config_file::ConfigFile;
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ContextList {
-    contexts: Vec<Context>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct GetContextsResponse {
-    data: ContextList,
-}
 
 #[derive(Debug, Parser)]
 pub struct ListCommand {}

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -1,6 +1,3 @@
-use calimero_primitives::application::ApplicationId;
-use calimero_primitives::context::Context;
-use calimero_primitives::identity::WalletType;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -64,7 +61,7 @@ pub struct SignatureMessage {
 #[serde(rename_all = "camelCase")]
 pub struct WalletMetadata {
     #[serde(rename = "wallet")]
-    pub wallet_type: WalletType,
+    pub wallet_type: calimero_primitives::identity::WalletType,
     pub signing_key: String,
 }
 
@@ -128,7 +125,7 @@ pub struct ContextStorage {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContextList {
-    pub contexts: Vec<Context>,
+    pub contexts: Vec<calimero_primitives::context::Context>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -139,12 +136,12 @@ pub struct GetContextsResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateContextRequest {
-    pub application_id: ApplicationId,
+    pub application_id: calimero_primitives::application::ApplicationId,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContextResponse {
-    pub context: Context,
+    pub context: calimero_primitives::context::Context,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -1,3 +1,5 @@
+use calimero_primitives::application::ApplicationId;
+use calimero_primitives::context::Context;
 use calimero_primitives::identity::WalletType;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -19,6 +21,16 @@ pub struct InstallDevApplicationRequest {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ApplicationListResult {
     pub apps: Vec<calimero_primitives::application::Application>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListApplicationsResponse {
+    pub data: ApplicationListResult,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InstallApplicationResponse {
+    pub data: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -112,4 +124,30 @@ pub struct NodeChallengeMessage {
 #[serde(rename_all = "camelCase")]
 pub struct ContextStorage {
     pub size_in_bytes: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContextList {
+    pub contexts: Vec<Context>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetContextsResponse {
+    pub data: ContextList,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateContextRequest {
+    pub application_id: ApplicationId,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContextResponse {
+    pub context: Context,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateContextResponse {
+    pub data: ContextResponse,
 }

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -3,13 +3,6 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
-use calimero_primitives::application::ApplicationId;
-use calimero_primitives::context::{Context, ContextId};
-use calimero_primitives::identity::{ClientKey, ContextUser};
-use calimero_server_primitives::admin::{
-    ContextList, ContextResponse, ContextStorage, CreateContextRequest, CreateContextResponse,
-    GetContextsResponse,
-};
 use rand::RngCore;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -20,7 +13,7 @@ use crate::admin::storage::client_keys::get_context_client_key;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContextObject {
-    context: Context,
+    context: calimero_primitives::context::Context,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,7 +22,7 @@ pub struct GetContextResponse {
 }
 
 pub async fn get_context_handler(
-    Path(context_id): Path<ContextId>,
+    Path(context_id): Path<calimero_primitives::context::ContextId>,
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
     // todo! experiment with Interior<Store>: WriteLayer<Interior>
@@ -59,7 +52,7 @@ pub async fn get_context_handler(
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientKeys {
-    client_keys: Vec<ClientKey>,
+    client_keys: Vec<calimero_primitives::identity::ClientKey>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -68,7 +61,7 @@ pub struct GetContextClientKeysResponse {
 }
 
 pub async fn get_context_client_keys_handler(
-    Path(context_id): Path<ContextId>,
+    Path(context_id): Path<calimero_primitives::context::ContextId>,
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
     // todo! experiment with Interior<Store>: WriteLayer<Interior>
@@ -88,7 +81,7 @@ pub async fn get_context_client_keys_handler(
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ContextUsers {
-    context_users: Vec<ContextUser>,
+    context_users: Vec<calimero_primitives::identity::ContextUser>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -121,8 +114,8 @@ pub async fn get_contexts_handler(
 
     return match contexts {
         Ok(contexts) => ApiResponse {
-            payload: GetContextsResponse {
-                data: ContextList { contexts },
+            payload: calimero_server_primitives::admin::GetContextsResponse {
+                data: calimero_server_primitives::admin::ContextList { contexts },
             },
         }
         .into_response(),
@@ -142,7 +135,7 @@ pub struct DeleteContextResponse {
 }
 
 pub async fn delete_context_handler(
-    Path(context_id): Path<ContextId>,
+    Path(context_id): Path<calimero_primitives::context::ContextId>,
     _session: Session,
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
@@ -166,14 +159,14 @@ pub async fn delete_context_handler(
 
 pub async fn create_context_handler(
     Extension(state): Extension<Arc<AdminState>>,
-    Json(req): Json<CreateContextRequest>,
+    Json(req): Json<calimero_server_primitives::admin::CreateContextRequest>,
 ) -> impl IntoResponse {
     let mut seed = [0; 32];
     rand::thread_rng().fill_bytes(&mut seed);
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&mut seed);
     let context_id = signing_key.verifying_key();
 
-    let context = Context {
+    let context = calimero_primitives::context::Context {
         id: (*context_id.as_bytes()).into(),
         // signing_key, // todo! move to the Identity column
         application_id: req.application_id,
@@ -188,8 +181,8 @@ pub async fn create_context_handler(
 
     let response = match result {
         Ok(_) => ApiResponse {
-            payload: CreateContextResponse {
-                data: ContextResponse { context },
+            payload: calimero_server_primitives::admin::CreateContextResponse {
+                data: calimero_server_primitives::admin::ContextResponse { context },
             },
         }
         .into_response(),
@@ -201,7 +194,7 @@ pub async fn create_context_handler(
 
 #[derive(Debug, Serialize)]
 struct GetContextStorageResponse {
-    data: ContextStorage,
+    data: calimero_server_primitives::admin::ContextStorage,
 }
 
 pub async fn get_context_storage_handler(
@@ -210,7 +203,7 @@ pub async fn get_context_storage_handler(
 ) -> impl IntoResponse {
     ApiResponse {
         payload: GetContextStorageResponse {
-            data: ContextStorage { size_in_bytes: 0 },
+            data: calimero_server_primitives::admin::ContextStorage { size_in_bytes: 0 },
         },
     }
     .into_response()

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -6,7 +6,10 @@ use axum::{Extension, Json};
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::identity::{ClientKey, ContextUser};
-use calimero_server_primitives::admin::ContextStorage;
+use calimero_server_primitives::admin::{
+    ContextList, ContextResponse, ContextStorage, CreateContextRequest, CreateContextResponse,
+    GetContextsResponse,
+};
 use rand::RngCore;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -107,16 +110,6 @@ pub async fn get_context_users_handler(
     .into_response()
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ContextList {
-    contexts: Vec<Context>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct GetContextsResponse {
-    data: ContextList,
-}
-
 pub async fn get_contexts_handler(
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
@@ -169,21 +162,6 @@ pub async fn delete_context_handler(
         .into_response(),
         Err(err) => err.into_response(),
     };
-}
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CreateContextRequest {
-    application_id: ApplicationId,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ContextResponse {
-    context: Context,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CreateContextResponse {
-    data: ContextResponse,
 }
 
 pub async fn create_context_handler(

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -6,7 +6,9 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post};
 use axum::{Extension, Json, Router};
-use calimero_server_primitives::admin::ApplicationListResult;
+use calimero_server_primitives::admin::{
+    ApplicationListResult, InstallApplicationResponse, ListApplicationsResponse,
+};
 use calimero_store::Store;
 use libp2p::identity::Keypair;
 use serde::{Deserialize, Serialize};
@@ -197,11 +199,6 @@ async fn health_check_handler() -> impl IntoResponse {
     .into_response()
 }
 
-#[derive(Debug, Serialize)]
-struct InstallApplicationResponse {
-    data: bool,
-}
-
 async fn install_application_handler(
     Extension(state): Extension<Arc<AdminState>>,
     Json(req): Json<calimero_server_primitives::admin::InstallApplicationRequest>,
@@ -217,11 +214,6 @@ async fn install_application_handler(
         .into_response(),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     }
-}
-
-#[derive(Debug, Serialize)]
-struct ListApplicationsResponse {
-    data: ApplicationListResult,
 }
 
 async fn list_applications_handler(


### PR DESCRIPTION
# Meroctl fix - short description

## Summary

Moved shared structs from `meroctl` and admin handler methods to `server-primitives`.
Node no longer subscribes to `application_id` when installing the app in `dev-mode`.