### PR TITLE
wip: Added indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "fixedstr",
  "hex",
  "indexmap 2.6.0",
+ "serde",
  "sha2",
  "thiserror",
  "uuid 1.10.0",
@@ -1124,6 +1125,7 @@ name = "calimero-storage-macros"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "calimero-sdk",
  "calimero-storage",
  "quote",
  "syn 2.0.72",

--- a/crates/sdk/src/tests/mocks.rs
+++ b/crates/sdk/src/tests/mocks.rs
@@ -1,24 +1,24 @@
+use core::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
+use std::thread_local;
 
-static MOCK_STORAGE: OnceLock<RwLock<HashMap<Vec<u8>, Vec<u8>>>> = OnceLock::new();
-
-fn get_mock_storage() -> &'static RwLock<HashMap<Vec<u8>, Vec<u8>>> {
-    MOCK_STORAGE.get_or_init(|| RwLock::new(HashMap::new()))
+thread_local! {
+    static MOCK_STORAGE: RefCell<HashMap<Vec<u8>, Vec<u8>>> = RefCell::new(HashMap::new());
 }
 
 pub fn mock_storage_read(key: &[u8]) -> Option<Vec<u8>> {
-    get_mock_storage().read().unwrap().get(key).cloned()
+    MOCK_STORAGE.with(|storage| storage.borrow().get(key).cloned())
 }
 
 pub fn mock_storage_remove(key: &[u8]) -> bool {
-    get_mock_storage().write().unwrap().remove(key).is_some()
+    MOCK_STORAGE.with(|storage| storage.borrow_mut().remove(key).is_some())
 }
 
 pub fn mock_storage_write(key: &[u8], value: &[u8]) -> bool {
-    get_mock_storage()
-        .write()
-        .unwrap()
-        .insert(key.to_vec(), value.to_vec())
-        .is_some()
+    MOCK_STORAGE.with(|storage| {
+        storage
+            .borrow_mut()
+            .insert(key.to_vec(), value.to_vec())
+            .is_some()
+    })
 }

--- a/crates/storage-macros/Cargo.toml
+++ b/crates/storage-macros/Cargo.toml
@@ -20,6 +20,7 @@ calimero-storage = { path = "../storage" }
 
 [dev-dependencies]
 trybuild.workspace = true
+calimero-sdk = { path = "../sdk" }
 
 [lints]
 workspace = true

--- a/crates/storage-macros/tests/atomic_unit.rs
+++ b/crates/storage-macros/tests/atomic_unit.rs
@@ -33,6 +33,7 @@ use calimero_storage::interface::Interface;
 use calimero_storage_macros::AtomicUnit;
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[root]
 struct Private {
     public: String,
     #[private]
@@ -52,6 +53,7 @@ impl Private {
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[root]
 struct Simple {
     name: String,
     value: i32,
@@ -70,6 +72,7 @@ impl Simple {
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[root]
 struct Skipped {
     included: String,
     #[skip]
@@ -155,7 +158,7 @@ mod basics {
     fn setters__confirm_set_dirty() {
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
-        assert!(Interface::save(unit.id(), &mut unit).unwrap());
+        assert!(Interface::save(&mut unit).unwrap());
         assert!(!unit.element().is_dirty());
 
         assert!(unit.set_name("Test Name".to_owned()));
@@ -166,12 +169,12 @@ mod basics {
     fn setters__confirm_not_set_not_dirty() {
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
-        assert!(Interface::save(unit.id(), &mut unit).unwrap());
+        assert!(Interface::save(&mut unit).unwrap());
         assert!(!unit.element().is_dirty());
 
         assert!(unit.set_name("Test Name".to_owned()));
         assert!(unit.element().is_dirty());
-        assert!(Interface::save(unit.id(), &mut unit).unwrap());
+        assert!(Interface::save(&mut unit).unwrap());
         assert!(!unit.set_name("Test Name".to_owned()));
         assert!(!unit.element().is_dirty());
     }

--- a/crates/storage-macros/tests/collection.rs
+++ b/crates/storage-macros/tests/collection.rs
@@ -27,7 +27,7 @@
 
 use borsh::{to_vec, BorshDeserialize};
 use calimero_storage::address::Path;
-use calimero_storage::entities::{ChildInfo, Data, Element};
+use calimero_storage::entities::{Data, Element};
 use calimero_storage::exports::{Digest, Sha256};
 use calimero_storage_macros::{AtomicUnit, Collection};
 
@@ -49,20 +49,16 @@ impl Child {
 
 #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[children(Child)]
-struct Group {
-    #[child_info]
-    child_info: Vec<ChildInfo>,
-}
+struct Group;
 
 impl Group {
     fn new() -> Self {
-        Self {
-            child_info: Vec::new(),
-        }
+        Self {}
     }
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[root]
 struct Parent {
     title: String,
     #[collection]
@@ -82,6 +78,7 @@ impl Parent {
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[root]
 struct Simple {
     name: String,
     value: i32,

--- a/crates/storage-macros/tests/compile_fail/collection.rs
+++ b/crates/storage-macros/tests/compile_fail/collection.rs
@@ -1,5 +1,5 @@
 use calimero_storage::address::Path;
-use calimero_storage::entities::{ChildInfo, Element};
+use calimero_storage::entities::{Data, Element};
 use calimero_storage::interface::Interface;
 use calimero_storage_macros::{AtomicUnit, Collection};
 
@@ -11,12 +11,10 @@ struct Child {
 
 #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[children(Child)]
-struct Group {
-    #[child_info]
-    child_info: Vec<ChildInfo>,
-}
+struct Group;
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[root]
 struct Parent {
     group: Group,
 	#[storage]
@@ -26,12 +24,12 @@ struct Parent {
 fn main() {
     fn child_type_specification() {
         let parent: Parent = Parent {
-            group: Group { child_info: vec![] },
+            group: Group {},
             storage: Element::new(&Path::new("::root::node").unwrap()),
         };
-        let _: Vec<Child> = Interface::children_of(&parent.group).unwrap();
+        let _: Vec<Child> = Interface::children_of(parent.id(), &parent.group).unwrap();
 
         // This should fail to compile if the child type is incorrect
-        let _: Vec<Parent> = Interface::children_of(&parent.group).unwrap();
+        let _: Vec<Parent> = Interface::children_of(parent.id(), &parent.group).unwrap();
     }
 }

--- a/crates/storage-macros/tests/compile_fail/collection.stderr
+++ b/crates/storage-macros/tests/compile_fail/collection.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> tests/compile_fail/collection.rs:35:30
+  --> tests/compile_fail/collection.rs:33:30
    |
-35 |         let _: Vec<Parent> = Interface::children_of(&parent.group).unwrap();
-   |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
+33 |         let _: Vec<Parent> = Interface::children_of(parent.id(), &parent.group).unwrap();
+   |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
    |                |
    |                expected due to this
    |

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,6 +12,7 @@ eyre.workspace = true
 fixedstr.workspace = true
 hex.workspace = true
 indexmap.workspace = true
+serde.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -15,6 +15,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::env::generate_uuid;
 use fixedstr::Flexstr;
+use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 use uuid::{Bytes, Uuid};
 
@@ -33,7 +34,7 @@ use uuid::{Bytes, Uuid};
 /// system operation. Abstracting the true type away provides a level of
 /// insulation that is useful for any future changes.
 ///
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Id(Uuid);
 
 impl Id {
@@ -478,7 +479,7 @@ impl BorshDeserialize for Path {
 
 impl BorshSerialize for Path {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), IoError> {
-        self.to_string().serialize(writer)
+        BorshSerialize::serialize(&self.to_string(), writer)
     }
 }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1,0 +1,465 @@
+//! Indexing system for efficient tree navigation.
+
+#[cfg(test)]
+#[path = "tests/index.rs"]
+mod tests;
+
+use std::collections::BTreeMap;
+
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use calimero_sdk::env::{storage_read, storage_remove, storage_write};
+use sha2::{Digest, Sha256};
+
+use crate::address::Id;
+use crate::entities::ChildInfo;
+use crate::interface::StorageError;
+
+/// Stored index information for an entity in the storage system.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct EntityIndex {
+    /// Unique identifier of the entity.
+    id: Id,
+
+    /// Identifier of the parent entity, if any.
+    parent_id: Option<Id>,
+
+    /// Information about the child entities, including their [`Id`]s and Merkle
+    /// hashes, organised by collection name.
+    children: BTreeMap<String, Vec<ChildInfo>>,
+
+    /// Merkle hash of the entity and its descendants.
+    full_hash: [u8; 32],
+
+    /// Merkle hash of the entity's immediate data only. This gets combined with
+    /// the hashes of its children to form the full hash.
+    own_hash: [u8; 32],
+}
+
+/// Manages the indexing system for efficient tree navigation.
+pub(crate) struct Index;
+
+impl Index {
+    /// Adds a child to a collection in the index.
+    ///
+    /// Most entities will get added in this fashion, as nearly all will have
+    /// parents. Only root entities are added without a parent.
+    ///
+    /// # Parameters
+    ///
+    /// * `parent_id`  - The [`Id`] of the parent entity.
+    /// * `collection` - The name of the collection to which the child is to be
+    ///                  added.
+    /// * `child`      - The [`ChildInfo`] of the child entity to be added.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or saving the index information, an error
+    /// will be returned.
+    ///
+    /// # See also
+    ///
+    /// * [`add_root()`](Index::add_root())
+    /// * [`remove_child_from()`](Index::remove_child_from())
+    ///
+    pub(crate) fn add_child_to(
+        parent_id: Id,
+        collection: &str,
+        child: ChildInfo,
+    ) -> Result<(), StorageError> {
+        let mut parent_index =
+            Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+
+        let mut child_index = Self::get_index(child.id())?.unwrap_or_else(|| EntityIndex {
+            id: child.id(),
+            parent_id: None,
+            children: BTreeMap::new(),
+            full_hash: [0; 32],
+            own_hash: [0; 32],
+        });
+        child_index.parent_id = Some(parent_id);
+        child_index.own_hash = child.merkle_hash();
+        Self::save_index(&child_index)?;
+        child_index.full_hash = Self::calculate_full_merkle_hash_for(child.id(), false)?;
+        Self::save_index(&child_index)?;
+
+        parent_index
+            .children
+            .entry(collection.to_owned())
+            .or_insert_with(Vec::new)
+            .push(ChildInfo::new(child.id(), child_index.full_hash));
+        Self::save_index(&parent_index)?;
+        parent_index.full_hash = Self::calculate_full_merkle_hash_for(parent_id, false)?;
+        Self::save_index(&parent_index)?;
+
+        Self::recalculate_ancestor_hashes_for(parent_id)?;
+        Ok(())
+    }
+
+    /// Adds an index for a root entity.
+    ///
+    /// Although entities can be added arbitrarily, adding one without a parent
+    /// makes it a root. Therefore, this is named to make that clear.
+    ///
+    /// # Parameters
+    ///
+    /// * `root` - The [`Id`] and Merkle hash of the entity to be added.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or saving the index information, an error
+    /// will be returned.
+    ///
+    /// # See also
+    ///
+    /// * [`add_child_to()`](Index::add_child_to())
+    ///
+    pub(crate) fn add_root(root: ChildInfo) -> Result<(), StorageError> {
+        let mut index = Self::get_index(root.id())?.unwrap_or_else(|| EntityIndex {
+            id: root.id(),
+            parent_id: None,
+            children: BTreeMap::new(),
+            full_hash: [0; 32],
+            own_hash: [0; 32],
+        });
+        index.own_hash = root.merkle_hash();
+        Self::save_index(&index)?;
+        Ok(())
+    }
+
+    /// Calculates the Merkle hash for the entity.
+    ///
+    /// This calculates the Merkle hash for the entity, which is a cryptographic
+    /// hash of the significant data in the "scope" of the entity, and is used
+    /// to determine whether the data has changed and is valid. It is calculated
+    /// by hashing the substantive data in the entity, along with the hashes of
+    /// the children of the entity, thereby representing the state of the entire
+    /// hierarchy below the entity.
+    ///
+    /// This method is called automatically when the entity is updated, but can
+    /// also be called manually if required.
+    ///
+    /// # Significant data
+    ///
+    /// The data considered "significant" to the state of the entity, and any
+    /// change to which is considered to constitute a change in the state of the
+    /// entity, is:
+    ///
+    ///   - The ID of the entity. This should never change. Arguably, this could
+    ///     be omitted, but at present it means that empty elements are given
+    ///     meaningful hashes.
+    ///   - The primary [`Data`] of the entity. This is the data that the
+    ///     consumer application has stored in the entity, and is the focus of
+    ///     the entity.
+    ///   - The metadata of the entity. This is the system-managed properties
+    ///     that are used to process the entity, but are not part of the primary
+    ///     data. Arguably the Merkle hash could be considered part of the
+    ///     metadata, but it is not included in the [`Data`] struct at present
+    ///     (as it obviously should not contribute to the hash, i.e. itself).
+    ///
+    /// Note that private data is not considered significant, as it is not part
+    /// of the shared state, and therefore does not contribute to the hash.
+    ///
+    /// # Parameters
+    ///
+    /// * `id`          - The unique identifier of the entity for which to
+    ///                   calculate the Merkle hash for.
+    /// * `recalculate` - Whether to recalculate or use the cached value for
+    ///                   child hashes. Under normal circumstances, the cached
+    ///                   value should be used, as it is more efficient. The
+    ///                   option to recalculate is provided for situations when
+    ///                   the entire subtree needs revalidating.
+    ///
+    /// # Errors
+    ///
+    /// If there is a problem in serialising the data, an error will be
+    /// returned.
+    ///
+    pub(crate) fn calculate_full_merkle_hash_for(
+        id: Id,
+        recalculate: bool,
+    ) -> Result<[u8; 32], StorageError> {
+        let own_hash = Self::get_hashes_for(id)?
+            .ok_or(StorageError::IndexNotFound(id))?
+            .1;
+        let mut hasher = Sha256::new();
+        hasher.update(own_hash);
+
+        for collection_name in Self::get_collection_names_for(id)? {
+            for child in Self::get_children_of(id, &collection_name)? {
+                let child_hash = if recalculate {
+                    Self::calculate_full_merkle_hash_for(child.id(), true)?
+                } else {
+                    child.merkle_hash()
+                };
+                hasher.update(child_hash);
+            }
+        }
+
+        Ok(hasher.finalize().into())
+    }
+
+    /// Retrieves the children of a given entity.
+    ///
+    /// # Parameters
+    ///
+    /// * `parent_id`  - The [`Id`] of the entity whose children are to be
+    ///                  retrieved.
+    /// * `collection` - The name of the collection from which to retrieve the
+    ///                  children.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or deserialising the index information,
+    /// an error will be returned.
+    ///
+    pub(crate) fn get_children_of(
+        parent_id: Id,
+        collection: &str,
+    ) -> Result<Vec<ChildInfo>, StorageError> {
+        Ok(Self::get_index(parent_id)?
+            .ok_or(StorageError::IndexNotFound(parent_id))?
+            .children
+            .get(collection)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    /// Retrieves the collection names of a given entity.
+    ///
+    /// # Parameters
+    ///
+    /// * `parent_id`  - The [`Id`] of the entity that owns the collections.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or deserialising the index information,
+    /// an error will be returned.
+    ///
+    pub(crate) fn get_collection_names_for(parent_id: Id) -> Result<Vec<String>, StorageError> {
+        Ok(Self::get_index(parent_id)?
+            .ok_or(StorageError::IndexNotFound(parent_id))?
+            .children
+            .keys()
+            .cloned()
+            .collect())
+    }
+
+    /// Retrieves the Merkel hashes of a given entity.
+    ///
+    /// This function returns a tuple of the "own" hash and the "full" hash of
+    /// the entity. The "own" hash is the hash of the entity's immediate data
+    /// only, while the "full" hash includes the hashes of its descendants.
+    ///
+    /// # Parameters
+    ///
+    /// * `id` - The [`Id`] of the entity whose Merkle hashes are to be
+    ///          retrieved.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or deserialising the index information,
+    /// an error will be returned.
+    ///
+    #[expect(clippy::type_complexity, reason = "Not too complex")]
+    pub(crate) fn get_hashes_for(id: Id) -> Result<Option<([u8; 32], [u8; 32])>, StorageError> {
+        Ok(Self::get_index(id)?.map(|index| (index.full_hash, index.own_hash)))
+    }
+
+    /// Retrieves the index information for an entity.
+    ///
+    /// # Parameters
+    ///
+    /// * `id` - The [`Id`] of the entity whose index information is to be
+    ///          retrieved.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or deserialising the index information,
+    /// an error will be returned.
+    ///
+    fn get_index(id: Id) -> Result<Option<EntityIndex>, StorageError> {
+        let key = format!("index:{id}");
+        match storage_read(key.as_bytes()) {
+            Some(data) => Ok(Some(
+                EntityIndex::try_from_slice(&data).map_err(StorageError::DeserializationError)?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Retrieves the ID of the parent of a given entity.
+    ///
+    /// # Parameters
+    ///
+    /// * `child_id` - The [`Id`] of the entity whose parent is to be retrieved.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or deserialising the index information,
+    /// an error will be returned.
+    ///
+    pub(crate) fn get_parent_id(child_id: Id) -> Result<Option<Id>, StorageError> {
+        Ok(Self::get_index(child_id)?.and_then(|index| index.parent_id))
+    }
+
+    /// Whether the collection has children.
+    ///
+    /// # Parameters
+    ///
+    /// * `parent_id`  - The [`Id`] of the parent entity.
+    /// * `collection` - The name of the collection to which the child is to be
+    ///                  added.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or saving the index information, an error
+    /// will be returned.
+    ///
+    pub(crate) fn has_children(parent_id: Id, collection: &str) -> Result<bool, StorageError> {
+        let parent_index =
+            Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+
+        Ok(parent_index
+            .children
+            .get(collection)
+            .map_or(false, |children| !children.is_empty()))
+    }
+
+    /// Recalculates the Merkle hashes of the ancestors of the entity.
+    ///
+    /// This function recalculates the Merkle hashes of the ancestors of the
+    /// entity with the specified ID. This is done by recalculating the Merkle
+    /// hash of the entity's parent, plus its children, and then repeating this
+    /// recursively up the hierarchy.
+    ///
+    /// # Parameters
+    ///
+    /// * `id` - The ID of the entity whose ancestors' hashes should be updated.
+    ///
+    pub(crate) fn recalculate_ancestor_hashes_for(id: Id) -> Result<(), StorageError> {
+        let mut current_id = id;
+
+        while let Some(parent_id) = Self::get_parent_id(current_id)? {
+            let mut parent_index =
+                Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+
+            // Update the child's hash in the parent's children list
+            for children in &mut parent_index.children.values_mut() {
+                if let Some(child) = children.iter_mut().find(|c| c.id() == current_id) {
+                    let new_child_hash = Self::calculate_full_merkle_hash_for(current_id, false)?;
+                    if child.merkle_hash() != new_child_hash {
+                        *child = ChildInfo::new(current_id, new_child_hash);
+                    }
+                    break;
+                }
+            }
+
+            // Recalculate the parent's full hash
+            Self::save_index(&parent_index)?;
+            let new_parent_hash = Self::calculate_full_merkle_hash_for(parent_id, false)?;
+            parent_index.full_hash = new_parent_hash;
+            Self::save_index(&parent_index)?;
+            current_id = parent_id;
+        }
+
+        Ok(())
+    }
+
+    /// Removes a child from a collection in the index.
+    ///
+    /// Note that removing a child from the index also deletes the child. To
+    /// move a child to a different parent, just add it to the new parent.
+    ///
+    /// # Parameters
+    ///
+    /// * `parent_id`  - The [`Id`] of the parent entity.
+    /// * `collection` - The name of the collection from which the child is to
+    ///                  be removed.
+    /// * `child_id`   - The [`Id`] of the child entity to be removed.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue retrieving or saving the index information, an error
+    /// will be returned.
+    ///
+    /// # See also
+    ///
+    /// * [`add_child_to()`](Index::add_child_to())
+    ///
+    pub(crate) fn remove_child_from(
+        parent_id: Id,
+        collection: &str,
+        child_id: Id,
+    ) -> Result<(), StorageError> {
+        let mut parent_index =
+            Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+
+        if let Some(children) = parent_index.children.get_mut(collection) {
+            children.retain(|child| child.id() != child_id);
+        }
+
+        Self::save_index(&parent_index)?;
+        parent_index.full_hash = Self::calculate_full_merkle_hash_for(parent_id, false)?;
+        Self::save_index(&parent_index)?;
+
+        Self::remove_index(child_id);
+
+        Self::recalculate_ancestor_hashes_for(parent_id)?;
+        Ok(())
+    }
+
+    /// Removes the index information for an entity.
+    ///
+    /// # Parameters
+    ///
+    /// * `index` - The [`EntityIndex`] to be saved.
+    ///
+    fn remove_index(id: Id) {
+        let key = format!("index:{id}");
+        _ = storage_remove(key.as_bytes());
+    }
+
+    /// Saves the index information for an entity.
+    ///
+    /// # Parameters
+    ///
+    /// * `index` - The [`EntityIndex`] to be saved.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue with serialisation, an error will be returned.
+    ///
+    fn save_index(index: &EntityIndex) -> Result<(), StorageError> {
+        let key = format!("index:{}", index.id);
+        _ = storage_write(
+            key.as_bytes(),
+            &to_vec(index).map_err(StorageError::SerializationError)?,
+        );
+        Ok(())
+    }
+
+    /// Updates the Merkle hash for an indexed entity.
+    ///
+    /// This accepts the Merkle hash for the entity's "own" hash only, i.e. not
+    /// including descendants. The "full" hash including those descendants is
+    /// then calculated and returned.
+    ///
+    /// # Parameters
+    ///
+    /// * `id`          - The [`Id`] of the entity being updated.
+    /// * `merkle_hash` - The new Merkle hash for the entity.
+    ///
+    /// # Errors
+    ///
+    /// If there's an issue updating or saving the index, an error will be
+    /// returned.
+    ///
+    pub(crate) fn update_hash_for(id: Id, merkle_hash: [u8; 32]) -> Result<[u8; 32], StorageError> {
+        let mut index = Self::get_index(id)?.ok_or(StorageError::IndexNotFound(id))?;
+        index.own_hash = merkle_hash;
+        Self::save_index(&index)?;
+        index.full_hash = Self::calculate_full_merkle_hash_for(id, false)?;
+        Self::save_index(&index)?;
+        Ok(index.full_hash)
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -71,6 +71,10 @@ pub mod exports {
     pub use sha2::{Digest, Sha256};
 }
 
+#[cfg(test)]
+#[path = "tests/mocks.rs"]
+mod mocks;
+
 /// Shared test functionality.
 #[cfg(test)]
 pub mod tests {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -63,6 +63,7 @@
 
 pub mod address;
 pub mod entities;
+pub mod index;
 pub mod interface;
 
 /// Re-exported types, mostly for use in macros (for convenience).

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -7,7 +7,7 @@ use velcro::btree_map;
 
 use super::*;
 use crate::index::Index;
-use crate::interface::Interface;
+use crate::interface::{Interface, MainStorage};
 use crate::tests::common::{Page, Paragraph, Paragraphs, Person};
 
 #[cfg(test)]
@@ -306,7 +306,8 @@ mod element__public_methods {
         assert_eq!(person.element().merkle_hash(), [0_u8; 32]);
 
         assert!(Interface::save(&mut person).unwrap());
-        let expected_hash = Index::calculate_full_merkle_hash_for(person.id(), false).unwrap();
+        let expected_hash =
+            <Index<MainStorage>>::calculate_full_merkle_hash_for(person.id(), false).unwrap();
         assert_eq!(person.element().merkle_hash(), expected_hash);
     }
 

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1,0 +1,568 @@
+use super::*;
+use crate::tests::common::TEST_ID;
+
+mod index__public_methods {
+    use super::*;
+
+    #[test]
+    fn add_child_to() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.id, root_id);
+        assert_eq!(root_index.own_hash, root_hash);
+        assert!(root_index.parent_id.is_none());
+        assert!(root_index.children.is_empty());
+
+        let collection_name = "Books";
+        let child_id = Id::new();
+        let child_own_hash = [2_u8; 32];
+        let child_full_hash: [u8; 32] =
+            hex::decode("75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection_name,
+            ChildInfo::new(child_id, child_own_hash)
+        )
+        .is_ok());
+
+        let updated_root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(updated_root_index.id, root_id);
+        assert_eq!(updated_root_index.own_hash, root_hash);
+        assert!(updated_root_index.parent_id.is_none());
+        assert_eq!(updated_root_index.children.len(), 1);
+        assert_eq!(
+            updated_root_index.children[collection_name][0],
+            ChildInfo::new(child_id, child_full_hash)
+        );
+
+        let child_index = Index::get_index(child_id).unwrap().unwrap();
+        assert_eq!(child_index.id, child_id);
+        assert_eq!(child_index.own_hash, child_own_hash);
+        assert_eq!(child_index.parent_id, Some(root_id));
+        assert!(child_index.children.is_empty());
+    }
+
+    #[test]
+    fn add_root() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.id, root_id);
+        assert_eq!(root_index.own_hash, root_hash);
+        assert!(root_index.parent_id.is_none());
+        assert!(root_index.children.is_empty());
+    }
+
+    #[test]
+    fn get_children_of__single_collection() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let collection_name = "Books";
+        let child1_id = Id::new();
+        let child1_own_hash = [2_u8; 32];
+        let child1_full_hash: [u8; 32] =
+            hex::decode("75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        let child2_id = Id::new();
+        let child2_own_hash = [3_u8; 32];
+        let child2_full_hash: [u8; 32] =
+            hex::decode("648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection_name,
+            ChildInfo::new(child1_id, child1_own_hash)
+        )
+        .is_ok());
+        assert!(Index::add_child_to(
+            root_id,
+            collection_name,
+            ChildInfo::new(child2_id, child2_own_hash)
+        )
+        .is_ok());
+
+        let children = Index::get_children_of(root_id, collection_name).unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0], ChildInfo::new(child1_id, child1_full_hash));
+        assert_eq!(children[1], ChildInfo::new(child2_id, child2_full_hash));
+    }
+
+    #[test]
+    fn get_children_of__two_collections() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let collection1_name = "Pages";
+        let child1_id = Id::new();
+        let child1_own_hash = [2_u8; 32];
+        let child1_full_hash: [u8; 32] =
+            hex::decode("75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let child2_id = Id::new();
+        let child2_own_hash = [3_u8; 32];
+        let child2_full_hash: [u8; 32] =
+            hex::decode("648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        let collection2_name = "Reviews";
+        let child3_id = Id::new();
+        let child3_own_hash = [4_u8; 32];
+        let child3_full_hash: [u8; 32] =
+            hex::decode("9f4fb68f3e1dac82202f9aa581ce0bbf1f765df0e9ac3c8c57e20f685abab8ed")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection1_name,
+            ChildInfo::new(child1_id, child1_own_hash)
+        )
+        .is_ok());
+        assert!(Index::add_child_to(
+            root_id,
+            collection1_name,
+            ChildInfo::new(child2_id, child2_own_hash)
+        )
+        .is_ok());
+        assert!(Index::add_child_to(
+            root_id,
+            collection2_name,
+            ChildInfo::new(child3_id, child3_own_hash)
+        )
+        .is_ok());
+
+        let children1 = Index::get_children_of(root_id, collection1_name).unwrap();
+        assert_eq!(children1.len(), 2);
+        assert_eq!(children1[0], ChildInfo::new(child1_id, child1_full_hash));
+        assert_eq!(children1[1], ChildInfo::new(child2_id, child2_full_hash));
+        let children2 = Index::get_children_of(root_id, collection2_name).unwrap();
+        assert_eq!(children2.len(), 1);
+        assert_eq!(children2[0], ChildInfo::new(child3_id, child3_full_hash));
+    }
+
+    #[test]
+    fn get_collection_names_for() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let collection1_name = "Pages";
+        let collection2_name = "Chapters";
+        let mut collection_names = vec![collection1_name.to_owned(), collection2_name.to_owned()];
+        collection_names.sort();
+        let child1_id = Id::new();
+        let child1_own_hash = [2_u8; 32];
+        let child2_id = Id::new();
+        let child2_own_hash = [3_u8; 32];
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection1_name,
+            ChildInfo::new(child1_id, child1_own_hash)
+        )
+        .is_ok());
+        assert!(Index::add_child_to(
+            root_id,
+            collection2_name,
+            ChildInfo::new(child2_id, child2_own_hash)
+        )
+        .is_ok());
+
+        assert_eq!(
+            Index::get_collection_names_for(root_id).unwrap(),
+            collection_names
+        );
+    }
+
+    #[test]
+    fn get_hashes_for() {
+        let root_id = TEST_ID[0];
+        let root_own_hash = [1_u8; 32];
+        let root_full_hash = [0_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_own_hash)).is_ok());
+
+        assert_eq!(
+            Index::get_hashes_for(root_id).unwrap().unwrap(),
+            (root_full_hash, root_own_hash)
+        );
+    }
+
+    #[test]
+    fn get_parent_id() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.id, root_id);
+        assert_eq!(root_index.own_hash, root_hash);
+        assert!(root_index.parent_id.is_none());
+        assert!(root_index.children.is_empty());
+
+        let collection_name = "Books";
+        let child_id = Id::new();
+        let child_own_hash = [2_u8; 32];
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection_name,
+            ChildInfo::new(child_id, child_own_hash)
+        )
+        .is_ok());
+
+        assert_eq!(Index::get_parent_id(child_id).unwrap(), Some(root_id));
+        assert_eq!(Index::get_parent_id(root_id).unwrap(), None);
+    }
+
+    #[test]
+    fn has_children() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+        let collection_name = "Books";
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(!Index::has_children(root_id, collection_name).unwrap());
+
+        let child_id = Id::new();
+        let child_own_hash = [2_u8; 32];
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection_name,
+            ChildInfo::new(child_id, child_own_hash)
+        )
+        .is_ok());
+        assert!(Index::has_children(root_id, collection_name).unwrap());
+    }
+
+    #[test]
+    fn remove_child_from() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.id, root_id);
+        assert_eq!(root_index.own_hash, root_hash);
+        assert!(root_index.parent_id.is_none());
+        assert!(root_index.children.is_empty());
+
+        let collection_name = "Books";
+        let child_id = Id::new();
+        let child_own_hash = [2_u8; 32];
+
+        assert!(Index::add_child_to(
+            root_id,
+            collection_name,
+            ChildInfo::new(child_id, child_own_hash)
+        )
+        .is_ok());
+        assert!(Index::remove_child_from(root_id, collection_name, child_id).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert!(root_index.children[collection_name].is_empty());
+        assert!(Index::get_index(child_id).unwrap().is_none());
+    }
+}
+
+mod index__private_methods {
+    use super::*;
+
+    #[test]
+    fn get_and_save_index() {
+        let id = Id::new();
+        let hash1 = [1_u8; 32];
+        let hash2 = [2_u8; 32];
+        assert!(Index::get_index(id).unwrap().is_none());
+
+        let index = EntityIndex {
+            id,
+            parent_id: None,
+            children: BTreeMap::new(),
+            full_hash: hash1,
+            own_hash: hash2,
+        };
+        Index::save_index(&index).unwrap();
+
+        assert_eq!(Index::get_index(id).unwrap().unwrap(), index);
+    }
+
+    #[test]
+    fn save_and_remove_index() {
+        let id = Id::new();
+        let hash1 = [1_u8; 32];
+        let hash2 = [2_u8; 32];
+        assert!(Index::get_index(id).unwrap().is_none());
+
+        let index = EntityIndex {
+            id,
+            parent_id: None,
+            children: BTreeMap::new(),
+            full_hash: hash1,
+            own_hash: hash2,
+        };
+        Index::save_index(&index).unwrap();
+        assert_eq!(Index::get_index(id).unwrap().unwrap(), index);
+
+        Index::remove_index(id);
+        assert!(Index::get_index(id).unwrap().is_none());
+    }
+}
+
+#[cfg(test)]
+mod hashing {
+    use super::*;
+
+    #[test]
+    fn calculate_full_merkle_hash_for__with_children() {
+        let root_id = TEST_ID[0];
+        assert!(Index::add_root(ChildInfo::new(TEST_ID[0], [0_u8; 32])).is_ok());
+
+        let collection_name = "Children";
+        let child1_id = TEST_ID[1];
+        let child1_hash = [1_u8; 32];
+        let child1_info = ChildInfo::new(child1_id, child1_hash);
+        assert!(Index::add_child_to(root_id, collection_name, child1_info).is_ok());
+        let child2_id = TEST_ID[2];
+        let child2_hash = [2_u8; 32];
+        let child2_info = ChildInfo::new(child2_id, child2_hash);
+        assert!(Index::add_child_to(root_id, collection_name, child2_info).is_ok());
+        let child3_id = TEST_ID[3];
+        let child3_hash = [3_u8; 32];
+        let child3_info = ChildInfo::new(child3_id, child3_hash);
+        assert!(Index::add_child_to(root_id, collection_name, child3_info).is_ok());
+
+        assert_eq!(
+            hex::encode(Index::calculate_full_merkle_hash_for(child1_id, false).unwrap()),
+            "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
+        );
+        assert_eq!(
+            hex::encode(Index::calculate_full_merkle_hash_for(child2_id, false).unwrap()),
+            "75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a",
+        );
+        assert_eq!(
+            hex::encode(Index::calculate_full_merkle_hash_for(child3_id, false).unwrap()),
+            "648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b",
+        );
+        assert_eq!(
+            hex::encode(Index::calculate_full_merkle_hash_for(root_id, false).unwrap()),
+            "866edea6f7ce51612ad0ea3bcde93b2494d77e8c466bc2a69817a6443f2a57f0",
+        );
+    }
+
+    #[test]
+    fn recalculate_ancestor_hashes_for() {
+        let root_id = Id::new();
+        let root_hash = [1_u8; 32];
+        let child_collection_name = "Books";
+        let grandchild_collection_name = "Pages";
+        let greatgrandchild_collection_name = "Paragraphs";
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.full_hash, [0_u8; 32]);
+
+        let child_id = Id::new();
+        let child_hash = [2_u8; 32];
+        let child_info = ChildInfo::new(child_id, child_hash);
+        assert!(Index::add_child_to(root_id, child_collection_name, child_info).is_ok());
+
+        let root_index_with_child = Index::get_index(root_id).unwrap().unwrap();
+        let child_index = Index::get_index(child_id).unwrap().unwrap();
+        assert_eq!(
+            hex::encode(root_index_with_child.full_hash),
+            "3f18867aec61c1c3cd3ca1b8a0ff42612a8dd0ad83f3e59055e3b9ba737e31d9"
+        );
+        assert_eq!(
+            hex::encode(child_index.full_hash),
+            "75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a"
+        );
+
+        let grandchild_id = Id::new();
+        let grandchild_hash = [3_u8; 32];
+        let grandchild_info = ChildInfo::new(grandchild_id, grandchild_hash);
+        assert!(Index::add_child_to(child_id, grandchild_collection_name, grandchild_info).is_ok());
+
+        let root_index_with_grandchild = Index::get_index(root_id).unwrap().unwrap();
+        let child_index_with_grandchild = Index::get_index(child_id).unwrap().unwrap();
+        let grandchild_index = Index::get_index(grandchild_id).unwrap().unwrap();
+        assert_eq!(
+            hex::encode(root_index_with_grandchild.full_hash),
+            "2504baa308dcb51f7046815258e36cd4a83d34c6b1d5f1cc1b8ffa321e40f0c6"
+        );
+        assert_eq!(
+            hex::encode(child_index_with_grandchild.full_hash),
+            "80c2b6364721221e7f87028c0482e1e16f49a29889e357c8acab8cb26d4d99da"
+        );
+        assert_eq!(
+            hex::encode(grandchild_index.full_hash),
+            "648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b"
+        );
+
+        let greatgrandchild_id = Id::new();
+        let greatgrandchild_hash = [4_u8; 32];
+        let greatgrandchild_info = ChildInfo::new(greatgrandchild_id, greatgrandchild_hash);
+        assert!(Index::add_child_to(
+            grandchild_id,
+            greatgrandchild_collection_name,
+            greatgrandchild_info
+        )
+        .is_ok());
+
+        let root_index_with_greatgrandchild = Index::get_index(root_id).unwrap().unwrap();
+        let child_index_with_greatgrandchild = Index::get_index(child_id).unwrap().unwrap();
+        let grandchild_index_with_greatgrandchild =
+            Index::get_index(grandchild_id).unwrap().unwrap();
+        let mut greatgrandchild_index = Index::get_index(greatgrandchild_id).unwrap().unwrap();
+        assert_eq!(
+            hex::encode(root_index_with_greatgrandchild.full_hash),
+            "6bdcb2f1a98eba952d3b2cf43c8bb36eb6a50b853d5b49dea089775e17d67b27"
+        );
+        assert_eq!(
+            hex::encode(child_index_with_greatgrandchild.full_hash),
+            "8aca1399f292c2ed8dfaba100a7885c7ac108b7b6b32f10d4a3e9c05fd7c38c0"
+        );
+        assert_eq!(
+            hex::encode(grandchild_index_with_greatgrandchild.full_hash),
+            "135605b30fda6d313c472745c4445edb4e8c619cdcc24caa2352c12aacd18a76"
+        );
+        assert_eq!(
+            hex::encode(greatgrandchild_index.full_hash),
+            "9f4fb68f3e1dac82202f9aa581ce0bbf1f765df0e9ac3c8c57e20f685abab8ed"
+        );
+
+        greatgrandchild_index.own_hash = [9_u8; 32];
+        Index::save_index(&greatgrandchild_index).unwrap();
+        greatgrandchild_index.full_hash =
+            Index::calculate_full_merkle_hash_for(greatgrandchild_id, false).unwrap();
+        Index::save_index(&greatgrandchild_index).unwrap();
+
+        Index::recalculate_ancestor_hashes_for(greatgrandchild_id).unwrap();
+
+        let updated_root_index_with_greatgrandchild = Index::get_index(root_id).unwrap().unwrap();
+        let updated_child_index_with_greatgrandchild = Index::get_index(child_id).unwrap().unwrap();
+        let updated_grandchild_index_with_greatgrandchild =
+            Index::get_index(grandchild_id).unwrap().unwrap();
+        let updated_greatgrandchild_index = Index::get_index(greatgrandchild_id).unwrap().unwrap();
+        assert_eq!(
+            hex::encode(updated_root_index_with_greatgrandchild.full_hash),
+            "f61c8077c7875e38a3cbdce3b3d4ce40a5a18add8ce386803760484772bcb85b"
+        );
+        assert_eq!(
+            hex::encode(updated_child_index_with_greatgrandchild.full_hash),
+            "abef09c52909317783e0c582553a8fb19124249d93f8878cf131b8dd28fbb4bf"
+        );
+        assert_eq!(
+            hex::encode(updated_grandchild_index_with_greatgrandchild.full_hash),
+            "97b2d3a1682881ec11e747f3dd4c242a33f8cff6c6d6224e1dd23278eef35554"
+        );
+        assert_eq!(
+            hex::encode(updated_greatgrandchild_index.full_hash),
+            "8c0cc17a04942cc4f8e0fe0b302606d3108860c126428ba2ceeb5f9ed41c2b05"
+        );
+
+        greatgrandchild_index.own_hash = [99_u8; 32];
+        Index::save_index(&greatgrandchild_index).unwrap();
+        greatgrandchild_index.full_hash =
+            Index::calculate_full_merkle_hash_for(greatgrandchild_id, false).unwrap();
+        Index::save_index(&greatgrandchild_index).unwrap();
+
+        Index::recalculate_ancestor_hashes_for(greatgrandchild_id).unwrap();
+
+        let updated_root_index_with_greatgrandchild = Index::get_index(root_id).unwrap().unwrap();
+        let updated_child_index_with_greatgrandchild = Index::get_index(child_id).unwrap().unwrap();
+        let updated_grandchild_index_with_greatgrandchild =
+            Index::get_index(grandchild_id).unwrap().unwrap();
+        let updated_greatgrandchild_index = Index::get_index(greatgrandchild_id).unwrap().unwrap();
+        assert_eq!(
+            hex::encode(updated_root_index_with_greatgrandchild.full_hash),
+            "0483e0a8a3c3002a94c3ce2e1f7fcadae4b2dc29e2dee9752b9caa683dfe39fc"
+        );
+        assert_eq!(
+            hex::encode(updated_child_index_with_greatgrandchild.full_hash),
+            "a7bad731e6767c36725a7c592174fdfe799c6bc32e92cc0f455e6ec5f6e5d42b"
+        );
+        assert_eq!(
+            hex::encode(updated_grandchild_index_with_greatgrandchild.full_hash),
+            "67eb9aff17a7db347e4c56264042dcfb1f4e465f70abb56a2108571316435ea5"
+        );
+        assert_eq!(
+            hex::encode(updated_greatgrandchild_index.full_hash),
+            "cd93782b7fb95559de14f738b65988af85d41dc1565f7c7d1ed2d035665b519c"
+        );
+    }
+
+    #[test]
+    fn update_hash_for__full() {
+        let root_id = Id::new();
+        let root_hash0 = [0_u8; 32];
+        let root_hash1 = [1_u8; 32];
+        let root_hash2 = [2_u8; 32];
+        let root_full_hash: [u8; 32] =
+            hex::decode("75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.id, root_id);
+        assert_eq!(root_index.full_hash, root_hash0);
+
+        assert!(Index::update_hash_for(root_id, root_hash2).is_ok());
+        let updated_root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(updated_root_index.id, root_id);
+        assert_eq!(updated_root_index.full_hash, root_full_hash);
+    }
+
+    #[test]
+    fn update_hash_for__own() {
+        let root_id = Id::new();
+        let root_hash1 = [1_u8; 32];
+        let root_hash2 = [2_u8; 32];
+
+        assert!(Index::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
+
+        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(root_index.id, root_id);
+        assert_eq!(root_index.own_hash, root_hash1);
+
+        assert!(Index::update_hash_for(root_id, root_hash2).is_ok());
+        let updated_root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert_eq!(updated_root_index.id, root_id);
+        assert_eq!(updated_root_index.own_hash, root_hash2);
+    }
+}

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::interface::MainStorage;
 use crate::tests::common::TEST_ID;
 
 mod index__public_methods {
@@ -9,9 +10,9 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
@@ -26,14 +27,14 @@ mod index__public_methods {
                 .try_into()
                 .unwrap();
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
             ChildInfo::new(child_id, child_own_hash)
         )
         .is_ok());
 
-        let updated_root_index = Index::get_index(root_id).unwrap().unwrap();
+        let updated_root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(updated_root_index.id, root_id);
         assert_eq!(updated_root_index.own_hash, root_hash);
         assert!(updated_root_index.parent_id.is_none());
@@ -43,7 +44,7 @@ mod index__public_methods {
             ChildInfo::new(child_id, child_full_hash)
         );
 
-        let child_index = Index::get_index(child_id).unwrap().unwrap();
+        let child_index = <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
         assert_eq!(child_index.id, child_id);
         assert_eq!(child_index.own_hash, child_own_hash);
         assert_eq!(child_index.parent_id, Some(root_id));
@@ -55,9 +56,9 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
@@ -69,7 +70,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
         let collection_name = "Books";
         let child1_id = Id::new();
@@ -88,20 +89,20 @@ mod index__public_methods {
                 .try_into()
                 .unwrap();
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
             ChildInfo::new(child1_id, child1_own_hash)
         )
         .is_ok());
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
             ChildInfo::new(child2_id, child2_own_hash)
         )
         .is_ok());
 
-        let children = Index::get_children_of(root_id, collection_name).unwrap();
+        let children = <Index<MainStorage>>::get_children_of(root_id, collection_name).unwrap();
         assert_eq!(children.len(), 2);
         assert_eq!(children[0], ChildInfo::new(child1_id, child1_full_hash));
         assert_eq!(children[1], ChildInfo::new(child2_id, child2_full_hash));
@@ -112,7 +113,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
         let collection1_name = "Pages";
         let child1_id = Id::new();
@@ -139,30 +140,30 @@ mod index__public_methods {
                 .try_into()
                 .unwrap();
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
             ChildInfo::new(child1_id, child1_own_hash)
         )
         .is_ok());
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
             ChildInfo::new(child2_id, child2_own_hash)
         )
         .is_ok());
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection2_name,
             ChildInfo::new(child3_id, child3_own_hash)
         )
         .is_ok());
 
-        let children1 = Index::get_children_of(root_id, collection1_name).unwrap();
+        let children1 = <Index<MainStorage>>::get_children_of(root_id, collection1_name).unwrap();
         assert_eq!(children1.len(), 2);
         assert_eq!(children1[0], ChildInfo::new(child1_id, child1_full_hash));
         assert_eq!(children1[1], ChildInfo::new(child2_id, child2_full_hash));
-        let children2 = Index::get_children_of(root_id, collection2_name).unwrap();
+        let children2 = <Index<MainStorage>>::get_children_of(root_id, collection2_name).unwrap();
         assert_eq!(children2.len(), 1);
         assert_eq!(children2[0], ChildInfo::new(child3_id, child3_full_hash));
     }
@@ -172,7 +173,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
         let collection1_name = "Pages";
         let collection2_name = "Chapters";
@@ -183,13 +184,13 @@ mod index__public_methods {
         let child2_id = Id::new();
         let child2_own_hash = [3_u8; 32];
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
             ChildInfo::new(child1_id, child1_own_hash)
         )
         .is_ok());
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection2_name,
             ChildInfo::new(child2_id, child2_own_hash)
@@ -197,7 +198,7 @@ mod index__public_methods {
         .is_ok());
 
         assert_eq!(
-            Index::get_collection_names_for(root_id).unwrap(),
+            <Index<MainStorage>>::get_collection_names_for(root_id).unwrap(),
             collection_names
         );
     }
@@ -208,10 +209,12 @@ mod index__public_methods {
         let root_own_hash = [1_u8; 32];
         let root_full_hash = [0_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_own_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_own_hash)).is_ok());
 
         assert_eq!(
-            Index::get_hashes_for(root_id).unwrap().unwrap(),
+            <Index<MainStorage>>::get_hashes_for(root_id)
+                .unwrap()
+                .unwrap(),
             (root_full_hash, root_own_hash)
         );
     }
@@ -221,9 +224,9 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
@@ -233,15 +236,18 @@ mod index__public_methods {
         let child_id = Id::new();
         let child_own_hash = [2_u8; 32];
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
             ChildInfo::new(child_id, child_own_hash)
         )
         .is_ok());
 
-        assert_eq!(Index::get_parent_id(child_id).unwrap(), Some(root_id));
-        assert_eq!(Index::get_parent_id(root_id).unwrap(), None);
+        assert_eq!(
+            <Index<MainStorage>>::get_parent_id(child_id).unwrap(),
+            Some(root_id)
+        );
+        assert_eq!(<Index<MainStorage>>::get_parent_id(root_id).unwrap(), None);
     }
 
     #[test]
@@ -250,19 +256,19 @@ mod index__public_methods {
         let root_hash = [1_u8; 32];
         let collection_name = "Books";
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
-        assert!(!Index::has_children(root_id, collection_name).unwrap());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(!<Index<MainStorage>>::has_children(root_id, collection_name).unwrap());
 
         let child_id = Id::new();
         let child_own_hash = [2_u8; 32];
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
             ChildInfo::new(child_id, child_own_hash)
         )
         .is_ok());
-        assert!(Index::has_children(root_id, collection_name).unwrap());
+        assert!(<Index<MainStorage>>::has_children(root_id, collection_name).unwrap());
     }
 
     #[test]
@@ -270,9 +276,9 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
@@ -282,17 +288,19 @@ mod index__public_methods {
         let child_id = Id::new();
         let child_own_hash = [2_u8; 32];
 
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
             ChildInfo::new(child_id, child_own_hash)
         )
         .is_ok());
-        assert!(Index::remove_child_from(root_id, collection_name, child_id).is_ok());
+        assert!(
+            <Index<MainStorage>>::remove_child_from(root_id, collection_name, child_id).is_ok()
+        );
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert!(root_index.children[collection_name].is_empty());
-        assert!(Index::get_index(child_id).unwrap().is_none());
+        assert!(<Index<MainStorage>>::get_index(child_id).unwrap().is_none());
     }
 }
 
@@ -304,7 +312,7 @@ mod index__private_methods {
         let id = Id::new();
         let hash1 = [1_u8; 32];
         let hash2 = [2_u8; 32];
-        assert!(Index::get_index(id).unwrap().is_none());
+        assert!(<Index<MainStorage>>::get_index(id).unwrap().is_none());
 
         let index = EntityIndex {
             id,
@@ -313,9 +321,9 @@ mod index__private_methods {
             full_hash: hash1,
             own_hash: hash2,
         };
-        Index::save_index(&index).unwrap();
+        <Index<MainStorage>>::save_index(&index).unwrap();
 
-        assert_eq!(Index::get_index(id).unwrap().unwrap(), index);
+        assert_eq!(<Index<MainStorage>>::get_index(id).unwrap().unwrap(), index);
     }
 
     #[test]
@@ -323,7 +331,7 @@ mod index__private_methods {
         let id = Id::new();
         let hash1 = [1_u8; 32];
         let hash2 = [2_u8; 32];
-        assert!(Index::get_index(id).unwrap().is_none());
+        assert!(<Index<MainStorage>>::get_index(id).unwrap().is_none());
 
         let index = EntityIndex {
             id,
@@ -332,11 +340,11 @@ mod index__private_methods {
             full_hash: hash1,
             own_hash: hash2,
         };
-        Index::save_index(&index).unwrap();
-        assert_eq!(Index::get_index(id).unwrap().unwrap(), index);
+        <Index<MainStorage>>::save_index(&index).unwrap();
+        assert_eq!(<Index<MainStorage>>::get_index(id).unwrap().unwrap(), index);
 
-        Index::remove_index(id);
-        assert!(Index::get_index(id).unwrap().is_none());
+        <Index<MainStorage>>::remove_index(id);
+        assert!(<Index<MainStorage>>::get_index(id).unwrap().is_none());
     }
 }
 
@@ -347,36 +355,44 @@ mod hashing {
     #[test]
     fn calculate_full_merkle_hash_for__with_children() {
         let root_id = TEST_ID[0];
-        assert!(Index::add_root(ChildInfo::new(TEST_ID[0], [0_u8; 32])).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(TEST_ID[0], [0_u8; 32])).is_ok());
 
         let collection_name = "Children";
         let child1_id = TEST_ID[1];
         let child1_hash = [1_u8; 32];
         let child1_info = ChildInfo::new(child1_id, child1_hash);
-        assert!(Index::add_child_to(root_id, collection_name, child1_info).is_ok());
+        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child1_info).is_ok());
         let child2_id = TEST_ID[2];
         let child2_hash = [2_u8; 32];
         let child2_info = ChildInfo::new(child2_id, child2_hash);
-        assert!(Index::add_child_to(root_id, collection_name, child2_info).is_ok());
+        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child2_info).is_ok());
         let child3_id = TEST_ID[3];
         let child3_hash = [3_u8; 32];
         let child3_info = ChildInfo::new(child3_id, child3_hash);
-        assert!(Index::add_child_to(root_id, collection_name, child3_info).is_ok());
+        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child3_info).is_ok());
 
         assert_eq!(
-            hex::encode(Index::calculate_full_merkle_hash_for(child1_id, false).unwrap()),
+            hex::encode(
+                <Index<MainStorage>>::calculate_full_merkle_hash_for(child1_id, false).unwrap()
+            ),
             "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793",
         );
         assert_eq!(
-            hex::encode(Index::calculate_full_merkle_hash_for(child2_id, false).unwrap()),
+            hex::encode(
+                <Index<MainStorage>>::calculate_full_merkle_hash_for(child2_id, false).unwrap()
+            ),
             "75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a",
         );
         assert_eq!(
-            hex::encode(Index::calculate_full_merkle_hash_for(child3_id, false).unwrap()),
+            hex::encode(
+                <Index<MainStorage>>::calculate_full_merkle_hash_for(child3_id, false).unwrap()
+            ),
             "648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b",
         );
         assert_eq!(
-            hex::encode(Index::calculate_full_merkle_hash_for(root_id, false).unwrap()),
+            hex::encode(
+                <Index<MainStorage>>::calculate_full_merkle_hash_for(root_id, false).unwrap()
+            ),
             "866edea6f7ce51612ad0ea3bcde93b2494d77e8c466bc2a69817a6443f2a57f0",
         );
     }
@@ -389,18 +405,20 @@ mod hashing {
         let grandchild_collection_name = "Pages";
         let greatgrandchild_collection_name = "Paragraphs";
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.full_hash, [0_u8; 32]);
 
         let child_id = Id::new();
         let child_hash = [2_u8; 32];
         let child_info = ChildInfo::new(child_id, child_hash);
-        assert!(Index::add_child_to(root_id, child_collection_name, child_info).is_ok());
+        assert!(
+            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info).is_ok()
+        );
 
-        let root_index_with_child = Index::get_index(root_id).unwrap().unwrap();
-        let child_index = Index::get_index(child_id).unwrap().unwrap();
+        let root_index_with_child = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
+        let child_index = <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
         assert_eq!(
             hex::encode(root_index_with_child.full_hash),
             "3f18867aec61c1c3cd3ca1b8a0ff42612a8dd0ad83f3e59055e3b9ba737e31d9"
@@ -413,11 +431,19 @@ mod hashing {
         let grandchild_id = Id::new();
         let grandchild_hash = [3_u8; 32];
         let grandchild_info = ChildInfo::new(grandchild_id, grandchild_hash);
-        assert!(Index::add_child_to(child_id, grandchild_collection_name, grandchild_info).is_ok());
+        assert!(<Index<MainStorage>>::add_child_to(
+            child_id,
+            grandchild_collection_name,
+            grandchild_info
+        )
+        .is_ok());
 
-        let root_index_with_grandchild = Index::get_index(root_id).unwrap().unwrap();
-        let child_index_with_grandchild = Index::get_index(child_id).unwrap().unwrap();
-        let grandchild_index = Index::get_index(grandchild_id).unwrap().unwrap();
+        let root_index_with_grandchild = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
+        let child_index_with_grandchild =
+            <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
+        let grandchild_index = <Index<MainStorage>>::get_index(grandchild_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             hex::encode(root_index_with_grandchild.full_hash),
             "2504baa308dcb51f7046815258e36cd4a83d34c6b1d5f1cc1b8ffa321e40f0c6"
@@ -434,18 +460,23 @@ mod hashing {
         let greatgrandchild_id = Id::new();
         let greatgrandchild_hash = [4_u8; 32];
         let greatgrandchild_info = ChildInfo::new(greatgrandchild_id, greatgrandchild_hash);
-        assert!(Index::add_child_to(
+        assert!(<Index<MainStorage>>::add_child_to(
             grandchild_id,
             greatgrandchild_collection_name,
             greatgrandchild_info
         )
         .is_ok());
 
-        let root_index_with_greatgrandchild = Index::get_index(root_id).unwrap().unwrap();
-        let child_index_with_greatgrandchild = Index::get_index(child_id).unwrap().unwrap();
-        let grandchild_index_with_greatgrandchild =
-            Index::get_index(grandchild_id).unwrap().unwrap();
-        let mut greatgrandchild_index = Index::get_index(greatgrandchild_id).unwrap().unwrap();
+        let root_index_with_greatgrandchild =
+            <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
+        let child_index_with_greatgrandchild =
+            <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
+        let grandchild_index_with_greatgrandchild = <Index<MainStorage>>::get_index(grandchild_id)
+            .unwrap()
+            .unwrap();
+        let mut greatgrandchild_index = <Index<MainStorage>>::get_index(greatgrandchild_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             hex::encode(root_index_with_greatgrandchild.full_hash),
             "6bdcb2f1a98eba952d3b2cf43c8bb36eb6a50b853d5b49dea089775e17d67b27"
@@ -464,18 +495,25 @@ mod hashing {
         );
 
         greatgrandchild_index.own_hash = [9_u8; 32];
-        Index::save_index(&greatgrandchild_index).unwrap();
+        <Index<MainStorage>>::save_index(&greatgrandchild_index).unwrap();
         greatgrandchild_index.full_hash =
-            Index::calculate_full_merkle_hash_for(greatgrandchild_id, false).unwrap();
-        Index::save_index(&greatgrandchild_index).unwrap();
+            <Index<MainStorage>>::calculate_full_merkle_hash_for(greatgrandchild_id, false)
+                .unwrap();
+        <Index<MainStorage>>::save_index(&greatgrandchild_index).unwrap();
 
-        Index::recalculate_ancestor_hashes_for(greatgrandchild_id).unwrap();
+        <Index<MainStorage>>::recalculate_ancestor_hashes_for(greatgrandchild_id).unwrap();
 
-        let updated_root_index_with_greatgrandchild = Index::get_index(root_id).unwrap().unwrap();
-        let updated_child_index_with_greatgrandchild = Index::get_index(child_id).unwrap().unwrap();
+        let updated_root_index_with_greatgrandchild =
+            <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
+        let updated_child_index_with_greatgrandchild =
+            <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
         let updated_grandchild_index_with_greatgrandchild =
-            Index::get_index(grandchild_id).unwrap().unwrap();
-        let updated_greatgrandchild_index = Index::get_index(greatgrandchild_id).unwrap().unwrap();
+            <Index<MainStorage>>::get_index(grandchild_id)
+                .unwrap()
+                .unwrap();
+        let updated_greatgrandchild_index = <Index<MainStorage>>::get_index(greatgrandchild_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             hex::encode(updated_root_index_with_greatgrandchild.full_hash),
             "f61c8077c7875e38a3cbdce3b3d4ce40a5a18add8ce386803760484772bcb85b"
@@ -494,18 +532,25 @@ mod hashing {
         );
 
         greatgrandchild_index.own_hash = [99_u8; 32];
-        Index::save_index(&greatgrandchild_index).unwrap();
+        <Index<MainStorage>>::save_index(&greatgrandchild_index).unwrap();
         greatgrandchild_index.full_hash =
-            Index::calculate_full_merkle_hash_for(greatgrandchild_id, false).unwrap();
-        Index::save_index(&greatgrandchild_index).unwrap();
+            <Index<MainStorage>>::calculate_full_merkle_hash_for(greatgrandchild_id, false)
+                .unwrap();
+        <Index<MainStorage>>::save_index(&greatgrandchild_index).unwrap();
 
-        Index::recalculate_ancestor_hashes_for(greatgrandchild_id).unwrap();
+        <Index<MainStorage>>::recalculate_ancestor_hashes_for(greatgrandchild_id).unwrap();
 
-        let updated_root_index_with_greatgrandchild = Index::get_index(root_id).unwrap().unwrap();
-        let updated_child_index_with_greatgrandchild = Index::get_index(child_id).unwrap().unwrap();
+        let updated_root_index_with_greatgrandchild =
+            <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
+        let updated_child_index_with_greatgrandchild =
+            <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
         let updated_grandchild_index_with_greatgrandchild =
-            Index::get_index(grandchild_id).unwrap().unwrap();
-        let updated_greatgrandchild_index = Index::get_index(greatgrandchild_id).unwrap().unwrap();
+            <Index<MainStorage>>::get_index(grandchild_id)
+                .unwrap()
+                .unwrap();
+        let updated_greatgrandchild_index = <Index<MainStorage>>::get_index(greatgrandchild_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             hex::encode(updated_root_index_with_greatgrandchild.full_hash),
             "0483e0a8a3c3002a94c3ce2e1f7fcadae4b2dc29e2dee9752b9caa683dfe39fc"
@@ -536,14 +581,14 @@ mod hashing {
                 .try_into()
                 .unwrap();
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.full_hash, root_hash0);
 
-        assert!(Index::update_hash_for(root_id, root_hash2).is_ok());
-        let updated_root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert!(<Index<MainStorage>>::update_hash_for(root_id, root_hash2).is_ok());
+        let updated_root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(updated_root_index.id, root_id);
         assert_eq!(updated_root_index.full_hash, root_full_hash);
     }
@@ -554,14 +599,14 @@ mod hashing {
         let root_hash1 = [1_u8; 32];
         let root_hash2 = [2_u8; 32];
 
-        assert!(Index::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
 
-        let root_index = Index::get_index(root_id).unwrap().unwrap();
+        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash1);
 
-        assert!(Index::update_hash_for(root_id, root_hash2).is_ok());
-        let updated_root_index = Index::get_index(root_id).unwrap().unwrap();
+        assert!(<Index<MainStorage>>::update_hash_for(root_id, root_hash2).is_ok());
+        let updated_root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(updated_root_index.id, root_id);
         assert_eq!(updated_root_index.own_hash, root_hash2);
     }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -2,10 +2,11 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use claims::{assert_none, assert_ok};
+use sha2::{Digest, Sha256};
 
 use super::*;
-use crate::entities::{ChildInfo, Data, Element};
-use crate::tests::common::{EmptyData, Page, Paragraph, TEST_ID};
+use crate::entities::{Data, Element};
+use crate::tests::common::{Page, Paragraph};
 
 #[cfg(test)]
 mod interface__public_methods {
@@ -15,8 +16,11 @@ mod interface__public_methods {
     fn children_of() {
         let element = Element::new(&Path::new("::root::node").unwrap());
         let mut page = Page::new_from_element("Node", element);
-        assert!(Interface::save(page.id(), &mut page).unwrap());
-        assert_eq!(Interface::children_of(&page.paragraphs).unwrap(), vec![]);
+        assert!(Interface::save(&mut page).unwrap());
+        assert_eq!(
+            Interface::children_of(page.id(), &page.paragraphs).unwrap(),
+            vec![]
+        );
 
         let child1 = Element::new(&Path::new("::root::node::leaf1").unwrap());
         let child2 = Element::new(&Path::new("::root::node::leaf2").unwrap());
@@ -24,29 +28,24 @@ mod interface__public_methods {
         let mut para1 = Paragraph::new_from_element("Leaf1", child1);
         let mut para2 = Paragraph::new_from_element("Leaf2", child2);
         let mut para3 = Paragraph::new_from_element("Leaf3", child3);
-        assert!(Interface::save(para1.id(), &mut para1).unwrap());
-        assert!(Interface::save(para2.id(), &mut para2).unwrap());
-        assert!(Interface::save(para3.id(), &mut para3).unwrap());
-        page.paragraphs.child_info = vec![
-            ChildInfo::new(para1.id(), para1.calculate_merkle_hash().unwrap()),
-            ChildInfo::new(para2.id(), para2.calculate_merkle_hash().unwrap()),
-            ChildInfo::new(para3.id(), para3.calculate_merkle_hash().unwrap()),
-        ];
-        assert!(Interface::save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(&mut page).unwrap());
+        assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para1).unwrap());
+        assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para2).unwrap());
+        assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para3).unwrap());
         assert_eq!(
-            Interface::children_of(&page.paragraphs).unwrap(),
+            Interface::children_of(page.id(), &page.paragraphs).unwrap(),
             vec![para1, para2, para3]
         );
     }
 
     #[test]
     fn find_by_id__existent() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
-        let mut para = Paragraph::new_from_element("Leaf", element);
-        let id = para.id();
-        assert!(Interface::save(id, &mut para).unwrap());
+        let element = Element::new(&Path::new("::root::node").unwrap());
+        let mut page = Page::new_from_element("Leaf", element);
+        let id = page.id();
+        assert!(Interface::save(&mut page).unwrap());
 
-        assert_eq!(Interface::find_by_id(id).unwrap(), Some(para));
+        assert_eq!(Interface::find_by_id(id).unwrap(), Some(page));
     }
 
     #[test]
@@ -74,10 +73,10 @@ mod interface__public_methods {
 
     #[test]
     fn save__basic() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
-        let mut para = Paragraph::new_from_element("Leaf", element);
+        let element = Element::new(&Path::new("::root::node").unwrap());
+        let mut page = Page::new_from_element("Node", element);
 
-        assert_ok!(Interface::save(para.id(), &mut para));
+        assert_ok!(Interface::save(&mut page));
     }
 
     #[test]
@@ -87,49 +86,47 @@ mod interface__public_methods {
         let mut page1 = Page::new_from_element("Node1", element1);
         let mut page2 = Page::new_from_element("Node2", element2);
 
-        assert!(Interface::save(page1.id(), &mut page1).unwrap());
-        assert!(Interface::save(page2.id(), &mut page2).unwrap());
+        assert!(Interface::save(&mut page1).unwrap());
+        assert!(Interface::save(&mut page2).unwrap());
         assert_eq!(Interface::find_by_id(page1.id()).unwrap(), Some(page1));
         assert_eq!(Interface::find_by_id(page2.id()).unwrap(), Some(page2));
     }
 
     #[test]
     fn save__not_dirty() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
-        let mut para = Paragraph::new_from_element("Leaf", element);
-        let id = para.id();
+        let element = Element::new(&Path::new("::root::node").unwrap());
+        let mut page = Page::new_from_element("Node", element);
 
-        assert!(Interface::save(id, &mut para).unwrap());
-        para.element_mut().update();
-        assert!(Interface::save(id, &mut para).unwrap());
+        assert!(Interface::save(&mut page).unwrap());
+        page.element_mut().update();
+        assert!(Interface::save(&mut page).unwrap());
     }
 
     #[test]
     fn save__too_old() {
-        let element1 = Element::new(&Path::new("::root::node::leaf").unwrap());
-        let mut para1 = Paragraph::new_from_element("Leaf", element1);
-        let mut para2 = para1.clone();
-        let id = para1.id();
+        let element1 = Element::new(&Path::new("::root::node").unwrap());
+        let mut page1 = Page::new_from_element("Node", element1);
+        let mut page2 = page1.clone();
 
-        assert!(Interface::save(id, &mut para1).unwrap());
-        para2.element_mut().update();
+        assert!(Interface::save(&mut page1).unwrap());
+        page2.element_mut().update();
         sleep(Duration::from_millis(1));
-        para1.element_mut().update();
-        assert!(Interface::save(id, &mut para1).unwrap());
-        assert!(!Interface::save(id, &mut para2).unwrap());
+        page1.element_mut().update();
+        assert!(Interface::save(&mut page1).unwrap());
+        assert!(!Interface::save(&mut page2).unwrap());
     }
 
     #[test]
     fn save__update_existing() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap());
-        let mut para = Paragraph::new_from_element("Leaf", element);
-        let id = para.id();
-        assert!(Interface::save(id, &mut para).unwrap());
+        let element = Element::new(&Path::new("::root::node").unwrap());
+        let mut page = Page::new_from_element("Node", element);
+        let id = page.id();
+        assert!(Interface::save(&mut page).unwrap());
 
         // TODO: Modify the element's data and check it changed
 
-        assert!(Interface::save(id, &mut para).unwrap());
-        assert_eq!(Interface::find_by_id(id).unwrap(), Some(para));
+        assert!(Interface::save(&mut page).unwrap());
+        assert_eq!(Interface::find_by_id(id).unwrap(), Some(page));
     }
 
     #[test]
@@ -182,7 +179,7 @@ mod interface__apply_actions {
     fn apply_action__update() {
         let mut page =
             Page::new_from_element("Old Title", Element::new(&Path::new("::test").unwrap()));
-        assert!(Interface::save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(&mut page).unwrap());
 
         page.title = "New Title".to_owned();
         page.element_mut().update();
@@ -200,7 +197,7 @@ mod interface__apply_actions {
     fn apply_action__delete() {
         let mut page =
             Page::new_from_element("Test Page", Element::new(&Path::new("::test").unwrap()));
-        assert!(Interface::save(page.id(), &mut page).unwrap());
+        assert!(Interface::save(&mut page).unwrap());
 
         let action = Action::Delete(page.id());
 
@@ -256,15 +253,19 @@ mod interface__comparison {
         let mut local = Page::new_from_element("Test Page", element);
         let mut foreign = local.clone();
 
-        assert!(Interface::save(local.id(), &mut local).unwrap());
+        assert!(Interface::save(&mut local).unwrap());
         foreign.element_mut().merkle_hash =
-            Interface::calculate_merkle_hash_for(&foreign, false).unwrap();
+            Index::calculate_full_merkle_hash_for(foreign.id(), false).unwrap();
         assert_eq!(
             local.element().merkle_hash(),
             foreign.element().merkle_hash()
         );
 
-        let result = Interface::compare_trees(&foreign).unwrap();
+        let result = Interface::compare_trees(
+            &foreign,
+            &Interface::generate_comparison_data(&foreign).unwrap(),
+        )
+        .unwrap();
         assert_eq!(result, (vec![], vec![]));
     }
 
@@ -274,15 +275,22 @@ mod interface__comparison {
         let mut local = Page::new_from_element("Test Page", element.clone());
         let mut foreign = Page::new_from_element("Old Test Page", element);
 
+        // Save the foreign entity to calculate the hash - this will be overwritten
+        assert!(Interface::save(&mut foreign).unwrap());
+        foreign.element_mut().merkle_hash =
+            Index::calculate_full_merkle_hash_for(foreign.id(), false).unwrap();
+
         // Make local newer
         sleep(Duration::from_millis(10));
         local.element_mut().update();
 
-        assert!(Interface::save(local.id(), &mut local).unwrap());
-        foreign.element_mut().merkle_hash =
-            Interface::calculate_merkle_hash_for(&foreign, false).unwrap();
+        assert!(Interface::save(&mut local).unwrap());
 
-        let result = Interface::compare_trees(&foreign).unwrap();
+        let result = Interface::compare_trees(
+            &foreign,
+            &Interface::generate_comparison_data(&foreign).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             result,
             (
@@ -298,15 +306,25 @@ mod interface__comparison {
         let mut local = Page::new_from_element("Old Test Page", element.clone());
         let mut foreign = Page::new_from_element("Test Page", element);
 
-        assert!(Interface::save(local.id(), &mut local).unwrap());
+        // Save the foreign entity to calculate the hash - this will be overwritten
+        assert!(Interface::save(&mut foreign).unwrap());
         foreign.element_mut().merkle_hash =
-            Interface::calculate_merkle_hash_for(&foreign, false).unwrap();
+            Index::calculate_full_merkle_hash_for(foreign.id(), false).unwrap();
+
+        // Make local newer
+        sleep(Duration::from_millis(10));
+        local.element_mut().update();
+        assert!(Interface::save(&mut local).unwrap());
 
         // Make foreign newer
         sleep(Duration::from_millis(10));
         foreign.element_mut().update();
 
-        let result = Interface::compare_trees(&foreign).unwrap();
+        let result = Interface::compare_trees(
+            &foreign,
+            &Interface::generate_comparison_data(&foreign).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             result,
             (
@@ -318,6 +336,14 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__with_collections() {
+        fn calculate_hash(data: Vec<[u8; 32]>) -> [u8; 32] {
+            let mut hasher = Sha256::new();
+            for item in data {
+                hasher.update(item);
+            }
+            hasher.finalize().into()
+        }
+
         let page_element = Element::new(&Path::new("::root::node").unwrap());
         let para1_element = Element::new(&Path::new("::root::node::leaf1").unwrap());
         let para2_element = Element::new(&Path::new("::root::node::leaf2").unwrap());
@@ -332,39 +358,35 @@ mod interface__comparison {
         let mut foreign_para1 = Paragraph::new_from_element("Updated Paragraph 1", para1_element);
         let mut foreign_para3 = Paragraph::new_from_element("Foreign Paragraph 3", para3_element);
 
-        local_page.paragraphs.child_info = vec![
-            ChildInfo::new(
-                local_para1.id(),
-                local_para1.calculate_merkle_hash().unwrap(),
-            ),
-            ChildInfo::new(
-                local_para2.id(),
-                local_para2.calculate_merkle_hash().unwrap(),
-            ),
-        ];
+        assert!(Interface::save(&mut local_page).unwrap());
+        assert!(Interface::add_child_to(
+            local_page.id(),
+            &mut local_page.paragraphs,
+            &mut local_para1
+        )
+        .unwrap());
+        assert!(Interface::add_child_to(
+            local_page.id(),
+            &mut local_page.paragraphs,
+            &mut local_para2
+        )
+        .unwrap());
 
-        foreign_page.paragraphs.child_info = vec![
-            ChildInfo::new(
-                local_para1.id(),
-                foreign_para1.calculate_merkle_hash().unwrap(),
-            ),
-            ChildInfo::new(
-                foreign_para3.id(),
-                foreign_para3.calculate_merkle_hash().unwrap(),
-            ),
-        ];
-
-        assert!(Interface::save(local_page.id(), &mut local_page).unwrap());
-        assert!(Interface::save(local_para1.id(), &mut local_para1).unwrap());
-        assert!(Interface::save(local_para2.id(), &mut local_para2).unwrap());
-        foreign_page.element_mut().merkle_hash =
-            Interface::calculate_merkle_hash_for(&foreign_page, false).unwrap();
         foreign_para1.element_mut().merkle_hash =
-            Interface::calculate_merkle_hash_for(&foreign_para1, false).unwrap();
+            calculate_hash(vec![foreign_para1.element().merkle_hash()]);
         foreign_para3.element_mut().merkle_hash =
-            Interface::calculate_merkle_hash_for(&foreign_para3, false).unwrap();
+            calculate_hash(vec![foreign_para3.element().merkle_hash()]);
+        foreign_page.element_mut().merkle_hash = calculate_hash(vec![
+            foreign_page.element().merkle_hash(),
+            foreign_para1.element().merkle_hash(),
+            foreign_para3.element().merkle_hash(),
+        ]);
 
-        let (local_actions, foreign_actions) = Interface::compare_trees(&foreign_page).unwrap();
+        let (local_actions, foreign_actions) = Interface::compare_trees(
+            &foreign_page,
+            &Interface::generate_comparison_data(&foreign_page).unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(
             local_actions,
@@ -389,8 +411,11 @@ mod interface__comparison {
         );
 
         // Compare the updated para1
-        let (local_para1_actions, foreign_para1_actions) =
-            Interface::compare_trees(&foreign_para1).unwrap();
+        let (local_para1_actions, foreign_para1_actions) = Interface::compare_trees(
+            &foreign_para1,
+            &Interface::generate_comparison_data(&foreign_para1).unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(
             local_para1_actions,
@@ -402,8 +427,11 @@ mod interface__comparison {
         assert_eq!(foreign_para1_actions, vec![]);
 
         // Compare para3 which doesn't exist locally
-        let (local_para3_actions, foreign_para3_actions) =
-            Interface::compare_trees(&foreign_para3).unwrap();
+        let (local_para3_actions, foreign_para3_actions) = Interface::compare_trees(
+            &foreign_para3,
+            &Interface::generate_comparison_data(&foreign_para3).unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(
             local_para3_actions,
@@ -413,171 +441,5 @@ mod interface__comparison {
             )]
         );
         assert_eq!(foreign_para3_actions, vec![]);
-    }
-}
-
-#[cfg(test)]
-mod hashing {
-    use super::*;
-
-    #[test]
-    fn calculate_merkle_hash_for__empty_record() {
-        let timestamp = 1_765_432_100_123_456_789;
-        let mut element = Element::new(&Path::new("::root::node::leaf").unwrap());
-        element.set_id(TEST_ID[0]);
-        element.metadata.set_created_at(timestamp);
-        element.metadata.updated_at = timestamp;
-        let data = EmptyData {
-            storage: element.clone(),
-        };
-
-        let hash = Interface::calculate_merkle_hash_for(&data, false).unwrap();
-        assert_eq!(
-            hex::encode(hash),
-            "173f9a17aa3c6acdad8cdaf06cea4aa4eb7c87cb99e07507a417d6588e679607"
-        );
-    }
-
-    #[test]
-    fn calculate_merkle_hash_for__with_children() {
-        let timestamp = 1_765_432_100_123_456_789;
-        let mut element = Element::new(&Path::new("::root::node").unwrap());
-        element.set_id(TEST_ID[0]);
-        element.metadata.set_created_at(1_765_432_100_123_456_789);
-        element.metadata.updated_at = timestamp;
-        let mut page = Page::new_from_element("Node", element);
-        assert!(Interface::save(page.id(), &mut page).unwrap());
-        let child1 = Element::new(&Path::new("::root::node::leaf1").unwrap());
-        let child2 = Element::new(&Path::new("::root::node::leaf2").unwrap());
-        let child3 = Element::new(&Path::new("::root::node::leaf3").unwrap());
-        let mut para1 = Paragraph::new_from_element("Leaf1", child1);
-        let mut para2 = Paragraph::new_from_element("Leaf2", child2);
-        let mut para3 = Paragraph::new_from_element("Leaf3", child3);
-        para1.element_mut().set_id(TEST_ID[1]);
-        para2.element_mut().set_id(TEST_ID[2]);
-        para3.element_mut().set_id(TEST_ID[3]);
-        para1.element_mut().metadata.set_created_at(timestamp);
-        para2.element_mut().metadata.set_created_at(timestamp);
-        para3.element_mut().metadata.set_created_at(timestamp);
-        para1.element_mut().metadata.updated_at = timestamp;
-        para2.element_mut().metadata.updated_at = timestamp;
-        para3.element_mut().metadata.updated_at = timestamp;
-        assert!(Interface::save(para1.id(), &mut para1).unwrap());
-        assert!(Interface::save(para2.id(), &mut para2).unwrap());
-        assert!(Interface::save(para3.id(), &mut para3).unwrap());
-        page.paragraphs.child_info = vec![
-            ChildInfo::new(para1.id(), para1.element().merkle_hash()),
-            ChildInfo::new(para2.id(), para2.element().merkle_hash()),
-            ChildInfo::new(para3.id(), para3.element().merkle_hash()),
-        ];
-        assert!(Interface::save(page.id(), &mut page).unwrap());
-
-        assert_eq!(
-            hex::encode(Interface::calculate_merkle_hash_for(&para1, false).unwrap()),
-            "9c4d6363cca5bdb5829f0aa832b573d6befd26227a0e2c3cc602edd9fda88db1",
-        );
-        assert_eq!(
-            hex::encode(Interface::calculate_merkle_hash_for(&para2, false).unwrap()),
-            "449f30903c94a488f1767b91bc6626fafd82189130cf41e427f96df19a727d8b",
-        );
-        assert_eq!(
-            hex::encode(Interface::calculate_merkle_hash_for(&para3, false).unwrap()),
-            "43098decf78bf10dc4c31191a5f59d277ae524859583e48689482c9ba85c5f61",
-        );
-        assert_eq!(
-            hex::encode(Interface::calculate_merkle_hash_for(&page, false).unwrap()),
-            "7593806c462bfadd97ed5228a3a60e492cce4b725f2c0e72e6e5b0f7996ee394",
-        );
-    }
-
-    #[test]
-    fn calculate_merkle_hash_for__cached_values() {
-        let element = Element::new(&Path::new("::root::node").unwrap());
-        let mut page = Page::new_from_element("Node", element);
-        assert!(Interface::save(page.id(), &mut page).unwrap());
-        assert_eq!(Interface::children_of(&page.paragraphs).unwrap(), vec![]);
-
-        let child1 = Element::new(&Path::new("::root::node::leaf1").unwrap());
-        let child2 = Element::new(&Path::new("::root::node::leaf2").unwrap());
-        let child3 = Element::new(&Path::new("::root::node::leaf3").unwrap());
-        let mut para1 = Paragraph::new_from_element("Leaf1", child1);
-        let mut para2 = Paragraph::new_from_element("Leaf2", child2);
-        let mut para3 = Paragraph::new_from_element("Leaf3", child3);
-        assert!(Interface::save(para1.id(), &mut para1).unwrap());
-        assert!(Interface::save(para2.id(), &mut para2).unwrap());
-        assert!(Interface::save(para3.id(), &mut para3).unwrap());
-        page.paragraphs.child_info = vec![
-            ChildInfo::new(para1.id(), para1.element().merkle_hash()),
-            ChildInfo::new(para2.id(), para2.element().merkle_hash()),
-            ChildInfo::new(para3.id(), para3.element().merkle_hash()),
-        ];
-        assert!(Interface::save(page.id(), &mut page).unwrap());
-
-        let mut hasher0 = Sha256::new();
-        hasher0.update(page.id().as_bytes());
-        hasher0.update(&to_vec(&page.title).unwrap());
-        hasher0.update(&to_vec(&page.element().metadata()).unwrap());
-        let expected_hash0: [u8; 32] = hasher0.finalize().into();
-
-        let mut hasher1 = Sha256::new();
-        hasher1.update(para1.id().as_bytes());
-        hasher1.update(&to_vec(&para1.text).unwrap());
-        hasher1.update(&to_vec(&para1.element().metadata()).unwrap());
-        let expected_hash1: [u8; 32] = hasher1.finalize().into();
-        let mut hasher1b = Sha256::new();
-        hasher1b.update(expected_hash1);
-        let expected_hash1b: [u8; 32] = hasher1b.finalize().into();
-
-        let mut hasher2 = Sha256::new();
-        hasher2.update(para2.id().as_bytes());
-        hasher2.update(&to_vec(&para2.text).unwrap());
-        hasher2.update(&to_vec(&para2.element().metadata()).unwrap());
-        let expected_hash2: [u8; 32] = hasher2.finalize().into();
-        let mut hasher2b = Sha256::new();
-        hasher2b.update(expected_hash2);
-        let expected_hash2b: [u8; 32] = hasher2b.finalize().into();
-
-        let mut hasher3 = Sha256::new();
-        hasher3.update(para3.id().as_bytes());
-        hasher3.update(&to_vec(&para3.text).unwrap());
-        hasher3.update(&to_vec(&para3.element().metadata()).unwrap());
-        let expected_hash3: [u8; 32] = hasher3.finalize().into();
-        let mut hasher3b = Sha256::new();
-        hasher3b.update(expected_hash3);
-        let expected_hash3b: [u8; 32] = hasher3b.finalize().into();
-
-        let mut hasher = Sha256::new();
-        hasher.update(&expected_hash0);
-        hasher.update(&expected_hash1b);
-        hasher.update(&expected_hash2b);
-        hasher.update(&expected_hash3b);
-        let expected_hash: [u8; 32] = hasher.finalize().into();
-
-        assert_eq!(page.calculate_merkle_hash().unwrap(), expected_hash0);
-        assert_eq!(
-            Interface::calculate_merkle_hash_for(&para1, false).unwrap(),
-            expected_hash1b
-        );
-        assert_eq!(
-            Interface::calculate_merkle_hash_for(&para2, false).unwrap(),
-            expected_hash2b
-        );
-        assert_eq!(
-            Interface::calculate_merkle_hash_for(&para3, false).unwrap(),
-            expected_hash3b
-        );
-        assert_eq!(
-            Interface::calculate_merkle_hash_for(&page, false).unwrap(),
-            expected_hash
-        );
-    }
-
-    #[test]
-    #[ignore]
-    fn calculate_merkle_hash_for__recalculated_values() {
-        // TODO: Later, tests should be added for recalculating the hashes, and
-        // TODO: especially checking when the data has been interfered with or
-        // TODO: otherwise arrived at an invalid state.
-        todo!()
     }
 }

--- a/crates/storage/src/tests/mocks.rs
+++ b/crates/storage/src/tests/mocks.rs
@@ -1,0 +1,37 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::index::Index;
+use crate::interface::{MainInterface, StorageAdaptor};
+
+thread_local! {
+    static FOREIGN_STORAGE: RefCell<HashMap<Vec<u8>, Vec<u8>>> = RefCell::new(HashMap::new());
+}
+
+pub(crate) type ForeignInterface = MainInterface<ForeignStorage>;
+
+#[expect(dead_code, reason = "Here to be used by tests")]
+pub(crate) type ForeignIndex = Index<ForeignStorage>;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub(crate) struct ForeignStorage;
+
+impl StorageAdaptor for ForeignStorage {
+    fn storage_read(key: &[u8]) -> Option<Vec<u8>> {
+        FOREIGN_STORAGE.with(|storage| storage.borrow().get(key).cloned())
+    }
+
+    fn storage_remove(key: &[u8]) -> bool {
+        FOREIGN_STORAGE.with(|storage| storage.borrow_mut().remove(key).is_some())
+    }
+
+    fn storage_write(key: &[u8], value: &[u8]) -> bool {
+        FOREIGN_STORAGE.with(|storage| {
+            storage
+                .borrow_mut()
+                .insert(key.to_vec(), value.to_vec())
+                .is_some()
+        })
+    }
+}


### PR DESCRIPTION
Added Merkle tree indexing

  - Added `index` module to the `storage` crate, to take care of all index management. For now this is registration of the IDs and hashes of nodes in the tree. For any nodes that have children, their child collections are stored in the index data - this means it no longer has to be stored in the `Data` side, reducing the amount of serialised data in the `Action` payloads, and also opening this up for various performance optimisations that can take place in the `Index` without affecting the data side.

  - Added an `Index` struct acting as an interface to the indexing, along with an `EntityIndex` struct for representing the data that gets stored. This is currently the ID, parent ID, child information (the IDs and hashes of all children, by collection), plus the hash of the node-local data and the full hash of the node's data plus its children. This should be sufficient for offloading many operations onto the index, but does not replace primary production of the data hashes, which still needs to occur on the `Data`-implementing type. Equally, knowledge of child collections also still has to come from the type knowledge.

  - Updated `Interface::children_of()` to take a parent ID, to hook in to the new `Index` functionality.

  - Implemented `Interface::find_children_by_id()` now that the `Index` is present to allow it nicely.

  - Added `add_child_to()`, `child_info_for()`, `has_children()`, `parent_of()`, `generate_comparison_data()`, `remove_child_from()`, and `root()` functions to `Interface`, to map through to use the new `Index` functionality.

  - Removed `Collection.child_info()` and `has_children()`, as these are now handled through the `Interface` as planned.

  - Removed `Interface::calculate_merkle_hash_for()` as this is now handled by the `Index`.

  - Added `Data::is_root()` to indicate if a type represents the root of the modelled hierarchy.

  - Added `#[root]` designator to the `AtomicUnit` macro.

  - Added a `ComparisonData` struct to encapsulate the information that gets exchanged between nodes to perform a comparison, now that this is no longer available from the entity directly.

Added `ForeignInterface` functionality

  - Added a `StorageAdaptor` trait to handle abstraction of the storage source, allowing it to be changed.

  - Added a `MainStorage` struct, used by the main Interface, now itself called `MainInterface`, but with a type alias to provide ease of use as `Interface`.

  - Added a `ForeignInterface` with `ForeignStorage`, for use in tests, to allow modelling of a separate data hierarchy representing another node's data.