### PR TITLE
chore(release): bump meroctl to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4411,7 +4411,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "meroctl"
-version = "0.2.0-beta.2"
+version = "0.1.0"
 dependencies = [
  "axum",
  "bs58 0.5.1",

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meroctl"
-version = "0.2.0-beta.2"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Following #748, it was identified that all the current releases v0.1, v0.2-beta-* don't contain binaries that are the versions they claim to

I've gone ahead to delete those tags and their releases to give us a fresh slate