### PR TITLE
refactor: ignore macro tests

### DIFF
--- a/crates/sdk/tests/macros.rs
+++ b/crates/sdk/tests/macros.rs
@@ -1,5 +1,6 @@
 #![allow(unused_crate_dependencies)]
 
+#[ignore]
 #[test]
 fn all() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
Ignore all macro tests as they are currently failing. We will go back to that with https://github.com/calimero-network/core/issues/245