### PR TITLE
fix: prevent external mutation on execution failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         uses: easimon/maximize-build-space@v10
         with:
           build-mount-path: ${{ env.STAGE_DIR }}
-          root-reserve-mb: 4096
+          root-reserve-mb: 8192
 
       - name: Relocate environment
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,6 @@ dependencies = [
  "borsh",
  "calimero-blobstore",
  "calimero-context",
- "calimero-context-config",
  "calimero-crypto",
  "calimero-network",
  "calimero-node-primitives",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -29,7 +29,6 @@ calimero-primitives = { path = "../primitives", features = ["borsh"] }
 calimero-runtime = { path = "../runtime" }
 calimero-server = { path = "../server", features = ["jsonrpc", "websocket", "admin"] }
 calimero-store = { path = "../store", features = ["datatypes"] }
-calimero-context-config = { path = "../context/config" }
 
 [lints]
 workspace = true

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -14,7 +14,6 @@ use calimero_blobstore::config::BlobStoreConfig;
 use calimero_blobstore::{BlobManager, FileSystem};
 use calimero_context::config::ContextConfig;
 use calimero_context::ContextManager;
-use calimero_context_config::ProposalAction;
 use calimero_crypto::SharedKey;
 use calimero_network::client::NetworkClient;
 use calimero_network::config::NetworkConfig;
@@ -466,7 +465,7 @@ impl Node {
         }
 
         for (proposal_id, actions) in &outcome.proposals {
-            let actions: Vec<ProposalAction> = from_slice(actions).map_err(|e| {
+            let actions = from_slice(actions).map_err(|e| {
                 error!(%e, "Failed to deserialize proposal actions.");
                 CallError::InternalError
             })?;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -461,8 +461,12 @@ impl Node {
             });
         };
 
+        if outcome.returns.is_err() {
+            return Ok(outcome);
+        }
+
         for (proposal_id, actions) in &outcome.proposals {
-            let actions: Vec<ProposalAction> = from_slice(&actions).map_err(|e| {
+            let actions: Vec<ProposalAction> = from_slice(actions).map_err(|e| {
                 error!(%e, "Failed to deserialize proposal actions.");
                 CallError::InternalError
             })?;
@@ -472,7 +476,7 @@ impl Node {
                     context_id,
                     executor_public_key,
                     proposal_id.clone(),
-                    actions.clone(),
+                    actions,
                 )
                 .await
                 .map_err(|e| {


### PR DESCRIPTION
Failed transactions should not;

1. Apply their changes to storage
2. Broadcast a state delta
3. Have any effect on external systems (blockchain)