### PR TITLE
fix(server): feature-gate host layer imports

### DIFF
--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -39,6 +39,8 @@ use crate::admin::handlers::root_keys::{create_root_key_handler, delete_auth_key
 use crate::config::ServerConfig;
 use crate::middleware;
 use crate::middleware::auth::AuthSignatureLayer;
+#[cfg(feature = "host_layer")]
+use crate::middleware::host::HostLayer;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -1,4 +1,5 @@
 pub mod auth;
 pub mod dev_auth;
+#[cfg(feature = "host_layer")]
 pub mod host;
 pub mod jwt;


### PR DESCRIPTION
#631 introduced host layer middleware that didn't have gated imports, and https://github.com/calimero-network/core/pull/666/files#r1742855310 removed some the imports which broke the crate when the feature is activated