### PR TITLE
[DO NOT MERGE/ Reference]feat: expose access to the Proxy Contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-primitives",
+ "near-sdk",
  "reqwest 0.12.5",
  "serde",
  "serde_json",

--- a/crates/context/config/Cargo.toml
+++ b/crates/context/config/Cargo.toml
@@ -11,6 +11,7 @@ bs58.workspace = true
 borsh = { workspace = true, features = ["derive"] }
 ed25519-dalek.workspace = true
 either = { workspace = true, optional = true }
+near-sdk.workspace = true
 near-crypto = { workspace = true, optional = true }
 near-jsonrpc-client = { workspace = true, optional = true }
 near-jsonrpc-primitives = { workspace = true, optional = true }

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -401,3 +401,5 @@ pub enum ProposalAction {
         value: Box<[u8]>,
     },
 }
+
+pub type ProposalId = u32;

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -7,6 +7,8 @@ use std::borrow::Cow;
 use borsh::{BorshDeserialize, BorshSerialize};
 use bs58::decode::Result as Bs58Result;
 use ed25519_dalek::{Signature, SignatureError, Verifier, VerifyingKey};
+use near_sdk::json_types::Base64VecU8;
+use near_sdk::{AccountId, Gas, NearToken};
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 
@@ -371,4 +373,31 @@ impl<'a, T: Deserialize<'a>> Signed<T> {
         key.verify(&self.payload, &self.signature)
             .map_or(Err(ConfigError::InvalidSignature), |()| Ok(parsed))
     }
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Proposal {
+    pub author_id: Repr<SignerId>,
+    pub actions: Vec<ProposalAction>,
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum ProposalAction {
+    ExternalFunctionCall {
+        receiver_id: AccountId,
+        method_name: String,
+        args: Base64VecU8,
+        deposit: NearToken,
+        gas: Gas,
+    },
+    SetNumApprovals {
+        num_approvals: u32,
+    },
+    SetActiveRequestsLimit {
+        active_proposals_limit: u32,
+    },
+    SetContextValue {
+        key: Box<[u8]>,
+        value: Box<[u8]>,
+    },
 }

--- a/crates/server/src/admin/handlers/context/get_contract_requests.rs
+++ b/crates/server/src/admin/handlers/context/get_contract_requests.rs
@@ -1,0 +1,9 @@
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use calimero_server_primitives::admin::{CreateContextRequest, CreateContextResponse};
+use tokio::sync::oneshot;
+
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;


### PR DESCRIPTION
# Refactor Context Client API for Proxy Contract Support

Abstracts query and mutate methods through a shared `Environment` trait, enabling support for both config and proxy contracts. This allows for foundation for future proxy contract integration

Key changes:
- Added Environment trait with associated Query/Mutate types
- Implemented trait for both ContextConfigClient and ContextProxyClient
- Added query methods needed for the rpc in the context manager

