### PR TITLE
fix: run proxy tests with a single worker instance

### DIFF
--- a/contracts/proxy-lib/src/lib.rs
+++ b/contracts/proxy-lib/src/lib.rs
@@ -102,7 +102,6 @@ impl ProxyContract {
         &self,
         proposal_id: Repr<ProposalId>,
     ) -> Option<Vec<Repr<SignerId>>> {
-        let approvals_for_proposal = self.approvals.get(&proposal_id);
         let approvals = self.approvals.get(&proposal_id)?;
         Some(approvals.iter().flat_map(|a| a.rt()).collect())
     }

--- a/contracts/proxy-lib/tests/common/mod.rs
+++ b/contracts/proxy-lib/tests/common/mod.rs
@@ -35,3 +35,17 @@ pub async fn create_account_with_balance(
         .into_result()?;
     Ok(account)
 }
+
+pub fn generate_near_account_id() -> Result<String> {
+    let random_account_id: String = rand::thread_rng()
+        .sample_iter(&rand::distributions::Uniform::new_inclusive('a', 'z')) // Lowercase letters
+        .take(6)
+        .chain(
+            rand::thread_rng()
+                .sample_iter(&rand::distributions::Uniform::new_inclusive('0', '9'))
+                .take(2),
+        ) // Append digits
+        .collect();
+
+    Ok(random_account_id)
+}

--- a/contracts/proxy-lib/tests/common/mod.rs
+++ b/contracts/proxy-lib/tests/common/mod.rs
@@ -36,16 +36,3 @@ pub async fn create_account_with_balance(
     Ok(account)
 }
 
-pub fn generate_near_account_id() -> Result<String> {
-    let random_account_id: String = rand::thread_rng()
-        .sample_iter(&rand::distributions::Uniform::new_inclusive('a', 'z')) // Lowercase letters
-        .take(6)
-        .chain(
-            rand::thread_rng()
-                .sample_iter(&rand::distributions::Uniform::new_inclusive('0', '9'))
-                .take(2),
-        ) // Append digits
-        .collect();
-
-    Ok(random_account_id)
-}

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -38,12 +38,12 @@ async fn setup_test(
     SigningKey,
     SigningKey,
 )> {
-    let config_helper = ConfigContractHelper::new(&worker).await?;
+    let config_helper = ConfigContractHelper::new(worker).await?;
     let bytes = fs::read(common::proxy_lib_helper::PROXY_CONTRACT_WASM)?;
     let alice_sk: SigningKey = common::generate_keypair()?;
     let context_sk = common::generate_keypair()?;
     let relayer_account =
-        common::create_account_with_balance(&worker, generate_near_account_id()?.as_str(), 1000)
+        common::create_account_with_balance(worker, generate_near_account_id()?.as_str(), 1000)
             .await?;
 
     let _test = config_helper
@@ -431,8 +431,9 @@ async fn test_action_change_active_proposals_limit() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_action_change_number_of_approvals(worker: &Worker<Sandbox>) -> Result<()> {
-    let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
+async fn test_action_change_number_of_approvals() -> Result<()> {
+    let worker = get_sandbox_worker().await;
+    let (proxy_helper, relayer_account, members) = setup_action_test(worker).await?;
 
     let default_new_num_approvals: u32 = proxy_helper.view_num_approvals(&relayer_account).await?;
     assert_eq!(default_new_num_approvals, 3);
@@ -450,7 +451,7 @@ async fn test_action_change_number_of_approvals(worker: &Worker<Sandbox>) -> Res
 #[tokio::test]
 async fn test_mutate_storage_value() -> Result<()> {
     let worker = get_sandbox_worker().await;
-    let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
+    let (proxy_helper, relayer_account, members) = setup_action_test(worker).await?;
 
     let key_data = b"example_key".to_vec().into_boxed_slice();
     let value_data = b"example_value".to_vec().into_boxed_slice();
@@ -482,7 +483,7 @@ async fn test_mutate_storage_value() -> Result<()> {
 #[tokio::test]
 async fn test_transfer() -> Result<()> {
     let worker = get_sandbox_worker().await;
-    let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
+    let (proxy_helper, relayer_account, members) = setup_action_test(worker).await?;
 
     let _res = worker
         .root_account()?
@@ -493,7 +494,7 @@ async fn test_transfer() -> Result<()> {
         .await?
         .into_result()?;
 
-    let recipient = create_account_with_balance(&worker, "new_account", 0).await?;
+    let recipient = create_account_with_balance(worker, "new_account", 0).await?;
 
     let recipient_balance = recipient.view_account().await?.balance;
     assert_eq!(
@@ -520,9 +521,9 @@ async fn test_transfer() -> Result<()> {
 #[tokio::test]
 async fn test_combined_proposals() -> Result<()> {
     let worker = get_sandbox_worker().await;
-    let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
+    let (proxy_helper, relayer_account, members) = setup_action_test(worker).await?;
 
-    let counter_helper = CounterContractHelper::deploy_and_initialize(&worker).await?;
+    let counter_helper = CounterContractHelper::deploy_and_initialize(worker).await?;
 
     let initial_counter_value: u32 = counter_helper.get_value().await?;
     assert_eq!(initial_counter_value, 0, "Counter should start at zero");
@@ -570,9 +571,9 @@ async fn test_combined_proposals() -> Result<()> {
 #[tokio::test]
 async fn test_combined_proposal_actions_with_promise_failure() -> Result<()> {
     let worker = get_sandbox_worker().await;
-    let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
+    let (proxy_helper, relayer_account, members) = setup_action_test(worker).await?;
 
-    let counter_helper = CounterContractHelper::deploy_and_initialize(&worker).await?;
+    let counter_helper = CounterContractHelper::deploy_and_initialize(worker).await?;
 
     let initial_active_proposals_limit: u32 = proxy_helper
         .view_active_proposals_limit(&relayer_account)

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -279,6 +279,7 @@ async fn test_create_proposal_and_approve_by_member() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
 async fn test_create_proposal_and_approve_by_non_member() -> Result<()> {
     let worker = get_sandbox_worker().await;
     let (_config_helper, proxy_helper, relayer_account, _context_sk, alice_sk) =
@@ -429,6 +430,7 @@ async fn test_action_change_active_proposals_limit() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
 async fn test_action_change_number_of_approvals(worker: &Worker<Sandbox>) -> Result<()> {
     let (proxy_helper, relayer_account, members) = setup_action_test(&worker).await?;
 

--- a/contracts/proxy-lib/tests/sandbox.rs
+++ b/contracts/proxy-lib/tests/sandbox.rs
@@ -6,7 +6,7 @@ use calimero_context_config::{Proposal, ProposalAction, ProposalWithApprovals};
 use common::config_helper::ConfigContractHelper;
 use common::counter_helper::CounterContractHelper;
 use common::proxy_lib_helper::ProxyContractHelper;
-use common::{create_account_with_balance, generate_near_account_id};
+use common::{create_account_with_balance};
 use ed25519_dalek::SigningKey;
 use eyre::{Ok, Result};
 use near_sdk::{AccountId, NearToken};
@@ -43,7 +43,7 @@ async fn setup_test(
     let alice_sk: SigningKey = common::generate_keypair()?;
     let context_sk = common::generate_keypair()?;
     let relayer_account =
-        common::create_account_with_balance(worker, generate_near_account_id()?.as_str(), 1000)
+        common::create_account_with_balance(worker, worker.dev_create_account().await?.id().as_str(), 1000)
             .await?;
 
     let _test = config_helper


### PR DESCRIPTION
* Introdued a single shared Worker instance across all tests to avoid conflicts caused by reusing ports.
