### PR TITLE
Improve relay registration

### DIFF
--- a/crates/meroctl/src/cli/init.rs
+++ b/crates/meroctl/src/cli/init.rs
@@ -9,7 +9,8 @@ use calimero_context_config::client::config::{
     Credentials,
 };
 use calimero_network::config::{
-    BootstrapConfig, BootstrapNodes, CatchupConfig, DiscoveryConfig, RendezvousConfig, SwarmConfig,
+    BootstrapConfig, BootstrapNodes, CatchupConfig, DiscoveryConfig, RelayConfig, RendezvousConfig,
+    SwarmConfig,
 };
 use calimero_server::admin::service::AdminConfig;
 use calimero_server::jsonrpc::JsonRpcConfig;
@@ -79,6 +80,9 @@ pub struct InitCommand {
 
     #[clap(long, default_value = "3")]
     pub rendezvous_registrations_limit: usize,
+
+    #[clap(long, default_value = "3")]
+    pub relay_registrations_limit: usize,
 
     /// Force initialization even if the directory already exists
     #[clap(long)]
@@ -198,6 +202,7 @@ impl InitCommand {
                 discovery: DiscoveryConfig::new(
                     mdns,
                     RendezvousConfig::new(self.rendezvous_registrations_limit),
+                    RelayConfig::new(self.relay_registrations_limit),
                 ),
                 server: ServerConfig {
                     listen: self

--- a/crates/network/src/config.rs
+++ b/crates/network/src/config.rs
@@ -127,12 +127,18 @@ pub struct DiscoveryConfig {
     pub mdns: bool,
 
     pub rendezvous: RendezvousConfig,
+
+    pub relay: RelayConfig,
 }
 
 impl DiscoveryConfig {
     #[must_use]
-    pub const fn new(mdns: bool, rendezvous: RendezvousConfig) -> Self {
-        Self { mdns, rendezvous }
+    pub const fn new(mdns: bool, rendezvous: RendezvousConfig, relay: RelayConfig) -> Self {
+        Self {
+            mdns,
+            rendezvous,
+            relay,
+        }
     }
 }
 
@@ -141,6 +147,30 @@ impl Default for DiscoveryConfig {
         Self {
             mdns: true,
             rendezvous: RendezvousConfig::default(),
+            relay: RelayConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct RelayConfig {
+    pub registrations_limit: usize,
+}
+
+impl RelayConfig {
+    #[must_use]
+    pub fn new(registrations_limit: usize) -> Self {
+        Self {
+            registrations_limit,
+        }
+    }
+}
+
+impl Default for RelayConfig {
+    fn default() -> Self {
+        Self {
+            registrations_limit: 3,
         }
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -172,7 +172,7 @@ fn init(
         sender: command_sender,
     };
 
-    let discovery = Discovery::new(&config.discovery.rendezvous);
+    let discovery = Discovery::new(&config.discovery.rendezvous, &config.discovery.relay);
 
     let event_loop = EventLoop::new(
         swarm,


### PR DESCRIPTION
# Improve relay registration implementation

## Regarding #481 

>At the moment we request our relay reservation from all relay peers. Implement selection of relay peers to avoid network congestion.

>One approach could be to select the first N peers as nominated peers. After our reservation has expired, we could nominate a new peer and request a reservation.