### PR TITLE
feat(context): revise context membership process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ dependencies = [
  "calimero-primitives",
  "calimero-store",
  "camino",
+ "ed25519-dalek",
  "eyre",
  "futures-util",
  "rand 0.8.5",

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 camino = { workspace = true, features = ["serde1"] }
+ed25519-dalek.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 rand.workspace = true

--- a/crates/context/config/src/client.rs
+++ b/crates/context/config/src/client.rs
@@ -154,9 +154,9 @@ impl<T> Response<T> {
         }
     }
 
-    pub fn parse(&self) -> Result<T, serde_json::Error>
+    pub fn parse<'a>(&'a self) -> Result<T, serde_json::Error>
     where
-        T: for<'a> Deserialize<'a>,
+        T: Deserialize<'a>,
     {
         serde_json::from_slice(&self.bytes)
     }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -673,19 +673,13 @@ impl ContextManager {
     pub fn is_application_installed(&self, application_id: &ApplicationId) -> EyreResult<bool> {
         let handle = self.store.handle();
 
-        let Some(application) = handle.get(&ApplicationMetaKey::new(*application_id))? else {
-            return Ok(false);
+        if let Some(application) = handle.get(&ApplicationMetaKey::new(*application_id))? {
+            if handle.has(&application.blob)? {
+                return Ok(true);
+            }
         };
 
-        if !handle.has(&application.blob)? {
-            bail!(
-                "fatal: application `{}` points to danling blob `{}`",
-                application_id,
-                application.blob.blob_id()
-            );
-        }
-
-        Ok(true)
+        Ok(false)
     }
 
     pub fn get_application(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -370,6 +370,7 @@ impl ContextManager {
 
         let invitation_payload = ContextInvitationPayload::new(
             context_id,
+            requester,
             context_config.network.into_string().into(),
             context_config.contract.into_string().into(),
         )?;

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -11,7 +11,7 @@ use calimero_network::types::IdentTopic;
 use calimero_node_primitives::{ExecutionRequest, Finality, ServerSender};
 use calimero_primitives::application::{Application, ApplicationId, ApplicationSource};
 use calimero_primitives::blobs::BlobId;
-use calimero_primitives::context::{Context, ContextId};
+use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::key::{

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -341,7 +341,7 @@ impl ContextManager {
         context_id: ContextId,
         requester: PublicKey,
         identity: PublicKey,
-    ) -> EyreResult<Option<()>> {
+    ) -> EyreResult<Option<ContextInvitationPayload>> {
         let handle = self.store.handle();
 
         let Some(context_config) = handle.get(&ContextConfigKey::new(context_id))? else {
@@ -368,7 +368,13 @@ impl ContextManager {
             .send(|b| SigningKey::from_bytes(&requester_secret).sign(b))
             .await?;
 
-        Ok(Some(()))
+        let invitation_payload = ContextInvitationPayload::new(
+            context_id,
+            context_config.network.into_string().into(),
+            context_config.contract.into_string().into(),
+        )?;
+
+        Ok(Some(invitation_payload))
     }
 
     pub async fn is_context_pending_catchup(&self, context_id: &ContextId) -> bool {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -253,16 +253,6 @@ impl ContextManager {
     ) -> EyreResult<Option<(ContextId, PublicKey)>> {
         let (context_id, invitee_id, network_id, contract_id) = invitation_payload.parts()?;
 
-        if self
-            .state
-            .read()
-            .await
-            .pending_catchup
-            .contains(&context_id)
-        {
-            return Ok(None);
-        }
-
         if identity_secret.public_key() != invitee_id {
             bail!("identity mismatch")
         }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -250,7 +250,7 @@ impl ContextManager {
         &self,
         identity_secret: PrivateKey,
         invitation_payload: ContextInvitationPayload,
-    ) -> EyreResult<Option<PublicKey>> {
+    ) -> EyreResult<Option<(ContextId, PublicKey)>> {
         let (context_id, invitee_id, network_id, contract_id) = invitation_payload.parts()?;
 
         if self
@@ -337,7 +337,7 @@ impl ContextManager {
 
         info!(%context_id, "Joined context with pending catchup");
 
-        Ok(Some(invitee_id))
+        Ok(Some((context_id, invitee_id)))
     }
 
     pub async fn invite_to_context(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -129,6 +129,10 @@ impl ContextManager {
         Ok(())
     }
 
+    pub fn new_identity(&self) -> PrivateKey {
+        PrivateKey::random(&mut rand::thread_rng())
+    }
+
     pub async fn create_context(
         &self,
         seed: Option<[u8; 32]>,
@@ -144,8 +148,7 @@ impl ContextManager {
                 None => PrivateKey::random(&mut rng),
             };
 
-            let identity_secret =
-                identity_secret.map_or_else(|| PrivateKey::random(&mut rng), PrivateKey::from);
+            let identity_secret = identity_secret.unwrap_or_else(|| self.new_identity());
 
             (context_secret, identity_secret)
         };

--- a/crates/meroctl/src/cli/context/join.rs
+++ b/crates/meroctl/src/cli/context/join.rs
@@ -1,6 +1,6 @@
 use calimero_primitives::context::ContextInvitationPayload;
 use calimero_primitives::identity::PrivateKey;
-use calimero_server_primitives::admin::JoinContextRequest;
+use calimero_server_primitives::admin::{JoinContextRequest, JoinContextResponse};
 use clap::Parser;
 use eyre::{bail, Result as EyreResult};
 use reqwest::Client;
@@ -50,7 +50,14 @@ impl JoinCommand {
             bail!("Request failed with status: {}", response.status())
         }
 
-        info!("Context {} sucesfully joined", self.context_id);
+        let Some(body) = response.json::<JoinContextResponse>().await?.data else {
+            bail!("Unable to join context");
+        };
+
+        info!(
+            "Context {} sucesfully joined as {}",
+            body.context_id, body.member_public_key
+        );
 
         Ok(())
     }

--- a/crates/node/src/catchup.rs
+++ b/crates/node/src/catchup.rs
@@ -400,7 +400,8 @@ impl Node {
                         last_transaction_hash: Hash::default(),
                     };
 
-                    self.ctx_manager.add_context(&context_inner)?;
+                    // todo! will be resolved in a coming PR
+                    // self.ctx_manager.add_context(&context_inner)?;
 
                     context = Some(context_inner);
                 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -662,12 +662,17 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
                             break 'done;
                         };
 
-                        let _ = node
+                        let Some(invitation_payload) = node
                             .ctx_manager
                             .invite_to_context(context_id, inviter_id, invitee_id)
-                            .await?;
+                            .await?
+                        else {
+                            println!("{IND} Unable to invite {invitee_id} to context {context_id}");
+                            break 'done;
+                        };
 
                         println!("{IND} Invited {invitee_id} to context {context_id}");
+                        println!("{IND} Invitation Payload: {invitation_payload}");
                     }
                     "delete" => {
                         let Some(context_id) = args else {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -732,8 +732,8 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
                                     let (k, v) = (k?, v?);
                                     let entry = format!(
                                         "{c1:44} | {}",
+                                        if v.private_key.is_some() { "*" } else { " " },
                                         c1 = k.public_key(),
-                                        if v.private_key.is_some() { "*" } else { " " }
                                     );
                                     for line in entry.lines() {
                                         println!("{IND} {}", line.cyan());

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -551,11 +551,19 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
                             break 'done;
                         };
 
-                        let Some((context_id, identity)) = node
+                        let response = match node
                             .ctx_manager
                             .join_context(private_key, invitation_payload)
-                            .await?
-                        else {
+                            .await
+                        {
+                            Ok(response) => response,
+                            Err(err) => {
+                                println!("{IND} Unable to join context: {err}");
+                                break 'done;
+                            }
+                        };
+
+                        let Some((context_id, identity)) = response else {
                             println!("{IND} Unable to join context at this time, a catchup is in progress.");
                             break 'done;
                         };

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -849,7 +849,9 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
 
                 break 'done;
             };
-            println!("{IND} Usage: context [ls|join|leave|create|delete|state] [args]");
+            println!(
+                "{IND} Usage: context [ls|join|leave|invite|create|delete|state|identity] [args]"
+            );
         }
         unknown => {
             println!("{IND} Unknown command: `{unknown}`");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -633,6 +633,42 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
 
                         println!("{IND} Created context {} as {}", context_id, identity);
                     }
+                    "invite" => {
+                        let Some((context_id, inviter_id, invitee_id)) = args.and_then(|args| {
+                            let mut iter = args.split(' ');
+                            let context_id = iter.next()?;
+                            let inviter_id = iter.next()?;
+                            let invitee_id = iter.next()?;
+                            Some((context_id, inviter_id, invitee_id))
+                        }) else {
+                            println!(
+                                "{IND} Usage: context invite <context_id> <inviter> <invitee>"
+                            );
+                            break 'done;
+                        };
+
+                        let Ok(context_id) = context_id.parse() else {
+                            println!("{IND} Invalid context ID: {context_id}");
+                            break 'done;
+                        };
+
+                        let Ok(inviter_id) = inviter_id.parse() else {
+                            println!("{IND} Invalid public key for inviter: {inviter_id}");
+                            break 'done;
+                        };
+
+                        let Ok(invitee_id) = invitee_id.parse() else {
+                            println!("{IND} Invalid public key for invitee: {invitee_id}");
+                            break 'done;
+                        };
+
+                        let _ = node
+                            .ctx_manager
+                            .invite_to_context(context_id, inviter_id, invitee_id)
+                            .await?;
+
+                        println!("{IND} Invited {invitee_id} to context {context_id}");
+                    }
                     "delete" => {
                         let Some(context_id) = args else {
                             println!("{IND} Usage: context delete <context_id>");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -502,7 +502,7 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
                 match subcommand {
                     "ls" => {
                         println!(
-                            "{IND} {c1:44} | {c2:64} | Last Transaction",
+                            "{IND} {c1:44} | {c2:44} | Last Transaction",
                             c1 = "Context ID",
                             c2 = "Application ID",
                         );

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -29,8 +29,9 @@ use calimero_server::config::ServerConfig;
 use calimero_store::config::StoreConfig;
 use calimero_store::db::RocksDB;
 use calimero_store::key::{
-    ApplicationMeta as ApplicationMetaKey, ContextMeta as ContextMetaKey,
-    ContextState as ContextStateKey, ContextTransaction as ContextTransactionKey,
+    ApplicationMeta as ApplicationMetaKey, ContextIdentity as ContextIdentityKey,
+    ContextMeta as ContextMetaKey, ContextState as ContextStateKey,
+    ContextTransaction as ContextTransactionKey,
 };
 use calimero_store::types::{ContextMeta, ContextTransaction};
 use calimero_store::Store;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -551,7 +551,7 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
                             break 'done;
                         };
 
-                        let Some(identity) = node
+                        let Some((context_id, identity)) = node
                             .ctx_manager
                             .join_context(private_key, invitation_payload)
                             .await?
@@ -561,7 +561,7 @@ async fn handle_line(node: &mut Node, line: String) -> EyreResult<()> {
                         };
 
                         println!(
-                            "{IND} Joined context {private_key} as {identity}, waiting for catchup to complete..."
+                            "{IND} Joined context {context_id} as {identity}, waiting for catchup to complete..."
                         );
                     }
                     "leave" => {

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -83,7 +83,7 @@ impl fmt::Debug for ContextInvitationPayload {
             .field("contract_id", &contract_id);
 
         if is_alternate {
-            let _ = d.field("raw", &self.0);
+            let _ = d.field("raw", &self.to_string());
         }
 
         d.finish()

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -1,6 +1,7 @@
 use core::fmt::{self, Display, Formatter};
 use core::ops::Deref;
 use core::str::FromStr;
+use std::io;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
@@ -63,6 +64,105 @@ impl FromStr for ContextId {
         Ok(Self(s.parse().map_err(InvalidContextId)?))
     }
 }
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(into = "String", try_from = "&str")]
+pub struct ContextInvitationPayload(Vec<u8>);
+
+impl fmt::Debug for ContextInvitationPayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (context_id, network, contract_id) = self.parts().map_err(|_| fmt::Error)?;
+
+        let is_alternate = f.alternate();
+
+        let mut d = f.debug_struct("ContextInvitationPayload");
+
+        let _ = d
+            .field("context_id", &context_id)
+            .field("network", &network)
+            .field("contract_id", &contract_id);
+
+        if is_alternate {
+            let _ = d.field("raw", &self.0);
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for ContextInvitationPayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(&bs58::encode(self.0.as_slice()).into_string())
+    }
+}
+
+impl FromStr for ContextInvitationPayload {
+    type Err = io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        bs58::decode(s)
+            .into_vec()
+            .map(Self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}
+
+impl From<ContextInvitationPayload> for String {
+    fn from(payload: ContextInvitationPayload) -> Self {
+        bs58::encode(payload.0.as_slice()).into_string()
+    }
+}
+
+impl TryFrom<&str> for ContextInvitationPayload {
+    type Error = io::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+#[cfg(feature = "borsh")]
+#[allow(single_use_lifetimes)]
+const _: () = {
+    use std::borrow::Cow;
+
+    use borsh::{BorshDeserialize, BorshSerialize};
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct InvitationPayload<'a> {
+        context_id: [u8; 32],
+        network: Cow<'a, str>,
+        contract_id: Cow<'a, str>,
+    }
+
+    impl ContextInvitationPayload {
+        #[must_use]
+        pub fn new(
+            context_id: ContextId,
+            network: Cow<'_, str>,
+            contract_id: Cow<'_, str>,
+        ) -> io::Result<Self> {
+            let payload = InvitationPayload {
+                context_id: *context_id,
+                network,
+                contract_id,
+            };
+
+            borsh::to_vec(&payload).map(Self)
+        }
+
+        #[must_use]
+        pub fn parts(&self) -> io::Result<(ContextId, String, String)> {
+            let payload: InvitationPayload<'_> = borsh::from_slice(&self.0)?;
+
+            Ok((
+                payload.context_id.into(),
+                payload.network.into_owned(),
+                payload.contract_id.into_owned(),
+            ))
+        }
+    }
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Display, Formatter};
+use core::fmt;
 use core::ops::Deref;
 use core::str::FromStr;
 use std::io;
@@ -35,8 +35,8 @@ impl ContextId {
     }
 }
 
-impl Display for ContextId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for ContextId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(self.as_str())
     }
 }

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -1,7 +1,7 @@
 use calimero_primitives::application::{Application, ApplicationId};
-use calimero_primitives::context::{Context, ContextId};
+use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
 use calimero_primitives::hash::Hash;
-use calimero_primitives::identity::{PublicKey, WalletType};
+use calimero_primitives::identity::{PrivateKey, PublicKey, WalletType};
 use camino::Utf8PathBuf;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -403,8 +403,15 @@ impl CreateContextResponse {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JoinContextRequest {
+    pub private_key: PrivateKey,
+    pub invitation_payload: ContextInvitationPayload,
+}
+
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct JoinContextResponseData {
+    pub context_id: ContextId,
     pub member_public_key: PublicKey,
 }
 

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -415,6 +415,11 @@ pub struct JoinContextResponseData {
     pub member_public_key: PublicKey,
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct JoinContextResponse {
+    pub data: Option<JoinContextResponseData>,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
-use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
-use calimero_primitives::identity::{ClientKey, ContextUser, PrivateKey, PublicKey};
+use calimero_primitives::context::{Context, ContextId};
+use calimero_primitives::identity::{ClientKey, ContextUser, PublicKey};
 use calimero_server_primitives::admin::{
     ContextStorage, CreateContextRequest, CreateContextResponse, GetContextsResponse,
-    JoinContextResponseData, UpdateContextApplicationRequest,
+    JoinContextRequest, JoinContextResponseData, UpdateContextApplicationRequest,
 };
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -276,13 +276,6 @@ pub async fn get_context_storage_handler(
     .into_response()
 }
 
-#[derive(Clone, Debug, Deserialize)]
-#[non_exhaustive]
-pub struct JoinContextRequest {
-    pub private_key: PrivateKey,
-    pub invitation_payload: ContextInvitationPayload,
-}
-
 #[derive(Debug, Serialize)]
 struct JoinContextResponse {
     data: Option<JoinContextResponseData>,
@@ -304,8 +297,9 @@ pub async fn join_context_handler(
     match result {
         Ok(r) => ApiResponse {
             payload: JoinContextResponse {
-                data: r.map(|r| JoinContextResponseData {
-                    member_public_key: r,
+                data: r.map(|(context_id, member_public_key)| JoinContextResponseData {
+                    context_id,
+                    member_public_key,
                 }),
             },
         }

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -8,7 +8,8 @@ use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::identity::{ClientKey, ContextUser, PublicKey};
 use calimero_server_primitives::admin::{
     ContextStorage, CreateContextRequest, CreateContextResponse, GetContextsResponse,
-    JoinContextRequest, JoinContextResponseData, UpdateContextApplicationRequest,
+    JoinContextRequest, JoinContextResponse, JoinContextResponseData,
+    UpdateContextApplicationRequest,
 };
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -274,11 +275,6 @@ pub async fn get_context_storage_handler(
         payload: GetContextStorageResponse::new(0),
     }
     .into_response()
-}
-
-#[derive(Debug, Serialize)]
-struct JoinContextResponse {
-    data: Option<JoinContextResponseData>,
 }
 
 pub async fn join_context_handler(

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -115,7 +115,7 @@ pub(crate) fn setup(
             "/contexts/:context_id/identities",
             get(get_context_identities_handler),
         )
-        .route("/contexts/:context_id/join", post(join_context_handler))
+        .route("/contexts/join", post(join_context_handler))
         .route("/contexts", get(get_contexts_handler))
         .route("/identity/keys", delete(delete_auth_keys_handler))
         .route("/refresh-jwt-token", post(refresh_jwt_token_handler))
@@ -147,7 +147,7 @@ pub(crate) fn setup(
             "/dev/contexts",
             get(get_contexts_handler).post(create_context_handler),
         )
-        .route("/dev/contexts/:context_id/join", post(join_context_handler))
+        .route("/dev/contexts/join", post(join_context_handler))
         .route(
             "/dev/contexts/:context_id/application",
             post(update_application_id),

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -18,6 +18,7 @@ pub use rocksdb::RocksDB;
 #[non_exhaustive]
 pub enum Column {
     Meta,
+    Config,
     Identity,
     State,
     Transaction,

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -22,7 +22,7 @@ mod storage;
 
 pub use application::ApplicationMeta;
 pub use blobs::BlobMeta;
-pub use context::{ContextIdentity, ContextMeta, ContextState, ContextTransaction};
+pub use context::{ContextConfig, ContextIdentity, ContextMeta, ContextState, ContextTransaction};
 pub use generic::Generic;
 pub use storage::Storage;
 

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -64,6 +64,50 @@ impl Debug for ContextMeta {
     }
 }
 
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextConfig(Key<ContextId>);
+
+impl ContextConfig {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId) -> Self {
+        Self(Key((*context_id).into()))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ContextConfig {
+    type Components = (ContextId,);
+
+    fn column() -> Column {
+        Column::Config
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ContextConfig {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ContextConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextConfig")
+            .field("id", &self.context_id())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct PublicKey;
 

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -9,7 +9,7 @@ mod generic;
 pub use application::ApplicationMeta;
 pub use blobs::BlobMeta;
 pub use context::{
-    ContextIdentity, ContextMeta, ContextState, ContextTransaction, TransactionHash,
+    ContextConfig, ContextIdentity, ContextMeta, ContextState, ContextTransaction, TransactionHash,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -2,9 +2,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::entry::{Borsh, Identity};
 use crate::key::{
-    ApplicationMeta as ApplicationMetaKey, ContextIdentity as ContextIdentityKey,
-    ContextMeta as ContextMetaKey, ContextState as ContextStateKey,
-    ContextTransaction as ContextTransactionKey,
+    ApplicationMeta as ApplicationMetaKey, ContextConfig as ContextConfigKey,
+    ContextIdentity as ContextIdentityKey, ContextMeta as ContextMetaKey,
+    ContextState as ContextStateKey, ContextTransaction as ContextTransactionKey,
 };
 use crate::slice::Slice;
 use crate::types::PredefinedEntry;
@@ -34,6 +34,24 @@ impl ContextMeta {
 impl PredefinedEntry for ContextMetaKey {
     type Codec = Borsh;
     type DataType<'a> = ContextMeta;
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
+pub struct ContextConfig {
+    pub network: Box<str>,
+    pub contract: Box<str>,
+}
+
+impl ContextConfig {
+    #[must_use]
+    pub const fn new(network: Box<str>, contract: Box<str>) -> Self {
+        Self { network, contract }
+    }
+}
+
+impl PredefinedEntry for ContextConfigKey {
+    type Codec = Borsh;
+    type DataType<'a> = ContextConfig;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
- Context creation registers it on the config contract
- Context joining now requires invitation

Admin Dashboard can now feature context invitation & joining

Updated catchup logic coming in another PR

Leave context behaviour under the current model is yet to be determined, for now, it stays at local deletion

```console
context ls
 │ Context ID                                   | Application ID                               | Last Transaction
application ls
 │ Application ID                               | Blob ID                                      | Version      | Source
 │ 3dTQEovDrrTVqFoTXRDef5M2VQM51osB66XRdTnT7uRb | Hht83G2PVqB9kZHEwBosdtDPQnmovmBXBfVnnbXJznHA |              | file:///Users/miraclx/git/calimero-is-near/cali2.0-experimental/apps/kv-store/res/kv_store.wasm
```

```console
$ meroctl --node-name node1 context create --application-id 3dTQEovDrrTVqFoTXRDef5M2VQM51osB66XRdTnT7uRb`
Context `GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv` created!
Context{GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv} -> Application{3dTQEovDrrTVqFoTXRDef5M2VQM51osB66XRdTnT7uRb}
```

```console
context ls
 │ Context ID                                   | Application ID                               | Last Transaction
 │ GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv | 3dTQEovDrrTVqFoTXRDef5M2VQM51osB66XRdTnT7uRb | DoQ99Yty1ygPcc4ek4zsMUNpyAEtaA4MnRC8beGaFtd
context identity ls GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv
 │ Identity                                     | Owned
 │ 62HEbeSo6NKLufZZALVvEUthQGcf6G3A4g1ug2KKjELg | *
context identity new
 │ Private Key: AJhcZCRsJZWTjBH33YCt6zRYJB4MjoxH6BFKfqt2fvAb
 │ Public Key: 7V5a8whLAyuoiWV9tJya1MUTmGsuFC4FcsF5iHgANWRb
context invite GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv 62HEbeSo6NKLufZZALVvEUthQGcf6G3A4g1ug2KKjELg 7V5a8whLAyuoiWV9tJya1MUTmGsuFC4FcsF5iHgANWRb
 │ Invited 7V5a8whLAyuoiWV9tJya1MUTmGsuFC4FcsF5iHgANWRb to context GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv
 │ Invitation Payload: 3FdouEaEdTWtP6YBH3tjXgBJixiVF921t9DxTPbie5GVneLNkznufabvWkF2uj3i5zVfuWvCF7xGCsB5QR35ATxfiQideNkKf86fAjivBXjedTYtSVUCwopHddY9LTB3M8YBug2TTz9hDZdgcRaQeZR
context join AJhcZCRsJZWTjBH33YCt6zRYJB4MjoxH6BFKfqt2fvAb 3FdouEaEdTWtP6YBH3tjXgBJixiVF921t9DxTPbie5GVoMDAaVMhVFmPU4xqLZeKe5ye6udnTCHmSNh12cSsbqZAQfrajg7cP4TRKchMbVnj1KDoiiN1rQwkbso1NV6ofJe9hVTZaNL3osxtdpe9Cx3
 │ Joined context GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv as 7V5a8whLAyuoiWV9tJya1MUTmGsuFC4FcsF5iHgANWRb, waiting for catchup to complete...
context identity ls GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv
 │ Identity                                     | Owned
 │ 62HEbeSo6NKLufZZALVvEUthQGcf6G3A4g1ug2KKjELg | *
 │ 7V5a8whLAyuoiWV9tJya1MUTmGsuFC4FcsF5iHgANWRb | *
```

Let's invite some other node

```console
# node2
context ls
 │ Context ID                                   | Application ID                               | Last Transaction
context identity new
 │ Private Key: G5pK45VAegesDwvHqyQsZ6NNQyRPjZ7YQLJSz1XBfpdc
 │ Public Key: 21A1pcDPMJTH6bQb1xRw1i1JqDRmvysxYp7eEQMnz3sp
```

```console
# node1
context invite GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv 62HEbeSo6NKLufZZALVvEUthQGcf6G3A4g1ug2KKjELg 21A1pcDPMJTH6bQb1xRw1i1JqDRmvysxYp7eEQMnz3sp
 │ Invited 21A1pcDPMJTH6bQb1xRw1i1JqDRmvysxYp7eEQMnz3sp to context GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv
 │ Invitation Payload: 3FdouEaEdTWtP6YBH3tjXgBJixiVF921t9DxTPbie5GVkhxjMQH7ipkB9h3RAA6EjGYEF5eugjuC154WRUx71eDRoZkdJ94ucZdyWXEA461BQyaQjS3GzQtimcqMWG9UbP7eGoci3jKnJycuoadLhVd
```

```console
# node2
context join G5pK45VAegesDwvHqyQsZ6NNQyRPjZ7YQLJSz1XBfpdc 3FdouEaEdTWtP6YBH3tjXgBJixiVF921t9DxTPbie5GVkhxjMQH7ipkB9h3RAA6EjGYEF5eugjuC154WRUx71eDRoZkdJ94ucZdyWXEA461BQyaQjS3GzQtimcqMWG9UbP7eGoci3jKnJycuoadLhVd
 │ Joined context GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv as 21A1pcDPMJTH6bQb1xRw1i1JqDRmvysxYp7eEQMnz3sp, waiting for catchup to complete...
context ls
 │ Context ID                                   | Application ID                               | Last Transaction
 │ GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv | 3dTQEovDrrTVqFoTXRDef5M2VQM51osB66XRdTnT7uRb | DoQ99Yty1ygPcc4ek4zsMUNpyAEtaA4MnRC8beGaFtd
context identity ls GjJEnAwfLVPveyUWaGqJspzUXndyJkNWgD7M5uDNQZqv
 │ Identity                                     | Owned
 │ 21A1pcDPMJTH6bQb1xRw1i1JqDRmvysxYp7eEQMnz3sp | *
 │ 62HEbeSo6NKLufZZALVvEUthQGcf6G3A4g1ug2KKjELg |
 │ 7V5a8whLAyuoiWV9tJya1MUTmGsuFC4FcsF5iHgANWRb |
```