### PR TITLE
adds docker and docker-compose to run coordinater and app nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 dist/
 lib/
 node_modules/
+certs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Use an official Rust image as the base
+FROM rust:latest
+
+# Install system dependencies
+RUN  apt-get update && apt-get install -y \
+    zlib1g-dev \
+    libsnappy-dev \
+    libbz2-dev \
+    liblz4-dev \
+    libzstd-dev \
+    clang \
+    libclang-dev \
+    curl \
+    build-essential \
+    pkg-config \
+    jq
+
+# Install Node.js (version 20) and pnpm
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g pnpm
+
+# Set the working directory
+WORKDIR /app
+
+# Copy only necessary files for building dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+COPY contracts ./contracts
+COPY apps ./apps
+COPY node-ui ./node-ui
+COPY packages ./packages
+
+# Build the node UI
+WORKDIR /app/node-ui
+RUN pnpm install && pnpm run build
+
+# Build the merod binary
+WORKDIR /app
+RUN cargo build --release -p merod
+
+# Set the binary as the entrypoint
+ENTRYPOINT ["/app/target/release/merod"]
+
+# Default command (can be overridden in docker-compose)
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  coordinator_init:
+    image: merod-image:latest
+    command: >
+      --node-name coordinator --home /data init --server-port 2427 --swarm-port 2527
+    volumes:
+      - ./data:/data
+
+  coordinator_run:
+    image: merod-image:latest
+    ports:
+      - "2427:2427"
+      - "2527:2527"
+    command: >
+      --node-name coordinator --home /data run --node-type coordinator
+    volumes:
+      - ./data:/data
+    depends_on:
+      - coordinator_init
+
+  app_node_init:
+    image: merod-image:latest
+    command: >
+      --node-name node1 --home /data init --server-port 2428 --swarm-port 2528
+    volumes:
+      - ./data:/data
+
+  app_node_run:
+    image: merod-image:latest
+    ports:
+      - "2428:2428"
+      - "2528:2528"
+    command: >
+      --node-name node1 --home /data run
+    volumes:
+      - ./data:/data
+      - ./certs:/certs
+    depends_on:
+      - app_node_init


### PR DESCRIPTION
I was having issues running the node on my machine via the `cargo run` in docs, so this PR introduces a Dockerfile and docker-compose to create an image and run the two nodes.

Please, feel free to make any changes to it -- it builds a 5.78 GB image that is reused across the two instances. The `init` could probably be better and not in the compose.

Also -- it doesn't come without an issue... I'm able to successfully build the image and run docker-image (proof below).

<img width="226" alt="Screenshot 2024-10-17 at 9 29 24 PM" src="https://github.com/user-attachments/assets/22f4745e-6b0c-4679-98d7-9e803bc7b1bf">

Inside the docker container, I can access the dashboard:

`docker exec -it core-app_node_run-1 /bin/sh`

then inside the bash, I download the certificate:

```
curl -k -o /certs/node_certificate.crt https://localhost:2428/admin-api/certificate
```

/certs is shared with my local machine, so I see it in finder, double click, add to MacOS keychain (according to docs, proof)

<img width="131" alt="Screenshot 2024-10-17 at 9 32 51 PM" src="https://github.com/user-attachments/assets/4338a4a2-a8bf-4264-b7ec-d91a73000357">

And I always trust, refresh browser. 

**I still cannot connect to node's admin-dashboard from my device**

Although I CAN successfully ping it.

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added a test plan that prove my fix is effective or that my feature
      works
- [ ] I squashed all commits and provided a meaningful commit message
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
