### PR TITLE
feat(admin-api): enable admin api for admin dashboard host only

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,6 +48,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 jsonrpc = []
+host_layer = []
 websocket = ["axum/ws", "dep:futures-util"]
 admin = ["dep:tower-sessions"]
 

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -142,8 +142,10 @@ pub(crate) fn setup(
     let admin_router = Router::new()
         .nest("/", unprotected_router)
         .nest("/", protected_router)
-        .layer(session_layer)
-        .layer(HostLayer::new(config.listen.clone()));
+        .layer(session_layer);
+
+    #[cfg(feature = "host_layer")]
+    let admin_router = admin_router.layer(HostLayer::new(config.listen.clone()));
 
     Some((admin_path, admin_router))
 }

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -62,10 +62,9 @@ pub struct AdminState {
 
 pub(crate) fn setup(
     config: &ServerConfig,
-    store: &Store,
+    store: Store,
     ctx_manager: ContextManager,
 ) -> Option<(&'static str, Router)> {
-    let listen = config.listen.clone();
     let _ = match &config.admin {
         Some(config) if config.enabled => config,
         _ => {
@@ -115,7 +114,7 @@ pub(crate) fn setup(
         .route("/contexts/:context_id/join", post(join_context_handler))
         .route("/contexts", get(get_contexts_handler))
         .route("/identity/keys", delete(delete_auth_keys_handler))
-        .layer(AuthSignatureLayer::new(store.clone()))
+        .layer(AuthSignatureLayer::new(store))
         .layer(Extension(Arc::clone(&shared_state)));
 
     let unprotected_router = Router::new()
@@ -144,7 +143,7 @@ pub(crate) fn setup(
         .nest("/", unprotected_router)
         .nest("/", protected_router)
         .layer(session_layer)
-        .layer(HostLayer::new(listen));
+        .layer(HostLayer::new(config.listen.clone()));
 
     Some((admin_path, admin_router))
 }

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -62,7 +62,7 @@ pub struct AdminState {
 
 pub(crate) fn setup(
     config: &ServerConfig,
-    store: Store,
+    store: &Store,
     ctx_manager: ContextManager,
 ) -> Option<(&'static str, Router)> {
     let listen = config.listen.clone();

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -105,7 +105,7 @@ pub async fn start(
 
     #[cfg(feature = "admin")]
     {
-        if let Some((api_path, router)) = setup(&config, &store, ctx_manager) {
+        if let Some((api_path, router)) = setup(&config, store.clone(), ctx_manager) {
             if let Some((site_path, serve_dir)) = site(&config) {
                 app = app.nest_service(site_path, serve_dir);
             }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -105,7 +105,7 @@ pub async fn start(
 
     #[cfg(feature = "admin")]
     {
-        if let Some((api_path, router)) = setup(&config, store.clone(), ctx_manager) {
+        if let Some((api_path, router)) = setup(&config, &store, ctx_manager) {
             if let Some((site_path, serve_dir)) = site(&config) {
                 app = app.nest_service(site_path, serve_dir);
             }

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod host;

--- a/crates/server/src/middleware/host.rs
+++ b/crates/server/src/middleware/host.rs
@@ -1,13 +1,14 @@
+use core::convert::Infallible;
+use core::fmt::{self, Display, Formatter};
+use core::task::{Context, Poll};
+use std::error::Error;
+
 use axum::body::Body;
 use axum::extract::Request;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use core::convert::Infallible;
-use core::fmt::{self, Display, Formatter};
-use core::task::{Context, Poll};
 use libp2p::futures::future::BoxFuture;
 use multiaddr::{Multiaddr, Protocol};
-use std::error::Error;
 use tower::{Layer, Service};
 
 #[derive(Clone)]
@@ -72,10 +73,10 @@ pub fn host(headers: &HeaderMap, listen: &[Multiaddr]) -> Result<(), Unauthorize
 
     let ip_caller = normalize_origin(caller_host)
         .ok_or_else(|| UnauthorizedError::new("Invalid referer format"))?;
-    let (ip_caller_host, ip_caller_port) = ip_caller.split_once(":")
-    .map(|(host, port)| (host, Some(port)))
-    .unwrap_or_else(|| (&ip_caller[..], None));
-
+    let (ip_caller_host, ip_caller_port) = ip_caller
+        .split_once(":")
+        .map(|(host, port)| (host, Some(port)))
+        .unwrap_or_else(|| (&ip_caller[..], None));
 
     for addr in listen.iter() {
         let mut host_matched = false;

--- a/crates/server/src/middleware/host.rs
+++ b/crates/server/src/middleware/host.rs
@@ -1,0 +1,146 @@
+use std::convert::Infallible;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use libp2p::futures::future::BoxFuture;
+use multiaddr::Multiaddr;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct HostLayer {
+    listen: Vec<Multiaddr>,
+}
+
+impl HostLayer {
+    pub fn new(listen: Vec<Multiaddr>) -> Self {
+        Self { listen }
+    }
+}
+
+impl<S> Layer<S> for HostLayer {
+    type Service = HostMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HostMiddleware {
+            inner,
+            listen: self.listen.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HostMiddleware<S> {
+    inner: S,
+    listen: Vec<Multiaddr>,
+}
+
+impl<S> Service<Request<Body>> for HostMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = Infallible> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let result = host(request.headers(), self.listen.clone());
+
+        if let Err(err) = result {
+            let error_response = err.into_response();
+            return Box::pin(async move { Ok(error_response) });
+        }
+
+        let future = self.inner.call(request);
+
+        Box::pin(async move {
+            let response: Response = future.await?;
+            Ok(response)
+        })
+    }
+}
+
+pub fn host(headers: &HeaderMap, listen: Vec<Multiaddr>) -> Result<(), UnauthorizedError<'static>> {
+    let caller_host = headers
+        .get("referer")
+        .ok_or_else(|| UnauthorizedError::new("Missing referer header"))?
+        .to_str()
+        .map_err(|_| UnauthorizedError::new("Invalid referer header"))?;
+
+    let ip_caller_host = normalize_origin(caller_host);
+
+    let hosts: Vec<String> = listen
+        .iter()
+        .filter_map(|addr| {
+            let mut components = addr.iter();
+            let host = match components.next() {
+                Some(multiaddr::Protocol::Ip4(host)) => host.to_string(),
+                Some(multiaddr::Protocol::Ip6(host)) => format!("[{}]", host),
+                _ => return None,
+            };
+
+            let port = match components.next() {
+                Some(multiaddr::Protocol::Tcp(port)) => port.to_string(),
+                _ => return None,
+            };
+
+            Some(format!("{}:{}", host, port))
+        })
+        .collect();
+
+    let server_host = &hosts[0];
+    if ip_caller_host == *server_host {
+        return Ok(());
+    }
+    Err(UnauthorizedError::new("Unauthorized: Origin does not match the expected address."))
+}
+
+fn normalize_origin(origin: &str) -> String {
+    let host: Vec<&str> = origin.split("://").collect();
+    let parts: Vec<&str> = host[1].split(':').collect();
+
+    let normalized_origin = if parts[0] == "localhost" {
+        "127.0.0.1".to_string()
+    } else {
+        parts[0].to_string()
+    };
+
+    if parts.len() > 1 {
+        let port = parts[1].split("/").next().unwrap();
+        format!("{}:{}", normalized_origin, port)
+    } else {
+        normalized_origin
+    }
+}
+
+#[derive(Debug)]
+pub struct UnauthorizedError<'a> {
+    reason: &'a str,
+}
+
+impl<'a> UnauthorizedError<'a> {
+    pub fn new(reason: &'a str) -> Self {
+        Self { reason }
+    }
+}
+
+impl std::fmt::Display for UnauthorizedError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(self.reason)
+    }
+}
+
+impl std::error::Error for UnauthorizedError<'_> {}
+
+impl IntoResponse for UnauthorizedError<'_> {
+    fn into_response(self) -> Response<Body> {
+        (StatusCode::UNAUTHORIZED, self.reason.to_string()).into_response()
+    }
+}


### PR DESCRIPTION
# feat(admin-api): enable admin api for admin dashboard host only

## Summary
Added new middleware which is "host" that checks if the api is called from the same location as server.
For web application this will make only admin dashboard work as it will be running on the same location as server (e.g. localhost:2428).
Used referer header as it gets added by browsers.

Connected with [this](https://github.com/calimero-network/core/issues/572) issue.

#Tests:
<img width="1182" alt="Screenshot 2024-08-23 at 15 19 03" src="https://github.com/user-attachments/assets/efd89f39-3994-414a-90bc-1a02a7b24571">
<img width="1403" alt="Screenshot 2024-08-23 at 15 19 16" src="https://github.com/user-attachments/assets/bbc4b4a9-82b6-40d1-bcdb-a7537905cfdb">



