### PR TITLE
fix(network): handle NewExternalAddrOfPeer event

### DIFF
--- a/crates/network/src/events.rs
+++ b/crates/network/src/events.rs
@@ -156,6 +156,9 @@ impl EventLoop {
                     };
                 }
             }
+            SwarmEvent::NewExternalAddrOfPeer { peer_id, address } => {
+                debug!("New external address of peer: {} {}", peer_id, address);
+            }
             unhandled => warn!("Unhandled event: {:?}", unhandled),
         }
     }


### PR DESCRIPTION
This event is generated by one of the 'newer' behaviors we integrated, so it was forgotten to handle. In `chat-example` which had those behaviors from get-go it is handled: https://github.com/calimero-network/boot-node/blob/45420bfacad5c0b82280f1b5a7f45bcd6d5f2a3f/examples/chat/src/network/events.rs#L139-L141

