### PR TITLE
feat: commit to new root hash following state mutations

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -234,13 +234,7 @@ impl ContextManager {
                 ),
             )?;
 
-            handle.put(
-                &ContextMetaKey::new(context.id),
-                &ContextMetaValue::new(
-                    ApplicationMetaKey::new(context.application_id),
-                    context.root_hash.into(),
-                ),
-            )?;
+            self.save_context(context)?;
 
             self.subscribe(&context.id).await?;
         }
@@ -250,6 +244,20 @@ impl ContextManager {
             &ContextIdentityValue {
                 private_key: Some(*identity_secret),
             },
+        )?;
+
+        Ok(())
+    }
+
+    pub fn save_context(&self, context: &Context) -> EyreResult<()> {
+        let mut handle = self.store.handle();
+
+        handle.put(
+            &ContextMetaKey::new(context.id),
+            &ContextMetaValue::new(
+                ApplicationMetaKey::new(context.application_id),
+                context.root_hash.into(),
+            ),
         )?;
 
         Ok(())

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -548,9 +548,11 @@ impl Node {
             &get_runtime_limits()?,
         )?;
 
-        storage.commit()?;
-
         if let Some(root_hash) = outcome.root_hash {
+            if outcome.actions.is_empty() {
+                eyre::bail!("State changed, but no actions were generated");
+            }
+
             context.root_hash = root_hash.into();
 
             drop(
@@ -564,6 +566,10 @@ impl Node {
             );
 
             self.ctx_manager.save_context(context);
+        }
+
+        if !storage.is_empty() {
+            storage.commit()?;
         }
 
         drop(

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -18,8 +18,8 @@ use calimero_network::types::{NetworkEvent, PeerId};
 use calimero_node_primitives::{CallError, ExecutionRequest};
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::{
-    ApplicationEvent, ApplicationEventPayload, ExecutedTransactionPayload, NodeEvent, OutcomeEvent,
-    OutcomeEventPayload, PeerJoinedPayload,
+    ApplicationEvent, ApplicationEventPayload, NodeEvent, OutcomeEvent, OutcomeEventPayload,
+    PeerJoinedPayload, StateMutationPayload,
 };
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
@@ -282,17 +282,18 @@ impl Node {
 
                 for action in action_list.actions {
                     debug!(?action, %source, "Received action");
-                    let Some(context) = self.ctx_manager.get_context(&action_list.context_id)?
+                    let Some(mut context) =
+                        self.ctx_manager.get_context(&action_list.context_id)?
                     else {
                         bail!("Context '{}' not found", action_list.context_id);
                     };
                     match action {
                         Action::Compare { id } => {
-                            self.send_comparison_message(&context, id, action_list.public_key)
+                            self.send_comparison_message(&mut context, id, action_list.public_key)
                                 .await
                         }
                         Action::Add { .. } | Action::Delete { .. } | Action::Update { .. } => {
-                            self.apply_action(&context, &action, action_list.public_key)
+                            self.apply_action(&mut context, &action, action_list.public_key)
                                 .await
                         }
                     }?;
@@ -302,11 +303,11 @@ impl Node {
             PeerAction::Sync(sync) => {
                 debug!(?sync, %source, "Received sync request");
 
-                let Some(context) = self.ctx_manager.get_context(&sync.context_id)? else {
+                let Some(mut context) = self.ctx_manager.get_context(&sync.context_id)? else {
                     bail!("Context '{}' not found", sync.context_id);
                 };
                 let outcome = self
-                    .compare_trees(&context, &sync.comparison, sync.public_key)
+                    .compare_trees(&mut context, &sync.comparison, sync.public_key)
                     .await?;
 
                 match outcome.returns {
@@ -318,13 +319,14 @@ impl Node {
                         for action in local_actions {
                             match action {
                                 Action::Compare { id } => {
-                                    self.send_comparison_message(&context, id, sync.public_key)
+                                    self.send_comparison_message(&mut context, id, sync.public_key)
                                         .await
                                 }
                                 Action::Add { .. }
                                 | Action::Delete { .. }
                                 | Action::Update { .. } => {
-                                    self.apply_action(&context, &action, sync.public_key).await
+                                    self.apply_action(&mut context, &action, sync.public_key)
+                                        .await
                                 }
                             }?;
                         }
@@ -357,7 +359,7 @@ impl Node {
 
     async fn send_comparison_message(
         &mut self,
-        context: &Context,
+        context: &mut Context,
         id: Id,
         public_key: PublicKey,
     ) -> EyreResult<()> {
@@ -393,7 +395,7 @@ impl Node {
     }
 
     pub async fn handle_call(&mut self, request: ExecutionRequest) {
-        let Ok(Some(context)) = self.ctx_manager.get_context(&request.context_id) else {
+        let Ok(Some(mut context)) = self.ctx_manager.get_context(&request.context_id) else {
             drop(request.outcome_sender.send(Err(CallError::ContextNotFound {
                 context_id: request.context_id,
             })));
@@ -401,7 +403,7 @@ impl Node {
         };
 
         let task = self.call_query(
-            &context,
+            &mut context,
             request.method,
             request.payload,
             request.executor_public_key,
@@ -416,19 +418,13 @@ impl Node {
 
     async fn call_query(
         &mut self,
-        context: &Context,
+        context: &mut Context,
         method: String,
         payload: Vec<u8>,
         executor_public_key: PublicKey,
     ) -> Result<Outcome, CallError> {
         let outcome_option = self
-            .checked_execute(
-                context,
-                Some(context.root_hash),
-                method,
-                payload,
-                executor_public_key,
-            )
+            .execute(context, method, payload, executor_public_key)
             .await
             .map_err(|e| {
                 error!(%e, "Failed to execute query call.");
@@ -440,6 +436,7 @@ impl Node {
                 application_id: context.application_id,
             });
         };
+
         if self
             .network_client
             .mesh_peer_count(TopicHash::from_raw(context.id))
@@ -455,6 +452,7 @@ impl Node {
                     error!(%err, "Failed to deserialize actions.");
                     CallError::InternalError
                 })?;
+
             self.push_action(
                 context.id,
                 PeerAction::ActionList(ActionMessage {
@@ -476,14 +474,13 @@ impl Node {
 
     async fn apply_action(
         &mut self,
-        context: &Context,
+        context: &mut Context,
         action: &Action,
         public_key: PublicKey,
     ) -> EyreResult<()> {
         let outcome = self
-            .checked_execute(
+            .execute(
                 context,
-                None,
                 "apply_action".to_owned(),
                 to_vec(action)?,
                 public_key,
@@ -496,13 +493,12 @@ impl Node {
 
     async fn compare_trees(
         &mut self,
-        context: &Context,
+        context: &mut Context,
         comparison: &Comparison,
         public_key: PublicKey,
     ) -> EyreResult<Outcome> {
-        self.checked_execute(
+        self.execute(
             context,
-            None,
             "compare_trees".to_owned(),
             to_vec(comparison)?,
             public_key,
@@ -513,13 +509,12 @@ impl Node {
 
     async fn generate_comparison_data(
         &mut self,
-        context: &Context,
+        context: &mut Context,
         id: Id,
         public_key: PublicKey,
     ) -> EyreResult<Outcome> {
-        self.checked_execute(
+        self.execute(
             context,
-            None,
             "generate_comparison_data".to_owned(),
             to_vec(&id)?,
             public_key,
@@ -528,49 +523,21 @@ impl Node {
         .and_then(|outcome| outcome.ok_or_else(|| eyre!("Application not installed")))
     }
 
-    async fn checked_execute(
+    async fn execute(
         &mut self,
-        context: &Context,
-        hash: Option<Hash>,
+        context: &mut Context,
         method: String,
         payload: Vec<u8>,
         executor_public_key: PublicKey,
     ) -> EyreResult<Option<Outcome>> {
-        if !self
-            .ctx_manager
-            .is_application_installed(&context.application_id)
-            .unwrap_or_default()
-        {
-            return Ok(None);
-        }
-
-        self.execute(context, hash, method, payload, executor_public_key)
-            .await
-            .map(Some)
-    }
-
-    async fn execute(
-        &mut self,
-        context: &Context,
-        hash: Option<Hash>,
-        method: String,
-        payload: Vec<u8>,
-        executor_public_key: PublicKey,
-    ) -> EyreResult<Outcome> {
-        let mut storage = match hash {
-            Some(_) => RuntimeCompatStore::temporal(&mut self.store, context.id),
-            None => RuntimeCompatStore::read_only(&self.store, context.id),
-        };
+        let mut storage = RuntimeCompatStore::new(&mut self.store, context.id);
 
         let Some(blob) = self
             .ctx_manager
             .load_application_blob(&context.application_id)
             .await?
         else {
-            bail!(
-                "fatal error: missing blob for application `{}`",
-                context.application_id
-            );
+            return Ok(None);
         };
 
         let outcome = calimero_runtime::run(
@@ -581,22 +548,22 @@ impl Node {
             &get_runtime_limits()?,
         )?;
 
-        if let Some(hash) = hash {
-            assert!(storage.commit()?, "do we have a non-temporal store?");
+        storage.commit()?;
 
-            // todo! return an error to the caller if the method did not write to storage
-            // todo! debate: when we switch to optimistic execution
-            // todo! we won't have query vs. mutate methods anymore, so this shouldn't matter
+        if let Some(root_hash) = outcome.root_hash {
+            context.root_hash = root_hash.into();
 
             drop(
                 self.node_events
                     .send(NodeEvent::Application(ApplicationEvent::new(
                         context.id,
-                        ApplicationEventPayload::TransactionExecuted(
-                            ExecutedTransactionPayload::new(hash),
-                        ),
+                        ApplicationEventPayload::StateMutation(StateMutationPayload::new(
+                            context.root_hash,
+                        )),
                     ))),
             );
+
+            self.ctx_manager.save_context(context);
         }
 
         drop(
@@ -613,7 +580,7 @@ impl Node {
                 ))),
         );
 
-        Ok(outcome)
+        Ok(Some(outcome))
     }
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -21,7 +21,6 @@ use calimero_primitives::events::{
     ApplicationEvent, ApplicationEventPayload, NodeEvent, OutcomeEvent, OutcomeEventPayload,
     PeerJoinedPayload, StateMutationPayload,
 };
-use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use calimero_runtime::logic::{Outcome, VMContext, VMLimits};
 use calimero_runtime::Constraint;

--- a/crates/node/src/runtime_compat.rs
+++ b/crates/node/src/runtime_compat.rs
@@ -46,6 +46,10 @@ impl<'this, 'entry> RuntimeCompatStore<'this, 'entry> {
     pub fn commit(self) -> EyreResult<()> {
         self.inner.commit()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
 }
 
 impl Storage for RuntimeCompatStore<'_, '_> {

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -34,7 +34,7 @@ impl ApplicationEvent {
 #[serde(tag = "type", content = "data", rename_all = "PascalCase")]
 #[non_exhaustive]
 pub enum ApplicationEventPayload {
-    TransactionExecuted(ExecutedTransactionPayload),
+    StateMutation(StateMutationPayload),
     PeerJoined(PeerJoinedPayload),
     OutcomeEvent(OutcomeEventPayload),
 }
@@ -42,14 +42,14 @@ pub enum ApplicationEventPayload {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct ExecutedTransactionPayload {
-    pub hash: Hash,
+pub struct StateMutationPayload {
+    pub new_root: Hash,
 }
 
-impl ExecutedTransactionPayload {
+impl StateMutationPayload {
     #[must_use]
-    pub const fn new(hash: Hash) -> Self {
-        Self { hash }
+    pub const fn new(new_root: Hash) -> Self {
+        Self { new_root }
     }
 }
 

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -93,6 +93,8 @@ fn main() -> EyreResult<()> {
 
         // dbg!(&outcome);
 
+        println!("New Root Hash: {:?}", outcome.root_hash);
+        println!("Actions: {}", outcome.actions.len());
         println!("Logs:");
 
         if outcome.logs.is_empty() {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -43,6 +43,7 @@ impl VMLogic<'_> {
             fn emit(kind_ptr: u64, kind_len: u64, data_ptr: u64, data_len: u64);
 
             fn send_action(action_ptr: u64, action_len: u64);
+            fn commit_root(ptr: u64, len: u64);
 
             fn storage_write(
                 key_ptr: u64,

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -149,6 +149,7 @@ impl ToTokens for PublicLogicMethod<'_> {
 
         let state_finalizer = match (&self.self_type, init_method) {
             (Some(SelfType::Mutable(_)), _) | (_, true) => quote! {
+                ::calimero_storage::entities::Data::element_mut(&mut app).update();
                 if let Err(_) = ::calimero_storage::interface::Interface::save(&mut app) {
                     ::calimero_sdk::env::panic_str("Failed to save app state")
                 }

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -162,6 +162,10 @@ pub fn send_action(action: &[u8]) {
     unsafe { sys::send_action(Buffer::from(action)) }
 }
 
+pub fn commit_root(action: &[u8; 32]) {
+    unsafe { sys::commit_root(Buffer::from(&action[..])) }
+}
+
 #[inline]
 pub fn storage_read(key: &[u8]) -> Option<Vec<u8>> {
     unsafe { sys::storage_read(Buffer::from(key), DATA_REGISTER) }

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -21,6 +21,8 @@ wasm_imports! {
         fn emit(event: Event<'_>);
         // --
         fn send_action(action: Buffer<'_>);
+        fn commit_root(root: Buffer<'_>);
+        // --
         fn storage_read(key: Buffer<'_>, register_id: RegisterId) -> Bool;
         fn storage_remove(key: Buffer<'_>, register_id: RegisterId) -> Bool;
         fn storage_write(key: Buffer<'_>, value: Buffer<'_>, register_id: RegisterId) -> Bool;

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -24,6 +24,13 @@ pub fn send_action(action: &Action) {
     imp::send_action(&to_vec(&action).expect("Failed to serialize action"));
 }
 
+/// Commits the root hash to the runtime.
+/// This function should be called after the root hash has been updated.
+///
+pub fn commit_root(root_hash: &[u8; 32]) {
+    imp::commit_root(root_hash);
+}
+
 /// Reads data from persistent storage.
 ///
 /// # Parameters
@@ -85,6 +92,12 @@ mod calimero_vm {
         env::send_action(action);
     }
 
+    /// Commits the root hash to the runtime.
+    /// This function should be called after the root hash has been updated.
+    pub(super) fn commit_root(root_hash: &[u8; 32]) {
+        env::commit_root(root_hash);
+    }
+
     /// Reads data from persistent storage.
     pub(super) fn storage_read(key: Key) -> Option<Vec<u8>> {
         env::storage_read(&key.to_bytes())
@@ -127,6 +140,12 @@ mod mocked {
 
     /// Sends an action to the runtime.
     pub(super) const fn send_action(_action: &[u8]) {
+        // Do nothing.
+    }
+
+    /// Commits the root hash to the runtime.
+    /// This function should be called after the root hash has been updated.
+    pub(super) fn commit_root(_root_hash: &[u8; 32]) {
         // Do nothing.
     }
 

--- a/crates/store/src/layer/temporal.rs
+++ b/crates/store/src/layer/temporal.rs
@@ -24,6 +24,10 @@ where
             shadow: Transaction::default(),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.shadow.is_empty()
+    }
 }
 
 impl<L> Layer for Temporal<'_, '_, L>

--- a/crates/store/src/tx.rs
+++ b/crates/store/src/tx.rs
@@ -18,6 +18,10 @@ pub enum Operation<'a> {
 }
 
 impl<'a> Transaction<'a> {
+    pub fn is_empty(&self) -> bool {
+        self.cols.is_empty()
+    }
+
     pub(crate) fn raw_get(&self, column: Column, key: &[u8]) -> Option<&Operation<'_>> {
         self.cols.get(&column).and_then(|ops| ops.get(key))
     }


### PR DESCRIPTION
Following a mutation, regardless of source, client or external peer, once the root hash of the state is updated, we need to pass that information to the node, which will aid later catchups