### PR TITLE
feat(node+storage): use CRDT-backed storage in the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "calimero-primitives",
  "calimero-runtime",
  "calimero-server",
+ "calimero-storage",
  "calimero-store",
  "camino",
  "eyre",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -28,6 +28,7 @@ calimero-primitives = { path = "../primitives" }
 calimero-runtime = { path = "../runtime" }
 calimero-server = { path = "../server", features = ["jsonrpc", "websocket", "admin"] }
 calimero-store = { path = "../store", features = ["datatypes"] }
+calimero-storage = { path = "../storage" }
 
 [lints]
 workspace = true

--- a/crates/node/src/runtime_compat_v2.rs
+++ b/crates/node/src/runtime_compat_v2.rs
@@ -1,0 +1,53 @@
+use calimero_runtime::store::{Key, Storage, Value};
+use calimero_storage::address::{Id, Path};
+use calimero_storage::entities::Element;
+use calimero_storage::interface::Interface;
+
+#[derive(Debug)]
+pub struct RuntimeCompatStore {
+    pub interface: Interface,
+}
+
+impl RuntimeCompatStore {
+    fn key_as_id(&self, key: &Key) -> Option<Id> {
+        let mut id = [0; 16];
+
+        (key.len() == id.len()).then_some(())?;
+
+        id.copy_from_slice(&key);
+
+        Some(id.into())
+    }
+}
+
+impl Storage for RuntimeCompatStore {
+    fn get(&self, key: &Key) -> Option<Vec<u8>> {
+        let id = self.key_as_id(key)?;
+
+        let element = self.interface.find_by_id(id).ok()??;
+
+        Some(element.data.0)
+    }
+
+    fn set(&mut self, key: Key, value: Value) -> Option<Value> {
+        let id = self.key_as_id(&key)?;
+
+        let mut old = None;
+
+        let mut element = match self.interface.find_by_id(id).ok()? {
+            Some(mut element) => {
+                old = Some(std::mem::take(&mut element.data.0));
+                element
+            }
+            None => Element::new(&Path::new("::").ok()?), // ??
+        };
+
+        element.data.0 = value;
+
+        old
+    }
+
+    fn has(&self, key: &Key) -> bool {
+        self.get(key).is_some()
+    }
+}

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -53,6 +53,10 @@ fn main() -> EyreResult<()> {
     let get_outcome = run(&file, "get", cx, &mut storage, &limits)?;
     dbg!(get_outcome);
 
+    let cx = VMContext::new(vec![], [0; 32]);
+    let init_outcome = run(&file, "init", cx, &mut storage, &limits)?;
+    dbg!(init_outcome);
+
     let cx = VMContext::new(
         to_json_vec(&json!({
             "key": "foo",

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -14,7 +14,7 @@ pub mod ext;
 
 const DATA_REGISTER: RegisterId = RegisterId::new(PtrSizedInt::MAX.as_usize() - 1);
 
-const STATE_KEY: &[u8] = b"STATE";
+const STATE_KEY: &[u8; 16] = &[0; 16]; // what is the root state?
 
 #[track_caller]
 #[inline]

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -20,9 +20,11 @@ use crate::address::{Id, Path};
 
 /// The primary data for an [`Element`], that is, the data that the consumer
 /// application has stored in the [`Element`].
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(
+    BorshDeserialize, BorshSerialize, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord,
+)]
 #[non_exhaustive]
-pub struct Data;
+pub struct Data(pub Vec<u8>);
 
 /// Represents an [`Element`] in the storage.
 ///
@@ -103,7 +105,7 @@ pub struct Element {
 
     /// The primary data for the [`Element`], that is, the data that the
     /// consumer application has stored in the [`Element`].
-    data: Data,
+    pub data: Data,
 
     /// Whether the [`Element`] is dirty, i.e. has been modified since it was
     /// last saved.
@@ -169,7 +171,7 @@ impl Element {
         Self {
             id: Id::new(),
             child_ids: Vec::new(),
-            data: Data {},
+            data: Data::default(),
             is_dirty: true,
             metadata: Metadata {
                 created_at: timestamp,


### PR DESCRIPTION
This demonstrates the expectation of the behavior of the `Data` stored in an `Element`, for which a hash can be computed without needing any type hints, using the `sys::storage_{read,write}` methods via the runtime-compat layer to serialize the app state.

In this model, the application is unchanged and serialized as a single atomic unit. I'll demonstrate collections in a coming PR using the new bridge interface discussed in Slack.