### PR TITLE
fix:  join context with proxy

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -354,7 +354,10 @@ impl ContextManager {
 
         let context_exists = handle.has(&ContextMetaKey::new(context_id))?;
         let mut config = if !context_exists {
-            let proxy_contract = self.get_proxy_contract(context_id).await?;
+            let proxy_contract = self
+                .get_proxy_contract(context_id)
+                .await
+                .unwrap_or_else(|_| "".to_owned());
             Some(ContextConfigParams {
                 protocol: protocol.into(),
                 network_id: network_id.into(),

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1083,9 +1083,13 @@ impl ContextManager {
             .mutate::<ContextProxy>(
                 context_config.protocol.as_ref().into(),
                 context_config.network.as_ref().into(),
-                context_config.contract.as_ref().into(),
+                context_config.proxy_contract.as_ref().into(),
             )
-            .propose(proposal_id, signer_id.rt().unwrap(), actions)
+            .propose(
+                proposal_id,
+                signer_id.rt().expect("infallible conversion"),
+                actions,
+            )
             .send(signing_key)
             .await?;
 
@@ -1116,9 +1120,9 @@ impl ContextManager {
             .mutate::<ContextProxy>(
                 context_config.protocol.as_ref().into(),
                 context_config.network.as_ref().into(),
-                context_config.contract.as_ref().into(),
+                context_config.proxy_contract.as_ref().into(),
             )
-            .approve(signer_id.rt().unwrap(), proposal_id)
+            .approve(signer_id.rt().expect("infallible conversion"), proposal_id)
             .send(signing_key)
             .await?;
 


### PR DESCRIPTION
Joining context throws

```
 ERROR calimero_node: Failed handling user command: 
   0: transport error: relayer response (500 Internal Server Error): left error: error while querying contract: handler error: [Function call returned an error: wasm execution failed with error: MethodResolveError(MethodNotFound)]

```