### PR TITLE
fix: expose execute in json rpc

### DIFF
--- a/packages/calimero-sdk/package.json
+++ b/packages/calimero-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-is-near/calimero-p2p-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Javascript library to interact with Calimero P2P node",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/calimero-sdk/src/types/rpc.ts
+++ b/packages/calimero-sdk/src/types/rpc.ts
@@ -11,6 +11,10 @@ export interface RpcClient {
     params: RpcMutateParams<Args>,
     config?: RequestConfig,
   ): Promise<RpcResult<RpcMutateResponse<Out>>>;
+  execute<Args, Out>(
+    params: RpcQueryParams<Args>,
+    config?: RequestConfig,
+  ): Promise<RpcResult<RpcQueryResponse<Out>>>;
 }
 
 interface Headers {


### PR DESCRIPTION
Expose `execute` method in new version.