### PR TITLE
feat: take initialization parameters at context creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ version = "0.1.0"
 dependencies = [
  "calimero-blobstore",
  "calimero-network",
+ "calimero-node-primitives",
  "calimero-primitives",
  "calimero-store",
  "camino",

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -21,4 +21,5 @@ tracing.workspace = true
 calimero-blobstore = { path = "../store/blobs" }
 calimero-primitives = { path = "../primitives", features = ["borsh"] }
 calimero-network = { path = "../network" }
+calimero-node-primitives = { path = "../node-primitives" }
 calimero-store = { path = "../store", features = ["datatypes"] }

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -26,7 +26,7 @@ pub struct CreateCommand {
     context_id: Option<ContextId>,
 
     #[clap(long, short = 'p')]
-    params: String,
+    params: Option<String>,
 }
 
 impl CreateCommand {
@@ -89,7 +89,7 @@ async fn create_context(
     base_multiaddr: &Multiaddr,
     application_id: calimero_primitives::application::ApplicationId,
     context_id: Option<ContextId>,
-    params: String,
+    params: Option<String>,
 ) -> eyre::Result<calimero_primitives::context::ContextId> {
     if !app_installed(&base_multiaddr, &application_id, client).await? {
         eyre::bail!("Application is not installed on node.")
@@ -99,7 +99,7 @@ async fn create_context(
     let request = calimero_server_primitives::admin::CreateContextRequest {
         application_id,
         context_id,
-        initialization_params: params.into_bytes(),
+        initialization_params: params.map(String::into_bytes).unwrap_or_default(),
     };
 
     let response = client.post(url).json(&request).send().await?;

--- a/crates/node-primitives/src/lib.rs
+++ b/crates/node-primitives/src/lib.rs
@@ -17,14 +17,16 @@ impl NodeType {
     }
 }
 
-pub type ServerSender = mpsc::Sender<(
-    calimero_primitives::context::ContextId,
-    String,
-    Vec<u8>,
-    bool,
-    [u8; 32],
-    oneshot::Sender<Result<calimero_runtime::logic::Outcome, CallError>>,
-)>;
+pub struct ExecutionRequest {
+    pub context_id: calimero_primitives::context::ContextId,
+    pub method: String,
+    pub payload: Vec<u8>,
+    pub writes: bool,
+    pub executor_public_key: [u8; 32],
+    pub outcome_sender: oneshot::Sender<Result<calimero_runtime::logic::Outcome, CallError>>,
+}
+
+pub type ServerSender = mpsc::Sender<ExecutionRequest>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Error)]
 #[error("CallError")]

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -156,6 +156,7 @@ pub struct GetContextsResponse {
 pub struct CreateContextRequest {
     pub application_id: calimero_primitives::application::ApplicationId,
     pub context_id: Option<calimero_primitives::context::ContextId>,
+    pub initialization_params: Vec<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -240,9 +240,15 @@ pub async fn create_context_handler(
     Json(req): Json<calimero_server_primitives::admin::CreateContextRequest>,
 ) -> impl IntoResponse {
     //TODO enable providing private key in the request
-    let result = create_context(&state.ctx_manager, req.application_id, None, req.context_id)
-        .await
-        .map_err(parse_api_error);
+    let result = create_context(
+        &state.ctx_manager,
+        req.application_id,
+        None,
+        req.context_id,
+        req.initialization_params,
+    )
+    .await
+    .map_err(parse_api_error);
 
     match result {
         Ok(context_create_result) => ApiResponse {

--- a/crates/server/src/admin/utils/context.rs
+++ b/crates/server/src/admin/utils/context.rs
@@ -13,6 +13,7 @@ pub async fn create_context(
     application_id: calimero_primitives::application::ApplicationId,
     private_key: Option<&str>,
     context_id: Option<ContextId>,
+    initialization_params: Vec<u8>,
 ) -> Result<ContextCreateResult, eyre::Error> {
     let context_id = match context_id {
         Some(context_id) => context_id,
@@ -46,7 +47,7 @@ pub async fn create_context(
     };
 
     ctx_manager
-        .create_context(&context, initial_identity.clone())
+        .create_context(&context, initial_identity.clone(), initialization_params)
         .await?;
 
     let context_create_result = ContextCreateResult {

--- a/crates/server/src/jsonrpc.rs
+++ b/crates/server/src/jsonrpc.rs
@@ -156,14 +156,14 @@ pub(crate) async fn call(
     let (outcome_sender, outcome_receiver) = oneshot::channel();
 
     sender
-        .send((
+        .send(calimero_node_primitives::ExecutionRequest {
             context_id,
             method,
-            args,
+            payload: args,
             writes,
             executor_public_key,
             outcome_sender,
-        ))
+        })
         .await
         .map_err(|e| CallError::InternalError(eyre::eyre!("Failed to send call message: {}", e)))?;
 


### PR DESCRIPTION
Context creation should initialize the context with the provided parameters

Concern: `meroctl context create --context-id` will also initialize the context with parameters, making histories in dev mode irreconcilable

Fix: make `context join` have `--watch` as well.