### PR TITLE
feat: release profile optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,13 @@ x509-parser = "0.16.0"
 axum-server = { version = "0.6", features = ["tls-rustls"] }
 axum-server-dual-protocol = "0.6.0"
 
+[profile.release]
+strip = "symbols"
+lto = "fat"
+codegen-units = 1
+opt-level = "z"
+panic = "abort"
+
 [profile.app-release]
 inherits = "release"
 codegen-units = 1


### PR DESCRIPTION
We're a bit bloated on the release build:

```text
Build Time: 3m43s
Binary Size: 51563272 (52M)
cmd:`strip`: 39163592 (39M)
cmd:`tgz`: 18664114 (19M)
```

\+ `strip = "symbols"`

```text
Build Time: 3m34s
Binary Size: 39163848 (39M)
cmd:`strip`: 39163832 (39M)
cmd:`tgz`: 16148833 (16M)
```

\+ `lto = "fat"`

```text
Build Time: 7m5s
Binary Size: 32735160 (33M)
cmd:`strip`: 32735144 (33M)
cmd:`tgz`: 15115760 (15M)
```

\+ `codegen-units = 1`

```text
Build Time: 6m59s
Binary Size: 30748200 (31M)
cmd:`strip`: 30748184 (31M)
cmd:`tgz`: 14381231 (14M)
```

\+ `opt-level = "z"`

```text
Build Time: 4m29s
Binary Size: 19113560 (19M)
cmd:`strip`: 19113544 (19M)
cmd:`tgz`: 10360714 (10M)
```

\+ `panic = "abort"`

```text
Build Time: 4m8s
Binary Size: 16643768 (17M)
cmd:`strip`: 16643752 (17M)
cmd:`tgz`: 9103019 (9.1M)
```