### PR TITLE
fix(sdk+runtime): identity exposure

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -134,11 +134,6 @@ impl<'a> VMLogic<'a> {
         }
         .build()
     }
-
-    pub fn get_executor_identity(&mut self, register_id: u64) -> VMLogicResult<()> {
-        self.registers
-            .set(self.limits, register_id, self.context.executor_public_key)
-    }
 }
 
 #[derive(Debug, Serialize)]
@@ -249,6 +244,14 @@ impl VMHostFunctions<'_> {
         }
         self.borrow_memory().write(ptr, data)?;
         Ok(1)
+    }
+
+    pub fn executor_id(&mut self, register_id: u64) -> VMLogicResult<()> {
+        self.with_logic_mut(|logic| {
+            logic
+                .registers
+                .set(logic.limits, register_id, logic.context.executor_public_key)
+        })
     }
 
     pub fn input(&mut self, register_id: u64) -> VMLogicResult<()> {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -34,6 +34,8 @@ impl VMLogic<'_> {
             fn register_len(register_id: u64) -> u64;
             fn read_register(register_id: u64, ptr: u64, len: u64) -> u32;
 
+            fn executor_id(register_id: u64);
+
             fn input(register_id: u64);
             fn value_return(tag: u64, value_ptr: u64, value_len: u64);
             fn log_utf8(ptr: u64, len: u64);

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -12,7 +12,8 @@ wasm_imports! {
         fn register_len(register_id: RegisterId) -> PtrSizedInt;
         fn read_register(register_id: RegisterId, buf: BufferMut<'_>) -> Bool;
         // --
-        fn get_executor_identity(register_id: RegisterId);
+        fn executor_id(register_id: RegisterId);
+        // --
         fn input(register_id: RegisterId);
         fn value_return(value: ValueReturn<'_>);
         fn log_utf8(msg: Buffer<'_>);


### PR DESCRIPTION
#536 was incomplete and merged in a semi-bricked state, #692 fixed some of the issues, while this fixes the exposure of the executor's identity to the runtime