### PR TITLE
Added all methods regarding context

### DIFF
--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -7,6 +7,7 @@ use semver::Version;
 use tracing::info;
 
 use crate::cli::RootArgs;
+use crate::common::RequestType::POST;
 use crate::common::{get_response, multiaddr_to_url};
 use crate::config_file::ConfigFile;
 
@@ -53,6 +54,7 @@ impl InstallCommand {
             install_url,
             Some(install_request),
             &config.identity,
+            POST,
         )
         .await?;
 

--- a/crates/meroctl/src/cli/app/list.rs
+++ b/crates/meroctl/src/cli/app/list.rs
@@ -4,6 +4,7 @@ use eyre::{bail, Result as EyreResult};
 use reqwest::Client;
 
 use crate::cli::RootArgs;
+use crate::common::RequestType::GET;
 use crate::common::{get_response, multiaddr_to_url};
 use crate::config_file::ConfigFile;
 
@@ -25,7 +26,7 @@ impl ListCommand {
 
         let url = multiaddr_to_url(multiaddr, "admin-api/dev/applications")?;
         let client = Client::new();
-        let response = get_response(&client, url, None::<()>, &config.identity).await?;
+        let response = get_response(&client, url, None::<()>, &config.identity, GET).await?;
 
         if !response.status().is_success() {
             bail!("Request failed with status: {}", response.status())

--- a/crates/meroctl/src/cli/context.rs
+++ b/crates/meroctl/src/cli/context.rs
@@ -3,11 +3,15 @@ use const_format::concatcp;
 use eyre::Result as EyreResult;
 
 use crate::cli::context::create::CreateCommand;
+use crate::cli::context::delete::DeleteCommand;
+use crate::cli::context::get::GetCommand;
 use crate::cli::context::join::JoinCommand;
 use crate::cli::context::list::ListCommand;
 use crate::cli::RootArgs;
 
 mod create;
+mod delete;
+mod get;
 mod join;
 mod list;
 
@@ -39,6 +43,9 @@ pub enum ContextSubCommands {
     List(ListCommand),
     Create(Box<CreateCommand>),
     Join(JoinCommand),
+    Get(GetCommand),
+    #[command(alias = "del")]
+    Delete(DeleteCommand),
 }
 
 impl ContextCommand {
@@ -47,6 +54,8 @@ impl ContextCommand {
             ContextSubCommands::List(list) => list.run(args).await,
             ContextSubCommands::Create(create) => create.run(args).await,
             ContextSubCommands::Join(join) => join.run(args).await,
+            ContextSubCommands::Get(get) => get.run(args).await,
+            ContextSubCommands::Delete(delete) => delete.run(args).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/context.rs
+++ b/crates/meroctl/src/cli/context.rs
@@ -51,11 +51,11 @@ pub enum ContextSubCommands {
 impl ContextCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
         match self.subcommand {
-            ContextSubCommands::List(list) => list.run(args).await,
             ContextSubCommands::Create(create) => create.run(args).await,
-            ContextSubCommands::Join(join) => join.run(args).await,
-            ContextSubCommands::Get(get) => get.run(args).await,
             ContextSubCommands::Delete(delete) => delete.run(args).await,
+            ContextSubCommands::Get(get) => get.run(args).await,
+            ContextSubCommands::Join(join) => join.run(args).await,
+            ContextSubCommands::List(list) => list.run(args).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -18,6 +18,7 @@ use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
 use crate::cli::RootArgs;
+use crate::common::RequestType::{GET, POST};
 use crate::common::{get_response, multiaddr_to_url};
 use crate::config_file::ConfigFile;
 
@@ -145,7 +146,7 @@ async fn create_context(
         params.map(String::into_bytes).unwrap_or_default(),
     );
 
-    let response = get_response(client, url, Some(request), &keypair).await?;
+    let response = get_response(client, url, Some(request), &keypair, POST).await?;
 
     if response.status().is_success() {
         let context_response: CreateContextResponse = response.json().await?;
@@ -244,7 +245,7 @@ async fn update_context_application(
 
     let request = UpdateContextApplicationRequest::new(application_id);
 
-    let response = get_response(client, url, Some(request), keypair).await?;
+    let response = get_response(client, url, Some(request), keypair, POST).await?;
 
     if response.status().is_success() {
         println!(
@@ -275,7 +276,7 @@ async fn app_installed(
         &format!("admin-api/dev/application/{application_id}"),
     )?;
 
-    let response = get_response(client, url, None::<()>, keypair).await?;
+    let response = get_response(client, url, None::<()>, keypair, GET).await?;
 
     if !response.status().is_success() {
         bail!("Request failed with status: {}", response.status())
@@ -299,7 +300,7 @@ async fn install_app(
         InstallDevApplicationRequest::new(path, None, metadata.unwrap_or_default());
 
     let install_response =
-        get_response(client, install_url, Some(install_request), keypair).await?;
+        get_response(client, install_url, Some(install_request), keypair, POST).await?;
 
     if !install_response.status().is_success() {
         let status = install_response.status();

--- a/crates/meroctl/src/cli/context/get.rs
+++ b/crates/meroctl/src/cli/context/get.rs
@@ -1,0 +1,148 @@
+use clap::{Parser, ValueEnum};
+use eyre::{bail, Result as EyreResult};
+use libp2p::Multiaddr;
+use reqwest::Client;
+
+use crate::cli::RootArgs;
+use crate::common::RequestType::GET;
+use crate::common::{get_response, multiaddr_to_url};
+use crate::config_file::ConfigFile;
+
+#[derive(Parser, Debug)]
+pub struct GetCommand {
+    #[clap(long, short)]
+    pub method: GetRequest,
+
+    #[clap(long, short)]
+    pub context_id: String,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum GetRequest {
+    Context,
+    Users,
+    ClientKeys,
+    Storage,
+    Identities,
+}
+
+impl GetCommand {
+    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
+        let path = root_args.home.join(&root_args.node_name);
+        if !ConfigFile::exists(&path) {
+            bail!("Config file does not exist")
+        }
+        let Ok(config) = ConfigFile::load(&path) else {
+            bail!("Failed to load config file");
+        };
+        let Some(multiaddr) = config.network.server.listen.first() else {
+            bail!("No address.")
+        };
+
+        let client = Client::new();
+
+        match self.method {
+            GetRequest::Context => {
+                self.get_context(multiaddr, &client, &config.identity)
+                    .await?
+            }
+            GetRequest::Users => self.get_users(multiaddr, &client, &config.identity).await?,
+            GetRequest::ClientKeys => {
+                self.get_client_keys(multiaddr, &client, &config.identity)
+                    .await?
+            }
+            GetRequest::Storage => {
+                self.get_storage(multiaddr, &client, &config.identity)
+                    .await?
+            }
+            GetRequest::Identities => {
+                self.get_identities(multiaddr, &client, &config.identity)
+                    .await?
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_context(
+        &self,
+        multiaddr: &Multiaddr,
+        client: &Client,
+        keypair: &libp2p::identity::Keypair,
+    ) -> EyreResult<()> {
+        let url = multiaddr_to_url(
+            multiaddr,
+            &format!("admin-api/dev/contexts/{}", self.context_id),
+        )?;
+        self.make_request(client, url, keypair).await
+    }
+
+    async fn get_users(
+        &self,
+        multiaddr: &Multiaddr,
+        client: &Client,
+        keypair: &libp2p::identity::Keypair,
+    ) -> EyreResult<()> {
+        let url = multiaddr_to_url(
+            multiaddr,
+            &format!("admin-api/dev/contexts/{}/users", self.context_id),
+        )?;
+        self.make_request(client, url, keypair).await
+    }
+
+    async fn get_client_keys(
+        &self,
+        multiaddr: &Multiaddr,
+        client: &Client,
+        keypair: &libp2p::identity::Keypair,
+    ) -> EyreResult<()> {
+        let url = multiaddr_to_url(
+            multiaddr,
+            &format!("admin-api/dev/contexts/{}/client-keys", self.context_id),
+        )?;
+        self.make_request(client, url, keypair).await
+    }
+
+    async fn get_storage(
+        &self,
+        multiaddr: &Multiaddr,
+        client: &Client,
+        keypair: &libp2p::identity::Keypair,
+    ) -> EyreResult<()> {
+        let url = multiaddr_to_url(
+            multiaddr,
+            &format!("admin-api/dev/contexts/{}/storage", self.context_id),
+        )?;
+        self.make_request(client, url, keypair).await
+    }
+
+    async fn get_identities(
+        &self,
+        multiaddr: &Multiaddr,
+        client: &Client,
+        keypair: &libp2p::identity::Keypair,
+    ) -> EyreResult<()> {
+        let url = multiaddr_to_url(
+            multiaddr,
+            &format!("admin-api/dev/contexts/{}/identities", self.context_id),
+        )?;
+        self.make_request(client, url, keypair).await
+    }
+
+    async fn make_request(
+        &self,
+        client: &Client,
+        url: reqwest::Url,
+        keypair: &libp2p::identity::Keypair,
+    ) -> EyreResult<()> {
+        let response = get_response(client, url, None::<()>, keypair, GET).await?;
+
+        if !response.status().is_success() {
+            bail!("Request failed with status: {}", response.status())
+        }
+
+        let text = response.text().await?;
+        println!("{}", text);
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/cli/context/list.rs
+++ b/crates/meroctl/src/cli/context/list.rs
@@ -4,6 +4,7 @@ use eyre::{bail, Result as EyreResult};
 use reqwest::Client;
 
 use crate::cli::RootArgs;
+use crate::common::RequestType::GET;
 use crate::common::{get_response, multiaddr_to_url};
 use crate::config_file::ConfigFile;
 
@@ -26,7 +27,7 @@ impl ListCommand {
         let url = multiaddr_to_url(multiaddr, "admin-api/dev/contexts")?;
         let client = Client::new();
 
-        let response = get_response(&client, url, None::<()>, &config.identity).await?;
+        let response = get_response(&client, url, None::<()>, &config.identity, GET).await?;
 
         if !response.status().is_success() {
             bail!("Request failed with status: {}", response.status())

--- a/crates/meroctl/src/common.rs
+++ b/crates/meroctl/src/common.rs
@@ -35,14 +35,15 @@ pub async fn get_response(
     url: Url,
     body: Option<impl Serialize>,
     keypair: &Keypair,
+    req_type: RequestType,
 ) -> EyreResult<Response> {
     let timestamp = Utc::now().timestamp().to_string();
     let signature = keypair.sign(timestamp.as_bytes())?;
 
-    let mut builder = if body.is_some() {
-        client.post(url).json(&body)
-    } else {
-        client.get(url)
+    let mut builder = match req_type {
+        RequestType::GET => client.get(url),
+        RequestType::POST => client.post(url).json(&body),
+        RequestType::DELETE => client.delete(url),
     };
 
     builder = builder
@@ -53,4 +54,10 @@ pub async fn get_response(
         .send()
         .await
         .map_err(|_| eyre!("Error with client request"))
+}
+
+pub enum RequestType {
+    GET,
+    POST,
+    DELETE,
 }

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -143,6 +143,24 @@ pub(crate) fn setup(
             post(update_application_id),
         )
         .route("/dev/applications", get(list_applications_handler))
+        .route("/dev/contexts/:context_id", get(get_context_handler))
+        .route(
+            "/dev/contexts/:context_id/users",
+            get(get_context_users_handler),
+        )
+        .route(
+            "/dev/contexts/:context_id/client-keys",
+            get(get_context_client_keys_handler),
+        )
+        .route(
+            "/dev/contexts/:context_id/storage",
+            get(get_context_storage_handler),
+        )
+        .route(
+            "/dev/contexts/:context_id/identities",
+            get(get_context_identities_handler),
+        )
+        .route("/dev/contexts/:context_id", delete(delete_context_handler))
         .route_layer(axum::middleware::from_fn(
             middleware::dev_auth::dev_mode_auth,
         ));


### PR DESCRIPTION
# Context CLI methods

## Summary

All out apis regarding context can now be used through the CLI. 

Fixes #592 

## Test plan

Ran these commands on my non coordinator node (node 2 in this case)
The context with the id `EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab` was already created

`cargo run -p meroctl -- --node-name node2 context get --method context  --context-id EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab 
`

`cargo run -p meroctl -- --node-name node2 context get --method client-keys  --context-id EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab 
`

`cargo run -p meroctl -- --node-name node2 context get --method storage  --context-id EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab 
`

`cargo run -p meroctl -- --node-name node2 context get --method identities  --context-id EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab 
`

All produce correct results.

input: `cargo run -p meroctl -- --node-name node2 context list `
output: 
```
EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab
2CR8b8pNXcFF72PYpKHfHsHYG8Konqh6bm1FhErKrNU6
AFqjzUVrg9yeK5DcbpNcWDRtE4HucFzKyf9Xc8ZEKv8R
```

input: `cargo run -p meroctl -- --node-name node2 context delete --context-id EDwcrKJ9uhywwjFYssNmLzzJaj3AfDty6SxG9Pi2Juab`
output: `Context deleted successfully: {"data":{"isDeleted":true}}`

input: `cargo run -p meroctl -- --node-name node2 context list `
output: 
```
2CR8b8pNXcFF72PYpKHfHsHYG8Konqh6bm1FhErKrNU6
AFqjzUVrg9yeK5DcbpNcWDRtE4HucFzKyf9Xc8ZEKv8R
```
