### PR TITLE
feat(sdk): add context identity logic

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/api/dataSource/NodeApiDataSource.ts
+++ b/packages/calimero-sdk/src/api/dataSource/NodeApiDataSource.ts
@@ -1,5 +1,6 @@
 import { ApiResponse } from '../../types/api-response';
 import {
+  ContextResponse,
   HealthRequest,
   HealthStatus,
   LoginRequest,
@@ -42,6 +43,16 @@ export class NodeApiDataSource implements NodeApi {
       {
         ...loginRequest,
       },
+    );
+  }
+
+  async getContextIdentity(rpcBaseUrl: string): ApiResponse<ContextResponse> {
+    const contextId = process.env['NEXT_PUBLIC_CONTEXT_ID'];
+    const headers: Header | null = await createAuthHeader(contextId);
+
+    return await this.client.get<ContextResponse>(
+      `${rpcBaseUrl}/admin-api/contexts/${contextId}/identities`,
+      headers
     );
   }
 

--- a/packages/calimero-sdk/src/api/dataSource/NodeApiDataSource.ts
+++ b/packages/calimero-sdk/src/api/dataSource/NodeApiDataSource.ts
@@ -46,8 +46,7 @@ export class NodeApiDataSource implements NodeApi {
     );
   }
 
-  async getContextIdentity(rpcBaseUrl: string): ApiResponse<ContextResponse> {
-    const contextId = process.env['NEXT_PUBLIC_CONTEXT_ID'];
+  async getContextIdentity(rpcBaseUrl: string, contextId: string): ApiResponse<ContextResponse> {
     const headers: Header | null = await createAuthHeader(contextId);
 
     return await this.client.get<ContextResponse>(

--- a/packages/calimero-sdk/src/api/httpClient.ts
+++ b/packages/calimero-sdk/src/api/httpClient.ts
@@ -6,7 +6,8 @@ export interface Header {
 }
 
 export interface HttpClient {
-  get<T>(url: string, headers?: Header[]): Promise<ResponseData<T>>;
+  get<T>(url: string,
+    headers?: Header,): Promise<ResponseData<T>>;
   post<T>(
     url: string,
     body?: unknown,
@@ -37,11 +38,9 @@ export class AxiosHttpClient implements HttpClient {
     this.axios = axios;
   }
 
-  async get<T>(url: string, headers?: Header[]): Promise<ResponseData<T>> {
+  async get<T>(url: string, headers?: Header): Promise<ResponseData<T>> {
     return this.request<T>(
-      this.axios.get<ResponseData<T>>(url, {
-        headers: headers?.reduce((acc, curr) => ({ ...acc, ...curr }), {}),
-      }),
+      this.axios.get<ResponseData<T>>(url, { headers }),
     );
   }
 

--- a/packages/calimero-sdk/src/api/nodeApi.ts
+++ b/packages/calimero-sdk/src/api/nodeApi.ts
@@ -149,6 +149,9 @@ export interface NodeApi {
     rpcBaseUrl: string,
     contextId: string,
   ): ApiResponse<RootKeyResponse>;
-  getContextIdentity(rpcBaseUrl: string): ApiResponse<ContextResponse>;
+  getContextIdentity(
+    rpcBaseUrl: string,
+    contextId: string,
+  ): ApiResponse<ContextResponse>;
   health(request: HealthRequest): ApiResponse<HealthStatus>;
 }

--- a/packages/calimero-sdk/src/api/nodeApi.ts
+++ b/packages/calimero-sdk/src/api/nodeApi.ts
@@ -132,7 +132,7 @@ export interface HealthStatus {
 }
 
 export interface ContextResponse {
-  contextIdentities: string[];
+  identities: string[];
 }
 
 export interface NodeApi {

--- a/packages/calimero-sdk/src/api/nodeApi.ts
+++ b/packages/calimero-sdk/src/api/nodeApi.ts
@@ -131,6 +131,10 @@ export interface HealthStatus {
   status: string;
 }
 
+export interface ContextResponse {
+  contextIdentities: string[];
+}
+
 export interface NodeApi {
   login(
     loginRequest: LoginRequest,
@@ -145,5 +149,6 @@ export interface NodeApi {
     rpcBaseUrl: string,
     contextId: string,
   ): ApiResponse<RootKeyResponse>;
+  getContextIdentity(rpcBaseUrl: string): ApiResponse<ContextResponse>;
   health(request: HealthRequest): ApiResponse<HealthStatus>;
 }

--- a/packages/calimero-sdk/src/storage/storage.ts
+++ b/packages/calimero-sdk/src/storage/storage.ts
@@ -3,6 +3,7 @@ import { ClientKey } from '../types/storage';
 export const CLIENT_KEY = 'client-key';
 export const APP_URL = 'app-url';
 export const AUTHORIZED = 'node-authorized';
+export const CONTEXT_IDENTITY = "context-identity";
 
 export const setStorageClientKey = (clientKey: ClientKey) => {
   localStorage.setItem(CLIENT_KEY, JSON.stringify(clientKey));
@@ -26,6 +27,10 @@ export const clearClientKey = () => {
 
 export const setStorageNodeAuthorized = () => {
   localStorage.setItem(AUTHORIZED, JSON.stringify(true));
+};
+
+export const setExecutorPublicKey = (publicKey: string) => {
+  localStorage.setItem(CONTEXT_IDENTITY, JSON.stringify(publicKey));
 };
 
 export const getStorageNodeAuthorized = (): boolean | null => {

--- a/packages/calimero-sdk/src/wallets/MetamaskLogin/LoginWithMetamask.tsx
+++ b/packages/calimero-sdk/src/wallets/MetamaskLogin/LoginWithMetamask.tsx
@@ -139,14 +139,14 @@ export function LoginWithMetamask({
           if (
             !identity ||
             !identity.data ||
-            !identity.data.contextIdentities ||
-            identity.data.contextIdentities.length === 0
+            !identity.data.identities ||
+            identity.data.identities.length === 0
           ) {
             console.error('Login error: No context identities found');
             setErrorMessage('Error while login! No context identities found.');
           }
 
-          setExecutorPublicKey(identity.data.contextIdentities[0]);
+          setExecutorPublicKey(identity.data.identities[0]);
           setStorageNodeAuthorized();
           successRedirect();
         } catch (identityError) {

--- a/packages/calimero-sdk/src/wallets/MetamaskLogin/LoginWithMetamask.tsx
+++ b/packages/calimero-sdk/src/wallets/MetamaskLogin/LoginWithMetamask.tsx
@@ -135,8 +135,7 @@ export function LoginWithMetamask({
         try {
           const identity = await apiClient
             .node()
-            .getContextIdentity(rpcBaseUrl);
-
+            .getContextIdentity(rpcBaseUrl, contextId);
           if (
             !identity ||
             !identity.data ||

--- a/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
+++ b/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
@@ -258,13 +258,13 @@ export const NearLogin: React.FC<NearLoginProps> = ({
           if (
             !identity ||
             !identity.data ||
-            !identity.data.contextIdentities ||
-            identity.data.contextIdentities.length === 0
+            !identity.data.identities ||
+            identity.data.identities.length === 0
           ) {
             console.error('Login error: No context identities found');
           }
 
-          setExecutorPublicKey(identity.data.contextIdentities[0]);
+          setExecutorPublicKey(identity.data.identities[0]);
           setStorageNodeAuthorized();
           successRedirect();
         } catch (identityError) {

--- a/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
+++ b/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
@@ -253,7 +253,7 @@ export const NearLogin: React.FC<NearLoginProps> = ({
         try {
           const identity = await apiClient
             .node()
-            .getContextIdentity(rpcBaseUrl);
+            .getContextIdentity(rpcBaseUrl, contextId);
 
           if (
             !identity ||

--- a/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
+++ b/packages/calimero-sdk/src/wallets/NearLogin/NearLogin.tsx
@@ -13,7 +13,7 @@ import { useWalletSelector } from './WalletSelectorContext';
 import { getOrCreateKeypair } from '../../auth/ed25519';
 import apiClient from '../../api';
 import { ResponseData } from '../../types/api-response';
-import { setStorageNodeAuthorized } from '../../storage/storage';
+import { setExecutorPublicKey, setStorageNodeAuthorized } from '../../storage/storage';
 import { Loading } from '../loading/Loading';
 import {
   LoginRequest,
@@ -242,24 +242,37 @@ export const NearLogin: React.FC<NearLoginProps> = ({
         contextId,
       };
 
-      await apiClient
-        .node()
-        .login(loginRequest, rpcBaseUrl)
-        .then((result) => {
-          console.log('result', result);
-          if (result.error) {
-            console.error('login error', result.error);
-            //TODO handle error
-          } else {
-            setStorageNodeAuthorized();
-            successRedirect();
-            console.log('login success');
+      try {
+        const result = await apiClient.node().login(loginRequest, rpcBaseUrl);
+
+        if (result.error) {
+          console.error('Login error: ', result.error);
+          return;
+        }
+
+        try {
+          const identity = await apiClient
+            .node()
+            .getContextIdentity(rpcBaseUrl);
+
+          if (
+            !identity ||
+            !identity.data ||
+            !identity.data.contextIdentities ||
+            identity.data.contextIdentities.length === 0
+          ) {
+            console.error('Login error: No context identities found');
           }
-        })
-        .catch(() => {
-          console.error('error while login');
-          //TODO handle error
-        });
+
+          setExecutorPublicKey(identity.data.contextIdentities[0]);
+          setStorageNodeAuthorized();
+          successRedirect();
+        } catch (identityError) {
+          console.error('Error fetching context identity: ', identityError);
+        }
+      } catch (loginError) {
+        console.error('Login error: ', loginError);
+      }
     } else {
       //TODO handle error
       console.error('Message not verified');


### PR DESCRIPTION
# feat(sdk): add context identity logic

## Summary
JSON rpc now requires executor public key (for query and mutate requests) which we get by calling admin api endpoint /contexts/id/identities.
This api is fetched and its data stored to local storage under "context-identity". The fetch occurs after user logged in successfully. 

From the applications side the user now when building FE for the app only needs to fetch and parse context identity from local storage and use it as a param in JSON rpc requests under "executorPublicKey".

