### PR TITLE
feat: Finalised Data trait and associated design

### DIFF
--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -33,7 +33,7 @@ use uuid::{Bytes, Uuid};
 /// system operation. Abstracting the true type away provides a level of
 /// insulation that is useful for any future changes.
 ///
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Id(Uuid);
 
 impl Id {
@@ -150,7 +150,7 @@ impl From<Id> for Uuid {
 /// There is no formal limit to the levels of hierarchy allowed, but in practice
 /// this is limited to 255 levels (assuming a single byte per segment name).
 ///
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Path {
     /// A list of path segment offsets, where offset `0` is assumed, and not
     /// stored.
@@ -528,7 +528,7 @@ impl TryFrom<String> for Path {
 }
 
 /// Errors that can occur when working with [`Path`]s.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, ThisError)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd, ThisError)]
 #[non_exhaustive]
 pub enum PathError {
     /// The path is empty.

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -1,11 +1,13 @@
 use std::sync::LazyLock;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_store::config::StoreConfig;
 use calimero_store::db::RocksDB;
 use calimero_store::Store;
 use tempfile::{tempdir, TempDir};
 
 use crate::address::Id;
+use crate::entities::{Data, Element, NoChildren};
 
 /// A set of non-empty test UUIDs.
 pub const TEST_UUID: [[u8; 16]; 5] = [
@@ -26,6 +28,102 @@ pub static TEST_ID: LazyLock<[Id; 5]> = LazyLock::new(|| {
         Id::from(TEST_UUID[4]),
     ]
 });
+
+/// For tests against empty data structs.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq, PartialOrd)]
+pub struct EmptyData {
+    pub storage: Element,
+}
+
+impl Data for EmptyData {
+    type Child = NoChildren;
+
+    fn element(&self) -> &Element {
+        &self.storage
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        &mut self.storage
+    }
+}
+
+/// A simple page with a title, and paragraphs as children.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq, PartialOrd)]
+pub struct Page {
+    pub title: String,
+    pub storage: Element,
+}
+
+impl Page {
+    /// Creates a new page with a title from an existing element.
+    pub fn new_from_element(title: &str, element: Element) -> Self {
+        Self {
+            title: title.to_owned(),
+            storage: element,
+        }
+    }
+}
+
+impl Data for Page {
+    type Child = Paragraph;
+
+    fn element(&self) -> &Element {
+        &self.storage
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        &mut self.storage
+    }
+}
+
+/// A simple paragraph with text. No children. Belongs to a page.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq, PartialOrd)]
+pub struct Paragraph {
+    pub text: String,
+    pub storage: Element,
+}
+
+impl Paragraph {
+    /// Creates a new paragraph with text, from an existing element.
+    pub fn new_from_element(text: &str, element: Element) -> Self {
+        Self {
+            text: text.to_owned(),
+            storage: element,
+        }
+    }
+}
+
+impl Data for Paragraph {
+    type Child = NoChildren;
+
+    fn element(&self) -> &Element {
+        &self.storage
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        &mut self.storage
+    }
+}
+
+/// A simple person example struct. No children.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq, PartialOrd)]
+pub struct Person {
+    pub name: String,
+    pub age: u8,
+    pub storage: Element,
+}
+
+impl Data for Person {
+    type Child = NoChildren;
+
+    fn element(&self) -> &Element {
+        &self.storage
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        &mut self.storage
+    }
+}
 
 /// Creates a new temporary store for testing.
 ///


### PR DESCRIPTION
  - Removed the temporary `Data` struct and implemented a proper `Data` trait in its place. This temporarily has an associated type called `Child`, to specify the (one-dimensional) type of children.

  - Added `element()`and `element_mut()` methods to obtain the `Element` that the `Data` type owns.

  - Added `id()` and `path()` methods for convenience to pass through from `Data` to `Element`.

  - Added documentation to explain the design choices behind the implemented structure.

  - Removed the `Element.data` property and matching `data()` method, as `Element` will no longer own or have any reference to `Data`; `Data` needs to own `Element` for the chosen design pattern.

  - Updated the `Element.update_data()` method to no longer accept `Data`, as it does not have access to it. Renamed it to simply `update()` to reflect this.

  - Added a `NoChildren` type to be used (for now) for those types that have no children.

  - Made some Interface functions generic around `D: Data` - these are `calculate_merkle_hash()`, `children_of()`, `find_by_id()`, `find_by_path()`, `find_children_by_id()`, and `save()`.

  - Updated `Interface.children_of()` to return types of `Data::Child`.

  - Updated tests and added new tests as appropriate.
