### PR TITLE
chore: remove client notification of peer connection events

### DIFF
--- a/crates/network/src/events/gossipsub.rs
+++ b/crates/network/src/events/gossipsub.rs
@@ -25,16 +25,26 @@ impl EventHandler<Event> for EventLoop {
                 }
             }
             Event::Subscribed { peer_id, topic } => {
-                if (self
+                if self
                     .event_sender
                     .send(NetworkEvent::Subscribed { peer_id, topic })
-                    .await)
+                    .await
                     .is_err()
                 {
                     error!("Failed to send subscribed event");
                 }
             }
-            Event::GossipsubNotSupported { .. } | Event::Unsubscribed { .. } => {}
+            Event::Unsubscribed { peer_id, topic } => {
+                if self
+                    .event_sender
+                    .send(NetworkEvent::Unsubscribed { peer_id, topic })
+                    .await
+                    .is_err()
+                {
+                    error!("Failed to send unsubscribed event");
+                }
+            }
+            Event::GossipsubNotSupported { .. } => {}
         }
     }
 }

--- a/crates/network/src/types.rs
+++ b/crates/network/src/types.rs
@@ -16,6 +16,10 @@ pub enum NetworkEvent {
         peer_id: PeerId,
         topic: TopicHash,
     },
+    Unsubscribed {
+        peer_id: PeerId,
+        topic: TopicHash,
+    },
     Message {
         id: MessageId,
         message: Message,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -18,7 +18,7 @@ use calimero_network::types::{NetworkEvent, PeerId};
 use calimero_node_primitives::{CallError, ExecutionRequest};
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::{
-    ApplicationEvent, ApplicationEventPayload, NodeEvent, OutcomeEvent, OutcomeEventPayload,
+    ContextEvent, ContextEventPayload, NodeEvent, OutcomeEvent, OutcomeEventPayload,
     StateMutationPayload,
 };
 use calimero_primitives::identity::PublicKey;
@@ -573,15 +573,12 @@ impl Node {
 
                 context.root_hash = root_hash.into();
 
-                drop(
-                    self.node_events
-                        .send(NodeEvent::Application(ApplicationEvent::new(
-                            context.id,
-                            ApplicationEventPayload::StateMutation(StateMutationPayload::new(
-                                context.root_hash,
-                            )),
-                        ))),
-                );
+                drop(self.node_events.send(NodeEvent::Context(ContextEvent::new(
+                    context.id,
+                    ContextEventPayload::StateMutation(StateMutationPayload::new(
+                        context.root_hash,
+                    )),
+                ))));
 
                 self.ctx_manager.save_context(context)?;
             }
@@ -591,17 +588,16 @@ impl Node {
             }
 
             drop(
-                self.node_events
-                    .send(NodeEvent::Application(ApplicationEvent::new(
-                        context.id,
-                        ApplicationEventPayload::OutcomeEvent(OutcomeEventPayload::new(
-                            outcome
-                                .events
-                                .iter()
-                                .map(|e| OutcomeEvent::new(e.kind.clone(), e.data.clone()))
-                                .collect(),
-                        )),
-                    ))),
+                self.node_events.send(NodeEvent::Context(ContextEvent::new(
+                    context.id,
+                    ContextEventPayload::OutcomeEvent(OutcomeEventPayload::new(
+                        outcome
+                            .events
+                            .iter()
+                            .map(|e| OutcomeEvent::new(e.kind.clone(), e.data.clone()))
+                            .collect(),
+                    )),
+                ))),
             );
         }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -18,7 +18,7 @@ use calimero_network::types::{NetworkEvent, PeerId};
 use calimero_node_primitives::{CallError, ExecutionRequest};
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::{
-    ContextEvent, ContextEventPayload, NodeEvent, OutcomeEvent, OutcomeEventPayload,
+    ContextEvent, ContextEventPayload, ExecutionEvent, ExecutionEventPayload, NodeEvent,
     StateMutationPayload,
 };
 use calimero_primitives::identity::PublicKey;
@@ -590,11 +590,11 @@ impl Node {
             drop(
                 self.node_events.send(NodeEvent::Context(ContextEvent::new(
                     context.id,
-                    ContextEventPayload::OutcomeEvent(OutcomeEventPayload::new(
+                    ContextEventPayload::ExecutionEvent(ExecutionEventPayload::new(
                         outcome
                             .events
                             .iter()
-                            .map(|e| OutcomeEvent::new(e.kind.clone(), e.data.clone()))
+                            .map(|e| ExecutionEvent::new(e.kind.clone(), e.data.clone()))
                             .collect(),
                     )),
                 ))),

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -35,7 +35,7 @@ impl ContextEvent {
 #[expect(variant_size_differences, reason = "fine for now")]
 pub enum ContextEventPayload {
     StateMutation(StateMutationPayload),
-    OutcomeEvent(OutcomeEventPayload),
+    ExecutionEvent(ExecutionEventPayload),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -54,12 +54,12 @@ impl StateMutationPayload {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
-pub struct OutcomeEvent {
+pub struct ExecutionEvent {
     pub kind: String,
     pub data: Vec<u8>,
 }
 
-impl OutcomeEvent {
+impl ExecutionEvent {
     #[must_use]
     pub const fn new(kind: String, data: Vec<u8>) -> Self {
         Self { kind, data }
@@ -69,13 +69,13 @@ impl OutcomeEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct OutcomeEventPayload {
-    pub events: Vec<OutcomeEvent>,
+pub struct ExecutionEventPayload {
+    pub events: Vec<ExecutionEvent>,
 }
 
-impl OutcomeEventPayload {
+impl ExecutionEventPayload {
     #[must_use]
-    pub const fn new(events: Vec<OutcomeEvent>) -> Self {
+    pub const fn new(events: Vec<ExecutionEvent>) -> Self {
         Self { events }
     }
 }

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -1,4 +1,3 @@
-use libp2p_identity::PeerId;
 use serde::{Deserialize, Serialize};
 
 use crate::context::ContextId;
@@ -33,9 +32,9 @@ impl ApplicationEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", content = "data", rename_all = "PascalCase")]
 #[non_exhaustive]
+#[expect(variant_size_differences, reason = "fine for now")]
 pub enum ApplicationEventPayload {
     StateMutation(StateMutationPayload),
-    PeerJoined(PeerJoinedPayload),
     OutcomeEvent(OutcomeEventPayload),
 }
 
@@ -50,20 +49,6 @@ impl StateMutationPayload {
     #[must_use]
     pub const fn new(new_root: Hash) -> Self {
         Self { new_root }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct PeerJoinedPayload {
-    pub peer_id: PeerId,
-}
-
-impl PeerJoinedPayload {
-    #[must_use]
-    pub const fn new(peer_id: PeerId) -> Self {
-        Self { peer_id }
     }
 }
 

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -7,21 +7,21 @@ use crate::hash::Hash;
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum NodeEvent {
-    Application(ApplicationEvent),
+    Context(ContextEvent),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct ApplicationEvent {
+pub struct ContextEvent {
     pub context_id: ContextId,
     #[serde(flatten)]
-    pub payload: ApplicationEventPayload,
+    pub payload: ContextEventPayload,
 }
 
-impl ApplicationEvent {
+impl ContextEvent {
     #[must_use]
-    pub const fn new(context_id: ContextId, payload: ApplicationEventPayload) -> Self {
+    pub const fn new(context_id: ContextId, payload: ContextEventPayload) -> Self {
         Self {
             context_id,
             payload,
@@ -33,7 +33,7 @@ impl ApplicationEvent {
 #[serde(tag = "type", content = "data", rename_all = "PascalCase")]
 #[non_exhaustive]
 #[expect(variant_size_differences, reason = "fine for now")]
-pub enum ApplicationEventPayload {
+pub enum ContextEventPayload {
     StateMutation(StateMutationPayload),
     OutcomeEvent(OutcomeEventPayload),
 }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -188,7 +188,7 @@ async fn handle_node_events(
         );
 
         let event = match event {
-            NodeEvent::Application(event)
+            NodeEvent::Context(event)
                 if {
                     connection_state
                         .inner
@@ -198,9 +198,9 @@ async fn handle_node_events(
                         .contains(&event.context_id)
                 } =>
             {
-                NodeEvent::Application(event)
+                NodeEvent::Context(event)
             }
-            NodeEvent::Application(_) => continue,
+            NodeEvent::Context(_) => continue,
             _ => unreachable!("Unexpected event type"),
         };
 

--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/subscriptions/subscriptions.ts
+++ b/packages/calimero-sdk/src/subscriptions/subscriptions.ts
@@ -5,26 +5,32 @@ export interface SubscriptionsClient {
   disconnect(connectionId?: string): void;
   subscribe(contextIds: string[], connectionId?: string): void;
   unsubscribe(contextIds: string[], connectionId?: string): void;
-  addCallback(callback: (data: NodeEvent) => void, connectionId?: string): void;
+  addCallback(callback: (event: NodeEvent) => void, connectionId?: string): void;
   removeCallback(
-    callback: (data: NodeEvent) => void,
+    callback: (event: NodeEvent) => void,
     connectionId?: string,
   ): void;
 }
 
-export type NodeEvent = ApplicationEvent;
+export type NodeEvent = ContextEvent;
 
-export interface ApplicationEvent {
-  context_id: ContextId;
-  type: 'TransactionExecuted';
-  data: OutcomeEvents;
+export type ContextEvent = ContextEventPayload & {
+  contextId: ContextId;
 }
 
-export interface OutcomeEvent {
-  kind: String;
-  data: number[];
+type ContextEventPayload = {
+  type: 'StateMutation',
+  data: StateMutation,
+} | {
+  type: 'ExecutionEvent',
+  data: ExecutionEvent,
+};
+
+export interface StateMutation {
+  newRoot: string;
 }
 
-export interface OutcomeEvents {
-  events: OutcomeEvent[];
+export interface ExecutionEvent {
+  kind: string,
+  data: any,
 }

--- a/packages/calimero-sdk/src/subscriptions/subscriptions.ts
+++ b/packages/calimero-sdk/src/subscriptions/subscriptions.ts
@@ -16,7 +16,7 @@ export type NodeEvent = ApplicationEvent;
 
 export interface ApplicationEvent {
   context_id: ContextId;
-  type: 'TransactionExecuted' | 'PeerJoined';
+  type: 'TransactionExecuted';
   data: OutcomeEvents;
 }
 

--- a/packages/calimero-sdk/src/subscriptions/ws.ts
+++ b/packages/calimero-sdk/src/subscriptions/ws.ts
@@ -27,7 +27,7 @@ interface UnsubscribeRequest {
 export class WsSubscriptionsClient implements SubscriptionsClient {
   private readonly url: string;
   private connections: Map<string, WebSocket>;
-  private callbacks: Map<string, Array<(data: NodeEvent) => void>>;
+  private callbacks: Map<string, Array<(event: NodeEvent) => void>>;
 
   public constructor(baseUrl: string, path: string) {
     this.url = `${baseUrl}${path}`;
@@ -98,7 +98,7 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
   }
 
   public addCallback(
-    callback: (data: NodeEvent) => void,
+    callback: (event: NodeEvent) => void,
     connectionId: string = DEFAULT_CONNECTION_ID,
   ): void {
     if (!this.callbacks.has(connectionId)) {
@@ -109,7 +109,7 @@ export class WsSubscriptionsClient implements SubscriptionsClient {
   }
 
   public removeCallback(
-    callback: (data: NodeEvent) => void,
+    callback: (event: NodeEvent) => void,
     connectionId: string = DEFAULT_CONNECTION_ID,
   ): void {
     const callbacks = this.callbacks.get(connectionId);


### PR DESCRIPTION
`PeerId`s are a networking concept and give clients subscribed to a context no useful information.

Doc patch: https://github.com/calimero-network/calimero-network.github.io/pull/44