### PR TITLE
feat(context-config): add base client w/ relayer impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ name = "calimero-context"
 version = "0.1.0"
 dependencies = [
  "calimero-blobstore",
+ "calimero-context-config",
  "calimero-network",
  "calimero-node-primitives",
  "calimero-primitives",
@@ -1107,9 +1108,11 @@ dependencies = [
  "borsh",
  "bs58 0.5.1",
  "ed25519-dalek",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -19,6 +19,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
 
+calimero-context-config = { path = "./config", features = ["client"] }
 calimero-blobstore = { path = "../store/blobs" }
 calimero-primitives = { path = "../primitives", features = ["borsh", "rand"] }
 calimero-network = { path = "../network" }

--- a/crates/context/config/Cargo.toml
+++ b/crates/context/config/Cargo.toml
@@ -20,4 +20,4 @@ url = { workspace = true, optional = true }
 workspace = true
 
 [features]
-client = ["dep:reqwest", "dep:url"]
+client = ["reqwest/json", "dep:url"]

--- a/crates/context/config/Cargo.toml
+++ b/crates/context/config/Cargo.toml
@@ -10,9 +10,14 @@ license.workspace = true
 bs58.workspace = true
 borsh = { workspace = true, features = ["derive"] }
 ed25519-dalek.workspace = true
+reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+url = { workspace = true, optional = true }
 
 [lints]
 workspace = true
+
+[features]
+client = ["dep:reqwest", "dep:url"]

--- a/crates/context/config/src/client.rs
+++ b/crates/context/config/src/client.rs
@@ -223,7 +223,7 @@ impl<T: Transport> ClientRequest<'_, '_, T> {
 }
 
 impl<T: Transport> ContextConfigMutateClient<'_, T> {
-    pub async fn add_context<'a>(
+    pub fn add_context<'a>(
         &self,
         context_id: ContextId,
         author_id: ContextIdentity,
@@ -240,7 +240,7 @@ impl<T: Transport> ContextConfigMutateClient<'_, T> {
         ClientRequest { client: self, kind }
     }
 
-    pub async fn update_application<'a>(
+    pub fn update_application<'a>(
         &self,
         context_id: ContextId,
         application: Application<'a>,
@@ -253,7 +253,7 @@ impl<T: Transport> ContextConfigMutateClient<'_, T> {
         ClientRequest { client: self, kind }
     }
 
-    pub async fn add_members(
+    pub fn add_members(
         &self,
         context_id: ContextId,
         members: &[ContextIdentity],
@@ -270,7 +270,7 @@ impl<T: Transport> ContextConfigMutateClient<'_, T> {
         ClientRequest { client: self, kind }
     }
 
-    pub async fn remove_members(
+    pub fn remove_members(
         &self,
         context_id: ContextId,
         members: &[ContextIdentity],
@@ -287,7 +287,7 @@ impl<T: Transport> ContextConfigMutateClient<'_, T> {
         ClientRequest { client: self, kind }
     }
 
-    pub async fn grant(
+    pub fn grant(
         &self,
         context_id: ContextId,
         capabilities: &[(ContextIdentity, Capability)],
@@ -304,7 +304,7 @@ impl<T: Transport> ContextConfigMutateClient<'_, T> {
         ClientRequest { client: self, kind }
     }
 
-    pub async fn revoke(
+    pub fn revoke(
         &self,
         context_id: ContextId,
         capabilities: &[(ContextIdentity, Capability)],

--- a/crates/context/config/src/client.rs
+++ b/crates/context/config/src/client.rs
@@ -12,7 +12,7 @@ use crate::repr::Repr;
 use crate::types::{self, Application, Capability, ContextId, ContextIdentity, Signed, SignerId};
 use crate::{ContextRequest, ContextRequestKind, Request, RequestKind};
 
-mod relayer;
+pub mod relayer;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Operation<'a> {

--- a/crates/context/config/src/client.rs
+++ b/crates/context/config/src/client.rs
@@ -1,0 +1,326 @@
+use core::fmt;
+use std::{borrow::Cow, collections::BTreeMap, mem};
+
+use ed25519_dalek::Signature;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use thiserror::Error;
+
+use crate::{
+    repr::Repr,
+    types::{self, Application, Capability, ContextId, ContextIdentity, Signed, SignerId},
+    ContextRequest, ContextRequestKind, Request, RequestKind,
+};
+
+mod relayer;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Operation<'a> {
+    Read { method: Cow<'a, str> },
+    Write { method: Cow<'a, str> },
+}
+
+pub trait Transport {
+    type Error: fmt::Display;
+
+    #[allow(async_fn_in_trait)]
+    async fn send(
+        &self,
+        operation: Operation<'_>,
+        payload: Vec<u8>,
+    ) -> Result<Vec<u8>, Self::Error>;
+}
+
+#[derive(Debug)]
+pub struct ContextConfigClient<T> {
+    transport: T,
+}
+
+impl<T: Transport> ContextConfigClient<T> {
+    pub fn new(transport: T) -> Self {
+        Self { transport }
+    }
+}
+
+impl<T: Transport> ContextConfigClient<T> {
+    pub fn query(&self) -> ContextConfigQueryClient<'_, T> {
+        ContextConfigQueryClient {
+            transport: &self.transport,
+        }
+    }
+
+    pub fn mutate(&self, signer_id: SignerId) -> ContextConfigMutateClient<'_, T> {
+        ContextConfigMutateClient {
+            signer_id,
+            transport: &self.transport,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error<T: Transport> {
+    #[error("transport error: {0}")]
+    Transport(T::Error),
+    #[error(transparent)]
+    Other(#[from] types::Error<std::convert::Infallible>),
+}
+
+#[derive(Debug)]
+pub struct Response<T> {
+    bytes: Vec<u8>,
+    _priv: std::marker::PhantomData<T>,
+}
+
+impl<T> Response<T> {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            _priv: Default::default(),
+        }
+    }
+
+    pub fn parse(&self) -> Result<T, serde_json::Error>
+    where
+        T: for<'a> Deserialize<'a>,
+    {
+        serde_json::from_slice(&self.bytes)
+    }
+}
+
+#[derive(Debug)]
+pub struct ContextConfigQueryClient<'a, T> {
+    transport: &'a T,
+}
+
+impl<'a, T: Transport> ContextConfigQueryClient<'a, T> {
+    async fn read<I: Serialize, O>(&self, method: &str, body: I) -> Result<Response<O>, Error<T>> {
+        let payload = serde_json::to_vec(&body).map_err(|err| Error::Other(err.into()))?;
+
+        let operation = Operation::Read {
+            method: Cow::Borrowed(method),
+        };
+
+        let response = self
+            .transport
+            .send(operation, payload)
+            .await
+            .map_err(Error::Transport)?;
+
+        Ok(Response::new(response))
+    }
+
+    pub async fn application(
+        &self,
+        context_id: ContextId,
+    ) -> Result<Response<Application<'static>>, Error<T>> {
+        self.read(
+            "application",
+            json!({
+                "context_id": Repr::new(context_id),
+            }),
+        )
+        .await
+    }
+
+    pub async fn members(
+        &self,
+        context_id: ContextId,
+        offset: usize,
+        length: usize,
+    ) -> Result<Response<Vec<Repr<ContextIdentity>>>, Error<T>> {
+        self.read(
+            "members",
+            json!({
+                "context_id": Repr::new(context_id),
+                "offset": offset,
+                "length": length,
+            }),
+        )
+        .await
+    }
+
+    pub async fn privileges(
+        &self,
+        context_id: ContextId,
+        identities: &[ContextIdentity],
+    ) -> Result<Response<BTreeMap<Repr<SignerId>, Vec<Capability>>>, Error<T>> {
+        let identities = unsafe { mem::transmute::<_, &[Repr<ContextIdentity>]>(identities) };
+
+        self.read(
+            "privileges",
+            json!({
+                "context_id": Repr::new(context_id),
+                "identities": identities,
+            }),
+        )
+        .await
+    }
+}
+
+#[derive(Debug)]
+pub struct ClientRequest<'a, R, T> {
+    request: R,
+    transport: &'a T,
+}
+
+impl<'a, R: Serialize, T: Transport> ClientRequest<'a, R, T> {
+    async fn send(&self, sign: impl FnOnce(&[u8]) -> Signature) -> Result<(), Error<T>> {
+        let signed = Signed::new(&self.request, sign)?;
+
+        let operation = Operation::Write {
+            method: Cow::Borrowed("mutate"),
+        };
+
+        let payload = serde_json::to_vec(&signed).map_err(|err| Error::Other(err.into()))?;
+
+        let _unused = self
+            .transport
+            .send(operation, payload)
+            .await
+            .map_err(Error::Transport)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ContextConfigMutateClient<'a, T> {
+    signer_id: SignerId,
+    transport: &'a T,
+}
+
+impl<T: Transport> ContextConfigMutateClient<'_, T> {
+    pub async fn add_context<'a>(
+        &self,
+        context_id: ContextId,
+        author_id: ContextIdentity,
+        application: Application<'a>,
+    ) -> ClientRequest<'_, Request<'a>, T> {
+        let request = Request::new(
+            self.signer_id,
+            RequestKind::Context(ContextRequest {
+                context_id: Repr::new(context_id),
+                kind: ContextRequestKind::Add {
+                    author_id: Repr::new(author_id),
+                    application,
+                },
+            }),
+        );
+
+        ClientRequest {
+            request,
+            transport: &self.transport,
+        }
+    }
+
+    pub async fn update_application<'a>(
+        &self,
+        context_id: ContextId,
+        application: Application<'a>,
+    ) -> ClientRequest<'_, Request<'a>, T> {
+        let request = Request::new(
+            self.signer_id,
+            RequestKind::Context(ContextRequest {
+                context_id: Repr::new(context_id),
+                kind: ContextRequestKind::UpdateApplication { application },
+            }),
+        );
+
+        ClientRequest {
+            request,
+            transport: &self.transport,
+        }
+    }
+
+    pub async fn add_members(
+        &self,
+        context_id: ContextId,
+        members: &[ContextIdentity],
+    ) -> ClientRequest<'_, Request<'static>, T> {
+        let members = unsafe { mem::transmute(members) };
+
+        let request = Request::new(
+            self.signer_id,
+            RequestKind::Context(ContextRequest {
+                context_id: Repr::new(context_id),
+                kind: ContextRequestKind::AddMembers {
+                    members: Cow::Borrowed(members),
+                },
+            }),
+        );
+
+        ClientRequest {
+            request,
+            transport: &self.transport,
+        }
+    }
+
+    pub async fn remove_members(
+        &self,
+        context_id: ContextId,
+        members: &[ContextIdentity],
+    ) -> ClientRequest<'_, Request<'static>, T> {
+        let members = unsafe { mem::transmute(members) };
+
+        let request = Request::new(
+            self.signer_id,
+            RequestKind::Context(ContextRequest {
+                context_id: Repr::new(context_id),
+                kind: ContextRequestKind::RemoveMembers {
+                    members: Cow::Borrowed(members),
+                },
+            }),
+        );
+
+        ClientRequest {
+            request,
+            transport: &self.transport,
+        }
+    }
+
+    pub async fn grant(
+        &self,
+        context_id: ContextId,
+        capabilities: &[(ContextIdentity, Capability)],
+    ) -> ClientRequest<'_, Request<'static>, T> {
+        let capabilities = unsafe { mem::transmute(capabilities) };
+
+        let request = Request::new(
+            self.signer_id,
+            RequestKind::Context(ContextRequest {
+                context_id: Repr::new(context_id),
+                kind: ContextRequestKind::Grant {
+                    capabilities: Cow::Borrowed(capabilities),
+                },
+            }),
+        );
+
+        ClientRequest {
+            request,
+            transport: &self.transport,
+        }
+    }
+
+    pub async fn revoke(
+        &self,
+        context_id: ContextId,
+        capabilities: &[(ContextIdentity, Capability)],
+    ) -> ClientRequest<'_, Request<'static>, T> {
+        let capabilities = unsafe { mem::transmute(capabilities) };
+
+        let request = Request::new(
+            self.signer_id,
+            RequestKind::Context(ContextRequest {
+                context_id: Repr::new(context_id),
+                kind: ContextRequestKind::Revoke {
+                    capabilities: Cow::Borrowed(capabilities),
+                },
+            }),
+        );
+
+        ClientRequest {
+            request,
+            transport: &self.transport,
+        }
+    }
+}

--- a/crates/context/config/src/client/relayer.rs
+++ b/crates/context/config/src/client/relayer.rs
@@ -1,22 +1,23 @@
 use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use super::{Operation, Transport, TransportRequest};
 
 #[derive(Debug)]
-pub struct RelayerConfig<'a> {
-    pub url: Cow<'a, str>,
+pub struct RelayerConfig {
+    pub url: Url,
 }
 
 #[derive(Debug)]
-pub struct RelayerTransport<'a> {
+pub struct RelayerTransport {
     client: reqwest::Client,
-    url: Cow<'a, str>,
+    url: Url,
 }
 
-impl<'a> RelayerTransport<'a> {
-    pub fn new(config: &RelayerConfig<'a>) -> Self {
+impl RelayerTransport {
+    pub fn new(config: &RelayerConfig) -> Self {
         let client = reqwest::Client::new();
 
         Self {
@@ -34,7 +35,7 @@ pub struct RelayRequest<'a> {
     pub payload: Vec<u8>,
 }
 
-impl Transport for RelayerTransport<'_> {
+impl Transport for RelayerTransport {
     type Error = reqwest::Error;
 
     async fn send(
@@ -44,7 +45,7 @@ impl Transport for RelayerTransport<'_> {
     ) -> Result<Vec<u8>, Self::Error> {
         let response = self
             .client
-            .post(&*self.url)
+            .post(self.url.clone())
             .json(&RelayRequest {
                 network_id: request.network_id,
                 contract_id: request.contract_id,

--- a/crates/context/config/src/client/relayer.rs
+++ b/crates/context/config/src/client/relayer.rs
@@ -6,9 +6,9 @@ use super::{Operation, Transport};
 
 #[derive(Debug)]
 pub struct RelayerConfig<'a> {
-    url: Cow<'a, str>,
-    network: Cow<'a, str>,
-    contract_id: Cow<'a, str>,
+    pub url: Cow<'a, str>,
+    pub network: Cow<'a, str>,
+    pub contract_id: Cow<'a, str>,
 }
 
 #[derive(Debug)]

--- a/crates/context/config/src/client/relayer.rs
+++ b/crates/context/config/src/client/relayer.rs
@@ -1,0 +1,63 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use super::{Operation, Transport};
+
+pub struct RelayerConfig<'a> {
+    url: Cow<'a, str>,
+    network: Cow<'a, str>,
+    contract_id: Cow<'a, str>,
+}
+
+pub struct RelayerTransport<'a> {
+    client: reqwest::Client,
+    url: Cow<'a, str>,
+    network: Cow<'a, str>,
+    contract_id: Cow<'a, str>,
+}
+
+impl<'a> RelayerTransport<'a> {
+    pub fn new(config: &RelayerConfig<'a>) -> Self {
+        let client = reqwest::Client::new();
+
+        Self {
+            client,
+            url: config.url.clone(),
+            network: config.network.clone(),
+            contract_id: config.contract_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RelayRequest<'a> {
+    network: Cow<'a, str>,
+    contract_id: Cow<'a, str>,
+    operation: Operation<'a>,
+    payload: Vec<u8>,
+}
+
+impl Transport for RelayerTransport<'_> {
+    type Error = reqwest::Error;
+
+    async fn send(
+        &self,
+        operation: Operation<'_>,
+        payload: Vec<u8>,
+    ) -> Result<Vec<u8>, Self::Error> {
+        let response = self
+            .client
+            .post(&*self.url)
+            .json(&RelayRequest {
+                network: Cow::Borrowed(&self.network),
+                contract_id: Cow::Borrowed(&self.contract_id),
+                operation,
+                payload,
+            })
+            .send()
+            .await?;
+
+        response.bytes().await.map(|bytes| bytes.to_vec())
+    }
+}

--- a/crates/context/config/src/client/relayer.rs
+++ b/crates/context/config/src/client/relayer.rs
@@ -60,6 +60,6 @@ impl Transport for RelayerTransport<'_> {
             .send()
             .await?;
 
-        response.bytes().await.map(|bytes| bytes.to_vec())
+        response.bytes().await.map(Into::into)
     }
 }

--- a/crates/context/config/src/client/relayer.rs
+++ b/crates/context/config/src/client/relayer.rs
@@ -4,12 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use super::{Operation, Transport};
 
+#[derive(Debug)]
 pub struct RelayerConfig<'a> {
     url: Cow<'a, str>,
     network: Cow<'a, str>,
     contract_id: Cow<'a, str>,
 }
 
+#[derive(Debug)]
 pub struct RelayerTransport<'a> {
     client: reqwest::Client,
     url: Cow<'a, str>,

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -5,6 +5,8 @@ use std::time;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "client")]
+pub mod client;
 pub mod repr;
 pub mod types;
 

--- a/crates/context/config/src/repr.rs
+++ b/crates/context/config/src/repr.rs
@@ -23,6 +23,7 @@ pub type Result<T, E> = std::result::Result<T, Error<E>>;
     BorshDeserialize,
 )]
 #[serde(transparent)]
+#[repr(transparent)]
 pub struct Repr<T> {
     #[serde(with = "serde_bytes", bound = "T: ReprBytes")]
     inner: T,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -137,8 +137,14 @@ impl ContextManager {
             (context_secret, identity_secret)
         };
 
+        let context_id = ContextId::from(*context_secret.public_key());
+
+        if self.get_context(&context_id)?.is_some() {
+            bail!("Context already exists on node.")
+        }
+
         let context = Context {
-            id: ContextId::from(*context_secret.public_key()),
+            id: context_id,
             application_id,
             last_transaction_hash: Default::default(),
         };

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -15,8 +15,9 @@ use calimero_store::key::{
     ApplicationMeta as ApplicationMetaKey, BlobMeta as BlobMetaKey,
     ContextIdentity as ContextIdentityKey, ContextMeta as ContextMetaKey,
 };
-use calimero_store::types::ContextIdentity as ContextIdentityValue;
-use calimero_store::types::{ApplicationMeta, ContextMeta};
+use calimero_store::types::{
+    ApplicationMeta, ContextIdentity as ContextIdentityValue, ContextMeta,
+};
 use calimero_store::Store;
 use camino::Utf8PathBuf;
 use eyre::{bail, Result as EyreResult};

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -65,12 +65,19 @@ impl CreateCommand {
             Self {
                 application_id: Some(app_id),
                 watch: None,
-                context_seed: None,
+                context_seed,
                 metadata: None,
                 params,
             } => {
-                let _ = create_context(&client, multiaddr, None, app_id, params, &config.identity)
-                    .await?;
+                let _ = create_context(
+                    &client,
+                    multiaddr,
+                    context_seed,
+                    app_id,
+                    params,
+                    &config.identity,
+                )
+                .await?;
             }
             Self {
                 application_id: None,

--- a/crates/node-primitives/src/lib.rs
+++ b/crates/node-primitives/src/lib.rs
@@ -1,5 +1,6 @@
+use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
-use calimero_primitives::{application::ApplicationId, identity::PublicKey};
+use calimero_primitives::identity::PublicKey;
 use calimero_runtime::logic::Outcome;
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;

--- a/crates/server/src/admin/utils/auth.rs
+++ b/crates/server/src/admin/utils/auth.rs
@@ -9,8 +9,7 @@ use calimero_server_primitives::admin::{
 use calimero_store::Store;
 use chrono::{Duration, TimeZone, Utc};
 use eyre::{bail, eyre, Result as EyreResult};
-use libp2p::identity::Keypair;
-use libp2p::identity::PublicKey;
+use libp2p::identity::{Keypair, PublicKey};
 use reqwest::StatusCode;
 use serde_json::to_string as to_json_string;
 use tracing::info;


### PR DESCRIPTION
Adds a foundational library for interacting with the context config contract à la #680.

This also introduces a relayer implementation. NEAR to come.