### PR TITLE
fix(blobstore): use defined chunk sizes

### DIFF
--- a/crates/primitives/src/blobs.rs
+++ b/crates/primitives/src/blobs.rs
@@ -10,12 +10,6 @@ use crate::hash::{Error as HashError, Hash};
 #[derive(Eq, Copy, Hash, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlobId(Hash);
 
-impl BlobId {
-    pub fn hash(bytes: &[u8]) -> Self {
-        Self(Hash::new(bytes))
-    }
-}
-
 impl From<[u8; 32]> for BlobId {
     fn from(id: [u8; 32]) -> Self {
         Self(id.into())

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -56,13 +56,16 @@ impl Hash {
     // todo! using generic-array;
     // todo! as_str(&self, buf: &mut [u8; N]) -> &str
     pub fn as_str(&self) -> &str {
-        let (len, bs58) = unsafe { &mut *self.bs58.as_ptr().cast_mut() };
+        let (_len, bs58) = unsafe { &mut *self.bs58.as_ptr().cast_mut() };
 
-        if *len == 0 {
-            *len = bs58::encode(&self.bytes).onto(&mut bs58[..]).unwrap();
+        let mut len = *_len;
+
+        if len == 0 {
+            len = bs58::encode(&self.bytes).onto(&mut bs58[..]).unwrap();
+            *_len = len;
         }
 
-        std::str::from_utf8(&bs58[..*len]).unwrap()
+        std::str::from_utf8(&bs58[..len]).unwrap()
     }
 
     fn from_str(s: &str) -> Result<Self, Option<bs58::decode::Error>> {

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -26,4 +26,4 @@ tempdir.workspace = true
 [features]
 borsh = ["borsh/derive"]
 serde = ["dep:serde", "dep:serde_json"]
-datatypes = ["borsh"]
+datatypes = ["borsh", "calimero-primitives/borsh"]

--- a/crates/store/blobs/Cargo.toml
+++ b/crates/store/blobs/Cargo.toml
@@ -8,12 +8,13 @@ license.workspace = true
 
 [[example]]
 name = "blobstore"
+required-features = ["examples"]
 
 [dependencies]
 async-stream.workspace = true
 camino.workspace = true
 eyre.workspace = true
-futures-util.workspace = true
+futures-util = { workspace = true, features = ["io"] }
 sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }
@@ -25,4 +26,11 @@ calimero-store = { path = "..", features = ["datatypes"] }
 tokio-util.workspace = true
 
 [features]
-examples = ["tokio/io-std", "tokio/io-util", "tokio/macros", "tokio/rt-multi-thread", "tokio-util/io"]
+examples = [
+  "tokio/io-std",
+  "tokio/io-util",
+  "tokio/macros",
+  "tokio/rt-multi-thread",
+  "tokio-util/io",
+  "tokio-util/compat",
+]

--- a/crates/store/blobs/examples/blobstore.rs
+++ b/crates/store/blobs/examples/blobstore.rs
@@ -1,6 +1,7 @@
 use calimero_blobstore::{BlobManager, FileSystem};
 use futures_util::TryStreamExt;
 use tokio::io::{self, AsyncWriteExt};
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
 const DATA_DIR: &'static str = "blob-tests/data";
 const BLOB_DIR: &'static str = "blob-tests/blob";
@@ -34,11 +35,9 @@ async fn main() -> eyre::Result<()> {
             }
         },
         None => {
-            let stdin = io::stdin();
+            let stdin = io::stdin().compat();
 
-            let stdin = tokio_util::io::ReaderStream::new(stdin);
-
-            println!("{}", blob_mgr.put(stdin).await?);
+            println!("{}", blob_mgr.put_sized(None, stdin).await?);
         }
     }
 

--- a/crates/store/src/types/blobs.rs
+++ b/crates/store/src/types/blobs.rs
@@ -9,6 +9,7 @@ pub struct BlobMeta {
     // todo! impl proper entry reference count
     // pub refs: usize,
     pub size: usize,
+    pub hash: [u8; 32],
     pub links: Box<[key::BlobMeta]>,
 }
 


### PR DESCRIPTION
This patch ensures each chunk from the stream that makes up a blob is exactly a specified chunk size, except the last where EOF might be encountered before the chunk size threshold.

While testing, I did notice that `Hash::as_str` doesn't work in release mode.

Specifically, this line:

https://github.com/calimero-network/core/blob/0ef2e9f52943f65c75540824846c583b0be8e77a/crates/primitives/src/hash.rs#L61-L63

The `*len = __` assignment doesn't apply. Even though it does in debug mode. So far, I observed that use of `len` like `dbg!(&len)` before the assignment fixes the issue, I guess the compiler thinks it's eliminating dead code somehow though it's not. Needs further investigation.

In the meantime, I added a mitigation that stays the same behaviour on debug mode, and in release mode, uses a temporal, non-ptr variable so we're consistent.