### PR TITLE
fix: invalid argument in app logic

### DIFF
--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -139,7 +139,7 @@ impl ToTokens for PublicLogicMethod<'_> {
                         ),
                     }
                 };
-                ::calimero_sdk::env::value_return(output);
+                ::calimero_sdk::env::value_return(&output);
             };
         }
 


### PR DESCRIPTION
Building only-peers was producing error 

```
   --> apps/only-peers/src/lib.rs:44:1
    |
44  | #[app::logic]
    | ^^^^^^^^^^^^^
    | |
    | expected `&Result<_, _>`, found `Result<Vec<u8>, Vec<u8>>`
    | arguments to this function are incorrect
    |
    = note: expected reference `&Result<_, _>`
                    found enum `Result<Vec<u8>, Vec<u8>>`
```