### PR TITLE
fix: state sync

### DIFF
--- a/apps/kv-store/src/__private.rs
+++ b/apps/kv-store/src/__private.rs
@@ -1,7 +1,6 @@
-use calimero_sdk::borsh::{from_slice, to_vec};
+use calimero_sdk::borsh::from_slice;
 use calimero_sdk::{app, env};
-use calimero_storage::collections::unordered_map::{Entry, UnorderedMap};
-use calimero_storage::entities::Data;
+use calimero_storage::address::Id;
 use calimero_storage::integration::Comparison;
 use calimero_storage::interface::{Action, Interface, StorageError};
 use calimero_storage::sync::{self, SyncArtifact};
@@ -16,66 +15,36 @@ impl KvStore {
         let artifact =
             from_slice::<SyncArtifact>(&args).map_err(StorageError::DeserializationError)?;
 
-        let this = Interface::root::<Self>()?;
-
         match artifact {
             SyncArtifact::Actions(actions) => {
                 for action in actions {
                     let _ignored = match action {
-                        Action::Add { type_id, .. } | Action::Update { type_id, .. } => {
-                            match type_id {
-                                1 => Interface::apply_action::<KvStore>(action)?,
-                                254 => Interface::apply_action::<Entry<String, String>>(action)?,
-                                255 => {
-                                    Interface::apply_action::<UnorderedMap<String, String>>(action)?
-                                }
-                                _ => return Err(StorageError::UnknownType(type_id)),
-                            }
+                        Action::Compare { id } => {
+                            sync::push_comparison(Comparison {
+                                data: Interface::find_by_id_raw(id)?,
+                                comparison_data: Interface::generate_comparison_data(Some(id))?,
+                            });
                         }
-                        Action::Delete { .. } => {
-                            todo!("how are we supposed to identify the entity to delete???????")
-                        }
-                        Action::Compare { .. } => {
-                            todo!("how are we supposed to compare when `Comparison` needs `type_id`???????")
+                        Action::Add { .. } | Action::Update { .. } | Action::Delete { .. } => {
+                            Interface::apply_action(action)?;
                         }
                     };
-                }
-
-                if let Some(this) = this {
-                    return Interface::commit_root(this);
                 }
             }
             SyncArtifact::Comparisons(comparisons) => {
                 if comparisons.is_empty() {
                     sync::push_comparison(Comparison {
-                        type_id: <Self as Data>::type_id(),
-                        data: this
-                            .as_ref()
-                            .map(to_vec)
-                            .transpose()
-                            .map_err(StorageError::SerializationError)?,
-                        comparison_data: Interface::generate_comparison_data(this.as_ref())?,
+                        data: Interface::find_by_id_raw(Id::root())?,
+                        comparison_data: Interface::generate_comparison_data(None)?,
                     });
                 }
 
                 for Comparison {
-                    type_id,
                     data,
                     comparison_data,
                 } in comparisons
                 {
-                    match type_id {
-                        1 => Interface::compare_affective::<KvStore>(data, comparison_data)?,
-                        254 => Interface::compare_affective::<Entry<String, String>>(
-                            data,
-                            comparison_data,
-                        )?,
-                        255 => Interface::compare_affective::<UnorderedMap<String, String>>(
-                            data,
-                            comparison_data,
-                        )?,
-                        _ => return Err(StorageError::UnknownType(type_id)),
-                    };
+                    Interface::compare_affective(data, comparison_data)?;
                 }
             }
         }

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -2,22 +2,18 @@
 
 use std::collections::BTreeMap;
 
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::types::Error;
 use calimero_sdk::{app, env};
 use calimero_storage::collections::UnorderedMap;
-use calimero_storage::entities::Element;
-use calimero_storage::AtomicUnit;
 
 mod __private;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(AtomicUnit, Clone, Debug, PartialEq, PartialOrd)]
-#[root]
-#[type_id(1)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
 pub struct KvStore {
     items: UnorderedMap<String, String>,
-    #[storage]
-    storage: Element,
 }
 
 #[app::event]
@@ -33,8 +29,7 @@ impl KvStore {
     #[app::init]
     pub fn init() -> KvStore {
         KvStore {
-            items: UnorderedMap::new().unwrap(),
-            storage: Element::root(),
+            items: UnorderedMap::new(),
         }
     }
 
@@ -93,7 +88,10 @@ impl KvStore {
 
         app::emit!(Event::Removed { key });
 
-        self.items.remove(key).map_err(Into::into)
+        self.items
+            .remove(key)
+            .map(|v| v.is_some())
+            .map_err(Into::into)
     }
 
     pub fn clear(&mut self) -> Result<(), Error> {

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::{quote, quote_spanned, ToTokens};
+use syn::spanned::Spanned;
 use syn::{Error as SynError, GenericParam, Ident, ImplItemFn, Path, ReturnType, Visibility};
 
 use crate::errors::{Errors, ParseError};
@@ -61,12 +62,14 @@ impl ToTokens for PublicLogicMethod<'_> {
 
             let input_lifetime = if self.has_refs {
                 let lifetime = lifetimes::input();
-                quote! { <#lifetime> }
+                quote_spanned! { name.span()=>
+                    <#lifetime>
+                }
             } else {
                 quote! {}
             };
 
-            quote! {
+            quote_spanned! {name.span()=>
                 #[derive(::calimero_sdk::serde::Deserialize)]
                 #[serde(crate = "::calimero_sdk::serde")]
                 struct #input_ident #input_lifetime {
@@ -94,38 +97,41 @@ impl ToTokens for PublicLogicMethod<'_> {
         let (def, mut call) = match &self.self_type {
             Some(type_) => (
                 {
-                    let mutability = match type_ {
-                        SelfType::Mutable(_) => Some(quote! {mut}),
-                        SelfType::Owned(_) | SelfType::Immutable(_) => None,
+                    let (mutability, ty) = match type_ {
+                        SelfType::Mutable(ty) => (Some(quote! {mut}), ty),
+                        SelfType::Owned(ty) | SelfType::Immutable(ty) => (None, ty),
                     };
-                    quote! {
-                        let Some(#mutability app) = ::calimero_storage::interface::Interface::root::<#self_>().ok().flatten()
+                    quote_spanned! {ty.span()=>
+                        let Some(#mutability app) = ::calimero_storage::collections::Root::<#self_>::fetch()
                         else {
                             ::calimero_sdk::env::panic_str("Failed to find or read app state")
                         };
                     }
                 },
-                quote! { app.#name(#(#arg_idents),*); },
+                quote_spanned! {name.span()=>
+                    app.#name(#(#arg_idents),*)
+                },
             ),
             None => (
                 if init_method {
-                    quote! {
-                        if let Some(mut app) = ::calimero_storage::interface::Interface::root::<#self_>().ok().flatten() {
+                    quote_spanned! {name.span()=>
+                        if let Some(mut app) = ::calimero_storage::collections::Root::<#self_>::fetch() {
                             ::calimero_sdk::env::panic_str("Cannot initialize over already existing state.")
                         };
 
-                        let mut app: #self_ =
+                        let mut app =
                     }
                 } else {
                     quote! {}
                 },
-                quote! { <#self_>::#name(#(#arg_idents),*); },
+                quote_spanned! {name.span()=>
+                    <#self_>::#name(#(#arg_idents),*)
+                },
             ),
         };
 
-        if let (Some(_), false) = (&self.ret, init_method) {
-            //only when it's not init
-            call = quote! {
+        if let (Some(ret), false) = (&self.ret, init_method) {
+            call = quote_spanned! {ret.ty.span()=>
                 let output = #call;
                 let output = {
                     #[expect(unused_imports)]
@@ -140,22 +146,24 @@ impl ToTokens for PublicLogicMethod<'_> {
                         ),
                     }
                 };
-                ::calimero_sdk::env::value_return(&output);
-            };
+                ::calimero_sdk::env::value_return(&output)
+            }
         }
 
         let state_finalizer = match (&self.self_type, init_method) {
             (Some(SelfType::Mutable(_)), _) | (_, true) => quote! {
-                if let Err(_) = ::calimero_storage::interface::Interface::commit_root(app) {
-                    ::calimero_sdk::env::panic_str("Failed to commit app state")
-                }
+                app.commit();
             },
             _ => quote! {},
         };
 
         // todo! when generics are present, strip them
         let init_impl = if init_method {
-            quote! {
+            call = quote_spanned! {name.span()=>
+                ::calimero_storage::collections::Root::new(|| #call)
+            };
+
+            quote_spanned! {name.span()=>
                 impl ::calimero_sdk::state::AppStateInit for #self_ {
                     type Return = #ret;
                 }
@@ -164,7 +172,7 @@ impl ToTokens for PublicLogicMethod<'_> {
             quote! {}
         };
 
-        quote! {
+        quote_spanned! {name.span()=>
             #[cfg(target_arch = "wasm32")]
             #[no_mangle]
             pub extern "C" fn #name() {
@@ -176,7 +184,7 @@ impl ToTokens for PublicLogicMethod<'_> {
 
                 #def
 
-                #call
+                #call;
 
                 #state_finalizer
             }

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -106,6 +106,11 @@ impl Id {
     pub const fn as_bytes(&self) -> &[u8; 32] {
         &self.bytes
     }
+
+    /// Checks if the ID is the root.
+    pub fn is_root(&self) -> bool {
+        self.bytes == context_id()
+    }
 }
 
 impl Display for Id {

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -1,14 +1,249 @@
 //! High-level data structures for storage.
 
-/// This module provides functionality for hashmap data structures.
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
 pub mod unordered_map;
 pub use unordered_map::UnorderedMap;
-/// This module provides functionality for hashset data structures.
 pub mod unordered_set;
 pub use unordered_set::UnorderedSet;
-/// This module provides functionality for vector data structures.
 pub mod vector;
 pub use vector::Vector;
-/// This module provides functionality for handling errors.
 pub mod error;
 pub use error::StoreError;
+
+use crate as calimero_storage;
+use crate::address::{Id, Path};
+use crate::entities::{Data, Element};
+use crate::interface::{Interface, StorageError};
+use crate::{AtomicUnit, Collection};
+
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(255)]
+#[root]
+struct Collection<T> {
+    /// The entries in the collection.
+    #[collection]
+    entries: Entries<T>,
+    /// The storage element for the map.
+    #[storage]
+    storage: Element,
+}
+
+/// A collection of entries in a map.
+#[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[children(Entry<T>)]
+struct Entries<T> {
+    /// Helper to associate the generic types with the collection.
+    _priv: PhantomData<T>,
+}
+
+/// An entry in a map.
+#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[type_id(254)]
+struct Entry<T> {
+    /// The item in the entry.
+    item: T,
+    /// The storage element for the entry.
+    #[storage]
+    storage: Element,
+}
+
+#[derive(Debug)]
+struct CollectionMut<'a, T: BorshSerialize + BorshDeserialize> {
+    collection: &'a mut Collection<T>,
+}
+
+#[derive(Debug)]
+struct EntryMut<'a, T: BorshSerialize + BorshDeserialize> {
+    collection: CollectionMut<'a, T>,
+    entry: Entry<T>,
+}
+
+type StoreResult<T> = std::result::Result<T, StoreError>;
+
+impl<T: BorshSerialize + BorshDeserialize> Collection<T> {
+    /// Creates a new collection.
+    fn new() -> Self {
+        let mut this = Self {
+            entries: Entries { _priv: PhantomData },
+            storage: Element::new(&Path::new("::unused").expect("valid path"), None),
+        };
+
+        let _ = Interface::save(&mut this).expect("save collection");
+
+        this
+    }
+
+    /// Inserts an item into the collection.
+    fn insert(&mut self, id: Option<Id>, item: T) -> StoreResult<()> {
+        let path = self.path();
+
+        let mut collection = CollectionMut::new(self);
+
+        collection.insert(Entry {
+            item,
+            storage: Element::new(&path, id),
+        })?;
+
+        Ok(())
+    }
+
+    fn get(&self, id: Id) -> StoreResult<Option<T>> {
+        let entry = Interface::find_by_id::<Entry<_>>(id)?;
+
+        Ok(entry.map(|entry| entry.item))
+    }
+
+    fn get_mut(&mut self, id: Id) -> StoreResult<Option<EntryMut<'_, T>>> {
+        let entry = Interface::find_by_id::<Entry<_>>(id)?;
+
+        Ok(entry.map(|entry| EntryMut {
+            collection: CollectionMut::new(self),
+            entry,
+        }))
+    }
+
+    fn entries(&self) -> StoreResult<impl ExactSizeIterator<Item = StoreResult<T>>> {
+        let children = Interface::child_info_for(self.id(), &self.entries)?;
+
+        let iter = children.into_iter().map(|child| {
+            let id = child.id();
+
+            let entry = Interface::find_by_id::<Entry<_>>(id)?
+                .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
+
+            Ok(entry.item)
+        });
+
+        Ok(iter)
+    }
+
+    fn clear(&mut self) -> StoreResult<()> {
+        let mut collection = CollectionMut::new(self);
+
+        collection.clear()?;
+
+        Ok(())
+    }
+}
+
+impl<T> EntryMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn remove(mut self) -> StoreResult<T> {
+        let old = self
+            .collection
+            .get(self.entry.id())?
+            .ok_or(StoreError::StorageError(StorageError::NotFound(
+                self.entry.id(),
+            )))?;
+
+        let _ = Interface::remove_child_from(
+            self.collection.id(),
+            &mut self.collection.entries,
+            self.entry.id(),
+        )?;
+
+        Ok(old)
+    }
+}
+
+impl<T> Deref for EntryMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entry.item
+    }
+}
+
+impl<T> DerefMut for EntryMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entry.item
+    }
+}
+
+impl<T> Drop for EntryMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn drop(&mut self) {
+        self.entry.element_mut().update();
+        let _ignored = Interface::save(&mut self.entry);
+    }
+}
+
+impl<'a, T> CollectionMut<'a, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn new(collection: &'a mut Collection<T>) -> Self {
+        Self { collection }
+    }
+
+    fn insert(&mut self, item: Entry<T>) -> StoreResult<()> {
+        let mut item = item;
+
+        let _ = Interface::add_child_to(
+            self.collection.id(),
+            &mut self.collection.entries,
+            &mut item,
+        )?;
+
+        Ok(())
+    }
+
+    fn clear(&mut self) -> StoreResult<()> {
+        let children =
+            Interface::child_info_for(self.collection.id(), &mut self.collection.entries)?;
+
+        for child in children {
+            let _ = Interface::remove_child_from(
+                self.collection.id(),
+                &mut self.collection.entries,
+                child.id(),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> Deref for CollectionMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    type Target = Collection<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.collection
+    }
+}
+
+impl<T> DerefMut for CollectionMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.collection
+    }
+}
+
+impl<T> Drop for CollectionMut<'_, T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn drop(&mut self) {
+        self.collection.element_mut().update();
+        let _ignored = Interface::save(self.collection);
+    }
+}

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -14,7 +14,8 @@ pub mod unordered_set;
 pub use unordered_set::UnorderedSet;
 pub mod vector;
 pub use vector::Vector;
-pub mod root;
+mod root;
+#[doc(hidden)]
 pub use root::Root;
 pub mod error;
 pub use error::StoreError;
@@ -323,6 +324,5 @@ where
 {
     fn drop(&mut self) {
         self.collection.element_mut().update();
-        let _ignored = Interface::save(self.collection);
     }
 }

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -12,8 +12,8 @@ pub mod unordered_map;
 pub use unordered_map::UnorderedMap;
 pub mod unordered_set;
 pub use unordered_set::UnorderedSet;
-pub mod vector;
-pub use vector::Vector;
+// pub mod vector;
+// pub use vector::Vector;
 pub mod error;
 pub use error::StoreError;
 
@@ -24,7 +24,7 @@ use crate::entities::{Data, Element};
 use crate::interface::{Interface, StorageError};
 use crate::{AtomicUnit, Collection};
 
-#[derive(AtomicUnit, BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(AtomicUnit, BorshSerialize, BorshDeserialize, Clone, Debug)]
 #[type_id(255)]
 #[root]
 struct Collection<T> {
@@ -41,6 +41,35 @@ struct Collection<T> {
     children_ids: RefCell<Option<IndexSet<Id>>>,
 }
 
+impl<T: Eq + BorshSerialize + BorshDeserialize> Eq for Collection<T> {}
+
+impl<T: PartialEq + BorshSerialize + BorshDeserialize> PartialEq for Collection<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries()
+            .unwrap()
+            .flatten()
+            .eq(other.entries().unwrap().flatten())
+    }
+}
+
+impl<T: Ord + BorshSerialize + BorshDeserialize> Ord for Collection<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.entries()
+            .unwrap()
+            .flatten()
+            .cmp(other.entries().unwrap().flatten())
+    }
+}
+
+impl<T: PartialOrd + BorshSerialize + BorshDeserialize> PartialOrd for Collection<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.entries()
+            .unwrap()
+            .flatten()
+            .partial_cmp(other.entries().unwrap().flatten())
+    }
+}
+
 /// A collection of entries in a map.
 #[derive(Collection, Copy, Clone, Debug, Eq, PartialEq)]
 #[children(Entry<T>)]
@@ -50,7 +79,7 @@ struct Entries<T> {
 }
 
 /// An entry in a map.
-#[derive(AtomicUnit, BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(AtomicUnit, BorshSerialize, BorshDeserialize, Clone, Debug)]
 #[type_id(254)]
 struct Entry<T> {
     /// The item in the entry.
@@ -71,6 +100,7 @@ struct EntryMut<'a, T: BorshSerialize + BorshDeserialize> {
     entry: Entry<T>,
 }
 
+#[expect(unused_qualifications, reason = "AtomicUnit macro is unsanitized")]
 type StoreResult<T> = std::result::Result<T, StoreError>;
 
 impl<T: BorshSerialize + BorshDeserialize> Collection<T> {

--- a/crates/storage/src/collections/error.rs
+++ b/crates/storage/src/collections/error.rs
@@ -1,6 +1,7 @@
+//! Error types for storage operations.
+
 use thiserror::Error;
 
-// fixme! macro expects `calimero_storage` to be in deps
 use crate::address::PathError;
 use crate::interface::StorageError;
 

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -1,0 +1,55 @@
+//! A root collection that stores a single value.
+
+use std::cell::RefCell;
+use std::ptr;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::env;
+
+use super::Collection;
+use crate::address::Id;
+
+/// A set collection that stores unqiue values once.
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub struct Root<T> {
+    id: Id,
+    inner: Collection<T>,
+    value: RefCell<Option<T>>,
+}
+
+impl<T> Root<T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    /// Creates a new root collection with the given value.
+    pub fn new(value: T) -> Self {
+        let id = Id::new(env::context_id());
+
+        let mut inner = Collection::new();
+
+        let value = inner.insert(Some(id), value).unwrap();
+
+        Self {
+            id,
+            inner,
+            value: RefCell::new(Some(value)),
+        }
+    }
+
+    /// Gets the value of the root collection.
+    pub fn get(&self) -> &T {
+        self.get_mut()
+    }
+
+    /// Gets the value of the root collection mutably.
+    pub fn get_mut(&self) -> &mut T {
+        let mut value = self.value.borrow_mut();
+
+        let value = value.get_or_insert_with(|| self.inner.get(self.id).unwrap().unwrap());
+
+        #[expect(unsafe_code, reason = "necessary for caching")]
+        let value = unsafe { &mut *ptr::from_mut(value) };
+
+        value
+    }
+}

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -2,7 +2,9 @@
 
 use std::cell::RefCell;
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::ptr;
+use std::sync::LazyLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -10,10 +12,11 @@ use super::{Collection, Entry};
 use crate::address::Id;
 use crate::entities::Data;
 use crate::env;
+use crate::interface::Interface;
 
 /// Thing.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct RootHandle<T> {
+pub(super) struct RootHandle<T> {
     /// The ID of the root collection.
     pub id: Id,
     _priv: PhantomData<T>,
@@ -41,12 +44,23 @@ thread_local! {
     pub static ROOT: RefCell<Option<RootHandle<Entry<()>>>> = RefCell::new(None);
 }
 
+static ID: LazyLock<Id> = LazyLock::new(|| Id::new(env::context_id()));
+
+/// Prepares the root collection.
+fn employ_root_guard() {
+    let old = ROOT.with(|root| root.borrow_mut().replace(RootHandle::new(*ID)));
+
+    if old.is_some() {
+        panic!("root collection already defined");
+    }
+}
+
 /// A set collection that stores unqiue values once.
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug)]
 pub struct Root<T> {
-    id: Id,
     inner: Collection<T>,
     value: RefCell<Option<T>>,
+    dirty: bool,
 }
 
 impl<T> Root<T>
@@ -54,40 +68,86 @@ where
     T: BorshSerialize + BorshDeserialize,
 {
     /// Creates a new root collection with the given value.
-    pub fn new(value: T) -> Self {
-        let id = Id::new(env::context_id());
+    pub fn new<F: FnOnce() -> T>(f: F) -> Self {
+        employ_root_guard();
 
-        let old = ROOT.with(|root| root.borrow_mut().replace(RootHandle::new(id)));
+        let mut inner = Collection::new(Some(*ID));
 
-        if old.is_some() {
-            panic!("root collection already defined");
-        }
+        let id = Self::entry_id();
 
-        let mut inner = Collection::new(Some(id));
-
-        let value = inner.insert(Some(id), value).unwrap();
+        let value = inner.insert(Some(id), f()).unwrap();
 
         Self {
-            id,
             inner,
+            dirty: false,
             value: RefCell::new(Some(value)),
         }
     }
 
-    /// Gets the value of the root collection.
-    pub fn get(&self) -> &T {
-        self.get_mut()
+    fn entry_id() -> Id {
+        Id::new([118; 32])
     }
 
-    /// Gets the value of the root collection mutably.
-    pub fn get_mut(&self) -> &mut T {
+    fn get(&self) -> &mut T {
         let mut value = self.value.borrow_mut();
 
-        let value = value.get_or_insert_with(|| self.inner.get(self.id).unwrap().unwrap());
+        let id = Self::entry_id();
+
+        let value = value.get_or_insert_with(|| self.inner.get(id).unwrap().unwrap());
 
         #[expect(unsafe_code, reason = "necessary for caching")]
         let value = unsafe { &mut *ptr::from_mut(value) };
 
         value
+    }
+
+    /// Fetches the root collection.
+    pub fn fetch() -> Option<Self> {
+        employ_root_guard();
+
+        let inner = Interface::root().unwrap()?;
+
+        Some(Self {
+            inner,
+            dirty: false,
+            value: RefCell::new(None),
+        })
+    }
+
+    /// Commits the root collection.
+    pub fn commit(mut self) {
+        let _ignored = ROOT.with(|root| root.borrow_mut().take());
+
+        if self.dirty {
+            if let Some(value) = self.value.into_inner() {
+                if let Some(mut entry) = self.inner.get_mut(Self::entry_id()).unwrap() {
+                    *entry = value;
+                }
+            }
+        }
+
+        Interface::commit_root(self.inner).unwrap();
+    }
+}
+
+impl<T> Deref for Root<T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.get()
+    }
+}
+
+impl<T> DerefMut for Root<T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.dirty = true;
+
+        self.get()
     }
 }

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -1,13 +1,45 @@
 //! A root collection that stores a single value.
 
 use std::cell::RefCell;
+use std::marker::PhantomData;
 use std::ptr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_sdk::env;
 
-use super::Collection;
+use super::{Collection, Entry};
 use crate::address::Id;
+use crate::entities::Data;
+use crate::env;
+
+/// Thing.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct RootHandle<T> {
+    /// The ID of the root collection.
+    pub id: Id,
+    _priv: PhantomData<T>,
+}
+
+impl<T: Data> RootHandle<T> {
+    fn new(id: Id) -> Self {
+        Self {
+            id,
+            _priv: PhantomData,
+        }
+    }
+}
+
+impl<T: Data> crate::entities::Collection for RootHandle<T> {
+    type Child = T;
+
+    fn name(&self) -> &str {
+        "RootHandle"
+    }
+}
+
+thread_local! {
+    /// The root collection handle.
+    pub static ROOT: RefCell<Option<RootHandle<Entry<()>>>> = RefCell::new(None);
+}
 
 /// A set collection that stores unqiue values once.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
@@ -25,7 +57,13 @@ where
     pub fn new(value: T) -> Self {
         let id = Id::new(env::context_id());
 
-        let mut inner = Collection::new();
+        let old = ROOT.with(|root| root.borrow_mut().replace(RootHandle::new(id)));
+
+        if old.is_some() {
+            panic!("root collection already defined");
+        }
+
+        let mut inner = Collection::new(Some(id));
 
         let value = inner.insert(Some(id), value).unwrap();
 

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -202,9 +202,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_basic_operations() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key".to_string(), "value".to_string())
@@ -253,9 +251,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_insert_and_get() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key1".to_string(), "value1".to_string())
@@ -278,9 +274,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_update_value() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key".to_string(), "value".to_string())
@@ -299,9 +293,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key".to_string(), "value".to_string())
@@ -317,9 +309,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key1".to_string(), "value1".to_string())
@@ -338,9 +328,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_len() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert_eq!(map.len().expect("len failed"), 0);
 
@@ -369,9 +357,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_contains() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key".to_string(), "value".to_string())
@@ -384,9 +370,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entries() {
-        let _root = Root::new(());
-
-        let mut map = UnorderedMap::<String, String>::new();
+        let mut map = Root::new(|| UnorderedMap::new());
 
         assert!(map
             .insert("key1".to_string(), "value1".to_string())

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -24,12 +24,6 @@ where
 {
     /// Create a new map collection.
     ///
-    /// # Errors
-    ///
-    /// If an error occurs when interacting with the storage system, or a child
-    /// [`Element`](crate::entities::Element) cannot be found, an error will be
-    /// returned.
-    ///
     pub fn new() -> Self {
         Self {
             inner: Collection::new(),
@@ -78,11 +72,7 @@ where
     /// returned.
     ///
     pub fn entries(&self) -> Result<impl Iterator<Item = (K, V)> + '_, StoreError> {
-        let iter = self.inner.entries()?;
-
-        let iter = iter.flat_map(|entry| entry.ok());
-
-        Ok(iter.fuse())
+        Ok(self.inner.entries()?.flatten().fuse())
     }
 
     /// Get the number of entries in the map.
@@ -94,7 +84,7 @@ where
     /// returned.
     ///
     pub fn len(&self) -> Result<usize, StoreError> {
-        Ok(self.inner.entries()?.len())
+        self.inner.len()
     }
 
     /// Get the value for a key in the map.

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1,3 +1,5 @@
+//! This module provides functionality for the unordered map data structure.
+
 use core::borrow::Borrow;
 use core::marker::PhantomData;
 

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -58,7 +58,7 @@ where
             return Ok(Some(mem::replace(v, value)));
         }
 
-        self.inner.insert(Some(id), (key, value))?;
+        let _ignored = self.inner.insert(Some(id), (key, value))?;
 
         Ok(None)
     }

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -26,7 +26,7 @@ where
     ///
     pub fn new() -> Self {
         Self {
-            inner: Collection::new(),
+            inner: Collection::new(None),
         }
     }
 
@@ -198,9 +198,12 @@ where
 #[cfg(test)]
 mod tests {
     use crate::collections::unordered_map::UnorderedMap;
+    use crate::collections::Root;
 
     #[test]
     fn test_unordered_map_basic_operations() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map
@@ -250,6 +253,8 @@ mod tests {
 
     #[test]
     fn test_unordered_map_insert_and_get() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map
@@ -273,6 +278,8 @@ mod tests {
 
     #[test]
     fn test_unordered_map_update_value() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map
@@ -292,6 +299,8 @@ mod tests {
 
     #[test]
     fn test_remove() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map
@@ -308,6 +317,8 @@ mod tests {
 
     #[test]
     fn test_clear() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map
@@ -327,6 +338,8 @@ mod tests {
 
     #[test]
     fn test_unordered_map_len() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert_eq!(map.len().expect("len failed"), 0);
@@ -356,6 +369,8 @@ mod tests {
 
     #[test]
     fn test_unordered_map_contains() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map
@@ -369,6 +384,8 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entries() {
+        let _root = Root::new(());
+
         let mut map = UnorderedMap::<String, String>::new();
 
         assert!(map

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -24,7 +24,7 @@ where
     ///
     pub fn new() -> Self {
         Self {
-            inner: Collection::new(),
+            inner: Collection::new(None),
         }
     }
 
@@ -171,10 +171,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::collections::UnorderedSet;
+    use crate::collections::{Root, UnorderedSet};
 
     #[test]
     fn test_unordered_set_operations() {
+        let _root = Root::new(());
+
         let mut set = UnorderedSet::<String>::new();
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
@@ -203,6 +205,8 @@ mod tests {
 
     #[test]
     fn test_unordered_set_len() {
+        let _root = Root::new(());
+
         let mut set = UnorderedSet::<String>::new();
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
@@ -218,6 +222,8 @@ mod tests {
 
     #[test]
     fn test_unordered_set_clear() {
+        let _root = Root::new(());
+
         let mut set = UnorderedSet::<String>::new();
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
@@ -234,6 +240,8 @@ mod tests {
 
     #[test]
     fn test_unordered_set_entries() {
+        let _root = Root::new(());
+
         let mut set = UnorderedSet::<String>::new();
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -175,9 +175,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_operations() {
-        let _root = Root::new(());
-
-        let mut set = UnorderedSet::<String>::new();
+        let mut set = Root::new(|| UnorderedSet::new());
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
 
@@ -205,9 +203,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_len() {
-        let _root = Root::new(());
-
-        let mut set = UnorderedSet::<String>::new();
+        let mut set = Root::new(|| UnorderedSet::new());
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
         assert!(set.insert("value2".to_string()).expect("insert failed"));
@@ -222,9 +218,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_clear() {
-        let _root = Root::new(());
-
-        let mut set = UnorderedSet::<String>::new();
+        let mut set = Root::new(|| UnorderedSet::new());
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
         assert!(set.insert("value2".to_string()).expect("insert failed"));
@@ -240,9 +234,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_entries() {
-        let _root = Root::new(());
-
-        let mut set = UnorderedSet::<String>::new();
+        let mut set = Root::new(|| UnorderedSet::new());
 
         assert!(set.insert("value1".to_string()).expect("insert failed"));
         assert!(set.insert("value2".to_string()).expect("insert failed"));

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -22,12 +22,6 @@ where
 {
     /// Create a new set collection.
     ///
-    /// # Errors
-    ///
-    /// If an error occurs when interacting with the storage system, or a child
-    /// [`Element`](crate::entities::Element) cannot be found, an error will be
-    /// returned.
-    ///
     pub fn new() -> Self {
         Self {
             inner: Collection::new(),
@@ -74,11 +68,7 @@ where
     /// returned.
     ///
     pub fn entries(&self) -> Result<impl Iterator<Item = V> + '_, StoreError> {
-        let iter = self.inner.entries()?;
-
-        let iter = iter.flat_map(|entry| entry.ok());
-
-        Ok(iter)
+        Ok(self.inner.entries()?.flatten().fuse())
     }
 
     /// Get the number of entries in the set.
@@ -90,7 +80,7 @@ where
     /// returned.
     ///
     pub fn len(&self) -> Result<usize, StoreError> {
-        Ok(self.inner.entries()?.len())
+        self.inner.len()
     }
 
     /// Get the value for a key in the set.

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -1,3 +1,5 @@
+//! This module provides functionality for the unordered set data structure.
+
 use core::borrow::Borrow;
 use core::marker::PhantomData;
 

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -54,7 +54,7 @@ where
             return Ok(false);
         };
 
-        self.inner.insert(Some(id), value)?;
+        let _ignored = self.inner.insert(Some(id), value)?;
 
         Ok(true)
     }

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -5,9 +5,8 @@ use std::mem;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::collections::error::StoreError;
-
 use super::Collection;
+use crate::collections::error::StoreError;
 
 /// A vector collection that stores key-value pairs.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
@@ -36,7 +35,9 @@ where
     /// returned.
     ///
     pub fn push(&mut self, value: V) -> Result<(), StoreError> {
-        self.inner.insert(None, value)
+        let _ignored = self.inner.insert(None, value)?;
+
+        Ok(())
     }
 
     /// Remove and return the last value from the vector.

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -22,7 +22,7 @@ where
     ///
     pub fn new() -> Self {
         Self {
-            inner: Collection::new(),
+            inner: Collection::new(None),
         }
     }
 
@@ -159,9 +159,12 @@ where
 #[cfg(test)]
 mod tests {
     use crate::collections::vector::Vector;
+    use crate::collections::Root;
 
     #[test]
     fn test_vector_push() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let result = vector.push(value.clone());
@@ -171,6 +174,8 @@ mod tests {
 
     #[test]
     fn test_vector_get() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
@@ -180,6 +185,8 @@ mod tests {
 
     #[test]
     fn test_vector_update() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value1 = "test_data1".to_string();
         let value2 = "test_data2".to_string();
@@ -192,6 +199,8 @@ mod tests {
 
     #[test]
     fn test_vector_get_non_existent() {
+        let _root = Root::new(());
+
         let vector: Vector<String> = Vector::new();
         match vector.get(0) {
             Ok(retrieved_value) => assert_eq!(retrieved_value, None),
@@ -201,6 +210,8 @@ mod tests {
 
     #[test]
     fn test_vector_pop() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
@@ -211,6 +222,8 @@ mod tests {
 
     #[test]
     fn test_vector_entries() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value1 = "test_data1".to_string();
         let value2 = "test_data2".to_string();
@@ -222,6 +235,8 @@ mod tests {
 
     #[test]
     fn test_vector_contains() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
@@ -232,6 +247,8 @@ mod tests {
 
     #[test]
     fn test_vector_clear() {
+        let _root = Root::new(());
+
         let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -1,69 +1,30 @@
 //! This module provides functionality for the vector data structure.
 
 use core::borrow::Borrow;
-use core::marker::PhantomData;
+use std::mem;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::address::{Id, Path};
 use crate::collections::error::StoreError;
-use crate::entities::{Data, Element};
-use crate::interface::{Interface, StorageError};
-use crate::{self as calimero_storage, AtomicUnit, Collection};
+
+use super::Collection;
 
 /// A vector collection that stores key-value pairs.
-#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
-#[type_id(251)]
-#[root]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct Vector<V> {
-    /// The entries in the vector.
-    entries: Entries<V>,
-    /// The storage element for the vector.
-    #[storage]
-    storage: Element,
+    inner: Collection<V>,
 }
 
-/// A collection of entries in a vector.
-#[derive(Collection, Clone, Debug, Eq, PartialEq, PartialOrd)]
-#[children(Entry<V>)]
-struct Entries<V> {
-    /// Helper to associate the generic types with the collection.
-    _priv: PhantomData<V>,
-}
-
-/// An entry in a vector.
-#[derive(AtomicUnit, Clone, Debug, Eq, PartialEq, PartialOrd)]
-#[type_id(250)]
-pub struct Entry<V> {
-    /// The value for the entry.
-    value: V,
-    /// The storage element for the entry.
-    #[storage]
-    storage: Element,
-}
-
-impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
+impl<V> Vector<V>
+where
+    V: BorshSerialize + BorshDeserialize,
+{
     /// Create a new vector collection.
     ///
-    /// # Errors
-    ///
-    /// If an error occurs when interacting with the storage system, or a child
-    /// [`Element`](crate::entities::Element) cannot be found, an error will be
-    /// returned.
-    ///
-    pub fn new() -> Result<Self, StoreError> {
-        let id = Id::random();
-        let mut this = Self {
-            entries: Entries::default(),
-            storage: Element::new(
-                &Path::new(format!("::unused::vector::{id}::path"))?,
-                Some(id),
-            ),
-        };
-
-        let _ = Interface::save(&mut this)?;
-
-        Ok(this)
+    pub fn new() -> Self {
+        Self {
+            inner: Collection::new(),
+        }
     }
 
     /// Add a value to the end of the vector.
@@ -75,18 +36,7 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     /// returned.
     ///
     pub fn push(&mut self, value: V) -> Result<(), StoreError> {
-        let mut entry = Entry {
-            value,
-            storage: Element::new(&self.path(), None),
-        };
-
-        if Interface::add_child_to(self.id(), &mut self.entries, &mut entry)? {
-            return Ok(());
-        }
-
-        Err(StoreError::StorageError(StorageError::ActionNotAllowed(
-            "Failed to add child".to_owned(),
-        )))
+        self.inner.insert(None, value)
     }
 
     /// Remove and return the last value from the vector.
@@ -98,35 +48,17 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     /// returned.
     ///
     pub fn pop(&mut self) -> Result<Option<V>, StoreError> {
-        let id = match Interface::child_info_for(self.id(), &self.entries)?.pop() {
-            Some(info) => info.id(),
-            None => return Ok(None),
-        };
-        let entry = Interface::find_by_id::<Entry<V>>(id)?;
-        let _ = Interface::remove_child_from(self.id(), &mut self.entries, id)?;
-        Ok(entry.map(|e| e.value))
-    }
-
-    /// Get the raw storage entry at a specific index in the vector.
-    ///
-    /// # Errors
-    ///
-    /// If an error occurs when interacting with the storage system, or a child
-    /// [`Element`](crate::entities::Element) cannot be found, an error will be
-    /// returned.
-    ///
-    fn get_raw(&self, index: usize) -> Result<Option<Entry<V>>, StoreError> {
-        let id = match Interface::child_info_for(self.id(), &self.entries)?.get(index) {
-            Some(info) => info.id(),
-            None => return Ok(None),
+        let Some(last) = self.inner.last()? else {
+            return Ok(None);
         };
 
-        let entry = match Interface::find_by_id::<Entry<V>>(id) {
-            Ok(entry) => entry,
-            Err(_) => return Ok(None),
+        let Some(entry) = self.inner.get_mut(last)? else {
+            return Ok(None);
         };
 
-        Ok(entry)
+        let last = entry.remove()?;
+
+        Ok(Some(last))
     }
 
     /// Get the value at a specific index in the vector.
@@ -138,7 +70,7 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     /// returned.
     ///
     pub fn get(&self, index: usize) -> Result<Option<V>, StoreError> {
-        Ok(self.get_raw(index)?.map(|entry| entry.value))
+        self.inner.entries()?.nth(index).transpose()
     }
 
     /// Update the value at a specific index in the vector.
@@ -149,18 +81,18 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned.
     ///
-    pub fn update(&mut self, index: usize, value: V) -> Result<(), StoreError> {
-        let mut entry = self.get_raw(index)?.ok_or(StoreError::StorageError(
-            StorageError::ActionNotAllowed("error".to_owned()),
-        ))?;
+    pub fn update(&mut self, index: usize, value: V) -> Result<Option<V>, StoreError> {
+        let Some(id) = self.inner.nth(index)? else {
+            return Ok(None);
+        };
 
-        // has to be called to update the entry
-        entry.value = value;
-        entry.element_mut().update();
+        let Some(mut entry) = self.inner.get_mut(id)? else {
+            return Ok(None);
+        };
 
-        let _ = Interface::save::<Entry<V>>(&mut entry)?;
+        let old = mem::replace(&mut *entry, value);
 
-        Ok(())
+        Ok(Some(old))
     }
 
     /// Get an iterator over the entries in the vector.
@@ -171,10 +103,8 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned.
     ///
-    pub fn entries(&self) -> Result<impl Iterator<Item = V>, StoreError> {
-        let entries = Interface::children_of(self.id(), &self.entries)?;
-
-        Ok(entries.into_iter().map(|entry| (entry.value)))
+    pub fn entries(&self) -> Result<impl Iterator<Item = V> + '_, StoreError> {
+        Ok(self.inner.entries()?.flatten().fuse())
     }
 
     /// Get the number of entries in the vector.
@@ -187,7 +117,7 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     ///
     #[expect(clippy::len_without_is_empty, reason = "TODO: will be implemented")]
     pub fn len(&self) -> Result<usize, StoreError> {
-        Ok(Interface::child_info_for(self.id(), &self.entries)?.len())
+        self.inner.len()
     }
 
     /// Get the value for a key in the vector.
@@ -201,10 +131,10 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     pub fn contains<Q>(&self, value: &Q) -> Result<bool, StoreError>
     where
         V: Borrow<Q>,
-        Q: PartialEq<V> + ?Sized,
+        Q: PartialEq,
     {
         for entry in self.entries()? {
-            if value.borrow() == &entry {
+            if value == entry.borrow() {
                 return Ok(true);
             }
         }
@@ -221,30 +151,17 @@ impl<V: BorshSerialize + BorshDeserialize> Vector<V> {
     /// returned.
     ///
     pub fn clear(&mut self) -> Result<(), StoreError> {
-        let entries = Interface::children_of(self.id(), &self.entries)?;
-
-        for entry in entries {
-            let _ = Interface::remove_child_from(self.id(), &mut self.entries, entry.id())?;
-        }
-
-        Ok(())
+        self.inner.clear()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::collections::error::StoreError;
     use crate::collections::vector::Vector;
 
     #[test]
-    fn test_vector_new() {
-        let vector: Result<Vector<String>, StoreError> = Vector::new();
-        assert!(vector.is_ok());
-    }
-
-    #[test]
     fn test_vector_push() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let result = vector.push(value.clone());
         assert!(result.is_ok());
@@ -253,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_vector_get() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         let retrieved_value = vector.get(0).unwrap();
@@ -262,18 +179,19 @@ mod tests {
 
     #[test]
     fn test_vector_update() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value1 = "test_data1".to_string();
         let value2 = "test_data2".to_string();
         let _ = vector.push(value1.clone()).unwrap();
-        let _ = vector.update(0, value2.clone()).unwrap();
+        let old = vector.update(0, value2.clone()).unwrap();
         let retrieved_value = vector.get(0).unwrap();
         assert_eq!(retrieved_value, Some(value2));
+        assert_eq!(old, Some(value1));
     }
 
     #[test]
     fn test_vector_get_non_existent() {
-        let vector: Vector<String> = Vector::new().unwrap();
+        let vector: Vector<String> = Vector::new();
         match vector.get(0) {
             Ok(retrieved_value) => assert_eq!(retrieved_value, None),
             Err(e) => panic!("Error occurred: {:?}", e),
@@ -282,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_vector_pop() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         let popped_value = vector.pop().unwrap();
@@ -292,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_vector_entries() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value1 = "test_data1".to_string();
         let value2 = "test_data2".to_string();
         let _ = vector.push(value1.clone()).unwrap();
@@ -303,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_vector_contains() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         assert!(vector.contains(&value).unwrap());
@@ -313,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_vector_clear() {
-        let mut vector: Vector<String> = Vector::new().unwrap();
+        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         vector.clear().unwrap();

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -11,6 +11,7 @@ use crate::collections::error::StoreError;
 /// A vector collection that stores key-value pairs.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct Vector<V> {
+    // Borrow/ToOwned
     inner: Collection<V>,
 }
 
@@ -163,9 +164,8 @@ mod tests {
 
     #[test]
     fn test_vector_push() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let result = vector.push(value.clone());
         assert!(result.is_ok());
@@ -174,9 +174,8 @@ mod tests {
 
     #[test]
     fn test_vector_get() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         let retrieved_value = vector.get(0).unwrap();
@@ -185,9 +184,8 @@ mod tests {
 
     #[test]
     fn test_vector_update() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value1 = "test_data1".to_string();
         let value2 = "test_data2".to_string();
         let _ = vector.push(value1.clone()).unwrap();
@@ -199,9 +197,8 @@ mod tests {
 
     #[test]
     fn test_vector_get_non_existent() {
-        let _root = Root::new(());
+        let vector = Root::new(|| Vector::<String>::new());
 
-        let vector: Vector<String> = Vector::new();
         match vector.get(0) {
             Ok(retrieved_value) => assert_eq!(retrieved_value, None),
             Err(e) => panic!("Error occurred: {:?}", e),
@@ -210,9 +207,8 @@ mod tests {
 
     #[test]
     fn test_vector_pop() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         let popped_value = vector.pop().unwrap();
@@ -222,9 +218,8 @@ mod tests {
 
     #[test]
     fn test_vector_entries() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value1 = "test_data1".to_string();
         let value2 = "test_data2".to_string();
         let _ = vector.push(value1.clone()).unwrap();
@@ -235,9 +230,8 @@ mod tests {
 
     #[test]
     fn test_vector_contains() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         assert!(vector.contains(&value).unwrap());
@@ -247,9 +241,8 @@ mod tests {
 
     #[test]
     fn test_vector_clear() {
-        let _root = Root::new(());
+        let mut vector = Root::new(|| Vector::new());
 
-        let mut vector: Vector<String> = Vector::new();
         let value = "test_data".to_string();
         let _ = vector.push(value.clone()).unwrap();
         vector.clear().unwrap();

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -5,7 +5,6 @@ use core::marker::PhantomData;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-// fixme! macro expects `calimero_storage` to be in deps
 use crate::address::{Id, Path};
 use crate::collections::error::StoreError;
 use crate::entities::{Data, Element};

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -1,3 +1,5 @@
+//! This module provides functionality for the vector data structure.
+
 use core::borrow::Borrow;
 use core::marker::PhantomData;
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -788,6 +788,7 @@ pub struct Metadata {
     pub(crate) updated_at: UpdatedAt,
 }
 
+/// The timestamp when the [`Element`] was last updated.
 #[derive(
     BorshDeserialize, BorshSerialize, Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialOrd,
 )]

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -163,7 +163,7 @@ mod mocked {
 
     /// Return the context id.
     pub(super) const fn context_id() -> [u8; 32] {
-        [0; 32]
+        [236; 32]
     }
 
     /// Gets the current time.

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -11,7 +11,8 @@ use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use sha2::{Digest, Sha256};
 
 use crate::address::Id;
-use crate::entities::ChildInfo;
+use crate::entities::{ChildInfo, Metadata};
+use crate::env;
 use crate::interface::StorageError;
 use crate::store::{Key, StorageAdaptor};
 
@@ -35,11 +36,8 @@ struct EntityIndex {
     /// the hashes of its children to form the full hash.
     own_hash: [u8; 32],
 
-    /// Type identifier of the entity. This is noted so that the entity can be
-    /// deserialised correctly in the absence of other semantic information. It
-    /// is intended that the [`Path`](crate::address::Path) will be used to help
-    /// with this at some point, but at present paths are not fully utilised.
-    type_id: u8,
+    /// Metadata about the entity.
+    metadata: Metadata,
 }
 
 /// Manages the indexing system for efficient tree navigation.
@@ -73,7 +71,6 @@ impl<S: StorageAdaptor> Index<S> {
         parent_id: Id,
         collection: &str,
         child: ChildInfo,
-        type_id: u8,
     ) -> Result<(), StorageError> {
         let mut parent_index =
             Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
@@ -84,7 +81,7 @@ impl<S: StorageAdaptor> Index<S> {
             children: BTreeMap::new(),
             full_hash: [0; 32],
             own_hash: [0; 32],
-            type_id,
+            metadata: child.metadata,
         });
         child_index.parent_id = Some(parent_id);
         child_index.own_hash = child.merkle_hash();
@@ -96,7 +93,11 @@ impl<S: StorageAdaptor> Index<S> {
             .children
             .entry(collection.to_owned())
             .or_insert_with(Vec::new)
-            .push(ChildInfo::new(child.id(), child_index.full_hash));
+            .push(ChildInfo::new(
+                child.id(),
+                child_index.full_hash,
+                child.metadata,
+            ));
         Self::save_index(&parent_index)?;
         parent_index.full_hash = Self::calculate_full_merkle_hash_for(parent_id, false)?;
         Self::save_index(&parent_index)?;
@@ -123,14 +124,14 @@ impl<S: StorageAdaptor> Index<S> {
     ///
     /// * [`add_child_to()`](Index::add_child_to())
     ///
-    pub(crate) fn add_root(root: ChildInfo, type_id: u8) -> Result<(), StorageError> {
+    pub(crate) fn add_root(root: ChildInfo) -> Result<(), StorageError> {
         let mut index = Self::get_index(root.id())?.unwrap_or_else(|| EntityIndex {
             id: root.id(),
             parent_id: None,
             children: BTreeMap::new(),
             full_hash: [0; 32],
             own_hash: [0; 32],
-            type_id,
+            metadata: root.metadata,
         });
         index.own_hash = root.merkle_hash();
         Self::save_index(&index)?;
@@ -231,11 +232,17 @@ impl<S: StorageAdaptor> Index<S> {
         while let Some(parent_id) = Self::get_parent_id(current_id)? {
             let (parent_full_hash, _) =
                 Self::get_hashes_for(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
-            ancestors.push(ChildInfo::new(parent_id, parent_full_hash));
+            let metadata =
+                Self::get_metadata(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+            ancestors.push(ChildInfo::new(parent_id, parent_full_hash, metadata));
             current_id = parent_id;
         }
 
         Ok(ancestors)
+    }
+
+    pub(crate) fn get_metadata(id: Id) -> Result<Option<Metadata>, StorageError> {
+        Ok(Self::get_index(id)?.map(|index| index.metadata))
     }
 
     /// Retrieves the children of a given entity.
@@ -341,23 +348,6 @@ impl<S: StorageAdaptor> Index<S> {
         Ok(Self::get_index(child_id)?.and_then(|index| index.parent_id))
     }
 
-    /// Retrieves the type of the given entity.
-    ///
-    /// # Parameters
-    ///
-    /// * `id` - The [`Id`] of the entity whose type is to be retrieved.
-    ///
-    /// # Errors
-    ///
-    /// If there's an issue retrieving or deserialising the index information,
-    /// an error will be returned.
-    ///
-    pub(crate) fn get_type_id(id: Id) -> Result<u8, StorageError> {
-        Ok(Self::get_index(id)?
-            .ok_or(StorageError::IndexNotFound(id))?
-            .type_id)
-    }
-
     /// Whether the collection has children.
     ///
     /// # Parameters
@@ -404,7 +394,7 @@ impl<S: StorageAdaptor> Index<S> {
                 if let Some(child) = children.iter_mut().find(|c| c.id() == current_id) {
                     let new_child_hash = Self::calculate_full_merkle_hash_for(current_id, false)?;
                     if child.merkle_hash() != new_child_hash {
-                        *child = ChildInfo::new(current_id, new_child_hash);
+                        *child = ChildInfo::new(current_id, new_child_hash, child.metadata);
                     }
                     break;
                 }
@@ -513,6 +503,7 @@ impl<S: StorageAdaptor> Index<S> {
         index.own_hash = merkle_hash;
         Self::save_index(&index)?;
         index.full_hash = Self::calculate_full_merkle_hash_for(id, false)?;
+        index.metadata.updated_at = env::time_now().into();
         Self::save_index(&index)?;
         Ok(index.full_hash)
     }

--- a/crates/storage/src/integration.rs
+++ b/crates/storage/src/integration.rs
@@ -8,9 +8,6 @@ use crate::interface::ComparisonData;
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[expect(clippy::exhaustive_structs, reason = "Exhaustive")]
 pub struct Comparison {
-    /// The type of the entity.
-    pub type_id: u8,
-
     /// The serialised data of the entity.
     pub data: Option<Vec<u8>>,
 

--- a/crates/storage/src/integration.rs
+++ b/crates/storage/src/integration.rs
@@ -1,24 +1,11 @@
 //! Types used for integration with the runtime.
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_sdk::serde::{Deserialize, Serialize};
 
 use crate::interface::ComparisonData;
 
 /// Comparison data for synchronisation.
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Deserialize,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[expect(clippy::exhaustive_structs, reason = "Exhaustive")]
 pub struct Comparison {
     /// The type of the entity.

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -385,7 +385,7 @@ impl<S: StorageAdaptor> MainInterface<S> {
     ///
     pub fn add_child_to<C: Collection, D: Data>(
         parent_id: Id,
-        collection: &mut C,
+        collection: &C,
         child: &mut D,
     ) -> Result<bool, StorageError> {
         let own_hash = child.calculate_merkle_hash()?;
@@ -950,7 +950,7 @@ impl<S: StorageAdaptor> MainInterface<S> {
     ///
     pub fn remove_child_from<C: Collection>(
         parent_id: Id,
-        collection: &mut C,
+        collection: &C,
         child_id: Id,
     ) -> Result<bool, StorageError> {
         let child_exists = <Index<S>>::get_children_of(parent_id, collection.name())?

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -218,14 +218,15 @@ use core::marker::PhantomData;
 use std::collections::BTreeMap;
 use std::io::Error as IoError;
 
-use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 use eyre::Report;
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 use thiserror::Error as ThisError;
 
 use crate::address::{Id, Path};
-use crate::entities::{ChildInfo, Collection, Data};
+use crate::entities::{ChildInfo, Collection, Data, Metadata};
 use crate::index::Index;
 use crate::store::{Key, MainStorage, StorageAdaptor};
 use crate::sync;
@@ -262,19 +263,7 @@ pub type Interface = MainInterface<MainStorage>;
 /// Note: This enum contains the entity type, for passing to the guest for
 /// processing along with the ID and data.
 ///
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Deserialize,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[expect(clippy::exhaustive_enums, reason = "Exhaustive")]
 pub enum Action {
     /// Add an entity with the given ID, type, and data.
@@ -282,14 +271,14 @@ pub enum Action {
         /// Unique identifier of the entity.
         id: Id,
 
-        /// Type identifier of the entity.
-        type_id: u8,
-
         /// Serialised data of the entity.
         data: Vec<u8>,
 
         /// Details of the ancestors of the entity.
         ancestors: Vec<ChildInfo>,
+
+        /// The metadata of the entity.
+        metadata: Metadata,
     },
 
     /// Compare the entity with the given ID and type. Note that this results in
@@ -316,31 +305,19 @@ pub enum Action {
         /// Unique identifier of the entity.
         id: Id,
 
-        /// Type identifier of the entity.
-        type_id: u8,
-
         /// Serialised data of the entity.
         data: Vec<u8>,
 
         /// Details of the ancestors of the entity.
         ancestors: Vec<ChildInfo>,
+
+        /// The metadata of the entity.
+        metadata: Metadata,
     },
 }
 
 /// Data that is used for comparison between two nodes.
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Deserialize,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ComparisonData {
     /// The unique identifier of the entity being compared.
     id: Id,
@@ -359,6 +336,9 @@ pub struct ComparisonData {
     /// The list of children of the entity, with their IDs and hashes,
     /// organised by collection name.
     children: BTreeMap<String, Vec<ChildInfo>>,
+
+    /// The metadata of the entity.
+    metadata: Metadata,
 }
 
 /// The primary interface for the storage system.
@@ -388,15 +368,28 @@ impl<S: StorageAdaptor> MainInterface<S> {
         collection: &C,
         child: &mut D,
     ) -> Result<bool, StorageError> {
-        let own_hash = child.calculate_merkle_hash()?;
+        if !child.element().is_dirty() {
+            return Ok(false);
+        }
+
+        let data = to_vec(child).map_err(|e| StorageError::SerializationError(e.into()))?;
+
+        let own_hash = Sha256::digest(&data).into();
+
         <Index<S>>::add_child_to(
             parent_id,
             collection.name(),
-            ChildInfo::new(child.id(), own_hash),
-            D::type_id(),
+            ChildInfo::new(child.id(), own_hash, child.element().metadata),
         )?;
-        child.element_mut().merkle_hash = <Index<S>>::update_hash_for(child.id(), own_hash)?;
-        Self::save(child)
+
+        let Some(hash) = Self::save_raw(child.id(), data, child.element().metadata)? else {
+            return Ok(false);
+        };
+
+        child.element_mut().is_dirty = false;
+        child.element_mut().merkle_hash = hash;
+
+        Ok(true)
     }
 
     /// Applies an [`Action`] to the storage system.
@@ -427,17 +420,21 @@ impl<S: StorageAdaptor> MainInterface<S> {
     /// If there is an error when deserialising into the specified type, or when
     /// applying the [`Action`], an error will be returned.
     ///
-    pub fn apply_action<D: Data>(action: Action) -> Result<Option<Id>, StorageError> {
+    pub fn apply_action(action: Action) -> Result<Option<Id>, StorageError> {
         let ancestors = match action {
             Action::Add {
-                data, ancestors, ..
+                id,
+                data,
+                ancestors,
+                metadata,
             }
             | Action::Update {
-                data, ancestors, ..
+                id,
+                data,
+                ancestors,
+                metadata,
             } => {
-                let mut entity =
-                    D::try_from_slice(&data).map_err(StorageError::DeserializationError)?;
-                _ = Self::save(&mut entity)?;
+                _ = Self::save_raw(id, data, metadata)?;
                 ancestors
             }
             Action::Compare { .. } => {
@@ -574,34 +571,34 @@ impl<S: StorageAdaptor> MainInterface<S> {
     /// This function will return an error if there are issues accessing local
     /// data or if there are problems during the comparison process.
     ///
-    pub fn compare_trees<D: Data>(
+    pub fn compare_trees(
         foreign_entity_data: Option<Vec<u8>>,
         foreign_index_data: &ComparisonData,
     ) -> Result<(Vec<Action>, Vec<Action>), StorageError> {
         let mut actions = (vec![], vec![]);
 
-        let foreign_entity = foreign_entity_data
-            .as_ref()
-            .map(|d| D::try_from_slice(d))
-            .transpose()
-            .map_err(StorageError::DeserializationError)?;
+        let id = foreign_index_data.id;
 
-        let Some(local_entity) = Self::find_by_id::<D>(foreign_index_data.id)? else {
+        let local_metadata = <Index<S>>::get_metadata(id)?;
+
+        let Some(local_entity) = Self::find_by_id_raw(id)? else {
             if let Some(foreign_entity) = foreign_entity_data {
                 // Local entity doesn't exist, so we need to add it
                 actions.0.push(Action::Add {
-                    id: foreign_index_data.id,
-                    type_id: D::type_id(),
+                    id,
                     data: foreign_entity,
                     ancestors: foreign_index_data.ancestors.clone(),
+                    metadata: foreign_index_data.metadata,
                 });
             }
 
             return Ok(actions);
         };
 
-        let (local_full_hash, local_own_hash) = <Index<S>>::get_hashes_for(local_entity.id())?
-            .ok_or(StorageError::IndexNotFound(local_entity.id()))?;
+        let local_metadata = local_metadata.ok_or(StorageError::IndexNotFound(id))?;
+
+        let (local_full_hash, local_own_hash) =
+            <Index<S>>::get_hashes_for(id)?.ok_or(StorageError::IndexNotFound(id))?;
 
         // Compare full Merkle hashes
         if local_full_hash == foreign_index_data.full_hash {
@@ -610,24 +607,23 @@ impl<S: StorageAdaptor> MainInterface<S> {
 
         // Compare own hashes and timestamps
         if local_own_hash != foreign_index_data.own_hash {
-            match (foreign_entity, foreign_entity_data) {
-                (Some(foreign_entity), Some(foreign_entity_data))
-                    if local_entity.element().updated_at()
-                        <= foreign_entity.element().updated_at() =>
+            match foreign_entity_data {
+                Some(foreign_entity_data)
+                    if local_metadata.updated_at <= foreign_index_data.metadata.updated_at =>
                 {
                     actions.0.push(Action::Update {
-                        id: local_entity.id(),
-                        type_id: D::type_id(),
+                        id,
                         data: foreign_entity_data,
                         ancestors: foreign_index_data.ancestors.clone(),
+                        metadata: foreign_index_data.metadata,
                     });
                 }
                 _ => {
                     actions.1.push(Action::Update {
-                        id: foreign_index_data.id,
-                        type_id: D::type_id(),
-                        data: to_vec(&local_entity).map_err(StorageError::SerializationError)?,
-                        ancestors: <Index<S>>::get_ancestors_of(local_entity.id())?,
+                        id,
+                        data: local_entity,
+                        ancestors: <Index<S>>::get_ancestors_of(id)?,
+                        metadata: local_metadata,
                     });
                 }
             }
@@ -635,7 +631,16 @@ impl<S: StorageAdaptor> MainInterface<S> {
 
         // The list of collections from the type will be the same on both sides, as
         // the type is the same.
-        let local_collections = local_entity.collections();
+
+        let local_collection_names = <Index<S>>::get_collection_names_for(id)?;
+
+        let local_collections = local_collection_names
+            .iter()
+            .map(|name| {
+                let children = <Index<S>>::get_children_of(id, name)?;
+                Ok((name.clone(), children))
+            })
+            .collect::<Result<BTreeMap<_, _>, StorageError>>()?;
 
         // Compare children
         for (local_coll_name, local_children) in &local_collections {
@@ -649,19 +654,22 @@ impl<S: StorageAdaptor> MainInterface<S> {
                     .map(|child| (child.id(), child.merkle_hash()))
                     .collect();
 
-                for (id, local_hash) in &local_child_map {
-                    match foreign_child_map.get(id) {
+                for (child_id, local_hash) in &local_child_map {
+                    match foreign_child_map.get(child_id) {
                         Some(foreign_hash) if local_hash != foreign_hash => {
-                            actions.0.push(Action::Compare { id: *id });
-                            actions.1.push(Action::Compare { id: *id });
+                            actions.0.push(Action::Compare { id: *child_id });
+                            actions.1.push(Action::Compare { id: *child_id });
                         }
                         None => {
-                            if let Some(local_child) = Self::find_by_id_raw(*id)? {
+                            if let Some(local_child) = Self::find_by_id_raw(*child_id)? {
+                                let metadata = <Index<S>>::get_metadata(*child_id)?
+                                    .ok_or(StorageError::IndexNotFound(*child_id))?;
+
                                 actions.1.push(Action::Add {
-                                    id: *id,
-                                    type_id: <Index<S>>::get_type_id(*id)?,
+                                    id: *child_id,
                                     data: local_child,
-                                    ancestors: <Index<S>>::get_ancestors_of(local_entity.id())?,
+                                    ancestors: <Index<S>>::get_ancestors_of(id)?,
+                                    metadata,
                                 });
                             }
                         }
@@ -682,11 +690,14 @@ impl<S: StorageAdaptor> MainInterface<S> {
                 // The entire collection is missing from the foreign entity
                 for child in local_children {
                     if let Some(local_child) = Self::find_by_id_raw(child.id())? {
+                        let metadata = <Index<S>>::get_metadata(child.id())?
+                            .ok_or(StorageError::IndexNotFound(child.id()))?;
+
                         actions.1.push(Action::Add {
                             id: child.id(),
-                            type_id: <Index<S>>::get_type_id(child.id())?,
                             data: local_child,
-                            ancestors: <Index<S>>::get_ancestors_of(local_entity.id())?,
+                            ancestors: <Index<S>>::get_ancestors_of(child.id())?,
+                            metadata,
                         });
                     }
                 }
@@ -714,14 +725,14 @@ impl<S: StorageAdaptor> MainInterface<S> {
     /// This function will return an error if there are issues accessing local
     /// data or if there are problems during the comparison process.
     ///
-    pub fn compare_affective<D: Data>(
+    pub fn compare_affective(
         data: Option<Vec<u8>>,
         comparison_data: ComparisonData,
     ) -> Result<(), StorageError> {
-        let (local, remote) = Interface::compare_trees::<D>(data, &comparison_data)?;
+        let (local, remote) = Interface::compare_trees(data, &comparison_data)?;
 
         for action in local {
-            let _ignored = Interface::apply_action::<D>(action)?;
+            let _ignored = Interface::apply_action(action)?;
         }
 
         for action in remote {
@@ -750,18 +761,21 @@ impl<S: StorageAdaptor> MainInterface<S> {
     pub fn find_by_id<D: Data>(id: Id) -> Result<Option<D>, StorageError> {
         let value = S::storage_read(Key::Entry(id));
 
-        match value {
-            Some(slice) => {
-                let mut entity =
-                    D::try_from_slice(&slice).map_err(StorageError::DeserializationError)?;
-                // TODO: This is needed for now, as the field gets stored. Later we will
-                // TODO: implement a custom serialiser that will skip this field along with
-                // TODO: any others that should not be stored.
-                entity.element_mut().is_dirty = false;
-                Ok(Some(entity))
-            }
-            None => Ok(None),
-        }
+        let Some(slice) = value else {
+            return Ok(None);
+        };
+
+        let mut item = from_slice::<D>(&slice).map_err(StorageError::DeserializationError)?;
+
+        let (full_hash, _) =
+            <Index<S>>::get_hashes_for(id)?.ok_or(StorageError::IndexNotFound(id))?;
+
+        item.element_mut().merkle_hash = full_hash;
+
+        item.element_mut().metadata =
+            <Index<S>>::get_metadata(id)?.ok_or(StorageError::IndexNotFound(id))?;
+
+        Ok(Some(item))
     }
 
     /// Finds an [`Element`](crate::entities::Element) by its unique identifier
@@ -859,38 +873,42 @@ impl<S: StorageAdaptor> MainInterface<S> {
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
     ///
-    pub fn generate_comparison_data<D: Data>(
-        entity: Option<&D>,
-    ) -> Result<ComparisonData, StorageError> {
-        let Some(entity) = entity else {
+    pub fn generate_comparison_data(id: Option<Id>) -> Result<ComparisonData, StorageError> {
+        let Some(id) = id else {
             return Ok(ComparisonData {
                 id: Id::root(),
                 own_hash: [0; 32],
                 full_hash: [0; 32],
                 ancestors: Vec::new(),
                 children: BTreeMap::new(),
+                metadata: Metadata::default(),
             });
         };
 
-        let (full_hash, own_hash) = <Index<S>>::get_hashes_for(entity.id())?
-            .ok_or(StorageError::IndexNotFound(entity.id()))?;
+        let (full_hash, own_hash) =
+            <Index<S>>::get_hashes_for(id)?.ok_or(StorageError::IndexNotFound(id))?;
 
-        let ancestors = <Index<S>>::get_ancestors_of(entity.id())?;
-        let children = entity
-            .collections()
-            .into_keys()
+        let metadata = <Index<S>>::get_metadata(id)?.ok_or(StorageError::IndexNotFound(id))?;
+
+        let ancestors = <Index<S>>::get_ancestors_of(id)?;
+
+        let collection_names = <Index<S>>::get_collection_names_for(id)?;
+
+        let children = collection_names
+            .into_iter()
             .map(|collection_name| {
-                <Index<S>>::get_children_of(entity.id(), &collection_name)
+                <Index<S>>::get_children_of(id, &collection_name)
                     .map(|children| (collection_name.clone(), children))
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
         Ok(ComparisonData {
-            id: entity.id(),
+            id,
             own_hash,
             full_hash,
             ancestors,
             children,
+            metadata,
         })
     }
 
@@ -965,7 +983,9 @@ impl<S: StorageAdaptor> MainInterface<S> {
         let (parent_full_hash, _) =
             <Index<S>>::get_hashes_for(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
         let mut ancestors = <Index<S>>::get_ancestors_of(parent_id)?;
-        ancestors.insert(0, ChildInfo::new(parent_id, parent_full_hash));
+        let metadata =
+            <Index<S>>::get_metadata(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+        ancestors.insert(0, ChildInfo::new(parent_id, parent_full_hash, metadata));
 
         _ = S::storage_remove(Key::Entry(child_id));
 
@@ -1002,19 +1022,21 @@ impl<S: StorageAdaptor> MainInterface<S> {
     /// This function will return an error if there are issues accessing local
     /// data or if there are problems during the comparison process.
     ///
-    pub fn commit_root<D: Data>(mut root: D) -> Result<(), StorageError> {
+    pub fn commit_root<D: Data>(root: D) -> Result<(), StorageError> {
         if root.id() != Id::root() {
             return Err(StorageError::UnexpectedId(root.id()));
         }
 
-        // fixme! mutations (action application) doesn't propagate to the root
-        // fixme! so, a best-attempt approach is to force a save on the root
-        // fixme! deeply nested entries have undefined behaviour
-        root.element_mut().is_dirty = true;
+        if !root.element().is_dirty() {
+            return Ok(());
+        }
 
-        let _ = Self::save(&mut root)?;
+        let data = to_vec(&root).map_err(|e| StorageError::SerializationError(e.into()))?;
 
-        sync::commit_root(&root.element().merkle_hash())?;
+        let hash = Self::save_raw(root.id(), data, root.element().metadata)?
+            .expect("root should always be successfully committed");
+
+        sync::commit_root(&hash)?;
 
         Ok(())
     }
@@ -1083,78 +1105,76 @@ impl<S: StorageAdaptor> MainInterface<S> {
     ///
     pub fn save<D: Data>(entity: &mut D) -> Result<bool, StorageError> {
         if !entity.element().is_dirty() {
-            return Ok(true);
+            return Ok(false);
         }
-        let id = entity.id();
 
-        if !D::is_root() && <Index<S>>::get_parent_id(id)?.is_none() {
+        let data = to_vec(entity).map_err(|e| StorageError::SerializationError(e.into()))?;
+
+        let Some(hash) = Self::save_raw(entity.id(), data, entity.element().metadata)? else {
+            return Ok(false);
+        };
+
+        entity.element_mut().is_dirty = false;
+        entity.element_mut().merkle_hash = hash;
+
+        Ok(true)
+    }
+
+    /// Saves raw data to the storage system.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when serialising data or interacting with the storage
+    /// system, an error will be returned.
+    ///
+    pub fn save_raw(
+        id: Id,
+        data: Vec<u8>,
+        metadata: Metadata,
+    ) -> Result<Option<[u8; 32]>, StorageError> {
+        if !id.is_root() && <Index<S>>::get_parent_id(id)?.is_none() {
             return Err(StorageError::CannotCreateOrphan(id));
         }
 
-        let is_new = Self::find_by_id::<D>(id)?.is_none();
-        if !is_new {
-            if let Some(existing) = Self::find_by_id::<D>(id)? {
-                if existing.element().metadata.updated_at >= entity.element().metadata.updated_at {
-                    return Ok(false);
-                }
+        let last_metadata = <Index<S>>::get_metadata(id)?;
+
+        let is_new = last_metadata.is_none();
+
+        if let Some(last_metadata) = &last_metadata {
+            if last_metadata.updated_at > metadata.updated_at {
+                return Ok(None);
             }
-        } else if D::is_root() {
-            <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32]), D::type_id())?;
+        } else if id.is_root() {
+            <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32], metadata))?;
         }
 
-        let own_hash = entity.calculate_merkle_hash()?;
-        entity.element_mut().merkle_hash = <Index<S>>::update_hash_for(id, own_hash)?;
+        let own_hash = Sha256::digest(&data).into();
 
-        _ = S::storage_write(
-            Key::Entry(id),
-            &to_vec(entity).map_err(StorageError::SerializationError)?,
-        );
+        let full_hash = <Index<S>>::update_hash_for(id, own_hash)?;
 
-        entity.element_mut().is_dirty = false;
+        _ = S::storage_write(Key::Entry(id), &data);
+
+        let ancestors = <Index<S>>::get_ancestors_of(id)?;
 
         let action = if is_new {
             Action::Add {
                 id,
-                type_id: D::type_id(),
-                data: to_vec(entity).map_err(StorageError::SerializationError)?,
-                ancestors: <Index<S>>::get_ancestors_of(id)?,
+                data,
+                ancestors,
+                metadata,
             }
         } else {
             Action::Update {
                 id,
-                type_id: D::type_id(),
-                data: to_vec(entity).map_err(StorageError::SerializationError)?,
-                ancestors: <Index<S>>::get_ancestors_of(id)?,
+                data,
+                ancestors,
+                metadata,
             }
         };
 
         sync::push_action(action);
 
-        Ok(true)
-    }
-
-    /// Type identifier of the entity.
-    ///
-    /// This is noted so that the entity can be deserialised correctly in the
-    /// absence of other semantic information. It is intended that the [`Path`]
-    /// will be used to help with this at some point, but at present paths are
-    /// not fully utilised.
-    ///
-    /// The value returned is arbitrary, and is up to the implementer to decide
-    /// what it should be. It is recommended that it be unique for each type of
-    /// entity.
-    ///
-    /// # Parameters
-    ///
-    /// * `id` - The [`Id`] of the entity whose type is to be retrieved.
-    ///
-    /// # Errors
-    ///
-    /// If an error occurs when interacting with the storage system, an error
-    /// will be returned.
-    ///
-    pub fn type_of(id: Id) -> Result<u8, StorageError> {
-        <Index<S>>::get_type_id(id)
+        Ok(Some(full_hash))
     }
 
     /// Validates the stored state.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -6,11 +6,11 @@
 
 #![forbid(
     unreachable_pub,
-    unsafe_code,
     unsafe_op_in_unsafe_fn,
     clippy::missing_docs_in_private_items
 )]
 #![deny(
+    unsafe_code,
     clippy::expect_used,
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -1,14 +1,11 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use borsh::to_vec;
 use claims::{assert_ge, assert_le};
 use sha2::{Digest, Sha256};
 use velcro::btree_map;
 
 use super::*;
-use crate::index::Index;
 use crate::interface::Interface;
-use crate::store::MainStorage;
 use crate::tests::common::{Page, Paragraph, Paragraphs, Person};
 
 #[cfg(test)]
@@ -25,81 +22,6 @@ mod collection__public_methods {
 #[cfg(test)]
 mod data__public_methods {
     use super::*;
-
-    #[test]
-    fn calculate_merkle_hash() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
-        let person = Person {
-            name: "Alice".to_owned(),
-            age: 30,
-            storage: element.clone(),
-        };
-
-        let mut hasher = Sha256::new();
-        hasher.update(person.id().as_bytes());
-        hasher.update(&to_vec(&person.name).unwrap());
-        hasher.update(&to_vec(&person.age).unwrap());
-        hasher.update(&to_vec(&person.element().metadata).unwrap());
-        let expected_hash: [u8; 32] = hasher.finalize().into();
-
-        assert_eq!(person.calculate_merkle_hash().unwrap(), expected_hash);
-    }
-
-    #[test]
-    fn calculate_merkle_hash_for_child__valid() {
-        let parent = Element::new(&Path::new("::root::node").unwrap(), None);
-        let mut page = Page::new_from_element("Node", parent);
-        let child1 = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
-        let mut para1 = Paragraph::new_from_element("Leaf1", child1);
-        assert!(Interface::save(&mut page).unwrap());
-
-        assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para1).unwrap());
-        let para1_slice = to_vec(&para1).unwrap();
-        let para1_hash = page
-            .calculate_merkle_hash_for_child("Paragraphs", &para1_slice)
-            .unwrap();
-        let expected_hash1 = para1.calculate_merkle_hash().unwrap();
-        assert_eq!(para1_hash, expected_hash1);
-
-        let child2 = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
-        let para2 = Paragraph::new_from_element("Leaf2", child2);
-        let para2_slice = to_vec(&para2).unwrap();
-        let para2_hash = page
-            .calculate_merkle_hash_for_child("Paragraphs", &para2_slice)
-            .unwrap();
-        assert_ne!(para2_hash, para1_hash);
-    }
-
-    #[test]
-    fn calculate_merkle_hash_for_child__invalid() {
-        let parent = Element::new(&Path::new("::root::node").unwrap(), None);
-        let mut page = Page::new_from_element("Node", parent);
-        let child1 = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
-        let mut para1 = Paragraph::new_from_element("Leaf1", child1);
-        assert!(Interface::save(&mut page).unwrap());
-
-        assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para1).unwrap());
-        let invalid_slice = &[0, 1, 2, 3];
-        let result = page.calculate_merkle_hash_for_child("Paragraphs", invalid_slice);
-        assert!(matches!(result, Err(StorageError::DeserializationError(_))));
-    }
-
-    #[test]
-    fn calculate_merkle_hash_for_child__unknown_collection() {
-        let parent = Element::new(&Path::new("::root::node").unwrap(), None);
-        let mut page = Page::new_from_element("Node", parent);
-        let child = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
-        let mut para = Paragraph::new_from_element("Leaf", child);
-        assert!(Interface::save(&mut page).unwrap());
-
-        assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para).unwrap());
-        let para_slice = to_vec(&para).unwrap();
-        let result = page.calculate_merkle_hash_for_child("unknown_collection", &para_slice);
-        assert!(matches!(
-            result,
-            Err(StorageError::UnknownCollectionType(_))
-        ));
-    }
 
     #[test]
     fn collections() {
@@ -179,7 +101,7 @@ mod child_info__constructor {
     fn new() {
         let id = Id::random();
         let hash = Sha256::digest(b"1").into();
-        let info = ChildInfo::new(id, hash);
+        let info = ChildInfo::new(id, hash, Metadata::default());
         assert_eq!(info.id, id);
         assert_eq!(info.merkle_hash, hash);
     }
@@ -191,13 +113,21 @@ mod child_info__public_methods {
 
     #[test]
     fn id() {
-        let info = ChildInfo::new(Id::random(), Sha256::digest(b"1").into());
+        let info = ChildInfo::new(
+            Id::random(),
+            Sha256::digest(b"1").into(),
+            Metadata::default(),
+        );
         assert_eq!(info.id(), info.id);
     }
 
     #[test]
     fn merkle_hash() {
-        let info = ChildInfo::new(Id::random(), Sha256::digest(b"1").into());
+        let info = ChildInfo::new(
+            Id::random(),
+            Sha256::digest(b"1").into(),
+            Metadata::default(),
+        );
         assert_eq!(info.merkle_hash(), info.merkle_hash);
     }
 }
@@ -208,7 +138,11 @@ mod child_info__traits {
 
     #[test]
     fn display() {
-        let info = ChildInfo::new(Id::random(), Sha256::digest(b"1").into());
+        let info = ChildInfo::new(
+            Id::random(),
+            Sha256::digest(b"1").into(),
+            Metadata::default(),
+        );
         assert_eq!(
             format!("{info}"),
             format!(
@@ -247,8 +181,8 @@ mod element__constructor {
         assert_eq!(element.path, path);
         assert_ge!(element.metadata.created_at, timestamp1);
         assert_le!(element.metadata.created_at, timestamp2);
-        assert_ge!(element.metadata.updated_at, timestamp1);
-        assert_le!(element.metadata.updated_at, timestamp2);
+        assert_ge!(*element.metadata.updated_at, timestamp1);
+        assert_le!(*element.metadata.updated_at, timestamp2);
         assert!(element.is_dirty);
     }
 }
@@ -281,7 +215,7 @@ mod element__public_methods {
 
     #[test]
     fn is_dirty() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
+        let element = Element::root();
         assert!(element.is_dirty());
 
         let mut person = Person {
@@ -294,22 +228,6 @@ mod element__public_methods {
 
         person.element_mut().update();
         assert!(person.element().is_dirty());
-    }
-
-    #[test]
-    fn merkle_hash() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
-        let mut person = Person {
-            name: "Steve".to_owned(),
-            age: 50,
-            storage: element.clone(),
-        };
-        assert_eq!(person.element().merkle_hash(), [0_u8; 32]);
-
-        assert!(Interface::save(&mut person).unwrap());
-        let expected_hash =
-            <Index<MainStorage>>::calculate_full_merkle_hash_for(person.id(), false).unwrap();
-        assert_eq!(person.element().merkle_hash(), expected_hash);
     }
 
     #[test]
@@ -327,7 +245,7 @@ mod element__public_methods {
 
     #[test]
     fn update() {
-        let element = Element::new(&Path::new("::root::node::leaf").unwrap(), None);
+        let element = Element::root();
         let updated_at = element.metadata.updated_at;
         let mut person = Person {
             name: "Bob".to_owned(),

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -9,7 +9,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -29,8 +34,7 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash),
-            2,
+            ChildInfo::new(child_id, child_own_hash, Metadata::default()),
         )
         .is_ok());
 
@@ -41,7 +45,7 @@ mod index__public_methods {
         assert_eq!(updated_root_index.children.len(), 1);
         assert_eq!(
             updated_root_index.children[collection_name][0],
-            ChildInfo::new(child_id, child_full_hash)
+            ChildInfo::new(child_id, child_full_hash, Metadata::default())
         );
 
         let child_index = <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
@@ -56,7 +60,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -73,35 +82,41 @@ mod index__public_methods {
         let grandchild_collection_name = "Pages";
         let greatgrandchild_collection_name = "Paragraphs";
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let child_id = Id::random();
         let child_hash = [2_u8; 32];
-        let child_info = ChildInfo::new(child_id, child_hash);
+        let child_info = ChildInfo::new(child_id, child_hash, Metadata::default());
         assert!(
-            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info, 2)
-                .is_ok()
+            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info).is_ok()
         );
 
         let grandchild_id = Id::random();
         let grandchild_hash = [3_u8; 32];
-        let grandchild_info = ChildInfo::new(grandchild_id, grandchild_hash);
+        let grandchild_info = ChildInfo::new(grandchild_id, grandchild_hash, Metadata::default());
         assert!(<Index<MainStorage>>::add_child_to(
             child_id,
             grandchild_collection_name,
             grandchild_info,
-            3,
         )
         .is_ok());
 
         let greatgrandchild_id = Id::random();
         let greatgrandchild_hash = [4_u8; 32];
-        let greatgrandchild_info = ChildInfo::new(greatgrandchild_id, greatgrandchild_hash);
+        let greatgrandchild_info = ChildInfo::new(
+            greatgrandchild_id,
+            greatgrandchild_hash,
+            Metadata::default(),
+        );
         assert!(<Index<MainStorage>>::add_child_to(
             grandchild_id,
             greatgrandchild_collection_name,
             greatgrandchild_info,
-            4,
         )
         .is_ok());
 
@@ -114,7 +129,8 @@ mod index__public_methods {
                 <Index<MainStorage>>::get_hashes_for(grandchild_id)
                     .unwrap()
                     .unwrap()
-                    .0
+                    .0,
+                Metadata::default()
             )
         );
         assert_eq!(
@@ -124,7 +140,8 @@ mod index__public_methods {
                 <Index<MainStorage>>::get_hashes_for(child_id)
                     .unwrap()
                     .unwrap()
-                    .0
+                    .0,
+                Metadata::default()
             )
         );
         assert_eq!(
@@ -134,7 +151,8 @@ mod index__public_methods {
                 <Index<MainStorage>>::get_hashes_for(root_id)
                     .unwrap()
                     .unwrap()
-                    .0
+                    .0,
+                Metadata::default()
             )
         );
     }
@@ -144,7 +162,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let collection_name = "Books";
         let child1_id = Id::random();
@@ -166,22 +189,26 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child1_id, child1_own_hash),
-            2,
+            ChildInfo::new(child1_id, child1_own_hash, Metadata::default()),
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child2_id, child2_own_hash),
-            2,
+            ChildInfo::new(child2_id, child2_own_hash, Metadata::default()),
         )
         .is_ok());
 
         let children = <Index<MainStorage>>::get_children_of(root_id, collection_name).unwrap();
         assert_eq!(children.len(), 2);
-        assert_eq!(children[0], ChildInfo::new(child1_id, child1_full_hash));
-        assert_eq!(children[1], ChildInfo::new(child2_id, child2_full_hash));
+        assert_eq!(
+            children[0],
+            ChildInfo::new(child1_id, child1_full_hash, Metadata::default())
+        );
+        assert_eq!(
+            children[1],
+            ChildInfo::new(child2_id, child2_full_hash, Metadata::default())
+        );
     }
 
     #[test]
@@ -189,7 +216,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let collection1_name = "Pages";
         let child1_id = Id::random();
@@ -219,32 +251,38 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
-            ChildInfo::new(child1_id, child1_own_hash),
-            2,
+            ChildInfo::new(child1_id, child1_own_hash, Metadata::default()),
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
-            ChildInfo::new(child2_id, child2_own_hash),
-            2,
+            ChildInfo::new(child2_id, child2_own_hash, Metadata::default()),
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection2_name,
-            ChildInfo::new(child3_id, child3_own_hash),
-            2,
+            ChildInfo::new(child3_id, child3_own_hash, Metadata::default()),
         )
         .is_ok());
 
         let children1 = <Index<MainStorage>>::get_children_of(root_id, collection1_name).unwrap();
         assert_eq!(children1.len(), 2);
-        assert_eq!(children1[0], ChildInfo::new(child1_id, child1_full_hash));
-        assert_eq!(children1[1], ChildInfo::new(child2_id, child2_full_hash));
+        assert_eq!(
+            children1[0],
+            ChildInfo::new(child1_id, child1_full_hash, Metadata::default())
+        );
+        assert_eq!(
+            children1[1],
+            ChildInfo::new(child2_id, child2_full_hash, Metadata::default())
+        );
         let children2 = <Index<MainStorage>>::get_children_of(root_id, collection2_name).unwrap();
         assert_eq!(children2.len(), 1);
-        assert_eq!(children2[0], ChildInfo::new(child3_id, child3_full_hash));
+        assert_eq!(
+            children2[0],
+            ChildInfo::new(child3_id, child3_full_hash, Metadata::default())
+        );
     }
 
     #[test]
@@ -252,7 +290,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let collection1_name = "Pages";
         let collection2_name = "Chapters";
@@ -266,15 +309,13 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection1_name,
-            ChildInfo::new(child1_id, child1_own_hash),
-            2,
+            ChildInfo::new(child1_id, child1_own_hash, Metadata::default()),
         )
         .is_ok());
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection2_name,
-            ChildInfo::new(child2_id, child2_own_hash),
-            2,
+            ChildInfo::new(child2_id, child2_own_hash, Metadata::default()),
         )
         .is_ok());
 
@@ -290,7 +331,12 @@ mod index__public_methods {
         let root_own_hash = [1_u8; 32];
         let root_full_hash = [0_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_own_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_own_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         assert_eq!(
             <Index<MainStorage>>::get_hashes_for(root_id)
@@ -305,7 +351,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -320,8 +371,7 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash),
-            2,
+            ChildInfo::new(child_id, child_own_hash, Metadata::default()),
         )
         .is_ok());
 
@@ -333,27 +383,17 @@ mod index__public_methods {
     }
 
     #[test]
-    fn get_type_id() {
-        let root_id = Id::random();
-        let root_hash = [1_u8; 32];
-
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 99).is_ok());
-
-        let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
-        assert_eq!(root_index.id, root_id);
-        assert_eq!(root_index.own_hash, root_hash);
-        assert_eq!(root_index.type_id, 99);
-
-        assert_eq!(<Index<MainStorage>>::get_type_id(root_id).unwrap(), 99,);
-    }
-
-    #[test]
     fn has_children() {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
         let collection_name = "Books";
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
         assert!(!<Index<MainStorage>>::has_children(root_id, collection_name).unwrap());
 
         let child_id = Id::random();
@@ -362,8 +402,7 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash),
-            2,
+            ChildInfo::new(child_id, child_own_hash, Metadata::default()),
         )
         .is_ok());
         assert!(<Index<MainStorage>>::has_children(root_id, collection_name).unwrap());
@@ -374,7 +413,12 @@ mod index__public_methods {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -389,8 +433,7 @@ mod index__public_methods {
         assert!(<Index<MainStorage>>::add_child_to(
             root_id,
             collection_name,
-            ChildInfo::new(child_id, child_own_hash),
-            2,
+            ChildInfo::new(child_id, child_own_hash, Metadata::default()),
         )
         .is_ok());
         assert!(
@@ -419,7 +462,7 @@ mod index__private_methods {
             children: BTreeMap::new(),
             full_hash: hash1,
             own_hash: hash2,
-            type_id: 1,
+            metadata: Metadata::default(),
         };
         <Index<MainStorage>>::save_index(&index).unwrap();
 
@@ -439,7 +482,7 @@ mod index__private_methods {
             children: BTreeMap::new(),
             full_hash: hash1,
             own_hash: hash2,
-            type_id: 1,
+            metadata: Metadata::default(),
         };
         <Index<MainStorage>>::save_index(&index).unwrap();
         assert_eq!(<Index<MainStorage>>::get_index(id).unwrap().unwrap(), index);
@@ -456,27 +499,26 @@ mod hashing {
     #[test]
     fn calculate_full_merkle_hash_for__with_children() {
         let root_id = Id::random();
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, [0_u8; 32]), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            [0_u8; 32],
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let collection_name = "Children";
         let child1_id = Id::random();
         let child1_hash = [1_u8; 32];
-        let child1_info = ChildInfo::new(child1_id, child1_hash);
-        assert!(
-            <Index<MainStorage>>::add_child_to(root_id, collection_name, child1_info, 2).is_ok()
-        );
+        let child1_info = ChildInfo::new(child1_id, child1_hash, Metadata::default());
+        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child1_info).is_ok());
         let child2_id = Id::random();
         let child2_hash = [2_u8; 32];
-        let child2_info = ChildInfo::new(child2_id, child2_hash);
-        assert!(
-            <Index<MainStorage>>::add_child_to(root_id, collection_name, child2_info, 2).is_ok()
-        );
+        let child2_info = ChildInfo::new(child2_id, child2_hash, Metadata::default());
+        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child2_info).is_ok());
         let child3_id = Id::random();
         let child3_hash = [3_u8; 32];
-        let child3_info = ChildInfo::new(child3_id, child3_hash);
-        assert!(
-            <Index<MainStorage>>::add_child_to(root_id, collection_name, child3_info, 2).is_ok()
-        );
+        let child3_info = ChildInfo::new(child3_id, child3_hash, Metadata::default());
+        assert!(<Index<MainStorage>>::add_child_to(root_id, collection_name, child3_info).is_ok());
 
         assert_eq!(
             hex::encode(
@@ -512,17 +554,21 @@ mod hashing {
         let grandchild_collection_name = "Pages";
         let greatgrandchild_collection_name = "Paragraphs";
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.full_hash, [0_u8; 32]);
 
         let child_id = Id::random();
         let child_hash = [2_u8; 32];
-        let child_info = ChildInfo::new(child_id, child_hash);
+        let child_info = ChildInfo::new(child_id, child_hash, Metadata::default());
         assert!(
-            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info, 2)
-                .is_ok()
+            <Index<MainStorage>>::add_child_to(root_id, child_collection_name, child_info).is_ok()
         );
 
         let root_index_with_child = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
@@ -538,12 +584,11 @@ mod hashing {
 
         let grandchild_id = Id::random();
         let grandchild_hash = [3_u8; 32];
-        let grandchild_info = ChildInfo::new(grandchild_id, grandchild_hash);
+        let grandchild_info = ChildInfo::new(grandchild_id, grandchild_hash, Metadata::default());
         assert!(<Index<MainStorage>>::add_child_to(
             child_id,
             grandchild_collection_name,
             grandchild_info,
-            3,
         )
         .is_ok());
 
@@ -568,12 +613,15 @@ mod hashing {
 
         let greatgrandchild_id = Id::random();
         let greatgrandchild_hash = [4_u8; 32];
-        let greatgrandchild_info = ChildInfo::new(greatgrandchild_id, greatgrandchild_hash);
+        let greatgrandchild_info = ChildInfo::new(
+            greatgrandchild_id,
+            greatgrandchild_hash,
+            Metadata::default(),
+        );
         assert!(<Index<MainStorage>>::add_child_to(
             grandchild_id,
             greatgrandchild_collection_name,
             greatgrandchild_info,
-            4,
         )
         .is_ok());
 
@@ -691,7 +739,12 @@ mod hashing {
                 .try_into()
                 .unwrap();
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash1,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);
@@ -709,7 +762,12 @@ mod hashing {
         let root_hash1 = [1_u8; 32];
         let root_hash2 = [2_u8; 32];
 
-        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(root_id, root_hash1), 1).is_ok());
+        assert!(<Index<MainStorage>>::add_root(ChildInfo::new(
+            root_id,
+            root_hash1,
+            Metadata::default()
+        ),)
+        .is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(root_index.id, root_id);

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -14,7 +14,7 @@ mod interface__public_methods {
 
     #[test]
     fn children_of() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut page = Page::new_from_element("Node", element);
         assert!(Interface::save(&mut page).unwrap());
         assert_eq!(
@@ -28,7 +28,9 @@ mod interface__public_methods {
         let mut para1 = Paragraph::new_from_element("Leaf1", child1);
         let mut para2 = Paragraph::new_from_element("Leaf2", child2);
         let mut para3 = Paragraph::new_from_element("Leaf3", child3);
-        assert!(Interface::save(&mut page).unwrap());
+
+        assert!(!Interface::save(&mut page).unwrap());
+
         assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para1).unwrap());
         assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para2).unwrap());
         assert!(Interface::add_child_to(page.id(), &mut page.paragraphs, &mut para3).unwrap());
@@ -40,7 +42,7 @@ mod interface__public_methods {
 
     #[test]
     fn find_by_id__existent() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut page = Page::new_from_element("Leaf", element);
         let id = page.id();
         assert!(Interface::save(&mut page).unwrap());
@@ -73,28 +75,15 @@ mod interface__public_methods {
 
     #[test]
     fn save__basic() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut page = Page::new_from_element("Node", element);
 
         assert_ok!(Interface::save(&mut page));
     }
 
     #[test]
-    fn save__multiple() {
-        let element1 = Element::new(&Path::new("::root::node1").unwrap(), None);
-        let element2 = Element::new(&Path::new("::root::node2").unwrap(), None);
-        let mut page1 = Page::new_from_element("Node1", element1);
-        let mut page2 = Page::new_from_element("Node2", element2);
-
-        assert!(Interface::save(&mut page1).unwrap());
-        assert!(Interface::save(&mut page2).unwrap());
-        assert_eq!(Interface::find_by_id(page1.id()).unwrap(), Some(page1));
-        assert_eq!(Interface::find_by_id(page2.id()).unwrap(), Some(page2));
-    }
-
-    #[test]
     fn save__not_dirty() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut page = Page::new_from_element("Node", element);
 
         assert!(Interface::save(&mut page).unwrap());
@@ -104,13 +93,13 @@ mod interface__public_methods {
 
     #[test]
     fn save__too_old() {
-        let element1 = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element1 = Element::root();
         let mut page1 = Page::new_from_element("Node", element1);
         let mut page2 = page1.clone();
 
         assert!(Interface::save(&mut page1).unwrap());
         page2.element_mut().update();
-        sleep(Duration::from_millis(1));
+        sleep(Duration::from_millis(2));
         page1.element_mut().update();
         assert!(Interface::save(&mut page1).unwrap());
         assert!(!Interface::save(&mut page2).unwrap());
@@ -118,10 +107,12 @@ mod interface__public_methods {
 
     #[test]
     fn save__update_existing() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut page = Page::new_from_element("Node", element);
         let id = page.id();
         assert!(Interface::save(&mut page).unwrap());
+
+        page.storage.update();
 
         // TODO: Modify the element's data and check it changed
 
@@ -163,19 +154,16 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__add() {
-        let page = Page::new_from_element(
-            "Test Page",
-            Element::new(&Path::new("::test").unwrap(), None),
-        );
+        let page = Page::new_from_element("Test Page", Element::root());
         let serialized = to_vec(&page).unwrap();
         let action = Action::Add {
             id: page.id(),
-            type_id: 102,
             data: serialized,
             ancestors: vec![],
+            metadata: page.element().metadata,
         };
 
-        assert!(Interface::apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action(action).is_ok());
 
         // Verify the page was added
         let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap();
@@ -185,10 +173,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__update() {
-        let mut page = Page::new_from_element(
-            "Old Title",
-            Element::new(&Path::new("::test").unwrap(), None),
-        );
+        let mut page = Page::new_from_element("Old Title", Element::root());
         assert!(Interface::save(&mut page).unwrap());
 
         page.title = "New Title".to_owned();
@@ -196,12 +181,12 @@ mod interface__apply_actions {
         let serialized = to_vec(&page).unwrap();
         let action = Action::Update {
             id: page.id(),
-            type_id: 102,
             data: serialized,
             ancestors: vec![],
+            metadata: page.element().metadata,
         };
 
-        assert!(Interface::apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action(action).is_ok());
 
         // Verify the page was updated
         let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap().unwrap();
@@ -210,10 +195,7 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__delete() {
-        let mut page = Page::new_from_element(
-            "Test Page",
-            Element::new(&Path::new("::test").unwrap(), None),
-        );
+        let mut page = Page::new_from_element("Test Page", Element::root());
         assert!(Interface::save(&mut page).unwrap());
 
         let action = Action::Delete {
@@ -221,7 +203,7 @@ mod interface__apply_actions {
             ancestors: vec![],
         };
 
-        assert!(Interface::apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action(action).is_ok());
 
         // Verify the page was deleted
         let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap();
@@ -230,50 +212,26 @@ mod interface__apply_actions {
 
     #[test]
     fn apply_action__compare() {
-        let page = Page::new_from_element(
-            "Test Page",
-            Element::new(&Path::new("::test").unwrap(), None),
-        );
+        let page = Page::new_from_element("Test Page", Element::root());
         let action = Action::Compare { id: page.id() };
 
         // Compare should fail
-        assert!(Interface::apply_action::<Page>(action).is_err());
-    }
-
-    #[test]
-    fn apply_action__wrong_type() {
-        let page = Page::new_from_element(
-            "Test Page",
-            Element::new(&Path::new("::test").unwrap(), None),
-        );
-        let serialized = to_vec(&page).unwrap();
-        let action = Action::Add {
-            id: page.id(),
-            type_id: 102,
-            data: serialized,
-            ancestors: vec![],
-        };
-
-        // Trying to apply a Page action as if it were a Paragraph should fail
-        assert!(Interface::apply_action::<Paragraph>(action).is_err());
+        assert!(Interface::apply_action(action).is_err());
     }
 
     #[test]
     fn apply_action__non_existent_update() {
-        let page = Page::new_from_element(
-            "Test Page",
-            Element::new(&Path::new("::test").unwrap(), None),
-        );
+        let page = Page::new_from_element("Test Page", Element::root());
         let serialized = to_vec(&page).unwrap();
         let action = Action::Update {
             id: page.id(),
-            type_id: 102,
             data: serialized,
             ancestors: vec![],
+            metadata: page.element().metadata,
         };
 
         // Updating a non-existent page should still succeed (it will be added)
-        assert!(Interface::apply_action::<Page>(action).is_ok());
+        assert!(Interface::apply_action(action).is_ok());
 
         // Verify the page was added
         let retrieved_page = Interface::find_by_id::<Page>(page.id()).unwrap();
@@ -292,7 +250,7 @@ mod interface__comparison {
         foreign: Option<&D>,
         comparison_data: &ComparisonData,
     ) -> Result<(Vec<Action>, Vec<Action>), StorageError> {
-        Interface::compare_trees::<D>(
+        Interface::compare_trees(
             foreign
                 .map(to_vec)
                 .transpose()
@@ -303,7 +261,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__identical() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut local = Page::new_from_element("Test Page", element);
         let mut foreign = local.clone();
 
@@ -316,7 +274,7 @@ mod interface__comparison {
 
         let result = compare_trees(
             Some(&foreign),
-            &ForeignInterface::generate_comparison_data(Some(&foreign)).unwrap(),
+            &ForeignInterface::generate_comparison_data(Some(foreign.id())).unwrap(),
         )
         .unwrap();
         assert_eq!(result, (vec![], vec![]));
@@ -324,7 +282,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__local_newer() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut local = Page::new_from_element("Test Page", element.clone());
         let mut foreign = Page::new_from_element("Old Test Page", element);
 
@@ -337,7 +295,7 @@ mod interface__comparison {
 
         let result = compare_trees(
             Some(&foreign),
-            &ForeignInterface::generate_comparison_data(Some(&foreign)).unwrap(),
+            &ForeignInterface::generate_comparison_data(Some(foreign.id())).unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -346,9 +304,9 @@ mod interface__comparison {
                 vec![],
                 vec![Action::Update {
                     id: local.id(),
-                    type_id: 102,
                     data: to_vec(&local).unwrap(),
-                    ancestors: vec![]
+                    ancestors: vec![],
+                    metadata: local.element().metadata,
                 }]
             )
         );
@@ -356,7 +314,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__foreign_newer() {
-        let element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let element = Element::root();
         let mut local = Page::new_from_element("Old Test Page", element.clone());
         let mut foreign = Page::new_from_element("Test Page", element);
 
@@ -369,7 +327,7 @@ mod interface__comparison {
 
         let result = compare_trees(
             Some(&foreign),
-            &ForeignInterface::generate_comparison_data(Some(&foreign)).unwrap(),
+            &ForeignInterface::generate_comparison_data(Some(foreign.id())).unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -377,9 +335,9 @@ mod interface__comparison {
             (
                 vec![Action::Update {
                     id: foreign.id(),
-                    type_id: 102,
                     data: to_vec(&foreign).unwrap(),
-                    ancestors: vec![]
+                    ancestors: vec![],
+                    metadata: foreign.element().metadata,
                 }],
                 vec![]
             )
@@ -388,7 +346,7 @@ mod interface__comparison {
 
     #[test]
     fn compare_trees__with_collections() {
-        let page_element = Element::new(&Path::new("::root::node").unwrap(), None);
+        let page_element = Element::root();
         let para1_element = Element::new(&Path::new("::root::node::leaf1").unwrap(), None);
         let para2_element = Element::new(&Path::new("::root::node::leaf2").unwrap(), None);
         let para3_element = Element::new(&Path::new("::root::node::leaf3").unwrap(), None);
@@ -432,7 +390,7 @@ mod interface__comparison {
 
         let (local_actions, foreign_actions) = compare_trees(
             Some(&foreign_page),
-            &ForeignInterface::generate_comparison_data(Some(&foreign_page)).unwrap(),
+            &ForeignInterface::generate_comparison_data(Some(foreign_page.id())).unwrap(),
         )
         .unwrap();
 
@@ -442,9 +400,9 @@ mod interface__comparison {
                 // Page needs update due to different child structure
                 Action::Update {
                     id: foreign_page.id(),
-                    type_id: 102,
                     data: to_vec(&foreign_page).unwrap(),
-                    ancestors: vec![]
+                    ancestors: vec![],
+                    metadata: foreign_page.element().metadata,
                 },
                 // Para1 needs comparison due to different hash
                 Action::Compare {
@@ -463,9 +421,9 @@ mod interface__comparison {
                 // Para2 needs to be added to foreign
                 Action::Add {
                     id: local_para2.id(),
-                    type_id: 103,
                     data: to_vec(&local_para2).unwrap(),
-                    ancestors: vec![]
+                    ancestors: vec![],
+                    metadata: local_para2.element().metadata,
                 },
                 // Para3 needs to be added locally, but we don't have the data, so we compare
                 Action::Compare {
@@ -477,7 +435,7 @@ mod interface__comparison {
         // Compare the updated para1
         let (local_para1_actions, foreign_para1_actions) = compare_trees(
             Some(&foreign_para1),
-            &ForeignInterface::generate_comparison_data(Some(&foreign_para1)).unwrap(),
+            &ForeignInterface::generate_comparison_data(Some(foreign_para1.id())).unwrap(),
         )
         .unwrap();
 
@@ -498,9 +456,13 @@ mod interface__comparison {
             local_para1_actions,
             vec![Action::Update {
                 id: foreign_para1.id(),
-                type_id: 103,
                 data: to_vec(&foreign_para1).unwrap(),
-                ancestors: vec![ChildInfo::new(foreign_page.id(), local_para1_ancestor_hash,)],
+                ancestors: vec![ChildInfo::new(
+                    foreign_page.id(),
+                    local_para1_ancestor_hash,
+                    local_page.element().metadata
+                )],
+                metadata: foreign_para1.element().metadata,
             }]
         );
         assert_eq!(foreign_para1_actions, vec![]);
@@ -508,7 +470,7 @@ mod interface__comparison {
         // Compare para3 which doesn't exist locally
         let (local_para3_actions, foreign_para3_actions) = compare_trees(
             Some(&foreign_para3),
-            &ForeignInterface::generate_comparison_data(Some(&foreign_para3)).unwrap(),
+            &ForeignInterface::generate_comparison_data(Some(foreign_para3.id())).unwrap(),
         )
         .unwrap();
 
@@ -529,9 +491,13 @@ mod interface__comparison {
             local_para3_actions,
             vec![Action::Add {
                 id: foreign_para3.id(),
-                type_id: 103,
                 data: to_vec(&foreign_para3).unwrap(),
-                ancestors: vec![ChildInfo::new(foreign_page.id(), local_para3_ancestor_hash,)],
+                ancestors: vec![ChildInfo::new(
+                    foreign_page.id(),
+                    local_para3_ancestor_hash,
+                    foreign_page.element().metadata
+                )],
+                metadata: foreign_para3.element().metadata,
             }]
         );
         assert_eq!(foreign_para3_actions, vec![]);


### PR DESCRIPTION
Remove `type_id` from `calimero_storage`, which unblocks sync.

Address other classes of misuse of the crdt subsystem and questionable design