### PR TITLE
refactor: unify context creation

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -2,6 +2,7 @@ use calimero_primitives::events::OutcomeEvent;
 use calimero_primitives::identity::{KeyPair, PublicKey};
 use calimero_runtime::logic::VMLimits;
 use calimero_runtime::Constraint;
+use calimero_server::admin::utils::context::create_context;
 use calimero_store::Store;
 use libp2p::gossipsub::{IdentTopic, TopicHash};
 use libp2p::identity as p2p_identity;
@@ -524,22 +525,13 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                         println!("{IND} Left context {}", context_id);
                     }
                     "create" => {
-                        let Some((context_id, application_id, private_key)) =
-                            args.and_then(|args| {
-                                let mut iter = args.split(' ');
-                                let context = iter.next()?;
-                                let application = iter.next()?;
-                                let private_key = iter.next()?;
-
-                                Some((context, application, private_key))
-                            })
-                        else {
-                            println!("{IND} Usage: context create <context_id> <application_id> <private_key>");
-                            break 'done;
-                        };
-
-                        let Ok(context_id) = context_id.parse() else {
-                            println!("{IND} Invalid context ID: {}", context_id);
+                        let Some((application_id, private_key)) = args.and_then(|args| {
+                            let mut iter = args.split(' ');
+                            let application = iter.next()?;
+                            let private_key = iter.next();
+                            Some((application, private_key))
+                        }) else {
+                            println!("{IND} Usage: context create <application_id> [private_key]");
                             break 'done;
                         };
 
@@ -548,35 +540,10 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                             break 'done;
                         };
 
-                        let context = calimero_primitives::context::Context {
-                            id: context_id,
-                            application_id,
-                            last_transaction_hash: calimero_primitives::hash::Hash::default(),
-                        };
+                        let context_create_result =
+                            create_context(&node.ctx_manager, application_id, private_key).await?;
 
-                        // Parse the private key
-                        let private_key = bs58::decode(private_key)
-                            .into_vec()
-                            .map_err(|_| eyre::eyre!("Invalid private key"))?;
-                        let private_key: [u8; 32] = private_key
-                            .try_into()
-                            .map_err(|_| eyre::eyre!("Private key must be 32 bytes"))?;
-
-                        // Generate the public key from the private key
-                        let public_key = PublicKey::derive_from_private_key(&private_key);
-
-                        // Create the KeyPair
-                        let initial_identity = KeyPair {
-                            public_key,
-                            private_key: Some(private_key),
-                        };
-
-                        // We don't have the identity at this point
-                        node.ctx_manager
-                            .add_context(context, initial_identity)
-                            .await?;
-
-                        println!("{IND} Created context {}", context_id);
+                        println!("{IND} Created context {}", context_create_result.context.id);
                     }
                     "delete" => {
                         let Some(context_id) = args else {

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1,4 +1,4 @@
 pub mod handlers;
 pub mod service;
 pub mod storage;
-mod utils;
+pub mod utils;

--- a/crates/server/src/admin/utils.rs
+++ b/crates/server/src/admin/utils.rs
@@ -1,2 +1,3 @@
 pub mod auth;
+pub mod context;
 pub mod identity;

--- a/crates/server/src/admin/utils/context.rs
+++ b/crates/server/src/admin/utils/context.rs
@@ -1,0 +1,53 @@
+use calimero_primitives::context::Context;
+use calimero_primitives::identity::{KeyPair, PublicKey};
+
+use super::identity::{generate_context_id, generate_identity_keypair};
+
+pub struct ContextCreateResult {
+    pub context: Context,
+    pub identity: KeyPair,
+}
+
+pub async fn create_context(
+    ctx_manager: &calimero_context::ContextManager,
+    application_id: calimero_primitives::application::ApplicationId,
+    private_key: Option<&str>,
+) -> Result<ContextCreateResult, eyre::Error> {
+    let context_id = generate_context_id();
+    let context = calimero_primitives::context::Context {
+        id: context_id,
+        application_id,
+        last_transaction_hash: calimero_primitives::hash::Hash::default(),
+    };
+
+    let initial_identity = if let Some(private_key) = private_key {
+        // Parse the private key
+        let private_key = bs58::decode(private_key)
+            .into_vec()
+            .map_err(|_| eyre::eyre!("Invalid private key"))?;
+        let private_key: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| eyre::eyre!("Private key must be 32 bytes"))?;
+
+        // Generate the public key from the private key
+        let public_key = PublicKey::derive_from_private_key(&private_key);
+        // Create a KeyPair from the provided public and private keys
+        KeyPair {
+            public_key,
+            private_key: Some(private_key),
+        }
+    } else {
+        generate_identity_keypair()
+    };
+
+    ctx_manager
+        .add_context(context.clone(), initial_identity.clone())
+        .await?;
+
+    let context_create_result = ContextCreateResult {
+        context,
+        identity: initial_identity,
+    };
+
+    Ok(context_create_result)
+}

--- a/crates/server/src/admin/utils/identity.rs
+++ b/crates/server/src/admin/utils/identity.rs
@@ -1,5 +1,6 @@
 use calimero_primitives::identity::{KeyPair, PublicKey};
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::RngCore;
 
 pub fn generate_identity_keypair() -> KeyPair {
     let member_seed = [0u8; 32];
@@ -9,4 +10,15 @@ pub fn generate_identity_keypair() -> KeyPair {
         public_key: PublicKey(*member_verifying_key.as_bytes()),
         private_key: Some(*member_signing_key.as_bytes()),
     }
+}
+
+pub fn generate_context_id() -> calimero_primitives::context::ContextId {
+    // Create a Send-able RNG
+    let mut rng = rand::thread_rng();
+    // Generate a key pair for the context ID
+    let mut context_seed = [0u8; 32];
+    rng.fill_bytes(&mut context_seed);
+    let context_signing_key = SigningKey::from_bytes(&context_seed);
+    let context_verifying_key = VerifyingKey::from(&context_signing_key);
+    calimero_primitives::context::ContextId::from(*context_verifying_key.as_bytes())
 }


### PR DESCRIPTION
Unify context creation code in `node` and `server`.

- remove contextId from parameters during context creation with CLI
- indicate that private_key is optional in CLI

Test
`cargo run -p  meroctl -- --node-name node1 --home data context create --application-id 5Fi5jFcwoNVkV9Ngzc2Gs18GKKFtaAbsg72bdxi4FAhV`

`context create 5Fi5jFcwoNVkV9Ngzc2Gs18GKKFtaAbsg72bdxi4FAhV
`