### PR TITLE
feat(blobstore): abort stream once a specified content size is hit

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -392,7 +392,10 @@ impl ContextManager {
 
         let blob_id = self
             .blob_manager
-            .put_sized(Some(meta.len()), file.compat())
+            .put_sized(
+                Some(calimero_blobstore::Size::Exact(meta.len())),
+                file.compat(),
+            )
             .await?;
 
         let Ok(uri) = Url::from_file_path(path) else {
@@ -418,7 +421,9 @@ impl ContextManager {
         let blob_id = self
             .blob_manager
             .put_sized(
-                response.content_length(),
+                response
+                    .content_length()
+                    .map(calimero_blobstore::Size::Exact),
                 response
                     .bytes_stream()
                     .map_err(IoError::other)

--- a/crates/store/blobs/Cargo.toml
+++ b/crates/store/blobs/Cargo.toml
@@ -12,7 +12,7 @@ required-features = ["examples"]
 
 [dependencies]
 async-stream.workspace = true
-camino.workspace = true
+camino = { workspace = true, features = ["serde1"] }
 eyre.workspace = true
 futures-util = { workspace = true, features = ["io"] }
 sha2.workspace = true

--- a/crates/store/src/types/blobs.rs
+++ b/crates/store/src/types/blobs.rs
@@ -9,14 +9,14 @@ use crate::types::PredefinedEntry;
 pub struct BlobMeta {
     // todo! impl proper entry reference count
     // pub refs: usize,
-    pub size: usize,
+    pub size: u64,
     pub hash: [u8; 32],
     pub links: Box<[BlobMetaKey]>,
 }
 
 impl BlobMeta {
     #[must_use]
-    pub const fn new(size: usize, hash: [u8; 32], links: Box<[BlobMetaKey]>) -> Self {
+    pub const fn new(size: u64, hash: [u8; 32], links: Box<[BlobMetaKey]>) -> Self {
         Self { size, hash, links }
     }
 }


### PR DESCRIPTION
Since the eventual functionality is to request the blob from peers, and the only way to determine it's legit is to collect the entire thing, we have to limit the receipt to prevent malicious peers from infinitely flooding with useless data.

This is the foundation of further pieces that'll make it in as part of the general effort behind the other context config PRs.

We'll store the blob ID as well as the size of the blob on the contract, so you start with knowledge of how large the stream received from your peers is supposed to be.

For now, we don't immediately delete the received chunks, we'll eventually introduce garbage collection to a number of things, including this.