### PR TITLE
fix: stack size VM limits

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -549,20 +549,19 @@ impl Node {
 // TODO: move this into the config
 // TODO: also this would be nice to have global default with per application customization
 fn get_runtime_limits() -> EyreResult<VMLimits> {
-    Ok(VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/
-        (10 << 20).try_into()?, // 10 MiB
-                                // can_write: writes, // todo!
-    ))
+    Ok(calimero_runtime::logic::VMLimits {
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_stack_size: 200 << 10, // 200 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,               // 16 KiB
+        max_storage_key_size: (1 << 20).try_into()?, // 1 MiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+                                                     // can_write: writes, // todo!
+    })
 }

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -53,20 +53,20 @@ fn main() -> EyreResult<()> {
 
     let mut storage = InMemoryStorage::default();
 
-    let limits = VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
-    );
+    let limits = VMLimits {
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_stack_size: 200 << 10, // 200 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,                  // 16 KiB
+        max_storage_key_size: (1 << 20).try_into()?,    // 1 MiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+    };
 
     let mut execute = |name: &str, payload: Option<Value>| -> EyreResult<()> {
         println!("{}", "--".repeat(20).dimmed());

--- a/crates/runtime/examples/fetch.rs
+++ b/crates/runtime/examples/fetch.rs
@@ -28,20 +28,20 @@ fn main() -> EyreResult<()> {
 
     let mut storage = InMemoryStorage::default();
 
-    let limits = VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
-    );
+    let limits = VMLimits {
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_stack_size: 200 << 10, // 200 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,                  // 16 KiB
+        max_storage_key_size: (1 << 20).try_into()?,    // 1 MiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+    };
 
     let cx = VMContext::new(
         to_json_vec(&json!({

--- a/crates/runtime/examples/rps.rs
+++ b/crates/runtime/examples/rps.rs
@@ -67,20 +67,20 @@ fn main() -> EyreResult<()> {
 
     let mut storage = InMemoryStorage::default();
 
-    let limits = VMLimits::new(
-        /*max_stack_size:*/ 200 << 10, // 200 KiB
-        /*max_memory_pages:*/ 1 << 10, // 1 KiB
-        /*max_registers:*/ 100,
-        /*max_register_size:*/ (100 << 20).validate()?, // 100 MiB
-        /*max_registers_capacity:*/ 1 << 30, // 1 GiB
-        /*max_logs:*/ 100,
-        /*max_log_size:*/ 16 << 10, // 16 KiB
-        /*max_events:*/ 100,
-        /*max_event_kind_size:*/ 100,
-        /*max_event_data_size:*/ 16 << 10, // 16 KiB
-        /*max_storage_key_size:*/ (1 << 20).try_into()?, // 1 MiB
-        /*max_storage_value_size:*/ (10 << 20).try_into()?, // 10 MiB
-    );
+    let limits = VMLimits {
+        max_memory_pages: 1 << 10, // 1 KiB
+        max_stack_size: 200 << 10, // 200 KiB
+        max_registers: 100,
+        max_register_size: (100 << 20).validate()?, // 100 MiB
+        max_registers_capacity: 1 << 30,            // 1 GiB
+        max_logs: 100,
+        max_log_size: 16 << 10, // 16 KiB
+        max_events: 100,
+        max_event_kind_size: 100,
+        max_event_data_size: 16 << 10,                  // 16 KiB
+        max_storage_key_size: (1 << 20).try_into()?,    // 1 MiB
+        max_storage_value_size: (10 << 20).try_into()?, // 10 MiB
+    };
 
     println!("{}", "--".repeat(20).dimmed());
     println!("{:>35}", "First, we create a keypair for Joe".bold());

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -44,7 +44,6 @@ impl VMContext {
 }
 
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct VMLimits {
     pub max_memory_pages: u32,
     pub max_stack_size: usize,
@@ -62,40 +61,6 @@ pub struct VMLimits {
     pub max_storage_value_size: NonZeroU64,
     // pub max_execution_time: u64,
     // number of functions per contract
-}
-
-impl VMLimits {
-    #[expect(clippy::too_many_arguments, reason = "Acceptable here")]
-    #[must_use]
-    pub const fn new(
-        max_memory_pages: u32,
-        max_stack_size: usize,
-        max_registers: u64,
-        max_register_size: Constrained<u64, MaxU64<{ u64::MAX - 1 }>>,
-        max_registers_capacity: u64,
-        max_logs: u64,
-        max_log_size: u64,
-        max_events: u64,
-        max_event_kind_size: u64,
-        max_event_data_size: u64,
-        max_storage_key_size: NonZeroU64,
-        max_storage_value_size: NonZeroU64,
-    ) -> Self {
-        Self {
-            max_memory_pages,
-            max_stack_size,
-            max_registers,
-            max_register_size,
-            max_registers_capacity,
-            max_logs,
-            max_log_size,
-            max_events,
-            max_event_kind_size,
-            max_event_data_size,
-            max_storage_key_size,
-            max_storage_value_size,
-        }
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
#630 unintentionally swapped the values for `max_storage_pages` and `max_stack_size`.

Losing semantic information was a bad idea, and constructor functions for structs with all fields public are non-beneficial. Functions with many arguments, also a bad idea.

This seemingly subtle change led to a stack overflow on an intel machine, but not on M1 Pro for some reason, worth investigating later. As it's part of why it wasn't caught earlier.