### PR TITLE
feat(registry): add erase command

### DIFF
--- a/contracts/package-manager/src/lib.rs
+++ b/contracts/package-manager/src/lib.rs
@@ -1,7 +1,7 @@
 use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::store::iterable_map::IterableMap;
-use near_sdk::{env, near_bindgen, AccountId, BorshStorageKey};
+use near_sdk::{env, near_bindgen, require, AccountId, BorshStorageKey};
 
 #[derive(BorshStorageKey, BorshSerialize)]
 #[borsh(crate = "near_sdk::borsh")]
@@ -170,6 +170,18 @@ impl PackageManager {
             .expect("Package doesn't exist")
             .get(&version)
             .expect("Version doesn't exist")
+    }
+
+    pub fn erase(&mut self) {
+        require!(
+            env::signer_account_id() == env::current_account_id(),
+            "Not so fast, chief.."
+        );
+
+        self.packages.clear();
+        for (_, mut releases) in self.releases.drain() {
+            releases.clear();
+        }
     }
 }
 


### PR DESCRIPTION
Radioactive, stay away..

This is here temporarily, while the ABI/other node behaviors change, certain apps will be inevitably fall out of compatibility.

We need to garbage collect these from time to time.

So there are no guarantees for stability atm.

We guard against unauthorized erasure, only the account it's deployed on can call the method.

Example transaction from an unauthorized user:

https://testnet.nearblocks.io/txns/E93p86PiZSisVPJgUJs9in7cCMTbzsSSyNq5KJPoN4hk

<img src="https://github.com/user-attachments/assets/adc85754-cec5-4b4c-859e-e74e5181ac38" width="80%"/>
