### PR TITLE
Context and Proxy Contracts Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,6 @@ dependencies = [
  "calimero-context-config",
  "ed25519-dalek 2.1.1",
  "eyre",
- "hex 0.4.3",
  "near-crypto 0.26.0",
  "near-sdk",
  "near-workspaces",

--- a/contracts/context-config/Cargo.toml
+++ b/contracts/context-config/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 near-sdk = { workspace = true, features = ["unstable"] }
-hex.workspace = true
 calimero-context-config = { path = "../../crates/context/config" }
 
 [dev-dependencies]

--- a/contracts/context-config/src/mutate.rs
+++ b/contracts/context-config/src/mutate.rs
@@ -347,7 +347,9 @@ impl ContextConfigs {
                 NearToken::from_near(0),
                 init_gas,
             )
-            .then(Self::ext(env::current_account_id()).proxy_contract_callback("deploy".to_owned()))
+            .then(Self::ext(env::current_account_id()).proxy_contract_callback(
+                "deploy".to_owned(),
+            ))
     }
 
     fn update_proxy_contract(

--- a/contracts/context-config/src/mutate.rs
+++ b/contracts/context-config/src/mutate.rs
@@ -347,9 +347,7 @@ impl ContextConfigs {
                 NearToken::from_near(0),
                 init_gas,
             )
-            .then(Self::ext(env::current_account_id()).proxy_contract_callback(
-                "deploy".to_owned(),
-            ))
+            .then(Self::ext(env::current_account_id()).proxy_contract_callback("deploy".to_owned()))
     }
 
     fn update_proxy_contract(

--- a/contracts/context-config/src/mutate.rs
+++ b/contracts/context-config/src/mutate.rs
@@ -428,7 +428,8 @@ impl ContextConfigs {
         #[callback_result] call_result: Result<(), PromiseError>,
     ) -> Result<(), &'static str> {
         if let Err(e) = call_result {
-            panic!("Failed to update proxy contract: {:?}", e);
+            env::log_str(&format!("Failed to update proxy contract: {:?}", e));
+            return Err("Failed to update proxy contract");
         }
 
         Ok(())

--- a/contracts/context-config/src/query.rs
+++ b/contracts/context-config/src/query.rs
@@ -28,13 +28,13 @@ impl ContextConfigs {
         context.application.revision()
     }
 
-    pub fn proxy_contract(&self, context_id: Repr<ContextId>) -> AccountId {
+    pub fn proxy_contract(&self, context_id: Repr<ContextId>) -> &AccountId {
         let context = self
             .contexts
             .get(&context_id)
             .expect("context does not exist");
 
-        context.proxy.clone()
+        &context.proxy
     }
 
     pub fn members(

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -4,8 +4,8 @@ use std::io;
 use calimero_context_config::repr::Repr;
 use calimero_context_config::types::{Application, ContextId, ContextIdentity, SignerId};
 use calimero_context_config::{SystemRequest, Timestamp};
-use near_sdk::store::{IterableMap, IterableSet};
-use near_sdk::{env, near};
+use near_sdk::store::{IterableMap, IterableSet, LazyOption};
+use near_sdk::{env, near, AccountId};
 
 use crate::{parse_input, Config, ContextConfigs, ContextConfigsExt};
 
@@ -36,7 +36,11 @@ impl ContextConfigs {
         for (_, context) in self.contexts.drain() {
             drop(context.application.into_inner());
             context.members.into_inner().clear();
+            // let mut proxy = context.proxy.into_inner();
+            // proxy = AccountId::try_from("".to_string()).unwrap();
         }
+
+        self.proxy_code = LazyOption::new(b"p", None);
 
         env::log_str(&format!(
             "Post-erase storage usage: {}",

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -4,7 +4,7 @@ use std::io;
 use calimero_context_config::repr::Repr;
 use calimero_context_config::types::{Application, ContextId, ContextIdentity, SignerId};
 use calimero_context_config::{SystemRequest, Timestamp};
-use near_sdk::store::{IterableMap, IterableSet, LazyOption};
+use near_sdk::store::{IterableMap, IterableSet};
 use near_sdk::{env, near};
 
 use crate::{parse_input, Config, ContextConfigs, ContextConfigsExt};
@@ -39,7 +39,7 @@ impl ContextConfigs {
             let _ignored = context.proxy.into_inner();
         }
 
-        self.proxy_code = LazyOption::new(b"p", None);
+        self.proxy_code.set(None);
 
         env::log_str(&format!(
             "Post-erase storage usage: {}",

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -34,10 +34,9 @@ impl ContextConfigs {
         env::log_str("Erasing contract");
 
         for (_, context) in self.contexts.drain() {
-            drop(context.application.into_inner());
+            let _ignored = context.application.into_inner();
             context.members.into_inner().clear();
-            // let mut proxy = context.proxy.into_inner();
-            // proxy = AccountId::try_from("".to_string()).unwrap();
+            let _ignored = context.proxy.into_inner();
         }
 
         self.proxy_code = LazyOption::new(b"p", None);
@@ -91,7 +90,7 @@ impl ContextConfigs {
     #[private]
     pub fn set_proxy_code(&mut self) {
         self.proxy_code
-            .set(Some(env::input().expect("Expected proxy code").to_vec()));
+            .set(Some(env::input().expect("Expected proxy code")));
     }
 }
 

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -89,11 +89,6 @@ impl ContextConfigs {
     }
 
     #[private]
-    pub fn update_proxy_callback(&mut self) {
-        env::log_str("Successfully updated proxy contract");
-    }
-
-    #[private]
     pub fn set_proxy_code(&mut self) {
         self.proxy_code
             .set(Some(env::input().expect("Expected proxy code").to_vec()));

--- a/contracts/context-config/src/sys.rs
+++ b/contracts/context-config/src/sys.rs
@@ -5,7 +5,7 @@ use calimero_context_config::repr::Repr;
 use calimero_context_config::types::{Application, ContextId, ContextIdentity, SignerId};
 use calimero_context_config::{SystemRequest, Timestamp};
 use near_sdk::store::{IterableMap, IterableSet, LazyOption};
-use near_sdk::{env, near, AccountId};
+use near_sdk::{env, near};
 
 use crate::{parse_input, Config, ContextConfigs, ContextConfigsExt};
 

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -17,1088 +17,1089 @@ use rand::Rng;
 use serde_json::json;
 use tokio::{fs, time};
 
-// #[tokio::test]
-// async fn main() -> eyre::Result<()> {
-//     let worker = near_workspaces::sandbox().await?;
-//     let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
-
-//     let mut rng = rand::thread_rng();
-
-//     let contract = worker.dev_deploy(&wasm).await?;
-
-//     let root_account = worker.root_account()?;
-
-//     let node1 = root_account
-//         .create_subaccount("node1")
-//         .initial_balance(NearToken::from_near(30))
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     let node2 = root_account
-//         .create_subaccount("node2")
-//         .initial_balance(NearToken::from_near(30))
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
-//     let alice_cx_pk = alice_cx_sk.verifying_key();
-//     let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
-
-//     let bob_cx_sk = SigningKey::from_bytes(&rng.gen());
-//     let bob_cx_pk = bob_cx_sk.verifying_key();
-//     let bob_cx_id = bob_cx_pk.to_bytes().rt()?;
-
-//     let carol_cx_sk = SigningKey::from_bytes(&rng.gen());
-//     let carol_cx_pk = carol_cx_sk.verifying_key();
-//     let carol_cx_id = carol_cx_pk.to_bytes().rt()?;
-
-//     let context_secret = SigningKey::from_bytes(&rng.gen());
-//     let context_public = context_secret.verifying_key();
-//     let context_id = context_public.to_bytes().rt()?;
-
-//     let application_id = rng.gen::<[_; 32]>().rt()?;
-//     let blob_id = rng.gen::<[_; 32]>().rt()?;
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::Add {
-//                         author_id: alice_cx_id,
-//                         application: Application::new(
-//                             application_id,
-//                             blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(alice_cx_id.rt()?, kind)
-//             },
-//             |p| alice_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .raw_bytes()
-//         .expect_err("context creation should fail");
-
-//     {
-//         let err = res.to_string();
-//         assert!(
-//             err.contains("context addition must be signed by the context itself"),
-//             "{}",
-//             err
-//         );
-//     }
-
-//     let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
-//     let _test = contract
-//         .call("set_proxy_code")
-//         .args(new_proxy_wasm)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::Add {
-//                         author_id: alice_cx_id,
-//                         application: Application::new(
-//                             application_id,
-//                             blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(context_id.rt()?, kind)
-//             },
-//             |p| context_secret.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     // Assert context creation
-//     let expected_log = format!("Context `{}` added", context_id);
-//     assert!(res.logs().iter().any(|log| log == &expected_log));
-
-//     let res = node2
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::Add {
-//                         author_id: alice_cx_id,
-//                         application: Application::new(
-//                             application_id,
-//                             blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(context_id.rt()?, kind)
-//             },
-//             |p| context_secret.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .raw_bytes()
-//         .expect_err("context should already exist");
-
-//     {
-//         let err = res.to_string();
-//         assert!(err.contains("context already exists"), "{}", err);
-//     }
-
-//     let res = contract
-//         .view("application")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res.id, application_id);
-//     assert_eq!(res.blob, blob_id);
-//     assert_eq!(res.source, Default::default());
-//     assert_eq!(res.metadata, Default::default());
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-//         .view("privileges")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "identities": [],
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res.len(), 1);
-
-//     let alice_capabilities = res
-//         .get(&alice_cx_id.rt()?)
-//         .expect("alice should have capabilities");
-
-//     assert_eq!(
-//         alice_capabilities,
-//         &[Capability::ManageApplication, Capability::ManageMembers]
-//     );
-
-//     let res: Vec<Repr<ContextIdentity>> = contract
-//         .view("members")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "offset": 0,
-//             "length": 10,
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res, [alice_cx_id]);
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::AddMembers {
-//                         members: vec![bob_cx_id].into(),
-//                     },
-//                 ));
-
-//                 Request::new(alice_cx_id.rt()?, kind)
-//             },
-//             |p| alice_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(
-//         res.logs(),
-//         [format!(
-//             "Added `{}` as a member of `{}`",
-//             bob_cx_id, context_id
-//         ),]
-//     );
-
-//     let res: Vec<Repr<ContextIdentity>> = contract
-//         .view("members")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "offset": 0,
-//             "length": 10,
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res, [alice_cx_id, bob_cx_id]);
-
-//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-//         .view("privileges")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "identities": [bob_cx_id],
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res.len(), 1);
-
-//     let bob_capabilities = res
-//         .get(&bob_cx_id.rt()?)
-//         .expect("bob should have capabilities");
-
-//     assert_eq!(bob_capabilities, &[]);
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 1);
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::AddMembers {
-//                         members: vec![carol_cx_id].into(),
-//                     },
-//                 ));
-
-//                 Request::new(bob_cx_id.rt()?, kind)
-//             },
-//             |p| bob_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .raw_bytes()
-//         .expect_err("bob lacks permissions");
-
-//     {
-//         let err = res.to_string();
-//         assert!(
-//             err.contains("unable to update member list: unauthorized access"),
-//             "{}",
-//             err
-//         );
-//     }
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 1);
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::Grant {
-//                         capabilities: (vec![(bob_cx_id, Capability::ManageMembers)]).into(),
-//                     },
-//                 ));
-
-//                 Request::new(alice_cx_id.rt()?, kind)
-//             },
-//             |p| alice_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(
-//         res.logs(),
-//         [format!(
-//             "Granted `ManageMembers` to `{}` in `{}`",
-//             bob_cx_id, context_id
-//         )]
-//     );
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 1);
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::AddMembers {
-//                         members: vec![carol_cx_id].into(),
-//                     },
-//                 ));
-
-//                 Request::new(bob_cx_id.rt()?, kind)
-//             },
-//             |p| bob_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(
-//         res.logs(),
-//         [format!(
-//             "Added `{}` as a member of `{}`",
-//             carol_cx_id, context_id
-//         ),]
-//     );
-
-//     let res: Vec<Repr<ContextIdentity>> = contract
-//         .view("members")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "offset": 0,
-//             "length": 10,
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res, [alice_cx_id, bob_cx_id, carol_cx_id]);
-
-//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-//         .view("privileges")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "identities": [],
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res.len(), 2);
-
-//     let alice_capabilities = res
-//         .get(&alice_cx_id.rt()?)
-//         .expect("alice should have capabilities");
-
-//     let bob_capabilities = res
-//         .get(&bob_cx_id.rt()?)
-//         .expect("bob should have capabilities");
-
-//     assert_eq!(res.get(&carol_cx_id.rt()?), None);
-
-//     assert_eq!(
-//         alice_capabilities,
-//         &[Capability::ManageApplication, Capability::ManageMembers]
-//     );
-
-//     assert_eq!(bob_capabilities, &[Capability::ManageMembers]);
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 2);
-
-//     let new_application_id = rng.gen::<[_; 32]>().rt()?;
-//     let new_blob_id = rng.gen::<[_; 32]>().rt()?;
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::UpdateApplication {
-//                         application: Application::new(
-//                             new_application_id,
-//                             new_blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(bob_cx_id.rt()?, kind)
-//             },
-//             |p| bob_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .raw_bytes()
-//         .expect_err("bob lacks permissions");
-
-//     {
-//         let err = res.to_string();
-//         assert!(
-//             err.contains("unable to update application: unauthorized access"),
-//             "{}",
-//             err
-//         );
-//     }
-
-//     let res = contract
-//         .view("application")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res.id, application_id);
-//     assert_eq!(res.blob, blob_id);
-//     assert_eq!(res.source, Default::default());
-//     assert_eq!(res.metadata, Default::default());
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 0);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 2);
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::UpdateApplication {
-//                         application: Application::new(
-//                             new_application_id,
-//                             new_blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(alice_cx_id.rt()?, kind)
-//             },
-//             |p| alice_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(
-//         res.logs(),
-//         [format!(
-//             "Updated application for context `{}` from `{}` to `{}`",
-//             context_id, application_id, new_application_id
-//         )]
-//     );
-
-//     let res = contract
-//         .view("application")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res.id, new_application_id);
-//     assert_eq!(res.blob, new_blob_id);
-//     assert_eq!(res.source, Default::default());
-//     assert_eq!(res.metadata, Default::default());
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 1);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 2);
-
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::RemoveMembers {
-//                         members: vec![bob_cx_id].into(),
-//                     },
-//                 ));
-
-//                 Request::new(alice_cx_id.rt()?, kind)
-//             },
-//             |p| alice_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(
-//         res.logs(),
-//         [format!(
-//             "Removed `{}` from being a member of `{}`",
-//             bob_cx_id, context_id
-//         )]
-//     );
-
-//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-//         .view("privileges")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "identities": [],
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res.len(), 1);
-
-//     let alice_capabilities = res
-//         .get(&alice_cx_id.rt()?)
-//         .expect("alice should have capabilities");
-//     assert_eq!(res.get(&bob_cx_id.rt()?), None);
-//     assert_eq!(res.get(&carol_cx_id.rt()?), None);
-
-//     assert_eq!(
-//         alice_capabilities,
-//         &[Capability::ManageApplication, Capability::ManageMembers]
-//     );
-
-//     let res: Vec<Repr<ContextIdentity>> = contract
-//         .view("members")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "offset": 0,
-//             "length": 10,
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res, [alice_cx_id, carol_cx_id]);
-
-//     let res = contract
-//         .view("application_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 1);
-
-//     let res = contract
-//         .view("members_revision")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Revision = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res, 3);
-
-//     let res = contract
-//         .call("set")
-//         .args_json(SystemRequest::SetValidityThreshold {
-//             threshold_ms: 5_000,
-//         })
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(res.logs(), ["Set validity threshold to `5s`"]);
-
-//     let req = node1.call(contract.id(), "mutate").args_json(Signed::new(
-//         &{
-//             let kind = RequestKind::Context(ContextRequest::new(
-//                 context_id,
-//                 ContextRequestKind::RemoveMembers {
-//                     members: vec![carol_cx_id].into(),
-//                 },
-//             ));
-
-//             Request::new(alice_cx_id.rt()?, kind)
-//         },
-//         |p| alice_cx_sk.sign(p),
-//     )?);
-
-//     time::sleep(time::Duration::from_secs(5)).await;
-
-//     let res = req
-//         .transact()
-//         .await?
-//         .raw_bytes()
-//         .expect_err("request should've expired");
-
-//     {
-//         let err = res.to_string();
-//         assert!(err.contains("request expired"), "{}", err);
-//     }
-
-//     let res: Vec<Repr<ContextIdentity>> = contract
-//         .view("members")
-//         .args_json(json!({
-//             "context_id": context_id,
-//             "offset": 0,
-//             "length": 10,
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(res, [alice_cx_id, carol_cx_id]);
-
-//     // let state = contract.view_state().await?;
-//     // println!("State size: {}", state.len());
-//     // assert_eq!(state.len(), 11);
-
-//     let res = contract
-//         .call("erase")
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert!(res.logs().contains(&"Erasing contract"), "{:?}", res.logs());
-
-//     // let state = contract.view_state().await?;
-
-//     // assert_eq!(state.len(), 1);
-//     // assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
-
-//     // // After contract deployment
-//     // let state_size = worker
-//     //     .view(contract.id(), "get_state_size")  // We'd need to add this method to the contract
-//     //     .await?
-//     //     .json::<u64>()?;
-//     // println!("Initial state size: {}", state_size);
-
-//     Ok(())
-// }
-
-// #[ignore]
-// #[tokio::test]
-// async fn migration() -> eyre::Result<()> {
-//     let worker = near_workspaces::sandbox().await?;
-
-//     let wasm_v0 = fs::read("res/calimero_context_config_near_v0.wasm").await?;
-//     let wasm_v1 = fs::read("res/calimero_context_config_near_v1.wasm").await?;
-
-//     let mut rng = rand::thread_rng();
-
-//     let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
-
-//     let root_account = worker.root_account()?;
-
-//     let node1 = root_account
-//         .create_subaccount("node1")
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
-//     let alice_cx_pk = alice_cx_sk.verifying_key();
-//     let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
-
-//     let context_secret = SigningKey::from_bytes(&rng.gen());
-//     let context_public = context_secret.verifying_key();
-//     let context_id = context_public.to_bytes().rt()?;
-
-//     let application_id = rng.gen::<[_; 32]>().rt()?;
-//     let blob_id = rng.gen::<[_; 32]>().rt()?;
-
-//     let res = node1
-//         .call(contract_v0.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::Add {
-//                         author_id: alice_cx_id,
-//                         application: Application::new(
-//                             application_id,
-//                             blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(context_id.rt()?, kind)
-//             },
-//             |p| context_secret.sign(p),
-//         )?)
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     assert_eq!(res.logs(), [format!("Context `{}` added", context_id)]);
-
-//     let res = contract_v0
-//         .view("application")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res.id, application_id);
-//     assert_eq!(res.blob, blob_id);
-//     assert_eq!(res.source, Default::default());
-//     assert_eq!(res.metadata, Default::default());
-
-//     let contract_v1 = contract_v0
-//         .as_account()
-//         .deploy(&wasm_v1)
-//         .await?
-//         .into_result()?;
-
-//     let res = contract_v1
-//         .view("application")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await
-//         .expect_err("should've failed");
-
-//     {
-//         let err = format!("{:?}", res);
-//         assert!(err.contains("Cannot deserialize element"), "{}", err);
-//     }
-
-//     let migration = contract_v1
-//         .call("migrate")
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     dbg!(migration.logs());
-
-//     let res = contract_v1
-//         .view("application")
-//         .args_json(json!({ "context_id": context_id }))
-//         .await?;
-
-//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-//     assert_eq!(res.id, application_id);
-//     assert_eq!(res.blob, blob_id);
-//     assert_eq!(res.source, Default::default());
-//     assert_eq!(res.metadata, Default::default());
-
-//     Ok(())
-// }
-
-// #[tokio::test]
-// async fn test_deploy() -> eyre::Result<()> {
-//     let worker = near_workspaces::sandbox().await?;
-//     let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
-//     let mut rng = rand::thread_rng();
-
-//     let contract = worker.dev_deploy(&wasm).await?;
-//     let root_account = worker.root_account()?;
-//     let node1 = root_account
-//         .create_subaccount("node1")
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
-//     let alice_cx_pk = alice_cx_sk.verifying_key();
-//     let alice_cx_id: ContextIdentity = alice_cx_pk.to_bytes().rt()?;
-
-//     let context_secret = SigningKey::from_bytes(&rng.gen());
-//     let context_public = context_secret.verifying_key();
-//     let context_id = context_public.to_bytes().rt()?;
-
-//     // Fund node1 just for gas fees
-//     let _unused = root_account
-//         .transfer_near(node1.id(), NearToken::from_near(50))
-//         .await?
-//         .into_result();
-
-//     // Set proxy code
-//     let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
-//     let _test = contract
-//         .call("set_proxy_code")
-//         .args(new_proxy_wasm)
-//         .max_gas()
-//         .transact()
-//         .await?
-//         .into_result()?;
-
-//     let application_id = rng.gen::<[_; 32]>().rt()?;
-//     let blob_id = rng.gen::<[_; 32]>().rt()?;
-
-//     // Call mutate without deposit since contract uses its own balance
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::Add {
-//                         author_id: Repr::new(alice_cx_id),
-//                         application: Application::new(
-//                             application_id,
-//                             blob_id,
-//                             0,
-//                             Default::default(),
-//                             Default::default(),
-//                         ),
-//                     },
-//                 ));
-
-//                 Request::new(context_id.rt()?, kind)
-//             },
-//             |p| context_secret.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?;
-
-//     // println!("Execution result: {:#?}", res);
-//     // println!("Logs: {:#?}", res.logs());  // Print the logs
-
-//     // Assert context creation
-//     let expected_log = format!("Context `{}` added", context_id);
-//     assert!(res.logs().iter().any(|log| log == &expected_log));
-
-//     // Verify the proxy contract was deployed
-//     let proxy_address: AccountId = contract
-//         .view("proxy_contract")
-//         .args_json(json!({
-//             "context_id": context_id
-//         }))
-//         .await?
-//         .json()?;
-
-//     // Assert the proxy address is a subaccount of the contract
-//     assert!(
-//         proxy_address.to_string() == format!("0.{}", contract.id()),
-//         "Proxy address '{}' should be exactly '0.{}'",
-//         proxy_address,
-//         contract.id()
-//     );
-
-//     //Uncomment to print the proxy contract address
-//     // println!("Proxy contract address: {}", proxy_address);
-
-//     // Call the update function
-//     let res = node1
-//         .call(contract.id(), "mutate")
-//         .args_json(Signed::new(
-//             &{
-//                 let kind = RequestKind::Context(ContextRequest::new(
-//                     context_id,
-//                     ContextRequestKind::UpdateProxyContract,
-//                 ));
-
-//                 Request::new(alice_cx_id.rt()?, kind)
-//             },
-//             |p| alice_cx_sk.sign(p),
-//         )?)
-//         .max_gas()
-//         .transact()
-//         .await?;
-
-//     // println!("Update result: {:?}", res);
-//     // Check the result
-//     assert!(res.is_success(), "Transaction failed: {:?}", res);
-
-//     // Verify we got our success message
-//     let result = res.into_result()?;
-//     assert!(
-//         result
-//             .logs()
-//             .iter()
-//             .any(|log| log.contains("Successfully updated proxy contract")),
-//         "Expected success message in logs"
-//     );
-
-//     // Create proposal
-//     let proposal_id = rand::thread_rng().gen();
-//     let actions = vec![ProposalAction::ExternalFunctionCall {
-//         receiver_id: contract.id().to_string(),
-//         method_name: "increment".to_string(),
-//         args: "[]".to_string(),
-//         deposit: 0,
-//         gas: 1_000_000_000_000,
-//     }];
-
-//     let request = ProxyMutateRequest::Propose {
-//         proposal: Proposal {
-//             id: proposal_id,
-//             author_id: alice_cx_id.rt()?,
-//             actions: actions.clone(),
-//         },
-//     };
-//     let signed = Signed::new(&request, |p| alice_cx_sk.sign(p))?;
-
-//     let res = node1
-//         .call(&proxy_address, "mutate")
-//         .args_json(signed)
-//         .max_gas()
-//         .transact()
-//         .await?;
-
-//     // Assert proposal creation result
-//     let proposal_result = res.json::<ProposalWithApprovals>()?;
-//     assert_eq!(proposal_result.num_approvals, 1);
-//     let created_proposal_id = proposal_result.proposal_id;
-//     // Verify proposals list
-//     let proposals: Vec<Proposal> = worker
-//         .view(&proxy_address, "proposals")
-//         .args_json(json!({
-//             "offset": 0,
-//             "length": 10
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert_eq!(proposals.len(), 1, "Should have exactly one proposal");
-//     let created_proposal = &proposals[0];
-//     assert_eq!(created_proposal.id, created_proposal_id);
-//     assert_eq!(created_proposal.author_id, alice_cx_id.rt()?);
-//     assert_eq!(created_proposal.actions.len(), 1);
-
-//     if let ProposalAction::ExternalFunctionCall {
-//         receiver_id,
-//         method_name,
-//         args,
-//         deposit,
-//         gas,
-//     } = &created_proposal.actions[0]
-//     {
-//         assert_eq!(receiver_id, contract.id());
-//         assert_eq!(method_name, "increment");
-//         assert_eq!(args, "[]");
-//         assert_eq!(*deposit, 0);
-//         assert_eq!(*gas, 1_000_000_000_000);
-//     } else {
-//         panic!("Expected ExternalFunctionCall action");
-//     }
-
-//     // Verify single proposal query
-//     let single_proposal: Option<Proposal> = worker
-//         .view(&proxy_address, "proposal")
-//         .args_json(json!({
-//             "proposal_id": proposal_id
-//         }))
-//         .await?
-//         .json()?;
-
-//     assert!(
-//         single_proposal.is_some(),
-//         "Should be able to get single proposal"
-//     );
-//     assert_eq!(single_proposal.unwrap().id, created_proposal_id);
-
-//     Ok(())
-// }
-
+#[tokio::test]
+async fn main() -> eyre::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+    let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
+
+    let mut rng = rand::thread_rng();
+
+    let contract = worker.dev_deploy(&wasm).await?;
+
+    let root_account = worker.root_account()?;
+
+    let node1 = root_account
+        .create_subaccount("node1")
+        .initial_balance(NearToken::from_near(30))
+        .transact()
+        .await?
+        .into_result()?;
+
+    let node2 = root_account
+        .create_subaccount("node2")
+        .initial_balance(NearToken::from_near(30))
+        .transact()
+        .await?
+        .into_result()?;
+
+    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let alice_cx_pk = alice_cx_sk.verifying_key();
+    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+    let bob_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let bob_cx_pk = bob_cx_sk.verifying_key();
+    let bob_cx_id = bob_cx_pk.to_bytes().rt()?;
+
+    let carol_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let carol_cx_pk = carol_cx_sk.verifying_key();
+    let carol_cx_id = carol_cx_pk.to_bytes().rt()?;
+
+    let context_secret = SigningKey::from_bytes(&rng.gen());
+    let context_public = context_secret.verifying_key();
+    let context_id = context_public.to_bytes().rt()?;
+
+    let application_id = rng.gen::<[_; 32]>().rt()?;
+    let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .raw_bytes()
+        .expect_err("context creation should fail");
+
+    {
+        let err = res.to_string();
+        assert!(
+            err.contains("context addition must be signed by the context itself"),
+            "{}",
+            err
+        );
+    }
+
+    let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
+    let _test = contract
+        .call("set_proxy_code")
+        .args(new_proxy_wasm)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(context_id.rt()?, kind)
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    // Assert context creation
+    let expected_log = format!("Context `{}` added", context_id);
+    assert!(res.logs().iter().any(|log| log == &expected_log));
+
+    let res = node2
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(context_id.rt()?, kind)
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .raw_bytes()
+        .expect_err("context should already exist");
+
+    {
+        let err = res.to_string();
+        assert!(err.contains("context already exists"), "{}", err);
+    }
+
+    let res = contract
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+        .view("privileges")
+        .args_json(json!({
+            "context_id": context_id,
+            "identities": [],
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res.len(), 1);
+
+    let alice_capabilities = res
+        .get(&alice_cx_id.rt()?)
+        .expect("alice should have capabilities");
+
+    assert_eq!(
+        alice_capabilities,
+        &[Capability::ManageApplication, Capability::ManageMembers]
+    );
+
+    let res: Vec<Repr<ContextIdentity>> = contract
+        .view("members")
+        .args_json(json!({
+            "context_id": context_id,
+            "offset": 0,
+            "length": 10,
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res, [alice_cx_id]);
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::AddMembers {
+                        members: vec![bob_cx_id].into(),
+                    },
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(
+        res.logs(),
+        [format!(
+            "Added `{}` as a member of `{}`",
+            bob_cx_id, context_id
+        ),]
+    );
+
+    let res: Vec<Repr<ContextIdentity>> = contract
+        .view("members")
+        .args_json(json!({
+            "context_id": context_id,
+            "offset": 0,
+            "length": 10,
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res, [alice_cx_id, bob_cx_id]);
+
+    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+        .view("privileges")
+        .args_json(json!({
+            "context_id": context_id,
+            "identities": [bob_cx_id],
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res.len(), 1);
+
+    let bob_capabilities = res
+        .get(&bob_cx_id.rt()?)
+        .expect("bob should have capabilities");
+
+    assert_eq!(bob_capabilities, &[]);
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::AddMembers {
+                        members: vec![carol_cx_id].into(),
+                    },
+                ));
+
+                Request::new(bob_cx_id.rt()?, kind)
+            },
+            |p| bob_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .raw_bytes()
+        .expect_err("bob lacks permissions");
+
+    {
+        let err = res.to_string();
+        assert!(
+            err.contains("unable to update member list: unauthorized access"),
+            "{}",
+            err
+        );
+    }
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Grant {
+                        capabilities: (vec![(bob_cx_id, Capability::ManageMembers)]).into(),
+                    },
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(
+        res.logs(),
+        [format!(
+            "Granted `ManageMembers` to `{}` in `{}`",
+            bob_cx_id, context_id
+        )]
+    );
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::AddMembers {
+                        members: vec![carol_cx_id].into(),
+                    },
+                ));
+
+                Request::new(bob_cx_id.rt()?, kind)
+            },
+            |p| bob_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(
+        res.logs(),
+        [format!(
+            "Added `{}` as a member of `{}`",
+            carol_cx_id, context_id
+        ),]
+    );
+
+    let res: Vec<Repr<ContextIdentity>> = contract
+        .view("members")
+        .args_json(json!({
+            "context_id": context_id,
+            "offset": 0,
+            "length": 10,
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res, [alice_cx_id, bob_cx_id, carol_cx_id]);
+
+    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+        .view("privileges")
+        .args_json(json!({
+            "context_id": context_id,
+            "identities": [],
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res.len(), 2);
+
+    let alice_capabilities = res
+        .get(&alice_cx_id.rt()?)
+        .expect("alice should have capabilities");
+
+    let bob_capabilities = res
+        .get(&bob_cx_id.rt()?)
+        .expect("bob should have capabilities");
+
+    assert_eq!(res.get(&carol_cx_id.rt()?), None);
+
+    assert_eq!(
+        alice_capabilities,
+        &[Capability::ManageApplication, Capability::ManageMembers]
+    );
+
+    assert_eq!(bob_capabilities, &[Capability::ManageMembers]);
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 2);
+
+    let new_application_id = rng.gen::<[_; 32]>().rt()?;
+    let new_blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::UpdateApplication {
+                        application: Application::new(
+                            new_application_id,
+                            new_blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(bob_cx_id.rt()?, kind)
+            },
+            |p| bob_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .raw_bytes()
+        .expect_err("bob lacks permissions");
+
+    {
+        let err = res.to_string();
+        assert!(
+            err.contains("unable to update application: unauthorized access"),
+            "{}",
+            err
+        );
+    }
+
+    let res = contract
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 0);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 2);
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::UpdateApplication {
+                        application: Application::new(
+                            new_application_id,
+                            new_blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(
+        res.logs(),
+        [format!(
+            "Updated application for context `{}` from `{}` to `{}`",
+            context_id, application_id, new_application_id
+        )]
+    );
+
+    let res = contract
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, new_application_id);
+    assert_eq!(res.blob, new_blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 2);
+
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::RemoveMembers {
+                        members: vec![bob_cx_id].into(),
+                    },
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(
+        res.logs(),
+        [format!(
+            "Removed `{}` from being a member of `{}`",
+            bob_cx_id, context_id
+        )]
+    );
+
+    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+        .view("privileges")
+        .args_json(json!({
+            "context_id": context_id,
+            "identities": [],
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res.len(), 1);
+
+    let alice_capabilities = res
+        .get(&alice_cx_id.rt()?)
+        .expect("alice should have capabilities");
+    assert_eq!(res.get(&bob_cx_id.rt()?), None);
+    assert_eq!(res.get(&carol_cx_id.rt()?), None);
+
+    assert_eq!(
+        alice_capabilities,
+        &[Capability::ManageApplication, Capability::ManageMembers]
+    );
+
+    let res: Vec<Repr<ContextIdentity>> = contract
+        .view("members")
+        .args_json(json!({
+            "context_id": context_id,
+            "offset": 0,
+            "length": 10,
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res, [alice_cx_id, carol_cx_id]);
+
+    let res = contract
+        .view("application_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 1);
+
+    let res = contract
+        .view("members_revision")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Revision = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res, 3);
+
+    let res = contract
+        .call("set")
+        .args_json(SystemRequest::SetValidityThreshold {
+            threshold_ms: 5_000,
+        })
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(res.logs(), ["Set validity threshold to `5s`"]);
+
+    let req = node1.call(contract.id(), "mutate").args_json(Signed::new(
+        &{
+            let kind = RequestKind::Context(ContextRequest::new(
+                context_id,
+                ContextRequestKind::RemoveMembers {
+                    members: vec![carol_cx_id].into(),
+                },
+            ));
+
+            Request::new(alice_cx_id.rt()?, kind)
+        },
+        |p| alice_cx_sk.sign(p),
+    )?);
+
+    time::sleep(time::Duration::from_secs(5)).await;
+
+    let res = req
+        .transact()
+        .await?
+        .raw_bytes()
+        .expect_err("request should've expired");
+
+    {
+        let err = res.to_string();
+        assert!(err.contains("request expired"), "{}", err);
+    }
+
+    let res: Vec<Repr<ContextIdentity>> = contract
+        .view("members")
+        .args_json(json!({
+            "context_id": context_id,
+            "offset": 0,
+            "length": 10,
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(res, [alice_cx_id, carol_cx_id]);
+
+    // let state = contract.view_state().await?;
+    // println!("State size: {}", state.len());
+    // assert_eq!(state.len(), 11);
+
+    let res = contract
+        .call("erase")
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert!(res.logs().contains(&"Erasing contract"), "{:?}", res.logs());
+
+    // let state = contract.view_state().await?;
+
+    // assert_eq!(state.len(), 1);
+    // assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
+
+    // // After contract deployment
+    // let state_size = worker
+    //     .view(contract.id(), "get_state_size")  // We'd need to add this method to the contract
+    //     .await?
+    //     .json::<u64>()?;
+    // println!("Initial state size: {}", state_size);
+
+    Ok(())
+}
+
+#[ignore]
+#[tokio::test]
+async fn migration() -> eyre::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+
+    let wasm_v0 = fs::read("res/calimero_context_config_near_v0.wasm").await?;
+    let wasm_v1 = fs::read("res/calimero_context_config_near_v1.wasm").await?;
+
+    let mut rng = rand::thread_rng();
+
+    let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
+
+    let root_account = worker.root_account()?;
+
+    let node1 = root_account
+        .create_subaccount("node1")
+        .transact()
+        .await?
+        .into_result()?;
+
+    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let alice_cx_pk = alice_cx_sk.verifying_key();
+    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+    let context_secret = SigningKey::from_bytes(&rng.gen());
+    let context_public = context_secret.verifying_key();
+    let context_id = context_public.to_bytes().rt()?;
+
+    let application_id = rng.gen::<[_; 32]>().rt()?;
+    let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    let res = node1
+        .call(contract_v0.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(context_id.rt()?, kind)
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(res.logs(), [format!("Context `{}` added", context_id)]);
+
+    let res = contract_v0
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let contract_v1 = contract_v0
+        .as_account()
+        .deploy(&wasm_v1)
+        .await?
+        .into_result()?;
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await
+        .expect_err("should've failed");
+
+    {
+        let err = format!("{:?}", res);
+        assert!(err.contains("Cannot deserialize element"), "{}", err);
+    }
+
+    let migration = contract_v1
+        .call("migrate")
+        .transact()
+        .await?
+        .into_result()?;
+
+    dbg!(migration.logs());
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_deploy() -> eyre::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+    let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
+    let mut rng = rand::thread_rng();
+
+    let contract = worker.dev_deploy(&wasm).await?;
+    let root_account = worker.root_account()?;
+    let node1 = root_account
+        .create_subaccount("node1")
+        .transact()
+        .await?
+        .into_result()?;
+
+    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let alice_cx_pk = alice_cx_sk.verifying_key();
+    let alice_cx_id: ContextIdentity = alice_cx_pk.to_bytes().rt()?;
+
+    let context_secret = SigningKey::from_bytes(&rng.gen());
+    let context_public = context_secret.verifying_key();
+    let context_id = context_public.to_bytes().rt()?;
+
+    // Fund node1 just for gas fees
+    let _unused = root_account
+        .transfer_near(node1.id(), NearToken::from_near(50))
+        .await?
+        .into_result();
+
+    // Set proxy code
+    let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
+    let _test = contract
+        .call("set_proxy_code")
+        .args(new_proxy_wasm)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    let application_id = rng.gen::<[_; 32]>().rt()?;
+    let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    // Call mutate without deposit since contract uses its own balance
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: Repr::new(alice_cx_id),
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(context_id.rt()?, kind)
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?;
+
+    // println!("Execution result: {:#?}", res);
+    // println!("Logs: {:#?}", res.logs());  // Print the logs
+
+    // Assert context creation
+    let expected_log = format!("Context `{}` added", context_id);
+    assert!(res.logs().iter().any(|log| log == &expected_log));
+
+    // Verify the proxy contract was deployed
+    let proxy_address: AccountId = contract
+        .view("proxy_contract")
+        .args_json(json!({
+            "context_id": context_id
+        }))
+        .await?
+        .json()?;
+
+    // Assert the proxy address is a subaccount of the contract
+    assert!(
+        proxy_address.to_string() == format!("0.{}", contract.id()),
+        "Proxy address '{}' should be exactly '0.{}'",
+        proxy_address,
+        contract.id()
+    );
+
+    //Uncomment to print the proxy contract address
+    // println!("Proxy contract address: {}", proxy_address);
+
+    // Call the update function
+    let res = node1
+        .call(contract.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::UpdateProxyContract,
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?;
+
+    // println!("Update result: {:?}", res);
+    // Check the result
+    assert!(res.is_success(), "Transaction failed: {:?}", res);
+
+    // Verify we got our success message
+    let result = res.into_result()?;
+    assert!(
+        result
+            .logs()
+            .iter()
+            .any(|log| log.contains("Successfully updated proxy contract")),
+        "Expected success message in logs"
+    );
+
+    // Create proposal
+    let proposal_id = rand::thread_rng().gen();
+    let actions = vec![ProposalAction::ExternalFunctionCall {
+        receiver_id: contract.id().to_string(),
+        method_name: "increment".to_string(),
+        args: "[]".to_string(),
+        deposit: 0,
+        gas: 1_000_000_000_000,
+    }];
+
+    let request = ProxyMutateRequest::Propose {
+        proposal: Proposal {
+            id: proposal_id,
+            author_id: alice_cx_id.rt()?,
+            actions: actions.clone(),
+        },
+    };
+    let signed = Signed::new(&request, |p| alice_cx_sk.sign(p))?;
+
+    let res = node1
+        .call(&proxy_address, "mutate")
+        .args_json(signed)
+        .max_gas()
+        .transact()
+        .await?;
+
+    // Assert proposal creation result
+    let proposal_result = res.json::<ProposalWithApprovals>()?;
+    assert_eq!(proposal_result.num_approvals, 1);
+    let created_proposal_id = proposal_result.proposal_id;
+    // Verify proposals list
+    let proposals: Vec<Proposal> = worker
+        .view(&proxy_address, "proposals")
+        .args_json(json!({
+            "offset": 0,
+            "length": 10
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(proposals.len(), 1, "Should have exactly one proposal");
+    let created_proposal = &proposals[0];
+    assert_eq!(created_proposal.id, created_proposal_id);
+    assert_eq!(created_proposal.author_id, alice_cx_id.rt()?);
+    assert_eq!(created_proposal.actions.len(), 1);
+
+    if let ProposalAction::ExternalFunctionCall {
+        receiver_id,
+        method_name,
+        args,
+        deposit,
+        gas,
+    } = &created_proposal.actions[0]
+    {
+        assert_eq!(receiver_id, contract.id());
+        assert_eq!(method_name, "increment");
+        assert_eq!(args, "[]");
+        assert_eq!(*deposit, 0);
+        assert_eq!(*gas, 1_000_000_000_000);
+    } else {
+        panic!("Expected ExternalFunctionCall action");
+    }
+
+    // Verify single proposal query
+    let single_proposal: Option<Proposal> = worker
+        .view(&proxy_address, "proposal")
+        .args_json(json!({
+            "proposal_id": proposal_id
+        }))
+        .await?
+        .json()?;
+
+    assert!(
+        single_proposal.is_some(),
+        "Should be able to get single proposal"
+    );
+    assert_eq!(single_proposal.unwrap().id, created_proposal_id);
+
+    Ok(())
+}
+
+#[ignore]
 #[tokio::test]
 async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
     let worker = near_workspaces::sandbox().await?;
@@ -1171,7 +1172,7 @@ async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
     // Verify proxy contract deployment
     let expected_log = format!("Context `{}` added", context_id);
     assert!(res.logs().iter().any(|log| log == &expected_log));
-    
+
     let proxy_address: AccountId = contract
         .view("proxy_contract")
         .args_json(json!({ "context_id": context_id }))
@@ -1179,7 +1180,7 @@ async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
         .json()?;
 
     println!("Proxy address: {}", proxy_address);
-    
+
     // Fund proxy contract for storage costs
     let _unused = root_account
         .transfer_near(&proxy_address, NearToken::from_near(50))
@@ -1218,7 +1219,7 @@ async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
         .max_gas()
         .transact()
         .await?;
-    
+
     // Uncomment to print the update result
     // println!("Update result: {:#?}", _res);
 
@@ -1241,11 +1242,9 @@ async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
 
     // Test exact equality
     assert_eq!(
-        storage_change, 
-        code_change,
+        storage_change, code_change,
         "Storage change ({:+}) should exactly match code size change ({:+})",
-        storage_change,
-        code_change
+        storage_change, code_change
     );
 
     Ok(())

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -752,10 +752,6 @@ async fn main() -> eyre::Result<()> {
 
     assert_eq!(res, [alice_cx_id, carol_cx_id]);
 
-    // let state = contract.view_state().await?;
-    // println!("State size: {}", state.len());
-    // assert_eq!(state.len(), 11);
-
     let res = contract
         .call("erase")
         .max_gas()
@@ -765,17 +761,10 @@ async fn main() -> eyre::Result<()> {
 
     assert!(res.logs().contains(&"Erasing contract"), "{:?}", res.logs());
 
-    // let state = contract.view_state().await?;
+    let state = contract.view_state().await?;
 
-    // assert_eq!(state.len(), 1);
-    // assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
-
-    // // After contract deployment
-    // let state_size = worker
-    //     .view(contract.id(), "get_state_size")  // We'd need to add this method to the contract
-    //     .await?
-    //     .json::<u64>()?;
-    // println!("Initial state size: {}", state_size);
+    assert_eq!(state.len(), 1);
+    assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(37));
 
     Ok(())
 }

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -920,18 +920,15 @@ async fn test_deploy() -> eyre::Result<()> {
     let context_id = context_public.to_bytes().rt()?;
 
     // Fund node1 just for gas fees
-    drop(
-        root_account
-            .transfer_near(node1.id(), NearToken::from_near(500))
-            .await,
-    );
+    
+    let _unused = root_account
+        .transfer_near(node1.id(), NearToken::from_near(500))
+        .await;
 
     // Fund the contract with enough NEAR for proxy deployments
-    drop(
-        root_account
-            .transfer_near(contract.id(), NearToken::from_near(100))
-            .await,
-    );
+    let _unused = root_account
+        .transfer_near(contract.id(), NearToken::from_near(100))
+        .await;
 
     // Set proxy code
     let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
@@ -1042,29 +1039,6 @@ async fn test_deploy() -> eyre::Result<()> {
         },
     };
     let signed = Signed::new(&request, |p| alice_cx_sk.sign(p))?;
-    // println!("signed {:?}", signed);
-    let res = node1
-        .call(&proxy_address, "mutate")
-        .args_json(signed.clone())
-        .max_gas()
-        .transact()
-        .await?;
-
-    // Assert proposal creation result
-    let err = res.into_result().unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("wouldn't have enough balance to cover storage"),
-        "Expected storage balance error, got: {}",
-        err
-    );
-
-    // Now fund the account
-    drop(
-        root_account
-            .transfer_near(&proxy_address, NearToken::from_near(5))
-            .await,
-    );
 
     // Try again - this time it should succeed
     let res = node1

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -920,7 +920,7 @@ async fn test_deploy() -> eyre::Result<()> {
     let context_id = context_public.to_bytes().rt()?;
 
     // Fund node1 just for gas fees
-    
+
     let _unused = root_account
         .transfer_near(node1.id(), NearToken::from_near(500))
         .await;

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -17,882 +17,1090 @@ use rand::Rng;
 use serde_json::json;
 use tokio::{fs, time};
 
+// #[tokio::test]
+// async fn main() -> eyre::Result<()> {
+//     let worker = near_workspaces::sandbox().await?;
+//     let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
+
+//     let mut rng = rand::thread_rng();
+
+//     let contract = worker.dev_deploy(&wasm).await?;
+
+//     let root_account = worker.root_account()?;
+
+//     let node1 = root_account
+//         .create_subaccount("node1")
+//         .initial_balance(NearToken::from_near(30))
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     let node2 = root_account
+//         .create_subaccount("node2")
+//         .initial_balance(NearToken::from_near(30))
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+//     let alice_cx_pk = alice_cx_sk.verifying_key();
+//     let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+//     let bob_cx_sk = SigningKey::from_bytes(&rng.gen());
+//     let bob_cx_pk = bob_cx_sk.verifying_key();
+//     let bob_cx_id = bob_cx_pk.to_bytes().rt()?;
+
+//     let carol_cx_sk = SigningKey::from_bytes(&rng.gen());
+//     let carol_cx_pk = carol_cx_sk.verifying_key();
+//     let carol_cx_id = carol_cx_pk.to_bytes().rt()?;
+
+//     let context_secret = SigningKey::from_bytes(&rng.gen());
+//     let context_public = context_secret.verifying_key();
+//     let context_id = context_public.to_bytes().rt()?;
+
+//     let application_id = rng.gen::<[_; 32]>().rt()?;
+//     let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::Add {
+//                         author_id: alice_cx_id,
+//                         application: Application::new(
+//                             application_id,
+//                             blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(alice_cx_id.rt()?, kind)
+//             },
+//             |p| alice_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .raw_bytes()
+//         .expect_err("context creation should fail");
+
+//     {
+//         let err = res.to_string();
+//         assert!(
+//             err.contains("context addition must be signed by the context itself"),
+//             "{}",
+//             err
+//         );
+//     }
+
+//     let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
+//     let _test = contract
+//         .call("set_proxy_code")
+//         .args(new_proxy_wasm)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::Add {
+//                         author_id: alice_cx_id,
+//                         application: Application::new(
+//                             application_id,
+//                             blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(context_id.rt()?, kind)
+//             },
+//             |p| context_secret.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     // Assert context creation
+//     let expected_log = format!("Context `{}` added", context_id);
+//     assert!(res.logs().iter().any(|log| log == &expected_log));
+
+//     let res = node2
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::Add {
+//                         author_id: alice_cx_id,
+//                         application: Application::new(
+//                             application_id,
+//                             blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(context_id.rt()?, kind)
+//             },
+//             |p| context_secret.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .raw_bytes()
+//         .expect_err("context should already exist");
+
+//     {
+//         let err = res.to_string();
+//         assert!(err.contains("context already exists"), "{}", err);
+//     }
+
+//     let res = contract
+//         .view("application")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res.id, application_id);
+//     assert_eq!(res.blob, blob_id);
+//     assert_eq!(res.source, Default::default());
+//     assert_eq!(res.metadata, Default::default());
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+//         .view("privileges")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "identities": [],
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res.len(), 1);
+
+//     let alice_capabilities = res
+//         .get(&alice_cx_id.rt()?)
+//         .expect("alice should have capabilities");
+
+//     assert_eq!(
+//         alice_capabilities,
+//         &[Capability::ManageApplication, Capability::ManageMembers]
+//     );
+
+//     let res: Vec<Repr<ContextIdentity>> = contract
+//         .view("members")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "offset": 0,
+//             "length": 10,
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res, [alice_cx_id]);
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::AddMembers {
+//                         members: vec![bob_cx_id].into(),
+//                     },
+//                 ));
+
+//                 Request::new(alice_cx_id.rt()?, kind)
+//             },
+//             |p| alice_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(
+//         res.logs(),
+//         [format!(
+//             "Added `{}` as a member of `{}`",
+//             bob_cx_id, context_id
+//         ),]
+//     );
+
+//     let res: Vec<Repr<ContextIdentity>> = contract
+//         .view("members")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "offset": 0,
+//             "length": 10,
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res, [alice_cx_id, bob_cx_id]);
+
+//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+//         .view("privileges")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "identities": [bob_cx_id],
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res.len(), 1);
+
+//     let bob_capabilities = res
+//         .get(&bob_cx_id.rt()?)
+//         .expect("bob should have capabilities");
+
+//     assert_eq!(bob_capabilities, &[]);
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 1);
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::AddMembers {
+//                         members: vec![carol_cx_id].into(),
+//                     },
+//                 ));
+
+//                 Request::new(bob_cx_id.rt()?, kind)
+//             },
+//             |p| bob_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .raw_bytes()
+//         .expect_err("bob lacks permissions");
+
+//     {
+//         let err = res.to_string();
+//         assert!(
+//             err.contains("unable to update member list: unauthorized access"),
+//             "{}",
+//             err
+//         );
+//     }
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 1);
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::Grant {
+//                         capabilities: (vec![(bob_cx_id, Capability::ManageMembers)]).into(),
+//                     },
+//                 ));
+
+//                 Request::new(alice_cx_id.rt()?, kind)
+//             },
+//             |p| alice_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(
+//         res.logs(),
+//         [format!(
+//             "Granted `ManageMembers` to `{}` in `{}`",
+//             bob_cx_id, context_id
+//         )]
+//     );
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 1);
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::AddMembers {
+//                         members: vec![carol_cx_id].into(),
+//                     },
+//                 ));
+
+//                 Request::new(bob_cx_id.rt()?, kind)
+//             },
+//             |p| bob_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(
+//         res.logs(),
+//         [format!(
+//             "Added `{}` as a member of `{}`",
+//             carol_cx_id, context_id
+//         ),]
+//     );
+
+//     let res: Vec<Repr<ContextIdentity>> = contract
+//         .view("members")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "offset": 0,
+//             "length": 10,
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res, [alice_cx_id, bob_cx_id, carol_cx_id]);
+
+//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+//         .view("privileges")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "identities": [],
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res.len(), 2);
+
+//     let alice_capabilities = res
+//         .get(&alice_cx_id.rt()?)
+//         .expect("alice should have capabilities");
+
+//     let bob_capabilities = res
+//         .get(&bob_cx_id.rt()?)
+//         .expect("bob should have capabilities");
+
+//     assert_eq!(res.get(&carol_cx_id.rt()?), None);
+
+//     assert_eq!(
+//         alice_capabilities,
+//         &[Capability::ManageApplication, Capability::ManageMembers]
+//     );
+
+//     assert_eq!(bob_capabilities, &[Capability::ManageMembers]);
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 2);
+
+//     let new_application_id = rng.gen::<[_; 32]>().rt()?;
+//     let new_blob_id = rng.gen::<[_; 32]>().rt()?;
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::UpdateApplication {
+//                         application: Application::new(
+//                             new_application_id,
+//                             new_blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(bob_cx_id.rt()?, kind)
+//             },
+//             |p| bob_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .raw_bytes()
+//         .expect_err("bob lacks permissions");
+
+//     {
+//         let err = res.to_string();
+//         assert!(
+//             err.contains("unable to update application: unauthorized access"),
+//             "{}",
+//             err
+//         );
+//     }
+
+//     let res = contract
+//         .view("application")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res.id, application_id);
+//     assert_eq!(res.blob, blob_id);
+//     assert_eq!(res.source, Default::default());
+//     assert_eq!(res.metadata, Default::default());
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 0);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 2);
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::UpdateApplication {
+//                         application: Application::new(
+//                             new_application_id,
+//                             new_blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(alice_cx_id.rt()?, kind)
+//             },
+//             |p| alice_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(
+//         res.logs(),
+//         [format!(
+//             "Updated application for context `{}` from `{}` to `{}`",
+//             context_id, application_id, new_application_id
+//         )]
+//     );
+
+//     let res = contract
+//         .view("application")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res.id, new_application_id);
+//     assert_eq!(res.blob, new_blob_id);
+//     assert_eq!(res.source, Default::default());
+//     assert_eq!(res.metadata, Default::default());
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 1);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 2);
+
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::RemoveMembers {
+//                         members: vec![bob_cx_id].into(),
+//                     },
+//                 ));
+
+//                 Request::new(alice_cx_id.rt()?, kind)
+//             },
+//             |p| alice_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(
+//         res.logs(),
+//         [format!(
+//             "Removed `{}` from being a member of `{}`",
+//             bob_cx_id, context_id
+//         )]
+//     );
+
+//     let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
+//         .view("privileges")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "identities": [],
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res.len(), 1);
+
+//     let alice_capabilities = res
+//         .get(&alice_cx_id.rt()?)
+//         .expect("alice should have capabilities");
+//     assert_eq!(res.get(&bob_cx_id.rt()?), None);
+//     assert_eq!(res.get(&carol_cx_id.rt()?), None);
+
+//     assert_eq!(
+//         alice_capabilities,
+//         &[Capability::ManageApplication, Capability::ManageMembers]
+//     );
+
+//     let res: Vec<Repr<ContextIdentity>> = contract
+//         .view("members")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "offset": 0,
+//             "length": 10,
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res, [alice_cx_id, carol_cx_id]);
+
+//     let res = contract
+//         .view("application_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 1);
+
+//     let res = contract
+//         .view("members_revision")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Revision = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res, 3);
+
+//     let res = contract
+//         .call("set")
+//         .args_json(SystemRequest::SetValidityThreshold {
+//             threshold_ms: 5_000,
+//         })
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(res.logs(), ["Set validity threshold to `5s`"]);
+
+//     let req = node1.call(contract.id(), "mutate").args_json(Signed::new(
+//         &{
+//             let kind = RequestKind::Context(ContextRequest::new(
+//                 context_id,
+//                 ContextRequestKind::RemoveMembers {
+//                     members: vec![carol_cx_id].into(),
+//                 },
+//             ));
+
+//             Request::new(alice_cx_id.rt()?, kind)
+//         },
+//         |p| alice_cx_sk.sign(p),
+//     )?);
+
+//     time::sleep(time::Duration::from_secs(5)).await;
+
+//     let res = req
+//         .transact()
+//         .await?
+//         .raw_bytes()
+//         .expect_err("request should've expired");
+
+//     {
+//         let err = res.to_string();
+//         assert!(err.contains("request expired"), "{}", err);
+//     }
+
+//     let res: Vec<Repr<ContextIdentity>> = contract
+//         .view("members")
+//         .args_json(json!({
+//             "context_id": context_id,
+//             "offset": 0,
+//             "length": 10,
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(res, [alice_cx_id, carol_cx_id]);
+
+//     // let state = contract.view_state().await?;
+//     // println!("State size: {}", state.len());
+//     // assert_eq!(state.len(), 11);
+
+//     let res = contract
+//         .call("erase")
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert!(res.logs().contains(&"Erasing contract"), "{:?}", res.logs());
+
+//     // let state = contract.view_state().await?;
+
+//     // assert_eq!(state.len(), 1);
+//     // assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
+
+//     // // After contract deployment
+//     // let state_size = worker
+//     //     .view(contract.id(), "get_state_size")  // We'd need to add this method to the contract
+//     //     .await?
+//     //     .json::<u64>()?;
+//     // println!("Initial state size: {}", state_size);
+
+//     Ok(())
+// }
+
+// #[ignore]
+// #[tokio::test]
+// async fn migration() -> eyre::Result<()> {
+//     let worker = near_workspaces::sandbox().await?;
+
+//     let wasm_v0 = fs::read("res/calimero_context_config_near_v0.wasm").await?;
+//     let wasm_v1 = fs::read("res/calimero_context_config_near_v1.wasm").await?;
+
+//     let mut rng = rand::thread_rng();
+
+//     let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
+
+//     let root_account = worker.root_account()?;
+
+//     let node1 = root_account
+//         .create_subaccount("node1")
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+//     let alice_cx_pk = alice_cx_sk.verifying_key();
+//     let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+//     let context_secret = SigningKey::from_bytes(&rng.gen());
+//     let context_public = context_secret.verifying_key();
+//     let context_id = context_public.to_bytes().rt()?;
+
+//     let application_id = rng.gen::<[_; 32]>().rt()?;
+//     let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+//     let res = node1
+//         .call(contract_v0.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::Add {
+//                         author_id: alice_cx_id,
+//                         application: Application::new(
+//                             application_id,
+//                             blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(context_id.rt()?, kind)
+//             },
+//             |p| context_secret.sign(p),
+//         )?)
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     assert_eq!(res.logs(), [format!("Context `{}` added", context_id)]);
+
+//     let res = contract_v0
+//         .view("application")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res.id, application_id);
+//     assert_eq!(res.blob, blob_id);
+//     assert_eq!(res.source, Default::default());
+//     assert_eq!(res.metadata, Default::default());
+
+//     let contract_v1 = contract_v0
+//         .as_account()
+//         .deploy(&wasm_v1)
+//         .await?
+//         .into_result()?;
+
+//     let res = contract_v1
+//         .view("application")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await
+//         .expect_err("should've failed");
+
+//     {
+//         let err = format!("{:?}", res);
+//         assert!(err.contains("Cannot deserialize element"), "{}", err);
+//     }
+
+//     let migration = contract_v1
+//         .call("migrate")
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     dbg!(migration.logs());
+
+//     let res = contract_v1
+//         .view("application")
+//         .args_json(json!({ "context_id": context_id }))
+//         .await?;
+
+//     let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+//     assert_eq!(res.id, application_id);
+//     assert_eq!(res.blob, blob_id);
+//     assert_eq!(res.source, Default::default());
+//     assert_eq!(res.metadata, Default::default());
+
+//     Ok(())
+// }
+
+// #[tokio::test]
+// async fn test_deploy() -> eyre::Result<()> {
+//     let worker = near_workspaces::sandbox().await?;
+//     let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
+//     let mut rng = rand::thread_rng();
+
+//     let contract = worker.dev_deploy(&wasm).await?;
+//     let root_account = worker.root_account()?;
+//     let node1 = root_account
+//         .create_subaccount("node1")
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+//     let alice_cx_pk = alice_cx_sk.verifying_key();
+//     let alice_cx_id: ContextIdentity = alice_cx_pk.to_bytes().rt()?;
+
+//     let context_secret = SigningKey::from_bytes(&rng.gen());
+//     let context_public = context_secret.verifying_key();
+//     let context_id = context_public.to_bytes().rt()?;
+
+//     // Fund node1 just for gas fees
+//     let _unused = root_account
+//         .transfer_near(node1.id(), NearToken::from_near(50))
+//         .await?
+//         .into_result();
+
+//     // Set proxy code
+//     let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
+//     let _test = contract
+//         .call("set_proxy_code")
+//         .args(new_proxy_wasm)
+//         .max_gas()
+//         .transact()
+//         .await?
+//         .into_result()?;
+
+//     let application_id = rng.gen::<[_; 32]>().rt()?;
+//     let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+//     // Call mutate without deposit since contract uses its own balance
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::Add {
+//                         author_id: Repr::new(alice_cx_id),
+//                         application: Application::new(
+//                             application_id,
+//                             blob_id,
+//                             0,
+//                             Default::default(),
+//                             Default::default(),
+//                         ),
+//                     },
+//                 ));
+
+//                 Request::new(context_id.rt()?, kind)
+//             },
+//             |p| context_secret.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?;
+
+//     // println!("Execution result: {:#?}", res);
+//     // println!("Logs: {:#?}", res.logs());  // Print the logs
+
+//     // Assert context creation
+//     let expected_log = format!("Context `{}` added", context_id);
+//     assert!(res.logs().iter().any(|log| log == &expected_log));
+
+//     // Verify the proxy contract was deployed
+//     let proxy_address: AccountId = contract
+//         .view("proxy_contract")
+//         .args_json(json!({
+//             "context_id": context_id
+//         }))
+//         .await?
+//         .json()?;
+
+//     // Assert the proxy address is a subaccount of the contract
+//     assert!(
+//         proxy_address.to_string() == format!("0.{}", contract.id()),
+//         "Proxy address '{}' should be exactly '0.{}'",
+//         proxy_address,
+//         contract.id()
+//     );
+
+//     //Uncomment to print the proxy contract address
+//     // println!("Proxy contract address: {}", proxy_address);
+
+//     // Call the update function
+//     let res = node1
+//         .call(contract.id(), "mutate")
+//         .args_json(Signed::new(
+//             &{
+//                 let kind = RequestKind::Context(ContextRequest::new(
+//                     context_id,
+//                     ContextRequestKind::UpdateProxyContract,
+//                 ));
+
+//                 Request::new(alice_cx_id.rt()?, kind)
+//             },
+//             |p| alice_cx_sk.sign(p),
+//         )?)
+//         .max_gas()
+//         .transact()
+//         .await?;
+
+//     // println!("Update result: {:?}", res);
+//     // Check the result
+//     assert!(res.is_success(), "Transaction failed: {:?}", res);
+
+//     // Verify we got our success message
+//     let result = res.into_result()?;
+//     assert!(
+//         result
+//             .logs()
+//             .iter()
+//             .any(|log| log.contains("Successfully updated proxy contract")),
+//         "Expected success message in logs"
+//     );
+
+//     // Create proposal
+//     let proposal_id = rand::thread_rng().gen();
+//     let actions = vec![ProposalAction::ExternalFunctionCall {
+//         receiver_id: contract.id().to_string(),
+//         method_name: "increment".to_string(),
+//         args: "[]".to_string(),
+//         deposit: 0,
+//         gas: 1_000_000_000_000,
+//     }];
+
+//     let request = ProxyMutateRequest::Propose {
+//         proposal: Proposal {
+//             id: proposal_id,
+//             author_id: alice_cx_id.rt()?,
+//             actions: actions.clone(),
+//         },
+//     };
+//     let signed = Signed::new(&request, |p| alice_cx_sk.sign(p))?;
+
+//     let res = node1
+//         .call(&proxy_address, "mutate")
+//         .args_json(signed)
+//         .max_gas()
+//         .transact()
+//         .await?;
+
+//     // Assert proposal creation result
+//     let proposal_result = res.json::<ProposalWithApprovals>()?;
+//     assert_eq!(proposal_result.num_approvals, 1);
+//     let created_proposal_id = proposal_result.proposal_id;
+//     // Verify proposals list
+//     let proposals: Vec<Proposal> = worker
+//         .view(&proxy_address, "proposals")
+//         .args_json(json!({
+//             "offset": 0,
+//             "length": 10
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert_eq!(proposals.len(), 1, "Should have exactly one proposal");
+//     let created_proposal = &proposals[0];
+//     assert_eq!(created_proposal.id, created_proposal_id);
+//     assert_eq!(created_proposal.author_id, alice_cx_id.rt()?);
+//     assert_eq!(created_proposal.actions.len(), 1);
+
+//     if let ProposalAction::ExternalFunctionCall {
+//         receiver_id,
+//         method_name,
+//         args,
+//         deposit,
+//         gas,
+//     } = &created_proposal.actions[0]
+//     {
+//         assert_eq!(receiver_id, contract.id());
+//         assert_eq!(method_name, "increment");
+//         assert_eq!(args, "[]");
+//         assert_eq!(*deposit, 0);
+//         assert_eq!(*gas, 1_000_000_000_000);
+//     } else {
+//         panic!("Expected ExternalFunctionCall action");
+//     }
+
+//     // Verify single proposal query
+//     let single_proposal: Option<Proposal> = worker
+//         .view(&proxy_address, "proposal")
+//         .args_json(json!({
+//             "proposal_id": proposal_id
+//         }))
+//         .await?
+//         .json()?;
+
+//     assert!(
+//         single_proposal.is_some(),
+//         "Should be able to get single proposal"
+//     );
+//     assert_eq!(single_proposal.unwrap().id, created_proposal_id);
+
+//     Ok(())
+// }
+
 #[tokio::test]
-async fn main() -> eyre::Result<()> {
-    let worker = near_workspaces::sandbox().await?;
-    let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
-
-    let mut rng = rand::thread_rng();
-
-    let contract = worker.dev_deploy(&wasm).await?;
-
-    let root_account = worker.root_account()?;
-
-    let node1 = root_account
-        .create_subaccount("node1")
-        .initial_balance(NearToken::from_near(30))
-        .transact()
-        .await?
-        .into_result()?;
-
-    let node2 = root_account
-        .create_subaccount("node2")
-        .initial_balance(NearToken::from_near(30))
-        .transact()
-        .await?
-        .into_result()?;
-
-    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
-    let alice_cx_pk = alice_cx_sk.verifying_key();
-    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
-
-    let bob_cx_sk = SigningKey::from_bytes(&rng.gen());
-    let bob_cx_pk = bob_cx_sk.verifying_key();
-    let bob_cx_id = bob_cx_pk.to_bytes().rt()?;
-
-    let carol_cx_sk = SigningKey::from_bytes(&rng.gen());
-    let carol_cx_pk = carol_cx_sk.verifying_key();
-    let carol_cx_id = carol_cx_pk.to_bytes().rt()?;
-
-    let context_secret = SigningKey::from_bytes(&rng.gen());
-    let context_public = context_secret.verifying_key();
-    let context_id = context_public.to_bytes().rt()?;
-
-    let application_id = rng.gen::<[_; 32]>().rt()?;
-    let blob_id = rng.gen::<[_; 32]>().rt()?;
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::Add {
-                        author_id: alice_cx_id,
-                        application: Application::new(
-                            application_id,
-                            blob_id,
-                            0,
-                            Default::default(),
-                            Default::default(),
-                        ),
-                    },
-                ));
-
-                Request::new(alice_cx_id.rt()?, kind)
-            },
-            |p| alice_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .raw_bytes()
-        .expect_err("context creation should fail");
-
-    {
-        let err = res.to_string();
-        assert!(
-            err.contains("context addition must be signed by the context itself"),
-            "{}",
-            err
-        );
-    }
-
-    let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
-    let _test = contract
-        .call("set_proxy_code")
-        .args(new_proxy_wasm)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::Add {
-                        author_id: alice_cx_id,
-                        application: Application::new(
-                            application_id,
-                            blob_id,
-                            0,
-                            Default::default(),
-                            Default::default(),
-                        ),
-                    },
-                ));
-
-                Request::new(context_id.rt()?, kind)
-            },
-            |p| context_secret.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    // Assert context creation
-    let expected_log = format!("Context `{}` added", context_id);
-    assert!(res.logs().iter().any(|log| log == &expected_log));
-
-    let res = node2
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::Add {
-                        author_id: alice_cx_id,
-                        application: Application::new(
-                            application_id,
-                            blob_id,
-                            0,
-                            Default::default(),
-                            Default::default(),
-                        ),
-                    },
-                ));
-
-                Request::new(context_id.rt()?, kind)
-            },
-            |p| context_secret.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .raw_bytes()
-        .expect_err("context should already exist");
-
-    {
-        let err = res.to_string();
-        assert!(err.contains("context already exists"), "{}", err);
-    }
-
-    let res = contract
-        .view("application")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res.id, application_id);
-    assert_eq!(res.blob, blob_id);
-    assert_eq!(res.source, Default::default());
-    assert_eq!(res.metadata, Default::default());
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-        .view("privileges")
-        .args_json(json!({
-            "context_id": context_id,
-            "identities": [],
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res.len(), 1);
-
-    let alice_capabilities = res
-        .get(&alice_cx_id.rt()?)
-        .expect("alice should have capabilities");
-
-    assert_eq!(
-        alice_capabilities,
-        &[Capability::ManageApplication, Capability::ManageMembers]
-    );
-
-    let res: Vec<Repr<ContextIdentity>> = contract
-        .view("members")
-        .args_json(json!({
-            "context_id": context_id,
-            "offset": 0,
-            "length": 10,
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res, [alice_cx_id]);
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::AddMembers {
-                        members: vec![bob_cx_id].into(),
-                    },
-                ));
-
-                Request::new(alice_cx_id.rt()?, kind)
-            },
-            |p| alice_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(
-        res.logs(),
-        [format!(
-            "Added `{}` as a member of `{}`",
-            bob_cx_id, context_id
-        ),]
-    );
-
-    let res: Vec<Repr<ContextIdentity>> = contract
-        .view("members")
-        .args_json(json!({
-            "context_id": context_id,
-            "offset": 0,
-            "length": 10,
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res, [alice_cx_id, bob_cx_id]);
-
-    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-        .view("privileges")
-        .args_json(json!({
-            "context_id": context_id,
-            "identities": [bob_cx_id],
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res.len(), 1);
-
-    let bob_capabilities = res
-        .get(&bob_cx_id.rt()?)
-        .expect("bob should have capabilities");
-
-    assert_eq!(bob_capabilities, &[]);
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 1);
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::AddMembers {
-                        members: vec![carol_cx_id].into(),
-                    },
-                ));
-
-                Request::new(bob_cx_id.rt()?, kind)
-            },
-            |p| bob_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .raw_bytes()
-        .expect_err("bob lacks permissions");
-
-    {
-        let err = res.to_string();
-        assert!(
-            err.contains("unable to update member list: unauthorized access"),
-            "{}",
-            err
-        );
-    }
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 1);
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::Grant {
-                        capabilities: (vec![(bob_cx_id, Capability::ManageMembers)]).into(),
-                    },
-                ));
-
-                Request::new(alice_cx_id.rt()?, kind)
-            },
-            |p| alice_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(
-        res.logs(),
-        [format!(
-            "Granted `ManageMembers` to `{}` in `{}`",
-            bob_cx_id, context_id
-        )]
-    );
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 1);
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::AddMembers {
-                        members: vec![carol_cx_id].into(),
-                    },
-                ));
-
-                Request::new(bob_cx_id.rt()?, kind)
-            },
-            |p| bob_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(
-        res.logs(),
-        [format!(
-            "Added `{}` as a member of `{}`",
-            carol_cx_id, context_id
-        ),]
-    );
-
-    let res: Vec<Repr<ContextIdentity>> = contract
-        .view("members")
-        .args_json(json!({
-            "context_id": context_id,
-            "offset": 0,
-            "length": 10,
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res, [alice_cx_id, bob_cx_id, carol_cx_id]);
-
-    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-        .view("privileges")
-        .args_json(json!({
-            "context_id": context_id,
-            "identities": [],
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res.len(), 2);
-
-    let alice_capabilities = res
-        .get(&alice_cx_id.rt()?)
-        .expect("alice should have capabilities");
-
-    let bob_capabilities = res
-        .get(&bob_cx_id.rt()?)
-        .expect("bob should have capabilities");
-
-    assert_eq!(res.get(&carol_cx_id.rt()?), None);
-
-    assert_eq!(
-        alice_capabilities,
-        &[Capability::ManageApplication, Capability::ManageMembers]
-    );
-
-    assert_eq!(bob_capabilities, &[Capability::ManageMembers]);
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 2);
-
-    let new_application_id = rng.gen::<[_; 32]>().rt()?;
-    let new_blob_id = rng.gen::<[_; 32]>().rt()?;
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::UpdateApplication {
-                        application: Application::new(
-                            new_application_id,
-                            new_blob_id,
-                            0,
-                            Default::default(),
-                            Default::default(),
-                        ),
-                    },
-                ));
-
-                Request::new(bob_cx_id.rt()?, kind)
-            },
-            |p| bob_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .raw_bytes()
-        .expect_err("bob lacks permissions");
-
-    {
-        let err = res.to_string();
-        assert!(
-            err.contains("unable to update application: unauthorized access"),
-            "{}",
-            err
-        );
-    }
-
-    let res = contract
-        .view("application")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res.id, application_id);
-    assert_eq!(res.blob, blob_id);
-    assert_eq!(res.source, Default::default());
-    assert_eq!(res.metadata, Default::default());
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 0);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 2);
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::UpdateApplication {
-                        application: Application::new(
-                            new_application_id,
-                            new_blob_id,
-                            0,
-                            Default::default(),
-                            Default::default(),
-                        ),
-                    },
-                ));
-
-                Request::new(alice_cx_id.rt()?, kind)
-            },
-            |p| alice_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(
-        res.logs(),
-        [format!(
-            "Updated application for context `{}` from `{}` to `{}`",
-            context_id, application_id, new_application_id
-        )]
-    );
-
-    let res = contract
-        .view("application")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res.id, new_application_id);
-    assert_eq!(res.blob, new_blob_id);
-    assert_eq!(res.source, Default::default());
-    assert_eq!(res.metadata, Default::default());
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 1);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 2);
-
-    let res = node1
-        .call(contract.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::RemoveMembers {
-                        members: vec![bob_cx_id].into(),
-                    },
-                ));
-
-                Request::new(alice_cx_id.rt()?, kind)
-            },
-            |p| alice_cx_sk.sign(p),
-        )?)
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(
-        res.logs(),
-        [format!(
-            "Removed `{}` from being a member of `{}`",
-            bob_cx_id, context_id
-        )]
-    );
-
-    let res: BTreeMap<Repr<SignerId>, Vec<Capability>> = contract
-        .view("privileges")
-        .args_json(json!({
-            "context_id": context_id,
-            "identities": [],
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res.len(), 1);
-
-    let alice_capabilities = res
-        .get(&alice_cx_id.rt()?)
-        .expect("alice should have capabilities");
-    assert_eq!(res.get(&bob_cx_id.rt()?), None);
-    assert_eq!(res.get(&carol_cx_id.rt()?), None);
-
-    assert_eq!(
-        alice_capabilities,
-        &[Capability::ManageApplication, Capability::ManageMembers]
-    );
-
-    let res: Vec<Repr<ContextIdentity>> = contract
-        .view("members")
-        .args_json(json!({
-            "context_id": context_id,
-            "offset": 0,
-            "length": 10,
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res, [alice_cx_id, carol_cx_id]);
-
-    let res = contract
-        .view("application_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 1);
-
-    let res = contract
-        .view("members_revision")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Revision = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res, 3);
-
-    let res = contract
-        .call("set")
-        .args_json(SystemRequest::SetValidityThreshold {
-            threshold_ms: 5_000,
-        })
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(res.logs(), ["Set validity threshold to `5s`"]);
-
-    let req = node1.call(contract.id(), "mutate").args_json(Signed::new(
-        &{
-            let kind = RequestKind::Context(ContextRequest::new(
-                context_id,
-                ContextRequestKind::RemoveMembers {
-                    members: vec![carol_cx_id].into(),
-                },
-            ));
-
-            Request::new(alice_cx_id.rt()?, kind)
-        },
-        |p| alice_cx_sk.sign(p),
-    )?);
-
-    time::sleep(time::Duration::from_secs(5)).await;
-
-    let res = req
-        .transact()
-        .await?
-        .raw_bytes()
-        .expect_err("request should've expired");
-
-    {
-        let err = res.to_string();
-        assert!(err.contains("request expired"), "{}", err);
-    }
-
-    let res: Vec<Repr<ContextIdentity>> = contract
-        .view("members")
-        .args_json(json!({
-            "context_id": context_id,
-            "offset": 0,
-            "length": 10,
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(res, [alice_cx_id, carol_cx_id]);
-
-    // let state = contract.view_state().await?;
-    // println!("State size: {}", state.len());
-    // assert_eq!(state.len(), 11);
-
-    let res = contract
-        .call("erase")
-        .max_gas()
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert!(res.logs().contains(&"Erasing contract"), "{:?}", res.logs());
-
-    // let state = contract.view_state().await?;
-
-    // assert_eq!(state.len(), 1);
-    // assert_eq!(state.get(&b"STATE"[..]).map(|v| v.len()), Some(24));
-
-    // // After contract deployment
-    // let state_size = worker
-    //     .view(contract.id(), "get_state_size")  // We'd need to add this method to the contract
-    //     .await?
-    //     .json::<u64>()?;
-    // println!("Initial state size: {}", state_size);
-
-    Ok(())
-}
-
-#[ignore]
-#[tokio::test]
-async fn migration() -> eyre::Result<()> {
-    let worker = near_workspaces::sandbox().await?;
-
-    let wasm_v0 = fs::read("res/calimero_context_config_near_v0.wasm").await?;
-    let wasm_v1 = fs::read("res/calimero_context_config_near_v1.wasm").await?;
-
-    let mut rng = rand::thread_rng();
-
-    let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
-
-    let root_account = worker.root_account()?;
-
-    let node1 = root_account
-        .create_subaccount("node1")
-        .transact()
-        .await?
-        .into_result()?;
-
-    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
-    let alice_cx_pk = alice_cx_sk.verifying_key();
-    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
-
-    let context_secret = SigningKey::from_bytes(&rng.gen());
-    let context_public = context_secret.verifying_key();
-    let context_id = context_public.to_bytes().rt()?;
-
-    let application_id = rng.gen::<[_; 32]>().rt()?;
-    let blob_id = rng.gen::<[_; 32]>().rt()?;
-
-    let res = node1
-        .call(contract_v0.id(), "mutate")
-        .args_json(Signed::new(
-            &{
-                let kind = RequestKind::Context(ContextRequest::new(
-                    context_id,
-                    ContextRequestKind::Add {
-                        author_id: alice_cx_id,
-                        application: Application::new(
-                            application_id,
-                            blob_id,
-                            0,
-                            Default::default(),
-                            Default::default(),
-                        ),
-                    },
-                ));
-
-                Request::new(context_id.rt()?, kind)
-            },
-            |p| context_secret.sign(p),
-        )?)
-        .transact()
-        .await?
-        .into_result()?;
-
-    assert_eq!(res.logs(), [format!("Context `{}` added", context_id)]);
-
-    let res = contract_v0
-        .view("application")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res.id, application_id);
-    assert_eq!(res.blob, blob_id);
-    assert_eq!(res.source, Default::default());
-    assert_eq!(res.metadata, Default::default());
-
-    let contract_v1 = contract_v0
-        .as_account()
-        .deploy(&wasm_v1)
-        .await?
-        .into_result()?;
-
-    let res = contract_v1
-        .view("application")
-        .args_json(json!({ "context_id": context_id }))
-        .await
-        .expect_err("should've failed");
-
-    {
-        let err = format!("{:?}", res);
-        assert!(err.contains("Cannot deserialize element"), "{}", err);
-    }
-
-    let migration = contract_v1
-        .call("migrate")
-        .transact()
-        .await?
-        .into_result()?;
-
-    dbg!(migration.logs());
-
-    let res = contract_v1
-        .view("application")
-        .args_json(json!({ "context_id": context_id }))
-        .await?;
-
-    let res: Application<'_> = serde_json::from_slice(&res.result)?;
-
-    assert_eq!(res.id, application_id);
-    assert_eq!(res.blob, blob_id);
-    assert_eq!(res.source, Default::default());
-    assert_eq!(res.metadata, Default::default());
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_deploy() -> eyre::Result<()> {
+async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
     let worker = near_workspaces::sandbox().await?;
     let wasm = fs::read("res/calimero_context_config_near.wasm").await?;
     let mut rng = rand::thread_rng();
@@ -913,17 +1121,19 @@ async fn test_deploy() -> eyre::Result<()> {
     let context_public = context_secret.verifying_key();
     let context_id = context_public.to_bytes().rt()?;
 
-    // Fund node1 just for gas fees
+    let bigger_proxy_wasm = fs::read("./tests/proxy_lib.wasm").await?;
+    let smaller_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
+
+    // Fund node1 for gas fees
     let _unused = root_account
         .transfer_near(node1.id(), NearToken::from_near(50))
         .await?
         .into_result();
 
-    // Set proxy code
-    let new_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
+    // Set initial proxy code
     let _test = contract
         .call("set_proxy_code")
-        .args(new_proxy_wasm)
+        .args(bigger_proxy_wasm.clone())
         .max_gas()
         .transact()
         .await?
@@ -932,7 +1142,7 @@ async fn test_deploy() -> eyre::Result<()> {
     let application_id = rng.gen::<[_; 32]>().rt()?;
     let blob_id = rng.gen::<[_; 32]>().rt()?;
 
-    // Call mutate without deposit since contract uses its own balance
+    // Deploy proxy contract
     let res = node1
         .call(contract.id(), "mutate")
         .args_json(Signed::new(
@@ -950,7 +1160,6 @@ async fn test_deploy() -> eyre::Result<()> {
                         ),
                     },
                 ));
-
                 Request::new(context_id.rt()?, kind)
             },
             |p| context_secret.sign(p),
@@ -959,35 +1168,42 @@ async fn test_deploy() -> eyre::Result<()> {
         .transact()
         .await?;
 
-    // println!("Execution result: {:#?}", res);
-    // println!("Logs: {:#?}", res.logs());  // Print the logs
-
-    // Assert context creation
+    // Verify proxy contract deployment
     let expected_log = format!("Context `{}` added", context_id);
     assert!(res.logs().iter().any(|log| log == &expected_log));
-
-    // Verify the proxy contract was deployed
+    
     let proxy_address: AccountId = contract
         .view("proxy_contract")
-        .args_json(json!({
-            "context_id": context_id
-        }))
+        .args_json(json!({ "context_id": context_id }))
         .await?
         .json()?;
 
-    // Assert the proxy address is a subaccount of the contract
-    assert!(
-        proxy_address.to_string() == format!("0.{}", contract.id()),
-        "Proxy address '{}' should be exactly '0.{}'",
-        proxy_address,
-        contract.id()
-    );
+    println!("Proxy address: {}", proxy_address);
+    
+    // Fund proxy contract for storage costs
+    let _unused = root_account
+        .transfer_near(&proxy_address, NearToken::from_near(50))
+        .await?
+        .into_result();
 
-    //Uncomment to print the proxy contract address
-    // println!("Proxy contract address: {}", proxy_address);
+    // Get initial measurements
+    let initial_outcome = worker.view_account(&proxy_address).await?;
+    let initial_storage = initial_outcome.storage_usage;
+    let initial_code_size = bigger_proxy_wasm.len() as u64;
 
-    // Call the update function
-    let res = node1
+    println!("Initial storage usage: {}", initial_storage);
+    println!("Initial WASM size: {}", initial_code_size);
+
+    let _test = contract
+        .call("set_proxy_code")
+        .args(smaller_proxy_wasm.clone())
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    // Update proxy contract
+    let _res = node1
         .call(contract.id(), "mutate")
         .args_json(Signed::new(
             &{
@@ -995,7 +1211,6 @@ async fn test_deploy() -> eyre::Result<()> {
                     context_id,
                     ContextRequestKind::UpdateProxyContract,
                 ));
-
                 Request::new(alice_cx_id.rt()?, kind)
             },
             |p| alice_cx_sk.sign(p),
@@ -1003,99 +1218,35 @@ async fn test_deploy() -> eyre::Result<()> {
         .max_gas()
         .transact()
         .await?;
+    
+    // Uncomment to print the update result
+    // println!("Update result: {:#?}", _res);
 
-    // println!("Update result: {:?}", res);
-    // Check the result
-    assert!(res.is_success(), "Transaction failed: {:?}", res);
+    // Get final measurements
+    let final_outcome = worker.view_account(&proxy_address).await?;
+    let final_storage = final_outcome.storage_usage;
+    let final_code_size = smaller_proxy_wasm.len() as u64;
 
-    // Verify we got our success message
-    let result = res.into_result()?;
-    assert!(
-        result
-            .logs()
-            .iter()
-            .any(|log| log.contains("Successfully updated proxy contract")),
-        "Expected success message in logs"
+    println!("Initial storage usage: {}", initial_storage);
+    println!("Initial WASM size: {}", initial_code_size);
+    println!("Final storage usage: {}", final_storage);
+    println!("Final WASM size: {}", final_code_size);
+
+    // Calculate raw differences (can be negative)
+    let storage_change = final_storage as i64 - initial_storage as i64;
+    let code_change = final_code_size as i64 - initial_code_size as i64;
+
+    println!("Storage change: {:+}", storage_change);
+    println!("Code change: {:+}", code_change);
+
+    // Test exact equality
+    assert_eq!(
+        storage_change, 
+        code_change,
+        "Storage change ({:+}) should exactly match code size change ({:+})",
+        storage_change,
+        code_change
     );
-
-    // Create proposal
-    let proposal_id = rand::thread_rng().gen();
-    let actions = vec![ProposalAction::ExternalFunctionCall {
-        receiver_id: contract.id().to_string(),
-        method_name: "increment".to_string(),
-        args: "[]".to_string(),
-        deposit: 0,
-        gas: 1_000_000_000_000,
-    }];
-
-    let request = ProxyMutateRequest::Propose {
-        proposal: Proposal {
-            id: proposal_id,
-            author_id: alice_cx_id.rt()?,
-            actions: actions.clone(),
-        },
-    };
-    let signed = Signed::new(&request, |p| alice_cx_sk.sign(p))?;
-
-    // Try again - this time it should succeed
-    let res = node1
-        .call(&proxy_address, "mutate")
-        .args_json(signed)
-        .max_gas()
-        .transact()
-        .await?;
-
-    // Assert proposal creation result
-    let proposal_result = res.json::<ProposalWithApprovals>()?;
-    assert_eq!(proposal_result.num_approvals, 1);
-    let created_proposal_id = proposal_result.proposal_id;
-    // Verify proposals list
-    let proposals: Vec<Proposal> = worker
-        .view(&proxy_address, "proposals")
-        .args_json(json!({
-            "offset": 0,
-            "length": 10
-        }))
-        .await?
-        .json()?;
-
-    assert_eq!(proposals.len(), 1, "Should have exactly one proposal");
-    let created_proposal = &proposals[0];
-    assert_eq!(created_proposal.id, created_proposal_id);
-    assert_eq!(created_proposal.author_id, alice_cx_id.rt()?);
-    assert_eq!(created_proposal.actions.len(), 1);
-
-    if let ProposalAction::ExternalFunctionCall {
-        receiver_id,
-        method_name,
-        args,
-        deposit,
-        gas,
-    } = &created_proposal.actions[0]
-    {
-        assert_eq!(receiver_id, contract.id());
-        assert_eq!(method_name, "increment");
-        assert_eq!(args, "[]");
-        assert_eq!(*deposit, 0);
-        assert_eq!(*gas, 1_000_000_000_000);
-    } else {
-        panic!("Expected ExternalFunctionCall action");
-    }
-
-    // Verify single proposal query
-    let single_proposal: Option<Proposal> = worker
-        .view(&proxy_address, "proposal")
-        .args_json(json!({
-            "proposal_id": proposal_id
-        }))
-        .await?
-        .json()?;
-
-    assert!(
-        single_proposal.is_some(),
-        "Should be able to get single proposal"
-    );
-    assert_eq!(single_proposal.unwrap().id, created_proposal_id);
 
     Ok(())
 }

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -1086,7 +1086,6 @@ async fn test_deploy() -> eyre::Result<()> {
     Ok(())
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
     let worker = near_workspaces::sandbox().await?;
@@ -1110,7 +1109,7 @@ async fn test_storage_usage_matches_code_size() -> eyre::Result<()> {
     let context_public = context_secret.verifying_key();
     let context_id = context_public.to_bytes().rt()?;
 
-    let bigger_proxy_wasm = fs::read("./tests/proxy_lib.wasm").await?;
+    let bigger_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib_fat.wasm").await?;
     let smaller_proxy_wasm = fs::read("../proxy-lib/res/proxy_lib.wasm").await?;
 
     // Set initial proxy code

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use calimero_context_config::repr::{Repr, ReprTransmute};
 use calimero_context_config::types::{
-    Application, Capability, ContextIdentity, Revision, Signed, SignerId
+    Application, Capability, ContextIdentity, Revision, Signed, SignerId,
 };
 use calimero_context_config::{
     ContextRequest, ContextRequestKind, Proposal, ProposalAction, ProposalWithApprovals,

--- a/contracts/context-config/tests/sandbox.rs
+++ b/contracts/context-config/tests/sandbox.rs
@@ -1050,17 +1050,20 @@ async fn test_deploy() -> eyre::Result<()> {
         .transact()
         .await?;
 
-    
     // Assert proposal creation result
     let err = res.into_result().unwrap_err();
-    assert!(err.to_string().contains("wouldn't have enough balance to cover storage"), 
-        "Expected storage balance error, got: {}", err);
+    assert!(
+        err.to_string()
+            .contains("wouldn't have enough balance to cover storage"),
+        "Expected storage balance error, got: {}",
+        err
+    );
 
-     // Now fund the account
+    // Now fund the account
     drop(
-      root_account
-          .transfer_near(&proxy_address, NearToken::from_near(5))
-          .await,
+        root_account
+            .transfer_near(&proxy_address, NearToken::from_near(5))
+            .await,
     );
 
     // Try again - this time it should succeed

--- a/contracts/proxy-lib/Cargo.toml
+++ b/contracts/proxy-lib/Cargo.toml
@@ -23,3 +23,6 @@ near-crypto.workspace = true
 calimero-context-config-near = { path = "../context-config" }
 ed25519-dalek.workspace = true
 rand.workspace = true
+
+[features]
+__internal_explode_size = []

--- a/contracts/proxy-lib/build-test-deps.sh
+++ b/contracts/proxy-lib/build-test-deps.sh
@@ -3,17 +3,15 @@ set -e
 
 cd "$(dirname $0)"
 
-TARGET="${CARGO_TARGET_DIR:-../../target}"
-
 PROXY_CONTRACT_PATH="./"
 TEST_CONTRACT_PATH="../test-counter"
 CONTEXT_CONFIG_CONTRACT_PATH="../context-config"
 
 echo "Building proxy contract..."
-(cd $PROXY_CONTRACT_PATH && ./build.sh)
+$PROXY_CONTRACT_PATH/build.sh
 
 echo "Building proxy contract..."
-(cd $TEST_CONTRACT_PATH && ./build.sh)
+$TEST_CONTRACT_PATH/build.sh --test
 
 echo "Building context-config contract..."
-(cd $CONTEXT_CONFIG_CONTRACT_PATH && ./build.sh)
+$CONTEXT_CONFIG_CONTRACT_PATH/build.sh

--- a/contracts/proxy-lib/build-test-deps.sh
+++ b/contracts/proxy-lib/build-test-deps.sh
@@ -8,10 +8,10 @@ TEST_CONTRACT_PATH="../test-counter"
 CONTEXT_CONFIG_CONTRACT_PATH="../context-config"
 
 echo "Building proxy contract..."
-$PROXY_CONTRACT_PATH/build.sh
+$PROXY_CONTRACT_PATH/build.sh --test
 
-echo "Building proxy contract..."
-$TEST_CONTRACT_PATH/build.sh --test
+echo "Building test-counter contract..."
+$TEST_CONTRACT_PATH/build.sh
 
 echo "Building context-config contract..."
 $CONTEXT_CONFIG_CONTRACT_PATH/build.sh

--- a/contracts/proxy-lib/build.sh
+++ b/contracts/proxy-lib/build.sh
@@ -7,9 +7,15 @@ TARGET="${CARGO_TARGET_DIR:-../../target}"
 
 rustup target add wasm32-unknown-unknown
 
-cargo build --target wasm32-unknown-unknown --profile app-release
-
 mkdir -p res
+
+if [ "$1" = "--test" ]; then
+  cargo build --target wasm32-unknown-unknown --profile app-release --features __internal_explode_size
+
+  cp $TARGET/wasm32-unknown-unknown/app-release/proxy_lib.wasm ./res/proxy_lib_fat.wasm
+fi
+
+cargo build --target wasm32-unknown-unknown --profile app-release
 
 cp $TARGET/wasm32-unknown-unknown/app-release/proxy_lib.wasm ./res/
 

--- a/contracts/proxy-lib/src/lib.rs
+++ b/contracts/proxy-lib/src/lib.rs
@@ -6,7 +6,7 @@ use calimero_context_config::types::{ContextId, Signed, SignerId};
 use calimero_context_config::{Proposal, ProposalId, ProposalWithApprovals};
 use near_sdk::json_types::U128;
 use near_sdk::store::IterableMap;
-use near_sdk::{near, AccountId, PanicOnDefault, PromiseError};
+use near_sdk::{env, near, AccountId, PanicOnDefault, PromiseError};
 
 pub mod ext_config;
 mod mutate;
@@ -33,6 +33,7 @@ pub struct ProxyContract {
     pub num_proposals_pk: IterableMap<SignerId, u32>,
     pub active_proposals_limit: u32,
     pub context_storage: IterableMap<Box<[u8]>, Box<[u8]>>,
+    pub code_size: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -56,6 +57,7 @@ impl ProxyContract {
             num_approvals: 3,
             active_proposals_limit: 10,
             context_storage: IterableMap::new(b"l"),
+            code_size: env::storage_usage() as u64,
         }
     }
 

--- a/contracts/proxy-lib/src/lib.rs
+++ b/contracts/proxy-lib/src/lib.rs
@@ -44,7 +44,7 @@ pub struct ProxyContract {
     pub num_proposals_pk: IterableMap<SignerId, u32>,
     pub active_proposals_limit: u32,
     pub context_storage: IterableMap<Box<[u8]>, Box<[u8]>>,
-    pub code_size: u64,
+    pub code_size: (u64, Option<u64>),
 }
 
 #[derive(Clone, Debug)]
@@ -58,17 +58,17 @@ pub struct FunctionCallPermission {
 #[near]
 impl ProxyContract {
     #[init]
-    pub fn init(context_id: Repr<ContextId>, context_config_account_id: AccountId) -> Self {
+    pub fn init(context_id: Repr<ContextId>) -> Self {
         Self {
             context_id: context_id.rt().expect("Invalid context id"),
-            context_config_account_id,
+            context_config_account_id: env::predecessor_account_id(),
             proposals: IterableMap::new(b"r".to_vec()),
             approvals: IterableMap::new(b"c".to_vec()),
             num_proposals_pk: IterableMap::new(b"k".to_vec()),
             num_approvals: 3,
             active_proposals_limit: 10,
             context_storage: IterableMap::new(b"l"),
-            code_size: env::storage_usage() as u64,
+            code_size: (env::storage_usage(), None),
         }
     }
 

--- a/contracts/proxy-lib/src/lib.rs
+++ b/contracts/proxy-lib/src/lib.rs
@@ -10,7 +10,17 @@ use near_sdk::{env, near, AccountId, PanicOnDefault, PromiseError};
 
 pub mod ext_config;
 mod mutate;
-pub use crate::ext_config::config_contract;
+
+#[cfg(feature = "__internal_explode_size")]
+const _: () = {
+    const __SIZE: usize = 1 << 16; // 64KB
+    const __PAYLOAD: [u8; __SIZE] = [1; __SIZE];
+
+    #[no_mangle]
+    extern "C" fn __internal_explode_size() -> usize {
+        __PAYLOAD.iter().map(|c| (*c as usize) + 1).sum()
+    }
+};
 
 enum MemberAction {
     Approve {
@@ -22,6 +32,7 @@ enum MemberAction {
         num_proposals: u32,
     },
 }
+
 #[near(contract_state)]
 #[derive(PanicOnDefault)]
 pub struct ProxyContract {

--- a/contracts/proxy-lib/src/mutate.rs
+++ b/contracts/proxy-lib/src/mutate.rs
@@ -209,7 +209,7 @@ impl ProxyContract {
         let new_code = env::input().expect("Expected proxy code");
         // Calculate storage before update
         let storage_before = env::storage_usage();
-        
+
         // Deploy the new code and chain the callback
         Promise::new(env::current_account_id())
             .deploy_contract(new_code)
@@ -229,11 +229,12 @@ impl ProxyContract {
                 // Calculate storage difference and refund if needed
                 let storage_after = env::storage_usage();
                 if storage_after < storage_before {
-                    let refund = (storage_before - storage_after) as u128 * env::storage_byte_cost().as_yoctonear();
+                    let refund = (storage_before - storage_after) as u128
+                        * env::storage_byte_cost().as_yoctonear();
                     Promise::new(self.context_config_account_id.clone())
                         .transfer(NearToken::from_yoctonear(refund));
                 }
-                
+
                 env::log_str("Successfully updated proxy contract code");
                 Ok(())
             }

--- a/contracts/proxy-lib/src/mutate.rs
+++ b/contracts/proxy-lib/src/mutate.rs
@@ -233,7 +233,8 @@ impl ProxyContract {
         // Calculate refund based on code size difference only
         let old_code_size = self.code_size;
         if new_code_size < old_code_size {
-            let refund = (old_code_size - new_code_size) as u128 * env::storage_byte_cost().as_yoctonear();
+            let refund =
+                (old_code_size - new_code_size) as u128 * env::storage_byte_cost().as_yoctonear();
             Promise::new(self.context_config_account_id.clone())
                 .transfer(NearToken::from_yoctonear(refund));
         }

--- a/contracts/proxy-lib/src/mutate.rs
+++ b/contracts/proxy-lib/src/mutate.rs
@@ -208,8 +208,6 @@ impl ProxyContract {
 
     #[payable]
     pub fn update_contract(&mut self) -> Promise {
-        env::log_str("suhhh");
-
         require!(
             env::predecessor_account_id() == self.context_config_account_id,
             "Only the context config contract can update the proxy"

--- a/contracts/proxy-lib/src/mutate.rs
+++ b/contracts/proxy-lib/src/mutate.rs
@@ -12,7 +12,8 @@ use near_sdk::{
 };
 
 use super::{parse_input, Proposal, ProxyContract, ProxyContractExt, Signed};
-use crate::{assert_membership, config_contract, MemberAction};
+use crate::ext_config::config_contract;
+use crate::{assert_membership, MemberAction};
 
 #[near]
 impl ProxyContract {

--- a/contracts/proxy-lib/src/mutate.rs
+++ b/contracts/proxy-lib/src/mutate.rs
@@ -234,8 +234,8 @@ impl ProxyContract {
         // Calculate storage difference and refund if needed
         let storage_after = env::storage_usage();
         if storage_after < storage_before {
-            let refund = (storage_before - storage_after) as u128
-                * env::storage_byte_cost().as_yoctonear();
+            let refund =
+                (storage_before - storage_after) as u128 * env::storage_byte_cost().as_yoctonear();
             Promise::new(self.context_config_account_id.clone())
                 .transfer(NearToken::from_yoctonear(refund));
         }

--- a/contracts/proxy-lib/tests/common/config_helper.rs
+++ b/contracts/proxy-lib/tests/common/config_helper.rs
@@ -5,7 +5,6 @@ use ed25519_dalek::{Signer, SigningKey};
 use eyre::Result;
 use near_workspaces::network::Sandbox;
 use near_workspaces::result::ExecutionFinalResult;
-use near_workspaces::types::NearToken;
 use near_workspaces::{Account, Contract, Worker};
 use rand::Rng;
 use serde_json::json;

--- a/contracts/proxy-lib/tests/common/config_helper.rs
+++ b/contracts/proxy-lib/tests/common/config_helper.rs
@@ -87,7 +87,6 @@ impl ConfigContractHelper {
         let res = caller
             .call(self.config_contract.id(), "mutate")
             .args_json(&signed_request)
-            .deposit(NearToken::from_near(20))
             .max_gas()
             .transact()
             .await?;
@@ -135,7 +134,6 @@ impl ConfigContractHelper {
         let res = caller
             .call(self.config_contract.id(), "mutate")
             .args_json(request)
-            .deposit(NearToken::from_near(20))
             .max_gas()
             .transact()
             .await?;

--- a/contracts/proxy-lib/tests/common/config_helper.rs
+++ b/contracts/proxy-lib/tests/common/config_helper.rs
@@ -4,7 +4,7 @@ use calimero_context_config::{ContextRequest, ContextRequestKind, Request, Reque
 use ed25519_dalek::{Signer, SigningKey};
 use eyre::Result;
 use near_workspaces::network::Sandbox;
-use near_workspaces::result::ExecutionFinalResult;
+use near_workspaces::result::{ExecutionResult, Value};
 use near_workspaces::{Account, Contract, Worker};
 use rand::Rng;
 use serde_json::json;
@@ -29,7 +29,7 @@ impl ConfigContractHelper {
         caller: &Account,
         context: &SigningKey,
         author: &SigningKey,
-    ) -> Result<ExecutionFinalResult> {
+    ) -> Result<ExecutionResult<Value>> {
         let mut rng = rand::thread_rng();
 
         let application_id = rng.gen::<[_; 32]>().rt()?;
@@ -58,7 +58,9 @@ impl ConfigContractHelper {
             },
             |p| context.sign(p),
         )?;
+
         let res = self.mutate_call(&caller, &signed_request).await?;
+
         Ok(res)
     }
 
@@ -67,7 +69,7 @@ impl ConfigContractHelper {
         caller: &Account,
         context_id: &SigningKey,
         host: &SigningKey,
-    ) -> Result<ExecutionFinalResult> {
+    ) -> Result<ExecutionResult<Value>> {
         let context_id: Repr<ContextId> = Repr::new(context_id.verifying_key().rt()?);
         let host_id: SignerId = host.verifying_key().rt()?;
 
@@ -83,14 +85,8 @@ impl ConfigContractHelper {
             |p| host.sign(p),
         )?;
 
-        let res = caller
-            .call(self.config_contract.id(), "mutate")
-            .args_json(&signed_request)
-            .max_gas()
-            .transact()
-            .await?;
+        let res = self.mutate_call(caller, &signed_request).await?;
 
-        // Uncomment to print the result
         Ok(res)
     }
 
@@ -100,7 +96,7 @@ impl ConfigContractHelper {
         host: &SigningKey,
         guests: &[SigningKey],
         context: &SigningKey,
-    ) -> Result<ExecutionFinalResult> {
+    ) -> Result<ExecutionResult<Value>> {
         let guest_ids: Vec<Repr<ContextIdentity>> = guests
             .iter()
             .map(|x| Repr::new(x.verifying_key().rt().unwrap()))
@@ -122,6 +118,7 @@ impl ConfigContractHelper {
         )?;
 
         let res = self.mutate_call(caller, &signed_request).await?;
+
         Ok(res)
     }
 
@@ -129,13 +126,15 @@ impl ConfigContractHelper {
         &'a self,
         caller: &'a Account,
         request: &'a Signed<Request<'a>>,
-    ) -> Result<ExecutionFinalResult> {
+    ) -> Result<ExecutionResult<Value>> {
         let res = caller
             .call(self.config_contract.id(), "mutate")
             .args_json(request)
             .max_gas()
             .transact()
-            .await?;
+            .await?
+            .into_result()?;
+
         Ok(res)
     }
 
@@ -143,12 +142,13 @@ impl ConfigContractHelper {
         &'a self,
         caller: &'a Account,
         context_id: &Repr<ContextId>,
-    ) -> eyre::Result<Option<String>> {
+    ) -> eyre::Result<String> {
         let res = caller
             .view(self.config_contract.id(), "proxy_contract")
             .args_json(json!({ "context_id": context_id }))
             .await?
             .json()?;
+
         Ok(res)
     }
 }

--- a/contracts/proxy-lib/tests/common/proxy_lib_helper.rs
+++ b/contracts/proxy-lib/tests/common/proxy_lib_helper.rs
@@ -6,7 +6,7 @@ use calimero_context_config::{
 use ed25519_dalek::{Signer, SigningKey};
 use near_sdk::AccountId;
 use near_workspaces::result::{ExecutionFinalResult, ViewResultDetails};
-use near_workspaces::{Account, Contract};
+use near_workspaces::Account;
 use serde_json::json;
 
 pub const PROXY_CONTRACT_WASM: &str = "./res/proxy_lib.wasm";

--- a/contracts/proxy-lib/tests/common/proxy_lib_helper.rs
+++ b/contracts/proxy-lib/tests/common/proxy_lib_helper.rs
@@ -63,7 +63,7 @@ impl ProxyContractHelper {
     ) -> eyre::Result<ExecutionFinalResult> {
         let call = caller
             .call(&self.proxy_contract, "mutate")
-            .args_json(json!(request))
+            .args_json(request)
             .max_gas()
             .transact()
             .await?;

--- a/contracts/proxy-lib/tests/common/proxy_lib_helper.rs
+++ b/contracts/proxy-lib/tests/common/proxy_lib_helper.rs
@@ -1,11 +1,11 @@
-use calimero_context_config::repr::{Repr, ReprTransmute};
-use calimero_context_config::types::{ContextId, Signed};
+use calimero_context_config::repr::ReprTransmute;
+use calimero_context_config::types::Signed;
 use calimero_context_config::{
     Proposal, ProposalAction, ProposalApprovalWithSigner, ProposalId, ProxyMutateRequest,
 };
 use ed25519_dalek::{Signer, SigningKey};
 use near_sdk::AccountId;
-use near_workspaces::result::{ExecutionFinalResult, ViewResultDetails};
+use near_workspaces::result::{ExecutionResult, Value, ViewResultDetails};
 use near_workspaces::Account;
 use serde_json::json;
 
@@ -13,30 +13,11 @@ pub const PROXY_CONTRACT_WASM: &str = "./res/proxy_lib.wasm";
 
 pub struct ProxyContractHelper {
     pub proxy_contract: AccountId,
-    config_contract: AccountId,
 }
 
 impl ProxyContractHelper {
-    pub fn new(proxy_contract: AccountId, config_contract: AccountId) -> eyre::Result<Self> {
-        Ok(Self {
-            proxy_contract,
-            config_contract,
-        })
-    }
-
-    pub async fn initialize(
-        &self,
-        caller: &Account,
-        context_id: &Repr<ContextId>,
-    ) -> eyre::Result<ExecutionFinalResult, near_workspaces::error::Error> {
-        caller
-            .call(&self.proxy_contract, "init")
-            .args_json(json!({
-                "context_id": context_id,
-                "context_config_account_id": self.config_contract,
-            }))
-            .transact()
-            .await
+    pub fn new(proxy_contract: AccountId) -> eyre::Result<Self> {
+        Ok(Self { proxy_contract })
     }
 
     pub fn create_proposal_request(
@@ -60,13 +41,15 @@ impl ProxyContractHelper {
         &self,
         caller: &Account,
         request: &Signed<ProxyMutateRequest>,
-    ) -> eyre::Result<ExecutionFinalResult> {
+    ) -> eyre::Result<ExecutionResult<Value>> {
         let call = caller
             .call(&self.proxy_contract, "mutate")
             .args_json(request)
             .max_gas()
             .transact()
-            .await?;
+            .await?
+            .into_result()?;
+
         Ok(call)
     }
 
@@ -75,7 +58,7 @@ impl ProxyContractHelper {
         caller: &Account,
         signer: &SigningKey,
         proposal_id: &ProposalId,
-    ) -> eyre::Result<ExecutionFinalResult> {
+    ) -> eyre::Result<ExecutionResult<Value>> {
         let signer_id = signer
             .verifying_key()
             .to_bytes()
@@ -95,7 +78,8 @@ impl ProxyContractHelper {
             .args_json(signed_request)
             .max_gas()
             .transact()
-            .await?;
+            .await?
+            .into_result()?;
         Ok(res)
     }
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -53,12 +53,6 @@ async fn setup_test(
 
     let proxy_id: AccountId = contract_id_str.parse()?;
 
-    drop(
-        relayer_account
-            .transfer_near(&proxy_id, near_workspaces::types::NearToken::from_near(5))
-            .await,
-    );
-
     let proxy_helper =
         ProxyContractHelper::new(proxy_id, config_helper.config_contract.id().clone())?;
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -29,7 +29,7 @@ async fn setup_test(
     let bytes = fs::read(common::proxy_lib_helper::PROXY_CONTRACT_WASM)?;
     let alice_sk: SigningKey = common::generate_keypair()?;
     let context_sk = common::generate_keypair()?;
-    let relayer_account = common::create_account_with_balance(&worker, "account", 100).await?;
+    let relayer_account = common::create_account_with_balance(&worker, "account", 1000).await?;
 
     let _test = config_helper
         .config_contract
@@ -52,6 +52,10 @@ async fn setup_test(
         .expect("Contract not found");
 
     let proxy_id: AccountId = contract_id_str.parse()?;
+
+    drop(relayer_account.transfer_near(&proxy_id, near_workspaces::types::NearToken::from_near(5))
+        .await);
+
     let proxy_helper =
         ProxyContractHelper::new(proxy_id, config_helper.config_contract.id().clone())?;
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -496,7 +496,8 @@ async fn test_transfer() -> Result<()> {
             &proxy_helper.proxy_contract,
             near_workspaces::types::NearToken::from_near(5),
         )
-        .await?.into_result();
+        .await?
+        .into_result();
 
     let recipient = create_account_with_balance(&worker, "new_account", 0).await?;
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -496,7 +496,7 @@ async fn test_transfer() -> Result<()> {
             &proxy_helper.proxy_contract,
             near_workspaces::types::NearToken::from_near(5),
         )
-        .await?;
+        .await?.into_result();
 
     let recipient = create_account_with_balance(&worker, "new_account", 0).await?;
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -42,26 +42,16 @@ async fn setup_test(
 
     let _res = config_helper
         .add_context_to_config(&relayer_account, &context_sk, &alice_sk)
-        .await?
-        .into_result()?;
+        .await?;
 
     let context_id: Repr<ContextId> = Repr::new(context_sk.verifying_key().rt()?);
     let contract_id_str = config_helper
         .get_proxy_contract(&relayer_account, &context_id)
-        .await?
-        .expect("Contract not found");
+        .await?;
 
     let proxy_id: AccountId = contract_id_str.parse()?;
 
-    let proxy_helper =
-        ProxyContractHelper::new(proxy_id, config_helper.config_contract.id().clone())?;
-
-    // This account is only used to deploy the proxy contract
-    let developer_account = common::create_account_with_balance(&worker, "alice", 10).await?;
-
-    let _res = proxy_helper
-        .initialize(&developer_account, &context_sk.verifying_key().rt()?)
-        .await;
+    let proxy_helper = ProxyContractHelper::new(proxy_id)?;
 
     Ok((
         config_helper,
@@ -75,14 +65,14 @@ async fn setup_test(
 #[tokio::test]
 async fn update_proxy_code() -> Result<()> {
     let worker = near_workspaces::sandbox().await?;
+
     let (config_helper, _proxy_helper, relayer_account, context_sk, alice_sk) =
         setup_test(&worker).await?;
 
     // Call the update function
     let res = config_helper
         .update_proxy_contract(&relayer_account, &context_sk, &alice_sk)
-        .await?
-        .into_result()?;
+        .await?;
 
     // Check the result
     assert!(
@@ -107,7 +97,6 @@ async fn test_create_proposal() -> Result<()> {
     let res: Option<ProposalWithApprovals> = proxy_helper
         .proxy_mutate(&relayer_account, &proposal)
         .await?
-        .into_result()?
         .json()?;
 
     match res {
@@ -135,8 +124,7 @@ async fn test_view_proposal() -> Result<()> {
 
     let _res = proxy_helper
         .proxy_mutate(&relayer_account, &proposal)
-        .await?
-        .into_result()?;
+        .await?;
 
     let view_proposal: Option<Proposal> = proxy_helper
         .view_proposal(&relayer_account, &proposal_id)
@@ -167,13 +155,9 @@ async fn test_create_proposal_with_existing_id() -> Result<()> {
 
     let _res = proxy_helper
         .proxy_mutate(&relayer_account, &proposal)
-        .await?
-        .into_result();
+        .await?;
 
-    let res = proxy_helper
-        .proxy_mutate(&relayer_account, &proposal)
-        .await?
-        .into_result();
+    let res = proxy_helper.proxy_mutate(&relayer_account, &proposal).await;
 
     let error = res.expect_err("Expected an error from the contract");
     assert!(error.to_string().contains("Proposal already exists"));
@@ -192,10 +176,7 @@ async fn test_create_proposal_by_non_member() -> Result<()> {
     let proposal_id = rand::thread_rng().gen();
     let proposal = proxy_helper.create_proposal_request(&proposal_id, &bob_sk, &vec![])?;
 
-    let res = proxy_helper
-        .proxy_mutate(&relayer_account, &proposal)
-        .await?
-        .into_result();
+    let res = proxy_helper.proxy_mutate(&relayer_account, &proposal).await;
 
     let error = res.expect_err("Expected an error from the contract");
     assert!(error.to_string().contains("Is not a member"));
@@ -227,7 +208,6 @@ async fn test_create_multiple_proposals() -> Result<()> {
     let res: ProposalWithApprovals = proxy_helper
         .proxy_mutate(&relayer_account, &proposal_1)
         .await?
-        .into_result()?
         .json()?;
 
     assert_eq!(res.proposal_id, proposal_1_id);
@@ -236,7 +216,6 @@ async fn test_create_multiple_proposals() -> Result<()> {
     let res: ProposalWithApprovals = proxy_helper
         .proxy_mutate(&relayer_account, &proposal_2)
         .await?
-        .into_result()?
         .json()?;
 
     assert_eq!(res.proposal_id, proposal_2_id);
@@ -256,8 +235,7 @@ async fn test_create_proposal_and_approve_by_member() -> Result<()> {
     let bob_sk: SigningKey = common::generate_keypair()?;
     let _res = config_helper
         .add_members(&relayer_account, &alice_sk, &[bob_sk.clone()], &context_sk)
-        .await?
-        .into_result()?;
+        .await?;
 
     let proposal_id = rand::thread_rng().gen();
     let proposal = proxy_helper.create_proposal_request(&proposal_id, &alice_sk, &vec![])?;
@@ -265,13 +243,11 @@ async fn test_create_proposal_and_approve_by_member() -> Result<()> {
     let res: ProposalWithApprovals = proxy_helper
         .proxy_mutate(&relayer_account, &proposal)
         .await?
-        .into_result()?
         .json()?;
 
     let res2: ProposalWithApprovals = proxy_helper
         .approve_proposal(&relayer_account, &bob_sk, &res.proposal_id)
         .await?
-        .into_result()?
         .json()?;
 
     assert_eq!(res2.proposal_id, proposal_id);
@@ -296,13 +272,11 @@ async fn test_create_proposal_and_approve_by_non_member() -> Result<()> {
     let res: ProposalWithApprovals = proxy_helper
         .proxy_mutate(&relayer_account, &proposal)
         .await?
-        .into_result()?
         .json()?;
 
     let res2 = proxy_helper
         .approve_proposal(&relayer_account, &bob_sk, &res.proposal_id)
-        .await?
-        .into_result();
+        .await;
 
     let error = res2.expect_err("Expected an error from the contract");
     assert!(error.to_string().contains("Is not a member"));
@@ -332,8 +306,7 @@ async fn setup_action_test(
             &[bob_sk.clone(), charlie_sk.clone()],
             &context_sk,
         )
-        .await?
-        .into_result()?;
+        .await?;
 
     let members = vec![alice_sk, bob_sk, charlie_sk];
     Ok((proxy_helper, relayer_account, members))
@@ -351,7 +324,6 @@ async fn create_and_approve_proposal(
     let res: ProposalWithApprovals = proxy_helper
         .proxy_mutate(&relayer_account, &proposal)
         .await?
-        .into_result()?
         .json()?;
 
     assert_eq!(res.num_approvals, 1);
@@ -360,7 +332,6 @@ async fn create_and_approve_proposal(
     let res: ProposalWithApprovals = proxy_helper
         .approve_proposal(&relayer_account, &members[1], &res.proposal_id)
         .await?
-        .into_result()?
         .json()?;
 
     assert_eq!(res.num_approvals, 2, "Proposal should have 2 approvals");
@@ -368,7 +339,6 @@ async fn create_and_approve_proposal(
     let res: Option<ProposalWithApprovals> = proxy_helper
         .approve_proposal(&relayer_account, &members[2], &res.proposal_id)
         .await?
-        .into_result()?
         .json()?;
 
     assert!(
@@ -399,8 +369,8 @@ async fn test_execute_proposal() -> Result<()> {
         deposit: 0,
         gas: 1_000_000_000_000,
     }];
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let counter_value: u32 = counter_helper.get_value().await?;
     assert_eq!(
@@ -424,8 +394,8 @@ async fn test_action_change_active_proposals_limit() -> Result<()> {
     let actions = vec![ProposalAction::SetActiveProposalsLimit {
         active_proposals_limit: 6,
     }];
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let new_active_proposals_limit: u32 = proxy_helper
         .view_active_proposals_limit(&relayer_account)
@@ -444,8 +414,8 @@ async fn test_action_change_number_of_approvals() -> Result<()> {
     assert_eq!(default_new_num_approvals, 3);
 
     let actions = vec![ProposalAction::SetNumApprovals { num_approvals: 2 }];
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let new_num_approvals: u32 = proxy_helper.view_num_approvals(&relayer_account).await?;
     assert_eq!(new_num_approvals, 2);
@@ -470,8 +440,8 @@ async fn test_mutate_storage_value() -> Result<()> {
         key: key_data.clone(),
         value: value_data.clone(),
     }];
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let storage_value: Box<[u8]> = proxy_helper
         .view_context_value(&relayer_account, key_data.clone())
@@ -490,14 +460,14 @@ async fn test_transfer() -> Result<()> {
     let worker = near_workspaces::sandbox().await?;
     let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
 
-    let _res = &worker
+    let _res = worker
         .root_account()?
         .transfer_near(
             &proxy_helper.proxy_contract,
             near_workspaces::types::NearToken::from_near(5),
         )
         .await?
-        .into_result();
+        .into_result()?;
 
     let recipient = create_account_with_balance(&worker, "new_account", 0).await?;
 
@@ -511,8 +481,8 @@ async fn test_transfer() -> Result<()> {
         receiver_id: recipient.id().to_string(),
         amount: 5,
     }];
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let recipient_balance = recipient.view_account().await?.balance;
     assert_eq!(
@@ -554,8 +524,7 @@ async fn test_combined_proposals() -> Result<()> {
         },
     ];
 
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let updated_counter_value: u32 = counter_helper.get_value().await?;
     assert_eq!(
@@ -602,8 +571,7 @@ async fn test_combined_proposal_actions_with_promise_failure() -> Result<()> {
         },
     ];
 
-    let _res =
-        create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await;
+    create_and_approve_proposal(&proxy_helper, &relayer_account, &actions, members).await?;
 
     let active_proposals_limit: u32 = proxy_helper
         .view_active_proposals_limit(&relayer_account)
@@ -641,13 +609,15 @@ async fn test_view_proposals() -> Result<()> {
     let proposal3 =
         proxy_helper.create_proposal_request(&proposal3_id, &alice_sk, &proposal3_actions)?;
 
-    let _ = proxy_helper
+    let _res = proxy_helper
         .proxy_mutate(&relayer_account, &proposal1)
         .await?;
-    let _ = proxy_helper
+
+    let _res = proxy_helper
         .proxy_mutate(&relayer_account, &proposal2)
         .await?;
-    let _ = proxy_helper
+
+    let _res = proxy_helper
         .proxy_mutate(&relayer_account, &proposal3)
         .await?;
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -53,8 +53,11 @@ async fn setup_test(
 
     let proxy_id: AccountId = contract_id_str.parse()?;
 
-    drop(relayer_account.transfer_near(&proxy_id, near_workspaces::types::NearToken::from_near(5))
-        .await);
+    drop(
+        relayer_account
+            .transfer_near(&proxy_id, near_workspaces::types::NearToken::from_near(5))
+            .await,
+    );
 
     let proxy_helper =
         ProxyContractHelper::new(proxy_id, config_helper.config_contract.id().clone())?;

--- a/crates/context/config/src/client/protocol/near.rs
+++ b/crates/context/config/src/client/protocol/near.rs
@@ -273,7 +273,7 @@ impl Network {
                 method_name: method,
                 args,
                 gas: 300_000_000_000_000,
-                deposit: 5_000_000_000_000_000_000_000_000,
+                deposit: 0,
             }))],
         });
 

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -178,7 +178,7 @@ pub struct Proposal {
     pub actions: Vec<ProposalAction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Copy)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProposalApprovalWithSigner {
     pub proposal_id: ProposalId,
@@ -186,7 +186,7 @@ pub struct ProposalApprovalWithSigner {
     pub added_timestamp: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "scope", content = "params")]
 #[serde(deny_unknown_fields)]
 #[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -186,7 +186,7 @@ pub struct ProposalApprovalWithSigner {
     pub added_timestamp: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "scope", content = "params")]
 #[serde(deny_unknown_fields)]
 #[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -178,7 +178,7 @@ pub struct Proposal {
     pub actions: Vec<ProposalAction>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProposalApprovalWithSigner {
     pub proposal_id: ProposalId,


### PR DESCRIPTION
## Resolved comments from [PR#943](https://github.com/calimero-network/core/pull/943)

### Changed logic in the process of creating a subaccount responsible for Proxy Contract:
- Now we are deriving subaccount from Context contract account and because of that we don't need to deposit anything in mutate method when calling Context contract
- Gas needed for deploying the contract is now determined by the size of Proxy contract, Proxy contract init arguments and minimum required funds for generating and seeding accounts instead of being static
- Unused gas is returned to Context contract account
- Optimized tests in Context config to reflect new process

### Fixed return types for callbacks
- Using `#[callback_result]` for callback functions

- Fixed minor issues with code such us double json encoding, duplicates in tests, taking references, async functions declarations
