### PR TITLE
chore: simplified the use of multiaddrs and config inside the cli

### DIFF
--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use url::Url;
 
 use crate::cli::RootArgs;
-use crate::common::{get_response, load_config, load_multiaddr, multiaddr_to_url, RequestType};
+use crate::common::{get_response, load_config, fetch_multiaddr, multiaddr_to_url, RequestType};
 
 #[derive(Debug, Parser)]
 pub struct InstallCommand {
@@ -31,13 +31,8 @@ pub struct InstallCommand {
 
 impl InstallCommand {
     pub async fn run(self, args: RootArgs) -> Result<()> {
-        let path = args.home.join(&args.node_name);
-        let config = load_config(&path)?;
-        let multiaddr = load_multiaddr(&config)?;
-        let client = Client::new();
-
+        let config = load_config(&args.node_name)?;
         let mut is_dev_installation = false;
-
         let metadata = self.metadata.map(String::into_bytes).unwrap_or_default();
 
         let install_request = if let Some(app_path) = self.path {
@@ -53,14 +48,17 @@ impl InstallCommand {
             bail!("Either path or url must be provided");
         };
 
-        let install_url = if is_dev_installation {
-            multiaddr_to_url(&multiaddr, "admin-api/dev/install-dev-application")?
-        } else {
-            multiaddr_to_url(&multiaddr, "admin-api/dev/install-application")?
-        };
+        let install_url = multiaddr_to_url(
+            fetch_multiaddr(&config)?, 
+            if is_dev_installation { 
+                "admin-api/dev/install-dev-application"
+            } else {
+                "admin-api/dev/install-application"
+            }
+        )?;
 
         let install_response = get_response(
-            &client,
+            &Client::new(),
             install_url,
             Some(install_request),
             &config.identity,

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc;
 
 use crate::cli::RootArgs;
 use crate::common::{get_response, multiaddr_to_url, RequestType};
-use crate::common::{load_config, load_multiaddr};
+use crate::common::{load_config, fetch_multiaddr};
 
 #[derive(Debug, Parser)]
 pub struct CreateCommand {
@@ -47,10 +47,9 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
-        let path = root_args.home.join(&root_args.node_name);
-        let config = load_config(&path)?;
-        let multiaddr = load_multiaddr(&config)?;
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let config = load_config(&args.node_name)?;
+        let multiaddr = fetch_multiaddr(&config)?;
         let client = Client::new();
 
         match self {

--- a/crates/meroctl/src/cli/context/delete.rs
+++ b/crates/meroctl/src/cli/context/delete.rs
@@ -5,7 +5,7 @@ use libp2p::Multiaddr;
 use reqwest::Client;
 
 use crate::cli::RootArgs;
-use crate::common::{get_response, multiaddr_to_url, RequestType};
+use crate::common::{fetch_multiaddr, get_response, load_config, multiaddr_to_url, RequestType};
 
 #[derive(Debug, Parser)]
 pub struct DeleteCommand {
@@ -14,14 +14,14 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
-        let path = root_args.home.join(&root_args.node_name);
-        let config = crate::common::load_config(&path)?;
-        let multiaddr = crate::common::load_multiaddr(&config)?;
-        let client = Client::new();
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let config = load_config(&args.node_name)?;
 
-        self.delete_context(&multiaddr, &client, &config.identity)
-            .await
+        self.delete_context(
+            fetch_multiaddr(&config)?,
+            &Client::new(),
+            &config.identity
+        ).await
     }
 
     #[expect(clippy::print_stdout, reason = "Acceptable for CLI")]

--- a/crates/meroctl/src/cli/context/get.rs
+++ b/crates/meroctl/src/cli/context/get.rs
@@ -5,7 +5,7 @@ use libp2p::Multiaddr;
 use reqwest::Client;
 
 use crate::cli::RootArgs;
-use crate::common::{get_response, multiaddr_to_url, RequestType};
+use crate::common::{fetch_multiaddr, get_response, load_config, multiaddr_to_url, RequestType};
 
 #[derive(Parser, Debug)]
 pub struct GetCommand {
@@ -26,10 +26,9 @@ pub enum GetRequest {
 }
 
 impl GetCommand {
-    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
-        let path = root_args.home.join(&root_args.node_name);
-        let config = crate::common::load_config(&path)?;
-        let multiaddr = crate::common::load_multiaddr(&config)?;
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let config = load_config(&args.node_name)?;
+        let multiaddr = fetch_multiaddr(&config)?;
         let client = Client::new();
 
         match self.method {

--- a/crates/meroctl/src/cli/context/join.rs
+++ b/crates/meroctl/src/cli/context/join.rs
@@ -7,7 +7,7 @@ use reqwest::Client;
 use tracing::info;
 
 use crate::cli::RootArgs;
-use crate::common::{get_response, multiaddr_to_url, RequestType};
+use crate::common::{fetch_multiaddr, get_response, load_config, multiaddr_to_url, RequestType};
 
 #[derive(Debug, Parser)]
 pub struct JoinCommand {
@@ -18,16 +18,12 @@ pub struct JoinCommand {
 }
 
 impl JoinCommand {
-    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
-        let path = root_args.home.join(&root_args.node_name);
-        let config = crate::common::load_config(&path)?;
-        let multiaddr = crate::common::load_multiaddr(&config)?;
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let config = load_config(&args.node_name)?;
 
-        let url = multiaddr_to_url(&multiaddr, "admin-api/dev/contexts/join")?;
-        let client = Client::new();
         let response = get_response(
-            &client,
-            url,
+            &Client::new(),
+            multiaddr_to_url(fetch_multiaddr(&config)?, "admin-api/dev/contexts/join")?,
             Some(JoinContextRequest::new(
                 self.private_key,
                 self.invitation_payload,

--- a/crates/meroctl/src/cli/context/list.rs
+++ b/crates/meroctl/src/cli/context/list.rs
@@ -4,21 +4,23 @@ use eyre::{bail, Result as EyreResult};
 use reqwest::Client;
 
 use crate::cli::RootArgs;
-use crate::common::{get_response, multiaddr_to_url, RequestType};
+use crate::common::{fetch_multiaddr, get_response, load_config, multiaddr_to_url, RequestType};
 
 #[derive(Debug, Parser)]
 pub struct ListCommand;
 
 impl ListCommand {
-    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
-        let path = root_args.home.join(&root_args.node_name);
-        let config = crate::common::load_config(&path)?;
-        let multiaddr = crate::common::load_multiaddr(&config)?;
-        let url = multiaddr_to_url(&multiaddr, "admin-api/dev/contexts")?;
-        let client = Client::new();
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let config = load_config(&args.node_name)?;
 
         let response =
-            get_response(&client, url, None::<()>, &config.identity, RequestType::Get).await?;
+            get_response(
+                &Client::new(),
+                multiaddr_to_url(fetch_multiaddr(&config)?, "admin-api/dev/contexts")?,
+                None::<()>, 
+                &config.identity,
+                RequestType::Get
+            ).await?;
 
         if !response.status().is_success() {
             bail!("Request failed with status: {}", response.status())

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -6,7 +6,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::connect_async;
 
 use super::RootArgs;
-use crate::common::{load_config, load_multiaddr, multiaddr_to_url};
+use crate::common::{load_config, fetch_multiaddr, multiaddr_to_url};
 
 #[derive(Debug, Parser)]
 pub struct WatchCommand {
@@ -19,7 +19,7 @@ impl WatchCommand {
     pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
         let path = root_args.home.join(&root_args.node_name);
         let config = load_config(&path)?;
-        let multiaddr = load_multiaddr(&config)?;
+        let multiaddr = fetch_multiaddr(&config)?;
 
         let mut url = multiaddr_to_url(&multiaddr, "ws")?;
         url.set_scheme("ws")

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -16,12 +16,10 @@ pub struct WatchCommand {
 }
 
 impl WatchCommand {
-    pub async fn run(self, root_args: RootArgs) -> EyreResult<()> {
-        let path = root_args.home.join(&root_args.node_name);
-        let config = load_config(&path)?;
-        let multiaddr = fetch_multiaddr(&config)?;
+    pub async fn run(self, args: RootArgs) -> EyreResult<()> {
+        let config = load_config(&args.node_name)?;
 
-        let mut url = multiaddr_to_url(&multiaddr, "ws")?;
+        let mut url = multiaddr_to_url(fetch_multiaddr(&config)?, "ws")?;
         url.set_scheme("ws")
             .map_err(|_| eyre::eyre!("Failed to set URL scheme"))?;
 

--- a/crates/meroctl/src/common.rs
+++ b/crates/meroctl/src/common.rs
@@ -73,7 +73,7 @@ pub fn load_config(path: &Utf8PathBuf) -> EyreResult<ConfigFile> {
     Ok(config)
 }
 
-pub fn load_multiaddr(config: &ConfigFile) -> EyreResult<&Multiaddr> {
+pub fn fetch_multiaddr(config: &ConfigFile) -> EyreResult<&Multiaddr> {
     let Some(multiaddr) = config.network.server.listen.first() else {
         bail!("No address.")
     };


### PR DESCRIPTION
```
╭─    ~/workspace/core/apps   implement-watch-flag ▓▒░                                          ░▒▓ ✔  17:40:00 ─╮
╰─ cargo run -p meroctl -- --node-name coordinator app --help                                                           ─╯
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.87s
     Running `/Users/chefsale/workspace/core/target/debug/meroctl --node-name coordinator app --help`
Usage: meroctl --node-name <NAME> app <COMMAND>

Commands:
  get
  install
  list
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```