### PR TITLE
Implement CLI commands for interaction with WebSocket endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
  "sha1",
  "sync_wrapper 1.0.1",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4444,6 +4444,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "toml",
  "toml_edit 0.22.20",
  "tracing",
@@ -7740,7 +7741,21 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -8031,6 +8046,25 @@ dependencies = [
  "sha1",
  "thiserror",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
  "utf-8",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7752,9 +7752,7 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "tokio",
- "tokio-native-tls",
  "tungstenite 0.24.0",
 ]
 
@@ -8061,7 +8059,6 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.5",
  "sha1",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ thiserror = "1.0.56"
 thunderdome = "0.6.1"
 tokio = "1.35.1"
 tokio-test = "0.4.4"
-tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
+tokio-tungstenite = "0.24.0"
 tokio-util = "0.7.11"
 toml = "0.8.9"
 toml_edit = "0.22.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ thiserror = "1.0.56"
 thunderdome = "0.6.1"
 tokio = "1.35.1"
 tokio-test = "0.4.4"
+tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
 tokio-util = "0.7.11"
 toml = "0.8.9"
 toml_edit = "0.22.14"
@@ -290,8 +291,8 @@ unconditional_recursion = "deny"
 unnecessary_clippy_cfg = "deny"
 
 # Lint customisations
-doc_markdown = "allow" # Annoying number of false positives
+doc_markdown = "allow"            # Annoying number of false positives
 multiple_crate_versions = "allow" # Cannot resolve all these
-missing_errors_doc = "allow" # TODO: Remove later once documentation has been added
-missing_panics_doc = "allow" # TODO: Remove later once documentation has been added
-future_not_send = "allow" # TODO: Remove later once Send is implemented
+missing_errors_doc = "allow"      # TODO: Remove later once documentation has been added
+missing_panics_doc = "allow"      # TODO: Remove later once documentation has been added
+future_not_send = "allow"         # TODO: Remove later once Send is implemented

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std", "macros"] }
+tokio-tungstenite.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true

--- a/crates/meroctl/src/cli/context.rs
+++ b/crates/meroctl/src/cli/context.rs
@@ -7,6 +7,7 @@ use crate::cli::context::delete::DeleteCommand;
 use crate::cli::context::get::GetCommand;
 use crate::cli::context::join::JoinCommand;
 use crate::cli::context::list::ListCommand;
+use crate::cli::context::watch::WatchCommand;
 use crate::cli::RootArgs;
 
 mod create;
@@ -14,6 +15,7 @@ mod delete;
 mod get;
 mod join;
 mod list;
+mod watch;
 
 pub const EXAMPLES: &str = r"
   # List all contexts
@@ -46,6 +48,8 @@ pub enum ContextSubCommands {
     Get(GetCommand),
     #[command(alias = "del")]
     Delete(DeleteCommand),
+    #[command(alias = "ws")]
+    Watch(WatchCommand),
 }
 
 impl ContextCommand {
@@ -56,6 +60,7 @@ impl ContextCommand {
             ContextSubCommands::Get(get) => get.run(args).await,
             ContextSubCommands::Join(join) => join.run(args).await,
             ContextSubCommands::List(list) => list.run(args).await,
+            ContextSubCommands::Watch(watch) => watch.run(args).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -1,0 +1,67 @@
+use calimero_primitives::context::ContextId;
+use calimero_server_primitives::ws::{RequestPayload, SubscribeRequest};
+use clap::Parser;
+use eyre::{bail, Result as EyreResult};
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::connect_async;
+
+use super::RootArgs;
+use crate::common::multiaddr_to_url;
+use crate::config_file::ConfigFile;
+
+#[derive(Debug, Parser)]
+pub struct WatchCommand {
+    /// ContextId to stream events from
+    #[arg(long)]
+    pub context_id: ContextId,
+}
+
+impl WatchCommand {
+    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
+        let path = root_args.home.join(&root_args.node_name);
+
+        if !ConfigFile::exists(&path) {
+            bail!("Config file does not exist");
+        }
+
+        let config = ConfigFile::load(&path)?;
+
+        let Some(multiaddr) = config.network.server.listen.first() else {
+            bail!("No address found in config");
+        };
+
+        let mut url = multiaddr_to_url(multiaddr, "ws")?;
+        url.set_scheme("ws")
+            .map_err(|_| eyre::eyre!("Failed to set URL scheme"))?;
+
+        println!("Connecting to WebSocket at {}", url);
+
+        let (ws_stream, _) = connect_async(url.as_str()).await?;
+
+        let (mut write, mut read) = ws_stream.split();
+
+        // Send subscribe message
+        let subscribe_request =
+            RequestPayload::Subscribe(SubscribeRequest::new(vec![self.context_id]));
+        let subscribe_msg = serde_json::to_string(&subscribe_request)?;
+        write
+            .send(tokio_tungstenite::tungstenite::Message::Text(subscribe_msg))
+            .await?;
+
+        println!("Subscribed to context {}", self.context_id);
+        println!("Streaming events (press Ctrl+C to stop):");
+
+        while let Some(message) = read.next().await {
+            match message {
+                Ok(msg) => {
+                    if let tokio_tungstenite::tungstenite::Message::Text(text) = msg {
+                        println!("{}", text);
+                    }
+                }
+                Err(e) => eprintln!("Error receiving message: {}", e),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/server-primitives/src/ws.rs
+++ b/crates/server-primitives/src/ws.rs
@@ -83,6 +83,13 @@ pub struct SubscribeRequest {
     pub context_ids: Vec<ContextId>,
 }
 
+impl SubscribeRequest {
+    #[must_use]
+    pub const fn new(context_ids: Vec<ContextId>) -> Self {
+        Self { context_ids }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]


### PR DESCRIPTION
# MeroCLI now supports consuming WebSocket stream from the CLI

## Summary

Described in #541, you can "listen" to incoming data regarding a context 

Fixes #541

## Test plan

`cargo run -p meroctl -- --node-name <node-name> context watch --context-id <context-id>` starts the process
