### PR TITLE
feat: Add ancestor hashes and type IDs

### DIFF
--- a/crates/storage-macros/tests/atomic_unit.rs
+++ b/crates/storage-macros/tests/atomic_unit.rs
@@ -34,6 +34,7 @@ use calimero_storage_macros::AtomicUnit;
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[root]
+#[type_id(1)]
 struct Private {
     public: String,
     #[private]
@@ -54,6 +55,7 @@ impl Private {
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[root]
+#[type_id(2)]
 struct Simple {
     name: String,
     value: i32,
@@ -73,6 +75,7 @@ impl Simple {
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[root]
+#[type_id(3)]
 struct Skipped {
     included: String,
     #[skip]

--- a/crates/storage-macros/tests/collection.rs
+++ b/crates/storage-macros/tests/collection.rs
@@ -32,6 +32,7 @@ use calimero_storage::exports::{Digest, Sha256};
 use calimero_storage_macros::{AtomicUnit, Collection};
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(22)]
 struct Child {
     content: String,
     #[storage]
@@ -58,6 +59,7 @@ impl Group {
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(21)]
 #[root]
 struct Parent {
     title: String,
@@ -78,6 +80,7 @@ impl Parent {
 }
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(23)]
 #[root]
 struct Simple {
     name: String,

--- a/crates/storage-macros/tests/compile_fail/collection.rs
+++ b/crates/storage-macros/tests/compile_fail/collection.rs
@@ -4,6 +4,7 @@ use calimero_storage::interface::Interface;
 use calimero_storage_macros::{AtomicUnit, Collection};
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(2)]
 struct Child {
     #[storage]
     storage: Element,
@@ -15,6 +16,7 @@ struct Group;
 
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[root]
+#[type_id(1)]
 struct Parent {
     group: Group,
 	#[storage]

--- a/crates/storage-macros/tests/compile_fail/collection.stderr
+++ b/crates/storage-macros/tests/compile_fail/collection.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> tests/compile_fail/collection.rs:33:30
+  --> tests/compile_fail/collection.rs:35:30
    |
-33 |         let _: Vec<Parent> = Interface::children_of(parent.id(), &parent.group).unwrap();
+35 |         let _: Vec<Parent> = Interface::children_of(parent.id(), &parent.group).unwrap();
    |                -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<Parent>`, found `Vec<Child>`
    |                |
    |                expected due to this

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -237,6 +237,7 @@ use crate::interface::StorageError;
 /// use calimero_storage_macros::AtomicUnit;
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+/// #[type_id(43)]
 /// struct Page {
 ///     title: String,
 ///     #[private]
@@ -261,6 +262,7 @@ pub trait AtomicUnit: Data {}
 /// use calimero_storage::entities::{ChildInfo, Data, Element};
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+/// #[type_id(42)]
 /// struct Book {
 ///     title: String,
 ///     pages: Pages,
@@ -273,6 +275,7 @@ pub trait AtomicUnit: Data {}
 /// struct Pages;
 ///
 /// #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+/// #[type_id(43)]
 /// struct Page {
 ///     content: String,
 ///     #[storage]
@@ -429,6 +432,19 @@ pub trait Data:
     fn path(&self) -> Path {
         self.element().path()
     }
+
+    /// The type identifier of the entity.
+    ///
+    /// This is noted so that the entity can be deserialised correctly in the
+    /// absence of other semantic information. It is intended that the [`Path`]
+    /// will be used to help with this at some point, but at present paths are
+    /// not fully utilised.
+    ///
+    /// The value returned is arbitrary, and is up to the implementer to decide
+    /// what it should be. It is recommended that it be unique for each type of
+    /// entity.
+    ///
+    fn type_id() -> u8;
 }
 
 /// Summary information for the child of an [`Element`] in the storage.

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -33,6 +33,12 @@ struct EntityIndex {
     /// Merkle hash of the entity's immediate data only. This gets combined with
     /// the hashes of its children to form the full hash.
     own_hash: [u8; 32],
+
+    /// Type identifier of the entity. This is noted so that the entity can be
+    /// deserialised correctly in the absence of other semantic information. It
+    /// is intended that the [`Path`](crate::address::Path) will be used to help
+    /// with this at some point, but at present paths are not fully utilised.
+    type_id: u8,
 }
 
 /// Manages the indexing system for efficient tree navigation.
@@ -50,6 +56,7 @@ impl<S: StorageAdaptor> Index<S> {
     /// * `collection` - The name of the collection to which the child is to be
     ///                  added.
     /// * `child`      - The [`ChildInfo`] of the child entity to be added.
+    /// * `type_id`    - The type identifier of the entity.
     ///
     /// # Errors
     ///
@@ -65,6 +72,7 @@ impl<S: StorageAdaptor> Index<S> {
         parent_id: Id,
         collection: &str,
         child: ChildInfo,
+        type_id: u8,
     ) -> Result<(), StorageError> {
         let mut parent_index =
             Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
@@ -75,6 +83,7 @@ impl<S: StorageAdaptor> Index<S> {
             children: BTreeMap::new(),
             full_hash: [0; 32],
             own_hash: [0; 32],
+            type_id,
         });
         child_index.parent_id = Some(parent_id);
         child_index.own_hash = child.merkle_hash();
@@ -113,13 +122,14 @@ impl<S: StorageAdaptor> Index<S> {
     ///
     /// * [`add_child_to()`](Index::add_child_to())
     ///
-    pub(crate) fn add_root(root: ChildInfo) -> Result<(), StorageError> {
+    pub(crate) fn add_root(root: ChildInfo, type_id: u8) -> Result<(), StorageError> {
         let mut index = Self::get_index(root.id())?.unwrap_or_else(|| EntityIndex {
             id: root.id(),
             parent_id: None,
             children: BTreeMap::new(),
             full_hash: [0; 32],
             own_hash: [0; 32],
+            type_id,
         });
         index.own_hash = root.merkle_hash();
         Self::save_index(&index)?;

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -339,6 +339,7 @@ impl<S: StorageAdaptor> MainInterface<S> {
             parent_id,
             collection.name(),
             ChildInfo::new(child.id(), own_hash),
+            D::type_id(),
         )?;
         child.element_mut().merkle_hash = <Index<S>>::update_hash_for(child.id(), own_hash)?;
         Self::save(child)
@@ -909,7 +910,7 @@ impl<S: StorageAdaptor> MainInterface<S> {
                 return Ok(false);
             }
         } else if D::is_root() {
-            <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32]))?;
+            <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32]), D::type_id())?;
         }
 
         let own_hash = entity.calculate_merkle_hash()?;

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -66,6 +66,10 @@ impl Data for EmptyData {
     fn is_root() -> bool {
         true
     }
+
+    fn type_id() -> u8 {
+        101
+    }
 }
 
 /// A simple page with a title, and paragraphs as children.
@@ -130,6 +134,10 @@ impl Data for Page {
     fn is_root() -> bool {
         true
     }
+
+    fn type_id() -> u8 {
+        102
+    }
 }
 
 /// A simple paragraph with text. No children. Belongs to a page.
@@ -182,6 +190,10 @@ impl Data for Paragraph {
 
     fn is_root() -> bool {
         false
+    }
+
+    fn type_id() -> u8 {
+        103
     }
 }
 
@@ -244,5 +256,9 @@ impl Data for Person {
 
     fn is_root() -> bool {
         true
+    }
+
+    fn type_id() -> u8 {
+        104
     }
 }

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -10,7 +10,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -30,7 +30,8 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash)
+            ChildInfo::new(child_id, child_own_hash),
+            2,
         )
         .is_ok());
 
@@ -56,7 +57,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -70,7 +71,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let collection_name = "Books";
         let child1_id = Id::new();
@@ -92,13 +93,15 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child1_id, child1_own_hash)
+            ChildInfo::new(child1_id, child1_own_hash),
+            2,
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child2_id, child2_own_hash)
+            ChildInfo::new(child2_id, child2_own_hash),
+            2,
         )
         .is_ok());
 
@@ -113,7 +116,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let collection1_name = "Pages";
         let child1_id = Id::new();
@@ -143,19 +146,22 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
-            ChildInfo::new(child1_id, child1_own_hash)
+            ChildInfo::new(child1_id, child1_own_hash),
+            2,
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
-            ChildInfo::new(child2_id, child2_own_hash)
+            ChildInfo::new(child2_id, child2_own_hash),
+            2,
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection2_name,
-            ChildInfo::new(child3_id, child3_own_hash)
+            ChildInfo::new(child3_id, child3_own_hash),
+            2,
         )
         .is_ok());
 
@@ -173,7 +179,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let collection1_name = "Pages";
         let collection2_name = "Chapters";
@@ -187,13 +193,15 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
-            ChildInfo::new(child1_id, child1_own_hash)
+            ChildInfo::new(child1_id, child1_own_hash),
+            2,
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection2_name,
-            ChildInfo::new(child2_id, child2_own_hash)
+            ChildInfo::new(child2_id, child2_own_hash),
+            2,
         )
         .is_ok());
 
@@ -209,7 +217,7 @@ mod index__public_methods {
         let root_own_hash = [1_u8; 32];
         let root_full_hash = [0_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_own_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_own_hash), 1).is_ok());
 
         assert_eq!(
             <Index<MainStorage>>::get_hashes_for(root_id)
@@ -224,7 +232,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -239,7 +247,8 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash)
+            ChildInfo::new(child_id, child_own_hash),
+            2,
         )
         .is_ok());
 
@@ -256,7 +265,7 @@ mod index__public_methods {
         let root_hash = [1_u8; 32];
         let collection_name = "Books";
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
         assert!(!<Index<MainStorage>>::has_children(root_id, collection_name).unwrap());
 
         let child_id = Id::new();
@@ -265,7 +274,8 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash)
+            ChildInfo::new(child_id, child_own_hash),
+            2,
         )
         .is_ok());
         assert!(<Index<MainStorage>>::has_children(root_id, collection_name).unwrap());
@@ -276,7 +286,7 @@ mod index__public_methods {
         let root_id = Id::new();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -291,7 +301,8 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash)
+            ChildInfo::new(child_id, child_own_hash),
+            2,
         )
         .is_ok());
         assert!(
@@ -320,6 +331,7 @@ mod index__private_methods {
             children: BTreeMap::new(),
             full_hash: hash1,
             own_hash: hash2,
+            type_id: 1,
         };
         <Index<MainStorage>>::save_index(&index).unwrap();
 
@@ -339,6 +351,7 @@ mod index__private_methods {
             children: BTreeMap::new(),
             full_hash: hash1,
             own_hash: hash2,
+            type_id: 1,
         };
         <Index<MainStorage>>::save_index(&index).unwrap();
         assert_eq!(<Index<MainStorage>>::get_index(id).unwrap().unwrap(), index);
@@ -355,21 +368,27 @@ mod hashing {
     #[test]
     fn calculate_full_merkle_hash_for__with_children() {
         let root_id = TEST_ID[0];
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(TEST_ID[0], [0_u8; 32])).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(TEST_ID[0], [0_u8; 32]), 1).is_ok());
 
         let collection_name = "Children";
         let child1_id = TEST_ID[1];
         let child1_hash = [1_u8; 32];
         let child1_info = ChildInfo::new(child1_id, child1_hash);
-        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child1_info).is_ok());
+        assert!(
+            <Index<MainStorage>>::add_child_to(root_id, collection_name, child1_info, 2).is_ok()
+        );
         let child2_id = TEST_ID[2];
         let child2_hash = [2_u8; 32];
         let child2_info = ChildInfo::new(child2_id, child2_hash);
-        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child2_info).is_ok());
+        assert!(
+            <Index<MainStorage>>::add_child_to(root_id, collection_name, child2_info, 2).is_ok()
+        );
         let child3_id = TEST_ID[3];
         let child3_hash = [3_u8; 32];
         let child3_info = ChildInfo::new(child3_id, child3_hash);
-        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child3_info).is_ok());
+        assert!(
+            <Index<MainStorage>>::add_child_to(root_id, collection_name, child3_info, 2).is_ok()
+        );
 
         assert_eq!(
             hex::encode(
@@ -405,7 +424,7 @@ mod hashing {
         let grandchild_collection_name = "Pages";
         let greatgrandchild_collection_name = "Paragraphs";
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.full_hash, [0_u8; 32]);
@@ -414,7 +433,8 @@ mod hashing {
         let child_hash = [2_u8; 32];
         let child_info = ChildInfo::new(child_id, child_hash);
         assert!(
-            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info).is_ok()
+            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info, 2)
+                .is_ok()
         );
 
         let root_index_with_child = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
@@ -434,7 +454,8 @@ mod hashing {
         assert!(<Index<MainStorage>>::add_child_to(
             child_id,
             grandchild_collection_name,
-            grandchild_info
+            grandchild_info,
+            3,
         )
         .is_ok());
 
@@ -463,7 +484,8 @@ mod hashing {
         assert!(<Index<MainStorage>>::add_child_to(
             grandchild_id,
             greatgrandchild_collection_name,
-            greatgrandchild_info
+            greatgrandchild_info,
+            4,
         )
         .is_ok());
 
@@ -581,7 +603,7 @@ mod hashing {
                 .try_into()
                 .unwrap();
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -599,7 +621,7 @@ mod hashing {
         let root_hash1 = [1_u8; 32];
         let root_hash2 = [2_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1)).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1), 1).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);


### PR DESCRIPTION
Added type ID to entities

  - Added a `type_id()` method to the `Data` trait, to provide a unique type ID per implemented `Data` type, formalising the approach to type identification.

  - Added a `type_id` parameter to `Index::add_child_to()` and `Index::root()`.

Added ancestor hashes to `Action`

  - Added ancestor information to `Action::Add`, `Delete`, and `Update`. This allows the ancestor hashes to be checked after applying an action, to see if further syncing is needed.

  - Added an `ancestors` field to `ComparisonData`. This will be useful for checking the higher tree levels in some cases.

  - Added `get_ancestors_of()` and `get_type_id()` to `Index`. The type ID is now formalised as a `u8`.

  - Changed the `Action` `id` field to be a `u8`, to match `type_id`.

  - Made the Action variants into struct variants for greater clarity.

Changed `apply_action()` to check ancestors

  - Amended the behaviour of `Interface::apply_action()` to check the recalculated ancestor hashes of an updated entity after applying the update, and indicate if any of the ancestors need re-syncing as a result (based on the expectation that the hashes will all match).