### PR TITLE
Added nonce handling

### DIFF
--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -10,12 +10,12 @@ license.workspace = true
 curve25519-dalek.workspace = true
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 ring.workspace = true
+rand.workspace = true
 
 calimero-primitives = { path = "../primitives", features = ["rand"] }
 
 [dev-dependencies]
 eyre.workspace = true
-rand.workspace = true
 
 [lints]
 workspace = true

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,7 +16,7 @@ use calimero_context::config::ContextConfig;
 use calimero_context::ContextManager;
 use calimero_context_config::repr::ReprTransmute;
 use calimero_context_config::ProposalAction;
-use calimero_crypto::SharedKey;
+use calimero_crypto::{SharedKey, NONCE_LEN};
 use calimero_network::client::NetworkClient;
 use calimero_network::config::NetworkConfig;
 use calimero_network::types::{NetworkEvent, PeerId};
@@ -305,6 +305,7 @@ impl Node {
                 author_id,
                 root_hash,
                 artifact,
+                nonce,
             } => {
                 self.handle_state_delta(
                     source,
@@ -312,6 +313,7 @@ impl Node {
                     author_id,
                     root_hash,
                     artifact.into_owned(),
+                    nonce,
                 )
                 .await?;
             }
@@ -327,6 +329,7 @@ impl Node {
         author_id: PublicKey,
         root_hash: Hash,
         artifact: Vec<u8>,
+        nonce: [u8; NONCE_LEN],
     ) -> EyreResult<()> {
         let Some(mut context) = self.ctx_manager.get_context(&context_id)? else {
             bail!("context '{}' not found", context_id);
@@ -341,10 +344,10 @@ impl Node {
             return self.initiate_sync(context_id, source).await;
         };
 
-        let shared_key = SharedKey::from_sk(&sender_key);
+        let (shared_key, _) = SharedKey::from_sk(&sender_key);
 
         let artifact = &shared_key
-            .decrypt(artifact, [0; 12])
+            .decrypt(artifact, nonce)
             .ok_or_eyre("failed to decrypt message")?;
 
         let Some(outcome) = self
@@ -385,10 +388,10 @@ impl Node {
                 .get_sender_key(&context.id, &executor_public_key)?
                 .ok_or_eyre("expected own identity to have sender key")?;
 
-            let shared_key = SharedKey::from_sk(&sender_key);
+            let (shared_key, nonce) = SharedKey::from_sk(&sender_key);
 
             let artifact_encrypted = shared_key
-                .encrypt(outcome.artifact.clone(), [0; 12])
+                .encrypt(outcome.artifact.clone(), nonce)
                 .ok_or_eyre("encryption failed")?;
 
             let message = to_vec(&BroadcastMessage::StateDelta {
@@ -396,6 +399,7 @@ impl Node {
                 author_id: executor_public_key,
                 root_hash: context.root_hash,
                 artifact: artifact_encrypted.as_slice().into(),
+                nonce,
             })?;
 
             let _ignored = self

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -37,6 +37,7 @@ impl Node {
                 payload: InitPayload::BlobShare { blob_id },
             },
             None,
+            None,
         )
         .await?;
 
@@ -75,7 +76,7 @@ impl Node {
             .get_private_key(context.id, our_identity)?
             .ok_or_eyre("expected own identity to have private key")?;
 
-        let shared_key = SharedKey::new(&private_key, &their_identity);
+        let (shared_key, _) = SharedKey::new(&private_key, &their_identity);
 
         let (tx, mut rx) = mpsc::channel(1);
 
@@ -162,7 +163,7 @@ impl Node {
             .get_private_key(context.id, our_identity)?
             .ok_or_eyre("expected own identity to have private key")?;
 
-        let shared_key = SharedKey::new(&private_key, &their_identity);
+        let (shared_key, nonce) = SharedKey::new(&private_key, &their_identity);
 
         send(
             stream,
@@ -171,6 +172,7 @@ impl Node {
                 party_id: our_identity,
                 payload: InitPayload::BlobShare { blob_id },
             },
+            None,
             None,
         )
         .await?;
@@ -187,6 +189,7 @@ impl Node {
                     },
                 },
                 Some(shared_key),
+                Some(nonce),
             )
             .await?;
         }
@@ -198,6 +201,7 @@ impl Node {
                 payload: MessagePayload::BlobShare { chunk: b"".into() },
             },
             Some(shared_key),
+            Some(nonce),
         )
         .await?;
 

--- a/crates/node/src/sync/key.rs
+++ b/crates/node/src/sync/key.rs
@@ -30,6 +30,7 @@ impl Node {
                 payload: InitPayload::KeyShare,
             },
             None,
+            None,
         )
         .await?;
 
@@ -75,6 +76,7 @@ impl Node {
                 payload: InitPayload::KeyShare,
             },
             None,
+            None,
         )
         .await?;
 
@@ -101,7 +103,7 @@ impl Node {
             .get_private_key(context.id, our_identity)?
             .ok_or_eyre("expected own identity to have private key")?;
 
-        let shared_key = SharedKey::new(&private_key, &their_identity);
+        let (shared_key, nonce) = SharedKey::new(&private_key, &their_identity);
 
         let sender_key = self
             .ctx_manager
@@ -117,6 +119,7 @@ impl Node {
                 payload: MessagePayload::KeyShare { sender_key },
             },
             Some(shared_key),
+            Some(nonce),
         )
         .await?;
 

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_crypto::NONCE_LEN;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::ContextId;
@@ -18,6 +19,7 @@ pub enum BroadcastMessage<'a> {
         author_id: PublicKey,
         root_hash: Hash,
         artifact: Cow<'a, [u8]>,
+        nonce: [u8; NONCE_LEN],
     },
 }
 


### PR DESCRIPTION
Nonces are created in the `SharedKey`s constructor.

Sent as a part of the message in the `send()` funciton and extracted in the `recv()` function.