### PR TITLE
fix(near): handle request timeout

### DIFF
--- a/crates/context/config/src/client/protocol/near.rs
+++ b/crates/context/config/src/client/protocol/near.rs
@@ -4,6 +4,9 @@ use std::{time, vec};
 
 pub use near_crypto::SecretKey;
 use near_crypto::{InMemorySigner, PublicKey, Signer};
+use near_jsonrpc_client::errors::{
+    JsonRpcError, JsonRpcServerError, JsonRpcServerResponseStatusError,
+};
 use near_jsonrpc_client::methods::query::{RpcQueryRequest, RpcQueryResponse};
 use near_jsonrpc_client::methods::send_tx::RpcSendTransactionRequest;
 use near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest;
@@ -298,12 +301,20 @@ impl Network {
             match response {
                 Ok(response) => break response,
                 Err(err) => {
-                    let Some(RpcTransactionError::TimeoutError) = err.handler_error() else {
-                        return Err(NearError::Custom {
-                            operation: ErrorOperation::Mutate,
-                            reason: err.to_string(),
-                        });
-                    };
+                    match err {
+                        JsonRpcError::ServerError(
+                            JsonRpcServerError::ResponseStatusError(
+                                JsonRpcServerResponseStatusError::TimeoutError,
+                            )
+                            | JsonRpcServerError::HandlerError(RpcTransactionError::TimeoutError),
+                        ) => {}
+                        _ => {
+                            return Err(NearError::Custom {
+                                operation: ErrorOperation::Mutate,
+                                reason: err.to_string(),
+                            });
+                        }
+                    }
 
                     if sent_at.elapsed().as_secs() > 60 {
                         return Err(NearError::TransactionTimeout);

--- a/crates/context/config/src/client/protocol/near.rs
+++ b/crates/context/config/src/client/protocol/near.rs
@@ -301,6 +301,10 @@ impl Network {
             match response {
                 Ok(response) => break response,
                 Err(err) => {
+                    #[expect(
+                        clippy::wildcard_enum_match_arm,
+                        reason = "quite terse, these variants"
+                    )]
                     match err {
                         JsonRpcError::ServerError(
                             JsonRpcServerError::ResponseStatusError(


### PR DESCRIPTION
`TimeoutError` on `TxStatusError` is [effectively a dud](https://github.com/near/nearcore/blob/29f388f058a6fc908902b79018844c79eb95baa6/chain/rosetta-rpc/src/errors.rs#L52-L54), and from semantic analysis, it's never actually constructed by the node.

We should, instead.. match for the RPC timeout represented as the `408 Request Timeout` status code.

I've retained the check for `TxStatusError::TimeoutError` to be more exhaustive anyway.