### PR TITLE
fix: incorporate review feedback from #799

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "ureq",
- "uuid 1.10.0",
  "wasmer",
  "wasmer-types",
 ]
@@ -1029,7 +1028,6 @@ dependencies = [
  "serde",
  "serde_json",
  "trybuild",
- "uuid 1.10.0",
 ]
 
 [[package]]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,10 +11,10 @@ borsh = { workspace = true, features = ["derive"] }
 fragile.workspace = true
 ouroboros.workspace = true
 owo-colors = { workspace = true, optional = true }
+rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 ureq.workspace = true
-uuid = { workspace = true, features = ["serde", "v4"] }
 wasmer.workspace = true
 wasmer-types.workspace = true
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -458,14 +458,14 @@ impl VMHostFunctions<'_> {
         Ok(status)
     }
 
-    pub fn random_bytes(&mut self, len: u64, register_id: u64) -> VMLogicResult<()> {
+    pub fn random_bytes(&mut self, ptr: u64, len: u64) -> VMLogicResult<()> {
         let len = usize::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
 
         let mut buf = vec![0; len];
 
         rand::thread_rng().fill_bytes(&mut buf);
 
-        self.with_logic_mut(|logic| logic.registers.set(logic.limits, register_id, buf))?;
+        self.borrow_memory().write(ptr, &buf)?;
 
         Ok(())
     }

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -459,12 +459,9 @@ impl VMHostFunctions<'_> {
     }
 
     pub fn random_bytes(&mut self, ptr: u64, len: u64) -> VMLogicResult<()> {
-        let len = usize::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
-
-        let mut buf = vec![0; len];
+        let mut buf = vec![0; usize::try_from(len).map_err(|_| HostError::IntegerOverflow)?];
 
         rand::thread_rng().fill_bytes(&mut buf);
-
         self.borrow_memory().write(ptr, &buf)?;
 
         Ok(())

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -136,17 +136,6 @@ impl<'a> VMLogic<'a> {
         }
         .build()
     }
-
-    /// Generates a new UUID using v4 standard.
-    ///
-    /// This function generates a new UUID using the v4 standard. The UUID is
-    /// dependent on randomness, which is not available inside the guest
-    /// runtime. Therefore the guest needs to request this from the host.
-    ///
-    #[must_use]
-    pub fn generate_uuid(&self) -> Uuid {
-        Uuid::new_v4()
-    }
 }
 
 #[derive(Debug, Serialize)]
@@ -476,12 +465,14 @@ impl VMHostFunctions<'_> {
     /// runtime. Therefore the guest needs to request this from the host.
     ///
     pub fn generate_uuid(&mut self, register_id: u64) -> VMLogicResult<()> {
+        let uuid = Uuid::new_v4();
+
         self.with_logic_mut(|logic| {
-            let uuid = logic.generate_uuid();
             logic
                 .registers
                 .set(logic.limits, register_id, uuid.into_bytes())
         })?;
+
         Ok(())
     }
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -485,16 +485,18 @@ impl VMHostFunctions<'_> {
         clippy::unwrap_in_result,
         reason = "Effectively infallible here"
     )]
-    pub fn time_now(&mut self, register_id: u64) -> VMLogicResult<()> {
+    pub fn time_now(&mut self, ptr: u64, len: u64) -> VMLogicResult<()> {
+        if len != 8 {
+            return Err(HostError::InvalidMemoryAccess.into());
+        }
+
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards to before the Unix epoch!")
             .as_nanos() as u64;
-        self.with_logic_mut(|logic| {
-            logic
-                .registers
-                .set(logic.limits, register_id, now.to_le_bytes())
-        })?;
+
+        self.borrow_memory().write(ptr, &now.to_le_bytes())?;
+
         Ok(())
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -64,7 +64,7 @@ impl VMLogic<'_> {
             ) -> u32;
 
             fn random_bytes(ptr: u64, len: u64);
-            fn time_now(register_id: u64);
+            fn time_now(ptr: u64, len: u64);
         }
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -63,7 +63,7 @@ impl VMLogic<'_> {
                 register_id: u64
             ) -> u32;
 
-            fn random_bytes(len: u64, register_id: u64);
+            fn random_bytes(ptr: u64, len: u64);
             fn time_now(register_id: u64);
         }
     }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -63,7 +63,7 @@ impl VMLogic<'_> {
                 register_id: u64
             ) -> u32;
 
-            fn generate_uuid(register_id: u64);
+            fn random_bytes(len: u64, register_id: u64);
             fn time_now(register_id: u64);
         }
     }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -12,12 +12,8 @@ cfg-if.workspace = true
 hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-uuid.workspace = true
 
 calimero-sdk-macros = { path = "./macros" }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-uuid = { workspace = true, features = ["serde", "v4"] }
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -3,7 +3,6 @@ use std::panic::set_hook;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use borsh::{from_slice as from_borsh_slice, to_vec as to_borsh_vec};
-use uuid::Uuid;
 
 use crate::event::AppEvent;
 #[cfg(not(target_arch = "wasm32"))]
@@ -222,20 +221,14 @@ pub fn state_write<T: AppState>(state: &T) {
     _ = storage_write(STATE_KEY, &data);
 }
 
-/// Generate a new random UUID v4.
 #[inline]
 #[must_use]
-pub fn generate_uuid() -> Uuid {
-    #[cfg(target_arch = "wasm32")]
-    {
-        unsafe { sys::generate_uuid(DATA_REGISTER) };
-        Uuid::from_slice(&read_register_sized::<16>(DATA_REGISTER).expect("Must have UUID"))
-            .expect("UUID must be valid")
+pub fn random_bytes<const N: usize>() -> [u8; N] {
+    unsafe {
+        sys::random_bytes(N as u64, DATA_REGISTER);
     }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        Uuid::new_v4()
-    }
+
+    read_register_sized::<N>(DATA_REGISTER).expect("Must have random bytes.")
 }
 
 /// Gets the current time.

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -221,14 +221,11 @@ pub fn state_write<T: AppState>(state: &T) {
     _ = storage_write(STATE_KEY, &data);
 }
 
+/// Fill the buffer with random bytes.
 #[inline]
 #[must_use]
-pub fn random_bytes<const N: usize>() -> [u8; N] {
-    unsafe {
-        sys::random_bytes(N as u64, DATA_REGISTER);
-    }
-
-    read_register_sized::<N>(DATA_REGISTER).expect("Must have random bytes.")
+pub fn random_bytes(buf: &mut [u8]) {
+    unsafe { sys::random_bytes(BufferMut::new(buf)) }
 }
 
 /// Gets the current time.

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -1,6 +1,4 @@
 use std::panic::set_hook;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use borsh::{from_slice as from_borsh_slice, to_vec as to_borsh_vec};
 
@@ -232,26 +230,9 @@ pub fn random_bytes(buf: &mut [u8]) {
 #[inline]
 #[must_use]
 pub fn time_now() -> u64 {
-    #[cfg(target_arch = "wasm32")]
-    {
-        unsafe { sys::time_now(DATA_REGISTER) };
-        u64::from_le_bytes(
-            read_register(DATA_REGISTER)
-                .expect("Must have time")
-                .try_into()
-                .expect("Invalid time bytes"),
-        )
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "Impossible to overflow in normal circumstances"
-    )]
-    #[expect(clippy::expect_used, reason = "Effectively infallible here")]
-    {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards to before the Unix epoch!")
-            .as_nanos() as u64
-    }
+    let mut bytes = [0; 8];
+
+    unsafe { sys::time_now(BufferMut::new(&mut bytes)) }
+
+    u64::from_le_bytes(bytes)
 }

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -221,7 +221,6 @@ pub fn state_write<T: AppState>(state: &T) {
 
 /// Fill the buffer with random bytes.
 #[inline]
-#[must_use]
 pub fn random_bytes(buf: &mut [u8]) {
     unsafe { sys::random_bytes(BufferMut::new(buf)) }
 }

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -102,7 +102,6 @@ pub fn read_register(register_id: RegisterId) -> Option<Vec<u8>> {
 #[inline]
 fn read_register_sized<const N: usize>(register_id: RegisterId) -> Option<[u8; N]> {
     let len = register_len(register_id)?;
-
     let mut buffer = [0; N];
 
     #[expect(

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -105,6 +105,10 @@ fn read_register_sized<const N: usize>(register_id: RegisterId) -> Option<[u8; N
 
     let mut buffer = [0; N];
 
+    #[expect(
+        clippy::needless_borrows_for_generic_args,
+        reason = "we don't want to copy the buffer, but write to the same one that's returned"
+    )]
     let succeed: bool = unsafe {
         sys::read_register(register_id, BufferMut::new(&mut buffer))
             .try_into()
@@ -231,7 +235,13 @@ pub fn random_bytes(buf: &mut [u8]) {
 pub fn time_now() -> u64 {
     let mut bytes = [0; 8];
 
-    unsafe { sys::time_now(BufferMut::new(&mut bytes)) }
+    #[expect(
+        clippy::needless_borrows_for_generic_args,
+        reason = "we don't want to copy the buffer, but write to the same one that's returned"
+    )]
+    unsafe {
+        sys::time_now(BufferMut::new(&mut bytes));
+    }
 
     u64::from_le_bytes(bytes)
 }

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -30,7 +30,8 @@ wasm_imports! {
             body: Buffer<'_>,
             register_id: RegisterId
         ) -> Bool;
-        fn generate_uuid(register_id: RegisterId);
+        // --
+        fn random_bytes(len: u64, register_id: RegisterId);
         fn time_now(register_id: RegisterId);
     }
 }

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -31,7 +31,7 @@ wasm_imports! {
             register_id: RegisterId
         ) -> Bool;
         // --
-        fn random_bytes(len: u64, register_id: RegisterId);
+        fn random_bytes(buf: BufferMut<'_>);
         fn time_now(register_id: RegisterId);
     }
 }

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -32,7 +32,7 @@ wasm_imports! {
         ) -> Bool;
         // --
         fn random_bytes(buf: BufferMut<'_>);
-        fn time_now(register_id: RegisterId);
+        fn time_now(buf: BufferMut<'_>);
     }
 }
 


### PR DESCRIPTION
1. remove `VMLogic::generate_uuid` - [ref](https://github.com/calimero-network/core/pull/799#discussion_r1800159587)
2. remove `uuid` dep from runtime & SDK - [ref](https://github.com/calimero-network/core/pull/799#discussion_r1800313072)
3. generalize `sys::generate_uuid` to `sys::random_bytes` - [ref](https://github.com/calimero-network/core/pull/799#discussion_r1800168580)
4. remove mocks for SDK functionality - ref [1](https://github.com/calimero-network/core/pull/799#discussion_r1800172131) & [2](https://github.com/calimero-network/core/pull/799#discussion_r1800172227)
	- as mentioned in https://github.com/calimero-network/core/pull/781#discussion_r1801073836, this will be accommodated inside the storage crate
5. clean up `uuid` in root manifest - [ref](https://github.com/calimero-network/core/pull/799#discussion_r1801168500)
	- the others - `fixedstr`, `axum-server` will be addressed in a separate PR targeting `master`

additionally, this includes optimizations for sized data exchanged between the runtime and the SDK, skipping register heap allocations & copying