### PR TITLE
fix(rocksdb): pre-sought iter accomodations

### DIFF
--- a/crates/store/src/db/memory.rs
+++ b/crates/store/src/db/memory.rs
@@ -192,8 +192,10 @@ impl<'this> InMemoryDBIter<'this> {
         K: Ord + CastsTo<Slice<'a>>,
         V: CastsTo<Slice<'a>>,
     {
-        // safety: {K, V}: CastsTo<Slice>
-        unsafe { std::mem::transmute(inner) }
+        InMemoryDBIter {
+            // safety: {K, V}: CastsTo<Slice>
+            inner: unsafe { std::mem::transmute(inner) },
+        }
     }
 }
 


### PR DESCRIPTION
RocksDB's raw iter requires seeking [to the start](https://github.com/calimero-network/core/blob/a35dd9a1ec16ebf83c2b3e15cf9960f4ec923dd4/crates/store/src/db/rocksdb.rs#L77), at which point we have the first item. Since this isn't a product of calling `DBIter::seek`, we haven't gotten the item, so this is an accommodation for reading the value in the first call of `next`.

This makes us behaviorally equivalent to `InMemoryIter`.