### PR TITLE
feat(context-config): impl guard revision, restructure modules

### DIFF
--- a/contracts/context-config/src/guard.rs
+++ b/contracts/context-config/src/guard.rs
@@ -1,7 +1,7 @@
 use core::ops::{Deref, DerefMut};
 use std::fmt;
 
-use calimero_context_config::types::SignerId;
+use calimero_context_config::types::{Revision, SignerId};
 use near_sdk::near;
 use near_sdk::store::IterableSet;
 
@@ -11,6 +11,7 @@ use super::Prefix;
 #[near(serializers = [borsh])]
 pub struct Guard<T> {
     inner: T,
+    revision: Revision,
     priviledged: IterableSet<SignerId>,
 }
 
@@ -36,15 +37,19 @@ impl<T> Guard<T> {
         let mut priviledged = IterableSet::new(prefix);
         let _ = priviledged.insert(signer_id);
 
-        Self { inner, priviledged }
+        Self {
+            inner,
+            revision: 0,
+            priviledged,
+        }
     }
 
-    pub fn get_mut(&mut self, signer_id: &SignerId) -> Result<GuardMut<'_, T>, UnauthorizedAccess> {
+    pub fn get(&mut self, signer_id: &SignerId) -> Result<GuardHandle<'_, T>, UnauthorizedAccess> {
         if !self.priviledged.contains(signer_id) {
             return Err(UnauthorizedAccess { _priv: () });
         }
 
-        Ok(GuardMut { inner: self })
+        Ok(GuardHandle { inner: self })
     }
 
     pub fn into_inner(self) -> T {
@@ -62,6 +67,10 @@ impl<T> Guard<T> {
             inner: &mut self.priviledged,
         }
     }
+
+    pub fn revision(&self) -> Revision {
+        self.revision
+    }
 }
 
 impl<T> Deref for Guard<T> {
@@ -73,15 +82,28 @@ impl<T> Deref for Guard<T> {
 }
 
 #[derive(Debug)]
+pub struct GuardHandle<'a, T> {
+    inner: &'a mut Guard<T>,
+}
+
+impl<'a, T> GuardHandle<'a, T> {
+    pub fn get_mut(self) -> GuardMut<'a, T> {
+        GuardMut { inner: self.inner }
+    }
+
+    pub fn priviledges(&mut self) -> Priviledges<'_> {
+        self.inner.priviledges()
+    }
+}
+
+#[derive(Debug)]
 pub struct GuardMut<'a, T> {
     inner: &'a mut Guard<T>,
 }
 
 impl<T> GuardMut<'_, T> {
     pub fn priviledges(&mut self) -> Priviledges<'_> {
-        Priviledges {
-            inner: &mut self.inner.priviledged,
-        }
+        self.inner.priviledges()
     }
 }
 
@@ -96,6 +118,12 @@ impl<T> Deref for GuardMut<'_, T> {
 impl<T> DerefMut for GuardMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner.inner
+    }
+}
+
+impl<T> Drop for GuardMut<'_, T> {
+    fn drop(&mut self) {
+        self.inner.revision += 1;
     }
 }
 

--- a/contracts/context-config/src/guard.rs
+++ b/contracts/context-config/src/guard.rs
@@ -123,7 +123,7 @@ impl<T> DerefMut for GuardMut<'_, T> {
 
 impl<T> Drop for GuardMut<'_, T> {
     fn drop(&mut self) {
-        self.inner.revision += 1;
+        self.inner.revision = self.inner.revision.wrapping_add(1);
     }
 }
 

--- a/contracts/context-config/src/guard.rs
+++ b/contracts/context-config/src/guard.rs
@@ -68,7 +68,7 @@ impl<T> Guard<T> {
         }
     }
 
-    pub fn revision(&self) -> Revision {
+    pub const fn revision(&self) -> Revision {
         self.revision
     }
 }

--- a/contracts/context-config/src/lib.rs
+++ b/contracts/context-config/src/lib.rs
@@ -8,6 +8,7 @@ use near_sdk::{near, BorshStorageKey};
 mod guard;
 mod mutate;
 mod query;
+mod sys;
 
 use guard::Guard;
 
@@ -64,3 +65,13 @@ impl Default for ContextConfigs {
         }
     }
 }
+
+macro_rules! _parse_input {
+    ($input:ident $(: $input_ty:ty)?) => {
+        let $input = ::near_sdk::env::input().unwrap_or_default();
+
+        let $input $(: $input_ty )? = ::near_sdk::serde_json::from_slice(&$input).expect("failed to parse input");
+    };
+}
+
+use _parse_input as parse_input;

--- a/contracts/context-config/src/lib.rs
+++ b/contracts/context-config/src/lib.rs
@@ -1,4 +1,8 @@
 #![allow(unused_crate_dependencies, reason = "False positives")]
+#![allow(
+    clippy::multiple_inherent_impl,
+    reason = "Needed to separate NEAR functionality"
+)]
 
 use calimero_context_config::types::{Application, ContextId, ContextIdentity};
 use calimero_context_config::Timestamp;

--- a/contracts/context-config/src/mutate.rs
+++ b/contracts/context-config/src/mutate.rs
@@ -1,8 +1,3 @@
-#![allow(
-    clippy::multiple_inherent_impl,
-    reason = "Needed to separate NEAR functionality"
-)]
-
 use core::mem;
 
 use calimero_context_config::repr::{Repr, ReprBytes, ReprTransmute};

--- a/contracts/context-config/src/query.rs
+++ b/contracts/context-config/src/query.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 use calimero_context_config::repr::{Repr, ReprTransmute};
 use calimero_context_config::types::{
-    Application, Capability, ContextId, ContextIdentity, SignerId,
+    Application, Capability, ContextId, ContextIdentity, Revision, SignerId,
 };
 use near_sdk::near;
 
@@ -22,6 +22,15 @@ impl ContextConfigs {
             .expect("context does not exist");
 
         &context.application
+    }
+
+    pub fn application_revision(&self, context_id: Repr<ContextId>) -> Revision {
+        let context = self
+            .contexts
+            .get(&context_id)
+            .expect("context does not exist");
+
+        context.application.revision()
     }
 
     pub fn members(
@@ -42,6 +51,15 @@ impl ContextConfigs {
         }
 
         members
+    }
+
+    pub fn members_revision(&self, context_id: Repr<ContextId>) -> Revision {
+        let context = self
+            .contexts
+            .get(&context_id)
+            .expect("context does not exist");
+
+        context.members.revision()
     }
 
     pub fn privileges(

--- a/contracts/context-config/src/query.rs
+++ b/contracts/context-config/src/query.rs
@@ -1,8 +1,3 @@
-#![allow(
-    clippy::multiple_inherent_impl,
-    reason = "Needed to separate NEAR functionality"
-)]
-
 use std::collections::BTreeMap;
 
 use calimero_context_config::repr::{Repr, ReprTransmute};

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -1,0 +1,100 @@
+use core::time;
+use std::io;
+
+use calimero_context_config::repr::Repr;
+use calimero_context_config::types::{Application, ContextId, ContextIdentity, SignerId};
+use calimero_context_config::{SystemRequest, Timestamp};
+use near_sdk::store::{IterableMap, IterableSet};
+use near_sdk::{env, near};
+
+use crate::{parse_input, Config, ContextConfigs, ContextConfigsExt};
+
+const MIN_VALIDITY_THRESHOLD_MS: Timestamp = 5_000;
+
+#[near]
+impl ContextConfigs {
+    #[private]
+    pub fn set(&mut self) {
+        parse_input!(request);
+
+        match request {
+            SystemRequest::SetValidityThreshold { threshold_ms } => {
+                self.set_validity_threshold_ms(threshold_ms);
+            }
+        }
+    }
+
+    #[private]
+    pub fn erase(&mut self) {
+        env::log_str(&format!(
+            "Pre-erase storage usage: {}",
+            env::storage_usage()
+        ));
+
+        env::log_str("Erasing contract");
+
+        for (_, context) in self.contexts.drain() {
+            drop(context.application.into_inner());
+            context.members.into_inner().clear();
+        }
+
+        env::log_str(&format!(
+            "Post-erase storage usage: {}",
+            env::storage_usage()
+        ));
+    }
+
+    #[private]
+    pub fn migrate() {
+        // IterableMap doesn't support raw access to the underlying storage
+        // Which hinders migration of the data, so we have to employ this trick
+
+        #[derive(Debug)]
+        #[near(serializers = [borsh])]
+        pub struct OldContextConfigs {
+            contexts: IterableMap<ContextId, OldContext>,
+            config: Config,
+        }
+
+        #[derive(Debug)]
+        #[near(serializers = [borsh])]
+        struct OldContext {
+            pub application: OldGuard<Application<'static>>,
+            pub members: OldGuard<IterableSet<ContextIdentity>>,
+        }
+
+        #[derive(Debug)]
+        #[near(serializers = [borsh])]
+        pub struct OldGuard<T> {
+            inner: T,
+            #[borsh(deserialize_with = "skipped")]
+            revision: u64,
+            priviledged: IterableSet<SignerId>,
+        }
+
+        pub fn skipped<R: io::Read>(_reader: &mut R) -> Result<u64, io::Error> {
+            Ok(Default::default())
+        }
+
+        let mut state = env::state_read::<OldContextConfigs>().expect("failed to read state");
+
+        for (context_id, _) in state.contexts.iter_mut() {
+            env::log_str(&format!("Migrating context `{}`", Repr::new(*context_id)));
+        }
+    }
+}
+
+impl ContextConfigs {
+    fn set_validity_threshold_ms(&mut self, validity_threshold_ms: Timestamp) {
+        if validity_threshold_ms < MIN_VALIDITY_THRESHOLD_MS {
+            env::panic_str("invalid validity threshold");
+        }
+
+        self.config.validity_threshold_ms = validity_threshold_ms;
+
+        env::log_str(&format!(
+            "Set validity threshold to `{:?}`",
+            time::Duration::from_millis(validity_threshold_ms)
+        ));
+    }
+}

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -72,6 +72,7 @@ impl ContextConfigs {
             priviledged: IterableSet<SignerId>,
         }
 
+        #[expect(clippy::unnecessary_wraps, reason = "borsh needs this")]
         pub fn skipped<R: io::Read>(_reader: &mut R) -> Result<u64, io::Error> {
             Ok(Default::default())
         }

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -3,7 +3,9 @@
 use std::collections::BTreeMap;
 
 use calimero_context_config::repr::{Repr, ReprTransmute};
-use calimero_context_config::types::{Application, Capability, ContextIdentity, Signed, SignerId};
+use calimero_context_config::types::{
+    Application, Capability, ContextIdentity, Revision, Signed, SignerId,
+};
 use calimero_context_config::{
     ContextRequest, ContextRequestKind, Request, RequestKind, SystemRequest,
 };
@@ -30,7 +32,7 @@ async fn main() -> eyre::Result<()> {
         .into_result()?;
 
     let node2 = root_account
-        .create_subaccount("node3")
+        .create_subaccount("node2")
         .transact()
         .await?
         .into_result()?;
@@ -162,6 +164,24 @@ async fn main() -> eyre::Result<()> {
     assert_eq!(res.source, Default::default());
     assert_eq!(res.metadata, Default::default());
 
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
         .view("privileges")
         .args_json(json!({
@@ -250,6 +270,24 @@ async fn main() -> eyre::Result<()> {
 
     assert_eq!(bob_capabilities, &[]);
 
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
     let res = node1
         .call(contract.id(), "mutate")
         .args_json(Signed::new(
@@ -279,6 +317,24 @@ async fn main() -> eyre::Result<()> {
         );
     }
 
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
     let res = node1
         .call(contract.id(), "mutate")
         .args_json(Signed::new(
@@ -305,6 +361,24 @@ async fn main() -> eyre::Result<()> {
             bob_cx_id, context_id
         )]
     );
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
 
     let res = node1
         .call(contract.id(), "mutate")
@@ -373,6 +447,24 @@ async fn main() -> eyre::Result<()> {
 
     assert_eq!(bob_capabilities, &[Capability::ManageMembers]);
 
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 2);
+
     let new_application_id = rng.gen::<[_; 32]>().rt()?;
     let new_blob_id = rng.gen::<[_; 32]>().rt()?;
 
@@ -423,6 +515,24 @@ async fn main() -> eyre::Result<()> {
     assert_eq!(res.source, Default::default());
     assert_eq!(res.metadata, Default::default());
 
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 2);
+
     let res = node1
         .call(contract.id(), "mutate")
         .args_json(Signed::new(
@@ -467,6 +577,24 @@ async fn main() -> eyre::Result<()> {
     assert_eq!(res.blob, new_blob_id);
     assert_eq!(res.source, Default::default());
     assert_eq!(res.metadata, Default::default());
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 2);
 
     let res = node1
         .call(contract.id(), "mutate")
@@ -528,6 +656,24 @@ async fn main() -> eyre::Result<()> {
         .json()?;
 
     assert_eq!(res, [alice_cx_id, carol_cx_id]);
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 3);
 
     let res = contract
         .call("set")
@@ -596,6 +742,117 @@ async fn main() -> eyre::Result<()> {
 
     assert_eq!(state.len(), 1);
     assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
+
+    Ok(())
+}
+
+#[ignore]
+#[tokio::test]
+async fn migration() -> eyre::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+
+    let wasm_v0 = fs::read("res/calimero_context_config_near_v0.wasm").await?;
+    let wasm_v1 = fs::read("res/calimero_context_config_near_v1.wasm").await?;
+
+    let mut rng = rand::thread_rng();
+
+    let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
+
+    let root_account = worker.root_account()?;
+
+    let node1 = root_account
+        .create_subaccount("node1")
+        .transact()
+        .await?
+        .into_result()?;
+
+    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let alice_cx_pk = alice_cx_sk.verifying_key();
+    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+    let context_secret = SigningKey::from_bytes(&rng.gen());
+    let context_public = context_secret.verifying_key();
+    let context_id = context_public.to_bytes().rt()?;
+
+    let application_id = rng.gen::<[_; 32]>().rt()?;
+    let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    let res = node1
+        .call(contract_v0.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(context_id.rt()?, kind)
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(res.logs(), [format!("Context `{}` added", context_id)]);
+
+    let res = contract_v0
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let contract_v1 = contract_v0
+        .as_account()
+        .deploy(&wasm_v1)
+        .await?
+        .into_result()?;
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await
+        .expect_err("should've failed");
+
+    {
+        let err = format!("{:?}", res);
+        assert!(err.contains("Cannot deserialize element"), "{}", err);
+    }
+
+    let migration = contract_v1
+        .call("migrate")
+        .transact()
+        .await?
+        .into_result()?;
+
+    dbg!(migration.logs());
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
 
     Ok(())
 }

--- a/crates/context/config/src/client.rs
+++ b/crates/context/config/src/client.rs
@@ -12,7 +12,9 @@ use serde_json::{json, Error as JsonError};
 use thiserror::Error;
 
 use crate::repr::Repr;
-use crate::types::{self, Application, Capability, ContextId, ContextIdentity, Signed, SignerId};
+use crate::types::{
+    self, Application, Capability, ContextId, ContextIdentity, Revision, Signed, SignerId,
+};
 use crate::{ContextRequest, ContextRequestKind, Request, RequestKind};
 
 pub mod config;
@@ -228,6 +230,19 @@ impl<'a, T: Transport> ContextConfigQueryClient<'a, T> {
         .await
     }
 
+    pub async fn application_revision(
+        &self,
+        context_id: ContextId,
+    ) -> Result<Response<Revision>, ConfigError<T>> {
+        self.read(
+            "application_revision",
+            json!({
+                "context_id": Repr::new(context_id),
+            }),
+        )
+        .await
+    }
+
     pub async fn members(
         &self,
         context_id: ContextId,
@@ -240,6 +255,19 @@ impl<'a, T: Transport> ContextConfigQueryClient<'a, T> {
                 "context_id": Repr::new(context_id),
                 "offset": offset,
                 "length": length,
+            }),
+        )
+        .await
+    }
+
+    pub async fn members_revision(
+        &self,
+        context_id: ContextId,
+    ) -> Result<Response<Revision>, ConfigError<T>> {
+        self.read(
+            "members_revision",
+            json!({
+                "context_id": Repr::new(context_id),
             }),
         )
         .await

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -12,6 +12,8 @@ use thiserror::Error as ThisError;
 
 use crate::repr::{self, LengthMismatch, Repr, ReprBytes, ReprTransmute};
 
+pub type Revision = u64;
+
 #[derive(
     BorshDeserialize,
     BorshSerialize,


### PR DESCRIPTION
Introduce revisions to `Guard` that let's us more efficiently determine when to update  `application` and `members` on the node