### PR TITLE
feat(node-ui): new application login popup

### DIFF
--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -229,12 +229,12 @@ export interface ContextIdentitiesResponse {
 }
 
 export interface JsonWebToken {
-  access_token: string;
-  refresh_token: string;
+  accessToken: string;
+  refreshToken: string;
 }
 
 export interface CreateTokenResponse {
-  jwt_token: JsonWebToken;
+  data: JsonWebToken;
 }
 
 export class NodeDataSource implements NodeApi {
@@ -543,7 +543,7 @@ export class NodeDataSource implements NodeApi {
     }
 
     return await this.client.post<CreateTokenResponse>(
-      `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities`,
+      `${getAppEndpointKey()}/admin-api/generate-jwt-token`,
       {
         contextId,
         executorPublicKey: contextIdentity,

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -522,7 +522,7 @@ export class NodeDataSource implements NodeApi {
       JSON.stringify(contextId),
     );
     if (!headers) {
-      return { error: { code: 401, message: 'Unauthorized' } };
+      return { error: { code: 401, message: t.unauthorizedErrorMessage } };
     }
 
     return await this.client.get<ContextIdentitiesResponse>(
@@ -539,7 +539,7 @@ export class NodeDataSource implements NodeApi {
       JSON.stringify(contextId),
     );
     if (!headers) {
-      return { error: { code: 401, message: 'Unauthorized' } };
+      return { error: { code: 401, message: t.unauthorizedErrorMessage } };
     }
 
     return await this.client.post<CreateTokenResponse>(

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -224,6 +224,19 @@ export interface InstallApplicationResponse {
   application_id: string;
 }
 
+export interface ContextIdentitiesResponse {
+  identities: string[];
+}
+
+export interface JsonWebToken {
+  access_token: string;
+  refresh_token: string;
+}
+
+export interface CreateTokenResponse {
+  jwt_token: JsonWebToken;
+}
+
 export class NodeDataSource implements NodeApi {
   private client: HttpClient;
 
@@ -499,6 +512,38 @@ export class NodeDataSource implements NodeApi {
         ...rootKeyRequest,
       },
       headers,
+    );
+  }
+
+  async getContextIdentity(contextId: string): ApiResponse<ContextIdentitiesResponse> {
+    const headers: Header | null = await createAuthHeader(
+      JSON.stringify(contextId),
+    );
+    if (!headers) {
+      return { error: { code: 401, message: 'Unauthorized' } };
+    }
+
+    return await this.client.get<ContextIdentitiesResponse>(
+      `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities`,
+      headers
+    );
+  }
+
+  async createAccessToken(contextId: string, contextIdentity: string): ApiResponse<CreateTokenResponse> {
+    const headers: Header | null = await createAuthHeader(
+      JSON.stringify(contextId),
+    );
+    if (!headers) {
+      return { error: { code: 401, message: 'Unauthorized' } };
+    }
+
+    return await this.client.post<CreateTokenResponse>(
+      `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities`,
+      {
+        contextId,
+        executorPublicKey: contextIdentity
+      },
+      headers
     );
   }
 }

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -515,7 +515,9 @@ export class NodeDataSource implements NodeApi {
     );
   }
 
-  async getContextIdentity(contextId: string): ApiResponse<ContextIdentitiesResponse> {
+  async getContextIdentity(
+    contextId: string,
+  ): ApiResponse<ContextIdentitiesResponse> {
     const headers: Header | null = await createAuthHeader(
       JSON.stringify(contextId),
     );
@@ -525,11 +527,14 @@ export class NodeDataSource implements NodeApi {
 
     return await this.client.get<ContextIdentitiesResponse>(
       `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities`,
-      headers
+      headers,
     );
   }
 
-  async createAccessToken(contextId: string, contextIdentity: string): ApiResponse<CreateTokenResponse> {
+  async createAccessToken(
+    contextId: string,
+    contextIdentity: string,
+  ): ApiResponse<CreateTokenResponse> {
     const headers: Header | null = await createAuthHeader(
       JSON.stringify(contextId),
     );
@@ -541,9 +546,9 @@ export class NodeDataSource implements NodeApi {
       `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities`,
       {
         contextId,
-        executorPublicKey: contextIdentity
+        executorPublicKey: contextIdentity,
       },
-      headers
+      headers,
     );
   }
 }

--- a/node-ui/src/api/nodeApi.ts
+++ b/node-ui/src/api/nodeApi.ts
@@ -51,5 +51,8 @@ export interface NodeApi {
   requestChallenge(): ApiResponse<NodeChallenge>;
   addRootKey(rootKeyRequest: LoginRequest): ApiResponse<RootKeyResponse>;
   getContextIdentity(contextId: string): ApiResponse<ContextIdentitiesResponse>;
-  createAccessToken(contextId: string, contextIdentity: string): ApiResponse<CreateTokenResponse>
+  createAccessToken(
+    contextId: string,
+    contextIdentity: string,
+  ): ApiResponse<CreateTokenResponse>;
 }

--- a/node-ui/src/api/nodeApi.ts
+++ b/node-ui/src/api/nodeApi.ts
@@ -18,6 +18,8 @@ import {
   RootKeyResponse,
   InstallApplicationResponse,
   InstalledApplication,
+  ContextIdentitiesResponse,
+  CreateTokenResponse,
 } from './dataSource/NodeDataSource';
 
 export interface NodeApi {
@@ -48,4 +50,6 @@ export interface NodeApi {
   login(loginRequest: LoginRequest): ApiResponse<LoginResponse>;
   requestChallenge(): ApiResponse<NodeChallenge>;
   addRootKey(rootKeyRequest: LoginRequest): ApiResponse<RootKeyResponse>;
+  getContextIdentity(contextId: string): ApiResponse<ContextIdentitiesResponse>;
+  createAccessToken(contextId: string, contextIdentity: string): ApiResponse<CreateTokenResponse>
 }

--- a/node-ui/src/auth/storage.ts
+++ b/node-ui/src/auth/storage.ts
@@ -25,7 +25,7 @@ export const getStorageCallbackUrl = (): string | null => {
 
 export const setStorageApplicationId = (applicationId: string) => {
   localStorage.setItem(APPLICATION_ID, JSON.stringify(applicationId));
-}
+};
 
 export const getStorageApplicationId = (): string | null => {
   if (typeof window !== 'undefined' && window.localStorage) {
@@ -38,7 +38,7 @@ export const getStorageApplicationId = (): string | null => {
     }
   }
   return null;
-}
+};
 
 export const setStorageClientKey = (clientKey: ClientKey) => {
   localStorage.setItem(CLIENT_KEY, JSON.stringify(clientKey));

--- a/node-ui/src/auth/storage.ts
+++ b/node-ui/src/auth/storage.ts
@@ -3,6 +3,42 @@ import { ClientKey } from './types';
 export const CLIENT_KEY = 'client-key';
 export const APP_URL = 'app-url';
 export const AUTHORIZED = 'node-authorized';
+export const CALLBACK_URL = 'callback-url';
+export const APPLICATION_ID = 'application-id';
+
+export const setStorageCallbackUrl = (callbackUrl: string) => {
+  localStorage.setItem(CALLBACK_URL, JSON.stringify(callbackUrl));
+};
+
+export const getStorageCallbackUrl = (): string | null => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const storageCallbackUrl = localStorage.getItem(CALLBACK_URL);
+    if (storageCallbackUrl) {
+      let callbackUrl: string = JSON.parse(storageCallbackUrl);
+      return callbackUrl;
+    } else {
+      return null;
+    }
+  }
+  return null;
+};
+
+export const setStorageApplicationId = (applicationId: string) => {
+  localStorage.setItem(APPLICATION_ID, JSON.stringify(applicationId));
+}
+
+export const getStorageApplicationId = (): string | null => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const storageApplicationId = localStorage.getItem(APPLICATION_ID);
+    if (storageApplicationId) {
+      let applicationId: string = JSON.parse(storageApplicationId);
+      return applicationId;
+    } else {
+      return null;
+    }
+  }
+  return null;
+}
 
 export const setStorageClientKey = (clientKey: ClientKey) => {
   localStorage.setItem(CLIENT_KEY, JSON.stringify(clientKey));
@@ -32,11 +68,14 @@ export const setStorageNodeAuthorized = () => {
 
 export const getStorageNodeAuthorized = (): boolean | null => {
   if (typeof window !== 'undefined' && window.localStorage) {
-    let authorized: boolean = JSON.parse(
-      localStorage.getItem(AUTHORIZED) ?? '',
-    );
-    if (authorized) {
-      return authorized;
+    const isAuthorized = localStorage.getItem(AUTHORIZED);
+    if (isAuthorized !== null) {
+      let authorized: boolean = JSON.parse(isAuthorized);
+      if (authorized) {
+        return authorized;
+      }
+    } else {
+      return null;
     }
   }
   return null;

--- a/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
+++ b/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
@@ -11,7 +11,10 @@ import { ResponseData } from '../../../api/response';
 import SelectContextStep from './SelectContextStep';
 import CreateAccessTokenStep from './CreateAccessTokenStep';
 import SelectIdentityStep from './SelectIdentityStep';
-import { setStorageApplicationId, setStorageCallbackUrl } from '../../../auth/storage';
+import {
+  setStorageApplicationId,
+  setStorageCallbackUrl,
+} from '../../../auth/storage';
 
 interface AppLoginPopupProps {
   showPopup: boolean;
@@ -87,8 +90,8 @@ export default function AppLoginPopup({
   };
 
   const onCreateToken = async () => {
-    setStorageApplicationId("");
-      setStorageCallbackUrl("");
+    setStorageApplicationId('');
+    setStorageCallbackUrl('');
     const createTokenResponse: ResponseData<CreateTokenResponse> =
       await apiClient(showServerDownPopup)
         .node()

--- a/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
+++ b/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
@@ -71,16 +71,16 @@ export default function AppLoginPopup({
     }
   }, [selectedContextId, showServerDownPopup]);
 
-  const finishLogin = (accessToken?: string) => {
-    if (!accessToken) {
+  const finishLogin = (accessTokens?: string) => {
+    if (!accessTokens) {
       window.location.href = callbackUrl;
       return;
     }
     try {
-      const tokenData = JSON.parse(accessToken);
-      const { access_token, refresh_token } = tokenData;
-      const encodedAccessToken = encodeURIComponent(access_token);
-      const encodedRefreshToken = encodeURIComponent(refresh_token);
+      const tokenData = JSON.parse(accessTokens);
+      const { accessToken, refreshToken } = tokenData;
+      const encodedAccessToken = encodeURIComponent(accessToken);
+      const encodedRefreshToken = encodeURIComponent(refreshToken);
       const newUrl = `${callbackUrl}?access_token=${encodedAccessToken}&refresh_token=${encodedRefreshToken}`;
       window.location.href = newUrl;
     } catch (error) {
@@ -96,9 +96,9 @@ export default function AppLoginPopup({
       await apiClient(showServerDownPopup)
         .node()
         .createAccessToken(selectedContextId, selectedIdentity);
-    const accessToken = createTokenResponse.data?.jwt_token;
-    if (accessToken) {
-      finishLogin(JSON.stringify(accessToken));
+    const accessTokens = createTokenResponse.data;
+    if (accessTokens) {
+      finishLogin(JSON.stringify(accessTokens));
     }
   };
 

--- a/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
+++ b/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import Modal from 'react-bootstrap/Modal';
+import { styled } from 'styled-components';
+import apiClient from '../../../api';
+import { ContextList } from '../../../api/dataSource/NodeDataSource';
+import { ResponseData } from '../../../api/response';
+
+interface AppLoginPopupProps {
+  showPopup: boolean;
+  callbackUrl: string;
+  applicationId: string;
+  showServerDownPopup: () => void;
+}
+
+const ModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.5rem;
+  border-radius: 0.375rem;
+  items-align: center;
+  background-color: #17191b;
+
+  .title {
+    text-align: center;
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+    color: #fff;
+  }
+
+  .subtitle {
+    margin-top: 1.25rem;
+    color: #fff;
+    font-weigth: 500;
+    font-size: 0.875rem;
+  }
+
+  .context-list {
+    margin-top: 1.25rem;
+    color: #fff;
+  }
+
+  .app-id {
+    color: #ff7a00;
+  }
+
+  .app-callbackurl {
+    color: #ff7a00;
+    text-decoration: none;
+`;
+
+export default function AppLoginPopup({
+  showPopup,
+  callbackUrl,
+  applicationId,
+  showServerDownPopup
+}: AppLoginPopupProps) {
+  const [contextList, setContextList] = useState<string[]>([]);
+  const finishLogin = () => {
+    window.location.href = callbackUrl;
+  };
+
+  useEffect(() => {
+    const fetchAvailableContexts = async () => {
+      const fetchContextsResponse: ResponseData<ContextList> = await apiClient(
+        showServerDownPopup,
+      )
+        .node()
+        .getContexts();
+        console.log(fetchContextsResponse.data);
+    }
+    fetchAvailableContexts();
+  }, []);
+  return (
+    <Modal
+      show={showPopup}
+      backdrop="static"
+      keyboard={false}
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <ModalWrapper>
+        <div className="title">Sign-in request</div>
+        <div className="subtitle">
+          This site: {' '}
+          <a href={callbackUrl} target="_blank" rel="noreferrer" className='app-callbackurl'>
+            {callbackUrl}
+          </a>, running application:{' '}
+          <span className="app-id">{applicationId}</span> requested to sign in
+        </div>
+        <div className="context-list">
+          <div className="context-title">Available contexts</div>
+        </div>
+      </ModalWrapper>
+    </Modal>
+  );
+}

--- a/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
+++ b/node-ui/src/components/login/applicationLogin/AppLoginPopup.tsx
@@ -11,6 +11,7 @@ import { ResponseData } from '../../../api/response';
 import SelectContextStep from './SelectContextStep';
 import CreateAccessTokenStep from './CreateAccessTokenStep';
 import SelectIdentityStep from './SelectIdentityStep';
+import { setStorageApplicationId, setStorageCallbackUrl } from '../../../auth/storage';
 
 interface AppLoginPopupProps {
   showPopup: boolean;
@@ -60,7 +61,6 @@ export default function AppLoginPopup({
           .node()
           .getContextIdentity(selectedContextId);
       const identities = fetchContextIdentitiesResponse.data?.identities ?? [];
-      console.log(identities);
       setContextIdentities(identities);
     };
     if (selectedContextId) {
@@ -87,6 +87,8 @@ export default function AppLoginPopup({
   };
 
   const onCreateToken = async () => {
+    setStorageApplicationId("");
+      setStorageCallbackUrl("");
     const createTokenResponse: ResponseData<CreateTokenResponse> =
       await apiClient(showServerDownPopup)
         .node()

--- a/node-ui/src/components/login/applicationLogin/ContextListItem.tsx
+++ b/node-ui/src/components/login/applicationLogin/ContextListItem.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Context } from '../../../api/dataSource/NodeDataSource';
+
+interface RowItemProps {
+  $hasBorders: boolean;
+}
+
+const RowItem = styled.div<RowItemProps>`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 1px;
+  font-size: 0.875rem;
+  font-optical-sizing: auto;
+  font-weight: 500;
+  font-style: normal;
+  font-variation-settings: 'slnt' 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-smooth: never;
+  line-height: 1.25rem;
+  text-align: left;
+  padding-right: 1.5rem;
+  border-top: 1px solid #23262d;
+  ${(props) => props.$hasBorders && `border-bottom: 1px solid #23262D;`}
+
+  .row-item {
+    padding: 0.75rem 0rem;
+    display: flex;
+    align-items: center;
+    width: 25%;
+  }
+  .name {
+    text-align: left;
+    &:hover {
+      color: #4cfafc;
+      cursor: pointer;
+    }
+  }
+ 
+`;
+
+interface ContextListItemProps {
+  item: Context;
+  id: number;
+  count: number;
+  onRowItemClick?: (id: string) => void;
+}
+
+export default function ContextListItem({
+  item,
+  id,
+  count,
+  onRowItemClick,
+}: ContextListItemProps) {
+  return (
+    <RowItem key={item.id} $hasBorders={id === count}>
+      <div
+        className="row-item name"
+        onClick={() => onRowItemClick && onRowItemClick(item.id)}
+      >
+        {item.id}
+      </div>
+    </RowItem>
+  );
+}

--- a/node-ui/src/components/login/applicationLogin/CreateAccessTokenStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/CreateAccessTokenStep.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Button from '../../common/Button';
 import { ModalWrapper } from './SelectContextStep';
+import translations from '../../../constants/en.global.json';
 
 interface CreateAccessTokenStepProps {
   applicationId: string;
   callbackUrl: string;
   selectedContextId: string;
+  selectedIdentity: string;
   onCreateToken: () => void;
 }
 
@@ -13,14 +15,16 @@ export default function CreateAccessTokenStep({
   applicationId,
   callbackUrl,
   selectedContextId,
+  selectedIdentity,
   onCreateToken,
 }: CreateAccessTokenStepProps) {
+  const t = translations.appLoginPopup.createToken;
   return (
     <ModalWrapper>
-      <div className="title">Sign-in request</div>
+      <div className="title">{t.title}</div>
       <div className="wrapper">
         <div className="subtitle">
-          From site:{' '}
+          {t.websiteText}
           <a
             href={callbackUrl}
             target="_blank"
@@ -31,14 +35,20 @@ export default function CreateAccessTokenStep({
           </a>
         </div>
         <div className="subtitle">
-          Application Id: <span className="app-id">{applicationId}</span>
+          {t.appIdText}
+          <span className="app-id">{applicationId}</span>
         </div>
         <div className="subtitle">
-          Context Id: <span className="app-id">{selectedContextId}</span>
+          {t.contextIdText}
+          <span className="app-id">{selectedContextId}</span>
+        </div>
+        <div className="subtitle">
+          {t.contextIdentityText}
+          <span className="app-id">{selectedIdentity}</span>
         </div>
       </div>
       <div className="wrapper">
-        <Button text="Create token" onClick={onCreateToken} width="100%" />
+        <Button text={t.buttonNextText} onClick={onCreateToken} width="100%" />
       </div>
     </ModalWrapper>
   );

--- a/node-ui/src/components/login/applicationLogin/CreateAccessTokenStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/CreateAccessTokenStep.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Button from '../../common/Button';
+import { ModalWrapper } from './SelectContextStep';
+
+interface CreateAccessTokenStepProps {
+  applicationId: string;
+  callbackUrl: string;
+  selectedContextId: string;
+  onCreateToken: () => void;
+}
+
+export default function CreateAccessTokenStep({
+  applicationId,
+  callbackUrl,
+  selectedContextId,
+  onCreateToken,
+}: CreateAccessTokenStepProps) {
+  return (
+    <ModalWrapper>
+      <div className="title">Sign-in request</div>
+      <div className="wrapper">
+        <div className="subtitle">
+          From site:{' '}
+          <a
+            href={callbackUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="app-callbackurl"
+          >
+            {callbackUrl}
+          </a>
+        </div>
+        <div className="subtitle">
+          Application Id: <span className="app-id">{applicationId}</span>
+        </div>
+        <div className="subtitle">
+          Context Id: <span className="app-id">{selectedContextId}</span>
+        </div>
+      </div>
+      <div className="wrapper">
+        <Button text="Create token" onClick={onCreateToken} width="100%" />
+      </div>
+    </ModalWrapper>
+  );
+}

--- a/node-ui/src/components/login/applicationLogin/ListItem.tsx
+++ b/node-ui/src/components/login/applicationLogin/ListItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Context } from '../../../api/dataSource/NodeDataSource';
 
 interface RowItemProps {
   $hasBorders: boolean;
@@ -41,26 +40,26 @@ const RowItem = styled.div<RowItemProps>`
  
 `;
 
-interface ContextListItemProps {
-  item: Context;
+interface ListItemProps {
+  item: string;
   id: number;
   count: number;
   onRowItemClick?: (id: string) => void;
 }
 
-export default function ContextListItem({
+export default function ListItem({
   item,
   id,
   count,
   onRowItemClick,
-}: ContextListItemProps) {
+}: ListItemProps) {
   return (
-    <RowItem key={item.id} $hasBorders={id === count}>
+    <RowItem key={id} $hasBorders={id === count}>
       <div
         className="row-item name"
-        onClick={() => onRowItemClick && onRowItemClick(item.id)}
+        onClick={() => onRowItemClick && onRowItemClick(item)}
       >
-        {item.id}
+        {item}
       </div>
     </RowItem>
   );

--- a/node-ui/src/components/login/applicationLogin/ListItem.tsx
+++ b/node-ui/src/components/login/applicationLogin/ListItem.tsx
@@ -37,7 +37,6 @@ const RowItem = styled.div<RowItemProps>`
       cursor: pointer;
     }
   }
- 
 `;
 
 interface ListItemProps {

--- a/node-ui/src/components/login/applicationLogin/SelectContextStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/SelectContextStep.tsx
@@ -3,8 +3,7 @@ import { styled } from 'styled-components';
 import Button from '../../common/Button';
 import { Context } from '../../../api/dataSource/NodeDataSource';
 import ListItem from './ListItem';
-import translations from "../../../constants/en.global.json";
-
+import translations from '../../../constants/en.global.json';
 
 export const ModalWrapper = styled.div`
   display: flex;
@@ -130,14 +129,13 @@ export default function SelectContextStep({
           </a>
         </div>
         <div className="subtitle">
-          {t.appIdText}<span className="app-id">{applicationId}</span>
+          {t.appIdText}
+          <span className="app-id">{applicationId}</span>
         </div>
       </div>
       <div className="wrapper">
         <div className="context-title">{t.contextsTitle}</div>
-        <div className="context-subtitle">
-          {t.contextsSubtitle}
-        </div>
+        <div className="context-subtitle">{t.contextsSubtitle}</div>
         <div className="context-list">
           {contextList.length > 0 ? (
             contextList.map((context, i) => (
@@ -164,8 +162,12 @@ export default function SelectContextStep({
         {selectedContextId && (
           <div className="flex-container">
             <div className="selected-text-wrapper">
-              <span className="subtitle wrap-text">{t.selectedContextText}</span>
-              <span className="context-title wrap-text">{selectedContextId}</span>
+              <span className="subtitle wrap-text">
+                {t.selectedContextText}
+              </span>
+              <span className="context-title wrap-text">
+                {selectedContextId}
+              </span>
             </div>
             <Button
               text={t.buttonNextText}

--- a/node-ui/src/components/login/applicationLogin/SelectContextStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/SelectContextStep.tsx
@@ -144,6 +144,7 @@ export default function SelectContextStep({
                 id={i}
                 count={contextList.length}
                 onRowItemClick={setSelectedContextId}
+                key={i}
               />
             ))
           ) : (

--- a/node-ui/src/components/login/applicationLogin/SelectContextStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/SelectContextStep.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import Button from '../../common/Button';
+import ContextListItem from './ContextListItem';
+import { Context } from '../../../api/dataSource/NodeDataSource';
+
+export const ModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.5rem;
+  border-radius: 0.375rem;
+  items-align: center;
+  background-color: #17191b;
+
+  .title,
+  .context-title {
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.25rem;
+    color: #fff;
+  }
+  .title {
+    text-align: center;
+  }
+
+  .subtitle,
+  .context-subtitle {
+    color: #6b7280;
+    font-weigth: 500;
+    font-size: 0.875rem;
+  }
+
+  .subtitle {
+    word-break: break-all;
+  }
+
+  .wrapper {
+    margin-top: 1.25rem;
+    color: #fff;
+  }
+
+  .app-id {
+    color: #6b7280;
+  }
+
+  .app-callbackurl {
+    color: #6b7280;
+    text-decoration: none;
+  }
+
+  .context-list {
+    display: flex;
+    flex-direction: column;
+    max-height: 200px;
+    overflow-y: scroll;
+  }
+
+  .list-item {
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    width: fit-content;
+    white-space: break-spaces;
+    margin-top: 1.25rem;
+    color: #fff;
+    font-weigth: 500;
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+
+  .list-item:hover {
+    color: #4cfafc;
+  }
+
+  .list-wrapper {
+    background-color: #17191b;
+  }
+
+  .flex-container {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .selected-text-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+`;
+
+interface SelectContextStepProps {
+  applicationId: string;
+  callbackUrl: string;
+  contextList: Context[];
+  selectedContextId: string;
+  setSelectedContextId: (selectedContextId: string) => void;
+  updateLoginStep: () => void;
+}
+
+export default function SelectContextStep({
+  applicationId,
+  callbackUrl,
+  contextList,
+  selectedContextId,
+  setSelectedContextId,
+  updateLoginStep,
+}: SelectContextStepProps) {
+  return (
+    <ModalWrapper>
+      <div className="title">Sign-in request</div>
+      <div className="wrapper">
+        <div className="subtitle">
+          From site:{' '}
+          <a
+            href={callbackUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="app-callbackurl"
+          >
+            {callbackUrl}
+          </a>
+        </div>
+        <div className="subtitle">
+          Application Id: <span className="app-id">{applicationId}</span>
+        </div>
+      </div>
+      <div className="wrapper">
+        <div className="context-title">Available contexts</div>
+        <div className="context-subtitle">
+          Select context to create login token
+        </div>
+        <div className="context-list">
+          {contextList.map((context, i) => (
+            <ContextListItem
+              item={context}
+              id={i}
+              count={contextList.length}
+              onRowItemClick={setSelectedContextId}
+            />
+          ))}
+        </div>
+      </div>
+      <div>
+        {selectedContextId && (
+          <div className="flex-container">
+            <div className='selected-text-wrapper'>
+              <span className="subtitle">Selected context ID:</span>
+              <span className="context-title">{selectedContextId}</span>
+            </div>
+            <Button
+              text="Confirm context id"
+              onClick={updateLoginStep}
+              width="100%"
+            />
+          </div>
+        )}
+      </div>
+    </ModalWrapper>
+  );
+}

--- a/node-ui/src/components/login/applicationLogin/SelectIdentityStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/SelectIdentityStep.tsx
@@ -147,6 +147,7 @@ export default function SelectIdentityStep({
                 id={i}
                 count={contextIdentities.length}
                 onRowItemClick={setSelectedIdentity}
+                key={i}
               />
             ))
           ) : (

--- a/node-ui/src/components/login/applicationLogin/SelectIdentityStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/SelectIdentityStep.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { styled } from 'styled-components';
 import Button from '../../common/Button';
-import { Context } from '../../../api/dataSource/NodeDataSource';
 import ListItem from './ListItem';
 import translations from "../../../constants/en.global.json";
-
 
 export const ModalWrapper = styled.div`
   display: flex;
@@ -85,35 +83,35 @@ export const ModalWrapper = styled.div`
     gap: 1rem;
   }
 
-  .wrap-text {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
+  .selected-text-wrapper {
+    display: flex;
+    flex-direction: column;
   }
   .no-context-text {
     text-align: center;
   }
 `;
 
-interface SelectContextStepProps {
+interface SelectIdentityStepProps {
   applicationId: string;
   callbackUrl: string;
-  contextList: Context[];
-  selectedContextId: string;
-  setSelectedContextId: (selectedContextId: string) => void;
+  contextIdentities: string[];
+  selectedIdentity: string;
+  setSelectedIdentity: (selectedIdentity: string) => void;
   updateLoginStep: () => void;
   finishLogin: () => void;
 }
 
-export default function SelectContextStep({
+export default function SelectIdentityStep({
   applicationId,
   callbackUrl,
-  contextList,
-  selectedContextId,
-  setSelectedContextId,
+  contextIdentities,
+  selectedIdentity,
+  setSelectedIdentity,
   updateLoginStep,
-  finishLogin,
-}: SelectContextStepProps) {
-  const t = translations.appLoginPopup.selectContext;
+  finishLogin
+}: SelectIdentityStepProps) {
+  const t = translations.appLoginPopup.selectIdentity;
   return (
     <ModalWrapper>
       <div className="title">{t.title}</div>
@@ -132,6 +130,9 @@ export default function SelectContextStep({
         <div className="subtitle">
           {t.appIdText}<span className="app-id">{applicationId}</span>
         </div>
+        <div className="subtitle">
+          {t.contextIdText}<span className="app-id">{applicationId}</span>
+        </div>
       </div>
       <div className="wrapper">
         <div className="context-title">{t.contextsTitle}</div>
@@ -139,33 +140,32 @@ export default function SelectContextStep({
           {t.contextsSubtitle}
         </div>
         <div className="context-list">
-          {contextList.length > 0 ? (
-            contextList.map((context, i) => (
-              <ListItem
-                item={context.id}
-                id={i}
-                count={contextList.length}
-                onRowItemClick={setSelectedContextId}
-              />
-            ))
-          ) : (
-            <div className="flex-container">
-              <div className="no-context-text">{t.noContextsText}</div>
-              <Button
-                text={t.buttonBackText}
-                onClick={finishLogin}
-                width="100%"
-              />
-            </div>
-          )}
+          {contextIdentities.length > 0 ? contextIdentities.map((identity, i) => (
+            <ListItem
+              item={identity}
+              id={i}
+              count={contextIdentities.length}
+              onRowItemClick={setSelectedIdentity}
+            />
+          )) : (
+          <div className='flex-container'>
+          <div className='no-context-text'>{t.noContextsText}</div>
+          <Button
+              text={t.buttonBackText}
+              onClick={finishLogin}
+              width="100%"
+            />
+          </div>
+          )
+        }
         </div>
       </div>
       <div>
-        {selectedContextId && (
+        {selectedIdentity && (
           <div className="flex-container">
-            <div className="selected-text-wrapper">
-              <span className="subtitle wrap-text">{t.selectedContextText}</span>
-              <span className="context-title wrap-text">{selectedContextId}</span>
+            <div className='selected-text-wrapper'>
+              <span className="subtitle">{t.selectedContextText}</span>
+              <span className="context-title">{selectedIdentity}</span>
             </div>
             <Button
               text={t.buttonNextText}

--- a/node-ui/src/components/login/applicationLogin/SelectIdentityStep.tsx
+++ b/node-ui/src/components/login/applicationLogin/SelectIdentityStep.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { styled } from 'styled-components';
 import Button from '../../common/Button';
 import ListItem from './ListItem';
-import translations from "../../../constants/en.global.json";
+import translations from '../../../constants/en.global.json';
 
 export const ModalWrapper = styled.div`
   display: flex;
@@ -109,7 +109,7 @@ export default function SelectIdentityStep({
   selectedIdentity,
   setSelectedIdentity,
   updateLoginStep,
-  finishLogin
+  finishLogin,
 }: SelectIdentityStepProps) {
   const t = translations.appLoginPopup.selectIdentity;
   return (
@@ -128,42 +128,43 @@ export default function SelectIdentityStep({
           </a>
         </div>
         <div className="subtitle">
-          {t.appIdText}<span className="app-id">{applicationId}</span>
+          {t.appIdText}
+          <span className="app-id">{applicationId}</span>
         </div>
         <div className="subtitle">
-          {t.contextIdText}<span className="app-id">{applicationId}</span>
+          {t.contextIdText}
+          <span className="app-id">{applicationId}</span>
         </div>
       </div>
       <div className="wrapper">
         <div className="context-title">{t.contextsTitle}</div>
-        <div className="context-subtitle">
-          {t.contextsSubtitle}
-        </div>
+        <div className="context-subtitle">{t.contextsSubtitle}</div>
         <div className="context-list">
-          {contextIdentities.length > 0 ? contextIdentities.map((identity, i) => (
-            <ListItem
-              item={identity}
-              id={i}
-              count={contextIdentities.length}
-              onRowItemClick={setSelectedIdentity}
-            />
-          )) : (
-          <div className='flex-container'>
-          <div className='no-context-text'>{t.noContextsText}</div>
-          <Button
-              text={t.buttonBackText}
-              onClick={finishLogin}
-              width="100%"
-            />
-          </div>
-          )
-        }
+          {contextIdentities.length > 0 ? (
+            contextIdentities.map((identity, i) => (
+              <ListItem
+                item={identity}
+                id={i}
+                count={contextIdentities.length}
+                onRowItemClick={setSelectedIdentity}
+              />
+            ))
+          ) : (
+            <div className="flex-container">
+              <div className="no-context-text">{t.noContextsText}</div>
+              <Button
+                text={t.buttonBackText}
+                onClick={finishLogin}
+                width="100%"
+              />
+            </div>
+          )}
         </div>
       </div>
       <div>
         {selectedIdentity && (
           <div className="flex-container">
-            <div className='selected-text-wrapper'>
+            <div className="selected-text-wrapper">
               <span className="subtitle">{t.selectedContextText}</span>
               <span className="context-title">{selectedIdentity}</span>
             </div>

--- a/node-ui/src/components/protectedRoutes/ProtectedRoute.tsx
+++ b/node-ui/src/components/protectedRoutes/ProtectedRoute.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
-import { useNavigate, Outlet } from 'react-router-dom';
+import { useNavigate, Outlet, useLocation } from 'react-router-dom';
 import { isNodeAuthorized, getClientKey } from '../../utils/storage';
 import { getPathname } from '../../utils/protectedRoute';
 
 export default function ProtectedRoute() {
+  const { search } = useLocation();
   const navigate = useNavigate();
   const clientKey = getClientKey();
   const isAuthorized = isNodeAuthorized();
@@ -14,12 +15,12 @@ export default function ProtectedRoute() {
     if (isAuthPath) {
       if (isAuthorized && clientKey) {
         //navigate to home page after auth is successfull
-        navigate('/identity');
+        navigate(`/identity${search}`);
       }
     } else {
       if (!(isAuthorized && clientKey)) {
-        //show auth if not authorized
-        navigate('/auth');
+        //show setup if not authorized
+        navigate(`/${search}`);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/node-ui/src/components/protectedRoutes/ProtectedRoute.tsx
+++ b/node-ui/src/components/protectedRoutes/ProtectedRoute.tsx
@@ -20,7 +20,7 @@ export default function ProtectedRoute() {
     } else {
       if (!(isAuthorized && clientKey)) {
         //show setup if not authorized
-        navigate(`/${search}`);
+        navigate(`/${search ? `${search}` : '/'}`);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/node-ui/src/constants/en.global.json
+++ b/node-ui/src/constants/en.global.json
@@ -276,5 +276,38 @@
   "walletSelectorContext": {
     "alertErrorText": "Failed to initialise wallet selector",
     "componentErrorText": "useWalletSelector must be used within a WalletSelectorContextProvider"
+  },
+  "appLoginPopup": {
+    "selectContext": {
+      "title": "Sign-in request",
+      "websiteText": "From site: ",
+      "appIdText": "Application Id: ",
+      "contextsTitle": "Available contexts",
+      "contextsSubtitle": "Select context",
+      "noContextsText": "No contexts found",
+      "selectedContextText": "Selected context Id:",
+      "buttonNextText": "Confirm context Id",
+      "buttonBackText": "Return to application"
+    },
+    "selectIdentity": {
+      "title": "Sign-in request",
+      "websiteText": "From site: ",
+      "appIdText": "Application Id: ",
+      "contextIdText": "Context Id: ",
+      "contextsTitle": "Available contexts identities",
+      "contextsSubtitle": "Select context identity",
+      "noContextsText": "No contexts identities found",
+      "selectedContextText": "Selected context identity:",
+      "buttonNextText": "Confirm context identity",
+      "buttonBackText": "Return to application"
+    },
+    "createToken": {
+      "title": "Sign-in request",
+      "websiteText": "From site: ",
+      "appIdText": "Application Id: ",
+      "contextIdText": "Context Id: ",
+      "contextIdentityText": "Context Identity: ",
+      "buttonNextText": "Create token"
+    }
   }
 }

--- a/node-ui/src/constants/en.global.json
+++ b/node-ui/src/constants/en.global.json
@@ -268,7 +268,8 @@
   },
   "nodeDataSource": {
     "joinContextErrorTitle": "Error joining context",
-    "joinContextErrorMessage": "Failed to join context"
+    "joinContextErrorMessage": "Failed to join context",
+    "unauthorizedErrorMessage": "Unauthorized"
   },
   "authHeaders": {
     "errorText": "Error extracting private key"

--- a/node-ui/src/context/AppLoginContext.tsx
+++ b/node-ui/src/context/AppLoginContext.tsx
@@ -20,9 +20,6 @@ const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
         const callbackParam = decodeURIComponent(
           urlParams.get('callback_url') ?? '',
         );
-        console.log(applicationIdParam);
-        console.log(callbackParam);
-        console.log('params');
         if (applicationIdParam && callbackParam) {
           setApplicationId(applicationIdParam);
           setCallbackUrl(callbackParam);

--- a/node-ui/src/context/AppLoginContext.tsx
+++ b/node-ui/src/context/AppLoginContext.tsx
@@ -7,38 +7,94 @@ interface AppLoginProviderProps {
   children: React.ReactNode;
 }
 
+interface AuthorizedPopupProps {
+  applicationIdParam: string | null;
+  callbackParam: string | null;
+  storageApplicationId: string | null;
+  storageCallbackUrl: string | null;
+  setApplicationId: (value: string) => void;
+  setCallbackUrl: (value: string) => void;
+  setShowPopup: (value: boolean) => void;
+}
+
+interface UnAuthorizedPopupProps {
+  applicationIdParam: string | null;
+  callbackParam: string | null;
+  setStorageApplicationId: (value: string) => void;
+  setStorageCallbackUrl: (value: string) => void;
+}
+
 const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
   const { showServerDownPopup } = useServerDown();
   const [applicationId, setApplicationId] = useState('');
   const [callbackUrl, setCallbackUrl] = useState('');
   const [showPopup, setShowPopup] = useState(false);
 
+  const getUrlParams = () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    return {
+      applicationId: urlParams.get('application_id'),
+      callbackUrl: decodeURIComponent(urlParams.get('callback_url') ?? ''),
+    };
+  };
+
+  const handleAuthorizedNode = ({
+    applicationIdParam,
+    callbackParam,
+    storageApplicationId,
+    storageCallbackUrl,
+    setApplicationId,
+    setCallbackUrl,
+    setShowPopup
+  }: AuthorizedPopupProps) => {
+    if (applicationIdParam && callbackParam) {
+      setApplicationId(applicationIdParam);
+      setCallbackUrl(callbackParam);
+      setShowPopup(true);
+    } else if (storageApplicationId && storageCallbackUrl) {
+      setApplicationId(storageApplicationId);
+      setCallbackUrl(storageCallbackUrl);
+      setShowPopup(true);
+    }
+  };
+
+  const handleUnauthorizedNode = ({
+    applicationIdParam,
+    callbackParam,
+    setStorageApplicationId,
+    setStorageCallbackUrl
+  }: UnAuthorizedPopupProps) => {
+    if (applicationIdParam && callbackParam) {
+      setStorageApplicationId(applicationIdParam);
+      setStorageCallbackUrl(callbackParam);
+    }
+  };
+
   useEffect(() => {
     const setupLoginPopup = () => {
       try {
-        const urlParams = new URLSearchParams(window.location.search);
-        const applicationIdParam = urlParams.get('application_id');
-        const callbackParam = decodeURIComponent(
-          urlParams.get('callback_url') ?? '',
-        );
+        const { applicationId: applicationIdParam, callbackUrl: callbackParam } = getUrlParams();
         const isNodeAuthorized = getStorageNodeAuthorized();
         const storageApplicationId = getStorageApplicationId();
         const storageCallbackUrl = getStorageCallbackUrl();
+
         if (isNodeAuthorized) {
-          if (applicationIdParam && callbackParam) {
-            setApplicationId(applicationIdParam);
-            setCallbackUrl(callbackParam);
-            setShowPopup(true);
-          } else if (storageApplicationId && storageCallbackUrl) {
-            setApplicationId(storageApplicationId);
-            setCallbackUrl(storageCallbackUrl);
-            setShowPopup(true);
-          }
+          handleAuthorizedNode({
+            applicationIdParam,
+            callbackParam,
+            storageApplicationId,
+            storageCallbackUrl,
+            setApplicationId,
+            setCallbackUrl,
+            setShowPopup
+        });
         } else {
-          if (applicationIdParam && callbackParam) {
-            setStorageApplicationId(applicationIdParam);
-            setStorageCallbackUrl(callbackParam);
-          }
+          handleUnauthorizedNode({
+            applicationIdParam,
+            callbackParam,
+            setStorageApplicationId,
+            setStorageCallbackUrl
+        });
         }
       } catch (e) {
         console.error(e);

--- a/node-ui/src/context/AppLoginContext.tsx
+++ b/node-ui/src/context/AppLoginContext.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import AppLoginPopup from '../components/login/applicationLogin/AppLoginPopup';
+import { useServerDown } from './ServerDownContext';
+
+interface AppLoginProviderProps {
+  children: React.ReactNode;
+}
+
+const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
+  const { showServerDownPopup } = useServerDown();
+  const [applicationId, setApplicationId] = useState('');
+  const [callbackUrl, setCallbackUrl] = useState('');
+  const [showPopup, setShowPopup] = useState(false);
+
+  useEffect(() => {
+    const setupLoginPopup = () => {
+      try {
+        const urlParams = new URLSearchParams(window.location.search);
+        const applicationIdParam = urlParams.get('application_id');
+        const callbackParam = decodeURIComponent(
+          urlParams.get('callback_url') ?? '',
+        );
+        console.log(applicationIdParam);
+        console.log(callbackParam);
+        console.log('params');
+        if (applicationIdParam && callbackParam) {
+          setApplicationId(applicationIdParam);
+          setCallbackUrl(callbackParam);
+          setShowPopup(true);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    setupLoginPopup();
+  }, []);
+
+  return (
+    <div>
+      <AppLoginPopup
+        showPopup={showPopup}
+        callbackUrl={callbackUrl}
+        applicationId={applicationId}
+        showServerDownPopup={showServerDownPopup}
+      />
+      {children}
+    </div>
+  );
+};
+
+export default AppLoginProvider;

--- a/node-ui/src/context/AppLoginContext.tsx
+++ b/node-ui/src/context/AppLoginContext.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import AppLoginPopup from '../components/login/applicationLogin/AppLoginPopup';
 import { useServerDown } from './ServerDownContext';
-import { getStorageApplicationId, getStorageCallbackUrl, getStorageNodeAuthorized, setStorageApplicationId, setStorageCallbackUrl } from '../auth/storage';
+import {
+  getStorageApplicationId,
+  getStorageCallbackUrl,
+  getStorageNodeAuthorized,
+  setStorageApplicationId,
+  setStorageCallbackUrl,
+} from '../auth/storage';
 
 interface AppLoginProviderProps {
   children: React.ReactNode;
@@ -45,7 +51,7 @@ const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
     storageCallbackUrl,
     setApplicationId,
     setCallbackUrl,
-    setShowPopup
+    setShowPopup,
   }: AuthorizedPopupProps) => {
     if (applicationIdParam && callbackParam) {
       setApplicationId(applicationIdParam);
@@ -62,7 +68,7 @@ const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
     applicationIdParam,
     callbackParam,
     setStorageApplicationId,
-    setStorageCallbackUrl
+    setStorageCallbackUrl,
   }: UnAuthorizedPopupProps) => {
     if (applicationIdParam && callbackParam) {
       setStorageApplicationId(applicationIdParam);
@@ -73,7 +79,10 @@ const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
   useEffect(() => {
     const setupLoginPopup = () => {
       try {
-        const { applicationId: applicationIdParam, callbackUrl: callbackParam } = getUrlParams();
+        const {
+          applicationId: applicationIdParam,
+          callbackUrl: callbackParam,
+        } = getUrlParams();
         const isNodeAuthorized = getStorageNodeAuthorized();
         const storageApplicationId = getStorageApplicationId();
         const storageCallbackUrl = getStorageCallbackUrl();
@@ -86,15 +95,15 @@ const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
             storageCallbackUrl,
             setApplicationId,
             setCallbackUrl,
-            setShowPopup
-        });
+            setShowPopup,
+          });
         } else {
           handleUnauthorizedNode({
             applicationIdParam,
             callbackParam,
             setStorageApplicationId,
-            setStorageCallbackUrl
-        });
+            setStorageCallbackUrl,
+          });
         }
       } catch (e) {
         console.error(e);
@@ -116,12 +125,14 @@ const AppLoginProvider = ({ children }: AppLoginProviderProps) => {
 
   return (
     <div>
-      {showPopup && <AppLoginPopup
-        showPopup={showPopup}
-        callbackUrl={callbackUrl}
-        applicationId={applicationId}
-        showServerDownPopup={showServerDownPopup}
-      />}
+      {showPopup && (
+        <AppLoginPopup
+          showPopup={showPopup}
+          callbackUrl={callbackUrl}
+          applicationId={applicationId}
+          showServerDownPopup={showServerDownPopup}
+        />
+      )}
       {children}
     </div>
   );

--- a/node-ui/src/main.tsx
+++ b/node-ui/src/main.tsx
@@ -4,6 +4,7 @@ import './styles/index.css';
 import 'react-tooltip/dist/react-tooltip.css';
 import App from './App';
 import { ServerDownProvider } from './context/ServerDownContext';
+import AppLoginProvider from './context/AppLoginContext';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ServerDownProvider>
-      <App />
+      <AppLoginProvider>
+        <App />
+      </AppLoginProvider>
     </ServerDownProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
# feat(node-ui): new application login popup

## Summary
This login process will be used by frontends for installed applications. (e.g. only peers, app template).
Missing parts in this is handler from the SDK that will be used by apps itself.

When user is redirected to admin dashboard (with application id entered in the frontend app) he is shown login popup -> select context -> select identity -> create jwt -> redirected to frontend (callbackURL)

Last part in video missing as I'm waiting for JWT pr to be merged.

Fixes # [Issue](https://github.com/calimero-network/core/issues/571)

## Test plan

https://github.com/user-attachments/assets/6241bf6c-734e-487f-b667-e6a776e62dc9


