### PR TITLE
feat: Presented storage through SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "borsh",
  "calimero-sdk-macros",
  "cfg-if 1.0.0",
+ "hex",
  "serde",
  "serde_json",
  "trybuild",
@@ -1105,15 +1106,13 @@ name = "calimero-storage"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "calimero-sdk",
  "calimero-storage-macros",
- "calimero-store",
- "calimero-test-utils",
  "claims",
  "eyre",
  "fixedstr",
  "hex",
  "indexmap 2.6.0",
- "parking_lot",
  "sha2",
  "thiserror",
  "uuid 1.10.0",
@@ -1126,7 +1125,6 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "calimero-storage",
- "calimero-test-utils",
  "quote",
  "syn 2.0.72",
  "trybuild",

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 borsh = { workspace = true, features = ["derive"] }
 cfg-if.workspace = true
+hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 uuid.workspace = true

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -6,6 +6,8 @@ use borsh::{from_slice as from_borsh_slice, to_vec as to_borsh_vec};
 use uuid::Uuid;
 
 use crate::event::AppEvent;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::mocks::{mock_storage_read, mock_storage_remove, mock_storage_write};
 use crate::state::AppState;
 use crate::sys;
 use crate::sys::{
@@ -154,12 +156,36 @@ pub fn emit<T: AppEvent>(event: &T) {
     unsafe { sys::emit(Event::new(&kind, &data)) }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[inline]
 pub fn storage_read(key: &[u8]) -> Option<Vec<u8>> {
     unsafe { sys::storage_read(Buffer::from(key), DATA_REGISTER) }
         .try_into()
         .unwrap_or_else(expected_boolean::<bool>)
         .then(|| read_register(DATA_REGISTER).unwrap_or_else(expected_register))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[expect(clippy::print_stdout, reason = "Only used in testing")]
+#[must_use]
+pub fn storage_read(key: &[u8]) -> Option<Vec<u8>> {
+    println!("storage_read: {:?}", hex::encode(key));
+    mock_storage_read(key)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub fn storage_remove(key: &[u8]) -> bool {
+    unsafe { sys::storage_remove(Buffer::from(key), DATA_REGISTER).try_into() }
+        .unwrap_or_else(expected_boolean)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[expect(clippy::print_stdout, reason = "Only used in testing")]
+#[must_use]
+pub fn storage_remove(key: &[u8]) -> bool {
+    println!("storage_remove: {:?}", hex::encode(key));
+    mock_storage_remove(key)
 }
 
 #[must_use]
@@ -171,10 +197,19 @@ pub fn state_read<T: AppState>() -> Option<T> {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[inline]
 pub fn storage_write(key: &[u8], value: &[u8]) -> bool {
     unsafe { sys::storage_write(Buffer::from(key), Buffer::from(value), DATA_REGISTER).try_into() }
         .unwrap_or_else(expected_boolean)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[expect(clippy::print_stdout, reason = "Only used in testing")]
+#[must_use]
+pub fn storage_write(key: &[u8], value: &[u8]) -> bool {
+    println!("storage_write: {:?}", hex::encode(key));
+    mock_storage_write(key, value)
 }
 
 pub fn state_write<T: AppState>(state: &T) {
@@ -182,7 +217,7 @@ pub fn state_write<T: AppState>(state: &T) {
         Ok(data) => data,
         Err(err) => panic_str(&format!("Cannot serialize app state: {err:?}")),
     };
-    let _ = storage_write(STATE_KEY, &data);
+    _ = storage_write(STATE_KEY, &data);
 }
 
 /// Generate a new random UUID v4.

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -10,9 +10,18 @@ pub mod app {
     pub use calimero_sdk_macros::{destroy, emit, event, init, logic, state};
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "tests/mocks.rs"]
+mod mocks;
+
 #[doc(hidden)]
 pub mod __private {
     pub use crate::returns::{IntoResult, WrappedReturn};
+}
+
+#[doc(hidden)]
+mod wasm_mocks_package_usage {
+    use hex as _;
 }
 
 #[cfg(test)]

--- a/crates/sdk/src/tests/mocks.rs
+++ b/crates/sdk/src/tests/mocks.rs
@@ -1,0 +1,24 @@
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+static MOCK_STORAGE: OnceLock<RwLock<HashMap<Vec<u8>, Vec<u8>>>> = OnceLock::new();
+
+fn get_mock_storage() -> &'static RwLock<HashMap<Vec<u8>, Vec<u8>>> {
+    MOCK_STORAGE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+pub fn mock_storage_read(key: &[u8]) -> Option<Vec<u8>> {
+    get_mock_storage().read().unwrap().get(key).cloned()
+}
+
+pub fn mock_storage_remove(key: &[u8]) -> bool {
+    get_mock_storage().write().unwrap().remove(key).is_some()
+}
+
+pub fn mock_storage_write(key: &[u8], value: &[u8]) -> bool {
+    get_mock_storage()
+        .write()
+        .unwrap()
+        .insert(key.to_vec(), value.to_vec())
+        .is_some()
+}

--- a/crates/storage-macros/Cargo.toml
+++ b/crates/storage-macros/Cargo.toml
@@ -21,7 +21,5 @@ calimero-storage = { path = "../storage" }
 [dev-dependencies]
 trybuild.workspace = true
 
-calimero-test-utils = { path = "../test-utils" }
-
 [lints]
 workspace = true

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 
 #[cfg(test)]
 mod integration_tests_package_usage {
-    use {borsh as _, calimero_storage as _, calimero_test_utils as _, trybuild as _};
+    use {borsh as _, calimero_storage as _, trybuild as _};
 }
 
 /// Derives the [`AtomicUnit`](calimero_storage::entities::AtomicUnit) trait for

--- a/crates/storage-macros/tests/atomic_unit.rs
+++ b/crates/storage-macros/tests/atomic_unit.rs
@@ -31,7 +31,6 @@ use calimero_storage::entities::{Data, Element};
 use calimero_storage::exports::{Digest, Sha256};
 use calimero_storage::interface::Interface;
 use calimero_storage_macros::AtomicUnit;
-use calimero_test_utils::storage::create_test_store;
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 struct Private {
@@ -154,8 +153,7 @@ mod basics {
 
     #[test]
     fn setters__confirm_set_dirty() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
         assert!(interface.save(unit.id(), &mut unit).unwrap());
@@ -167,8 +165,7 @@ mod basics {
 
     #[test]
     fn setters__confirm_not_set_not_dirty() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
         assert!(interface.save(unit.id(), &mut unit).unwrap());

--- a/crates/storage-macros/tests/atomic_unit.rs
+++ b/crates/storage-macros/tests/atomic_unit.rs
@@ -153,10 +153,9 @@ mod basics {
 
     #[test]
     fn setters__confirm_set_dirty() {
-        let interface = Interface::new();
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
-        assert!(interface.save(unit.id(), &mut unit).unwrap());
+        assert!(Interface::save(unit.id(), &mut unit).unwrap());
         assert!(!unit.element().is_dirty());
 
         assert!(unit.set_name("Test Name".to_owned()));
@@ -165,15 +164,14 @@ mod basics {
 
     #[test]
     fn setters__confirm_not_set_not_dirty() {
-        let interface = Interface::new();
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
-        assert!(interface.save(unit.id(), &mut unit).unwrap());
+        assert!(Interface::save(unit.id(), &mut unit).unwrap());
         assert!(!unit.element().is_dirty());
 
         assert!(unit.set_name("Test Name".to_owned()));
         assert!(unit.element().is_dirty());
-        assert!(interface.save(unit.id(), &mut unit).unwrap());
+        assert!(Interface::save(unit.id(), &mut unit).unwrap());
         assert!(!unit.set_name("Test Name".to_owned()));
         assert!(!unit.element().is_dirty());
     }

--- a/crates/storage-macros/tests/compile_fail/collection.rs
+++ b/crates/storage-macros/tests/compile_fail/collection.rs
@@ -25,14 +25,13 @@ struct Parent {
 
 fn main() {
     fn child_type_specification() {
-        let interface = Interface::new();
         let parent: Parent = Parent {
             group: Group { child_info: vec![] },
             storage: Element::new(&Path::new("::root::node").unwrap()),
         };
-        let _: Vec<Child> = interface.children_of(&parent.group).unwrap();
+        let _: Vec<Child> = Interface::children_of(&parent.group).unwrap();
 
         // This should fail to compile if the child type is incorrect
-        let _: Vec<Parent> = interface.children_of(&parent.group).unwrap();
+        let _: Vec<Parent> = Interface::children_of(&parent.group).unwrap();
     }
 }

--- a/crates/storage-macros/tests/compile_fail/collection.rs
+++ b/crates/storage-macros/tests/compile_fail/collection.rs
@@ -2,7 +2,6 @@ use calimero_storage::address::Path;
 use calimero_storage::entities::{ChildInfo, Element};
 use calimero_storage::interface::Interface;
 use calimero_storage_macros::{AtomicUnit, Collection};
-use calimero_test_utils::storage::create_test_store;
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 struct Child {
@@ -26,8 +25,7 @@ struct Parent {
 
 fn main() {
     fn child_type_specification() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let parent: Parent = Parent {
             group: Group { child_info: vec![] },
             storage: Element::new(&Path::new("::root::node").unwrap()),

--- a/crates/storage-macros/tests/compile_fail/collection.stderr
+++ b/crates/storage-macros/tests/compile_fail/collection.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> tests/compile_fail/collection.rs:36:30
+  --> tests/compile_fail/collection.rs:35:30
    |
-36 |         let _: Vec<Parent> = interface.children_of(&parent.group).unwrap();
-   |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
+35 |         let _: Vec<Parent> = Interface::children_of(&parent.group).unwrap();
+   |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
    |                |
    |                expected due to this
    |

--- a/crates/storage-macros/tests/compile_fail/collection.stderr
+++ b/crates/storage-macros/tests/compile_fail/collection.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> tests/compile_fail/collection.rs:38:30
+  --> tests/compile_fail/collection.rs:36:30
    |
-38 |         let _: Vec<Parent> = interface.children_of(&parent.group).unwrap();
+36 |         let _: Vec<Parent> = interface.children_of(&parent.group).unwrap();
    |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
    |                |
    |                expected due to this

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,12 +12,11 @@ eyre.workspace = true
 fixedstr.workspace = true
 hex.workspace = true
 indexmap.workspace = true
-parking_lot.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
-calimero-store = { path = "../store", features = ["datatypes"] }
+calimero-sdk = { path = "../sdk" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { workspace = true, features = ["serde", "v4"] }
@@ -28,7 +27,6 @@ hex.workspace = true
 velcro.workspace = true
 
 calimero-storage-macros = { path = "../storage-macros" }
-calimero-test-utils = { path = "../test-utils" }
 
 [lints]
 workspace = true

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -13,6 +13,7 @@ use core::fmt::{self, Debug, Display, Formatter};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::env::generate_uuid;
 use fixedstr::Flexstr;
 use thiserror::Error as ThisError;
 use uuid::{Bytes, Uuid};
@@ -47,7 +48,7 @@ impl Id {
     ///
     #[must_use]
     pub fn new() -> Self {
-        Self(Uuid::new_v4())
+        Self(generate_uuid())
     }
 
     /// Returns a slice of 16 octets containing the value.

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -13,7 +13,6 @@ use core::fmt::{self, Debug, Display, Formatter};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_store::key::Storage as StorageKey;
 use fixedstr::Flexstr;
 use thiserror::Error as ThisError;
 use uuid::{Bytes, Uuid};
@@ -95,18 +94,6 @@ impl Default for Id {
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl From<Id> for StorageKey {
-    fn from(id: Id) -> Self {
-        Self::new(*id.0.as_bytes())
-    }
-}
-
-impl From<StorageKey> for Id {
-    fn from(storage: StorageKey) -> Self {
-        Self(Uuid::from_bytes(storage.id()))
     }
 }
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -214,9 +214,9 @@ mod tests;
 
 use core::fmt::{self, Debug, Display, Formatter};
 use std::collections::BTreeMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::env::time_now;
 
 use crate::address::{Id, Path};
 use crate::interface::StorageError;
@@ -644,15 +644,7 @@ impl Element {
     ///
     #[must_use]
     pub fn new(path: &Path) -> Self {
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "Impossible to overflow in normal circumstances"
-        )]
-        #[expect(clippy::expect_used, reason = "Effectively infallible here")]
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards to before the Unix epoch!")
-            .as_nanos() as u64;
+        let timestamp = time_now();
         Self {
             id: Id::new(),
             is_dirty: true,
@@ -758,17 +750,9 @@ impl Element {
     /// This method can technically panic if the system time goes backwards, to
     /// before the Unix epoch, which should never ever happen!
     ///
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "Impossible to overflow in normal circumstances"
-    )]
-    #[expect(clippy::expect_used, reason = "Effectively infallible here")]
     pub fn update(&mut self) {
         self.is_dirty = true;
-        self.metadata.updated_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards to before the Unix epoch!")
-            .as_nanos() as u64;
+        self.metadata.updated_at = time_now();
     }
 
     /// The timestamp when the [`Element`] was last updated.

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -215,16 +215,11 @@ mod tests;
 
 use core::fmt::Debug;
 use std::io::Error as IoError;
-use std::sync::Arc;
 
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
-use calimero_store::key::Storage as StorageKey;
-use calimero_store::layer::{ReadLayer, WriteLayer};
-use calimero_store::slice::Slice;
-use calimero_store::Store;
+use calimero_sdk::env::{storage_read, storage_remove, storage_write};
 use eyre::Report;
 use indexmap::IndexMap;
-use parking_lot::RwLock;
 use sha2::{Digest, Sha256};
 use thiserror::Error as ThisError;
 
@@ -278,12 +273,9 @@ pub enum Action {
 }
 
 /// The primary interface for the storage system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct Interface {
-    /// The backing store to use for the storage interface.
-    store: Arc<RwLock<Store>>,
-}
+pub struct Interface;
 
 impl Interface {
     /// Creates a new instance of the [`Interface`].
@@ -293,10 +285,8 @@ impl Interface {
     /// * `store` - The backing store to use for the storage interface.
     ///
     #[must_use]
-    pub fn new(store: Store) -> Self {
-        Self {
-            store: Arc::new(RwLock::new(store)),
-        }
+    pub const fn new() -> Self {
+        Self {}
     }
 
     /// Applies an [`Action`] to the storage system.
@@ -334,10 +324,7 @@ impl Interface {
             }
             Action::Compare(_) => return Err(StorageError::ActionNotAllowed("Compare".to_owned())),
             Action::Delete(id) => {
-                let mut store = self.store.write();
-                store
-                    .delete(&StorageKey::new(id.into()))
-                    .map_err(StorageError::StoreError)?;
+                _ = storage_remove(id.to_string().as_bytes());
             }
         }
         Ok(())
@@ -606,22 +593,8 @@ impl Interface {
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
     ///
-    #[expect(clippy::significant_drop_tightening, reason = "False positive")]
     pub fn find_by_id<D: Data>(&self, id: Id) -> Result<Option<D>, StorageError> {
-        // TODO: It seems fairly bizarre/unexpected that the put() method is sync
-        // TODO: and not async. The reasons and intentions need checking here, in
-        // TODO: case this find() method should be async and wrap the blocking call
-        // TODO: with spawn_blocking(). However, this is not straightforward at
-        // TODO: present because Slice uses Rc internally for some reason.
-        // TODO: let value = spawn_blocking(|| {
-        // TODO:     self.store.read()
-        // TODO:         .get(&StorageKey::new((*id).into()))
-        // TODO:         .map_err(StorageError::StoreError)
-        // TODO: }).await.map_err(|err| StorageError::DispatchError(err.to_string()))??;
-        let store = self.store.read();
-        let value = store
-            .get(&StorageKey::new(id.into()))
-            .map_err(StorageError::StoreError)?;
+        let value = storage_read(id.to_string().as_bytes());
 
         match value {
             Some(slice) => {
@@ -644,8 +617,8 @@ impl Interface {
     /// if it exists, regardless of where it may be in the hierarchy, or what
     /// state it may be in.
     ///
-    /// Notably it returns the raw [`Slice`] without attempting to deserialise
-    /// it into a [`Data`] type.
+    /// Notably it returns the raw bytes without attempting to deserialise them
+    /// into a [`Data`] type.
     ///
     /// # Parameters
     ///
@@ -657,13 +630,8 @@ impl Interface {
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
     ///
-    #[expect(clippy::significant_drop_tightening, reason = "False positive")]
     pub fn find_by_id_raw(&self, id: Id) -> Result<Option<Vec<u8>>, StorageError> {
-        let store = self.store.read();
-        let value = store
-            .get(&StorageKey::new(id.into()))
-            .map_err(StorageError::StoreError)?;
-        Ok(value.map(|slice| slice.to_vec()))
+        Ok(storage_read(id.to_string().as_bytes()))
     }
 
     /// Finds one or more [`Element`](crate::entities::Element)s by path in the
@@ -779,18 +747,10 @@ impl Interface {
         // TODO: recalculation for the ancestors.
         entity.element_mut().merkle_hash = self.calculate_merkle_hash_for(entity, false)?;
 
-        // TODO: It seems fairly bizarre/unexpected that the put() method is sync
-        // TODO: and not async. The reasons and intentions need checking here, in
-        // TODO: case this save() method should be async and wrap the blocking call
-        // TODO: with spawn_blocking(). However, this is not straightforward at
-        // TODO: present because Slice uses Rc internally for some reason.
-        self.store
-            .write()
-            .put(
-                &StorageKey::new(id.into()),
-                Slice::from(to_vec(entity).map_err(StorageError::SerializationError)?),
-            )
-            .map_err(StorageError::StoreError)?;
+        _ = storage_write(
+            id.to_string().as_bytes(),
+            &to_vec(entity).map_err(StorageError::SerializationError)?,
+        );
         entity.element_mut().is_dirty = false;
         Ok(true)
     }

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -1,7 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use borsh::to_vec;
-use calimero_test_utils::storage::create_test_store;
 use claims::{assert_ge, assert_le};
 use sha2::{Digest, Sha256};
 use velcro::btree_map;
@@ -304,8 +303,7 @@ mod element__public_methods {
 
     #[test]
     fn is_dirty() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         assert!(element.is_dirty());
 
@@ -323,8 +321,7 @@ mod element__public_methods {
 
     #[test]
     fn merkle_hash() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut person = Person {
             name: "Steve".to_owned(),
@@ -353,8 +350,7 @@ mod element__public_methods {
 
     #[test]
     fn update() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let updated_at = element.metadata.updated_at;
         let mut person = Person {

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -303,7 +303,6 @@ mod element__public_methods {
 
     #[test]
     fn is_dirty() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         assert!(element.is_dirty());
 
@@ -312,7 +311,7 @@ mod element__public_methods {
             age: 30,
             storage: element,
         };
-        assert!(interface.save(person.element().id(), &mut person).unwrap());
+        assert!(Interface::save(person.element().id(), &mut person).unwrap());
         assert!(!person.element().is_dirty());
 
         person.element_mut().update();
@@ -321,17 +320,16 @@ mod element__public_methods {
 
     #[test]
     fn merkle_hash() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut person = Person {
             name: "Steve".to_owned(),
             age: 50,
             storage: element.clone(),
         };
-        let expected_hash = interface.calculate_merkle_hash_for(&person, false).unwrap();
+        let expected_hash = Interface::calculate_merkle_hash_for(&person, false).unwrap();
         assert_ne!(person.element().merkle_hash(), expected_hash);
 
-        assert!(interface.save(person.element().id(), &mut person).unwrap());
+        assert!(Interface::save(person.element().id(), &mut person).unwrap());
         assert_eq!(person.element().merkle_hash(), expected_hash);
     }
 
@@ -350,7 +348,6 @@ mod element__public_methods {
 
     #[test]
     fn update() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let updated_at = element.metadata.updated_at;
         let mut person = Person {
@@ -358,7 +355,7 @@ mod element__public_methods {
             age: 40,
             storage: element,
         };
-        assert!(interface.save(person.element().id(), &mut person).unwrap());
+        assert!(Interface::save(person.element().id(), &mut person).unwrap());
         assert!(!person.element().is_dirty);
 
         person.element_mut().update();

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -8,26 +8,15 @@ use crate::entities::{ChildInfo, Data, Element};
 use crate::tests::common::{EmptyData, Page, Paragraph, TEST_ID};
 
 #[cfg(test)]
-mod interface__constructor {
-    use super::*;
-
-    #[test]
-    fn new() {
-        drop(Interface::new());
-    }
-}
-
-#[cfg(test)]
 mod interface__public_methods {
     use super::*;
 
     #[test]
     fn children_of() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut page = Page::new_from_element("Node", element);
-        assert!(interface.save(page.id(), &mut page).unwrap());
-        assert_eq!(interface.children_of(&page.paragraphs).unwrap(), vec![]);
+        assert!(Interface::save(page.id(), &mut page).unwrap());
+        assert_eq!(Interface::children_of(&page.paragraphs).unwrap(), vec![]);
 
         let child1 = Element::new(&Path::new("::root::node::leaf1").unwrap());
         let child2 = Element::new(&Path::new("::root::node::leaf2").unwrap());
@@ -35,37 +24,34 @@ mod interface__public_methods {
         let mut para1 = Paragraph::new_from_element("Leaf1", child1);
         let mut para2 = Paragraph::new_from_element("Leaf2", child2);
         let mut para3 = Paragraph::new_from_element("Leaf3", child3);
-        assert!(interface.save(para1.id(), &mut para1).unwrap());
-        assert!(interface.save(para2.id(), &mut para2).unwrap());
-        assert!(interface.save(para3.id(), &mut para3).unwrap());
+        assert!(Interface::save(para1.id(), &mut para1).unwrap());
+        assert!(Interface::save(para2.id(), &mut para2).unwrap());
+        assert!(Interface::save(para3.id(), &mut para3).unwrap());
         page.paragraphs.child_info = vec![
             ChildInfo::new(para1.id(), para1.calculate_merkle_hash().unwrap()),
             ChildInfo::new(para2.id(), para2.calculate_merkle_hash().unwrap()),
             ChildInfo::new(para3.id(), para3.calculate_merkle_hash().unwrap()),
         ];
-        assert!(interface.save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(page.id(), &mut page).unwrap());
         assert_eq!(
-            interface.children_of(&page.paragraphs).unwrap(),
+            Interface::children_of(&page.paragraphs).unwrap(),
             vec![para1, para2, para3]
         );
     }
 
     #[test]
     fn find_by_id__existent() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
         let id = para.id();
-        assert!(interface.save(id, &mut para).unwrap());
+        assert!(Interface::save(id, &mut para).unwrap());
 
-        assert_eq!(interface.find_by_id(id).unwrap(), Some(para));
+        assert_eq!(Interface::find_by_id(id).unwrap(), Some(para));
     }
 
     #[test]
     fn find_by_id__non_existent() {
-        let interface = Interface::new();
-
-        assert_none!(interface.find_by_id::<Page>(Id::new()).unwrap());
+        assert_none!(Interface::find_by_id::<Page>(Id::new()).unwrap());
     }
 
     #[test]
@@ -88,67 +74,62 @@ mod interface__public_methods {
 
     #[test]
     fn save__basic() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
 
-        assert_ok!(interface.save(para.id(), &mut para));
+        assert_ok!(Interface::save(para.id(), &mut para));
     }
 
     #[test]
     fn save__multiple() {
-        let interface = Interface::new();
         let element1 = Element::new(&Path::new("::root::node1").unwrap());
         let element2 = Element::new(&Path::new("::root::node2").unwrap());
         let mut page1 = Page::new_from_element("Node1", element1);
         let mut page2 = Page::new_from_element("Node2", element2);
 
-        assert!(interface.save(page1.id(), &mut page1).unwrap());
-        assert!(interface.save(page2.id(), &mut page2).unwrap());
-        assert_eq!(interface.find_by_id(page1.id()).unwrap(), Some(page1));
-        assert_eq!(interface.find_by_id(page2.id()).unwrap(), Some(page2));
+        assert!(Interface::save(page1.id(), &mut page1).unwrap());
+        assert!(Interface::save(page2.id(), &mut page2).unwrap());
+        assert_eq!(Interface::find_by_id(page1.id()).unwrap(), Some(page1));
+        assert_eq!(Interface::find_by_id(page2.id()).unwrap(), Some(page2));
     }
 
     #[test]
     fn save__not_dirty() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
         let id = para.id();
 
-        assert!(interface.save(id, &mut para).unwrap());
+        assert!(Interface::save(id, &mut para).unwrap());
         para.element_mut().update();
-        assert!(interface.save(id, &mut para).unwrap());
+        assert!(Interface::save(id, &mut para).unwrap());
     }
 
     #[test]
     fn save__too_old() {
-        let interface = Interface::new();
         let element1 = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para1 = Paragraph::new_from_element("Leaf", element1);
         let mut para2 = para1.clone();
         let id = para1.id();
 
-        assert!(interface.save(id, &mut para1).unwrap());
+        assert!(Interface::save(id, &mut para1).unwrap());
         para2.element_mut().update();
         sleep(Duration::from_millis(1));
         para1.element_mut().update();
-        assert!(interface.save(id, &mut para1).unwrap());
-        assert!(!interface.save(id, &mut para2).unwrap());
+        assert!(Interface::save(id, &mut para1).unwrap());
+        assert!(!Interface::save(id, &mut para2).unwrap());
     }
 
     #[test]
     fn save__update_existing() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
         let id = para.id();
-        assert!(interface.save(id, &mut para).unwrap());
+        assert!(Interface::save(id, &mut para).unwrap());
 
         // TODO: Modify the element's data and check it changed
 
-        assert!(interface.save(id, &mut para).unwrap());
-        assert_eq!(interface.find_by_id(id).unwrap(), Some(para));
+        assert!(Interface::save(id, &mut para).unwrap());
+        assert_eq!(Interface::find_by_id(id).unwrap(), Some(para));
     }
 
     #[test]
@@ -185,87 +166,81 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__add() {
-        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let serialized = to_vec(&page).unwrap();
         let action = Action::Add(page.id(), serialized);
 
-        assert!(interface.apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action::<Page>(action).is_ok());
 
         // Verify the page was added
-        let retrieved_page = interface.find_by_id::<Page>(page.id()).unwrap();
+        let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap();
         assert!(retrieved_page.is_some());
         assert_eq!(retrieved_page.unwrap().title, "Test Page");
     }
 
     #[test]
     fn apply_action__update() {
-        let interface = Interface::new();
         let mut page =
             Page::new_from_element("Old Title", Element::new(&Path::new("::test").unwrap()));
-        assert!(interface.save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(page.id(), &mut page).unwrap());
 
         page.title = "New Title".to_owned();
         page.element_mut().update();
         let serialized = to_vec(&page).unwrap();
         let action = Action::Update(page.id(), serialized);
 
-        assert!(interface.apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action::<Page>(action).is_ok());
 
         // Verify the page was updated
-        let retrieved_page = interface.find_by_id::<Page>(page.id()).unwrap().unwrap();
+        let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap().unwrap();
         assert_eq!(retrieved_page.title, "New Title");
     }
 
     #[test]
     fn apply_action__delete() {
-        let interface = Interface::new();
         let mut page =
             Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
-        assert!(interface.save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(page.id(), &mut page).unwrap());
 
         let action = Action::Delete(page.id());
 
-        assert!(interface.apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action::<Page>(action).is_ok());
 
         // Verify the page was deleted
-        let retrieved_page = interface.find_by_id::<Page>(page.id()).unwrap();
+        let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap();
         assert!(retrieved_page.is_none());
     }
 
     #[test]
     fn apply_action__compare() {
-        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let action = Action::Compare(page.id());
 
         // Compare should fail
-        assert!(interface.apply_action::<Page>(action).is_err());
+        assert!(Interface::apply_action::<Page>(action).is_err());
     }
 
     #[test]
     fn apply_action__wrong_type() {
-        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let serialized = to_vec(&page).unwrap();
         let action = Action::Add(page.id(), serialized);
 
         // Trying to apply a Page action as if it were a Paragraph should fail
-        assert!(interface.apply_action::<Paragraph>(action).is_err());
+        assert!(Interface::apply_action::<Paragraph>(action).is_err());
     }
 
     #[test]
     fn apply_action__non_existent_update() {
-        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let serialized = to_vec(&page).unwrap();
         let action = Action::Update(page.id(), serialized);
 
         // Updating a non-existent page should still succeed (it will be added)
-        assert!(interface.apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action::<Page>(action).is_ok());
 
         // Verify the page was added
-        let retrieved_page = interface.find_by_id::<Page>(page.id()).unwrap();
+        let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap();
         assert!(retrieved_page.is_some());
         assert_eq!(retrieved_page.unwrap().title, "Test Page");
     }
@@ -277,27 +252,24 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__identical() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut local = Page::new_from_element("Test Page", element);
         let mut foreign = local.clone();
 
-        assert!(interface.save(local.id(), &mut local).unwrap());
-        foreign.element_mut().merkle_hash = interface
-            .calculate_merkle_hash_for(&foreign, false)
-            .unwrap();
+        assert!(Interface::save(local.id(), &mut local).unwrap());
+        foreign.element_mut().merkle_hash =
+            Interface::calculate_merkle_hash_for(&foreign, false).unwrap();
         assert_eq!(
             local.element().merkle_hash(),
             foreign.element().merkle_hash()
         );
 
-        let result = interface.compare_trees(&foreign).unwrap();
+        let result = Interface::compare_trees(&foreign).unwrap();
         assert_eq!(result, (vec![], vec![]));
     }
 
     #[test]
     fn compare_trees__local_newer() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut local = Page::new_from_element("Test Page", element.clone());
         let mut foreign = Page::new_from_element("Old Test Page", element);
@@ -306,12 +278,11 @@ mod interface__comparison {
         sleep(Duration::from_millis(10));
         local.element_mut().update();
 
-        assert!(interface.save(local.id(), &mut local).unwrap());
-        foreign.element_mut().merkle_hash = interface
-            .calculate_merkle_hash_for(&foreign, false)
-            .unwrap();
+        assert!(Interface::save(local.id(), &mut local).unwrap());
+        foreign.element_mut().merkle_hash =
+            Interface::calculate_merkle_hash_for(&foreign, false).unwrap();
 
-        let result = interface.compare_trees(&foreign).unwrap();
+        let result = Interface::compare_trees(&foreign).unwrap();
         assert_eq!(
             result,
             (
@@ -323,21 +294,19 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__foreign_newer() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut local = Page::new_from_element("Old Test Page", element.clone());
         let mut foreign = Page::new_from_element("Test Page", element);
 
-        assert!(interface.save(local.id(), &mut local).unwrap());
-        foreign.element_mut().merkle_hash = interface
-            .calculate_merkle_hash_for(&foreign, false)
-            .unwrap();
+        assert!(Interface::save(local.id(), &mut local).unwrap());
+        foreign.element_mut().merkle_hash =
+            Interface::calculate_merkle_hash_for(&foreign, false).unwrap();
 
         // Make foreign newer
         sleep(Duration::from_millis(10));
         foreign.element_mut().update();
 
-        let result = interface.compare_trees(&foreign).unwrap();
+        let result = Interface::compare_trees(&foreign).unwrap();
         assert_eq!(
             result,
             (
@@ -349,8 +318,6 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__with_collections() {
-        let interface = Interface::new();
-
         let page_element = Element::new(&Path::new("::root::node").unwrap());
         let para1_element = Element::new(&Path::new("::root::node::leaf1").unwrap());
         let para2_element = Element::new(&Path::new("::root::node::leaf2").unwrap());
@@ -387,20 +354,17 @@ mod interface__comparison {
             ),
         ];
 
-        assert!(interface.save(local_page.id(), &mut local_page).unwrap());
-        assert!(interface.save(local_para1.id(), &mut local_para1).unwrap());
-        assert!(interface.save(local_para2.id(), &mut local_para2).unwrap());
-        foreign_page.element_mut().merkle_hash = interface
-            .calculate_merkle_hash_for(&foreign_page, false)
-            .unwrap();
-        foreign_para1.element_mut().merkle_hash = interface
-            .calculate_merkle_hash_for(&foreign_para1, false)
-            .unwrap();
-        foreign_para3.element_mut().merkle_hash = interface
-            .calculate_merkle_hash_for(&foreign_para3, false)
-            .unwrap();
+        assert!(Interface::save(local_page.id(), &mut local_page).unwrap());
+        assert!(Interface::save(local_para1.id(), &mut local_para1).unwrap());
+        assert!(Interface::save(local_para2.id(), &mut local_para2).unwrap());
+        foreign_page.element_mut().merkle_hash =
+            Interface::calculate_merkle_hash_for(&foreign_page, false).unwrap();
+        foreign_para1.element_mut().merkle_hash =
+            Interface::calculate_merkle_hash_for(&foreign_para1, false).unwrap();
+        foreign_para3.element_mut().merkle_hash =
+            Interface::calculate_merkle_hash_for(&foreign_para3, false).unwrap();
 
-        let (local_actions, foreign_actions) = interface.compare_trees(&foreign_page).unwrap();
+        let (local_actions, foreign_actions) = Interface::compare_trees(&foreign_page).unwrap();
 
         assert_eq!(
             local_actions,
@@ -426,7 +390,7 @@ mod interface__comparison {
 
         // Compare the updated para1
         let (local_para1_actions, foreign_para1_actions) =
-            interface.compare_trees(&foreign_para1).unwrap();
+            Interface::compare_trees(&foreign_para1).unwrap();
 
         assert_eq!(
             local_para1_actions,
@@ -439,7 +403,7 @@ mod interface__comparison {
 
         // Compare para3 which doesn't exist locally
         let (local_para3_actions, foreign_para3_actions) =
-            interface.compare_trees(&foreign_para3).unwrap();
+            Interface::compare_trees(&foreign_para3).unwrap();
 
         assert_eq!(
             local_para3_actions,
@@ -459,7 +423,6 @@ mod hashing {
     #[test]
     fn calculate_merkle_hash_for__empty_record() {
         let timestamp = 1_765_432_100_123_456_789;
-        let interface = Interface::new();
         let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
         element.set_id(TEST_ID[0]);
         element.metadata.set_created_at(timestamp);
@@ -468,7 +431,7 @@ mod hashing {
             storage: element.clone(),
         };
 
-        let hash = interface.calculate_merkle_hash_for(&data, false).unwrap();
+        let hash = Interface::calculate_merkle_hash_for(&data, false).unwrap();
         assert_eq!(
             hex::encode(hash),
             "173f9a17aa3c6acdad8cdaf06cea4aa4eb7c87cb99e07507a417d6588e679607"
@@ -478,13 +441,12 @@ mod hashing {
     #[test]
     fn calculate_merkle_hash_for__with_children() {
         let timestamp = 1_765_432_100_123_456_789;
-        let interface = Interface::new();
         let mut element = Element::new(&Path::new("::root::node").unwrap());
         element.set_id(TEST_ID[0]);
         element.metadata.set_created_at(1_765_432_100_123_456_789);
         element.metadata.updated_at = timestamp;
         let mut page = Page::new_from_element("Node", element);
-        assert!(interface.save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(page.id(), &mut page).unwrap());
         let child1 = Element::new(&Path::new("::root::node::leaf1").unwrap());
         let child2 = Element::new(&Path::new("::root::node::leaf2").unwrap());
         let child3 = Element::new(&Path::new("::root::node::leaf3").unwrap());
@@ -500,41 +462,40 @@ mod hashing {
         para1.element_mut().metadata.updated_at = timestamp;
         para2.element_mut().metadata.updated_at = timestamp;
         para3.element_mut().metadata.updated_at = timestamp;
-        assert!(interface.save(para1.id(), &mut para1).unwrap());
-        assert!(interface.save(para2.id(), &mut para2).unwrap());
-        assert!(interface.save(para3.id(), &mut para3).unwrap());
+        assert!(Interface::save(para1.id(), &mut para1).unwrap());
+        assert!(Interface::save(para2.id(), &mut para2).unwrap());
+        assert!(Interface::save(para3.id(), &mut para3).unwrap());
         page.paragraphs.child_info = vec![
             ChildInfo::new(para1.id(), para1.element().merkle_hash()),
             ChildInfo::new(para2.id(), para2.element().merkle_hash()),
             ChildInfo::new(para3.id(), para3.element().merkle_hash()),
         ];
-        assert!(interface.save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(page.id(), &mut page).unwrap());
 
         assert_eq!(
-            hex::encode(interface.calculate_merkle_hash_for(&para1, false).unwrap()),
+            hex::encode(Interface::calculate_merkle_hash_for(&para1, false).unwrap()),
             "9c4d6363cca5bdb5829f0aa832b573d6befd26227a0e2c3cc602edd9fda88db1",
         );
         assert_eq!(
-            hex::encode(interface.calculate_merkle_hash_for(&para2, false).unwrap()),
+            hex::encode(Interface::calculate_merkle_hash_for(&para2, false).unwrap()),
             "449f30903c94a488f1767b91bc6626fafd82189130cf41e427f96df19a727d8b",
         );
         assert_eq!(
-            hex::encode(interface.calculate_merkle_hash_for(&para3, false).unwrap()),
+            hex::encode(Interface::calculate_merkle_hash_for(&para3, false).unwrap()),
             "43098decf78bf10dc4c31191a5f59d277ae524859583e48689482c9ba85c5f61",
         );
         assert_eq!(
-            hex::encode(interface.calculate_merkle_hash_for(&page, false).unwrap()),
+            hex::encode(Interface::calculate_merkle_hash_for(&page, false).unwrap()),
             "7593806c462bfadd97ed5228a3a60e492cce4b725f2c0e72e6e5b0f7996ee394",
         );
     }
 
     #[test]
     fn calculate_merkle_hash_for__cached_values() {
-        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut page = Page::new_from_element("Node", element);
-        assert!(interface.save(page.id(), &mut page).unwrap());
-        assert_eq!(interface.children_of(&page.paragraphs).unwrap(), vec![]);
+        assert!(Interface::save(page.id(), &mut page).unwrap());
+        assert_eq!(Interface::children_of(&page.paragraphs).unwrap(), vec![]);
 
         let child1 = Element::new(&Path::new("::root::node::leaf1").unwrap());
         let child2 = Element::new(&Path::new("::root::node::leaf2").unwrap());
@@ -542,15 +503,15 @@ mod hashing {
         let mut para1 = Paragraph::new_from_element("Leaf1", child1);
         let mut para2 = Paragraph::new_from_element("Leaf2", child2);
         let mut para3 = Paragraph::new_from_element("Leaf3", child3);
-        assert!(interface.save(para1.id(), &mut para1).unwrap());
-        assert!(interface.save(para2.id(), &mut para2).unwrap());
-        assert!(interface.save(para3.id(), &mut para3).unwrap());
+        assert!(Interface::save(para1.id(), &mut para1).unwrap());
+        assert!(Interface::save(para2.id(), &mut para2).unwrap());
+        assert!(Interface::save(para3.id(), &mut para3).unwrap());
         page.paragraphs.child_info = vec![
             ChildInfo::new(para1.id(), para1.element().merkle_hash()),
             ChildInfo::new(para2.id(), para2.element().merkle_hash()),
             ChildInfo::new(para3.id(), para3.element().merkle_hash()),
         ];
-        assert!(interface.save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(page.id(), &mut page).unwrap());
 
         let mut hasher0 = Sha256::new();
         hasher0.update(page.id().as_bytes());
@@ -594,19 +555,19 @@ mod hashing {
 
         assert_eq!(page.calculate_merkle_hash().unwrap(), expected_hash0);
         assert_eq!(
-            interface.calculate_merkle_hash_for(&para1, false).unwrap(),
+            Interface::calculate_merkle_hash_for(&para1, false).unwrap(),
             expected_hash1b
         );
         assert_eq!(
-            interface.calculate_merkle_hash_for(&para2, false).unwrap(),
+            Interface::calculate_merkle_hash_for(&para2, false).unwrap(),
             expected_hash2b
         );
         assert_eq!(
-            interface.calculate_merkle_hash_for(&para3, false).unwrap(),
+            Interface::calculate_merkle_hash_for(&para3, false).unwrap(),
             expected_hash3b
         );
         assert_eq!(
-            interface.calculate_merkle_hash_for(&page, false).unwrap(),
+            Interface::calculate_merkle_hash_for(&page, false).unwrap(),
             expected_hash
         );
     }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1,7 +1,6 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use calimero_test_utils::storage::create_test_store;
 use claims::{assert_none, assert_ok};
 
 use super::*;
@@ -14,8 +13,7 @@ mod interface__constructor {
 
     #[test]
     fn new() {
-        let (db, _dir) = create_test_store();
-        drop(Interface::new(db));
+        drop(Interface::new());
     }
 }
 
@@ -25,8 +23,7 @@ mod interface__public_methods {
 
     #[test]
     fn children_of() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut page = Page::new_from_element("Node", element);
         assert!(interface.save(page.id(), &mut page).unwrap());
@@ -55,8 +52,7 @@ mod interface__public_methods {
 
     #[test]
     fn find_by_id__existent() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
         let id = para.id();
@@ -67,8 +63,7 @@ mod interface__public_methods {
 
     #[test]
     fn find_by_id__non_existent() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
 
         assert_none!(interface.find_by_id::<Page>(Id::new()).unwrap());
     }
@@ -93,8 +88,7 @@ mod interface__public_methods {
 
     #[test]
     fn save__basic() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
 
@@ -103,8 +97,7 @@ mod interface__public_methods {
 
     #[test]
     fn save__multiple() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element1 = Element::new(&Path::new("::root::node1").unwrap());
         let element2 = Element::new(&Path::new("::root::node2").unwrap());
         let mut page1 = Page::new_from_element("Node1", element1);
@@ -118,8 +111,7 @@ mod interface__public_methods {
 
     #[test]
     fn save__not_dirty() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
         let id = para.id();
@@ -131,8 +123,7 @@ mod interface__public_methods {
 
     #[test]
     fn save__too_old() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element1 = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para1 = Paragraph::new_from_element("Leaf", element1);
         let mut para2 = para1.clone();
@@ -148,8 +139,7 @@ mod interface__public_methods {
 
     #[test]
     fn save__update_existing() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node::leaf").unwrap());
         let mut para = Paragraph::new_from_element("Leaf", element);
         let id = para.id();
@@ -195,8 +185,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__add() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let serialized = to_vec(&page).unwrap();
         let action = Action::Add(page.id(), serialized);
@@ -211,8 +200,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__update() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let mut page =
             Page::new_from_element("Old Title", Element::new(&Path::new("::test").unwrap()));
         assert!(interface.save(page.id(), &mut page).unwrap());
@@ -231,8 +219,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__delete() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let mut page =
             Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         assert!(interface.save(page.id(), &mut page).unwrap());
@@ -248,8 +235,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__compare() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let action = Action::Compare(page.id());
 
@@ -259,8 +245,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__wrong_type() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let serialized = to_vec(&page).unwrap();
         let action = Action::Add(page.id(), serialized);
@@ -271,8 +256,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__non_existent_update() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let page = Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
         let serialized = to_vec(&page).unwrap();
         let action = Action::Update(page.id(), serialized);
@@ -293,8 +277,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__identical() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut local = Page::new_from_element("Test Page", element);
         let mut foreign = local.clone();
@@ -314,8 +297,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__local_newer() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut local = Page::new_from_element("Test Page", element.clone());
         let mut foreign = Page::new_from_element("Old Test Page", element);
@@ -341,8 +323,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__foreign_newer() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut local = Page::new_from_element("Old Test Page", element.clone());
         let mut foreign = Page::new_from_element("Test Page", element);
@@ -368,8 +349,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__with_collections() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
 
         let page_element = Element::new(&Path::new("::root::node").unwrap());
         let para1_element = Element::new(&Path::new("::root::node::leaf1").unwrap());
@@ -479,8 +459,7 @@ mod hashing {
     #[test]
     fn calculate_merkle_hash_for__empty_record() {
         let timestamp = 1_765_432_100_123_456_789;
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
         element.set_id(TEST_ID[0]);
         element.metadata.set_created_at(timestamp);
@@ -499,8 +478,7 @@ mod hashing {
     #[test]
     fn calculate_merkle_hash_for__with_children() {
         let timestamp = 1_765_432_100_123_456_789;
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let mut element = Element::new(&Path::new("::root::node").unwrap());
         element.set_id(TEST_ID[0]);
         element.metadata.set_created_at(1_765_432_100_123_456_789);
@@ -552,8 +530,7 @@ mod hashing {
 
     #[test]
     fn calculate_merkle_hash_for__cached_values() {
-        let (db, _dir) = create_test_store();
-        let interface = Interface::new(db);
+        let interface = Interface::new();
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut page = Page::new_from_element("Node", element);
         assert!(interface.save(page.id(), &mut page).unwrap());


### PR DESCRIPTION
  - Changed the `storage` crate to be accessible through the SDK for direct use by guest runtimes.

  - Removed the `store` parameter from `Interface::new()`, as it will now use the central store provided to the guest and available through `env` functions.

  - Removed conversion to/from `StorageKey` for `Id`, as this is no longer accessible due to the move to the SDK.

  - Added mock storage to use during non-WASM testing, where the guest env's storage is not available.

  - Added non-WASM calls into the mocked storage from `env`.

  - Made `Interface` fully static; `Interface` no longer needs to be instantiated, and so use of `self` has been removed, along with the `new()` constructor.

  - Updated storage to use WASM-compatible functions for time and UUID.