### PR TITLE
fix(calimero-sdk): revert near wallet type

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.28",
+  "version": "0.0.30",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/api/nodeApi.ts
+++ b/packages/calimero-sdk/src/api/nodeApi.ts
@@ -12,16 +12,12 @@ interface ETHWalletType extends WalletTypeBase<'ETH'> {
   chainId: number;
 }
 
-interface NEARWalletType extends WalletTypeBase<'NEAR'> {
-  networkId: string;
-}
+interface NEARWalletType extends WalletTypeBase<'NEAR'> {}
 
 export type WalletType = ETHWalletType | NEARWalletType;
 
 export namespace WalletType {
-  export function NEAR({ networkId = "mainnet" }: { networkId?: string }): WalletType {
-    return { type: 'NEAR', networkId } as NEARWalletType;
-  }
+  export let NEAR: WalletType = { type: 'NEAR' } as NEARWalletType;
 
   export function ETH({ chainId = 1 }: { chainId?: number }): WalletType {
     return { type: 'ETH', chainId } as ETHWalletType;

--- a/packages/calimero-sdk/src/auth/headers.ts
+++ b/packages/calimero-sdk/src/auth/headers.ts
@@ -1,9 +1,9 @@
 import { unmarshalPrivateKey } from '@libp2p/crypto/keys';
 import { PrivateKey } from '@libp2p/interface';
 import bs58 from 'bs58';
-// import { WalletType } from '../api/nodeApi';
 import { ClientKey } from '../types/storage';
 import { getStorageClientKey } from '../storage/storage';
+import { WalletType } from '../api/nodeApi';
 
 export interface Header {
   [key: string]: string;
@@ -32,8 +32,7 @@ export async function createAuthHeader(
   const contentBase58 = bs58.encode(hashArray);
 
   const headers: Header = {
-    // todo! what to do here?
-    // wallet_type: JSON.stringify(WalletType.NEAR),
+    wallet_type: JSON.stringify(WalletType.NEAR),
     signing_key: signingKey,
     signature: signatureBase58,
     challenge: contentBase58,

--- a/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
+++ b/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
@@ -232,7 +232,7 @@ export const NearLogin: React.FC<NearLoginProps> = ({
         publicKey: publicKey,
       };
       const walletMetadata: WalletMetadata = {
-        wallet: WalletType.NEAR({ networkId: selector.options.network.networkId }),
+        wallet: WalletType.NEAR,
         signingKey: publicKey,
       };
       const loginRequest: LoginRequest = {

--- a/packages/calimero-sdk/src/wallets/NearLogin/NearRootKey.tsx
+++ b/packages/calimero-sdk/src/wallets/NearLogin/NearRootKey.tsx
@@ -219,7 +219,7 @@ export const NearRootKey: React.FC<NearRootKeyProps> = ({
         metadata: signatureMetadata,
       };
       const walletMetadata: WalletMetadata = {
-        wallet: WalletType.NEAR({ networkId: selector.options.network.networkId }),
+        wallet: WalletType.NEAR,
         signingKey: publicKey,
       };
       const rootKeyRequest: RootKeyRequest = {


### PR DESCRIPTION
# fix(calimero-sdk): revert near wallet type

## Summary
As server does not need to know NEAR network (mainnet / testnet) reverted changes to previous implementation