### PR TITLE
feat: blockchain developer interface

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -142,6 +142,17 @@ impl<'a> VMLogic<'a> {
         }
         .build()
     }
+
+    /// Modifies a value through the blockchain bridge
+    ///
+    /// # Parameters
+    ///
+    /// * `value` - The value to be modified on the blockchain.
+    ///
+    pub fn modify_value(&mut self, _value: Vec<u8>) -> VMLogicResult<()> {
+        // TODO: Implement actual blockchain call
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -227,9 +238,7 @@ impl VMHostFunctions<'_> {
 
         String::from_utf8(buf).map_err(|_| HostError::BadUTF8.into())
     }
-}
 
-impl VMHostFunctions<'_> {
     pub fn panic(&self, file_ptr: u64, file_len: u64, line: u32, column: u32) -> VMLogicResult<()> {
         let file = self.get_string(file_ptr, file_len)?;
         Err(HostError::Panic {
@@ -555,5 +564,21 @@ impl VMHostFunctions<'_> {
         self.borrow_memory().write(ptr, &now.to_le_bytes())?;
 
         Ok(())
+    }
+
+    /// Call the contract's `modify_value()` function through the bridge.
+    ///
+    /// The value to be modified is of indeterminate type, and used as raw data.
+    ///
+    /// # Parameters
+    ///
+    /// * `ptr` - Pointer to the start of the value data in WASM memory.
+    /// * `len` - Length of the value data.
+    ///
+    pub fn modify_value(&mut self, ptr: u64, len: u64) -> VMLogicResult<()> {
+        let value = self.read_guest_memory(ptr, len)?;
+
+        // Call the bridge function to modify value on chain
+        self.with_logic_mut(|logic| logic.modify_value(value))
     }
 }

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -108,6 +108,7 @@ pub struct VMLogic<'a> {
     events: Vec<Event>,
     actions: Vec<Vec<u8>>,
     root_hash: Option<[u8; 32]>,
+    proposal_function: Option<Box<dyn FnMut() -> Vec<u8>>>,
 }
 
 impl<'a> VMLogic<'a> {
@@ -123,6 +124,7 @@ impl<'a> VMLogic<'a> {
             events: vec![],
             actions: vec![],
             root_hash: None,
+            proposal_function: None,
         }
     }
 
@@ -141,6 +143,21 @@ impl<'a> VMLogic<'a> {
             memory_builder: |store| memory.view(store),
         }
         .build()
+    }
+    
+    pub fn execute_proposal(&mut self) -> Option<Vec<u8>> {
+        self.proposal_function.as_mut().map(|f| f())
+    }
+    
+    /// Modifies a value through the blockchain bridge
+    ///
+    /// # Parameters
+    ///
+    /// * `value` - The value to be modified on the blockchain.
+    ///
+    pub fn modify_value(&mut self, value: Vec<u8>) -> VMLogicResult<()> {
+        // TODO: Implement actual blockchain call
+        Ok(())
     }
 }
 
@@ -555,5 +572,44 @@ impl VMHostFunctions<'_> {
         self.borrow_memory().write(ptr, &now.to_le_bytes())?;
 
         Ok(())
+    }
+    
+    /// Register a proposal function.
+    ///
+    /// This function accepts a function as input, and the provided function will be
+    /// called when proposals need to be handled.
+    ///
+    /// # Parameters
+    ///
+    /// * `func` - A closure that will be executed when processing proposals. The
+    ///            closure should return a `Vec<u8>` containing the proposal data.
+    ///
+    pub fn register_proposal_function(
+        &mut self,
+        func: Box<dyn FnMut() -> Vec<u8>>,
+    ) -> VMLogicResult<()> {
+        // Store the function for later use
+        self.with_logic_mut(|logic| {
+            logic.proposal_function = Some(func);
+            Ok(())
+        })
+    }
+    
+    /// Call the contract's `modify_value()` function through the bridge.
+    ///
+    /// The value to be modified is of indeterminate type, and used as raw data.
+    /// 
+    /// # Parameters
+    ///
+    /// * `ptr` - Pointer to the start of the value data in WASM memory.
+    /// * `len` - Length of the value data.
+    ///
+    pub fn modify_value(&mut self, ptr: u64, len: u64) -> VMLogicResult<()> {
+        let value = self.read_guest_memory(ptr, len)?;
+        
+        // Call the bridge function to modify value on chain
+        self.with_logic_mut(|logic| {
+            logic.modify_value(value)
+        })
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -69,9 +69,6 @@ impl VMLogic<'_> {
 
             fn random_bytes(ptr: u64, len: u64);
             fn time_now(ptr: u64, len: u64);
-            
-            fn register_proposal_function(f: Box<dyn FnMut() -> Vec<u8>>);
-            fn modify_value(ptr: u64, len: u64);
         }
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -69,6 +69,9 @@ impl VMLogic<'_> {
 
             fn random_bytes(ptr: u64, len: u64);
             fn time_now(ptr: u64, len: u64);
+            
+            fn register_proposal_function(f: Box<dyn FnMut() -> Vec<u8>>);
+            fn modify_value(ptr: u64, len: u64);
         }
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -69,6 +69,8 @@ impl VMLogic<'_> {
 
             fn random_bytes(ptr: u64, len: u64);
             fn time_now(ptr: u64, len: u64);
+
+            fn modify_value(ptr: u64, len: u64);
         }
     }
 }

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -208,3 +208,28 @@ pub fn time_now() -> u64 {
 
     u64::from_le_bytes(bytes)
 }
+
+/// Register a proposal function.
+///
+/// This function accepts a function as input, and the provided function will be
+/// called when proposals need to be handled.
+///
+/// # Parameters
+///
+/// * `func` - A closure that will be executed when processing proposals. The
+///            closure should return a `Vec<u8>` containing the proposal data.
+///
+pub fn register_proposal_function<F>(func: F) where F: FnMut() -> Vec<u8> + 'static {
+    unsafe { sys::register_proposal_function(Box::new(func) as Box<dyn FnMut() -> Vec<u8>>) }
+}
+
+/// Call the contract's `modify_value()` function through the bridge.
+///
+/// # Parameters
+///
+/// * `value` - The value to be modified. This is of indeterminate type, and
+///             used as raw data.
+///
+pub fn modify_value(value: &[u8]) {
+    unsafe { sys::modify_value(Buffer::from(value)) }
+}

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -208,3 +208,14 @@ pub fn time_now() -> u64 {
 
     u64::from_le_bytes(bytes)
 }
+
+/// Call the contract's `modify_value()` function through the bridge.
+///
+/// # Parameters
+///
+/// * `value` - The value to be modified. This is of indeterminate type, and
+///             used as raw data.
+///
+pub fn modify_value(value: &[u8]) {
+    unsafe { sys::modify_value(Buffer::from(value)) }
+}

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -208,28 +208,3 @@ pub fn time_now() -> u64 {
 
     u64::from_le_bytes(bytes)
 }
-
-/// Register a proposal function.
-///
-/// This function accepts a function as input, and the provided function will be
-/// called when proposals need to be handled.
-///
-/// # Parameters
-///
-/// * `func` - A closure that will be executed when processing proposals. The
-///            closure should return a `Vec<u8>` containing the proposal data.
-///
-pub fn register_proposal_function<F>(func: F) where F: FnMut() -> Vec<u8> + 'static {
-    unsafe { sys::register_proposal_function(Box::new(func) as Box<dyn FnMut() -> Vec<u8>>) }
-}
-
-/// Call the contract's `modify_value()` function through the bridge.
-///
-/// # Parameters
-///
-/// * `value` - The value to be modified. This is of indeterminate type, and
-///             used as raw data.
-///
-pub fn modify_value(value: &[u8]) {
-    unsafe { sys::modify_value(Buffer::from(value)) }
-}

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -37,6 +37,8 @@ wasm_imports! {
         // --
         fn random_bytes(buf: BufferMut<'_>);
         fn time_now(buf: BufferMut<'_>);
+        // --
+        fn modify_value(value: Buffer<'_>);
     }
 }
 

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -37,9 +37,6 @@ wasm_imports! {
         // --
         fn random_bytes(buf: BufferMut<'_>);
         fn time_now(buf: BufferMut<'_>);
-        // --
-        fn register_proposal_function(func: Box<dyn FnMut() -> Vec<u8>>);
-        fn modify_value(value: Buffer<'_>);
     }
 }
 

--- a/crates/sdk/src/sys.rs
+++ b/crates/sdk/src/sys.rs
@@ -37,6 +37,9 @@ wasm_imports! {
         // --
         fn random_bytes(buf: BufferMut<'_>);
         fn time_now(buf: BufferMut<'_>);
+        // --
+        fn register_proposal_function(func: Box<dyn FnMut() -> Vec<u8>>);
+        fn modify_value(value: Buffer<'_>);
     }
 }
 


### PR DESCRIPTION
# Purpose

This brings in the developer interface that's needed to support the blockchain integration, with the WASM bridge.

  - It has moved from the originally-intended closure registration approach to using a predefined function that must be implemented in the guest code.
  - `handle_proposal()` on `Node` is how the host calls into the guest implementation.
  - `modify_value()` is still needed as it's the bridge function that lets guest code modify blockchain values.

The path for `modify_value()` goes from:

  1. Guest code calls it via `sdk/src/env.rs`,
  2. Which uses the syscall in `sdk/src/sys.rs`,
  3. Which gets handled by `VMHostFunctions`/`VMLogic` through `runtime/src/logic.rs` and `imports.rs`.

This relies on the standard method calling pattern used elsewhere in the codebase.

# Description of changes

  - Added a `modify_value()` function to the guest WASM and host functions in order for values on the blockchain to be modified. The intention is that this should then, from the host VMLogic side, call through to the appropriate blockchain function.

  - Added a `handle_proposal()` function to Node, to call a corresponding function on the guest (this is expected to exist).

# How to test

This cannot really be tested until it's hooked up to the wider blockchain integration.

# Notes / advisories

  - It needs hooking in to the wider blockchain integration, likely at the places indicated.
  - The parameters to pass to the guest function need to be defined, along with the exact nature of the data it should return.