### PR TITLE
Added all application functions to the cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,11 +4881,13 @@ dependencies = [
  "reqwest 0.12.5",
  "semver",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
  "toml_edit 0.22.20",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -24,11 +24,13 @@ rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std", "macros"] }
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url.workspace = true
 
 calimero-context = { path = "../context" }
 calimero-node = { path = "../node" }

--- a/crates/meroctl/src/cli/app.rs
+++ b/crates/meroctl/src/cli/app.rs
@@ -2,9 +2,11 @@ use clap::{Parser, Subcommand};
 use eyre::Result as EyreResult;
 
 use super::RootArgs;
+use crate::cli::app::get::GetCommand;
 use crate::cli::app::install::InstallCommand;
 use crate::cli::app::list::ListCommand;
 
+mod get;
 mod install;
 mod list;
 
@@ -19,6 +21,7 @@ pub enum AppSubCommands {
     Install(InstallCommand),
     #[command(alias = "ls")]
     List(ListCommand),
+    Get(GetCommand),
 }
 
 impl AppCommand {
@@ -26,6 +29,7 @@ impl AppCommand {
         match self.subcommand {
             AppSubCommands::Install(install) => install.run(args).await,
             AppSubCommands::List(list) => list.run(args).await,
+            AppSubCommands::Get(get) => get.run(args).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/app.rs
+++ b/crates/meroctl/src/cli/app.rs
@@ -18,18 +18,18 @@ pub struct AppCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum AppSubCommands {
+    Get(GetCommand),
     Install(InstallCommand),
     #[command(alias = "ls")]
     List(ListCommand),
-    Get(GetCommand),
 }
 
 impl AppCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
         match self.subcommand {
+            AppSubCommands::Get(get) => get.run(args).await,
             AppSubCommands::Install(install) => install.run(args).await,
             AppSubCommands::List(list) => list.run(args).await,
-            AppSubCommands::Get(get) => get.run(args).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/app/get.rs
+++ b/crates/meroctl/src/cli/app/get.rs
@@ -1,0 +1,56 @@
+use clap::{Parser, ValueEnum};
+use eyre::{bail, Result as EyreResult};
+use reqwest::Client;
+
+use crate::cli::RootArgs;
+use crate::common::{get_response, multiaddr_to_url};
+use crate::config_file::ConfigFile;
+
+#[derive(Parser, Debug)]
+pub struct GetCommand {
+    #[arg(long, short)]
+    pub method: GetValues,
+
+    #[arg(long, short)]
+    pub app_id: String,
+}
+#[derive(ValueEnum, Debug, Clone)]
+pub enum GetValues {
+    Details,
+}
+
+impl GetCommand {
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let path = args.home.join(&args.node_name);
+
+        if !ConfigFile::exists(&path) {
+            bail!("Config file does not exist")
+        };
+
+        let Ok(config) = ConfigFile::load(&path) else {
+            bail!("Failed to load config file")
+        };
+
+        let Some(multiaddr) = config.network.server.listen.first() else {
+            bail!("No address.")
+        };
+
+        let client = Client::new();
+
+        let url = multiaddr_to_url(
+            multiaddr,
+            &format!("admin-api/dev/applications/{}", self.app_id),
+        )?;
+
+        let response = get_response(&client, url, None::<()>, &config.identity).await?;
+
+        if !response.status().is_success() {
+            bail!("Request failed with status: {}", response.status())
+        }
+
+        let text = response.text().await?;
+        println!("{}", text);
+
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/cli/app/get.rs
+++ b/crates/meroctl/src/cli/app/get.rs
@@ -48,8 +48,7 @@ impl GetCommand {
             bail!("Request failed with status: {}", response.status())
         }
 
-        let text = response.text().await?;
-        println!("{}", text);
+        println!("{}", response.text().await?);
 
         Ok(())
     }

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -1,10 +1,14 @@
-use calimero_server_primitives::admin::{InstallApplicationResponse, InstallDevApplicationRequest};
+use calimero_primitives::hash::Hash;
+use calimero_server_primitives::admin::{
+    InstallApplicationRequest, InstallApplicationResponse, InstallDevApplicationRequest,
+};
 use camino::Utf8PathBuf;
 use clap::Parser;
 use eyre::{bail, Result};
 use reqwest::Client;
 use semver::Version;
 use tracing::info;
+use url::Url;
 
 use crate::cli::RootArgs;
 use crate::common::{get_response, multiaddr_to_url};
@@ -13,13 +17,21 @@ use crate::config_file::ConfigFile;
 #[derive(Debug, Parser)]
 pub struct InstallCommand {
     /// Path to the application
-    #[arg(long, short)]
-    pub path: Utf8PathBuf,
+    #[arg(long, short, conflicts_with = "url")]
+    pub path: Option<Utf8PathBuf>,
 
-    /// Version of the application
+    /// Url of the application
+    #[clap(long, short, conflicts_with = "path", requires = "metadata")]
+    pub url: Option<String>,
+
     #[clap(short, long, help = "Version of the application")]
     pub version: Option<Version>,
+
+    #[clap(short, long, help = "Metadata for the application")]
     pub metadata: Option<Vec<u8>>,
+
+    #[clap(long, help = "Hash of the application")]
+    pub hash: Option<Hash>,
 }
 
 impl InstallCommand {
@@ -40,13 +52,33 @@ impl InstallCommand {
 
         let client = Client::new();
 
-        let install_url = multiaddr_to_url(multiaddr, "admin-api/dev/install-application")?;
+        let mut is_dev_installation = false;
 
-        let install_request = InstallDevApplicationRequest::new(
-            self.path.canonicalize_utf8()?,
-            self.version,
-            self.metadata.unwrap_or_default(),
-        );
+        let install_request = if let Some(app_path) = self.path {
+            let install_dev_request = InstallDevApplicationRequest::new(
+                app_path.canonicalize_utf8()?,
+                self.version,
+                self.metadata.unwrap_or_default(),
+            );
+            is_dev_installation = true;
+            serde_json::to_value(install_dev_request)?
+        } else if let Some(app_url) = self.url {
+            let install_request = InstallApplicationRequest::new(
+                Url::parse(&app_url)?,
+                self.version,
+                self.hash,
+                self.metadata.unwrap_or_default(),
+            );
+            serde_json::to_value(install_request)?
+        } else {
+            bail!("Either path or url must be provided");
+        };
+
+        let install_url = if is_dev_installation {
+            multiaddr_to_url(multiaddr, "admin-api/dev/install-dev-application")?
+        } else {
+            multiaddr_to_url(multiaddr, "admin-api/dev/install-application")?
+        };
 
         let install_response = get_response(
             &client,

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -293,7 +293,7 @@ async fn install_app(
     metadata: Option<Vec<u8>>,
     keypair: &Keypair,
 ) -> EyreResult<ApplicationId> {
-    let install_url = multiaddr_to_url(base_multiaddr, "admin-api/dev/install-application")?;
+    let install_url = multiaddr_to_url(base_multiaddr, "admin-api/dev/install-dev-application")?;
 
     let install_request =
         InstallDevApplicationRequest::new(path, None, metadata.unwrap_or_default());

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -17,6 +17,23 @@ pub struct InstallApplicationRequest {
     pub metadata: Vec<u8>,
 }
 
+impl InstallApplicationRequest {
+    #[must_use]
+    pub const fn new(
+        url: Url,
+        version: Option<Version>,
+        hash: Option<Hash>,
+        metadata: Vec<u8>,
+    ) -> Self {
+        Self {
+            url,
+            hash,
+            version,
+            metadata,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InstallDevApplicationRequest {

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -129,10 +129,18 @@ pub(crate) fn setup(
 
     let dev_router = Router::new()
         .route(
-            "/dev/install-application",
+            "/dev/install-dev-application",
             post(install_dev_application_handler),
         )
+        .route(
+            "/dev/install-application",
+            post(install_application_handler),
+        )
         .route("/dev/application/:application_id", get(get_application))
+        .route(
+            "/dev/applications/:app_id",
+            get(get_application_details_handler),
+        )
         .route(
             "/dev/contexts",
             get(get_contexts_handler).post(create_context_handler),


### PR DESCRIPTION
# Application control through the cli

## Summary

All apis regarding applications are now available through the cli, including installing an app with an URL
Solves #593 and #585 

## Usage

`cargo run -p meroctl -- --node-name node2 app get --method details --app-id <app-id>
`
`cargo run -p meroctl -- --node-name node2 app install --url <url> --metadata <metadata>`