### PR TITLE
Implemented save and update logic in storage system

### DIFF
--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -3,6 +3,7 @@
 use claims::{assert_none, assert_ok};
 
 use super::*;
+use crate::entities::Data;
 use crate::tests::common::create_test_store;
 
 #[cfg(test)]
@@ -24,9 +25,9 @@ mod interface__public_methods {
     fn find_by_id__existent() {
         let (db, _dir) = create_test_store();
         let interface = Interface::new(db);
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
+        let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let id = element.id();
-        interface.save(id, &element).unwrap();
+        assert!(interface.save(id, &mut element).unwrap());
 
         assert_eq!(interface.find_by_id(id).unwrap(), Some(element));
     }
@@ -55,35 +56,62 @@ mod interface__public_methods {
     fn test_save__basic() {
         let (db, _dir) = create_test_store();
         let interface = Interface::new(db);
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
+        let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
 
-        assert_ok!(interface.save(element.id(), &element));
+        assert_ok!(interface.save(element.id(), &mut element));
     }
 
     #[test]
     fn test_save__multiple() {
         let (db, _dir) = create_test_store();
         let interface = Interface::new(db);
-        let element1 = Element::new(&Path::new("::root::node1").unwrap());
-        let element2 = Element::new(&Path::new("::root::node2").unwrap());
+        let mut element1 = Element::new(&Path::new("::root::node1").unwrap());
+        let mut element2 = Element::new(&Path::new("::root::node2").unwrap());
 
-        interface.save(element1.id(), &element1).unwrap();
-        interface.save(element2.id(), &element2).unwrap();
+        assert!(interface.save(element1.id(), &mut element1).unwrap());
+        assert!(interface.save(element2.id(), &mut element2).unwrap());
         assert_eq!(interface.find_by_id(element1.id()).unwrap(), Some(element1));
         assert_eq!(interface.find_by_id(element2.id()).unwrap(), Some(element2));
+    }
+
+    #[test]
+    fn test_save__not_dirty() {
+        let (db, _dir) = create_test_store();
+        let interface = Interface::new(db);
+        let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
+        let id = element.id();
+
+        assert!(interface.save(id, &mut element).unwrap());
+        element.update_data(Data {});
+        assert!(interface.save(id, &mut element).unwrap());
+    }
+
+    #[test]
+    fn test_save__too_old() {
+        let (db, _dir) = create_test_store();
+        let interface = Interface::new(db);
+        let mut element1 = Element::new(&Path::new("::root::node::leaf").unwrap());
+        let mut element2 = element1.clone();
+        let id = element1.id();
+
+        assert!(interface.save(id, &mut element1).unwrap());
+        element1.update_data(Data {});
+        element2.update_data(Data {});
+        assert!(interface.save(id, &mut element2).unwrap());
+        assert!(!interface.save(id, &mut element1).unwrap());
     }
 
     #[test]
     fn test_save__update_existing() {
         let (db, _dir) = create_test_store();
         let interface = Interface::new(db);
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
+        let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let id = element.id();
-        interface.save(id, &element).unwrap();
+        assert!(interface.save(id, &mut element).unwrap());
 
         // TODO: Modify the element's data and check it changed
 
-        interface.save(id, &element).unwrap();
+        assert!(interface.save(id, &mut element).unwrap());
         assert_eq!(interface.find_by_id(id).unwrap(), Some(element));
     }
 


### PR DESCRIPTION
# Purpose

This is the sixth of a series of PRs bringing in the storage and synchronisation functionality. This one brings save and load functionality, and builds on the previous https://github.com/calimero-network/core/pull/704

# Description of changes

  - Implemented save and update logic in storage system
      - Added `created_at` and `updated_at` timestamps to `Metadata`.
      - Added an `is_dirty` flag to `Element`.
      - Updated `Element::new()` to set the timestamps and dirty flag.
      - Added an `update_data()` method to `Element`, to allow the stored data to be updated. This sets the dirty flag and updates the `updated_at` timestamp.
      - Added `created_at()` and `updated_at()` methods to `Element`, to obtain the timestamps from its metadata.
      - Added an `is_dirty()` method to `Element`, to get the dirty flag state.
      - Updated `Interface::save()` to carry out checks on the dirty flag and the `updated_at` timestamp, to determine whether or not the record should be saved. The function now returns a boolean to indicate whether the update was accepted.

# Notes and advisories

  - This is mergeable but not complete. Further functionality will come in further PRs.
  - This is based on a stable origin point. All added tests pass.
  - The previous PR https://github.com/calimero-network/core/pull/704 needs to merge to master first, then the target of this PR can change.

