### PR TITLE
feat(node-ui): remove join context

### DIFF
--- a/node-ui/src/components/context/ContextTable.tsx
+++ b/node-ui/src/components/context/ContextTable.tsx
@@ -17,7 +17,6 @@ const FlexWrapper = styled.div`
 interface ContextTableProps {
   nodeContextList: ContextsList<ContextObject>;
   navigateToStartContext: () => void;
-  navigateToJoinContext: () => void;
   currentOption: string;
   setCurrentOption: (option: string) => void;
   tableOptions: TableOptions[];
@@ -34,7 +33,6 @@ interface ContextTableProps {
 export default function ContextTable({
   nodeContextList,
   navigateToStartContext,
-  navigateToJoinContext,
   currentOption,
   setCurrentOption,
   tableOptions,
@@ -55,8 +53,6 @@ export default function ContextTable({
       headerOptionText={t.startNewContextText}
       headerDescription={t.contextPageDescription}
       headerOnOptionClick={navigateToStartContext}
-      headerSecondOptionText={t.joinContextText}
-      headerOnSecondOptionClick={navigateToJoinContext}
     >
       <StatusModal
         show={showStatusModal}

--- a/node-ui/src/pages/Contexts.tsx
+++ b/node-ui/src/pages/Contexts.tsx
@@ -158,7 +158,6 @@ export default function ContextsPage() {
         <ContextTable
           nodeContextList={nodeContextList}
           navigateToStartContext={() => navigate('/contexts/start-context')}
-          navigateToJoinContext={() => navigate('/contexts/join-context')}
           currentOption={currentOption}
           setCurrentOption={setCurrentOption}
           tableOptions={tableOptions}

--- a/node-ui/src/pages/JoinContext.tsx
+++ b/node-ui/src/pages/JoinContext.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigation } from '../components/Navigation';
 import { FlexLayout } from '../components/layout/FlexLayout';
 import { useNavigate } from 'react-router-dom';
@@ -74,6 +74,10 @@ export default function JoinContextPage() {
       navigate('/contexts');
     }
   };
+
+  useEffect(() => {
+    navigate('/contexts');
+  }, [navigate]);
 
   return (
     <FlexLayout>


### PR DESCRIPTION
# feat(node-ui): remove join context

## Summary
Removed join context button from context page and added redirect when user navigates to that page with url