### PR TITLE
feat: Added AtomicUnit macro and trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "calimero-storage-macros"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "calimero-storage",
+ "calimero-test-utils",
+ "quote",
+ "syn 2.0.72",
+ "trybuild",
+]
+
+[[package]]
 name = "calimero-store"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,13 +1104,13 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "calimero-store",
+ "calimero-test-utils",
  "claims",
  "eyre",
  "fixedstr",
  "hex",
  "parking_lot",
  "sha2",
- "tempfile",
  "thiserror",
  "uuid 1.10.0",
 ]
@@ -1131,6 +1131,14 @@ dependencies = [
  "tempdir",
  "thiserror",
  "thunderdome",
+]
+
+[[package]]
+name = "calimero-test-utils"
+version = "0.1.0"
+dependencies = [
+ "calimero-store",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "./crates/server",
   "./crates/server-primitives",
   "./crates/storage",
+  "./crates/storage-macros",
   "./crates/store",
   "./crates/store/blobs",
   "./crates/test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "./crates/storage",
   "./crates/store",
   "./crates/store/blobs",
+  "./crates/test-utils",
 
   "./apps/kv-store",
   "./apps/only-peers",

--- a/crates/storage-macros/Cargo.toml
+++ b/crates/storage-macros/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "calimero-storage-macros"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+borsh.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+calimero-storage = { path = "../storage" }
+
+[dev-dependencies]
+trybuild.workspace = true
+
+calimero-test-utils = { path = "../test-utils" }
+
+[lints]
+workspace = true

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -1,0 +1,290 @@
+use borsh as _;
+/// For documentation links
+use calimero_storage as _;
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Fields, Type};
+
+#[cfg(test)]
+mod integration_tests_package_usage {
+    use {borsh as _, calimero_storage as _, calimero_test_utils as _, trybuild as _};
+}
+
+/// Derives the [`AtomicUnit`](calimero_storage::entities::AtomicUnit) trait for
+/// a struct.
+///
+/// This macro automatically implements the [`AtomicUnit`](calimero_storage::entities::AtomicUnit)
+/// trait for a struct, which extends the [`Data`](calimero_storage::entities::Data)
+/// trait.
+///
+/// # Requirements
+///
+/// The following are mandatory requirements for the struct:
+///
+///   - A private `storage` field of type [`Element`](calimero_storage::entities::Element).
+///     This is needed as the [`Data`](calimero_storage::entities::Data)-based
+///     struct needs to own an [`Element`](calimero_storage::entities::Element).
+///
+/// # Generated implementations
+///
+/// This macro will generate the following implementations:
+///
+///   - [`Data`](calimero_storage::entities::Data) trait implementation.
+///   - [`AtomicUnit`](calimero_storage::entities::AtomicUnit) trait
+///     implementation.
+///   - Getter and setter methods for each field. These help to ensure that the
+///     access to the fields is controlled, and that any changes to the fields
+///     are reflected in the [`Element`](calimero_storage::entities::Element)'s
+///     state.
+///   - [`BorshSerialize`](borsh::BorshSerialize) and [`BorshDeserialize`](borsh::BorshDeserialize)
+///     will be implemented for the struct, so they should be omitted from the
+///     struct definition.
+///
+/// # Struct attributes
+///
+/// * `#[children]` - An optional attribute to specify the child type for the
+///                   struct, written as `#[children(ChildType)]`. If the
+///                   attribute or its value are omitted, then the child type
+///                   will default to [`NoChildren`](calimero_storage::entities::NoChildren).
+///
+/// # Field attributes
+///
+/// * `#[collection]` - Indicates that the field is a collection of other
+///                     [`Data`] types.
+/// * `#[private]`    - Designates fields that are local-only, and so should not
+///                     be shared with other nodes in the network. These fields
+///                     will not be serialised or included in the Merkle hash
+///                     calculation. Note that being local-only is not the same
+///                     as applying permissions via ACLs to share with only the
+///                     current user — these fields are not shared at all.
+/// * `#[skip]`       - Can be applied to fields that should not be serialised
+///                     or included in the Merkle hash calculation. These fields
+///                     will be completely ignored by the storage system, and
+///                     not even have getters and setters implemented.
+/// * `#[storage]`    - Indicates that the field is the storage element for the
+///                     struct. This is a mandatory field, and if it is missing,
+///                     there will be a panic during compilation. The name is
+///                     arbitrary, but the type has to be an [`Element`](calimero_storage::entities::Element).
+///
+/// Note that fields marked with `#[private]` or `#[skip]` must have [`Default`]
+/// implemented so that they can be initialised when deserialising.
+///
+/// TODO: The `#[collection]` attribute is not yet implemented, and the
+///       `#[private]` attribute is implemented with the same functionality as
+///       `#[skip]`, but in future these will be differentiated.
+///
+/// # Getters and setters
+///
+/// The macro will generate getter and setter methods for each field. These
+/// methods will allow the struct to control access to its fields, and ensure
+/// that any changes to the fields are reflected in the [`Element`](calimero_storage::entities::Element)'s
+/// state.
+///
+/// The getter methods will have the same name as the field, and the setter
+/// methods will be prefixed with `set_`. For example, given a field `name`, the
+/// getter method will be `name()`, and the setter method will be `set_name()`.
+///
+/// The setter methods will return a boolean indicating whether the update was
+/// carried out. Note that this is more an indication of change than it is of
+/// error — if the value is the same as the current value, the update will not
+/// be carried out, and the method will return `false`.
+///
+/// # Examples
+///
+/// ```
+/// use calimero_storage::entities::Element;
+/// use calimero_storage_macros::AtomicUnit;
+///
+/// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+/// #[children(Paragraph)]
+/// struct Page {
+///     title: String,
+///     #[private]
+///     secret: String,
+///     #[storage]
+///     storage: Element,
+/// }
+///
+/// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+/// struct Paragraph {
+///     text: String,
+///     #[storage]
+///     storage: Element,
+/// }
+/// ```
+///
+/// TODO: Once multiple child types are supported, this example will represent
+///       the correct approach.
+///
+/// ```ignore
+/// use calimero_storage::entities::Element;
+/// use calimero_storage_macros::AtomicUnit;
+///
+/// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+///     #[private]
+///     secret: String,
+///     #[collection]
+///     friends: Vec<Person>,
+///     #[storage]
+///     storage: Element,
+/// }
+/// ```
+///
+/// # Panics
+///
+/// This macro will panic during compilation if:
+///
+///   - It is applied to anything other than a struct
+///   - The struct has unnamed fields
+///   - The struct does not have a field annotated as `#[storage]`
+///   - The struct has fields with types that do not implement [`Default`]
+///   - The struct already has methods with the same names as the generated
+///     getter and setter methods
+///
+#[expect(
+    clippy::too_many_lines,
+    reason = "Okay for now - will be restructured later"
+)]
+#[proc_macro_derive(AtomicUnit, attributes(children, collection, private, skip, storage))]
+pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let child_type = input
+        .attrs
+        .iter()
+        .find_map(|attr| {
+            if attr.path().is_ident("children") {
+                attr.parse_args::<Type>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| parse_quote!(calimero_storage::entities::NoChildren));
+
+    let fields = match &input.data {
+        Data::Struct(data) => &data.fields,
+        Data::Enum(_) | Data::Union(_) => panic!("AtomicUnit can only be derived for structs"),
+    };
+
+    let named_fields = match fields {
+        Fields::Named(fields) => &fields.named,
+        Fields::Unnamed(_) | Fields::Unit => {
+            panic!("AtomicUnit can only be derived for structs with named fields")
+        }
+    };
+
+    // Find the field marked with the #[storage] attribute
+    let storage_field = named_fields
+        .iter()
+        .find(|f| f.attrs.iter().any(|attr| attr.path().is_ident("storage")))
+        .expect("You must designate one field with #[storage] for the Element");
+
+    let storage_ident = storage_field.ident.as_ref().unwrap();
+    let storage_ty = &storage_field.ty;
+
+    let field_implementations = named_fields
+        .iter()
+        .filter_map(|f| {
+            let ident = f.ident.as_ref().unwrap();
+            let ty = &f.ty;
+
+            let skip = f.attrs.iter().any(|attr| attr.path().is_ident("skip"));
+
+            if skip || ident == storage_ident {
+                None
+            } else {
+                let getter = format_ident!("{}", ident);
+                let setter = format_ident!("set_{}", ident);
+
+                Some(quote! {
+                    pub fn #getter(&self) -> &#ty {
+                        &self.#ident
+                    }
+
+                    pub fn #setter(&mut self, value: #ty) -> bool {
+                        if self.#ident == value {
+                            false
+                        } else {
+                            self.#ident = value;
+                            self.#storage_ident.update();
+                            true
+                        }
+                    }
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let serializable_fields: Vec<_> = named_fields
+        .iter()
+        .filter(|f| {
+            !f.attrs
+                .iter()
+                .any(|attr| attr.path().is_ident("skip") || attr.path().is_ident("private"))
+                && f.ident.as_ref().unwrap() != storage_ident
+        })
+        .map(|f| f.ident.as_ref().unwrap())
+        .collect();
+
+    let skipped_fields: Vec<_> = named_fields
+        .iter()
+        .filter(|f| {
+            f.attrs
+                .iter()
+                .any(|attr| attr.path().is_ident("skip") || attr.path().is_ident("private"))
+        })
+        .map(|f| f.ident.as_ref().unwrap())
+        .collect();
+
+    let deserialize_impl = quote! {
+        impl borsh::BorshDeserialize for #name {
+            fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+                let #storage_ident = #storage_ty::deserialize_reader(reader)?;
+                Ok(Self {
+                    #storage_ident,
+                    #(#serializable_fields: borsh::BorshDeserialize::deserialize_reader(reader)?,)*
+                    #(#skipped_fields: Default::default(),)*
+                })
+            }
+        }
+    };
+
+    let serialize_impl = quote! {
+        impl borsh::BorshSerialize for #name {
+            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+                borsh::BorshSerialize::serialize(&self.#storage_ident, writer)?;
+                #(borsh::BorshSerialize::serialize(&self.#serializable_fields, writer)?;)*
+                Ok(())
+            }
+        }
+    };
+
+    let expanded = quote! {
+        impl #name {
+            #(#field_implementations)*
+        }
+
+        impl calimero_storage::entities::Data for #name {
+            type Child = #child_type;
+
+            fn element(&self) -> &calimero_storage::entities::Element {
+                &self.#storage_ident
+            }
+
+            fn element_mut(&mut self) -> &mut calimero_storage::entities::Element {
+                &mut self.#storage_ident
+            }
+        }
+
+        impl calimero_storage::entities::AtomicUnit for #name {}
+
+        #deserialize_impl
+
+        #serialize_impl
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/storage-macros/tests/atomic_unit.rs
+++ b/crates/storage-macros/tests/atomic_unit.rs
@@ -1,0 +1,326 @@
+#![allow(unused_crate_dependencies, reason = "Creates a lot of noise")]
+//	Lints specifically disabled for integration tests
+#![allow(
+    non_snake_case,
+    unreachable_pub,
+    clippy::cast_lossless,
+    clippy::cast_precision_loss,
+    clippy::cognitive_complexity,
+    clippy::default_numeric_fallback,
+    clippy::exhaustive_enums,
+    clippy::exhaustive_structs,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::let_underscore_must_use,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::missing_panics_doc,
+    clippy::mod_module_files,
+    clippy::must_use_candidate,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::tests_outside_test_module,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    reason = "Not useful in tests"
+)]
+
+use borsh::{to_vec, BorshDeserialize};
+use calimero_storage::address::Path;
+use calimero_storage::entities::{Data, Element, NoChildren};
+use calimero_storage::interface::Interface;
+use calimero_storage_macros::AtomicUnit;
+use calimero_test_utils::storage::create_test_store;
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+struct Child {
+    content: String,
+    #[storage]
+    storage: Element,
+}
+
+impl Child {
+    fn new(path: &Path) -> Self {
+        Self {
+            content: String::new(),
+            storage: Element::new(path),
+        }
+    }
+}
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[children(Child)]
+struct Parent {
+    title: String,
+    #[storage]
+    storage: Element,
+}
+
+impl Parent {
+    fn new(path: &Path) -> Self {
+        Self {
+            title: String::new(),
+            storage: Element::new(path),
+        }
+    }
+}
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+struct Private {
+    public: String,
+    #[private]
+    private: String,
+    #[storage]
+    storage: Element,
+}
+
+impl Private {
+    fn new(path: &Path) -> Self {
+        Self {
+            public: String::new(),
+            private: String::new(),
+            storage: Element::new(path),
+        }
+    }
+}
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+struct Simple {
+    name: String,
+    value: i32,
+    #[storage]
+    storage: Element,
+}
+
+impl Simple {
+    fn new(path: &Path) -> Self {
+        Self {
+            name: String::new(),
+            value: 0,
+            storage: Element::new(path),
+        }
+    }
+}
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+struct Skipped {
+    included: String,
+    #[skip]
+    skipped: String,
+    #[storage]
+    storage: Element,
+}
+
+impl Skipped {
+    fn new(path: &Path) -> Self {
+        Self {
+            included: String::new(),
+            skipped: String::new(),
+            storage: Element::new(path),
+        }
+    }
+}
+
+#[cfg(test)]
+mod basics {
+    use super::*;
+
+    #[test]
+    fn creation() {
+        let path = Path::new("::root::node").unwrap();
+        let unit = Simple::new(&path);
+
+        assert_eq!(unit.path(), path);
+        assert_eq!(unit.element().path(), path);
+        assert!(unit.element().is_dirty());
+    }
+
+    #[test]
+    fn getters() {
+        let path = Path::new("::root::node").unwrap();
+        let unit = Simple::new(&path);
+
+        assert_eq!(unit.name(), "");
+        assert_eq!(unit.value(), &0);
+    }
+
+    #[test]
+    fn setters__set() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+
+        _ = unit.set_name("Test Name".to_owned());
+        _ = unit.set_value(42);
+
+        assert_eq!(unit.name(), "Test Name");
+        assert_eq!(unit.value(), &42);
+    }
+
+    #[test]
+    fn setters__confirm_set() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+        assert_ne!(unit.name(), "Test Name");
+        assert_ne!(unit.value(), &42);
+
+        assert!(unit.set_name("Test Name".to_owned()));
+        assert!(unit.set_value(42));
+        assert_eq!(unit.name(), "Test Name");
+        assert_eq!(unit.value(), &42);
+    }
+
+    #[test]
+    fn setters__confirm_not_set() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+        assert_ne!(unit.name(), "Test Name");
+        assert_ne!(unit.value(), &42);
+
+        assert!(unit.set_name("Test Name".to_owned()));
+        assert!(unit.set_value(42));
+        assert_eq!(unit.name(), "Test Name");
+        assert_eq!(unit.value(), &42);
+        assert!(!unit.set_name("Test Name".to_owned()));
+        assert!(!unit.set_value(42));
+    }
+
+    #[test]
+    fn setters__confirm_set_dirty() {
+        let (db, _dir) = create_test_store();
+        let interface = Interface::new(db);
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+        assert!(interface.save(unit.id(), &mut unit).unwrap());
+        assert!(!unit.element().is_dirty());
+
+        assert!(unit.set_name("Test Name".to_owned()));
+        assert!(unit.element().is_dirty());
+    }
+
+    #[test]
+    fn setters__confirm_not_set_not_dirty() {
+        let (db, _dir) = create_test_store();
+        let interface = Interface::new(db);
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+        assert!(interface.save(unit.id(), &mut unit).unwrap());
+        assert!(!unit.element().is_dirty());
+
+        assert!(unit.set_name("Test Name".to_owned()));
+        assert!(unit.element().is_dirty());
+        assert!(interface.save(unit.id(), &mut unit).unwrap());
+        assert!(!unit.set_name("Test Name".to_owned()));
+        assert!(!unit.element().is_dirty());
+    }
+}
+
+#[cfg(test)]
+mod visibility {
+    use super::*;
+
+    #[test]
+    fn private_field() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Private::new(&path);
+
+        _ = unit.set_public("Public".to_owned());
+        _ = unit.set_private("Private".to_owned());
+
+        let serialized = to_vec(&unit).unwrap();
+        let deserialized = Private::try_from_slice(&serialized).unwrap();
+
+        assert_eq!(unit.public(), deserialized.public());
+        assert_ne!(unit.private(), deserialized.private());
+        assert_eq!(deserialized.private(), "");
+    }
+
+    #[test]
+    fn public_field() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+
+        _ = unit.set_name("Public".to_owned());
+
+        let serialized = to_vec(&unit).unwrap();
+        let deserialized = Simple::try_from_slice(&serialized).unwrap();
+
+        assert_eq!(unit.name(), deserialized.name());
+    }
+
+    #[test]
+    fn skipped_field() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Skipped::new(&path);
+
+        _ = unit.set_included("Public".to_owned());
+        // Skipping fields also skips the setters
+        // _ = unit.set_skipped("Skipped".to_owned());
+        unit.skipped = "Skipped".to_owned();
+
+        let serialized = to_vec(&unit).unwrap();
+        let deserialized = Skipped::try_from_slice(&serialized).unwrap();
+
+        assert_eq!(unit.included(), deserialized.included());
+        // Skipping fields also skips the getters
+        // assert_ne!(unit.skipped(), deserialized.skipped());
+        assert_ne!(unit.skipped, deserialized.skipped);
+        assert_eq!(deserialized.skipped, "");
+    }
+}
+
+#[cfg(test)]
+mod hierarchy {
+    use super::*;
+
+    #[test]
+    fn parent_child() {
+        let parent_path = Path::new("::root::node").unwrap();
+        let mut parent = Parent::new(&parent_path);
+        _ = parent.set_title("Parent Title".to_owned());
+
+        let child_path = Path::new("::root::node::leaf").unwrap();
+        let mut child = Child::new(&child_path);
+        _ = child.set_content("Child Content".to_owned());
+
+        assert_eq!(parent.title(), "Parent Title");
+
+        // TODO: Add in tests for loading and checking children
+    }
+
+    #[test]
+    fn no_children() {
+        let _unit: Simple = Simple::new(&Path::new("::root::node").unwrap());
+        let _: Option<<Simple as Data>::Child> = None::<NoChildren>;
+    }
+
+    #[test]
+    fn compile_fail() {
+        trybuild::TestCases::new().compile_fail("tests/compile_fail/atomic_unit.rs");
+    }
+}
+
+#[cfg(test)]
+mod traits {
+    use super::*;
+
+    #[test]
+    fn serialization_and_deserialization() {
+        let path = Path::new("::root::node").unwrap();
+        let mut unit = Simple::new(&path);
+
+        _ = unit.set_name("Test Name".to_owned());
+        _ = unit.set_value(42);
+
+        let serialized = to_vec(&unit).unwrap();
+        let deserialized = Simple::try_from_slice(&serialized).unwrap();
+
+        assert_eq!(unit, deserialized);
+        assert_eq!(unit.id(), deserialized.id());
+        assert_eq!(unit.name(), deserialized.name());
+        assert_eq!(unit.path(), deserialized.path());
+        assert_eq!(unit.value(), deserialized.value());
+        assert_eq!(unit.element().id(), deserialized.element().id());
+        assert_eq!(unit.element().path(), deserialized.element().path());
+        assert_eq!(unit.element().metadata(), deserialized.element().metadata());
+    }
+}

--- a/crates/storage-macros/tests/compile_fail/atomic_unit.rs
+++ b/crates/storage-macros/tests/compile_fail/atomic_unit.rs
@@ -1,0 +1,30 @@
+use calimero_storage::address::Path;
+use calimero_storage::entities::Element;
+use calimero_storage::interface::Interface;
+use calimero_storage_macros::AtomicUnit;
+use calimero_test_utils::storage::create_test_store;
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+struct Child {
+    #[storage]
+    storage: Element,
+}
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[children(Child)]
+struct Parent {
+	#[storage]
+	storage: Element,
+}
+
+fn main() {
+    fn child_type_specification() {
+        let (db, _dir) = create_test_store();
+        let interface = Interface::new(db);
+        let parent: Parent = Parent { storage: Element::new(&Path::new("::root::node").unwrap()) };
+        let _: Vec<Child> = interface.children_of(&parent).unwrap();
+
+        // This should fail to compile if the child type is incorrect
+        let _: Vec<Parent> = interface.children_of(&parent).unwrap();
+    }
+}

--- a/crates/storage-macros/tests/compile_fail/atomic_unit.stderr
+++ b/crates/storage-macros/tests/compile_fail/atomic_unit.stderr
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+  --> tests/compile_fail/atomic_unit.rs:28:30
+   |
+28 |         let _: Vec<Parent> = interface.children_of(&parent).unwrap();
+   |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
+   |                |
+   |                expected due to this
+   |
+   = note: expected struct `Vec<Parent>`
+              found struct `Vec<Child>`

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -20,7 +20,8 @@ calimero-store = { path = "../store", features = ["datatypes"] }
 [dev-dependencies]
 claims.workspace = true
 hex.workspace = true
-tempfile.workspace = true
+
+calimero-test-utils = { path = "../test-utils" }
 
 [lints]
 workspace = true

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -198,6 +198,16 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::address::{Id, Path};
 
+/// Represents an atomic unit in the storage system.
+///
+/// An atomic unit is a self-contained piece of data that can be stored and
+/// retrieved as a single entity. It extends the [`Data`] trait with additional
+/// methods specific to how it's stored and identified in the system.
+///
+/// This is a marker trait, and does not have any special functionality.
+///
+pub trait AtomicUnit: Data {}
+
 /// The primary data for the [`Element`].
 ///
 /// This is the primary data for the [`Element`], that is, the data that the

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -1,10 +1,6 @@
 use std::sync::LazyLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_store::config::StoreConfig;
-use calimero_store::db::RocksDB;
-use calimero_store::Store;
-use tempfile::{tempdir, TempDir};
 
 use crate::address::Id;
 use crate::entities::{Data, Element, NoChildren};
@@ -123,31 +119,4 @@ impl Data for Person {
     fn element_mut(&mut self) -> &mut Element {
         &mut self.storage
     }
-}
-
-/// Creates a new temporary store for testing.
-///
-/// This function creates a new temporary directory and opens a new store in it,
-/// returning the store and the directory. The directory and its test data will
-/// be cleaned up when the test completes.
-///
-#[must_use]
-pub fn create_test_store() -> (Store, TempDir) {
-    // Note: It would be nice to have a way to test against an in-memory store,
-    // but InMemoryDB is not integrated with Store and there's currently no way
-    // to support both. It may be that the Database trait is later applied to
-    // InMemoryDB as well as RocksDB, in which case the storage Interface could
-    // be changed to work against Database implementations and not just Store.
-    let temp_dir = tempdir().expect("Could not create temp dir");
-    let config = StoreConfig::new(
-        temp_dir
-            .path()
-            .to_path_buf()
-            .try_into()
-            .expect("Invalid UTF-8 path"),
-    );
-    (
-        Store::open::<RocksDB>(&config).expect("Could not create store"),
-        temp_dir,
-    )
 }

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -1,8 +1,9 @@
+use calimero_test_utils::storage::create_test_store;
 use claims::{assert_ge, assert_le};
 
 use super::*;
 use crate::interface::Interface;
-use crate::tests::common::{create_test_store, Person};
+use crate::tests::common::Person;
 
 #[cfg(test)]
 mod data__public_methods {

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1,8 +1,9 @@
+use calimero_test_utils::storage::create_test_store;
 use claims::{assert_none, assert_ok};
 
 use super::*;
 use crate::entities::{Data, Element};
-use crate::tests::common::{create_test_store, EmptyData, Page, Paragraph, TEST_ID};
+use crate::tests::common::{EmptyData, Page, Paragraph, TEST_ID};
 
 #[cfg(test)]
 mod interface__constructor {

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "calimero-test-utils"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+tempfile.workspace = true
+
+calimero-store = { path = "../store", features = ["datatypes"] }
+
+[lints]
+workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -1,0 +1,3 @@
+//! Test utilities and data structures for use in the Calimero crates.
+
+pub mod storage;

--- a/crates/test-utils/src/storage.rs
+++ b/crates/test-utils/src/storage.rs
@@ -1,0 +1,33 @@
+//! Structs for testing storage.
+
+use calimero_store::config::StoreConfig;
+use calimero_store::db::RocksDB;
+use calimero_store::Store;
+use tempfile::{tempdir, TempDir};
+
+/// Creates a new temporary store for testing.
+///
+/// This function creates a new temporary directory and opens a new store in it,
+/// returning the store and the directory. The directory and its test data will
+/// be cleaned up when the test completes.
+///
+#[must_use]
+pub fn create_test_store() -> (Store, TempDir) {
+    // Note: It would be nice to have a way to test against an in-memory store,
+    // but InMemoryDB is not integrated with Store and there's currently no way
+    // to support both. It may be that the Database trait is later applied to
+    // InMemoryDB as well as RocksDB, in which case the storage Interface could
+    // be changed to work against Database implementations and not just Store.
+    let temp_dir = tempdir().expect("Could not create temp dir");
+    let config = StoreConfig::new(
+        temp_dir
+            .path()
+            .to_path_buf()
+            .try_into()
+            .expect("Invalid UTF-8 path"),
+    );
+    (
+        Store::open::<RocksDB>(&config).expect("Could not create store"),
+        temp_dir,
+    )
+}


### PR DESCRIPTION
Added `AtomicUnit` macro and trait

  - Added a new `AtomicUnit` marker trait.

  - Added a new `storage-macros` crate, to contain the macros needed for presenting the high-level developer interface.

  - Added an `AtomicUnit` proc macro to automatically derive `AtomicUnit` and `Data` traits for a struct.

Added `test-utils` crate

  - Created a new `test-utils` crate, to contain common functions and data structures for the purpose of testing.

  - Moved common functionality that has a wider scope from `storage::common` to `tests-utils::storage`.