### PR TITLE
feat: context config relayer impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,6 +4195,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 name = "meroctl"
 version = "0.2.0-beta.1"
 dependencies = [
+ "axum",
  "bs58 0.5.1",
  "calimero-blobstore",
  "calimero-context",
@@ -4213,6 +4214,7 @@ dependencies = [
  "const_format",
  "dirs",
  "eyre",
+ "futures-util",
  "hex",
  "libp2p",
  "multiaddr",

--- a/crates/context/config/src/client/config.rs
+++ b/crates/context/config/src/client/config.rs
@@ -55,7 +55,6 @@ pub struct Credentials {
 }
 
 mod serde_creds {
-
     use super::*;
 
     #[derive(Debug, Deserialize, Serialize)]

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -9,7 +9,7 @@ use calimero_context_config::repr::{Repr, ReprBytes, ReprTransmute};
 use calimero_network::client::NetworkClient;
 use calimero_network::types::IdentTopic;
 use calimero_node_primitives::{ExecutionRequest, Finality, ServerSender};
-use calimero_primitives::application::{Application, ApplicationId, ApplicationSource};
+use calimero_primitives::application::{self, Application, ApplicationId, ApplicationSource};
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
 use calimero_primitives::hash::Hash;

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -9,7 +9,7 @@ use calimero_context_config::repr::{Repr, ReprBytes, ReprTransmute};
 use calimero_network::client::NetworkClient;
 use calimero_network::types::IdentTopic;
 use calimero_node_primitives::{ExecutionRequest, Finality, ServerSender};
-use calimero_primitives::application::{self, Application, ApplicationId, ApplicationSource};
+use calimero_primitives::application::{Application, ApplicationId, ApplicationSource};
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
 use calimero_primitives::hash::Hash;

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+axum.workspace = true
 bs58.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 chrono.workspace = true
@@ -17,6 +18,7 @@ color-eyre.workspace = true
 const_format.workspace = true
 dirs.workspace = true
 eyre.workspace = true
+futures-util.workspace = true
 hex.workspace = true
 libp2p.workspace = true
 multiaddr.workspace = true

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -3,12 +3,6 @@ use clap::{Parser, Subcommand};
 use const_format::concatcp;
 use eyre::Result as EyreResult;
 
-use crate::cli::app::AppCommand;
-use crate::cli::config::ConfigCommand;
-use crate::cli::context::ContextCommand;
-use crate::cli::init::InitCommand;
-use crate::cli::jsonrpc::JsonRpcCommand;
-use crate::cli::run::RunCommand;
 use crate::defaults;
 
 mod app;
@@ -16,7 +10,16 @@ mod config;
 mod context;
 mod init;
 mod jsonrpc;
+mod relay;
 mod run;
+
+use app::AppCommand;
+use config::ConfigCommand;
+use context::ContextCommand;
+use init::InitCommand;
+use jsonrpc::JsonRpcCommand;
+use relay::RelayCommand;
+use run::RunCommand;
 
 pub const EXAMPLES: &str = r"
   # Initialize a new node
@@ -50,14 +53,15 @@ pub struct RootCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum SubCommands {
-    App(AppCommand),
-    Config(ConfigCommand),
-    Context(ContextCommand),
     Init(InitCommand),
-    #[command(alias = "call")]
-    JsonRpc(JsonRpcCommand),
+    Config(ConfigCommand),
     #[command(alias = "up")]
     Run(RunCommand),
+    Context(ContextCommand),
+    App(AppCommand),
+    #[command(alias = "call")]
+    JsonRpc(JsonRpcCommand),
+    Relay(RelayCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -81,6 +85,7 @@ impl RootCommand {
             SubCommands::Context(context) => context.run(self.args).await,
             SubCommands::App(application) => application.run(self.args).await,
             SubCommands::JsonRpc(jsonrpc) => jsonrpc.run(self.args).await,
+            SubCommands::Relay(relay) => relay.run(self.args).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/relay.rs
+++ b/crates/meroctl/src/cli/relay.rs
@@ -1,0 +1,161 @@
+use std::env;
+use std::net::{AddrParseError, IpAddr, Ipv4Addr, SocketAddr};
+
+use axum::extract::State;
+use axum::http::status::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
+use calimero_context_config::client::relayer::RelayRequest;
+use calimero_context_config::client::{near, Transport, TransportRequest};
+use clap::{Parser, ValueEnum};
+use eyre::{bail, Result as EyreResult};
+use futures_util::FutureExt;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, info, warn};
+
+use super::RootArgs;
+use crate::config_file::ConfigFile;
+
+pub const DEFAULT_PORT: u16 = 63529; // Mero-rELAY = MELAY
+pub const DEFAULT_ADDR: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), DEFAULT_PORT);
+
+#[derive(Debug, Parser)]
+pub struct RelayCommand {
+    /// Sets the address to listen on [default: 0.0.0.0:63529]
+    /// Valid: `63529`, `127.0.0.1`, `127.0.0.1:63529` [env: PORT]
+    #[clap(short, long, value_name = "URI")]
+    #[clap(verbatim_doc_comment, value_parser = addr_from_str)]
+    #[clap(default_value = "0.0.0.0", hide_default_value = true)]
+    pub listen: SocketAddr,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum CallType {
+    Query,
+    Mutate,
+}
+
+impl RelayCommand {
+    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
+        let path = root_args.home.join(root_args.node_name);
+
+        if !ConfigFile::exists(&path) {
+            bail!("Node is not initialized in {:?}", path);
+        }
+
+        let config = ConfigFile::load(&path)?;
+
+        let (tx, mut rx) = mpsc::channel::<RequestPayload>(32);
+
+        let transport = near::NearTransport::new(&near::NearConfig {
+            networks: config
+                .context
+                .client
+                .signer
+                .local
+                .iter()
+                .map(|(network, config)| {
+                    (
+                        network.into(),
+                        near::NetworkConfig {
+                            rpc_url: config.rpc_url.clone(),
+                            account_id: config.credentials.account_id.clone(),
+                            access_key: config.credentials.secret_key.clone(),
+                        },
+                    )
+                })
+                .collect(),
+        });
+
+        let handle = async move {
+            while let Some((request, res_tx)) = rx.recv().await {
+                let payload = request.payload;
+
+                let request = TransportRequest {
+                    network_id: request.network_id,
+                    contract_id: request.contract_id,
+                    operation: request.operation,
+                };
+
+                let _ignored =
+                    res_tx.send(transport.send(request, payload).await.map_err(Into::into));
+            }
+        };
+
+        let app = Router::new().route("/", post(handler)).with_state(tx);
+
+        let listener = tokio::net::TcpListener::bind(self.listen).await?;
+
+        info!("Listening on '\x1b[1;33mhttp://{}\x1b[0m'", self.listen);
+
+        let server = axum::serve(listener, app);
+
+        tokio::try_join!(handle.map(Ok), server)?;
+
+        Ok(())
+    }
+}
+
+type AppState = mpsc::Sender<RequestPayload>;
+type RequestPayload = (RelayRequest<'static>, HandlerSender);
+type HandlerSender = oneshot::Sender<EyreResult<Vec<u8>>>;
+
+async fn handler(
+    State(req_tx): State<AppState>,
+    Json(request): Json<RelayRequest<'static>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let (res_tx, res_rx) = oneshot::channel();
+
+    req_tx
+        .send((request, res_tx))
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let res = res_rx
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    match res {
+        Ok(res) => Ok(res.into_response()),
+        Err(err) => {
+            debug!("failed to send request to handler: {:?}", err);
+
+            Ok((StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response())
+        }
+    }
+}
+
+pub fn addr_from_str(s: &str) -> Result<SocketAddr, AddrParseError> {
+    let mut addr = DEFAULT_ADDR;
+
+    let env_port = 'port: {
+        if let Ok(env_port) = env::var("PORT") {
+            if let Ok(env_port) = env_port.parse() {
+                break 'port Some(env_port);
+            } else {
+                warn!(
+                    "invalid '\x1b[1mPORT\x1b[0m' environment variable: '\x1b[33m{}\x1b[0m', ignoring..",
+                    env_port
+                );
+            }
+        }
+        None
+    };
+
+    if let Ok(port) = s.parse() {
+        addr.set_port(port);
+        return Ok(addr);
+    }
+
+    if let Ok(host) = s.parse() {
+        addr.set_ip(host);
+        if let Some(port) = env_port {
+            addr.set_port(port);
+        }
+        return Ok(addr);
+    }
+
+    s.parse()
+}


### PR DESCRIPTION
Add `meroctl relay` command. This will use the NEAR credentials defined in `config.toml`.