### PR TITLE
feat: Interface sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "uuid 1.10.0",
+ "velcro",
 ]
 
 [[package]]
@@ -8205,6 +8206,36 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "velcro"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c6a51883ba1034757307e06dc4856cd5439ecf6804ce6c90d13d49496196fc"
+dependencies = [
+ "velcro_macros",
+]
+
+[[package]]
+name = "velcro_core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742cf45d07989b7614877e083602a8973890c75a81f47216b238d2f326ec916c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "velcro_macros"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b23c806d7b49977e6e12ee6d120ac01dcab702b51c652fdf1a6709ab5b8868c"
+dependencies = [
+ "syn 1.0.109",
+ "velcro_core",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ trybuild = "1.0"
 ureq = "2.9.7"
 url = "2.5.2"
 uuid = { version = "1.10.0", features = ["v4"] }
+velcro = "0.5.4"
 wasmer = "4.2.5"
 wasmer-types = "4.2.5"
 web3 = "0.19.0"

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -342,6 +342,18 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
                 Ok(hasher.finalize().into())
             }
 
+            fn collections(&self) -> std::collections::HashMap<String, Vec<calimero_storage::entities::ChildInfo>> {
+                use calimero_storage::entities::Collection;
+                let mut collections = std::collections::HashMap::new();
+                #(
+                    collections.insert(
+                        stringify!(#collection_fields).to_owned(),
+                        self.#collection_fields.child_info().clone()
+                    );
+                )*
+                collections
+            }
+
             fn element(&self) -> &calimero_storage::entities::Element {
                 &self.#storage_ident
             }

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -309,14 +309,14 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 
                 // Hash collection fields
                 #(
-                    for child_id in self.#collection_fields.child_ids() {
-                        let child = interface.find_by_id
-                            ::<<#collection_field_types as calimero_storage::entities::Collection>::Child>(*child_id)?
-                                .ok_or_else(|| calimero_storage::interface::StorageError::NotFound(*child_id))?;
+                    for info in self.#collection_fields.child_info() {
                         if recalculate {
+                            let child = interface.find_by_id
+                                ::<<#collection_field_types as calimero_storage::entities::Collection>::Child>(info.id())?
+                                    .ok_or_else(|| calimero_storage::interface::StorageError::NotFound(info.id()))?;
                             hasher.update(&child.calculate_full_merkle_hash(interface, recalculate)?);
                         } else {
-                            hasher.update(&child.element().merkle_hash());
+                            hasher.update(&info.merkle_hash());
                         }
 
                     }
@@ -373,7 +373,7 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 ///
 ///   - A `#[children(Type)]` attribute to specify the type of the children in
 ///     the [`Collection`](calimero_storage::entities::Collection).
-///   - A private `child_ids` field of type [`Id`](calimero_storage::address::Id).
+///   - A private `child_info` field of type [`ChildInfo`](calimero_storage::entities::ChildInfo).
 ///     This is needed as the [`Collection`](calimero_storage::entities::Collection)
 ///     needs to own its child IDs so that they can be serialised into the
 ///     [`Data`](calimero_storage::entities::Data)-based [`Element`](calimero_storage::entities::Element)
@@ -397,17 +397,17 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 ///
 /// # Field attributes
 ///
-/// * `#[child_ids]` - Indicates that the field is the storage element for the
-///                    child ids. This is a mandatory field, and if it is
-///                    missing, there will be a panic during compilation. The
-///                    name is arbitrary, but the type has to be an [`Id`](calimero_storage::address::Id).
+/// * `#[child_info]` - Indicates that the field is the storage element for the
+///                     child info, i.e. the IDs and Merkle hashes. This is a
+///                     mandatory field, and if it is missing, there will be a
+///                     panic during compilation. The name is arbitrary, but the
+///                     type has to be `HashMap<`.
 ///
 /// # Examples
 ///
 /// ```
 /// use calimero_storage_macros::{AtomicUnit, Collection};
-/// use calimero_storage::address::Id;
-/// use calimero_storage::entities::{Data, Element};
+/// use calimero_storage::entities::{ChildInfo, Data, Element};
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 /// struct Book {
@@ -420,8 +420,8 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 /// #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 /// #[children(Page)]
 /// struct Pages {
-///     #[child_ids]
-///     child_ids: Vec<Id>,
+///     #[child_info]
+///     child_info: Vec<ChildInfo>,
 /// }
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
@@ -439,14 +439,14 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 ///   - It is applied to anything other than a struct
 ///   - The struct has unnamed fields
 ///   - The `#[children(Type)]` attribute is missing or invalid
-///   - The struct does not have a field annotated as `#[child_ids]`
+///   - The struct does not have a field annotated as `#[child_info]`
 ///
 /// # See also
 ///
 /// * [`AtomicUnit`] - For defining a single atomic unit of data that either
 ///                    stands alone, or owns one or more collections, or is a
 ///                    child in a collection.
-#[proc_macro_derive(Collection, attributes(children, child_ids))]
+#[proc_macro_derive(Collection, attributes(children, child_info))]
 pub fn collection_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
@@ -469,22 +469,26 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    // Find the field marked with the #[child_ids] attribute
-    let child_ids_field = named_fields
+    // Find the field marked with the #[child_info] attribute
+    let child_info_field = named_fields
         .iter()
-        .find(|f| f.attrs.iter().any(|attr| attr.path().is_ident("child_ids")))
-        .expect("You must designate one field with #[child_ids] for the Collection");
+        .find(|f| {
+            f.attrs
+                .iter()
+                .any(|attr| attr.path().is_ident("child_info"))
+        })
+        .expect("You must designate one field with #[child_info] for the Collection");
 
-    let child_ids_ident = child_ids_field.ident.as_ref().unwrap();
-    let child_ids_ty = &child_ids_field.ty;
-    let child_ids_type = syn::parse2::<Type>(quote! { #child_ids_ty }).unwrap();
+    let child_info_ident = child_info_field.ident.as_ref().unwrap();
+    let child_info_ty = &child_info_field.ty;
+    let child_info_type = syn::parse2::<Type>(quote! { #child_info_ty }).unwrap();
 
     let deserialize_impl = quote! {
         impl borsh::BorshDeserialize for #name {
             fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-                let #child_ids_ident = <#child_ids_type as borsh::BorshDeserialize>::deserialize_reader(reader)?;
+                let #child_info_ident = <#child_info_type as borsh::BorshDeserialize>::deserialize_reader(reader)?;
                 Ok(Self {
-                    #child_ids_ident,
+                    #child_info_ident,
                 })
             }
         }
@@ -493,7 +497,7 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
     let serialize_impl = quote! {
         impl borsh::BorshSerialize for #name {
             fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-                borsh::BorshSerialize::serialize(&self.#child_ids_ident, writer)
+                borsh::BorshSerialize::serialize(&self.#child_info_ident, writer)
             }
         }
     };
@@ -502,12 +506,12 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
         impl calimero_storage::entities::Collection for #name {
             type Child = #child_type;
 
-            fn child_ids(&self) -> &Vec<calimero_storage::address::Id> {
-                &self.#child_ids_ident
+            fn child_info(&self) -> &Vec<calimero_storage::entities::ChildInfo> {
+                &self.#child_info_ident
             }
 
             fn has_children(&self) -> bool {
-                !self.#child_ids_ident.is_empty()
+                !self.#child_info_ident.is_empty()
             }
         }
 

--- a/crates/storage-macros/tests/collection.rs
+++ b/crates/storage-macros/tests/collection.rs
@@ -26,8 +26,8 @@
 )]
 
 use borsh::{to_vec, BorshDeserialize};
-use calimero_storage::address::{Id, Path};
-use calimero_storage::entities::{Data, Element};
+use calimero_storage::address::Path;
+use calimero_storage::entities::{ChildInfo, Data, Element};
 use calimero_storage::exports::{Digest, Sha256};
 use calimero_storage::interface::Interface;
 use calimero_storage_macros::{AtomicUnit, Collection};
@@ -52,14 +52,14 @@ impl Child {
 #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[children(Child)]
 struct Group {
-    #[child_ids]
-    child_ids: Vec<Id>,
+    #[child_info]
+    child_info: Vec<ChildInfo>,
 }
 
 impl Group {
     fn new() -> Self {
         Self {
-            child_ids: Vec::new(),
+            child_info: Vec::new(),
         }
     }
 }
@@ -148,7 +148,11 @@ mod hashing {
         assert!(interface.save(child1.id(), &mut child1).unwrap());
         assert!(interface.save(child2.id(), &mut child2).unwrap());
         assert!(interface.save(child3.id(), &mut child3).unwrap());
-        parent.children.child_ids = vec![child1.id(), child2.id(), child3.id()];
+        parent.children.child_info = vec![
+            ChildInfo::new(child1.id(), child1.element().merkle_hash()),
+            ChildInfo::new(child2.id(), child2.element().merkle_hash()),
+            ChildInfo::new(child3.id(), child3.element().merkle_hash()),
+        ];
         assert!(interface.save(parent.id(), &mut parent).unwrap());
 
         let mut hasher0 = Sha256::new();

--- a/crates/storage-macros/tests/compile_fail/collection.rs
+++ b/crates/storage-macros/tests/compile_fail/collection.rs
@@ -1,5 +1,5 @@
-use calimero_storage::address::{Id, Path};
-use calimero_storage::entities::Element;
+use calimero_storage::address::Path;
+use calimero_storage::entities::{ChildInfo, Element};
 use calimero_storage::interface::Interface;
 use calimero_storage_macros::{AtomicUnit, Collection};
 use calimero_test_utils::storage::create_test_store;
@@ -13,8 +13,8 @@ struct Child {
 #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[children(Child)]
 struct Group {
-    #[child_ids]
-    child_ids: Vec<Id>,
+    #[child_info]
+    child_info: Vec<ChildInfo>,
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
@@ -29,7 +29,7 @@ fn main() {
         let (db, _dir) = create_test_store();
         let interface = Interface::new(db);
         let parent: Parent = Parent {
-            group: Group { child_ids: vec![] },
+            group: Group { child_info: vec![] },
             storage: Element::new(&Path::new("::root::node").unwrap()),
         };
         let _: Vec<Child> = interface.children_of(&parent.group).unwrap();

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -21,6 +21,7 @@ calimero-store = { path = "../store", features = ["datatypes"] }
 [dev-dependencies]
 claims.workspace = true
 hex.workspace = true
+velcro.workspace = true
 
 calimero-storage-macros = { path = "../storage-macros" }
 calimero-test-utils = { path = "../test-utils" }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 borsh.workspace = true
 eyre.workspace = true
 fixedstr.workspace = true
+hex.workspace = true
 parking_lot.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -213,6 +213,7 @@
 mod tests;
 
 use core::fmt::{self, Debug, Display, Formatter};
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -394,6 +395,14 @@ pub trait Data:
     /// * [`calculate_full_merkle_hash()`](Data::calculate_full_merkle_hash())
     ///
     fn calculate_merkle_hash(&self) -> Result<[u8; 32], StorageError>;
+
+    /// Information about the [`Collection`]s present in the [`Data`].
+    ///
+    /// This method allows details about the subtree structure and children to
+    /// be obtained. It does not return the actual [`Collection`] types, but
+    /// provides their names and child information.
+    ///
+    fn collections(&self) -> HashMap<String, Vec<ChildInfo>>;
 
     /// The associated [`Element`].
     ///

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -473,7 +473,7 @@ pub struct ChildInfo {
     /// The Merkle hash of the child [`Element`]. This is a cryptographic hash
     /// of the significant data in the "scope" of the child [`Element`], and is
     /// used to determine whether the data has changed and is valid.
-    merkle_hash: [u8; 32],
+    pub(crate) merkle_hash: [u8; 32],
 }
 
 impl ChildInfo {

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -256,8 +256,7 @@ pub trait AtomicUnit: Data {}
 ///
 /// ```
 /// use calimero_storage_macros::{AtomicUnit, Collection};
-/// use calimero_storage::address::Id;
-/// use calimero_storage::entities::{Data, Element};
+/// use calimero_storage::entities::{ChildInfo, Data, Element};
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 /// struct Book {
@@ -270,8 +269,8 @@ pub trait AtomicUnit: Data {}
 /// #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 /// #[children(Page)]
 /// struct Pages {
-///     #[child_ids]
-///     child_ids: Vec<Id>,
+///     #[child_info]
+///     child_info: Vec<ChildInfo>,
 /// }
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
@@ -286,13 +285,13 @@ pub trait Collection: Clone + Debug + PartialEq + PartialOrd + Send + Sync {
     /// The associated type of any children that the [`Collection`] may have.
     type Child: Data;
 
-    /// The unique identifiers of the children of the [`Collection`].
+    /// Information about the children of the [`Collection`].
     ///
-    /// This gets only the IDs of the children of the [`Collection`], which are
-    /// the [`Element`]s that are directly below the [`Collection`] in the
-    /// hierarchy.
+    /// This gets the IDs and Merkle hashes of the children of the
+    /// [`Collection`], which are the [`Element`]s that are directly below the
+    /// [`Collection`] in the hierarchy.
     ///
-    /// The order of the IDs is not guaranteed to be stable between calls.
+    /// The order of the results is guaranteed to be stable between calls.
     ///
     /// This is considered somewhat temporary, as there are efficiency gains to
     /// be made by storing this list elsewhere — but for now, it helps to get
@@ -303,7 +302,7 @@ pub trait Collection: Clone + Debug + PartialEq + PartialOrd + Send + Sync {
     ///       is implemented.
     ///
     #[must_use]
-    fn child_ids(&self) -> &Vec<Id>;
+    fn child_info(&self) -> &Vec<ChildInfo>;
 
     /// Whether the [`Collection`] has children.
     ///
@@ -448,6 +447,63 @@ pub trait Data:
     }
 }
 
+/// Summary information for the child of an [`Element`] in the storage.
+///
+/// This struct contains minimal information about a child of an [`Element`], to
+/// be stored with the associated [`Data`]. The primary purpose is to maintain
+/// an authoritative list of the children of the [`Element`], and the secondary
+/// purpose is to make information such as the Merkle hash trivially available
+/// and prevent the need for repeated lookups.
+///
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub struct ChildInfo {
+    /// The unique identifier for the child [`Element`].
+    id: Id,
+
+    /// The Merkle hash of the child [`Element`]. This is a cryptographic hash
+    /// of the significant data in the "scope" of the child [`Element`], and is
+    /// used to determine whether the data has changed and is valid.
+    merkle_hash: [u8; 32],
+}
+
+impl ChildInfo {
+    /// Creates a new [`ChildInfo`].
+    #[must_use]
+    pub const fn new(id: Id, merkle_hash: [u8; 32]) -> Self {
+        Self { id, merkle_hash }
+    }
+
+    /// The unique identifier for the child [`Element`].
+    ///
+    /// This is the unique identifier for the child [`Element`], which can
+    /// always be used to locate the [`Element`] in the storage system. It is
+    /// generated when the [`Element`] is first created, and never changes. It
+    /// is reflected onto all other systems and so is universally consistent.
+    ///
+    #[must_use]
+    pub const fn id(&self) -> Id {
+        self.id
+    }
+
+    /// Current Merkle hash of the [`Element`].
+    #[must_use]
+    pub const fn merkle_hash(&self) -> [u8; 32] {
+        self.merkle_hash
+    }
+}
+
+impl Display for ChildInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ChildInfo {}: {}",
+            self.id,
+            hex::encode(self.merkle_hash)
+        )
+    }
+}
+
 /// Represents an [`Element`] in the storage.
 ///
 /// This is a simple model of an [`Element`] in the storage system, with a
@@ -491,13 +547,13 @@ pub trait Data:
 ///
 /// # Storage structure
 ///
-/// TODO: Update when the `child_ids` field is replaced with an index.
+/// TODO: Update when the `child_info` field is replaced with an index.
 ///
-/// At present the [`Element`] has a `child_ids` field, which memoises the IDs
-/// of the children. This is because it is better than traversing the whole
-/// database to find the children (!).
+/// At present the [`Data`] trait has a `child_info` field, which memoises the
+/// IDs and Merkle hashes of the children. This is because it is better than
+/// traversing the whole database to find the children (!).
 ///
-/// Having a `child_ids` field is however non-optimal — this should come from
+/// Having a `child_info` field is however non-optimal — this should come from
 /// outside the struct. We should be able to look up the children by path, and
 /// so given that the path is the primary method of determining that an
 /// [`Element`] is a child of another, this should be the mechanism relied upon.

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -126,18 +126,21 @@ impl Interface {
     ///
     /// # Determinism
     ///
-    /// TODO: Update when the `child_ids` field is replaced with an index.
+    /// TODO: Update when the `child_info` field is replaced with an index.
     ///
     /// Depending on the source, simply looping through the children may be
     /// non-deterministic. At present we are using a [`Vec`], which is
     /// deterministic, but this is a temporary measure, and the order of
     /// children under a given path is not enforced, and therefore
-    /// non-deterministic. When the `child_ids` field is replaced with an index,
-    /// the order will be enforced using `created_at` timestamp and/or ID.
+    /// non-deterministic.
+    ///
+    /// When the `child_info` field is replaced with an index, the order may be
+    /// enforced using `created_at` timestamp, which then allows performance
+    /// optimisations with sharding and other techniques.
     ///
     /// # Performance
     ///
-    /// TODO: Update when the `child_ids` field is replaced with an index.
+    /// TODO: Update when the `child_info` field is replaced with an index.
     ///
     /// Looping through children and combining their hashes into the parent is
     /// logically correct. However, it does necessitate loading all the children
@@ -160,8 +163,11 @@ impl Interface {
         collection: &C,
     ) -> Result<Vec<C::Child>, StorageError> {
         let mut children = Vec::new();
-        for id in collection.child_ids() {
-            children.push(self.find_by_id(*id)?.ok_or(StorageError::NotFound(*id))?);
+        for info in collection.child_info() {
+            children.push(
+                self.find_by_id(info.id())?
+                    .ok_or(StorageError::NotFound(info.id()))?,
+            );
         }
         Ok(children)
     }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -8,15 +8,216 @@
 //! means of interacting with the storage system, rather than the ActiveRecord
 //! pattern where the model is the primary means of interaction.
 //!
+//! # Synchronisation
+//!
+//! There are two main mechanisms involved in synchronisation:
+//!
+//!   1. **Direct changes**: When a change is made locally, the resulting
+//!      actions need to be propagated to other nodes.
+//!   2. **Comparison**: When a comparison is made between two nodes, the
+//!      resulting actions need to be taken to bring the nodes into sync.
+//!
+//! The entry points for synchronisation are therefore either the
+//! [`apply_actions()`](Interface::apply_actions()) method, to carry out
+//! actions; or the [`compare_trees()`](Interface::compare_trees()) method, to
+//! compare two nodes, which will emit actions to pass to [`apply_actions()`](Interface::apply_actions())
+//! on either the local or remote node, or both.
+//!
+//! ## CRDT model
+//!
+//! Calimero primarily uses operation-based CRDTs, also called commutative
+//! replicated data types (CmRDTs). This means that the order of operations does
+//! not matter, and the outcome will be the same regardless of the order in
+//! which the operations are applied.
+//!
+//! It is worth noting that the orthodox CmRDT model does not feature or require
+//! a comparison activity, as there is an operating assumption that all updates
+//! have been carried out fully and reliably.
+//!
+//! The alternative CRDT approach is state-based, also called convergent
+//! replicated data types (CvRDTs). This is a comparison-based approach, but the
+//! downside is that this model requires the full state to be transmitted
+//! between nodes, which can be costly. Although this approach is easier to
+//! implement, and fits well with gossip protocols, it is not as efficient as
+//! the operation-based model.
+//!
+//! The standard choice therefore comes down to:
+//!
+//!   - Use CmRDTs and guarantee that all updates are carried out fully and
+//!     reliably, are not dropped or duplicated, and are replayed in causal
+//!     order.
+//!   - Use CvRDTs and accept the additional bandwidth cost of transmitting the
+//!     full state for every single CRDT.
+//!
+//! It does not fit the Calimero objectives to transmit the entire state for
+//! every update, but there is also no guarantee that all updates will be
+//! carried out fully and reliably. Therefore, Calimero uses a hybrid approach
+//! that represents the best of both worlds.
+//!
+//! In the first instance, operations are emitted (in the form of [`Action`]s)
+//! whenever a change is made. These operations are then propagated to other
+//! nodes, where they are executed. This is the CmRDT model.
+//!
+//! However, there are cases where a node may have missed an update, for
+//! instance, if it was offline. In this case, the node will be out of sync with
+//! the rest of the network. To bring the node back into sync, a comparison is
+//! made between the local node and a remote node, and the resulting actions are
+//! executed. This is the CvRDT model.
+//!
+//! The storage system maintains a set of Merkle hashes, which are stored
+//! against each element, and represent the state of the element and its
+//! children. The Merkle hash for an element can therefore be used to trivially
+//! determine whether an element or any of its descendants have changed,
+//! without actually needing to compare every entity in the tree.
+//!
+//! Therefore, when a comparison is carried out it is not a full state
+//! comparison, but a comparison of the immediate data and metadata of given
+//! element(s). This is sufficient to determine whether the nodes are in sync,
+//! and to generate the actions needed to bring them into sync. If there is any
+//! deviation detected, the comparison will recurse into the children of the
+//! element(s) in question, and generate further actions as necessary — but this
+//! will only ever examine those descendent entities for which the Merkle hash
+//! differs.
+//!
+//! We can therefore summarise this position as being: Calimero uses a CmRDT
+//! model for direct changes, and a CvRDT model for comparison as a fallback
+//! mechanism to bring nodes back into sync when needed.
+//!
+//! ## Direct changes
+//!
+//! When a change is made locally, the resulting actions need to be propagated
+//! to other nodes. An action list will be generated, which can be made up of
+//! [`Add`](Action::Add), [`Delete`](Action::Delete), and [`Update`](Action::Update)
+//! actions. These actions are then propagated to all the other nodes in the
+//! network, where they are executed using the [`apply_actions()`](Interface::apply_actions())
+//! method.
+//!
+//! This is a straightforward process, as the actions are known and are fully
+//! self-contained without any wider impact. Order does not strictly matter, as
+//! the actions are commutative, and the outcome will be the same regardless of
+//! the order in which they are applied. Any conflicts are handled using the
+//! last-write-wins strategy.
+//!
+//! There are certain cases where a mis-ordering of action, which is
+//! essentially the same as having missing actions, can result in an invalid
+//! state. For instance, if a child is added before the parent, the parent will
+//! not exist and the child will be orphaned. In this situation we can either
+//! ignore the child, or we can block its addition until the parent has been
+//! added, or we can store it as an orphaned entity to be resolved later. At
+//! present we follow the last approach, as it aligns well with the use of
+//! comparisons to bring nodes back into sync. We therefore know that the node
+//! will _eventually_ become consistent, which is all we guarantee.
+//!
+//! TODO: Examine whether this is the right approach, or whether we should for
+//! TODO: instance block and do a comparison on the parent to ensure that local
+//! TODO: state is as consistent as possible.
+//!
+//! Providing all generated actions are carried out, all nodes will eventually
+//! be in sync, without any need for comparisons, transmission of full states,
+//! or a transaction model (which requires linear history, and therefore
+//! becomes mathematically unsuitable for large distributed systems).
+//!
+//! ## Comparison
+//!
+//! There are a number of situations under which a comparison may be needed:
+//!
+//!   1. A node has missed an update, and needs to be brought back into sync
+//!      (i.e. there is a gap in the instruction set).
+//!   2. A node has been offline, and needs to be brought back into sync (i.e.
+//!      all instructions since a certain point have been missed).
+//!   3. A discrepancy has been detected between two nodes, and they need to be
+//!      brought back into sync.
+//!
+//! A comparison is primarily triggered from a catch-up as a proactive measure,
+//! i.e. without knowing if any changes exist, but can also arise at any point
+//! if a discrepancy is detected.
+//!
+//! When performing a comparison, the data we have is the result of the entity
+//! being serialised by the remote note, passed to us, and deserialised, so it
+//! should be comparable in structure to having loaded it from the local
+//! database.
+//!
+//! We therefore have access to the data and metadata, which includes the
+//! immediate fields of the entity (i.e. the [`AtomicUnit`](crate::entities::AtomicUnit))
+//! and also a list of the children.
+//!
+//! The stored list of children contains their Merkle hashes, thereby allowing
+//! us to check all children in one operation instead of needing to load each
+//! child in turn, as that would require remote data for each child, and that
+//! would not be as efficient.
+//!
+//!   - If a child exists on both sides and the hash is different, we recurse
+//!     into a comparison for that child.
+//!
+//!   - If a child is missing on one side then we can go with the side that has
+//!     the latest parent and add or remove the child.
+//!
+//! Notably, in the case of there being a missing child, the resolution
+//! mechanism does expose a small risk of erroneous outcome. For instance, if
+//! the local node has had a child added, and has been offline, and the parent
+//! has been updated remotely — in this situation, in the absence of any other
+//! activity, a comparison (e.g. a catch-up when coming back online) would
+//! result in losing the child, as the remote node would not have the child in
+//! its list of children. This edge case should usually be handled by the
+//! specific add and remove events generated at the time of the original
+//! activity, which should get propagated independently of a sync. However,
+//! there are three extended options that can be implemented:
+//!
+//!   1. Upon catch-up, any local list of actions can be held and replayed
+//!      locally after synchronisation. Alone, this would not correct the
+//!      situation, due to last-write-wins rules, but additional logic could be
+//!      considered for this particular situation.
+//!   2. During or after performing a comparison, all local children for an
+//!      entity can be loaded by path and checked against the parent's list of
+//!      children. If there are any deviations then appropriate action can be
+//!      taken. This does not fully cater for the edge case, and again would not
+//!      correct the situation on its own, but additional logic could be added.
+//!   3. A special kind of "deleted" element could be added to the system, which
+//!      would store metadata for checking. This would be beneficial as it would
+//!      allow differentiation between a missing child and a deleted child,
+//!      which is the main problem exposed by the edge case. However, although
+//!      this represents a full solution from a data mechanism perspective, it
+//!      would not be desirable to store deleted entries permanently. It would
+//!      be best combined with a cut-off constraint, that would limit the time
+//!      period in which a catch-up can be performed, and after which the
+//!      deleted entities would be purged. This does add complexity not only in
+//!      the effect on the wider system of implementing that constraint, but
+//!      also in the need for garbage collection to remove the deleted entities.
+//!      This would likely be better conducted the next time the parent entity
+//!      is updated, but there are a number of factors to consider here.
+//!   4. Another way to potentially handle situations of this nature is to
+//!      combine multiple granular updates into an atomic group operation that
+//!      ensures that all updates are applied together. However, this remains to
+//!      be explored, as it may not fit with the wider system design.
+//!
+//! Due to the potential complexity, this edge case is not currently mitigated,
+//! but will be the focus of future development.
+//!
+//! TODO: Assess the best approach for handling this edge case in a way that
+//! TODO: fits with the wider system design, and add extended tests for it.
+//!
+//! The outcome of a comparison is that the calling code receives a list of
+//! actions, which can be [`Add`](Action::Add), [`Delete`](Action::Delete),
+//! [`Update`](Action::Update), and [`Compare`](Action::Compare). The first
+//! three are the same as propagating the consequences of direct changes, but
+//! the comparison action is a special case that arises when a child entity is
+//! found to differ between the two nodes, whereupon the comparison process
+//! needs to recursively descend into the parts of the subtree found to differ.
+//!
+//! The calling code is then responsible for going away and obtaining the
+//! information necessary to carry out the next comparison action if there is
+//! one, as well as relaying the generated action list.
+//!
 
 #[cfg(test)]
 #[path = "tests/interface.rs"]
 mod tests;
 
+use std::collections::HashMap;
 use std::io::Error as IoError;
 use std::sync::Arc;
 
-use borsh::to_vec;
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use calimero_store::key::Storage as StorageKey;
 use calimero_store::layer::{ReadLayer, WriteLayer};
 use calimero_store::slice::Slice;
@@ -27,6 +228,51 @@ use thiserror::Error as ThisError;
 
 use crate::address::{Id, Path};
 use crate::entities::{Collection, Data};
+
+/// Actions to be taken during synchronisation.
+///
+/// The following variants represent the possible actions arising from either a
+/// direct change or a comparison between two nodes.
+///
+///   - **Direct change**: When a direct change is made, in other words, when
+///     there is local activity that results in data modification to propagate
+///     to other nodes, the possible resulting actions are [`Add`](Action::Add),
+///     [`Delete`](Action::Delete), and [`Update`](Action::Update). A comparison
+///     is not needed in this case, as the deltas are known, and assuming all of
+///     the actions are carried out, the nodes will be in sync.
+///
+///   - **Comparison**: When a comparison is made between two nodes, the
+///     possible resulting actions are [`Add`](Action::Add), [`Delete`](Action::Delete),
+///     [`Update`](Action::Update), and [`Compare`](Action::Compare). The extra
+///     comparison action arises in the case of tree traversal, where a child
+///     entity is found to differ between the two nodes. In this case, the child
+///     entity is compared, and the resulting actions are added to the list of
+///     actions to be taken. This process is recursive.
+///
+/// Note: The actions temporarily contain only the entity ID, and not the full
+/// entity data. This will be changed when action execution is implemented.
+///
+#[derive(
+    BorshDeserialize, BorshSerialize, Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd,
+)]
+#[expect(clippy::exhaustive_enums, reason = "Exhaustive")]
+pub enum Action {
+    /// Add an entity with the given ID.
+    Add(Id),
+
+    /// Compare the entity with the given ID. Note that this results in a direct
+    /// comparison of the specific entity in question, including data that is
+    /// immediately available to it, such as the hashes of its children. This
+    /// may well result in further actions being generated if children differ,
+    /// leading to a recursive comparison.
+    Compare(Id),
+
+    /// Delete an entity with the given ID.
+    Delete(Id),
+
+    /// Update the entity with the given ID.
+    Update(Id),
+}
 
 /// The primary interface for the storage system.
 #[derive(Debug, Clone)]
@@ -170,6 +416,102 @@ impl Interface {
             );
         }
         Ok(children)
+    }
+
+    /// Compares a foreign entity with a local one.
+    ///
+    /// This function compares a foreign entity, usually from a remote node,
+    /// with the version available in the tree in local storage, if present, and
+    /// generates a list of [`Action`]s to perform on the local tree, the
+    /// foreign tree, or both, to bring the two trees into sync.
+    ///
+    /// The tuple returned is composed of two lists of actions: the first list
+    /// contains the actions to be performed on the local tree, and the second
+    /// list contains the actions to be performed on the foreign tree.
+    ///
+    /// # Parameters
+    ///
+    /// * `foreign_entity` - The foreign entity to compare against the local
+    ///                      version. This will usually be from a remote node.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if there are issues accessing local
+    /// data or if there are problems during the comparison process.
+    ///
+    pub fn compare_trees<D: Data>(
+        &self,
+        foreign_entity: &D,
+    ) -> Result<(Vec<Action>, Vec<Action>), StorageError> {
+        let mut actions = (vec![], vec![]);
+        let Some(local_entity) = self.find_by_id::<D>(foreign_entity.id())? else {
+            // Local entity doesn't exist, so we need to add it
+            actions.0.push(Action::Add(foreign_entity.id()));
+            return Ok(actions);
+        };
+
+        if local_entity.element().merkle_hash() == foreign_entity.element().merkle_hash() {
+            return Ok(actions);
+        }
+        if local_entity.element().updated_at() <= foreign_entity.element().updated_at() {
+            actions.0.push(Action::Update(local_entity.id()));
+        } else {
+            actions.1.push(Action::Update(foreign_entity.id()));
+        }
+
+        let local_collections = local_entity.collections();
+        let foreign_collections = foreign_entity.collections();
+
+        #[expect(clippy::iter_over_hash_type, reason = "Order doesn't matter here")]
+        for (local_coll_name, local_children) in &local_collections {
+            if let Some(foreign_children) = foreign_collections.get(local_coll_name) {
+                let local_child_map: HashMap<_, _> = local_children
+                    .iter()
+                    .map(|child| (child.id(), child.merkle_hash()))
+                    .collect();
+                let foreign_child_map: HashMap<_, _> = foreign_children
+                    .iter()
+                    .map(|child| (child.id(), child.merkle_hash()))
+                    .collect();
+
+                #[expect(clippy::iter_over_hash_type, reason = "Order doesn't matter here")]
+                for (id, local_hash) in &local_child_map {
+                    match foreign_child_map.get(id) {
+                        Some(foreign_hash) if local_hash != foreign_hash => {
+                            actions.0.push(Action::Compare(*id));
+                            actions.1.push(Action::Compare(*id));
+                        }
+                        None => actions.1.push(Action::Add(*id)),
+                        // Hashes match, no action needed
+                        _ => {}
+                    }
+                }
+
+                #[expect(clippy::iter_over_hash_type, reason = "Order doesn't matter here")]
+                for id in foreign_child_map.keys() {
+                    if !local_child_map.contains_key(id) {
+                        actions.0.push(Action::Add(*id));
+                    }
+                }
+            } else {
+                // The entire collection is missing from the foreign entity
+                for child in local_children {
+                    actions.1.push(Action::Add(child.id()));
+                }
+            }
+        }
+
+        // Check for collections in the foreign entity that don't exist locally
+        #[expect(clippy::iter_over_hash_type, reason = "Order doesn't matter here")]
+        for (foreign_coll_name, foreign_children) in &foreign_collections {
+            if !local_collections.contains_key(foreign_coll_name) {
+                for child in foreign_children {
+                    actions.0.push(Action::Add(child.id()));
+                }
+            }
+        }
+
+        Ok(actions)
     }
 
     /// Finds an [`Element`](crate::entities::Element) by its unique identifier.

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use sha2::{Digest, Sha256};
+use velcro::hash_map;
 
 use crate::address::Id;
 use crate::entities::{AtomicUnit, ChildInfo, Collection, Data, Element};
@@ -49,6 +51,10 @@ impl Data for EmptyData {
         hasher.update(self.element().id().as_bytes());
         hasher.update(&to_vec(&self.element().metadata).map_err(StorageError::SerializationError)?);
         Ok(hasher.finalize().into())
+    }
+
+    fn collections(&self) -> HashMap<String, Vec<ChildInfo>> {
+        HashMap::new()
     }
 
     fn element(&self) -> &Element {
@@ -113,6 +119,12 @@ impl Data for Page {
         Ok(hasher.finalize().into())
     }
 
+    fn collections(&self) -> HashMap<String, Vec<ChildInfo>> {
+        hash_map! {
+            "paragraphs".to_owned(): self.paragraphs.child_info.clone()
+        }
+    }
+
     fn element(&self) -> &Element {
         &self.storage
     }
@@ -158,6 +170,10 @@ impl Data for Paragraph {
         hasher.update(&to_vec(&self.text).map_err(StorageError::SerializationError)?);
         hasher.update(&to_vec(&self.element().metadata).map_err(StorageError::SerializationError)?);
         Ok(hasher.finalize().into())
+    }
+
+    fn collections(&self) -> HashMap<String, Vec<ChildInfo>> {
+        HashMap::new()
     }
 
     fn element(&self) -> &Element {
@@ -220,6 +236,10 @@ impl Data for Person {
         hasher.update(&to_vec(&self.age).map_err(StorageError::SerializationError)?);
         hasher.update(&to_vec(&self.element().metadata).map_err(StorageError::SerializationError)?);
         Ok(hasher.finalize().into())
+    }
+
+    fn collections(&self) -> HashMap<String, Vec<ChildInfo>> {
+        HashMap::new()
     }
 
     fn element(&self) -> &Element {

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -4,7 +4,7 @@ use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use sha2::{Digest, Sha256};
 
 use crate::address::Id;
-use crate::entities::{AtomicUnit, Collection, Data, Element};
+use crate::entities::{AtomicUnit, ChildInfo, Collection, Data, Element};
 use crate::interface::{Interface, StorageError};
 
 /// A set of non-empty test UUIDs.
@@ -91,14 +91,14 @@ impl Data for Page {
         hasher.update(&self.calculate_merkle_hash()?);
 
         // Hash collection fields
-        for child_id in self.paragraphs.child_ids() {
-            let child = interface
-                .find_by_id::<<Paragraphs as Collection>::Child>(*child_id)?
-                .ok_or_else(|| StorageError::NotFound(*child_id))?;
+        for info in self.paragraphs.child_info() {
             if recalculate {
+                let child = interface
+                    .find_by_id::<<Paragraphs as Collection>::Child>(info.id())?
+                    .ok_or_else(|| StorageError::NotFound(info.id()))?;
                 hasher.update(&child.calculate_full_merkle_hash(interface, recalculate)?);
             } else {
-                hasher.update(&child.element().merkle_hash());
+                hasher.update(&info.merkle_hash());
             }
         }
 
@@ -172,25 +172,25 @@ impl Data for Paragraph {
 /// A collection of paragraphs for a page.
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq, PartialOrd)]
 pub struct Paragraphs {
-    pub child_ids: Vec<Id>,
+    pub child_info: Vec<ChildInfo>,
 }
 
 impl Paragraphs {
     /// Creates a new paragraph collection.
     pub fn new() -> Self {
-        Self { child_ids: vec![] }
+        Self { child_info: vec![] }
     }
 }
 
 impl Collection for Paragraphs {
     type Child = Paragraph;
 
-    fn child_ids(&self) -> &Vec<Id> {
-        &self.child_ids
+    fn child_info(&self) -> &Vec<ChildInfo> {
+        &self.child_info
     }
 
     fn has_children(&self) -> bool {
-        !self.child_ids.is_empty()
+        !self.child_info.is_empty()
     }
 }
 

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -12,12 +12,16 @@ mod collection__public_methods {
     use super::*;
 
     #[test]
-    fn child_ids() {
-        let child_ids = vec![Id::new(), Id::new(), Id::new()];
+    fn child_info() {
+        let child_info = vec![
+            ChildInfo::new(Id::new(), Sha256::digest(b"1").into()),
+            ChildInfo::new(Id::new(), Sha256::digest(b"2").into()),
+            ChildInfo::new(Id::new(), Sha256::digest(b"3").into()),
+        ];
         let mut paras = Paragraphs::new();
-        paras.child_ids = child_ids.clone();
-        assert_eq!(paras.child_ids(), &paras.child_ids);
-        assert_eq!(paras.child_ids(), &child_ids);
+        paras.child_info = child_info.clone();
+        assert_eq!(paras.child_info(), &paras.child_info);
+        assert_eq!(paras.child_info(), &child_info);
     }
 
     #[test]
@@ -25,8 +29,12 @@ mod collection__public_methods {
         let mut paras = Paragraphs::new();
         assert!(!paras.has_children());
 
-        let child_ids = vec![Id::new(), Id::new(), Id::new()];
-        paras.child_ids = child_ids;
+        let child_info = vec![
+            ChildInfo::new(Id::new(), Sha256::digest(b"1").into()),
+            ChildInfo::new(Id::new(), Sha256::digest(b"2").into()),
+            ChildInfo::new(Id::new(), Sha256::digest(b"3").into()),
+        ];
+        paras.child_info = child_info;
         assert!(paras.has_children());
     }
 }
@@ -53,7 +61,11 @@ mod data__public_methods {
         assert!(interface.save(para1.id(), &mut para1).unwrap());
         assert!(interface.save(para2.id(), &mut para2).unwrap());
         assert!(interface.save(para3.id(), &mut para3).unwrap());
-        page.paragraphs.child_ids = vec![para1.id(), para2.id(), para3.id()];
+        page.paragraphs.child_info = vec![
+            ChildInfo::new(para1.id(), para1.element().merkle_hash()),
+            ChildInfo::new(para2.id(), para2.element().merkle_hash()),
+            ChildInfo::new(para3.id(), para3.element().merkle_hash()),
+        ];
         assert!(interface.save(page.id(), &mut page).unwrap());
 
         let mut hasher0 = Sha256::new();
@@ -194,6 +206,63 @@ mod data__public_methods {
             storage: element,
         };
         assert_eq!(person.path(), path);
+    }
+}
+
+#[cfg(test)]
+mod child_info__constructor {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let id = Id::new();
+        let hash = Sha256::digest(b"1").into();
+        let info = ChildInfo::new(id, hash);
+        assert_eq!(info.id, id);
+        assert_eq!(info.merkle_hash, hash);
+    }
+}
+
+#[cfg(test)]
+mod child_info__public_methods {
+    use super::*;
+
+    #[test]
+    fn id() {
+        let info = ChildInfo::new(Id::new(), Sha256::digest(b"1").into());
+        assert_eq!(info.id(), info.id);
+    }
+
+    #[test]
+    fn merkle_hash() {
+        let info = ChildInfo::new(Id::new(), Sha256::digest(b"1").into());
+        assert_eq!(info.merkle_hash(), info.merkle_hash);
+    }
+}
+
+#[cfg(test)]
+mod child_info__traits {
+    use super::*;
+
+    #[test]
+    fn display() {
+        let info = ChildInfo::new(Id::new(), Sha256::digest(b"1").into());
+        assert_eq!(
+            format!("{info}"),
+            format!(
+                "ChildInfo {}: {}",
+                info.id(),
+                hex::encode(info.merkle_hash())
+            )
+        );
+        assert_eq!(
+            info.to_string(),
+            format!(
+                "ChildInfo {}: {}",
+                info.id(),
+                hex::encode(info.merkle_hash())
+            )
+        );
     }
 }
 

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -2,6 +2,7 @@ use borsh::to_vec;
 use calimero_test_utils::storage::create_test_store;
 use claims::{assert_ge, assert_le};
 use sha2::{Digest, Sha256};
+use velcro::hash_map;
 
 use super::*;
 use crate::interface::Interface;
@@ -153,6 +154,22 @@ mod data__public_methods {
         let expected_hash: [u8; 32] = hasher.finalize().into();
 
         assert_eq!(person.calculate_merkle_hash().unwrap(), expected_hash);
+    }
+
+    #[test]
+    fn collections() {
+        let parent = Element::new(&Path::new("::root::node").unwrap());
+        let page = Page::new_from_element("Node", parent);
+        assert_eq!(
+            page.collections(),
+            hash_map! {
+                "paragraphs".to_owned(): page.paragraphs.child_info().clone()
+            }
+        );
+
+        let child = Element::new(&Path::new("::root::node::leaf").unwrap());
+        let para = Paragraph::new_from_element("Leaf", child);
+        assert_eq!(para.collections(), HashMap::new());
     }
 
     #[test]

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -2,7 +2,7 @@ use calimero_test_utils::storage::create_test_store;
 use claims::{assert_none, assert_ok};
 
 use super::*;
-use crate::entities::{Data, Element};
+use crate::entities::{ChildInfo, Data, Element};
 use crate::tests::common::{EmptyData, Page, Paragraph, TEST_ID};
 
 #[cfg(test)]
@@ -69,7 +69,11 @@ mod interface__public_methods {
         assert!(interface.save(para1.id(), &mut para1).unwrap());
         assert!(interface.save(para2.id(), &mut para2).unwrap());
         assert!(interface.save(para3.id(), &mut para3).unwrap());
-        page.paragraphs.child_ids = vec![para1.id(), para2.id(), para3.id()];
+        page.paragraphs.child_info = vec![
+            ChildInfo::new(para1.id(), para1.element().merkle_hash()),
+            ChildInfo::new(para2.id(), para2.element().merkle_hash()),
+            ChildInfo::new(para3.id(), para3.element().merkle_hash()),
+        ];
         assert!(interface.save(page.id(), &mut page).unwrap());
 
         assert_eq!(
@@ -108,7 +112,11 @@ mod interface__public_methods {
         assert!(interface.save(para1.id(), &mut para1).unwrap());
         assert!(interface.save(para2.id(), &mut para2).unwrap());
         assert!(interface.save(para3.id(), &mut para3).unwrap());
-        page.paragraphs.child_ids = vec![para1.id(), para2.id(), para3.id()];
+        page.paragraphs.child_info = vec![
+            ChildInfo::new(para1.id(), para1.calculate_merkle_hash().unwrap()),
+            ChildInfo::new(para2.id(), para2.calculate_merkle_hash().unwrap()),
+            ChildInfo::new(para3.id(), para3.calculate_merkle_hash().unwrap()),
+        ];
         assert!(interface.save(page.id(), &mut page).unwrap());
         assert_eq!(
             interface.children_of(&page.paragraphs).unwrap(),


### PR DESCRIPTION
Added `ChildInfo`

  - Added a `ChildInfo` struct to encapsulate basic information about the children of an `Element`, which needs to be stored with the `Element`. At present this is the child `Element`'s ID and Merkle hash.

  - Renamed the `child_ids()` method and `#[child_ids]` field attribute to `child_info`.

  - Amended the `AtomicUnit` implementation of `Interface.calculate_full_merkle_hash()` to only load from the database if recursing, and to otherwise use the now-available stored hash.

Added `Data.collections()`

  - Added a `collections()` method to the `Data` trait, to return a list of all collections with `ChildInfo` for all their children.

Added `Interface.compare_trees()`

  - Added an `Action` enum to represent the various actions that can be required as a result of tree comparison, in order to sync.

  - Added `Interface.compare_trees()` to perform a comparison on tree data and emit local and remote action lists.

  - Added documentation to explain the design choices behind the implemented approach.

Added `Interface.apply_action()`

  - Added an `Interface.apply_action()` method, to carry out CRDT actions.

  - Added entity payload to `Action::Add` and `Action::Update`.

  - Added a new `Interface::find_by_id_raw()` function to find without deserialising, for efficient passthrough (prevents reserialising).