### PR TITLE
chore(release): bump meroctl to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4413,7 +4413,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "meroctl"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "bs58 0.5.1",

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meroctl"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Notable changes:

- https://github.com/calimero-network/core/pull/721
- https://github.com/calimero-network/core/pull/760
- https://github.com/calimero-network/core/pull/752
- https://github.com/calimero-network/core/pull/778