### PR TITLE
fix(node-ui): expired client key

### DIFF
--- a/node-ui/build/index.html
+++ b/node-ui/build/index.html
@@ -36,7 +36,7 @@
       })(window.location);
     </script>
     <!-- End Single Page Apps for GitHub Pages -->
-    <script type="module" crossorigin src="/admin-dashboard/assets/main-CEAaf8Ev.js"></script>
+    <script type="module" crossorigin src="/admin-dashboard/assets/main-Bzv535nm.js"></script>
     <link rel="stylesheet" crossorigin href="/admin-dashboard/assets/main-BesWMiQO.css">
   </head>
   <body>

--- a/node-ui/src/api/httpClient.ts
+++ b/node-ui/src/api/httpClient.ts
@@ -42,7 +42,7 @@ export class AxiosHttpClient implements HttpClient {
       (response: AxiosResponse) => response,
       (error: AxiosError) => {
         if (error.response?.status === 401) {
-          window.location.href = "/admin-dashboard/";
+          window.location.href = '/admin-dashboard/';
         }
         if (!error.response) {
           this.showServerDownPopup();

--- a/node-ui/src/api/httpClient.ts
+++ b/node-ui/src/api/httpClient.ts
@@ -41,6 +41,9 @@ export class AxiosHttpClient implements HttpClient {
     this.axios.interceptors.response.use(
       (response: AxiosResponse) => response,
       (error: AxiosError) => {
+        if (error.response?.status === 401) {
+          window.location.href = "/admin-dashboard/";
+        }
         if (!error.response) {
           this.showServerDownPopup();
         }

--- a/node-ui/src/pages/setup/index.tsx
+++ b/node-ui/src/pages/setup/index.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { setAppEndpointKey } from '../../utils/storage';
+import { clearStorage, setAppEndpointKey } from '../../utils/storage';
 import ContentWrapper from '../../components/login/ContentWrapper';
 import { SetupModal } from '../../components/setup/SetupModal';
 import { getNodeUrl } from '../../utils/node';
 
 export default function SetupPage() {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    clearStorage();
+  }, []);
 
   return (
     <ContentWrapper>

--- a/node-ui/src/utils/storage.ts
+++ b/node-ui/src/utils/storage.ts
@@ -12,6 +12,13 @@ export interface ClientKey {
   publicKey: string;
 }
 
+
+export const clearStorage = () => {
+  localStorage.removeItem(APP_URL);
+  localStorage.removeItem(AUTHORIZED);
+  localStorage.removeItem(CLIENT_KEY);
+}
+
 export const getAppEndpointKey = (): string | null => {
   try {
     if (typeof window !== 'undefined' && window.localStorage) {

--- a/node-ui/src/utils/storage.ts
+++ b/node-ui/src/utils/storage.ts
@@ -12,12 +12,11 @@ export interface ClientKey {
   publicKey: string;
 }
 
-
 export const clearStorage = () => {
   localStorage.removeItem(APP_URL);
   localStorage.removeItem(AUTHORIZED);
   localStorage.removeItem(CLIENT_KEY);
-}
+};
 
 export const getAppEndpointKey = (): string | null => {
   try {


### PR DESCRIPTION
# fix(node-ui): expired client key

## Summary
Axios interceptor for all calls that checks if user is authorized (if no returns 401). If status is 401 it redirects user to setup page to setup again node url + login.

This can be recreated by init + setup node + run admin dashboard login. Then delete node data and recreate the steps.

The page will have in local storage items that tell the page thats its authorized but requests are not authorized as storage client key does not match the server one.

## Test plan

https://github.com/user-attachments/assets/f3a2aac6-6df3-4db2-8630-1729fadca1d8

