### PR TITLE
Feat/storage integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,7 @@ name = "calimero-storage"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "calimero-store",
  "claims",
  "fixedstr",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
 name = "calimero-storage"
 version = "0.1.0"
 dependencies = [
+ "borsh",
  "claims",
  "fixedstr",
  "thiserror",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,6 +12,7 @@ fixedstr.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
+calimero-store = { path = "../store", features = ["datatypes"] }
 
 [dev-dependencies]
 claims.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+borsh.workspace = true
 fixedstr.workspace = true
 thiserror.workspace = true
 uuid.workspace = true

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -484,11 +484,6 @@ impl Path {
 }
 
 impl BorshDeserialize for Path {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, IoError> {
-        Self::new(&String::deserialize(buf)?)
-            .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))
-    }
-
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, IoError> {
         Self::new(&String::deserialize_reader(reader)?)
             .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -10,7 +10,9 @@
 mod tests;
 
 use core::fmt::{self, Debug, Display, Formatter};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use fixedstr::Flexstr;
 use thiserror::Error as ThisError;
 use uuid::{Bytes, Uuid};
@@ -52,6 +54,34 @@ impl Id {
     #[must_use]
     pub const fn as_bytes(&self) -> &Bytes {
         self.0.as_bytes()
+    }
+}
+
+impl BorshDeserialize for Id {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, IoError> {
+        if buf.len() < 16 {
+            return Err(IoError::new(
+                IoErrorKind::UnexpectedEof,
+                "Not enough bytes to deserialize Id",
+            ));
+        }
+        let (bytes, rest) = buf.split_at(16);
+        *buf = rest;
+        Ok(Self(Uuid::from_slice(bytes).map_err(|err| {
+            IoError::new(IoErrorKind::InvalidData, err)
+        })?))
+    }
+
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, IoError> {
+        let mut bytes = [0_u8; 16];
+        reader.read_exact(&mut bytes)?;
+        Ok(Self(Uuid::from_bytes(bytes)))
+    }
+}
+
+impl BorshSerialize for Id {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), IoError> {
+        writer.write_all(self.0.as_bytes())
     }
 }
 
@@ -419,6 +449,24 @@ impl Path {
     ///
     pub fn segments(&self) -> impl Iterator<Item = &str> {
         (0..=self.depth()).filter_map(|i| self.segment(i))
+    }
+}
+
+impl BorshDeserialize for Path {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, IoError> {
+        Self::new(&String::deserialize(buf)?)
+            .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))
+    }
+
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, IoError> {
+        Self::new(&String::deserialize_reader(reader)?)
+            .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))
+    }
+}
+
+impl BorshSerialize for Path {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), IoError> {
+        self.to_string().serialize(writer)
     }
 }
 

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -13,6 +13,7 @@ use core::fmt::{self, Debug, Display, Formatter};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_store::key::Storage as StorageKey;
 use fixedstr::Flexstr;
 use thiserror::Error as ThisError;
 use uuid::{Bytes, Uuid};
@@ -94,6 +95,36 @@ impl Default for Id {
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl From<Id> for StorageKey {
+    fn from(id: Id) -> Self {
+        Self::new(*id.0.as_bytes())
+    }
+}
+
+impl From<StorageKey> for Id {
+    fn from(storage: StorageKey) -> Self {
+        Self(Uuid::from_bytes(storage.id()))
+    }
+}
+
+impl From<[u8; 16]> for Id {
+    fn from(bytes: [u8; 16]) -> Self {
+        Self(Uuid::from_bytes(bytes))
+    }
+}
+
+impl From<&[u8; 16]> for Id {
+    fn from(bytes: &[u8; 16]) -> Self {
+        Self(Uuid::from_bytes(*bytes))
+    }
+}
+
+impl From<Id> for [u8; 16] {
+    fn from(id: Id) -> Self {
+        *id.0.as_bytes()
     }
 }
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -11,11 +11,13 @@ mod tests;
 
 use core::fmt::{self, Display, Formatter};
 
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use crate::address::{Id, Path};
 
 /// The primary data for an [`Element`], that is, the data that the consumer
 /// application has stored in the [`Element`].
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub struct Data;
 
@@ -31,7 +33,7 @@ pub struct Data;
 /// handling via the storage [`Interface`](crate::interface::Interface). The
 /// actual nature of the [`Element`] can be determined by inspection.
 ///
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub struct Element {
     /// The unique identifier for the [`Element`].
@@ -164,6 +166,6 @@ impl Display for Element {
 /// This represents a range of system-managed properties that are used to
 /// process the [`Element`], but are not part of the primary data.
 ///
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub struct Metadata;

--- a/crates/storage/src/tests/address.rs
+++ b/crates/storage/src/tests/address.rs
@@ -65,7 +65,7 @@ mod path__constructor {
     fn new__valid() {
         let path1 = Path::new("::root").unwrap();
         assert_eq!(path1.path, "root");
-        assert_eq!(path1.offsets, vec![]);
+        assert_eq!(path1.offsets, Vec::<u8>::new());
 
         let path2 = Path::new("::root::node").unwrap();
         assert_eq!(path2.path, "rootnode");
@@ -99,7 +99,7 @@ mod path__constructor {
     fn new__valid_and_long() {
         let path = Path::new(format!("::{}", "a".repeat(255))).unwrap();
         assert_eq!(path.path, "a".repeat(255).as_str());
-        assert_eq!(path.offsets, vec![]);
+        assert_eq!(path.offsets, Vec::<u8>::new());
     }
 
     #[test]

--- a/crates/storage/src/tests/address.rs
+++ b/crates/storage/src/tests/address.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 
+use borsh::to_vec;
 use claims::assert_err;
 
 use super::*;
@@ -19,6 +20,33 @@ mod id__public_methods {
 #[cfg(test)]
 mod id__traits {
     use super::*;
+
+    #[test]
+    fn borsh_deserialization__valid() {
+        assert_eq!(
+            Id::try_from_slice(&TEST_UUID).unwrap(),
+            Id(Uuid::from_bytes(TEST_UUID))
+        );
+    }
+
+    #[test]
+    fn borsh_deserialization__too_short() {
+        assert_err!(Id::try_from_slice(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn borsh_serialization__valid() {
+        let serialized = to_vec(&Id(Uuid::from_bytes(TEST_UUID))).unwrap();
+        assert_eq!(serialized.len(), 16);
+        assert_eq!(serialized, TEST_UUID);
+    }
+
+    #[test]
+    fn borsh_serialization__roundtrip() {
+        let id1 = Id::new();
+        let id2 = Id::try_from_slice(&to_vec(&id1).unwrap()).unwrap();
+        assert_eq!(id1, id2);
+    }
 
     #[test]
     fn from__for_uuid() {
@@ -245,6 +273,33 @@ mod path__public_methods {
 #[cfg(test)]
 mod path__traits {
     use super::*;
+
+    #[test]
+    fn borsh_deserialization__valid() {
+        assert_eq!(
+            Path::try_from_slice(&to_vec("::root::node::leaf").unwrap()).unwrap(),
+            Path::new("::root::node::leaf").unwrap()
+        );
+    }
+
+    #[test]
+    fn borsh_deserialization__invalid() {
+        assert_err!(Path::try_from_slice(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn borsh_serialization__valid() {
+        let path = Path::new("::root::node::leaf").unwrap();
+        let serialized = to_vec(&path).unwrap();
+        assert_eq!(serialized, to_vec("::root::node::leaf").unwrap());
+    }
+
+    #[test]
+    fn borsh_serialization__roundtrip() {
+        let path1 = Path::new("::root::node::leaf").unwrap();
+        let path2 = Path::try_from_slice(&to_vec(&path1).unwrap()).unwrap();
+        assert_eq!(path1, path2);
+    }
 
     #[test]
     fn display() {

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -18,11 +18,13 @@ mod blobs;
 mod component;
 mod context;
 mod generic;
+mod storage;
 
 pub use application::ApplicationMeta;
 pub use blobs::BlobMeta;
 pub use context::{ContextIdentity, ContextMeta, ContextState, ContextTransaction};
 pub use generic::Generic;
+pub use storage::Storage;
 
 pub struct Key<T: KeyComponents>(GenericArray<u8, T::LEN>);
 

--- a/crates/store/src/key/storage.rs
+++ b/crates/store/src/key/storage.rs
@@ -1,0 +1,85 @@
+//! Storage key.
+//!
+//! This module contains the storage key type and related functionality. It is
+//! used to identify records in the storage system, and to provide a means of
+//! accessing and manipulating them.
+//!
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use generic_array::typenum::U16;
+use generic_array::GenericArray;
+
+use super::component::KeyComponent;
+use crate::db::Column;
+use crate::key::{AsKeyParts, FromKeyParts, Key};
+
+/// The identifier for a storage record, based around a UUID.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct StorageId;
+
+impl KeyComponent for StorageId {
+    // UUIDs are 16 bytes long.
+    type LEN = U16;
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct Storage(Key<(StorageId,)>);
+
+impl Storage {
+    /// Creates a new instance of the [`Storage`] key.
+    ///
+    /// # Parameters
+    ///
+    /// * `id` - The unique identifier for the storage record. This is a UUID.
+    ///
+    #[must_use]
+    pub fn new(id: [u8; 16]) -> Self {
+        Self(Key(GenericArray::from(id)))
+    }
+
+    /// The unique identifier for the storage record. This is a UUID.
+    #[must_use]
+    pub fn id(&self) -> [u8; 16] {
+        *self.0.as_ref()
+    }
+}
+
+impl AsKeyParts for Storage {
+    type Components = (StorageId,);
+
+    fn column() -> Column {
+        // TODO: Check if this is the most appropriate column type.
+        Column::Generic
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        &self.0
+    }
+}
+
+impl From<Storage> for [u8; 16] {
+    fn from(storage: Storage) -> Self {
+        *storage.0.as_ref()
+    }
+}
+
+impl From<[u8; 16]> for Storage {
+    fn from(bytes: [u8; 16]) -> Self {
+        Self(Key(GenericArray::from(bytes)))
+    }
+}
+
+impl From<&[u8; 16]> for Storage {
+    fn from(bytes: &[u8; 16]) -> Self {
+        Self(Key(GenericArray::from(*bytes)))
+    }
+}
+
+impl FromKeyParts for Storage {
+    type Error = ();
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(parts))
+    }
+}


### PR DESCRIPTION
# Purpose

This is the fourth of a series of PRs bringing in the storage and synchronisation functionality. This one integrates the storage types with the store, and builds on the previous https://github.com/calimero-network/core/pull/702

# Description of changes

  - Added a `Storage` key to the store
      - Added a new `storage` module to `store::key`, with `Storage` and `StorageId` structs, and all of the implementations necessary to use these for storing the storage ID types.
  - Implemented (de)serialisation
      - Made `Element`/`Data`/`Metadata` (de)serialisable with Borsh.
      - Added manual Borsh (de)serialisation implementations for `Id` and `Path`.
  - Integrated `storage` types with `store` types
      - Added conversions between `Id` and `StorageKey` and related types.

# Notes and advisories

  - This is mergeable but not complete. Further functionality will come in further PRs.
  - This is based on a stable origin point. All added tests pass.
  - The previous PR https://github.com/calimero-network/core/pull/702 needs to merge to master first, then the target of this PR can change.

