### PR TITLE
feat(config-contract): add erase method

### DIFF
--- a/contracts/context-config/src/guard.rs
+++ b/contracts/context-config/src/guard.rs
@@ -48,6 +48,12 @@ impl<T> Guard<T> {
         Ok(GuardMut { inner: self })
     }
 
+    pub fn into_inner(self) -> T {
+        let mut this = self;
+        this.priviledged.clear();
+        this.inner
+    }
+
     pub fn priviledged(&self) -> &IterableSet<SignerId> {
         &self.priviledged
     }

--- a/contracts/context-config/src/mutate.rs
+++ b/contracts/context-config/src/mutate.rs
@@ -42,6 +42,30 @@ impl ContextConfigs {
         }
     }
 
+    pub fn erase(&mut self) {
+        require!(
+            env::signer_account_id() == env::current_account_id(),
+            "Not so fast, chief.."
+        );
+
+        env::log_str(&format!(
+            "Pre-erase storage usage: {}",
+            env::storage_usage()
+        ));
+
+        env::log_str("Erasing contract");
+
+        for (_, context) in self.contexts.drain() {
+            context.application.into_inner();
+            context.members.into_inner().clear();
+        }
+
+        env::log_str(&format!(
+            "Post-erase storage usage: {}",
+            env::storage_usage()
+        ));
+    }
+
     pub fn mutate(&mut self) {
         parse_input!(request: Signed<Request<'_>>);
 

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -579,5 +579,23 @@ async fn main() -> eyre::Result<()> {
 
     assert_eq!(res, [alice_cx_id, carol_cx_id]);
 
+    let state = contract.view_state().await?;
+
+    assert_eq!(state.len(), 11);
+
+    let res = contract
+        .call("erase")
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert!(res.logs().contains(&"Erasing contract"), "{:?}", res.logs());
+
+    let state = contract.view_state().await?;
+
+    assert_eq!(state.len(), 1);
+    assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
+
     Ok(())
 }


### PR DESCRIPTION
Add erase method to context config contract

Needed to nuke the contract after #738.

I've since nuked the contract and redeployed the new version.