### PR TITLE
feat: revise default relayer url

### DIFF
--- a/crates/meroctl/src/defaults.rs
+++ b/crates/meroctl/src/defaults.rs
@@ -3,7 +3,7 @@ use dirs::home_dir;
 use url::Url;
 
 pub const DEFAULT_CALIMERO_HOME: &str = ".calimero";
-pub const DEFAULT_RELAYER_URL: &str = "https://relayer.calimero.org";
+pub const DEFAULT_RELAYER_URL: &str = "http://3.125.79.112:63529";
 
 pub fn default_node_dir() -> Utf8PathBuf {
     if let Some(home) = home_dir() {


### PR DESCRIPTION
Use the deployed instance of the relayer as the default