### PR TITLE
fix/ssl-server-wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server-dual-protocol"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea4cd08ae2a5f075d28fa31190163c8106a1d2d3189442494bae22b39040a0d"
+dependencies = [
+ "axum-server",
+ "bytes",
+ "http 1.1.0",
+ "http-body-util",
+ "pin-project",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.11",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1070,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "axum-server",
+ "axum-server-dual-protocol",
  "base64 0.22.0",
  "borsh 1.4.0",
  "bs58 0.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,8 +260,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl 0.1.0",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
+dependencies = [
+ "asn1-rs-derive 0.5.0",
+ "asn1-rs-impl 0.2.0",
  "displaydoc",
  "nom",
  "num-traits",
@@ -273,7 +295,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -285,6 +319,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -434,7 +479,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -476,6 +521,29 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad46c3ec4e12f4a4b6835e173ba21c25e484c9d02b49770bf006ce5367c036"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 2.1.2",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-service",
 ]
 
 [[package]]
@@ -983,6 +1051,7 @@ name = "calimero-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-server",
  "base64 0.22.0",
  "borsh 1.4.0",
  "bs58 0.5.1",
@@ -998,8 +1067,10 @@ dependencies = [
  "eyre",
  "futures-util",
  "libp2p",
+ "local-ip-address",
  "multiaddr",
  "rand 0.8.5",
+ "rcgen 0.13.1",
  "reqwest 0.12.2",
  "semver",
  "serde",
@@ -1012,6 +1083,7 @@ dependencies = [
  "tower-sessions",
  "tracing",
  "tracing-subscriber",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -1732,7 +1804,21 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.1",
  "displaydoc",
  "nom",
  "num-bigint 0.4.4",
@@ -2798,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2850,7 +2936,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2869,7 +2955,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3233,7 +3319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3725,12 +3811,12 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen",
+ "rcgen 0.11.3",
  "ring 0.16.20",
  "rustls 0.21.12",
  "rustls-webpki 0.101.7",
  "thiserror",
- "x509-parser",
+ "x509-parser 0.15.1",
  "yasna",
 ]
 
@@ -3813,6 +3899,18 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "local-ip-address"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136ef34e18462b17bf39a7826f8f3bbc223341f8e83822beb8b77db9a3d49696"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "lock_api"
@@ -4531,6 +4629,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4736,7 +4859,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
+dependencies = [
+ "asn1-rs 0.6.1",
 ]
 
 [[package]]
@@ -5589,6 +5721,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+dependencies = [
+ "pem",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,7 +5863,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5749,7 +5894,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -5760,7 +5905,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5960,7 +6105,7 @@ dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
@@ -5975,10 +6120,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.4.1"
+name = "rustls-pemfile"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -5992,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -6685,6 +6840,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6898,6 +7064,16 @@ checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
  "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -7488,7 +7664,7 @@ dependencies = [
  "once_cell",
  "rustls 0.22.4",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.5",
  "url",
  "webpki-roots",
 ]
@@ -8204,12 +8380,29 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
  "data-encoding",
- "der-parser",
+ "der-parser 8.2.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.6.1",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.1",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.0",
  "rusticata-macros",
  "thiserror",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ ureq = "2.9.7"
 wasmer = "4.2.5"
 wasmer-types = "4.2.5"
 web3 = "0.19.0"
+local-ip-address = "0.6.1"
+rcgen = "0.13.1"
+x509-parser = "0.16.0"
+axum-server = { version = "0.6", features = ["tls-rustls"] }
+axum-server-dual-protocol = "0.6.0"
 
 [profile.app-release]
 inherits = "release"

--- a/crates/meroctl/src/cli/init.rs
+++ b/crates/meroctl/src/cli/init.rs
@@ -35,7 +35,7 @@ pub struct InitCommand {
 
     /// Host to listen on for RPC
     #[clap(long, value_name = "HOST")]
-    #[clap(default_value = "127.0.0.1,::1")]
+    #[clap(default_value = "0.0.0.0,::1")]
     #[clap(use_value_delimiter = true)]
     pub server_host: Vec<IpAddr>,
 

--- a/crates/meroctl/src/cli/init.rs
+++ b/crates/meroctl/src/cli/init.rs
@@ -35,7 +35,7 @@ pub struct InitCommand {
 
     /// Host to listen on for RPC
     #[clap(long, value_name = "HOST")]
-    #[clap(default_value = "0.0.0.0,::1")]
+    #[clap(default_value = "127.0.0.1,::1")]
     #[clap(use_value_delimiter = true)]
     pub server_host: Vec<IpAddr>,
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -29,10 +29,11 @@ tower.workspace = true
 tower-http = { workspace = true, features = ["cors", "fs"] }
 tower-sessions = { workspace = true, optional = true }
 tracing.workspace = true
-axum-server = { version = "0.6", features = ["tls-rustls"] }
-local-ip-address = "0.6.1"
-rcgen = "0.13.1"
-x509-parser = "0.16.0"
+axum-server.workspace = true
+axum-server-dual-protocol.workspace = true
+rcgen.workspace = true
+x509-parser.workspace = true
+local-ip-address.workspace = true
 
 calimero-context = { path = "../context" }
 calimero-node-primitives = { path = "../node-primitives" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -29,6 +29,10 @@ tower.workspace = true
 tower-http = { workspace = true, features = ["cors", "fs"] }
 tower-sessions = { workspace = true, optional = true }
 tracing.workspace = true
+axum-server = { version = "0.6", features = ["tls-rustls"] }
+local-ip-address = "0.6.1"
+rcgen = "0.13.1"
+x509-parser = "0.16.0"
 
 calimero-context = { path = "../context" }
 calimero-node-primitives = { path = "../node-primitives" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 
 [dependencies]
 axum.workspace = true
+axum-server.workspace = true
+axum-server-dual-protocol.workspace = true
 base64.workspace = true
 borsh = { workspace = true, features = ["derive"] }
 bs58.workspace = true
@@ -16,8 +18,10 @@ ed25519-dalek.workspace = true
 eyre.workspace = true
 futures-util = { workspace = true, optional = true }
 libp2p.workspace = true
+local-ip-address.workspace = true
 multiaddr.workspace = true
 rand.workspace = true
+rcgen.workspace = true
 reqwest.workspace = true
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -29,11 +33,7 @@ tower.workspace = true
 tower-http = { workspace = true, features = ["cors", "fs"] }
 tower-sessions = { workspace = true, optional = true }
 tracing.workspace = true
-axum-server.workspace = true
-axum-server-dual-protocol.workspace = true
-rcgen.workspace = true
 x509-parser.workspace = true
-local-ip-address.workspace = true
 
 calimero-context = { path = "../context" }
 calimero-node-primitives = { path = "../node-primitives" }

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -1,8 +1,9 @@
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
+use std::str;
 use std::sync::Arc;
 
-use axum::http::StatusCode;
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post};
 use axum::{Extension, Json, Router};
@@ -15,6 +16,7 @@ use tower_sessions::{MemoryStore, SessionManagerLayer};
 use tracing::info;
 
 use super::handlers;
+use super::storage::ssl::get_ssl;
 use crate::middleware;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -91,6 +93,7 @@ pub(crate) fn setup(
 
     let unprotected_router = Router::new()
         .route("/health", get(health_check_handler))
+        .route("/certificate", get(certificate_handler))
         .route(
             "/request-challenge",
             post(handlers::challenge::request_challenge_handler),
@@ -235,5 +238,48 @@ async fn list_applications_handler(
         }
         .into_response(),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+    }
+}
+
+async fn certificate_handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {
+    let certificate = match get_ssl(state.store.clone()) {
+        Ok(Some(cert)) => Some(cert),
+        Ok(None) => None,
+        Err(err) => {
+            eprintln!("Failed to get the certificate: {}", err);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to get the certificate",
+            )
+                .into_response();
+        }
+    };
+
+    if let Some(certificate) = certificate {
+        // Generate the file content
+        let file_content = match str::from_utf8(&certificate.cert()) {
+            Ok(content) => content.to_string(),
+            Err(_) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to read certificate content",
+                )
+                    .into_response()
+            }
+        };
+        let file_name = "cert.pem";
+
+        // Create headers for file download
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(
+            header::CONTENT_DISPOSITION,
+            HeaderValue::from_str(&format!("attachment; filename=\"{}\"", file_name)).unwrap(),
+        );
+
+        // Create the response with the file content and headers
+        (headers, file_content).into_response()
+    } else {
+        (StatusCode::NOT_FOUND, "Certificate not found").into_response()
     }
 }

--- a/crates/server/src/admin/storage.rs
+++ b/crates/server/src/admin/storage.rs
@@ -1,3 +1,4 @@
 pub mod client_keys;
 pub mod did;
 pub mod root_key;
+pub mod ssl;

--- a/crates/server/src/admin/storage/ssl.rs
+++ b/crates/server/src/admin/storage/ssl.rs
@@ -59,7 +59,7 @@ pub fn get_ssl(store: Store) -> eyre::Result<Option<SSLCert>> {
     let handle = store.handle();
 
     match handle.get(&entry) {
-        Ok(Some(ssl_document)) => Ok(Some(ssl_document.value().clone())),
+        Ok(Some(ssl_document)) => Ok(Some(ssl_document.value())),
         Ok(None) => Ok(None),
         Err(e) => Err(e.into()),
     }

--- a/crates/server/src/admin/storage/ssl.rs
+++ b/crates/server/src/admin/storage/ssl.rs
@@ -1,0 +1,66 @@
+use calimero_store::entry::{Entry, Json};
+use calimero_store::key::Generic;
+use calimero_store::Store;
+use serde::{Deserialize, Serialize};
+
+struct SSLEntry {
+    key: Generic,
+}
+
+impl Entry for SSLEntry {
+    type Key = Generic;
+    type DataType<'a> = Json<SSLCert>;
+
+    fn key(&self) -> &Self::Key {
+        &self.key
+    }
+}
+
+impl SSLEntry {
+    fn new() -> Self {
+        Self {
+            key: Generic::new(*b"ssl_certs:server", [0; 32]),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SSLCert {
+    cert: Vec<u8>,
+    key: Vec<u8>,
+}
+
+impl SSLCert {
+    pub fn cert(&self) -> &Vec<u8> {
+        &self.cert
+    }
+
+    pub fn key(&self) -> &Vec<u8> {
+        &self.key
+    }
+}
+
+pub fn insert_or_update_ssl(store: Store, cert: &[u8], key: &[u8]) -> eyre::Result<SSLCert> {
+    let ssl_cert = SSLCert {
+        cert: cert.to_vec(),
+        key: key.to_vec(),
+    };
+
+    let ssl_document = Json::new(ssl_cert.clone());
+    let entry = SSLEntry::new();
+    let mut handle = store.handle();
+    handle.put(&entry, &ssl_document)?;
+
+    Ok(ssl_cert)
+}
+
+pub fn get_ssl(store: Store) -> eyre::Result<Option<SSLCert>> {
+    let entry = SSLEntry::new();
+    let handle = store.handle();
+
+    match handle.get(&entry) {
+        Ok(Some(ssl_document)) => Ok(Some(ssl_document.value().clone())),
+        Ok(None) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/crates/server/src/certificates.rs
+++ b/crates/server/src/certificates.rs
@@ -1,8 +1,8 @@
-use tokio::fs;
 use std::path::{Path, PathBuf};
 
 use local_ip_address::local_ip;
 use rcgen::{CertificateParams, DnType};
+use tokio::fs;
 use x509_parser::extensions::GeneralName;
 use x509_parser::prelude::{parse_x509_pem, ParsedExtension};
 
@@ -135,7 +135,7 @@ async fn check_certificate() -> eyre::Result<(Vec<u8>, Vec<u8>)> {
 fn write_out_instructions() {
     println!("*******************************************************************************");
     println!("To install the generated self-signed SSL certificate, follow the steps in our documentation:");
-    println!("https://https://calimero-network.github.io/getting-started/setup");
+    println!("https://calimero-network.github.io/getting-started/setup");
     println!("*******************************************************************************");
 }
 

--- a/crates/server/src/certificates.rs
+++ b/crates/server/src/certificates.rs
@@ -1,0 +1,164 @@
+use rcgen::{CertificateParams, DnType};
+use local_ip_address::local_ip;
+use std::fs;
+use std::path::Path;
+use x509_parser::prelude::*;
+use x509_parser::extensions::GeneralName;
+use std::path::PathBuf;
+
+pub fn check_for_certificate() -> eyre::Result<()> {
+    // Get the path to the certificate and key files
+    let certificate_dir = get_certificate_dir();
+    let cert_path = certificate_dir.join("cert.pem");
+    let key_path = certificate_dir.join("key.pem");
+
+    // Ensure paths exist
+    if !cert_path.exists() || !key_path.exists() {
+        generate_certificate()?;
+        write_out_instructions();
+        return Ok(());
+    }
+
+    // Check if a certificate contains local IP address
+    check_certificate()?;
+    write_out_instructions();
+    Ok(())
+}
+
+fn generate_certificate() -> eyre::Result<()> {
+    // Get the local IP address
+    let local_ip = local_ip()?;
+
+    // Generate a self-signed certificate for IP address and localhost
+    let subject_alt_names = vec![
+        local_ip.to_string(),
+        "127.0.0.1".to_string(),
+  	    "localhost".to_string()
+    ];
+
+    // Certificate name
+    let certificate_name = format!("Calimero self-signed certificate for local IP: {:?}", &local_ip.to_string());
+
+    // Create certificate parameters
+    let mut params = CertificateParams::new(subject_alt_names.clone())?;
+    // Set the distinguished name
+    params.distinguished_name.push(DnType::CommonName, certificate_name);
+
+    // Load keypair if it exists or generate a new one
+    let certificate_dir = get_certificate_dir();
+    let key_file_path = certificate_dir.join("key.pem");
+    let key_pair = if key_file_path.exists() {
+        let key_pem = fs::read_to_string(key_file_path)?;
+        rcgen::KeyPair::from_pem(&key_pem)?
+    }else {
+        rcgen::KeyPair::generate().unwrap()
+    };
+
+    // Generate the certificate with the customized parameters
+    let cert = CertificateParams::self_signed(params, &key_pair).unwrap();
+
+    // Serialize the certificate and private key to PEM format
+    let cert_pem = cert.pem();
+    let key_pem = key_pair.serialize_pem();
+
+    // Get the path to the certificate and key files
+    let certificate_dir = get_certificate_dir();
+    let cert_file_path = certificate_dir.join("cert.pem");
+    let key_file_path = certificate_dir.join("key.pem");
+    
+    // Save the certificate and key to files
+    fs::write(cert_file_path, cert_pem)?;
+    fs::write(key_file_path, key_pem)?;
+
+    Ok(())
+}
+
+fn delete_certificate() -> eyre::Result<()> {
+    let certificate_dir = get_certificate_dir();
+    let cert_path = certificate_dir.join("cert.pem");
+    fs::remove_file(cert_path)?;
+
+    Ok(())
+}
+
+fn check_certificate() -> eyre::Result<()> {
+    
+    let certificate_dir = get_certificate_dir();
+    let cert_file = certificate_dir.join("cert.pem");
+    // Read the certificate file
+    let cert_pem = fs::read_to_string(cert_file)?;
+    let (_, pem) = parse_x509_pem(cert_pem.as_bytes())?;
+    let x509_cert = pem.parse_x509()?;
+
+    // Get the local IP address
+    let local_ip = local_ip()?;
+
+    // Parse the local IP address to Vec<u8>
+    let local_ip_bytes = match local_ip {
+        std::net::IpAddr::V4(ip) => ip.octets().to_vec(),
+        std::net::IpAddr::V6(ip) => ip.octets().to_vec(),
+    };
+
+    // Flag for found IP address in certificate
+    let mut ip_found = false;
+
+    for ext in x509_cert.extensions() {
+      // Parse the extension
+      let parsed_ext = ext.parsed_extension();
+      
+      // Check if it's a SubjectAlternativeName extension
+      if let ParsedExtension::SubjectAlternativeName(san) = parsed_ext {
+          // Iterate over the general names
+          for gn in &san.general_names {
+              // Check if the general name is an IP address
+              if let GeneralName::IPAddress(dns_name) = gn {
+                  if *dns_name == local_ip_bytes {
+                      ip_found = true;
+                      break;
+                  }
+              }
+          }
+      }  
+    }
+
+    if !ip_found {
+        delete_certificate()?;
+        generate_certificate()?;
+    }
+
+    Ok(())
+}
+
+fn write_out_instructions() {
+    // Get full path to the certificate directory
+    let certificate_dir = get_certificate_dir();
+
+    println!("*******************************************************************************");
+    println!("To install the generated self-signed SSL certificate, follow these steps:");
+    println!("1. Navigate to {:?} directory", certificate_dir.to_str().unwrap());
+    println!("2. Depending on your operating system, the installation process will vary:");
+    println!("   - For macOS:");
+    println!("     a. Open Keychain Access and select the 'System' keychain.");
+    println!("     b. Drag the cert.pem file into Keychain Access.");
+    println!("     c. Double-click the certificate, expand the 'Trust' section, and set 'When using this certificate' to 'Always Trust'.");
+    println!("   - For Windows:");
+    println!("     a. Double-click the cert.pem file.");
+    println!("     b. Select 'Install Certificate...', choose the 'Local Machine' store location, and place it in the 'Trusted Root Certification Authorities' store.");
+    println!("   - For Linux:");
+    println!("     a. The process varies by distribution and browser. For most browsers, importing the certificate through the browser's settings by navigating to 'Privacy and Security' -> 'Manage Certificates' should work.");
+    println!("3. After installation, you may need to restart your browser or any application that needs to trust the certificate.");
+    println!("*******************************************************************************");    
+}
+
+pub fn get_certificate_dir() -> PathBuf {
+  // Convert the current file path to a PathBuf
+  let current_file_path = Path::new(file!());
+  // Get the directory containing the current file
+  let parent_dir = current_file_path.parent().expect("Failed to get parent directory");
+  // Get the grandparent directory
+  let server_dir = parent_dir.parent().expect("Failed to get parent directory");
+  // Get certificates directory
+  let certificate_dir = server_dir.join("certificates");
+
+  certificate_dir
+}

--- a/crates/server/src/certificates.rs
+++ b/crates/server/src/certificates.rs
@@ -1,12 +1,12 @@
-use rcgen::{CertificateParams, DnType};
-use local_ip_address::local_ip;
 use std::fs;
-use std::path::Path;
-use x509_parser::prelude::*;
-use x509_parser::extensions::GeneralName;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub fn check_for_certificate() -> eyre::Result<()> {
+use local_ip_address::local_ip;
+use rcgen::{CertificateParams, DnType};
+use x509_parser::extensions::GeneralName;
+use x509_parser::prelude::{parse_x509_pem, ParsedExtension};
+
+pub async fn get_certificate() -> eyre::Result<(Vec<u8>, Vec<u8>)> {
     // Get the path to the certificate and key files
     let certificate_dir = get_certificate_dir();
     let cert_path = certificate_dir.join("cert.pem");
@@ -14,18 +14,18 @@ pub fn check_for_certificate() -> eyre::Result<()> {
 
     // Ensure paths exist
     if !cert_path.exists() || !key_path.exists() {
-        generate_certificate()?;
+        let (cert_pem, key_pem) = generate_certificate()?;
         write_out_instructions();
-        return Ok(());
+        return Ok((cert_pem, key_pem));
     }
 
     // Check if a certificate contains local IP address
-    check_certificate()?;
+    let (cert_pem, key_pem) = check_certificate().await?;
     write_out_instructions();
-    Ok(())
+    Ok((cert_pem, key_pem))
 }
 
-fn generate_certificate() -> eyre::Result<()> {
+fn generate_certificate() -> eyre::Result<(Vec<u8>, Vec<u8>)> {
     // Get the local IP address
     let local_ip = local_ip()?;
 
@@ -33,16 +33,21 @@ fn generate_certificate() -> eyre::Result<()> {
     let subject_alt_names = vec![
         local_ip.to_string(),
         "127.0.0.1".to_string(),
-  	    "localhost".to_string()
+        "localhost".to_string(),
     ];
 
     // Certificate name
-    let certificate_name = format!("Calimero self-signed certificate for local IP: {:?}", &local_ip.to_string());
+    let certificate_name = format!(
+        "Calimero self-signed certificate for local IP: {:?}",
+        &local_ip.to_string()
+    );
 
     // Create certificate parameters
     let mut params = CertificateParams::new(subject_alt_names.clone())?;
     // Set the distinguished name
-    params.distinguished_name.push(DnType::CommonName, certificate_name);
+    params
+        .distinguished_name
+        .push(DnType::CommonName, certificate_name);
 
     // Load keypair if it exists or generate a new one
     let certificate_dir = get_certificate_dir();
@@ -50,7 +55,7 @@ fn generate_certificate() -> eyre::Result<()> {
     let key_pair = if key_file_path.exists() {
         let key_pem = fs::read_to_string(key_file_path)?;
         rcgen::KeyPair::from_pem(&key_pem)?
-    }else {
+    } else {
         rcgen::KeyPair::generate().unwrap()
     };
 
@@ -62,15 +67,14 @@ fn generate_certificate() -> eyre::Result<()> {
     let key_pem = key_pair.serialize_pem();
 
     // Get the path to the certificate and key files
-    let certificate_dir = get_certificate_dir();
     let cert_file_path = certificate_dir.join("cert.pem");
     let key_file_path = certificate_dir.join("key.pem");
-    
-    // Save the certificate and key to files
-    fs::write(cert_file_path, cert_pem)?;
-    fs::write(key_file_path, key_pem)?;
 
-    Ok(())
+    // Save the certificate and key to files
+    fs::write(cert_file_path, cert_pem.clone())?;
+    fs::write(key_file_path, key_pem.clone())?;
+
+    Ok((cert_pem.as_bytes().to_vec(), key_pem.as_bytes().to_vec()))
 }
 
 fn delete_certificate() -> eyre::Result<()> {
@@ -81,84 +85,71 @@ fn delete_certificate() -> eyre::Result<()> {
     Ok(())
 }
 
-fn check_certificate() -> eyre::Result<()> {
-    
+async fn check_certificate() -> eyre::Result<(Vec<u8>, Vec<u8>)> {
     let certificate_dir = get_certificate_dir();
     let cert_file = certificate_dir.join("cert.pem");
+    let key_file = certificate_dir.join("key.pem");
     // Read the certificate file
-    let cert_pem = fs::read_to_string(cert_file)?;
+    let cert_pem = fs::read_to_string(cert_file.clone())?;
     let (_, pem) = parse_x509_pem(cert_pem.as_bytes())?;
     let x509_cert = pem.parse_x509()?;
 
     // Get the local IP address
     let local_ip = local_ip()?;
 
-    // Parse the local IP address to Vec<u8>
-    let local_ip_bytes = match local_ip {
-        std::net::IpAddr::V4(ip) => ip.octets().to_vec(),
-        std::net::IpAddr::V6(ip) => ip.octets().to_vec(),
-    };
-
     // Flag for found IP address in certificate
     let mut ip_found = false;
 
     for ext in x509_cert.extensions() {
-      // Parse the extension
-      let parsed_ext = ext.parsed_extension();
-      
-      // Check if it's a SubjectAlternativeName extension
-      if let ParsedExtension::SubjectAlternativeName(san) = parsed_ext {
-          // Iterate over the general names
-          for gn in &san.general_names {
-              // Check if the general name is an IP address
-              if let GeneralName::IPAddress(dns_name) = gn {
-                  if *dns_name == local_ip_bytes {
-                      ip_found = true;
-                      break;
-                  }
-              }
-          }
-      }  
+        // Parse the extension
+        let parsed_ext = ext.parsed_extension();
+
+        // Check if it's a SubjectAlternativeName extension
+        if let ParsedExtension::SubjectAlternativeName(san) = parsed_ext {
+            // Iterate over the general names
+            for gn in &san.general_names {
+                // Check if the general name is an IP address
+                if let GeneralName::IPAddress(dns_name) = gn {
+                    ip_found = match local_ip {
+                        std::net::IpAddr::V4(ip) => ip.octets() == *dns_name,
+                        std::net::IpAddr::V6(ip) => ip.octets() == *dns_name,
+                    };
+                    if ip_found {
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     if !ip_found {
         delete_certificate()?;
-        generate_certificate()?;
+        return Ok(generate_certificate()?);
     }
 
-    Ok(())
+    let cert_pem = tokio::fs::read(&cert_file).await?;
+    let key_pem = tokio::fs::read(&key_file).await?;
+    Ok((cert_pem, key_pem))
 }
 
 fn write_out_instructions() {
-    // Get full path to the certificate directory
-    let certificate_dir = get_certificate_dir();
-
     println!("*******************************************************************************");
-    println!("To install the generated self-signed SSL certificate, follow these steps:");
-    println!("1. Navigate to {:?} directory", certificate_dir.to_str().unwrap());
-    println!("2. Depending on your operating system, the installation process will vary:");
-    println!("   - For macOS:");
-    println!("     a. Open Keychain Access and select the 'System' keychain.");
-    println!("     b. Drag the cert.pem file into Keychain Access.");
-    println!("     c. Double-click the certificate, expand the 'Trust' section, and set 'When using this certificate' to 'Always Trust'.");
-    println!("   - For Windows:");
-    println!("     a. Double-click the cert.pem file.");
-    println!("     b. Select 'Install Certificate...', choose the 'Local Machine' store location, and place it in the 'Trusted Root Certification Authorities' store.");
-    println!("   - For Linux:");
-    println!("     a. The process varies by distribution and browser. For most browsers, importing the certificate through the browser's settings by navigating to 'Privacy and Security' -> 'Manage Certificates' should work.");
-    println!("3. After installation, you may need to restart your browser or any application that needs to trust the certificate.");
-    println!("*******************************************************************************");    
+    println!("To install the generated self-signed SSL certificate, follow the steps in our documentation:");
+    println!("https://https://calimero-network.github.io/getting-started/setup");
+    println!("*******************************************************************************");
 }
 
 pub fn get_certificate_dir() -> PathBuf {
-  // Convert the current file path to a PathBuf
-  let current_file_path = Path::new(file!());
-  // Get the directory containing the current file
-  let parent_dir = current_file_path.parent().expect("Failed to get parent directory");
-  // Get the grandparent directory
-  let server_dir = parent_dir.parent().expect("Failed to get parent directory");
-  // Get certificates directory
-  let certificate_dir = server_dir.join("certificates");
+    // Convert the current file path to a PathBuf
+    let current_file_path = Path::new(file!());
+    // Get the directory containing the current file
+    let parent_dir = current_file_path
+        .parent()
+        .expect("Failed to get parent directory");
+    // Get the grandparent directory
+    let server_dir = parent_dir.parent().expect("Failed to get parent directory");
+    // Get certificates directory
+    let certificate_dir = server_dir.join("certificates");
 
-  certificate_dir
+    certificate_dir
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -89,7 +89,9 @@ pub async fn start(
 
     #[cfg(feature = "admin")]
     {
-        if let Some((api_path, router)) = admin::service::setup(&config, store, ctx_manager)? {
+        if let Some((api_path, router)) =
+            admin::service::setup(&config, store.clone(), ctx_manager)?
+        {
             app = app.nest(api_path, router);
             serviced = true;
         }
@@ -115,7 +117,7 @@ pub async fn start(
             .allow_private_network(true),
     );
     // Check if the certificate exists and if they contain the current local IP address
-    let (cert_pem, key_pem) = certificates::get_certificate().await?;
+    let (cert_pem, key_pem) = certificates::get_certificate(store.clone()).await?;
 
     // Configure certificate and private key used by https
     let rustls_config = match RustlsConfig::from_pem(cert_pem, key_pem).await {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,6 +7,7 @@ use config::ServerConfig;
 use tokio::sync::broadcast;
 use tower_http::cors;
 use tracing::warn;
+
 pub mod certificates;
 
 #[cfg(feature = "admin")]


### PR DESCRIPTION
# TLS Wrapper for Server

## Summary:
When trying to access the local server from a browser (such as GitHub Pages), users receive CORS issues for serving insecure content. This issue is mentioned here: [calimero-network/admin-dashboard#26](https://github.com/calimero-network/admin-dashboard/issues/26).

To resolve this, we generate a self-signed SSL certificate for the server based on the current local IP address. The implementation includes:
- If a certificate doesn't exist, create a new certificate.
- If a certificate exists for the current IP address, use the existing one.
- If a certificate exists but is not configured for the current IP address, create a new certificate.

Additionally, instructions have been added with steps to add the certificate to the device to the CLI. The server is wrapped in TLS using the `axum-server` crate.

## Changes:
- **/crates/server/Cargo.toml**: Modified to include necessary crates.
- **Cargo.lock**: Updated to reflect changes in dependencies.
- **/crates/server/src/lib.rs**: Updated to call methods from `certificates.rs` and wrap the server with TLS.
- **/crates/server/src/certificates.rs**: Added for SSL certificate generation and validation.
- **/crates/server/certificates/**: Created a folder for generated certificates.
- **/crates/meroctl/src/cli/init.rs**: Updated for initial setup to start the server on the local IP address.

## How to test:
1. Initialize the node.
```sh 
cargo run -p meroctl -- --node-name node1 --home data init --server-port 2428 --swarm-port 2528
```
3. Start the node.
```sh
cargo run -p meroctl -- --node-name node1 --home data run
```
4. Follow the instructions in CLI to add the SSL certificate to your device.
5. Try accessing the local server using the HTTPS URL: [https://calimero-network.github.io/getting-started/admin-dashboard/](https://calimero-network.github.io/getting-started/admin-dashboard/)
