### PR TITLE
feat: v2 runtime CRDT dependence

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -53,14 +53,14 @@ use tokio::time::{interval_at, Instant};
 use tokio::{select, spawn};
 use tracing::{debug, error, info, warn};
 
-use crate::runtime_compat::RuntimeCompatStore;
-use crate::transaction_pool::{TransactionPool, TransactionPoolEntry};
-use crate::types::{PeerAction, TransactionConfirmation, TransactionRejection};
-
 pub mod catchup;
 pub mod runtime_compat;
 pub mod transaction_pool;
 pub mod types;
+
+use crate::runtime_compat::RuntimeCompatStore;
+use crate::transaction_pool::{TransactionPool, TransactionPoolEntry};
+use crate::types::{PeerAction, TransactionConfirmation, TransactionRejection};
 
 type BoxedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
@@ -1455,20 +1455,18 @@ impl Node {
 // TODO: move this into the config
 // TODO: also this would be nice to have global default with per application customization
 fn get_runtime_limits() -> EyreResult<VMLimits> {
-    Ok(VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/
-        (10 << 20).try_into()?, // 10 MiB
-                                // can_write: writes, // todo!
-    ))
+    Ok(VMLimits {
+        max_stack_size: 200 << 10, // 200 KiB
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10, // 16 KiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+                                       // can_write: writes, // todo!
+    })
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,6 +11,7 @@ borsh = { workspace = true, features = ["derive"] }
 fragile.workspace = true
 ouroboros.workspace = true
 owo-colors = { workspace = true, optional = true }
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 ureq.workspace = true

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -29,20 +29,19 @@ fn main() -> EyreResult<()> {
 
     let mut storage = InMemoryStorage::default();
 
-    let limits = VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
-    );
+    let limits = VMLimits {
+        max_stack_size: 200 << 10, // 200 KiB
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,                  // 16 KiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+    };
 
     let cx = VMContext::new(
         to_json_vec(&json!({
@@ -52,6 +51,10 @@ fn main() -> EyreResult<()> {
     );
     let get_outcome = run(&file, "get", cx, &mut storage, &limits)?;
     dbg!(get_outcome);
+
+    let cx = VMContext::new(vec![], [0; 32]);
+    let init_outcome = run(&file, "init", cx, &mut storage, &limits)?;
+    dbg!(init_outcome);
 
     let cx = VMContext::new(
         to_json_vec(&json!({

--- a/crates/runtime/examples/fetch.rs
+++ b/crates/runtime/examples/fetch.rs
@@ -28,20 +28,19 @@ fn main() -> EyreResult<()> {
 
     let mut storage = InMemoryStorage::default();
 
-    let limits = VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
-    );
+    let limits = VMLimits {
+        max_stack_size: 200 << 10, // 200 KiB
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,                  // 16 KiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+    };
 
     let cx = VMContext::new(
         to_json_vec(&json!({

--- a/crates/runtime/examples/rps.rs
+++ b/crates/runtime/examples/rps.rs
@@ -67,20 +67,19 @@ fn main() -> EyreResult<()> {
 
     let mut storage = InMemoryStorage::default();
 
-    let limits = VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
-    );
+    let limits = VMLimits {
+        max_stack_size: 200 << 10, // 200 KiB
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,                  // 16 KiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+    };
 
     println!("{}", "--".repeat(20).dimmed());
     println!("{:>35}", "First, we create a keypair for Joe".bold());

--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -9,6 +9,8 @@ use thiserror::Error as ThisError;
 use wasmer::{ExportError, InstantiationError, LinkError, RuntimeError};
 use wasmer_types::{CompileError, TrapCode};
 
+pub use crate::store::StorageError;
+
 #[derive(Debug, ThisError)]
 #[non_exhaustive]
 pub enum VMRuntimeError {
@@ -18,10 +20,6 @@ pub enum VMRuntimeError {
     #[error(transparent)]
     HostError(HostError),
 }
-
-#[derive(Copy, Clone, Debug, ThisError)]
-#[non_exhaustive]
-pub enum StorageError {}
 
 #[derive(Debug, Serialize, ThisError)]
 #[serde(tag = "type", content = "data")]
@@ -90,8 +88,6 @@ pub enum HostError {
     DeserializationError,
     #[error("integer overflow")]
     IntegerOverflow,
-    #[error("key length overflow")]
-    KeyLengthOverflow,
     #[error("value length overflow")]
     ValueLengthOverflow,
     #[error("logs overflow")]

--- a/crates/runtime/src/logic/errors.rs
+++ b/crates/runtime/src/logic/errors.rs
@@ -9,7 +9,7 @@ pub enum VMLogicError {
     #[error(transparent)]
     HostError(#[from] HostError),
     #[error(transparent)]
-    StorageError(StorageError),
+    StorageError(#[from] StorageError),
 }
 
 impl From<MemoryAccessError> for VMLogicError {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -41,6 +41,8 @@ impl VMLogic<'_> {
             fn log_utf8(ptr: u64, len: u64);
             fn emit(kind_ptr: u64, kind_len: u64, data_ptr: u64, data_len: u64);
 
+            fn storage_create(is_collection: u32, register_id: u64);
+            fn storage_read(key_ptr: u64, key_len: u64, register_id: u64) -> u32;
             fn storage_write(
                 key_ptr: u64,
                 key_len: u64,
@@ -48,7 +50,19 @@ impl VMLogic<'_> {
                 value_len: u64,
                 register_id: u64,
             ) -> u32;
-            fn storage_read(key_ptr: u64, key_len: u64, register_id: u64) -> u32;
+            fn storage_delete(key_ptr: u64, key_len: u64, register_id: u64) -> u32;
+            fn storage_adopt(
+                key_ptr: u64,
+                key_len: u64,
+                parent_ptr: u64,
+                parent_len: u64,
+            ) -> u32;
+            fn storage_orphan(
+                key_ptr: u64,
+                key_len: u64,
+                parent_ptr: u64,
+                parent_len: u64,
+            ) -> u32;
 
             fn fetch(
                 url_ptr: u64,
@@ -120,7 +134,7 @@ macro_rules! _imports {
 
                     #[cfg(feature = "host-traces")]
                     {
-                        #[expect(unused_mut, unused_assignments)]
+                        #[allow(unused_mut, unused_assignments)]
                         let mut return_ty = "()";
                         $( return_ty = stringify!($returns); )?
                         println!(

--- a/crates/runtime/src/logic/registers.rs
+++ b/crates/runtime/src/logic/registers.rs
@@ -58,6 +58,8 @@ impl Registers {
 
         match entry {
             Entry::Occupied(mut entry) => {
+                // todo! if the old box is large enough, copy the data into the new box
+                // todo! this will suffer in the case of `String` which is a `Vec<u8>` which is a `Box<[u8]>`
                 drop(entry.insert(data.into()));
             }
             Entry::Vacant(entry) => {

--- a/crates/runtime/src/store.rs
+++ b/crates/runtime/src/store.rs
@@ -1,36 +1,151 @@
 use core::fmt::Debug;
-use std::collections::BTreeMap;
+use std::{
+    collections::{btree_map::Entry as BTreeMapEntry, BTreeMap, HashSet},
+    mem,
+};
 
-pub type Key = Vec<u8>;
+use thiserror::Error;
+
+pub type Id = [u8; 32];
 pub type Value = Vec<u8>;
 
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("id points at a collection, not a value")]
+    NotAValue,
+    #[error("id points at a value, not a collection")]
+    NotACollection,
+    #[error("collection is not empty")]
+    CollectionNotEmpty,
+    #[error(transparent)]
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
 pub trait Storage: Debug {
-    fn get(&self, key: &Key) -> Option<Value>;
-    fn set(&mut self, key: Key, value: Value) -> Option<Value>;
-    // fn remove(&mut self, key: &[u8]);
-    fn has(&self, key: &Key) -> bool;
+    fn create(&mut self, is_collection: bool) -> Result<Id, StorageError>;
+    fn exists(&self, key: &Id) -> Result<bool, StorageError>;
+    fn read(&self, key: &Id) -> Result<Option<Value>, StorageError>;
+    fn write(&mut self, key: Id, value: Value) -> Result<Option<Value>, StorageError>;
+    fn remove(&mut self, key: &Id) -> Result<Option<Value>, StorageError>;
+    fn adopt(&mut self, key: Id, parent: &Id) -> Result<bool, StorageError>;
+    fn orphan(&mut self, key: Id, parent: &Id) -> Result<bool, StorageError>;
+}
+
+#[derive(Debug)]
+enum Entry {
+    Bytes(Vec<u8>),
+    Collection(HashSet<Id>),
 }
 
 #[derive(Debug, Default)]
 pub struct InMemoryStorage {
-    inner: BTreeMap<Key, Value>,
+    inner: BTreeMap<Id, Entry>,
 }
 
 impl Storage for InMemoryStorage {
-    fn get(&self, key: &Key) -> Option<Value> {
-        self.inner.get(key).cloned()
+    fn create(&mut self, is_collection: bool) -> Result<Id, StorageError> {
+        let id = loop {
+            let id = rand::random::<Id>();
+
+            if !self.inner.contains_key(&id) {
+                break id;
+            }
+        };
+
+        let entry = if is_collection {
+            Entry::Collection(HashSet::default())
+        } else {
+            Entry::Bytes(vec![])
+        };
+
+        let _ignored = self.inner.insert(id, entry);
+
+        Ok(id)
     }
 
-    fn set(&mut self, key: Key, value: Value) -> Option<Value> {
-        self.inner.insert(key, value)
+    fn exists(&self, key: &Id) -> Result<bool, StorageError> {
+        Ok(self.inner.contains_key(key))
     }
 
-    // todo! revisit this, should we return the value by default?
-    // fn remove(&mut self, key: &[u8]) {
-    //     self.inner.remove(key);
-    // }
+    fn read(&self, key: &Id) -> Result<Option<Value>, StorageError> {
+        let bytes = match self.inner.get(key) {
+            Some(Entry::Bytes(bytes)) => Some(bytes.clone()),
+            _ => None,
+        };
 
-    fn has(&self, key: &Key) -> bool {
-        self.inner.contains_key(key)
+        Ok(bytes)
+    }
+
+    fn write(&mut self, key: Id, value: Value) -> Result<Option<Value>, StorageError> {
+        let old = match self.inner.entry(key) {
+            BTreeMapEntry::Vacant(entry) => {
+                let _ = entry.insert(Entry::Bytes(value));
+                None
+            }
+            BTreeMapEntry::Occupied(mut entry) => match entry.get_mut() {
+                Entry::Collection(_) => return Err(StorageError::NotAValue),
+                Entry::Bytes(bytes) => Some(mem::replace(bytes, value)),
+            },
+        };
+
+        Ok(old)
+    }
+
+    fn remove(&mut self, key: &Id) -> Result<Option<Value>, StorageError> {
+        let old = match self.inner.entry(*key) {
+            BTreeMapEntry::Vacant(_) => None,
+            BTreeMapEntry::Occupied(occupied_entry) => {
+                let entry = occupied_entry.get();
+
+                if let Entry::Collection(collection) = entry {
+                    if !collection.is_empty() {
+                        return Err(StorageError::CollectionNotEmpty);
+                    }
+                }
+
+                Some(occupied_entry.remove())
+            }
+        };
+
+        Ok(old.and_then(|entry| match entry {
+            Entry::Bytes(bytes) => Some(bytes),
+            Entry::Collection(_) => None,
+        }))
+    }
+
+    fn adopt(&mut self, key: Id, parent: &Id) -> Result<bool, StorageError> {
+        if !self.inner.contains_key(&key) {
+            return Ok(false);
+        }
+
+        let Some(entry) = self.inner.get_mut(parent) else {
+            return Ok(false);
+        };
+
+        let Entry::Collection(collection) = entry else {
+            return Err(StorageError::NotACollection);
+        };
+
+        let _ = collection.insert(key);
+
+        Ok(true)
+    }
+
+    fn orphan(&mut self, key: Id, parent: &Id) -> Result<bool, StorageError> {
+        if !self.inner.contains_key(&key) {
+            return Ok(false);
+        }
+
+        let Some(entry) = self.inner.get_mut(parent) else {
+            return Ok(false);
+        };
+
+        let Entry::Collection(collection) = entry else {
+            return Err(StorageError::NotACollection);
+        };
+
+        let _ = collection.remove(&key);
+
+        Ok(true)
     }
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 pub use {borsh, serde, serde_json};
 
 pub mod env;
@@ -8,6 +9,17 @@ mod sys;
 
 pub mod app {
     pub use calimero_sdk_macros::{destroy, emit, event, init, logic, state};
+}
+
+#[derive(Eq, Ord, Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Id([u8; 32]);
+
+impl Deref for Id {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -19,8 +19,12 @@ wasm_imports! {
         fn log_utf8(msg: Buffer<'_>);
         fn emit(event: Event<'_>);
         // --
+        fn storage_create(is_collection: Bool, register_id: RegisterId);
         fn storage_read(key: Buffer<'_>, register_id: RegisterId) -> Bool;
         fn storage_write(key: Buffer<'_>, value: Buffer<'_>, register_id: RegisterId) -> Bool;
+        fn storage_delete(key: Buffer<'_>, register_id: RegisterId) -> Bool;
+        fn storage_adopt(key: Buffer<'_>, parent: Buffer<'_>) -> Bool;
+        fn storage_orphan(key: Buffer<'_>, parent: Buffer<'_>) -> Bool;
         // --
         fn fetch(
             url: Buffer<'_>,

--- a/crates/sdk/src/sys/types/bool.rs
+++ b/crates/sdk/src/sys/types/bool.rs
@@ -14,3 +14,10 @@ impl TryFrom<Bool> for bool {
         }
     }
 }
+
+impl From<bool> for Bool {
+    #[inline]
+    fn from(value: bool) -> Self {
+        Bool(value as u32)
+    }
+}

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -1,6 +1,7 @@
 use core::cmp::Ordering;
 use core::fmt::{Debug, Formatter};
 use core::{fmt, ptr};
+use std::hash::{Hash, Hasher};
 #[cfg(feature = "borsh")]
 use std::io::{Read, Result as IoResult, Write};
 
@@ -66,6 +67,15 @@ where
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl<T: KeyComponents> Hash for Key<T>
+where
+    GenericArray<u8, T::LEN>: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
     }
 }
 

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -182,7 +182,7 @@ impl KeyComponent for StateKey {
     type LEN = U32;
 }
 
-#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, Hash, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextState(Key<(ContextId, StateKey)>);
 


### PR DESCRIPTION
alternative model to #780, which uses a new interface across the bridge for storage operations

here's the interface so far:

```rust
fn storage_create(is_collection: bool) -> Id;
fn storage_read(key: Id) -> Value;
fn storage_write(key: Id, value: Value) -> Option<Value>;
fn storage_delete(key: Id) -> Option<Value>;
fn storage_adopt(key: Id, parent: Id);
fn storage_orphan(key: Id, parent: Id);
```

for the mock, storage is backed by the `InMemoryStorage`, while for the node, `RuntimeCompatStore` which should incorporate the CRDT base.

Collections are effectively lists of further IDs, which may be raw data, or collections.

```rust
#[derive(Debug)]
enum Entry {
    Bytes(Vec<u8>),
    Collection(HashSet<Id>),
}

#[derive(Debug, Default)]
pub struct InMemoryStorage {
    inner: BTreeMap<Id, Entry>,
}
```

```rust
struct App {
    posts: List<Post>,
}

struct Post {
    message: String,
}
```

`App`, as the state root (currently a `[0; 32]`), encodes the whole state as an atomic unit.

A `List` then is encoded as just the `Id`, so to the root, this is what is encoded as the atomic unit:

```rust
struct App {
    posts: Id,
}
```

At the point a `List` is decoded back into an instance of the structure, infused with the `Id`, accesses on the `List` like index operations would fetch the constituent `Id`s of the `List` collection and index that.

Each `Post` in the list, backed by their individual `Id`s would then also be atomic units.

Finishing up the `List` structure, I'll push that soon.