### PR TITLE
feat: nuke proxy when erasing context config

### DIFF
--- a/contracts/proxy-lib/src/lib.rs
+++ b/contracts/proxy-lib/src/lib.rs
@@ -102,7 +102,6 @@ impl ProxyContract {
         &self,
         proposal_id: Repr<ProposalId>,
     ) -> Option<Vec<Repr<SignerId>>> {
-        let approvals_for_proposal = self.approvals.get(&proposal_id);
         let approvals = self.approvals.get(&proposal_id)?;
         Some(approvals.iter().flat_map(|a| a.rt()).collect())
     }

--- a/contracts/proxy-lib/src/mutate.rs
+++ b/contracts/proxy-lib/src/mutate.rs
@@ -40,6 +40,7 @@ impl ProxyContract {
         }
     }
 }
+
 #[near]
 impl ProxyContract {
     #[private]
@@ -224,6 +225,26 @@ impl ProxyContract {
                 Self::ext(env::current_account_id())
                     .update_contract_callback(env::attached_deposit()),
             )
+    }
+
+    fn erase(&mut self) {
+        // if this is going to be exposed, it should be a proposal
+        self.proposals.clear();
+        self.approvals.clear();
+        self.num_proposals_pk.clear();
+        self.context_storage.clear();
+    }
+
+    pub fn nuke(&mut self) -> Promise {
+        require!(
+            env::predecessor_account_id() == self.context_config_account_id,
+            "Only the context config contract can nuke the proxy"
+        );
+
+        self.erase();
+
+        Promise::new(env::current_account_id())
+            .delete_account(self.context_config_account_id.clone())
     }
 
     #[private]


### PR DESCRIPTION
for correctness, when erasing context config, the associated proxy contracts are dangling and should be nuked

ideally, we protect against trivially calling `erase` on the context config, since it's a single source of failure