### PR TITLE
fix: app install metadata

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -356,13 +356,13 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                             let mut iter = args.split(' ');
                             let type_ = iter.next()?;
                             let resource = iter.next()?;
-                            let version = iter.next();
-                            let metadata = iter.next()?.as_bytes().to_vec();
+                            let version = iter.next()?;
+                            let metadata = iter.next();
 
                             Some((type_, resource, version, metadata))
                         }) else {
                             println!(
-                                "{IND} Usage: application install <\"url\"|\"file\"> <resource> [version] <metadata>"
+                                "{IND} Usage: application install <\"url\"|\"file\"> <resource> [version] [metadata]"
                             );
                             break 'done;
                         };
@@ -387,6 +387,13 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                             }
                             "file" => {
                                 let path = camino::Utf8PathBuf::from(resource);
+
+                                let metadata = match metadata {
+                                    Some(metadata) => metadata.as_bytes().to_vec(),
+                                    None => {
+                                        vec![]
+                                    }
+                                };
 
                                 node.ctx_manager
                                     .install_application_from_path(path, version, metadata)

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -9,6 +9,7 @@ use calimero_store::Store;
 use libp2p::gossipsub::{IdentTopic, TopicHash};
 use libp2p::identity as p2p_identity;
 use owo_colors::OwoColorize;
+use semver::Version;
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{debug, error, info, warn};
@@ -367,7 +368,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                             break 'done;
                         };
 
-                        let Ok(version) = version.map(|v| v.parse()).transpose() else {
+                        let Ok(version) = version.parse::<Version>() else {
                             println!("{IND} Invalid version: {:?}", version);
                             break 'done;
                         };
@@ -382,7 +383,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                                 println!("{IND} Downloading application..");
 
                                 node.ctx_manager
-                                    .install_application_from_url(url, version, Vec::new())
+                                    .install_application_from_url(url, Some(version), Vec::new())
                                     .await?
                             }
                             "file" => {
@@ -396,7 +397,7 @@ async fn handle_line(node: &mut Node, line: String) -> eyre::Result<()> {
                                 };
 
                                 node.ctx_manager
-                                    .install_application_from_path(path, version, metadata)
+                                    .install_application_from_path(path, Some(version), metadata)
                                     .await?
                             }
                             unknown => {


### PR DESCRIPTION
Metadata field was mandatory and it only worked if something is sent at the end.

I have set now that version is required and metadata are optional.  Extending params to be passed with arg name requires too much work atm. 