### PR TITLE
fix: handle fallible context creation

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -237,6 +237,10 @@ impl ContextManager {
                 }
             }
 
+            if let Err(err) = this.subscribe(&context.id).await {
+                error!(%context_id, %err, "Failed to subscribe to context after creation");
+            }
+
             let _ignored = result_sender.send(result);
         });
 
@@ -261,8 +265,6 @@ impl ContextManager {
             )?;
 
             self.save_context(context)?;
-
-            self.subscribe(&context.id).await?;
         }
 
         handle.put(
@@ -377,6 +379,8 @@ impl ContextManager {
 
         self.add_context(&context, identity_secret, !context_exists)
             .await?;
+
+        self.subscribe(&context.id).await?;
 
         let _ = self.state.write().await.pending_catchup.insert(context_id);
 

--- a/crates/node-primitives/src/lib.rs
+++ b/crates/node-primitives/src/lib.rs
@@ -38,13 +38,17 @@ impl ExecutionRequest {
 pub type ServerSender = mpsc::Sender<ExecutionRequest>;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, ThisError)]
-#[error("CallError")]
 #[serde(tag = "type", content = "data")]
 #[non_exhaustive]
 pub enum CallError {
-    ApplicationNotInstalled { application_id: ApplicationId },
+    #[error("no connected peers")]
     NoConnectedPeers,
-    ActionRejected,
-    InternalError,
+    #[error("context not found: {context_id}")]
     ContextNotFound { context_id: ContextId },
+    #[error("application not installed: {application_id}")]
+    ApplicationNotInstalled { application_id: ApplicationId },
+    #[error("action rejected")]
+    ActionRejected,
+    #[error("internal error")]
+    InternalError,
 }

--- a/crates/server/src/admin/handlers/context/create_context.rs
+++ b/crates/server/src/admin/handlers/context/create_context.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use calimero_server_primitives::admin::{CreateContextRequest, CreateContextResponse};
+use tokio::sync::oneshot;
 
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
@@ -11,6 +12,8 @@ pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
     Json(req): Json<CreateContextRequest>,
 ) -> impl IntoResponse {
+    let (tx, rx) = oneshot::channel();
+
     let result = state
         .ctx_manager
         .create_context(
@@ -18,15 +21,24 @@ pub async fn handler(
             req.application_id,
             None,
             req.initialization_params,
+            tx,
         )
         .await
         .map_err(parse_api_error);
+
+    if let Err(err) = result {
+        return err.into_response();
+    }
+
+    let Ok(result) = rx.await else {
+        return "internal error".into_response();
+    };
 
     match result {
         Ok((context_id, member_public_key)) => ApiResponse {
             payload: CreateContextResponse::new(context_id, member_public_key),
         }
         .into_response(),
-        Err(err) => err.into_response(),
+        Err(err) => parse_api_error(err).into_response(),
     }
 }


### PR DESCRIPTION
`context create` may fail, especially during initialization, we shouldn't assume success when it does.

This patch ensures to only return the context id and public key of the user if creation succeeds.

And to rollback store mutations when we encounter a failure.