### PR TITLE
fix(release): use upload-artifact instead of cache for artifact smuggling

### DIFF
--- a/.github/workflows/calimero_node_linux.yml
+++ b/.github/workflows/calimero_node_linux.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - "**"
-    paths:
-      - Cargo.toml
-      - Cargo.lock
-      - "crates/**"
+    # paths:
+    #   - Cargo.toml
+    #   - Cargo.lock
+    #   - "crates/**"
   pull_request:
     types: [closed]
 

--- a/.github/workflows/calimero_node_linux.yml
+++ b/.github/workflows/calimero_node_linux.yml
@@ -91,13 +91,11 @@ jobs:
           echo "artifact_path=meroctl_${{ matrix.target }}.tar.gz" >> $GITHUB_OUTPUT
           echo "target=${{ matrix.target }}" >> $GITHUB_OUTPUT
 
-      - name: Cache build artifact
-        uses: actions/cache@v4
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: meroctl_${{ matrix.target }}.tar.gz
           path: meroctl_${{ matrix.target }}.tar.gz
-          key: build-artifact-meroctl-${{ matrix.target }}-${{ github.sha }}
-          restore-keys: |
-            build-artifact-meroctl-${{ matrix.target }}
 
   upload_branch_artifact:
     runs-on: ubuntu-latest
@@ -108,13 +106,10 @@ jobs:
     if: ${{ github.ref != 'refs/heads/master' }}
 
     steps:
-      - name: Restore build artifact
-        uses: actions/cache@v4
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
         with:
-          path: meroctl_${{ matrix.target }}.tar.gz
-          key: build-artifact-meroctl-${{ matrix.target }}-${{ github.sha }}
-          restore-keys: |
-            build-artifact-meroctl-${{ matrix.target }}
+          name: meroctl_${{ matrix.target }}.tar.gz
 
       - name: Sanitize ref name
         id: sanitize
@@ -171,13 +166,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore build artifact
-        uses: actions/cache@v4
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
         with:
-          path: meroctl_${{ matrix.target }}.tar.gz
-          key: build-artifact-meroctl-${{ matrix.target }}-${{ github.sha }}
-          restore-keys: |
-            build-artifact-meroctl-${{ matrix.target }}
+          name: meroctl_${{ matrix.target }}.tar.gz
 
       - name: Check if artifact exists in release
         id: check_artifact

--- a/.github/workflows/calimero_node_linux.yml
+++ b/.github/workflows/calimero_node_linux.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           name: meroctl_${{ matrix.target }}.tar.gz
           path: meroctl_${{ matrix.target }}.tar.gz
+          retention-days: 2
 
   upload_branch_artifact:
     runs-on: ubuntu-latest
@@ -116,13 +117,6 @@ jobs:
         run: |
           sanitized_ref_name=$(echo "${GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9_-]/-/g; s/^-*//; s/-*$//')
           echo "sanitized_ref_name=${sanitized_ref_name}" >> $GITHUB_OUTPUT
-
-      - name: Upload binary as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: meroctl_${{ steps.sanitize.outputs.sanitized_ref_name }}_${{ matrix.target }}.tar.gz
-          path: meroctl_${{ matrix.target }}.tar.gz
-          retention-days: 2
 
   create_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/calimero_node_linux.yml
+++ b/.github/workflows/calimero_node_linux.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - "**"
-    # paths:
-    #   - Cargo.toml
-    #   - Cargo.lock
-    #   - "crates/**"
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - "crates/**"
   pull_request:
     types: [closed]
 

--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           name: meroctl_${{ matrix.target }}.tar.gz
           path: meroctl_${{ matrix.target }}.tar.gz
+          retention-days: 2
 
   upload_branch_artifact:
     runs-on: ubuntu-latest
@@ -81,13 +82,6 @@ jobs:
         run: |
           sanitized_ref_name=$(echo "${GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9_-]/-/g; s/^-*//; s/-*$//')
           echo "sanitized_ref_name=${sanitized_ref_name}" >> $GITHUB_OUTPUT
-
-      - name: Upload meroctl as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: meroctl_${{ steps.sanitize.outputs.sanitized_ref_name }}_${{ matrix.target }}.tar.gz
-          path: meroctl_${{ matrix.target }}.tar.gz
-          retention-days: 2
 
   create_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - "**"
-    paths:
-      - Cargo.toml
-      - Cargo.lock
-      - "crates/**"
+    # paths:
+    #   - Cargo.toml
+    #   - Cargo.lock
+    #   - "crates/**"
   pull_request:
     types: [closed]
 

--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - "**"
-    # paths:
-    #   - Cargo.toml
-    #   - Cargo.lock
-    #   - "crates/**"
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - "crates/**"
   pull_request:
     types: [closed]
 

--- a/.github/workflows/calimero_node_macos.yml
+++ b/.github/workflows/calimero_node_macos.yml
@@ -56,13 +56,11 @@ jobs:
           echo "artifact_path=meroctl_${{ matrix.target }}.tar.gz" >> $GITHUB_OUTPUT
           echo "target=${{ matrix.target }}" >> $GITHUB_OUTPUT
 
-      - name: Cache build artifact
-        uses: actions/cache@v4
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: meroctl_${{ matrix.target }}.tar.gz
           path: meroctl_${{ matrix.target }}.tar.gz
-          key: build-artifact-meroctl-${{ matrix.target }}-${{ github.sha }}
-          restore-keys: |
-            build-artifact-meroctl-${{ matrix.target }}
 
   upload_branch_artifact:
     runs-on: ubuntu-latest
@@ -73,13 +71,10 @@ jobs:
     if: ${{ github.ref != 'refs/heads/master' }}
 
     steps:
-      - name: Restore build artifact
-        uses: actions/cache@v4
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
         with:
-          path: meroctl_${{ matrix.target }}.tar.gz
-          key: build-artifact-meroctl-${{ matrix.target }}-${{ github.sha }}
-          restore-keys: |
-            build-artifact-meroctl-${{ matrix.target }}
+          name: meroctl_${{ matrix.target }}.tar.gz
 
       - name: Sanitize ref name
         id: sanitize
@@ -137,13 +132,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore build artifact
-        uses: actions/cache@v4
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
         with:
-          path: meroctl_${{ matrix.target }}.tar.gz
-          key: build-artifact-meroctl-${{ matrix.target }}-${{ github.sha }}
-          restore-keys: |
-            build-artifact-meroctl-${{ matrix.target }}
+          name: meroctl_${{ matrix.target }}.tar.gz
 
       - name: Check if artifact exists in release
         id: check_artifact


### PR DESCRIPTION
`actions/cache@v4` performs counter-intuitively from what the code expects, as will pull old versions of the artifact if it deems it sufficient, which will use old versions of the application instead of the one we just built.

`actions/upload-artifact@v4` and `actions/download-artifact@v4` more appropriately matches what the intent is.

https://github.com/calimero-network/core/releases/tag/v0.2.0-beta.2 for example, contains the binary for `v0.2.0-beta.1` and https://github.com/calimero-network/core/releases/tag/v0.2.0-beta.1, contains the binary for `v0.1.0`