### PR TITLE
feat(admin-api): update install application logic

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -252,7 +252,8 @@ impl ContextManager {
         path: &str,
         hash: Option<&str>,
     ) -> eyre::Result<()> {
-        self.download_and_install_release(&application_id, &version, &path, hash).await?;
+        self.download_and_install_release(&application_id, &version, &path, hash)
+            .await?;
 
         Ok(())
     }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -250,10 +250,10 @@ impl ContextManager {
         // todo! permit None version for latest
         version: &semver::Version,
          // represents the url path to the release binary (e.g. ipfs path)
-        path: &str,
+         url: &str,
         hash: Option<&str>,
     ) -> eyre::Result<()> {
-        self.download_and_install_release(&application_id, &version, &path, hash)
+        self.download_and_install_release(&application_id, &version, &url, hash)
             .await?;
 
         Ok(())
@@ -352,7 +352,7 @@ impl ContextManager {
         application_id: &calimero_primitives::application::ApplicationId,
         version: &semver::Version,
         // represents the url path to the release binary (e.g. ipfs path)
-        path: &str,
+        url: &str,
         hash: Option<&str>,
     ) -> eyre::Result<bool> {
         // todo! download to a tempdir
@@ -367,7 +367,7 @@ impl ContextManager {
 
         let mut file = File::create(&file_path)?;
 
-        let mut response = reqwest::Client::new().get(path).send().await?;
+        let mut response = reqwest::Client::new().get(url).send().await?;
         let mut hasher = Sha256::new();
         while let Some(chunk) = response.chunk().await? {
             hasher.update(&chunk);

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -249,6 +249,7 @@ impl ContextManager {
         application_id: &calimero_primitives::application::ApplicationId,
         // todo! permit None version for latest
         version: &semver::Version,
+         // represents the url path to the release binary (e.g. ipfs path)
         path: &str,
         hash: Option<&str>,
     ) -> eyre::Result<()> {
@@ -350,6 +351,7 @@ impl ContextManager {
         &self,
         application_id: &calimero_primitives::application::ApplicationId,
         version: &semver::Version,
+        // represents the url path to the release binary (e.g. ipfs path)
         path: &str,
         hash: Option<&str>,
     ) -> eyre::Result<bool> {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -364,7 +364,7 @@ impl ContextManager {
 
         let mut file = File::create(&file_path)?;
 
-        let mut response = reqwest::Client::new().get(path.to_string()).send().await?;
+        let mut response = reqwest::Client::new().get(path).send().await?;
         let mut hasher = Sha256::new();
         while let Some(chunk) = response.chunk().await? {
             hasher.update(&chunk);

--- a/crates/network/src/events/mdns.rs
+++ b/crates/network/src/events/mdns.rs
@@ -2,9 +2,8 @@ use libp2p::mdns;
 use owo_colors::OwoColorize;
 use tracing::{debug, error};
 
-use crate::discovery;
-
 use super::{EventHandler, EventLoop, RelayedMultiaddr};
+use crate::discovery;
 
 impl EventHandler<mdns::Event> for EventLoop {
     async fn handle(&mut self, event: mdns::Event) {

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -89,7 +89,7 @@ impl Node {
                 types::CatchupApplicationChanged {
                     application_id,
                     version: application_version,
-                    path,
+                    url,
                     hash,
                 },
             ))?;
@@ -201,7 +201,7 @@ impl Node {
                     application_id: Some(context.application_id),
                     last_executed_transaction_hash: context.last_transaction_hash,
                     batch_size: self.network_client.catchup_config.batch_size,
-                    path: None,
+                    url: None,
                     hash: None,
                 },
             ),
@@ -212,7 +212,7 @@ impl Node {
                     application_id: None,
                     last_executed_transaction_hash: calimero_primitives::hash::Hash::default(),
                     batch_size: self.network_client.catchup_config.batch_size,
-                    path: None,
+                    url: None,
                     hash: None,
                 },
             ),
@@ -349,7 +349,7 @@ impl Node {
                         .install_application(
                             &change.application_id,
                             &change.version,
-                            &change.path,
+                            &change.url,
                             Some(change.hash.as_str()),
                         )
                         .await?;

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -65,15 +65,11 @@ impl Node {
 
         let application_id = context.application_id.clone();
 
-        let path = if let Some(path) = request.path {
-            path
-        } else {
+        let Some(url) = request.url else {
             eyre::bail!("Path is missing in the request")
         };
 
-        let hash = if let Some(hash) = request.hash {
-            hash
-        } else {
+        let Some(hash) = request.hash else {
             eyre::bail!("Hash is missing in the request")
         };
 

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -347,7 +347,7 @@ impl Node {
                     .is_application_installed(&change.application_id)
                 {
                     self.ctx_manager
-                        .install_application(&change.application_id, &change.version, &change.path, &change.hash)
+                        .install_application(&change.application_id, &change.version, &change.path, Some(change.hash.as_str()))
                         .await?;
                 }
 

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -64,19 +64,18 @@ impl Node {
         };
 
         let application_id = context.application_id.clone();
-        
+
         let path = if let Some(path) = request.path {
             path
         } else {
             eyre::bail!("Path is missing in the request")
         };
-        
+
         let hash = if let Some(hash) = request.hash {
             hash
         } else {
             eyre::bail!("Hash is missing in the request")
         };
-
 
         if request
             .application_id
@@ -347,7 +346,12 @@ impl Node {
                     .is_application_installed(&change.application_id)
                 {
                     self.ctx_manager
-                        .install_application(&change.application_id, &change.version, &change.path, Some(change.hash.as_str()))
+                        .install_application(
+                            &change.application_id,
+                            &change.version,
+                            &change.path,
+                            Some(change.hash.as_str()),
+                        )
                         .await?;
                 }
 

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -64,6 +64,19 @@ impl Node {
         };
 
         let application_id = context.application_id.clone();
+        
+        let path = if let Some(path) = request.path {
+            path
+        } else {
+            eyre::bail!("Path is missing in the request")
+        };
+        
+        let hash = if let Some(hash) = request.hash {
+            hash
+        } else {
+            eyre::bail!("Hash is missing in the request")
+        };
+
 
         if request
             .application_id
@@ -77,6 +90,8 @@ impl Node {
                 types::CatchupApplicationChanged {
                     application_id,
                     version: application_version,
+                    path,
+                    hash,
                 },
             ))?;
             stream
@@ -187,6 +202,8 @@ impl Node {
                     application_id: Some(context.application_id),
                     last_executed_transaction_hash: context.last_transaction_hash,
                     batch_size: self.network_client.catchup_config.batch_size,
+                    path: None,
+                    hash: None,
                 },
             ),
             None => (
@@ -196,6 +213,8 @@ impl Node {
                     application_id: None,
                     last_executed_transaction_hash: calimero_primitives::hash::Hash::default(),
                     batch_size: self.network_client.catchup_config.batch_size,
+                    path: None,
+                    hash: None,
                 },
             ),
         };
@@ -328,7 +347,7 @@ impl Node {
                     .is_application_installed(&change.application_id)
                 {
                     self.ctx_manager
-                        .install_application(&change.application_id, &change.version)
+                        .install_application(&change.application_id, &change.version, &change.path, &change.hash)
                         .await?;
                 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -416,7 +416,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
 
                         // todo! we should be able to install latest version
                         node.ctx_manager
-                            .install_application(&application_id, &version, &path, &hash)
+                            .install_application(&application_id, &version, &path, Some(hash))
                             .await?;
 
                         let context = calimero_primitives::context::Context {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -385,16 +385,15 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                         println!("{IND} Left context {}", context_id);
                     }
                     "create" => {
-                        let Some((context_id, application_id, version, url, hash)) = args
+                        let Some((context_id, application_id, version, url)) = args
                             .and_then(|args| {
                                 let mut iter = args.split(' ');
                                 let context = iter.next()?;
                                 let application = iter.next()?;
                                 let version = iter.next()?;
                                 let url = iter.next()?;
-                                let hash = iter.next()?;
 
-                                Some((context, application, version, url, hash))
+                                Some((context, application, version, url))
                             })
                         else {
                             println!("{IND} Usage: context create <context_id> <application_id> <version> <url>");
@@ -417,7 +416,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
 
                         // todo! we should be able to install latest version
                         node.ctx_manager
-                            .install_application(&application_id, &version, &url, Some(hash))
+                            .install_application(&application_id, &version, &url, None)
                             .await?;
 
                         let context = calimero_primitives::context::Context {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,4 +1,5 @@
 use calimero_primitives::events::OutcomeEvent;
+use calimero_primitives::hash;
 use calimero_runtime::logic::VMLimits;
 use calimero_runtime::Constraint;
 use calimero_store::Store;
@@ -385,15 +386,17 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                         println!("{IND} Left context {}", context_id);
                     }
                     "create" => {
-                        let Some((context_id, application_id, version)) = args.and_then(|args| {
+                        let Some((context_id, application_id, version, path, hash)) = args.and_then(|args| {
                             let mut iter = args.split(' ');
                             let context = iter.next()?;
                             let application = iter.next()?;
                             let version = iter.next()?;
+                            let path = iter.next()?;
+                            let hash= iter.next()?;
 
-                            Some((context, application, version))
+                            Some((context, application, version, path, hash))
                         }) else {
-                            println!("{IND} Usage: context create <context_id> <application_id> <version>");
+                            println!("{IND} Usage: context create <context_id> <application_id> <version> <path> <hash>");
                             break 'done;
                         };
 
@@ -413,7 +416,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
 
                         // todo! we should be able to install latest version
                         node.ctx_manager
-                            .install_application(&application_id, &version)
+                            .install_application(&application_id, &version, &path, &hash)
                             .await?;
 
                         let context = calimero_primitives::context::Context {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -385,19 +385,19 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                         println!("{IND} Left context {}", context_id);
                     }
                     "create" => {
-                        let Some((context_id, application_id, version, path, hash)) = args
+                        let Some((context_id, application_id, version, url, hash)) = args
                             .and_then(|args| {
                                 let mut iter = args.split(' ');
                                 let context = iter.next()?;
                                 let application = iter.next()?;
                                 let version = iter.next()?;
-                                let path = iter.next()?;
+                                let url = iter.next()?;
                                 let hash = iter.next()?;
 
-                                Some((context, application, version, path, hash))
+                                Some((context, application, version, url, hash))
                             })
                         else {
-                            println!("{IND} Usage: context create <context_id> <application_id> <version> <path>");
+                            println!("{IND} Usage: context create <context_id> <application_id> <version> <url>");
                             break 'done;
                         };
 
@@ -417,7 +417,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
 
                         // todo! we should be able to install latest version
                         node.ctx_manager
-                            .install_application(&application_id, &version, &path, Some(hash))
+                            .install_application(&application_id, &version, &url, Some(hash))
                             .await?;
 
                         let context = calimero_primitives::context::Context {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -398,7 +398,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                                 Some((context, application, version, path, hash))
                             })
                         else {
-                            println!("{IND} Usage: context create <context_id> <application_id> <version> <path> <hash>");
+                            println!("{IND} Usage: context create <context_id> <application_id> <version> <path>");
                             break 'done;
                         };
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -386,16 +386,18 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                         println!("{IND} Left context {}", context_id);
                     }
                     "create" => {
-                        let Some((context_id, application_id, version, path, hash)) = args.and_then(|args| {
-                            let mut iter = args.split(' ');
-                            let context = iter.next()?;
-                            let application = iter.next()?;
-                            let version = iter.next()?;
-                            let path = iter.next()?;
-                            let hash= iter.next()?;
+                        let Some((context_id, application_id, version, path, hash)) = args
+                            .and_then(|args| {
+                                let mut iter = args.split(' ');
+                                let context = iter.next()?;
+                                let application = iter.next()?;
+                                let version = iter.next()?;
+                                let path = iter.next()?;
+                                let hash = iter.next()?;
 
-                            Some((context, application, version, path, hash))
-                        }) else {
+                                Some((context, application, version, path, hash))
+                            })
+                        else {
                             println!("{IND} Usage: context create <context_id> <application_id> <version> <path> <hash>");
                             break 'done;
                         };

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_primitives::events::OutcomeEvent;
-use calimero_primitives::hash;
 use calimero_runtime::logic::VMLimits;
 use calimero_runtime::Constraint;
 use calimero_store::Store;

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -35,6 +35,8 @@ pub enum CatchupStreamMessage {
 pub struct CatchupRequest {
     pub context_id: calimero_primitives::context::ContextId,
     pub application_id: Option<calimero_primitives::application::ApplicationId>,
+    pub path: Option<String>,
+    pub hash: Option<String>,
     pub last_executed_transaction_hash: calimero_primitives::hash::Hash,
     pub batch_size: u8,
 }
@@ -43,6 +45,8 @@ pub struct CatchupRequest {
 pub struct CatchupApplicationChanged {
     pub application_id: calimero_primitives::application::ApplicationId,
     pub version: semver::Version,
+    pub path: String,
+    pub hash: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -35,7 +35,7 @@ pub enum CatchupStreamMessage {
 pub struct CatchupRequest {
     pub context_id: calimero_primitives::context::ContextId,
     pub application_id: Option<calimero_primitives::application::ApplicationId>,
-    pub path: Option<String>,
+    pub url: Option<String>,
     pub hash: Option<String>,
     pub last_executed_transaction_hash: calimero_primitives::hash::Hash,
     pub batch_size: u8,
@@ -45,7 +45,7 @@ pub struct CatchupRequest {
 pub struct CatchupApplicationChanged {
     pub application_id: calimero_primitives::application::ApplicationId,
     pub version: semver::Version,
-    pub path: String,
+    pub url: String,
     pub hash: String,
 }
 

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 pub struct InstallApplicationRequest {
     pub application: calimero_primitives::application::ApplicationId, // TODO: rename to application_id
     pub version: semver::Version,
-    pub path: String,  // represents the url path to the release binary (e.g. ipfs path)
+    pub url: String,  // represents the url path to the release binary (e.g. ipfs path)
     pub hash: Option<String>,
 }
 

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -7,7 +7,7 @@ pub struct InstallApplicationRequest {
     pub application: calimero_primitives::application::ApplicationId, // TODO: rename to application_id
     pub version: semver::Version,
     pub path: String,
-    pub hash: String,
+    pub hash: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -6,6 +6,8 @@ use serde_json::Value;
 pub struct InstallApplicationRequest {
     pub application: calimero_primitives::application::ApplicationId, // TODO: rename to application_id
     pub version: semver::Version,
+    pub path: String,
+    pub hash: String,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 pub struct InstallApplicationRequest {
     pub application: calimero_primitives::application::ApplicationId, // TODO: rename to application_id
     pub version: semver::Version,
-    pub path: String,
+    pub path: String,  // represents the url path to the release binary (e.g. ipfs path)
     pub hash: Option<String>,
 }
 

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -212,7 +212,7 @@ async fn install_application_handler(
         .install_application(
             &req.application,
             &req.version,
-            &req.path,
+            &req.url,
             req.hash.as_deref(),
         )
         .await

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -209,7 +209,7 @@ async fn install_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application(&req.application, &req.version, &req.path, &req.hash)
+        .install_application(&req.application, &req.version, &req.path, req.hash.as_deref())
         .await
     {
         Ok(()) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -209,7 +209,12 @@ async fn install_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application(&req.application, &req.version, &req.path, req.hash.as_deref())
+        .install_application(
+            &req.application,
+            &req.version,
+            &req.path,
+            req.hash.as_deref(),
+        )
         .await
     {
         Ok(()) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -209,7 +209,7 @@ async fn install_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application(&req.application, &req.version)
+        .install_application(&req.application, &req.version, &req.path, &req.hash)
         .await
     {
         Ok(()) => ApiResponse {


### PR DESCRIPTION
# feat(admin-api): update install application logic

## Summary
Goal is that the node does not have to know where the application binary is hosted (testnet / mainnet NEAR view calls). Node should only get the path and download the release from the path + compare downloaded hash with hash passed in the request. 

With this update we don't need function to fetch application release to get that metadata because its passed in the API request. 

Connected with [this](https://github.com/calimero-network/admin-dashboard/pull/43) PR. 

Fixes # [Issue](https://github.com/calimero-network/core/issues/477)

