### PR TITLE
fix(admin-api): link installed application with package manager

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -431,8 +431,7 @@ impl ContextManager {
             blob: application.blob.blob_id(),
             version: application.version.as_deref().map(str::parse).transpose()?,
             source: application.source.parse()?,
-            metadata: application
-                .metadata.to_vec()
+            metadata: application.metadata.to_vec(),
         }))
     }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -334,6 +334,7 @@ impl ContextManager {
         &self,
         path: Utf8PathBuf,
         version: Option<semver::Version>,
+        metadata: Vec<u8>,
     ) -> eyre::Result<calimero_primitives::application::ApplicationId> {
         let file = fs::File::open(&path).await?;
 
@@ -346,7 +347,7 @@ impl ContextManager {
             eyre::bail!("non-absolute path")
         };
 
-        self.install_application(blob_id, uri.as_str().parse()?, version, Vec::new())
+        self.install_application(blob_id, uri.as_str().parse()?, version, metadata)
     }
 
     pub async fn install_application_from_url(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -313,7 +313,7 @@ impl ContextManager {
             blob: calimero_store::key::BlobMeta::new(blob_id),
             version: version.map(|v| v.to_string().into_boxed_str()),
             source: source.to_string().into_boxed_str(),
-            metadata: metadata.map(|s| s.into_boxed_str()),
+            metadata: metadata.map(|s| s.into_bytes().into_boxed_slice()),
         };
 
         let application_id = calimero_primitives::application::ApplicationId::from(
@@ -379,13 +379,12 @@ impl ContextManager {
 
         for (id, app) in iter.entries() {
             let (id, app) = (id?, app?);
-
             applications.push(calimero_primitives::application::Application {
                 id: id.application_id(),
                 blob: app.blob.blob_id(),
                 version: app.version.as_deref().map(str::parse).transpose()?,
                 source: app.source.parse()?,
-                metadata: app.metadata.as_deref().map(str::parse).transpose()?,
+                metadata: app.metadata.map(|m| m.into_vec()),
             })
         }
 
@@ -433,10 +432,7 @@ impl ContextManager {
             version: application.version.as_deref().map(str::parse).transpose()?,
             source: application.source.parse()?,
             metadata: application
-                .metadata
-                .as_deref()
-                .map(str::parse)
-                .transpose()?,
+                .metadata.map(|m| m.into_vec())
         }))
     }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -307,18 +307,13 @@ impl ContextManager {
         blob_id: calimero_primitives::blobs::BlobId,
         source: calimero_primitives::application::ApplicationSource,
         version: Option<semver::Version>,
-        contract_app_id: Option<String>,
+        metadata: Option<String>,
     ) -> eyre::Result<calimero_primitives::application::ApplicationId> {
-        let contract_app_id: Box<str> = match contract_app_id {
-            Some(s) => s.into_boxed_str(),
-            None => Box::from(""),
-        };
-
         let application = calimero_store::types::ApplicationMeta {
             blob: calimero_store::key::BlobMeta::new(blob_id),
             version: version.map(|v| v.to_string().into_boxed_str()),
             source: source.to_string().into_boxed_str(),
-            contract_app_id: Some(contract_app_id),
+            metadata: metadata.map(|s| s.into_boxed_str()),
         };
 
         let application_id = calimero_primitives::application::ApplicationId::from(
@@ -358,7 +353,7 @@ impl ContextManager {
         &self,
         url: Url,
         version: Option<semver::Version>,
-        contract_app_id: Option<String>,
+        metadata: Option<String>,
         // hash: calimero_primitives::hash::Hash,
         // todo! BlobMgr should return hash of content
     ) -> eyre::Result<calimero_primitives::application::ApplicationId> {
@@ -370,7 +365,7 @@ impl ContextManager {
 
         // todo! if blob hash doesn't match, remove it
 
-        self.install_application(blob_id, uri, version, Some(contract_app_id).unwrap())
+        self.install_application(blob_id, uri, version, metadata)
     }
 
     pub fn list_installed_applications(
@@ -390,7 +385,7 @@ impl ContextManager {
                 blob: app.blob.blob_id(),
                 version: app.version.as_deref().map(str::parse).transpose()?,
                 source: app.source.parse()?,
-                contract_app_id: app.contract_app_id.as_deref().map(str::parse).transpose()?,
+                metadata: app.metadata.as_deref().map(str::parse).transpose()?,
             })
         }
 
@@ -437,7 +432,11 @@ impl ContextManager {
             blob: application.blob.blob_id(),
             version: application.version.as_deref().map(str::parse).transpose()?,
             source: application.source.parse()?,
-            contract_app_id: application.contract_app_id.as_deref().map(str::parse).transpose()?,
+            metadata: application
+                .metadata
+                .as_deref()
+                .map(str::parse)
+                .transpose()?,
         }))
     }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -309,7 +309,7 @@ impl ContextManager {
         version: Option<semver::Version>,
         contract_app_id: Option<String>,
     ) -> eyre::Result<calimero_primitives::application::ApplicationId> {
-        let boxed_id: Box<str> = match contract_app_id {
+        let contract_app_id: Box<str> = match contract_app_id {
             Some(s) => s.into_boxed_str(),
             None => Box::from(""),
         };
@@ -318,7 +318,7 @@ impl ContextManager {
             blob: calimero_store::key::BlobMeta::new(blob_id),
             version: version.map(|v| v.to_string().into_boxed_str()),
             source: source.to_string().into_boxed_str(),
-            contract_app_id: Some(boxed_id),
+            contract_app_id: Some(contract_app_id),
         };
 
         let application_id = calimero_primitives::application::ApplicationId::from(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -307,13 +307,13 @@ impl ContextManager {
         blob_id: calimero_primitives::blobs::BlobId,
         source: calimero_primitives::application::ApplicationSource,
         version: Option<semver::Version>,
-        metadata: Option<String>,
+        metadata: Vec<u8>,
     ) -> eyre::Result<calimero_primitives::application::ApplicationId> {
         let application = calimero_store::types::ApplicationMeta {
             blob: calimero_store::key::BlobMeta::new(blob_id),
             version: version.map(|v| v.to_string().into_boxed_str()),
             source: source.to_string().into_boxed_str(),
-            metadata: metadata.map(|s| s.into_bytes().into_boxed_slice()),
+            metadata: metadata.into_boxed_slice(),
         };
 
         let application_id = calimero_primitives::application::ApplicationId::from(
@@ -346,14 +346,14 @@ impl ContextManager {
             eyre::bail!("non-absolute path")
         };
 
-        self.install_application(blob_id, uri.as_str().parse()?, version, None)
+        self.install_application(blob_id, uri.as_str().parse()?, version, Vec::new())
     }
 
     pub async fn install_application_from_url(
         &self,
         url: Url,
         version: Option<semver::Version>,
-        metadata: Option<String>,
+        metadata: Vec<u8>,
         // hash: calimero_primitives::hash::Hash,
         // todo! BlobMgr should return hash of content
     ) -> eyre::Result<calimero_primitives::application::ApplicationId> {
@@ -384,7 +384,7 @@ impl ContextManager {
                 blob: app.blob.blob_id(),
                 version: app.version.as_deref().map(str::parse).transpose()?,
                 source: app.source.parse()?,
-                metadata: app.metadata.map(|m| m.into_vec()),
+                metadata: app.metadata.to_vec(),
             })
         }
 
@@ -432,7 +432,7 @@ impl ContextManager {
             version: application.version.as_deref().map(str::parse).transpose()?,
             source: application.source.parse()?,
             metadata: application
-                .metadata.map(|m| m.into_vec())
+                .metadata.to_vec()
         }))
     }
 

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -17,6 +17,7 @@ pub struct InstallCommand {
     /// Version of the application
     #[clap(short, long, help = "Version of the application")]
     pub version: Option<Version>,
+    pub metadata: Option<Vec<u8>>,
 }
 
 impl InstallCommand {
@@ -42,6 +43,7 @@ impl InstallCommand {
         let install_request = calimero_server_primitives::admin::InstallDevApplicationRequest {
             path: self.path.canonicalize_utf8()?,
             version: self.version,
+            metadata: self.metadata.unwrap_or(Vec::new()),
         };
 
         let install_response = client

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -30,7 +30,6 @@ impl InstallCommand {
         let Ok(config) = ConfigFile::load(&path) else {
             eyre::bail!("Failed to load config file")
         };
-
         let Some(multiaddr) = config.network.server.listen.first() else {
             eyre::bail!("No address.")
         };
@@ -40,7 +39,7 @@ impl InstallCommand {
         let install_url = multiaddr_to_url(multiaddr, "admin-api/dev/install-application")?;
 
         let install_request = calimero_server_primitives::admin::InstallDevApplicationRequest {
-            path: self.path,
+            path: self.path.canonicalize_utf8()?,
             version: self.version,
         };
 

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -30,6 +30,7 @@ impl InstallCommand {
         let Ok(config) = ConfigFile::load(&path) else {
             eyre::bail!("Failed to load config file")
         };
+
         let Some(multiaddr) = config.network.server.listen.first() else {
             eyre::bail!("No address.")
         };

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -391,7 +391,7 @@ impl Node {
                         .install_application_from_url(
                             change.source.to_string().parse()?,
                             change.version,
-                            Vec::new()
+                            Vec::new(),
                         )
                         .await?;
                 }

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -391,7 +391,7 @@ impl Node {
                         .install_application_from_url(
                             change.source.to_string().parse()?,
                             change.version,
-                            None
+                            Vec::new()
                         )
                         .await?;
                 }

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -391,6 +391,7 @@ impl Node {
                         .install_application_from_url(
                             change.source.to_string().parse()?,
                             change.version,
+                            None
                         )
                         .await?;
                 }

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -89,6 +89,7 @@ impl Node {
                     version: application.version,
                     source: url,
                     hash: None, // todo! blob_mgr(application.blob)?.hash
+                    metadata: Some(Vec::new()),
                 },
             ))?;
             stream

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -344,16 +344,17 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
 
                 match subcommand {
                     "install" => {
-                        let Some((type_, resource, version)) = args.and_then(|args| {
+                        let Some((type_, resource, version, metadata)) = args.and_then(|args| {
                             let mut iter = args.split(' ');
                             let type_ = iter.next()?;
                             let resource = iter.next()?;
                             let version = iter.next();
+                            let metadata = iter.next()?.as_bytes().to_vec();
 
-                            Some((type_, resource, version))
+                            Some((type_, resource, version, metadata))
                         }) else {
                             println!(
-                                "{IND} Usage: application install <\"url\"|\"file\"> <resource> [version]"
+                                "{IND} Usage: application install <\"url\"|\"file\"> <resource> [version] <metadata>"
                             );
                             break 'done;
                         };
@@ -380,7 +381,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                                 let path = camino::Utf8PathBuf::from(resource);
 
                                 node.ctx_manager
-                                    .install_application_from_path(path, version)
+                                    .install_application_from_path(path, version, metadata)
                                     .await?
                             }
                             unknown => {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -373,7 +373,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                                 println!("{IND} Downloading application..");
 
                                 node.ctx_manager
-                                    .install_application_from_url(url, version, None)
+                                    .install_application_from_url(url, version, Vec::new())
                                     .await?
                             }
                             "file" => {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -373,7 +373,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                                 println!("{IND} Downloading application..");
 
                                 node.ctx_manager
-                                    .install_application_from_url(url, version)
+                                    .install_application_from_url(url, version, None)
                                     .await?
                             }
                             "file" => {

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -50,6 +50,7 @@ pub struct CatchupApplicationChanged {
     pub version: Option<semver::Version>,
     pub source: calimero_primitives::application::ApplicationSource,
     pub hash: Option<calimero_primitives::hash::Hash>,
+    pub metadata: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -94,13 +94,12 @@ impl fmt::Display for ApplicationSource {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Application {
-    // Metadata - Contains application ID is hash(owner,name) saved in package manager contract
-    pub metadata: Option<Vec<u8>>,
     // id - Application ID created in the node for identification - see line 324 crates/context/src/lib.rs
     pub id: ApplicationId,
     pub blob: BlobId,
     pub version: Option<semver::Version>,
     pub source: ApplicationSource,
+    pub metadata: Vec<u8>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -94,7 +94,6 @@ impl fmt::Display for ApplicationSource {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Application {
-    // id - Application ID created in the node for identification - see line 324 crates/context/src/lib.rs
     pub id: ApplicationId,
     pub blob: BlobId,
     pub version: Option<semver::Version>,

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -94,8 +94,8 @@ impl fmt::Display for ApplicationSource {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Application {
-    // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
-    pub contract_app_id: Option<String>,
+    // Metadata - Contains application ID is hash(owner,name) saved in package manager contract
+    pub metadata: Option<String>,
     // id - Application ID created in the node for identification - see line 324 crates/context/src/lib.rs
     pub id: ApplicationId,
     pub blob: BlobId,

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -96,7 +96,7 @@ impl fmt::Display for ApplicationSource {
 pub struct Application {
     // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
     pub contract_app_id: Option<String>,
-    // id - Applicaiton ID created in the node for identification - see line 324 crates/context/src/lib.rs
+    // id - Application ID created in the node for identification - see line 324 crates/context/src/lib.rs
     pub id: ApplicationId,
     pub blob: BlobId,
     pub version: Option<semver::Version>,

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -95,7 +95,7 @@ impl fmt::Display for ApplicationSource {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Application {
     // Metadata - Contains application ID is hash(owner,name) saved in package manager contract
-    pub metadata: Option<String>,
+    pub metadata: Option<Vec<u8>>,
     // id - Application ID created in the node for identification - see line 324 crates/context/src/lib.rs
     pub id: ApplicationId,
     pub blob: BlobId,

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -94,7 +94,9 @@ impl fmt::Display for ApplicationSource {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Application {
+    // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
     pub contract_app_id: Option<String>,
+    // id - Applicaiton ID created in the node for identification - see line 324 crates/context/src/lib.rs
     pub id: ApplicationId,
     pub blob: BlobId,
     pub version: Option<semver::Version>,

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -94,6 +94,7 @@ impl fmt::Display for ApplicationSource {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Application {
+    pub contract_app_id: Option<String>,
     pub id: ApplicationId,
     pub blob: BlobId,
     pub version: Option<semver::Version>,

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -5,11 +5,10 @@ use serde_json::Value;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct InstallApplicationRequest {
-    // Metadata - Contains application ID is hash(owner,name) saved in package manager contract
-    pub metadata: String,
     pub url: url::Url,
     pub version: Option<semver::Version>,
     pub hash: Option<calimero_primitives::hash::Hash>,
+    pub metadata: Vec<u8>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -5,9 +5,10 @@ use serde_json::Value;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct InstallApplicationRequest {
+    pub contract_app_id: String,
     pub url: url::Url,
     pub version: Option<semver::Version>,
-    pub hash: calimero_primitives::hash::Hash,
+    pub hash: Option<calimero_primitives::hash::Hash>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct InstallApplicationRequest {
+    // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
     pub contract_app_id: String,
     pub url: url::Url,
     pub version: Option<semver::Version>,

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct InstallApplicationRequest {
-    // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
-    pub contract_app_id: String,
+    // Metadata - Contains application ID is hash(owner,name) saved in package manager contract
+    pub metadata: String,
     pub url: url::Url,
     pub version: Option<semver::Version>,
     pub hash: Option<calimero_primitives::hash::Hash>,

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -15,6 +15,7 @@ pub struct InstallApplicationRequest {
 pub struct InstallDevApplicationRequest {
     pub path: Utf8PathBuf,
     pub version: Option<semver::Version>,
+    pub metadata: Vec<u8>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/server/src/admin/handlers/applications.rs
+++ b/crates/server/src/admin/handlers/applications.rs
@@ -17,7 +17,7 @@ pub async fn install_dev_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application_from_path(req.path, req.version)
+        .install_application_from_path(req.path, req.version, req.metadata)
         .await
     {
         Ok(application_id) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -225,7 +225,11 @@ async fn install_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application_from_url(req.url, req.version, Some(req.contract_app_id) /*, req.hash */)
+        .install_application_from_url(
+            req.url,
+            req.version,
+            Some(req.metadata), /*, req.hash */
+        )
         .await
     {
         Ok(application_id) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -225,7 +225,7 @@ async fn install_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application_from_url(req.url, req.version /*, req.hash */)
+        .install_application_from_url(req.url, req.version, Some(req.contract_app_id) /*, req.hash */)
         .await
     {
         Ok(application_id) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -225,11 +225,7 @@ async fn install_application_handler(
 ) -> impl IntoResponse {
     match state
         .ctx_manager
-        .install_application_from_url(
-            req.url,
-            req.version,
-            req.metadata, /*, req.hash */
-        )
+        .install_application_from_url(req.url, req.version, req.metadata /*, req.hash */)
         .await
     {
         Ok(application_id) => ApiResponse {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -228,7 +228,7 @@ async fn install_application_handler(
         .install_application_from_url(
             req.url,
             req.version,
-            Some(req.metadata), /*, req.hash */
+            req.metadata, /*, req.hash */
         )
         .await
     {

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -11,8 +11,8 @@ pub struct ApplicationMeta {
     pub blob: key::BlobMeta,
     pub version: Option<Box<str>>,
     pub source: Box<str>,
-    // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
-    pub contract_app_id: Option<Box<str>>,
+    // metadata - Contains application ID is hash(owner,name) saved in package manager contract
+    pub metadata: Option<Box<str>>,
 }
 
 impl PredefinedEntry for key::ApplicationMeta {

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -11,6 +11,7 @@ pub struct ApplicationMeta {
     pub blob: key::BlobMeta,
     pub version: Option<Box<str>>,
     pub source: Box<str>,
+    pub contract_app_id: Option<Box<str>>,
 }
 
 impl PredefinedEntry for key::ApplicationMeta {

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -11,8 +11,7 @@ pub struct ApplicationMeta {
     pub blob: key::BlobMeta,
     pub version: Option<Box<str>>,
     pub source: Box<str>,
-    // metadata - Contains application ID is hash(owner,name) saved in package manager contract
-    pub metadata: Option<Box<[u8]>>,
+    pub metadata: Box<[u8]>,
 }
 
 impl PredefinedEntry for key::ApplicationMeta {

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -11,6 +11,7 @@ pub struct ApplicationMeta {
     pub blob: key::BlobMeta,
     pub version: Option<Box<str>>,
     pub source: Box<str>,
+    // contract_app_id - Application ID is hash(owner,name) saved in package manager contract
     pub contract_app_id: Option<Box<str>>,
 }
 

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -12,7 +12,7 @@ pub struct ApplicationMeta {
     pub version: Option<Box<str>>,
     pub source: Box<str>,
     // metadata - Contains application ID is hash(owner,name) saved in package manager contract
-    pub metadata: Option<Box<str>>,
+    pub metadata: Option<Box<[u8]>>,
 }
 
 impl PredefinedEntry for key::ApplicationMeta {


### PR DESCRIPTION
# fix(admin-api): link installed application with package manager

## Summary
The issue with previous approach is that it is missing a link between application metadata that is saved in the package-manager smart contract and this is needed for properly displaying and identifying applications from the admin dashboard.
