### PR TITLE
feat: update kv store to use new CRDT store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,7 +3659,6 @@ version = "0.1.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "calimero-storage-macros",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,6 +3658,9 @@ name = "kv-store"
 version = "0.1.0"
 dependencies = [
  "calimero-sdk",
+ "calimero-storage",
+ "calimero-storage-macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/apps/kv-store/Cargo.toml
+++ b/apps/kv-store/Cargo.toml
@@ -10,4 +10,7 @@ license.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+thiserror.workspace = true
 calimero-sdk = { path = "../../crates/sdk" }
+calimero-storage = { path = "../../crates/storage" }
+calimero-storage-macros = { path = "../../crates/storage-macros" }

--- a/apps/kv-store/Cargo.toml
+++ b/apps/kv-store/Cargo.toml
@@ -13,4 +13,3 @@ crate-type = ["cdylib"]
 thiserror.workspace = true
 calimero-sdk = { path = "../../crates/sdk" }
 calimero-storage = { path = "../../crates/storage" }
-calimero-storage-macros = { path = "../../crates/storage-macros" }

--- a/apps/kv-store/src/collections.rs
+++ b/apps/kv-store/src/collections.rs
@@ -1,0 +1,119 @@
+use calimero_storage::{
+    address::{Path, PathError},
+    entities::{Data, Element},
+    interface::{Interface, StorageError},
+};
+use calimero_storage_macros::{AtomicUnit, Collection};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+    #[error(transparent)]
+    PathError(#[from] PathError),
+}
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(255)]
+#[root]
+pub struct Map {
+    entries: Entries,
+    #[storage]
+    storage: Element,
+}
+
+#[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[children(Entry)]
+pub struct Entries;
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(254)]
+pub struct Entry {
+    key: String,
+    value: String,
+    #[storage]
+    storage: Element,
+}
+
+impl Map {
+    pub fn new(path: &Path) -> Result<Self, Error> {
+        let mut this = Self {
+            entries: Entries,
+            storage: Element::new(path),
+        };
+
+        Interface::save(&mut this)?;
+
+        Ok(this)
+    }
+
+    pub fn set(&mut self, key: String, value: String) -> Result<Option<String>, Error> {
+        let previous = self.get(&key)?;
+
+        let path = self.path();
+        // fixme! Reusing the Map's path for now. We "could" concatenate, but it's
+        // fixme! non-trivial and currently non-functional, so it's been left out
+
+        let storage = Element::new(&path);
+        // fixme! This uses a random id for the map's entries, which will impair
+        // fixme! perf on the lookup, as we'd have to fetch and look through all
+        // fixme! entries to find the one that matches the key we're looking for
+        // fixme! ideally, the Id should be defined as hash(concat(map_id, key))
+        // fixme! which will save on map-wide lookups, getting the item directly
+
+        Interface::add_child_to(
+            self.storage.id(),
+            &mut self.entries,
+            &mut Entry {
+                key,
+                value,
+                storage,
+            },
+        )?;
+
+        Ok(previous)
+    }
+
+    pub fn entries(&self) -> Result<impl Iterator<Item = (String, String)>, Error> {
+        let entries = Interface::children_of(self.id(), &self.entries)?;
+
+        Ok(entries.into_iter().map(|entry| (entry.key, entry.value)))
+    }
+
+    pub fn len(&self) -> Result<usize, Error> {
+        Ok(Interface::child_info_for(self.id(), &self.entries)?.len())
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<String>, Error> {
+        for (key_, value) in self.entries()? {
+            if key_ == key {
+                return Ok(Some(value));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn remove(&mut self, key: &str) -> Result<Option<String>, Error> {
+        let entries = Interface::children_of(self.id(), &self.entries)?;
+
+        let entry = entries.into_iter().find(|entry| entry.key == key);
+
+        if let Some(entry) = &entry {
+            Interface::remove_child_from(self.id(), &mut self.entries, entry.id())?;
+        }
+
+        Ok(entry.map(|entry| entry.value))
+    }
+
+    pub fn clear(&mut self) -> Result<(), Error> {
+        let entries = Interface::children_of(self.id(), &self.entries)?;
+
+        for entry in entries {
+            Interface::remove_child_from(self.id(), &mut self.entries, entry.id())?;
+        }
+
+        Ok(())
+    }
+}

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use calimero_sdk::types::Error;
 use calimero_sdk::{app, env};
+use calimero_storage::AtomicUnit;
 use calimero_storage::{address::Path, entities::Element};
-use calimero_storage_macros::AtomicUnit;
 
 mod collections;
 

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -1,13 +1,22 @@
-use std::collections::hash_map::{Entry as HashMapEntry, HashMap};
+use std::collections::BTreeMap;
 
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::types::Error;
 use calimero_sdk::{app, env};
+use calimero_storage::{address::Path, entities::Element};
+use calimero_storage_macros::AtomicUnit;
+
+mod collections;
+
+use collections::Map;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(BorshDeserialize, BorshSerialize, Default)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(AtomicUnit, Clone, Debug, PartialEq, PartialOrd)]
+#[root]
+#[type_id(1)]
 pub struct KvStore {
-    items: HashMap<String, String>,
+    items: Map,
+    #[storage]
+    storage: Element,
 }
 
 #[app::event]
@@ -22,70 +31,73 @@ pub enum Event<'a> {
 impl KvStore {
     #[app::init]
     pub fn init() -> KvStore {
-        KvStore::default()
+        KvStore {
+            items: Map::new(&Path::new("::items").unwrap()).unwrap(),
+            storage: Element::root(),
+        }
     }
 
-    pub fn set(&mut self, key: String, value: String) {
+    pub fn set(&mut self, key: String, value: String) -> Result<(), Error> {
         env::log(&format!("Setting key: {:?} to value: {:?}", key, value));
 
-        match self.items.entry(key) {
-            HashMapEntry::Occupied(mut entry) => {
-                app::emit!(Event::Updated {
-                    key: entry.key(),
-                    value: &value,
-                });
-                entry.insert(value);
-            }
-            HashMapEntry::Vacant(entry) => {
-                app::emit!(Event::Inserted {
-                    key: entry.key(),
-                    value: &value,
-                });
-                entry.insert(value);
-            }
+        if self.items.set(key.clone(), value.clone())?.is_some() {
+            app::emit!(Event::Updated {
+                key: &key,
+                value: &value,
+            });
+        } else {
+            app::emit!(Event::Inserted {
+                key: &key,
+                value: &value,
+            });
         }
+
+        Ok(())
     }
 
-    pub fn entries(&self) -> &HashMap<String, String> {
+    pub fn entries(&self) -> Result<BTreeMap<String, String>, Error> {
         env::log("Getting all entries");
 
-        &self.items
+        Ok(self.items.entries()?.collect())
     }
 
-    pub fn get(&self, key: &str) -> Option<&str> {
+    pub fn len(&self) -> Result<usize, Error> {
+        env::log("Getting the number of entries");
+
+        Ok(self.items.len()?)
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<String>, Error> {
         env::log(&format!("Getting key: {:?}", key));
 
-        self.items.get(key).map(|v| v.as_str())
+        self.items.get(key).map_err(Into::into)
     }
 
-    pub fn get_unchecked(&self, key: &str) -> &str {
+    pub fn get_unchecked(&self, key: &str) -> Result<String, Error> {
         env::log(&format!("Getting key without checking: {:?}", key));
 
-        match self.items.get(key) {
-            Some(value) => value.as_str(),
-            None => env::panic_str("Key not found."),
-        }
+        Ok(self.items.get(key)?.expect("Key not found."))
     }
 
-    pub fn get_result(&self, key: &str) -> Result<&str, &str> {
+    pub fn get_result(&self, key: &str) -> Result<String, Error> {
         env::log(&format!("Getting key, possibly failing: {:?}", key));
 
-        self.get(key).ok_or("Key not found.")
+        self.get(key)?.ok_or_else(|| Error::msg("Key not found."))
     }
 
-    pub fn remove(&mut self, key: &str) {
+    pub fn remove(&mut self, key: &str) -> Result<Option<String>, Error> {
         env::log(&format!("Removing key: {:?}", key));
 
         app::emit!(Event::Removed { key });
 
-        self.items.remove(key);
+        self.items.remove(key).map_err(Into::into)
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self) -> Result<(), Error> {
         env::log("Clearing all entries");
 
         app::emit!(Event::Cleared);
 
-        self.items.clear();
+        self.items.clear().map_err(Into::into)
     }
 }

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -1,5 +1,6 @@
 #![allow(unused_crate_dependencies, reason = "Not actually unused")]
 
+use core::str;
 use std::env;
 use std::fs::File;
 use std::io::Read;
@@ -10,7 +11,28 @@ use calimero_runtime::store::InMemoryStorage;
 use calimero_runtime::{run, Constraint};
 use eyre::Result as EyreResult;
 use owo_colors::OwoColorize;
-use serde_json::{json, to_vec as to_json_vec};
+use serde_json::{json, to_vec as to_json_vec, Value};
+
+fn parse_payload(payload: &[u8], pretty: bool) -> EyreResult<String> {
+    match serde_json::from_slice::<Value>(payload) {
+        Ok(json) => {
+            return (if pretty {
+                serde_json::to_string_pretty
+            } else {
+                serde_json::to_string
+            })(&json)
+            .map_err(Into::into)
+        }
+        Err(_) => {}
+    };
+
+    match str::from_utf8(&payload) {
+        Ok(string) => return Ok(string.to_owned()),
+        Err(_) => {}
+    };
+
+    Ok(format!("{:?}", payload))
+}
 
 fn main() -> EyreResult<()> {
     let args: Vec<String> = env::args().collect();
@@ -44,62 +66,109 @@ fn main() -> EyreResult<()> {
         /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
     );
 
-    let cx = VMContext::new(
-        to_json_vec(&json!({
-            "key": "foo"
-        }))?,
-        [0; 32],
-        [0; 32],
-    );
-    let get_outcome = run(&file, "get", cx, &mut storage, &limits)?;
-    dbg!(get_outcome);
+    let mut execute = |name: &str, payload: Option<Value>| -> EyreResult<()> {
+        println!("{}", "--".repeat(20).dimmed());
+        println!(
+            "method: {}\nparams: {}",
+            name.bold(),
+            payload
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "{}".to_owned())
+                .bold()
+        );
 
-    let cx = VMContext::new(
-        to_json_vec(&json!({
-            "key": "foo",
-            "value": "bar"
-        }))?,
-        [0; 32],
-        [0; 32],
-    );
-    let set_outcome = run(&file, "set", cx, &mut storage, &limits)?;
-    dbg!(set_outcome);
+        let cx = VMContext::new(
+            payload
+                .map(|p| to_json_vec(&p))
+                .transpose()?
+                .unwrap_or_default(),
+            [0; 32],
+            [0; 32],
+        );
 
-    let cx = VMContext::new(
-        to_json_vec(&json!({
-            "key": "foo"
-        }))?,
-        [0; 32],
-        [0; 32],
-    );
-    let get_outcome = run(&file, "get", cx, &mut storage, &limits)?;
-    dbg!(get_outcome);
+        let outcome = run(&file, name, cx, &mut storage, &limits)?;
 
-    let cx = VMContext::new(
-        to_json_vec(&json!({
-            "key": "food"
-        }))?,
-        [0; 32],
-        [0; 32],
-    );
-    let get_result_outcome = run(&file, "get_result", cx, &mut storage, &limits)?;
-    dbg!(get_result_outcome);
+        // dbg!(&outcome);
 
-    let cx = VMContext::new(
-        to_json_vec(&json!({
-            "key": "food"
-        }))?,
-        [0; 32],
-        [0; 32],
-    );
-    let get_unchecked_outcome = run(&file, "get_unchecked", cx, &mut storage, &limits)?;
-    dbg!(get_unchecked_outcome);
+        println!("Logs:");
 
-    println!("{}", "--".repeat(20).dimmed());
-    println!("{:>35}", "Now, let's inspect the storage".bold());
-    println!("{}", "--".repeat(20).dimmed());
+        if outcome.logs.is_empty() {
+            println!("  <no logs>");
+        }
 
-    dbg!(storage);
+        for log in outcome.logs {
+            println!("  | {}", log);
+        }
+
+        println!("Events:");
+
+        if outcome.events.is_empty() {
+            println!("  <no events>");
+        }
+
+        for event in outcome.events {
+            println!("  kind: {}", event.kind);
+            println!("  data: {}", parse_payload(&event.data, false)?);
+        }
+
+        match outcome.returns {
+            Ok(returns) => {
+                println!("Returns:");
+
+                let payload = returns
+                    .as_ref()
+                    .map(|p| parse_payload(p, true))
+                    .transpose()?
+                    .unwrap_or_else(|| "  <no reponse>".to_owned());
+
+                println!("{}", payload);
+            }
+            Err(err) => {
+                println!("Error:");
+                println!(
+                    "{}",
+                    match err {
+                        calimero_runtime::errors::FunctionCallError::ExecutionError(payload) => {
+                            parse_payload(&payload, true)?
+                        }
+                        _ => format!("{:?}", err),
+                    }
+                );
+            }
+        }
+
+        Ok(())
+    };
+
+    execute("init", None)?;
+
+    execute("get", Some(json!({ "key": "foo" })))?;
+
+    execute("set", Some(json!({ "key": "foo", "value": "bar" })))?;
+    execute("get", Some(json!({ "key": "foo" })))?;
+
+    execute("entries", None)?;
+
+    execute("set", Some(json!({ "key": "foo", "value": "baz" })))?;
+    execute("get", Some(json!({ "key": "foo" })))?;
+
+    execute("set", Some(json!({ "key": "name", "value": "Jane" })))?;
+    execute("get", Some(json!({ "key": "name" })))?;
+
+    execute("entries", None)?;
+
+    execute("get_result", Some(json!({ "key": "foo" })))?;
+    execute("get_result", Some(json!({ "key": "height" })))?;
+
+    execute("get_unchecked", Some(json!({ "key": "name" })))?;
+    execute("get_unchecked", Some(json!({ "key": "age" })))?;
+
+    // println!("{}", "--".repeat(20).dimmed());
+    // println!("{:>35}", "Now, let's inspect the storage".bold());
+    // println!("{}", "--".repeat(20).dimmed());
+
+    // dbg!(storage);
 
     Ok(())
 }

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -13,20 +13,25 @@ use eyre::Result as EyreResult;
 use owo_colors::OwoColorize;
 use serde_json::{json, to_vec as to_json_vec, Value};
 
-fn parse_payload(payload: &[u8], pretty: bool) -> EyreResult<String> {
-    if let Ok(json) = serde_json::from_slice::<Value>(payload) {
-        let func = if pretty {
-            serde_json::to_string_pretty
-        } else {
-            serde_json::to_string
+fn parse_payload<const PRETTY: bool>(
+    payload: impl AsRef<[u8]> + ToOwned<Owned = Vec<u8>>,
+) -> EyreResult<String> {
+    if let Ok(json) = serde_json::from_slice::<Value>(payload.as_ref()) {
+        let func = const {
+            if PRETTY {
+                serde_json::to_string_pretty
+            } else {
+                serde_json::to_string
+            }
         };
 
         return func(&json).map_err(Into::into);
     }
 
-    if let Ok(string) = str::from_utf8(payload) {
-        return Ok(string.to_owned());
-    }
+    let payload = match String::from_utf8(payload.to_owned()) {
+        Ok(string) => return Ok(string),
+        Err(err) => err.into_bytes(),
+    };
 
     Ok(format!("{:?}", payload))
 }
@@ -106,7 +111,7 @@ fn main() -> EyreResult<()> {
 
         for event in outcome.events {
             println!("  kind: {}", event.kind);
-            println!("  data: {}", parse_payload(&event.data, false)?);
+            println!("  data: {}", parse_payload::<false>(event.data)?);
         }
 
         match outcome.returns {
@@ -114,8 +119,7 @@ fn main() -> EyreResult<()> {
                 println!("Returns:");
 
                 let payload = returns
-                    .as_ref()
-                    .map(|p| parse_payload(p, true))
+                    .map(|p| parse_payload::<true>(p))
                     .transpose()?
                     .unwrap_or_else(|| "  <no reponse>".to_owned());
 
@@ -127,7 +131,7 @@ fn main() -> EyreResult<()> {
                     "{}",
                     match err {
                         calimero_runtime::errors::FunctionCallError::ExecutionError(payload) => {
-                            parse_payload(&payload, true)?
+                            parse_payload::<true>(payload)?
                         }
                         _ => format!("{:?}", err),
                     }

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -14,22 +14,19 @@ use owo_colors::OwoColorize;
 use serde_json::{json, to_vec as to_json_vec, Value};
 
 fn parse_payload(payload: &[u8], pretty: bool) -> EyreResult<String> {
-    match serde_json::from_slice::<Value>(payload) {
-        Ok(json) => {
-            return (if pretty {
-                serde_json::to_string_pretty
-            } else {
-                serde_json::to_string
-            })(&json)
-            .map_err(Into::into)
-        }
-        Err(_) => {}
-    };
+    if let Ok(json) = serde_json::from_slice::<Value>(payload) {
+        let func = if pretty {
+            serde_json::to_string_pretty
+        } else {
+            serde_json::to_string
+        };
 
-    match str::from_utf8(&payload) {
-        Ok(string) => return Ok(string.to_owned()),
-        Err(_) => {}
-    };
+        return func(&json).map_err(Into::into);
+    }
+
+    if let Ok(string) = str::from_utf8(payload) {
+        return Ok(string.to_owned());
+    }
 
     Ok(format!("{:?}", payload))
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -5,6 +5,9 @@ pub mod event;
 mod returns;
 pub mod state;
 mod sys;
+pub mod types;
+
+pub type Result<T> = std::result::Result<T, types::Error>;
 
 pub mod app {
     pub use calimero_sdk_macros::{destroy, emit, event, init, logic, state};

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,0 +1,26 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct Error(#[serde(serialize_with = "error_string")] Box<dyn std::error::Error>);
+
+fn error_string<S>(error: &Box<dyn std::error::Error>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&error.to_string())
+}
+
+impl Error {
+    pub fn msg(s: &str) -> Self {
+        Self(s.to_owned().into())
+    }
+}
+
+impl<T> From<T> for Error
+where
+    T: std::error::Error + 'static,
+{
+    fn from(error: T) -> Self {
+        Error(Box::new(error))
+    }
+}

--- a/crates/storage-macros/Cargo.toml
+++ b/crates/storage-macros/Cargo.toml
@@ -16,11 +16,10 @@ borsh.workspace = true
 quote.workspace = true
 syn.workspace = true
 
-calimero-storage = { path = "../storage" }
-
 [dev-dependencies]
 trybuild.workspace = true
 calimero-sdk = { path = "../sdk" }
+calimero-storage = { path = "../storage" }
 
 [lints]
 workspace = true

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -1,6 +1,4 @@
 use borsh as _;
-/// For documentation links
-use calimero_storage as _;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput, Fields, LitInt, Type};

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -217,6 +217,9 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
                 };
 
                 Some(quote! {
+                    #[doc = "Setter for the "]
+                    #[doc = stringify!(#ident)]
+                    #[doc = " field."]
                     pub fn #setter(&mut self, value: #ty) -> bool {
                         if self.#ident == value {
                             false

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -201,7 +201,6 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
             if skip || ident == storage_ident {
                 None
             } else {
-                let getter = format_ident!("{}", ident);
                 let setter = format_ident!("set_{}", ident);
 
                 let setter_action = if private {
@@ -216,10 +215,6 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
                 };
 
                 Some(quote! {
-                    pub fn #getter(&self) -> &#ty {
-                        &self.#ident
-                    }
-
                     pub fn #setter(&mut self, value: #ty) -> bool {
                         if self.#ident == value {
                             false

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -156,8 +156,10 @@ mod integration_tests_package_usage {
     attributes(children, collection, private, root, skip, storage, type_id)
 )]
 pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    let mut input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
+    let where_clause = input.generics.make_where_clause().clone();
+    let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
     let is_root = input.attrs.iter().any(|attr| attr.path().is_ident("root"));
     let type_id = input
         .attrs
@@ -282,8 +284,18 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
         .map(|f| f.ident.as_ref().unwrap())
         .collect();
 
+    let mut data_where_clause = where_clause.clone();
+
+    for ty in input.generics.type_params() {
+        let ident = &ty.ident;
+        data_where_clause.predicates.push(syn::parse_quote!(
+            #ident: calimero_sdk::borsh::BorshSerialize
+                + calimero_sdk::borsh::BorshDeserialize
+        ));
+    }
+
     let deserialize_impl = quote! {
-        impl calimero_sdk::borsh::BorshDeserialize for #name {
+        impl #impl_generics calimero_sdk::borsh::BorshDeserialize for #name #ty_generics #data_where_clause {
             fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
                 let #storage_ident = #storage_ty::deserialize_reader(reader)?;
                 Ok(Self {
@@ -296,7 +308,7 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
     };
 
     let serialize_impl = quote! {
-        impl calimero_sdk::borsh::BorshSerialize for #name {
+        impl #impl_generics calimero_sdk::borsh::BorshSerialize for #name #ty_generics #data_where_clause {
             fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 calimero_sdk::borsh::BorshSerialize::serialize(&self.#storage_ident, writer)?;
                 #(calimero_sdk::borsh::BorshSerialize::serialize(&self.#serializable_fields, writer)?;)*
@@ -319,12 +331,21 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
         }
     };
 
+    let mut local_where_clause = where_clause.clone();
+
+    for ty in input.generics.type_params() {
+        let ident = &ty.ident;
+        local_where_clause.predicates.push(syn::parse_quote!(
+            #ident: PartialEq
+        ));
+    }
+
     let expanded = quote! {
-        impl #name {
+        impl #impl_generics #name #ty_generics #local_where_clause {
             #(#field_implementations)*
         }
 
-        impl calimero_storage::entities::Data for #name {
+        impl #impl_generics calimero_storage::entities::Data for #name #ty_generics #data_where_clause {
             fn calculate_merkle_hash(&self) -> Result<[u8; 32], calimero_storage::interface::StorageError> {
                 use calimero_storage::exports::Digest;
                 let mut hasher = calimero_storage::exports::Sha256::new();
@@ -351,7 +372,7 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
                 match collection {
                     #(
                         stringify!(#collection_fields) => {
-                            let child = <#collection_field_types as calimero_storage::entities::Collection>::Child::try_from_slice(slice)
+                            let child = <#collection_field_types #ty_generics as calimero_storage::entities::Collection>::Child::try_from_slice(slice)
                                 .map_err(|e| calimero_storage::interface::StorageError::DeserializationError(e))?;
                             child.calculate_merkle_hash()
                         },
@@ -387,7 +408,7 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
             }
         }
 
-        impl calimero_storage::entities::AtomicUnit for #name {}
+        impl #impl_generics calimero_storage::entities::AtomicUnit for #name #ty_generics #data_where_clause {}
 
         #deserialize_impl
 
@@ -473,8 +494,10 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 ///                    child in a collection.
 #[proc_macro_derive(Collection, attributes(children))]
 pub fn collection_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    let mut input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
+    let where_clause = input.generics.make_where_clause().clone();
+    let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
     let child_type = input
         .attrs
         .iter()
@@ -482,35 +505,65 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
         .and_then(|attr| attr.parse_args::<Type>().ok())
         .expect("Collection derive requires #[children(Type)] attribute");
 
-    match &input.data {
-        Data::Struct(_) => {}
+    let fields = match input.data {
+        Data::Struct(data) => data.fields,
         Data::Enum(_) | Data::Union(_) => panic!("Collection can only be derived for structs"),
-    }
+    };
 
     let deserialize_impl = quote! {
-        impl calimero_sdk::borsh::BorshDeserialize for #name {
+        impl #impl_generics calimero_sdk::borsh::BorshDeserialize for #name #ty_generics #where_clause {
             fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-                Ok(Self {})
+                Ok(Self::default())
             }
         }
     };
 
     let serialize_impl = quote! {
-        impl calimero_sdk::borsh::BorshSerialize for #name {
+        impl #impl_generics calimero_sdk::borsh::BorshSerialize for #name #ty_generics #where_clause {
             fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 Ok(())
             }
         }
     };
 
+    let data = fields
+        .iter()
+        .map(|field| {
+            let ident = field.ident.as_ref().unwrap();
+            quote! { #ident: Default::default(), }
+        })
+        .collect::<Vec<_>>();
+
+    let data = (!data.is_empty()).then(|| quote! { { #(#data)* } });
+
+    let default_impl = quote! {
+        impl #impl_generics ::core::default::Default for #name #ty_generics #where_clause {
+            fn default() -> Self {
+                Self #data
+            }
+        }
+    };
+
+    let mut collection_where_clause = where_clause.clone();
+
+    for ty in input.generics.type_params() {
+        let ident = &ty.ident;
+        collection_where_clause.predicates.push(syn::parse_quote!(
+            #ident: calimero_sdk::borsh::BorshSerialize
+                + calimero_sdk::borsh::BorshDeserialize
+        ));
+    }
+
     let expanded = quote! {
-        impl calimero_storage::entities::Collection for #name {
+        impl #impl_generics calimero_storage::entities::Collection for #name #ty_generics #collection_where_clause {
             type Child = #child_type;
 
             fn name(&self) -> &str {
                 stringify!(#name)
             }
         }
+
+        #default_impl
 
         #deserialize_impl
 

--- a/crates/storage-macros/tests/atomic_unit.rs
+++ b/crates/storage-macros/tests/atomic_unit.rs
@@ -113,8 +113,8 @@ mod basics {
         let path = Path::new("::root::node").unwrap();
         let unit = Simple::new(&path);
 
-        assert_eq!(unit.name(), "");
-        assert_eq!(unit.value(), &0);
+        assert_eq!(unit.name, "");
+        assert_eq!(unit.value, 0);
     }
 
     #[test]
@@ -125,34 +125,34 @@ mod basics {
         _ = unit.set_name("Test Name".to_owned());
         _ = unit.set_value(42);
 
-        assert_eq!(unit.name(), "Test Name");
-        assert_eq!(unit.value(), &42);
+        assert_eq!(unit.name, "Test Name");
+        assert_eq!(unit.value, 42);
     }
 
     #[test]
     fn setters__confirm_set() {
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
-        assert_ne!(unit.name(), "Test Name");
-        assert_ne!(unit.value(), &42);
+        assert_ne!(unit.name, "Test Name");
+        assert_ne!(unit.value, 42);
 
         assert!(unit.set_name("Test Name".to_owned()));
         assert!(unit.set_value(42));
-        assert_eq!(unit.name(), "Test Name");
-        assert_eq!(unit.value(), &42);
+        assert_eq!(unit.name, "Test Name");
+        assert_eq!(unit.value, 42);
     }
 
     #[test]
     fn setters__confirm_not_set() {
         let path = Path::new("::root::node").unwrap();
         let mut unit = Simple::new(&path);
-        assert_ne!(unit.name(), "Test Name");
-        assert_ne!(unit.value(), &42);
+        assert_ne!(unit.name, "Test Name");
+        assert_ne!(unit.value, 42);
 
         assert!(unit.set_name("Test Name".to_owned()));
         assert!(unit.set_value(42));
-        assert_eq!(unit.name(), "Test Name");
-        assert_eq!(unit.value(), &42);
+        assert_eq!(unit.name, "Test Name");
+        assert_eq!(unit.value, 42);
         assert!(!unit.set_name("Test Name".to_owned()));
         assert!(!unit.set_value(42));
     }
@@ -198,9 +198,9 @@ mod visibility {
         let serialized = to_vec(&unit).unwrap();
         let deserialized = Private::try_from_slice(&serialized).unwrap();
 
-        assert_eq!(unit.public(), deserialized.public());
-        assert_ne!(unit.private(), deserialized.private());
-        assert_eq!(deserialized.private(), "");
+        assert_eq!(unit.public, deserialized.public);
+        assert_ne!(unit.private, deserialized.private);
+        assert_eq!(deserialized.private, "");
     }
 
     #[test]
@@ -213,7 +213,7 @@ mod visibility {
         let serialized = to_vec(&unit).unwrap();
         let deserialized = Simple::try_from_slice(&serialized).unwrap();
 
-        assert_eq!(unit.name(), deserialized.name());
+        assert_eq!(unit.name, deserialized.name);
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod visibility {
         let serialized = to_vec(&unit).unwrap();
         let deserialized = Skipped::try_from_slice(&serialized).unwrap();
 
-        assert_eq!(unit.included(), deserialized.included());
+        assert_eq!(unit.included, deserialized.included);
         // Skipping fields also skips the getters
         // assert_ne!(unit.skipped(), deserialized.skipped());
         assert_ne!(unit.skipped, deserialized.skipped);
@@ -294,7 +294,7 @@ mod hashing {
 
         let mut hasher = Sha256::new();
         hasher.update(unit.id().as_bytes());
-        hasher.update(&to_vec(&unit.included()).unwrap());
+        hasher.update(&to_vec(&unit.included).unwrap());
         hasher.update(&to_vec(&unit.element().metadata()).unwrap());
         let expected_hash: [u8; 32] = hasher.finalize().into();
 
@@ -325,9 +325,9 @@ mod traits {
 
         assert_eq!(unit, deserialized);
         assert_eq!(unit.id(), deserialized.id());
-        assert_eq!(unit.name(), deserialized.name());
+        assert_eq!(unit.name, deserialized.name);
         assert_eq!(unit.path(), deserialized.path());
-        assert_eq!(unit.value(), deserialized.value());
+        assert_eq!(unit.value, deserialized.value);
         assert_eq!(unit.element().id(), deserialized.element().id());
         assert_eq!(unit.element().path(), deserialized.element().path());
         assert_eq!(unit.element().metadata(), deserialized.element().metadata());

--- a/crates/storage-macros/tests/collection.rs
+++ b/crates/storage-macros/tests/collection.rs
@@ -113,7 +113,7 @@ mod hierarchy {
         let mut child = Child::new(&child_path);
         _ = child.set_content("Child Content".to_owned());
 
-        assert_eq!(parent.title(), "Parent Title");
+        assert_eq!(parent.title, "Parent Title");
 
         // TODO: Add in tests for loading and checking children
     }
@@ -174,9 +174,9 @@ mod traits {
 
         assert_eq!(unit, deserialized);
         assert_eq!(unit.id(), deserialized.id());
-        assert_eq!(unit.name(), deserialized.name());
+        assert_eq!(unit.name, deserialized.name);
         assert_eq!(unit.path(), deserialized.path());
-        assert_eq!(unit.value(), deserialized.value());
+        assert_eq!(unit.value, deserialized.value);
         assert_eq!(unit.element().id(), deserialized.element().id());
         assert_eq!(unit.element().path(), deserialized.element().path());
         assert_eq!(unit.element().metadata(), deserialized.element().metadata());

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,6 +18,7 @@ thiserror.workspace = true
 uuid.workspace = true
 
 calimero-sdk = { path = "../sdk" }
+calimero-storage-macros = { path = "../storage-macros" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rand.workspace = true
@@ -28,7 +29,6 @@ hex.workspace = true
 velcro.workspace = true
 
 calimero-sdk = { path = "../sdk" }
-calimero-storage-macros = { path = "../storage-macros" }
 
 [lints]
 workspace = true

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -679,7 +679,7 @@ impl Element {
             },
             merkle_hash: [0; 32],
             #[expect(clippy::unwrap_used, reason = "This is expected to be valid")]
-            path: Path::new("::").unwrap(),
+            path: Path::new("::root").unwrap(),
         }
     }
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -283,7 +283,7 @@ pub trait AtomicUnit: Data {}
 /// }
 /// ```
 ///
-pub trait Collection: Clone + Debug + PartialEq + PartialOrd + Send + Sync {
+pub trait Collection {
     /// The associated type of any children that the [`Collection`] may have.
     type Child: Data;
 
@@ -313,9 +313,7 @@ pub trait Collection: Clone + Debug + PartialEq + PartialOrd + Send + Sync {
 /// implemented, but for now only the most useful and least likely to be
 /// contentious methods are included, to keep the interface simple and focused.
 ///
-pub trait Data:
-    BorshDeserialize + BorshSerialize + Clone + Debug + PartialEq + PartialOrd + Send + Sync
-{
+pub trait Data: BorshDeserialize + BorshSerialize {
     /// Calculates the Merkle hash of the [`Element`].
     ///
     /// This method calculates the Merkle hash of the [`Data`] for the

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -69,6 +69,8 @@ pub mod integration;
 pub mod interface;
 pub mod store;
 
+pub use calimero_storage_macros::{AtomicUnit, Collection};
+
 /// Re-exported types, mostly for use in macros (for convenience).
 pub mod exports {
     pub use sha2::{Digest, Sha256};
@@ -82,5 +84,5 @@ pub mod tests {
 
 #[cfg(test)]
 mod doc_tests_package_usage {
-    use {calimero_sdk as _, calimero_storage_macros as _};
+    use calimero_sdk as _;
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -68,6 +68,7 @@ pub mod index;
 pub mod integration;
 pub mod interface;
 pub mod store;
+pub mod types;
 
 pub use calimero_storage_macros::{AtomicUnit, Collection};
 

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -37,7 +37,7 @@ pub struct Map<K, V> {
 /// A collection of entries in a map.
 #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[children(Entry<K, V>)]
-pub struct Entries<K, V> {
+struct Entries<K, V> {
     _priv: PhantomData<(K, V)>,
 }
 

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -1,21 +1,22 @@
 //! High-level data structures for storage.
 
-use std::{borrow::Borrow, marker::PhantomData};
+use std::borrow::Borrow;
+use std::marker::PhantomData;
 
-use crate::{
-    address::{Path, PathError},
-    entities::{Data, Element},
-    interface::{Interface, StorageError},
-    AtomicUnit, Collection,
-};
 use borsh::{BorshDeserialize, BorshSerialize};
 use thiserror::Error;
 
-use crate as calimero_storage; // macro expects `calimero_storage` to be in deps
+// fixme! macro expects `calimero_storage` to be in deps
+use crate as calimero_storage;
+use crate::address::{Path, PathError};
+use crate::entities::{Data, Element};
+use crate::interface::{Interface, StorageError};
+use crate::{AtomicUnit, Collection};
 
 /// General error type for storage operations while interacting with complex collections.
 #[derive(Debug, Error)]
-pub enum Error {
+#[non_exhaustive]
+pub enum StoreError {
     /// Error while interacting with storage.
     #[error(transparent)]
     StorageError(#[from] StorageError),
@@ -29,7 +30,9 @@ pub enum Error {
 #[type_id(255)]
 #[root]
 pub struct Map<K, V> {
+    /// The entries in the map.
     entries: Entries<K, V>,
+    /// The storage element for the map.
     #[storage]
     storage: Element,
 }
@@ -38,6 +41,7 @@ pub struct Map<K, V> {
 #[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[children(Entry<K, V>)]
 struct Entries<K, V> {
+    /// Helper to associate the generic types with the collection.
     _priv: PhantomData<(K, V)>,
 }
 
@@ -45,15 +49,25 @@ struct Entries<K, V> {
 #[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
 #[type_id(254)]
 pub struct Entry<K, V> {
+    /// The key for the entry.
     key: K,
+    /// The value for the entry.
     value: V,
+    /// The storage element for the entry.
     #[storage]
     storage: Element,
 }
 
 impl<K: BorshSerialize + BorshDeserialize, V: BorshSerialize + BorshDeserialize> Map<K, V> {
     /// Create a new map collection.
-    pub fn new(path: &Path) -> Result<Self, Error> {
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn new(path: &Path) -> Result<Self, StoreError> {
         let mut this = Self {
             entries: Entries::default(),
             storage: Element::new(path),
@@ -65,7 +79,14 @@ impl<K: BorshSerialize + BorshDeserialize, V: BorshSerialize + BorshDeserialize>
     }
 
     /// Insert a key-value pair into the map.
-    pub fn insert(&mut self, key: K, value: V) -> Result<(), Error> {
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn insert(&mut self, key: K, value: V) -> Result<(), StoreError> {
         let path = self.path();
         // fixme! Reusing the Map's path for now. We "could" concatenate, but it's
         // fixme! non-trivial and currently non-functional, so it's been left out
@@ -91,19 +112,40 @@ impl<K: BorshSerialize + BorshDeserialize, V: BorshSerialize + BorshDeserialize>
     }
 
     /// Get an iterator over the entries in the map.
-    pub fn entries(&self) -> Result<impl Iterator<Item = (K, V)>, Error> {
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn entries(&self) -> Result<impl Iterator<Item = (K, V)>, StoreError> {
         let entries = Interface::children_of(self.id(), &self.entries)?;
 
         Ok(entries.into_iter().map(|entry| (entry.key, entry.value)))
     }
 
     /// Get the number of entries in the map.
-    pub fn len(&self) -> Result<usize, Error> {
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn len(&self) -> Result<usize, StoreError> {
         Ok(Interface::child_info_for(self.id(), &self.entries)?.len())
     }
 
     /// Get the value for a key in the map.
-    pub fn get<Q>(&self, key: &Q) -> Result<Option<V>, Error>
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn get<Q>(&self, key: &Q) -> Result<Option<V>, StoreError>
     where
         K: Borrow<Q>,
         Q: PartialEq + ?Sized,
@@ -118,7 +160,14 @@ impl<K: BorshSerialize + BorshDeserialize, V: BorshSerialize + BorshDeserialize>
     }
 
     /// Remove a key from the map, returning the value at the key if it previously existed.
-    pub fn remove<Q>(&mut self, key: &Q) -> Result<Option<V>, Error>
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn remove<Q>(&mut self, key: &Q) -> Result<Option<V>, StoreError>
     where
         K: Borrow<Q>,
         Q: PartialEq + ?Sized,
@@ -135,7 +184,14 @@ impl<K: BorshSerialize + BorshDeserialize, V: BorshSerialize + BorshDeserialize>
     }
 
     /// Clear the map, removing all entries.
-    pub fn clear(&mut self) -> Result<(), Error> {
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    ///
+    pub fn clear(&mut self) -> Result<(), StoreError> {
         let entries = Interface::children_of(self.id(), &self.entries)?;
 
         for entry in entries {


### PR DESCRIPTION
Updates the kv-store app to use the CRDT storage subsystem

Introduces a generic `Map` to simplify storage operations.

For now, `apply_action`, `compare_trees` and `generate_comparison_data` have not been introduced.

#### Test

```console
$ ./apps/kv-store/build.sh
$ cargo run -p calimero-runtime --example demo --features host-traces -- apps/kv-store/res/kv_store.wasm
```