### PR TITLE
feat(node): output logs for admin api and admin ui

### DIFF
--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -80,6 +80,13 @@ pub(crate) fn setup(
 
     let admin_path = "/admin-api";
 
+    for listen in &config.listen {
+        info!(
+            "Admin API server listening on {}/http{{{}}}",
+            listen, admin_path
+        );
+    }
+
     let session_store = MemoryStore::default();
     let session_layer = SessionManagerLayer::new(session_store).with_secure(false);
 
@@ -205,6 +212,13 @@ pub(crate) fn site(config: &ServerConfig) -> Option<(&'static str, Router)> {
     };
 
     let path = "/admin-dashboard";
+
+    for listen in &config.listen {
+        info!(
+            "Admin Dashboard UI available on {}/http{{{}}}",
+            listen, path
+        );
+    }
 
     // Create a router to serve static files and fallback to index.html
     let router = Router::new()


### PR DESCRIPTION
# feat(node): output logs for admin api and admin ui

## Summary
Output listening logs:
<img width="1043" alt="Screenshot 2024-10-08 at 14 43 41" src="https://github.com/user-attachments/assets/e8a7d8f0-3de0-4768-8a61-391e94d2bc4d">

# Issue #324 
