### PR TITLE
feat: update node execution flow

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -13,7 +13,7 @@ use calimero_context_config::types::{
 };
 use calimero_network::client::NetworkClient;
 use calimero_network::types::IdentTopic;
-use calimero_node_primitives::{ExecutionRequest, Finality, ServerSender};
+use calimero_node_primitives::{ExecutionRequest, ServerSender};
 use calimero_primitives::application::{Application, ApplicationId, ApplicationSource};
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
@@ -210,7 +210,6 @@ impl ContextManager {
                 initialization_params,
                 identity_secret.public_key(),
                 tx,
-                Some(Finality::Local),
             ))
             .await?;
 

--- a/crates/node-primitives/src/lib.rs
+++ b/crates/node-primitives/src/lib.rs
@@ -14,7 +14,6 @@ pub struct ExecutionRequest {
     pub payload: Vec<u8>,
     pub executor_public_key: PublicKey,
     pub outcome_sender: oneshot::Sender<Result<Outcome, CallError>>,
-    pub finality: Option<Finality>,
 }
 
 impl ExecutionRequest {
@@ -25,7 +24,6 @@ impl ExecutionRequest {
         payload: Vec<u8>,
         executor_public_key: PublicKey,
         outcome_sender: oneshot::Sender<Result<Outcome, CallError>>,
-        finality: Option<Finality>,
     ) -> Self {
         Self {
             context_id,
@@ -33,19 +31,8 @@ impl ExecutionRequest {
             payload,
             executor_public_key,
             outcome_sender,
-            finality,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[expect(
-    clippy::exhaustive_enums,
-    reason = "There will never be any other variants"
-)]
-pub enum Finality {
-    Local,
-    Global,
 }
 
 pub type ServerSender = mpsc::Sender<ExecutionRequest>;

--- a/crates/node/src/interactive_cli/call.rs
+++ b/crates/node/src/interactive_cli/call.rs
@@ -1,10 +1,8 @@
-use calimero_node_primitives::ExecutionRequest;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use clap::Parser;
 use owo_colors::OwoColorize;
 use serde_json::Value;
-use tokio::sync::oneshot;
 
 use crate::Node;
 
@@ -19,72 +17,48 @@ pub struct CallCommand {
 impl CallCommand {
     pub async fn run(self, node: &mut Node) -> eyre::Result<()> {
         let ind = ">>".blue();
-        let (outcome_sender, outcome_receiver) = oneshot::channel();
 
         let Ok(Some(context)) = node.ctx_manager.get_context(&self.context_id) else {
             println!("{} context not found: {}", ind, self.context_id);
             return Ok(());
         };
 
-        node.handle_call(ExecutionRequest::new(
-            context.id,
-            self.method.to_owned(),
-            serde_json::to_vec(&self.payload)?,
-            self.executor_key,
-            outcome_sender,
-        ))
-        .await;
+        let outcome_result = node
+            .handle_call(
+                context.id,
+                self.method.to_owned(),
+                serde_json::to_vec(&self.payload)?,
+                self.executor_key,
+            )
+            .await;
 
-        drop(tokio::spawn(async move {
-            if let Ok(outcome_result) = outcome_receiver.await {
-                println!("{}", ind);
+        match outcome_result {
+            Ok(outcome) => {
+                match outcome.returns {
+                    Ok(result) => match result {
+                        Some(result) => {
+                            println!("{}   return value:", ind);
+                            #[expect(clippy::option_if_let_else, reason = "clearer here")]
+                            let result = if let Ok(value) = serde_json::from_slice::<Value>(&result)
+                            {
+                                format!(
+                                    "(json): {}",
+                                    format!("{:#}", value)
+                                        .lines()
+                                        .map(|line| line.cyan().to_string())
+                                        .collect::<Vec<_>>()
+                                        .join("\n")
+                                )
+                            } else {
+                                format!("(raw): {:?}", result.cyan())
+                            };
 
-                match outcome_result {
-                    Ok(outcome) => {
-                        match outcome.returns {
-                            Ok(result) => match result {
-                                Some(result) => {
-                                    println!("{}   return value:", ind);
-                                    #[expect(clippy::option_if_let_else, reason = "clearer here")]
-                                    let result = if let Ok(value) =
-                                        serde_json::from_slice::<Value>(&result)
-                                    {
-                                        format!(
-                                            "(json): {}",
-                                            format!("{:#}", value)
-                                                .lines()
-                                                .map(|line| line.cyan().to_string())
-                                                .collect::<Vec<_>>()
-                                                .join("\n")
-                                        )
-                                    } else {
-                                        format!("(raw): {:?}", result.cyan())
-                                    };
-
-                                    for line in result.lines() {
-                                        println!("{}     > {}", ind, line);
-                                    }
-                                }
-                                None => println!("{}   (no return value)", ind),
-                            },
-                            Err(err) => {
-                                let err = format!("{:#?}", err);
-
-                                println!("{}   error:", ind);
-                                for line in err.lines() {
-                                    println!("{}     > {}", ind, line.yellow());
-                                }
+                            for line in result.lines() {
+                                println!("{}     > {}", ind, line);
                             }
                         }
-
-                        if !outcome.logs.is_empty() {
-                            println!("{}   logs:", ind);
-
-                            for log in outcome.logs {
-                                println!("{}     > {}", ind, log.cyan());
-                            }
-                        }
-                    }
+                        None => println!("{}   (no return value)", ind),
+                    },
                     Err(err) => {
                         let err = format!("{:#?}", err);
 
@@ -94,8 +68,24 @@ impl CallCommand {
                         }
                     }
                 }
+
+                if !outcome.logs.is_empty() {
+                    println!("{}   logs:", ind);
+
+                    for log in outcome.logs {
+                        println!("{}     > {}", ind, log.cyan());
+                    }
+                }
             }
-        }));
+            Err(err) => {
+                let err = format!("{:#?}", err);
+
+                println!("{}   error:", ind);
+                for line in err.lines() {
+                    println!("{}     > {}", ind, line.yellow());
+                }
+            }
+        }
 
         Ok(())
     }

--- a/crates/node/src/interactive_cli/call.rs
+++ b/crates/node/src/interactive_cli/call.rs
@@ -32,7 +32,6 @@ impl CallCommand {
             serde_json::to_vec(&self.payload)?,
             self.executor_key,
             outcome_sender,
-            None,
         ))
         .await;
 

--- a/crates/server/src/jsonrpc/mutate.rs
+++ b/crates/server/src/jsonrpc/mutate.rs
@@ -23,7 +23,6 @@ async fn handle(request: MutateRequest, state: Arc<ServiceState>) -> EyreResult<
         request.context_id,
         request.method,
         args,
-        true,
         request.executor_public_key,
     )
     .await

--- a/crates/server/src/jsonrpc/query.rs
+++ b/crates/server/src/jsonrpc/query.rs
@@ -23,7 +23,6 @@ async fn handle(request: QueryRequest, state: Arc<ServiceState>) -> EyreResult<Q
         request.context_id,
         request.method,
         args,
-        false,
         request.executor_public_key,
     )
     .await


### PR DESCRIPTION
Mutable & Query client execution requests now functionally do the same thing, to avoid breaking client apps (frontends), I'm retaining the `mutate` and `query` JSONRPC methods to be reconciled in a later PR

And due to optimistic execution, we no longer need `Finality` directives

cc: @fbozic & @petarjuki7, to keep you in the loop just in case