### PR TITLE
fix: json rpc subscriptions

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/subscriptions/subscriptions.ts
+++ b/packages/calimero-sdk/src/subscriptions/subscriptions.ts
@@ -1,10 +1,10 @@
 import { ContextId } from '../types/context';
 
 export interface SubscriptionsClient {
-  connect(connectionId: string): void;
-  disconnect(connectionId: string): void;
-  subscribe(applicationIds: string[], connectionId?: string): void;
-  unsubscribe(applicationIds: string[], connectionId?: string): void;
+  connect(connectionId?: string): Promise<void>;
+  disconnect(connectionId?: string): void;
+  subscribe(contextIds: string[], connectionId?: string): void;
+  unsubscribe(contextIds: string[], connectionId?: string): void;
   addCallback(callback: (data: NodeEvent) => void, connectionId?: string): void;
   removeCallback(
     callback: (data: NodeEvent) => void,
@@ -17,13 +17,14 @@ export type NodeEvent = ApplicationEvent;
 export interface ApplicationEvent {
   context_id: ContextId;
   type: 'TransactionExecuted' | 'PeerJoined';
-  data: TransactionExecuted | PeerJoined;
+  data: OutcomeEvents;
 }
 
-export interface TransactionExecuted {
-  hash: string;
+export interface OutcomeEvent {
+  kind: String;
+  data: number[];
 }
 
-export interface PeerJoined {
-  peerId: string;
+export interface OutcomeEvents {
+  events: OutcomeEvent[];
 }

--- a/packages/calimero-sdk/src/subscriptions/ws.ts
+++ b/packages/calimero-sdk/src/subscriptions/ws.ts
@@ -17,11 +17,11 @@ interface WsResponse {
 }
 
 interface SubscribeRequest {
-  applicationIds: string[];
+  contextIds: string[];
 }
 
 interface UnsubscribeRequest {
-  applicationIds: string[];
+  contextIds: string[];
 }
 
 export class WsSubscriptionsClient implements SubscriptionsClient {
@@ -61,7 +61,7 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
   }
 
   public subscribe(
-    applicationIds: string[],
+    contextIds: string[],
     connectionId: string = DEFAULT_CONNECTION_ID,
   ): void {
     const websocket = this.connections.get(connectionId);
@@ -71,15 +71,16 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
         id: requestId,
         method: 'subscribe',
         params: {
-          applicationIds: applicationIds,
+          contextIds: contextIds,
         },
       };
+
       websocket.send(JSON.stringify(request));
     }
   }
 
   public unsubscribe(
-    applicationIds: string[],
+    contextIds: string[],
     connectionId: string = DEFAULT_CONNECTION_ID,
   ): void {
     const websocket = this.connections.get(connectionId);
@@ -89,7 +90,7 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
         id: requestId,
         method: 'unsubscribe',
         params: {
-          applicationIds: applicationIds,
+          contextIds: contextIds,
         },
       };
       websocket.send(JSON.stringify(request));
@@ -120,7 +121,7 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
     }
   }
 
-  private handleMessage(connection_id: string, event: any): void {
+  private handleMessage(connectionId: string, event: any): void {
     const response: WsResponse = JSON.parse(event.data.toString());
     if (response.id !== null) {
       // TODO: handle non event messages gracefully
@@ -132,7 +133,7 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
       return;
     }
 
-    const callbacks = this.callbacks.get(connection_id);
+    const callbacks = this.callbacks.get(connectionId);
     if (callbacks) {
       for (const callback of callbacks) {
         const nodeEvent: NodeEvent = response.result;


### PR DESCRIPTION
Test:

I have an [app](https://github.com/calimero-network/core-app-template/pull/6) that receives new value after mutation with button. 

https://github.com/user-attachments/assets/64f9f9df-7b3e-4a57-b876-81b19fcf2574

