### PR TITLE
fix: side step coordinator for context initialization

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -109,9 +109,9 @@ impl ContextManager {
                 context_id: context.id,
                 method: "init".to_owned(),
                 payload: initialization_params,
-                writes: true,
                 executor_public_key: initial_identity.public_key.0,
                 outcome_sender: tx,
+                finality: Some(calimero_node_primitives::Finality::Local),
             })
             .await?;
 

--- a/crates/node-primitives/src/lib.rs
+++ b/crates/node-primitives/src/lib.rs
@@ -17,13 +17,20 @@ impl NodeType {
     }
 }
 
+#[derive(Debug)]
 pub struct ExecutionRequest {
     pub context_id: calimero_primitives::context::ContextId,
     pub method: String,
     pub payload: Vec<u8>,
-    pub writes: bool,
     pub executor_public_key: [u8; 32],
     pub outcome_sender: oneshot::Sender<Result<calimero_runtime::logic::Outcome, CallError>>,
+    pub finality: Option<Finality>,
+}
+
+#[derive(Debug)]
+pub enum Finality {
+    Local,
+    Global,
 }
 
 pub type ServerSender = mpsc::Sender<ExecutionRequest>;

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -330,7 +330,7 @@ impl Node {
                             }
                             calimero_node_primitives::NodeType::Coordinator => {
                                 self.validate_pending_transaction(
-                                    context_.clone(),
+                                    &context_,
                                     transaction,
                                     transaction_hash,
                                 )
@@ -341,21 +341,13 @@ impl Node {
                         },
                         types::TransactionStatus::Executed => match self.typ {
                             calimero_node_primitives::NodeType::Peer => {
-                                self.execute_transaction(
-                                    context_.clone(),
-                                    transaction.clone(),
-                                    transaction_hash,
-                                )
-                                .await?;
+                                self.execute_transaction(&context_, transaction, transaction_hash)
+                                    .await?;
 
                                 self.tx_pool.remove(&transaction_hash);
                             }
                             calimero_node_primitives::NodeType::Coordinator => {
-                                self.persist_transaction(
-                                    context_.clone(),
-                                    transaction.clone(),
-                                    transaction_hash,
-                                )?;
+                                self.persist_transaction(&context_, transaction, transaction_hash)?;
                             }
                         },
                     }

--- a/crates/server/src/jsonrpc.rs
+++ b/crates/server/src/jsonrpc.rs
@@ -160,7 +160,7 @@ pub(crate) async fn call(
             context_id,
             method,
             payload: args,
-            writes,
+            finality: writes.then_some(calimero_node_primitives::Finality::Global),
             executor_public_key,
             outcome_sender,
         })


### PR DESCRIPTION
The current (master) context initialization model would require context creation on the coordinator first, before it can be used elsewhere.

This is due to `init` being scheduled and awaiting confirmation from a coordinator that doesn't even know to subscribe to the context.

This is resolved by side stepping the coordinator flow entirely for context initialization.