### PR TITLE
chore: facilitate blob share during state sync if necessary

### DIFF
--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -215,44 +215,23 @@ impl Node {
                 .await?
             }
             InitPayload::StateSync {
-                root_hash,
-                application_id,
+                root_hash: their_root_hash,
+                application_id: their_application_id,
             } => {
-                if updated.is_none() && context.application_id != application_id {
+                if updated.is_none() && context.application_id != their_application_id {
                     updated = Some(self.ctx_manager.sync_context_config(context_id).await?);
                 }
 
                 if let Some(updated) = updated {
-                    if application_id != updated.application_id {
-                        bail!(
-                            "application mismatch: expected {}, got {}",
-                            updated.application_id,
-                            application_id
-                        );
-                    }
-
                     context = updated;
-                }
-
-                if let Some(application) = self.ctx_manager.get_application(&application_id)? {
-                    if !self.ctx_manager.has_blob_available(application.blob)? {
-                        self.initiate_blob_share_process(
-                            &context,
-                            our_identity,
-                            application.blob,
-                            application.size,
-                            stream,
-                        )
-                        .await?;
-                    }
                 }
 
                 self.handle_state_sync_request(
                     &mut context,
                     our_identity,
                     their_identity,
-                    root_hash,
-                    application_id,
+                    their_root_hash,
+                    their_application_id,
                     stream,
                 )
                 .await?

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -22,6 +22,13 @@ impl Node {
         size: u64,
         stream: &mut Stream,
     ) -> eyre::Result<()> {
+        debug!(
+            context_id=%context.id,
+            our_identity=%our_identity,
+            blob_id=%blob_id,
+            "Initiating blob share",
+        );
+
         send(
             stream,
             &StreamMessage::Init {
@@ -116,6 +123,14 @@ impl Node {
                 received_blob_id
             );
         }
+
+        debug!(
+            context_id=%context.id,
+            our_identity=%our_identity,
+            their_identity=%their_identity,
+            blob_id=%blob_id,
+            "Blob share completed",
+        );
 
         Ok(())
     }

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -122,7 +122,7 @@ impl Node {
 
     pub(super) async fn handle_blob_share_request(
         &self,
-        context: Context,
+        context: &Context,
         our_identity: PublicKey,
         their_identity: PublicKey,
         blob_id: BlobId,
@@ -185,6 +185,14 @@ impl Node {
             Some(shared_key),
         )
         .await?;
+
+        debug!(
+            context_id=%context.id,
+            our_identity=%our_identity,
+            their_identity=%their_identity,
+            blob_id=%blob_id,
+            "Blob share completed",
+        );
 
         Ok(())
     }

--- a/crates/node/src/sync/key.rs
+++ b/crates/node/src/sync/key.rs
@@ -50,7 +50,7 @@ impl Node {
 
     pub(super) async fn handle_key_share_request(
         &self,
-        context: Context,
+        context: &Context,
         our_identity: PublicKey,
         their_identity: PublicKey,
         stream: &mut Stream,
@@ -72,21 +72,19 @@ impl Node {
         )
         .await?;
 
-        let mut context = context;
-        self.bidirectional_key_sync(&mut context, our_identity, their_identity, stream)
+        self.bidirectional_key_sync(context, our_identity, their_identity, stream)
             .await
     }
 
     async fn bidirectional_key_sync(
         &self,
-        context: &mut Context,
+        context: &Context,
         our_identity: PublicKey,
         their_identity: PublicKey,
         stream: &mut Stream,
     ) -> eyre::Result<()> {
         debug!(
             context_id=%context.id,
-            our_root_hash=%context.root_hash,
             our_identity=%our_identity,
             their_identity=%their_identity,
             "Starting bidirectional key sync",
@@ -138,6 +136,13 @@ impl Node {
 
         self.ctx_manager
             .update_sender_key(&context.id, &their_identity, &sender_key)?;
+
+        debug!(
+            context_id=%context.id,
+            our_identity=%our_identity,
+            their_identity=%their_identity,
+            "Key sync completed",
+        );
 
         Ok(())
     }

--- a/crates/node/src/sync/key.rs
+++ b/crates/node/src/sync/key.rs
@@ -3,8 +3,6 @@ use calimero_network::stream::Stream;
 use calimero_primitives::context::Context;
 use calimero_primitives::identity::PublicKey;
 use eyre::{bail, OptionExt};
-use rand::seq::IteratorRandom;
-use rand::thread_rng;
 use tracing::debug;
 
 use crate::sync::{recv, send, Sequencer};
@@ -53,6 +51,7 @@ impl Node {
     pub(super) async fn handle_key_share_request(
         &self,
         context: Context,
+        our_identity: PublicKey,
         their_identity: PublicKey,
         stream: &mut Stream,
     ) -> eyre::Result<()> {
@@ -61,12 +60,6 @@ impl Node {
             their_identity=%their_identity,
             "Received key share request",
         );
-
-        let identities = self.ctx_manager.get_context_owned_identities(context.id)?;
-
-        let Some(our_identity) = identities.into_iter().choose(&mut thread_rng()) else {
-            bail!("no identities found for context: {}", context.id);
-        };
 
         send(
             stream,

--- a/crates/node/src/sync/key.rs
+++ b/crates/node/src/sync/key.rs
@@ -93,7 +93,7 @@ impl Node {
             context_id=%context.id,
             our_identity=%our_identity,
             their_identity=%their_identity,
-            "Starting bidirectional key sync",
+            "Starting bidirectional key share",
         );
 
         let private_key = self
@@ -147,7 +147,7 @@ impl Node {
             context_id=%context.id,
             our_identity=%our_identity,
             their_identity=%their_identity,
-            "Key sync completed",
+            "Key share completed",
         );
 
         Ok(())

--- a/crates/node/src/sync/key.rs
+++ b/crates/node/src/sync/key.rs
@@ -50,7 +50,7 @@ impl Node {
             }
         };
 
-        self.bidirectional_key_sync(context, our_identity, their_identity, stream)
+        self.bidirectional_key_share(context, our_identity, their_identity, stream)
             .await
     }
 
@@ -78,11 +78,11 @@ impl Node {
         )
         .await?;
 
-        self.bidirectional_key_sync(context, our_identity, their_identity, stream)
+        self.bidirectional_key_share(context, our_identity, their_identity, stream)
             .await
     }
 
-    async fn bidirectional_key_sync(
+    async fn bidirectional_key_share(
         &self,
         context: &Context,
         our_identity: PublicKey,

--- a/crates/node/src/sync/key.rs
+++ b/crates/node/src/sync/key.rs
@@ -16,6 +16,12 @@ impl Node {
         our_identity: PublicKey,
         stream: &mut Stream,
     ) -> eyre::Result<()> {
+        debug!(
+            context_id=%context.id,
+            our_identity=%our_identity,
+            "Initiating key share",
+        );
+
         send(
             stream,
             &StreamMessage::Init {


### PR DESCRIPTION
When on the receiving end of a state sync request, and we don't have the application, upgrade the sync channel to a blob share and reverse the roles. After receiving the application from the requester, go back to processing the state sync request.

This preserves the same guards employed for the traditional blob share, size, and integrity checks.