### PR TITLE
feat(sdk): update json rpc request type

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.29",
+  "version": "0.0.31",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/types/rpc.ts
+++ b/packages/calimero-sdk/src/types/rpc.ts
@@ -64,6 +64,8 @@ export interface RpcQueryParams<Args> {
   contextId: ContextId;
   method: string;
   argsJson: Args;
+  executorPublicKey: number[];
+
 }
 
 export interface RpcQueryResponse<Output> {
@@ -74,6 +76,7 @@ export interface RpcMutateParams<Args> {
   contextId: ContextId;
   method: string;
   argsJson: Args;
+  executorPublicKey: number[];
 }
 
 export interface RpcMutateResponse<Output> {


### PR DESCRIPTION
# feat(sdk): update json rpc request type

## Summary
Updated types as json rpc now requires executor public key.
Type of number as public key bytes need to be transformed from uint8Array because its throwing 
error from server:` "invalid type: map, expected an array of length 32"`