### PR TITLE
feat(sdk): update json rpc error handling

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/login/refreshToken.ts
+++ b/packages/calimero-sdk/src/login/refreshToken.ts
@@ -13,6 +13,23 @@ interface GetNewJwtTokenProps {
   getNodeUrl: () => string;
 }
 
+type JsonRpcErrorType =
+    'UnknownServerError' |
+    'RpcExecutionError' |
+    'FunctionCallError' |
+    'CallError' |
+    'MissmatchedRequestIdError' |
+    'InvalidRequestError';
+
+const errorTypes: JsonRpcErrorType[] = [
+  'UnknownServerError',
+  'RpcExecutionError',
+  'FunctionCallError',
+  'CallError',
+  'MissmatchedRequestIdError',
+  'InvalidRequestError'
+];
+
 export const getNewJwtToken = async ({
   refreshToken,
   getNodeUrl,
@@ -65,14 +82,7 @@ export const handleRpcError = async (
     return invalidSession;
   }
   const errorType = error?.error?.name;
-  if (
-    errorType === 'UnknownServerError' ||
-    errorType === 'RpcExecutionError' ||
-    errorType === 'FunctionCallError' ||
-    errorType === 'CallError' ||
-    errorType === 'MissmatchedRequestIdError' ||
-    errorType === 'InvalidRequestError'
-  ) {
+  if (errorTypes.includes(errorType as JsonRpcErrorType)) {
     return {
       message: `${errorType}: ${error.error.cause.info.message}`,
       code: error.code,

--- a/packages/calimero-sdk/src/login/refreshToken.ts
+++ b/packages/calimero-sdk/src/login/refreshToken.ts
@@ -47,7 +47,7 @@ export const handleRpcError = async (
   };
 
   if (error.code === 401) {
-    if (error.message === 'Token expired.') {
+    if (error?.error?.cause?.info?.message === 'Token expired.') {
       try {
         const refreshToken = getRefreshToken();
         const response = await getNewJwtToken({ refreshToken, getNodeUrl });
@@ -64,14 +64,18 @@ export const handleRpcError = async (
     clearJWT();
     return invalidSession;
   }
-
+  const errorType = error?.error?.name;
   if (
-    error.type === 'UnknownServerError' ||
-    error.type === 'RpcExecutionError'
+    errorType === 'UnknownServerError' ||
+    errorType === 'RpcExecutionError' ||
+    errorType === 'FunctionCallError' ||
+    errorType === 'CallError' ||
+    errorType === 'MissmatchedRequestIdError' ||
+    errorType === 'InvalidRequestError'
   ) {
     return {
-      message: `Error: ${error?.inner?.data?.data?.type}`,
-      code: 500,
+      message: `${errorType}: ${error.error.cause.info.message}`,
+      code: error.code,
     };
   } else {
     return unknownMessage;

--- a/packages/calimero-sdk/src/login/refreshToken.ts
+++ b/packages/calimero-sdk/src/login/refreshToken.ts
@@ -14,12 +14,12 @@ interface GetNewJwtTokenProps {
 }
 
 type JsonRpcErrorType =
-    'UnknownServerError' |
-    'RpcExecutionError' |
-    'FunctionCallError' |
-    'CallError' |
-    'MissmatchedRequestIdError' |
-    'InvalidRequestError';
+  | 'UnknownServerError'
+  | 'RpcExecutionError'
+  | 'FunctionCallError'
+  | 'CallError'
+  | 'MissmatchedRequestIdError'
+  | 'InvalidRequestError';
 
 const errorTypes: JsonRpcErrorType[] = [
   'UnknownServerError',
@@ -27,7 +27,7 @@ const errorTypes: JsonRpcErrorType[] = [
   'FunctionCallError',
   'CallError',
   'MissmatchedRequestIdError',
-  'InvalidRequestError'
+  'InvalidRequestError',
 ];
 
 export const getNewJwtToken = async ({

--- a/packages/calimero-sdk/src/types/rpc.ts
+++ b/packages/calimero-sdk/src/types/rpc.ts
@@ -32,39 +32,21 @@ export type RpcResult<Result> =
       error: RpcError;
     };
 
-export type RpcError =
-  | UnknownServerError
-  | InvalidRequestError
-  | MissmatchedRequestIdError
-  | RpcExecutionError;
-
-export interface UnknownServerError {
-  type: 'UnknownServerError';
-  inner: any;
-  code?: number;
-  message?: string;
+export interface RpcErrorInfo {
+  name: string;
+  cause: {
+    name: string;
+    info?: {
+      message: string;
+    };
+  };
 }
 
-export interface InvalidRequestError {
-  type: 'InvalidRequestError';
-  data: any;
+export interface RpcError {
+  id: RpcRequestId;
+  jsonrpc: string;
   code: number;
-  message?: string;
-}
-
-export interface MissmatchedRequestIdError {
-  type: 'MissmatchedRequestIdError';
-  expected: RpcRequestId;
-  got: RpcRequestId;
-  code?: number;
-  message?: string;
-}
-
-export interface RpcExecutionError {
-  type: 'RpcExecutionError';
-  inner: any;
-  code?: number;
-  message?: string;
+  error: RpcErrorInfo;
 }
 
 export interface RpcQueryParams<Args> {


### PR DESCRIPTION
# feat(sdk): update json rpc error handling

## Summary
With this PR error handling (parsing) is updated. Now all returned errors are handled with proper error messages and responses.

The Error structure is from proposed solution defined in Issue for this task.

Requires also bump version of sdk for App Template and Only Peers application

Fixes #114 

## Test plan
Alerts for RPC errors. The user who builds application decides how each error will be displayed.

<img width="453" alt="Screenshot 2024-09-30 at 18 23 17" src="https://github.com/user-attachments/assets/72647e54-7444-498a-aeb6-f999aa1c0b11">
<img width="454" alt="Screenshot 2024-09-30 at 18 23 28" src="https://github.com/user-attachments/assets/856f79d2-0660-45e0-ad91-5284a07328c9">
<img width="461" alt="Screenshot 2024-09-30 at 18 24 08" src="https://github.com/user-attachments/assets/76d36292-61c2-4c8d-9601-18e8d26f9459">
<img width="457" alt="Screenshot 2024-09-30 at 18 24 27" src="https://github.com/user-attachments/assets/5e63deab-bd7b-47ce-9b14-4c7561a1ec92">

