### PR TITLE
fix: load config should factor in node's home dir

### DIFF
--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -60,7 +60,7 @@ pub struct RootArgs {
 
     /// Name of node
     #[arg(short, long, value_name = "NAME")]
-    pub node_name: Utf8PathBuf,
+    pub node_name: String,
 }
 
 impl RootCommand {

--- a/crates/meroctl/src/cli/app/get.rs
+++ b/crates/meroctl/src/cli/app/get.rs
@@ -21,7 +21,7 @@ pub enum GetValues {
 impl GetCommand {
     #[expect(clippy::print_stdout, reason = "Acceptable for CLI")]
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
 
         let url = multiaddr_to_url(
             fetch_multiaddr(&config)?,

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -31,7 +31,7 @@ pub struct InstallCommand {
 
 impl InstallCommand {
     pub async fn run(self, args: RootArgs) -> Result<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
         let mut is_dev_installation = false;
         let metadata = self.metadata.map(String::into_bytes).unwrap_or_default();
 

--- a/crates/meroctl/src/cli/app/list.rs
+++ b/crates/meroctl/src/cli/app/list.rs
@@ -11,7 +11,7 @@ pub struct ListCommand;
 
 impl ListCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
 
         let response = get_response(
             &Client::new(),

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -48,7 +48,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
         let multiaddr = fetch_multiaddr(&config)?;
         let client = Client::new();
 

--- a/crates/meroctl/src/cli/context/delete.rs
+++ b/crates/meroctl/src/cli/context/delete.rs
@@ -15,7 +15,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
 
         self.delete_context(fetch_multiaddr(&config)?, &Client::new(), &config.identity)
             .await

--- a/crates/meroctl/src/cli/context/get.rs
+++ b/crates/meroctl/src/cli/context/get.rs
@@ -27,7 +27,7 @@ pub enum GetRequest {
 
 impl GetCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
         let multiaddr = fetch_multiaddr(&config)?;
         let client = Client::new();
 

--- a/crates/meroctl/src/cli/context/join.rs
+++ b/crates/meroctl/src/cli/context/join.rs
@@ -19,7 +19,7 @@ pub struct JoinCommand {
 
 impl JoinCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
 
         let response = get_response(
             &Client::new(),

--- a/crates/meroctl/src/cli/context/list.rs
+++ b/crates/meroctl/src/cli/context/list.rs
@@ -11,7 +11,7 @@ pub struct ListCommand;
 
 impl ListCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
 
         let response = get_response(
             &Client::new(),

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -17,7 +17,7 @@ pub struct WatchCommand {
 
 impl WatchCommand {
     pub async fn run(self, args: RootArgs) -> EyreResult<()> {
-        let config = load_config(&args.node_name)?;
+        let config = load_config(&args.home, &args.node_name)?;
 
         let mut url = multiaddr_to_url(fetch_multiaddr(&config)?, "ws")?;
         url.set_scheme("ws")

--- a/crates/meroctl/src/common.rs
+++ b/crates/meroctl/src/common.rs
@@ -1,4 +1,4 @@
-use camino::Utf8PathBuf;
+use camino::Utf8Path;
 use chrono::Utc;
 use eyre::{bail, eyre, Result as EyreResult};
 use libp2p::identity::Keypair;
@@ -62,7 +62,9 @@ where
         .map_err(|_| eyre!("Error with client request"))
 }
 
-pub fn load_config(path: &Utf8PathBuf) -> EyreResult<ConfigFile> {
+pub fn load_config(home: &Utf8Path, node_name: &str) -> EyreResult<ConfigFile> {
+    let path = home.join(node_name);
+
     if !ConfigFile::exists(&path) {
         bail!("Config file does not exist")
     };


### PR DESCRIPTION
The `load_config` refactor in #793 lost some information, notably no longer loading the config from the node's home dir, the effect of which only works when the executor's CWD is inside the node's home dir