### PR TITLE
feat: iterate on transport generalization for recursive declaration

### DIFF
--- a/crates/context/config/src/client/env.rs
+++ b/crates/context/config/src/client/env.rs
@@ -23,7 +23,7 @@ mod utils {
     use crate::client::{CallClient, ClientError, Operation};
 
     // todo! when crates are broken up, appropriately locate this
-    pub(super) async fn send_near_or_starknet<M, R, T: Transport>(
+    pub(super) async fn send<M, R, T: Transport>(
         client: &CallClient<'_, T>,
         params: Operation<M>,
     ) -> Result<R, ClientError<T>>
@@ -34,9 +34,10 @@ mod utils {
         match &*client.protocol {
             Near::PROTOCOL => client.send::<Near, _>(params).await,
             Starknet::PROTOCOL => client.send::<Starknet, _>(params).await,
-            unsupported_protocol => Err(ClientError::UnsupportedProtocol(
-                unsupported_protocol.to_owned(),
-            )),
+            unsupported_protocol => Err(ClientError::UnsupportedProtocol {
+                found: unsupported_protocol.to_owned(),
+                expected: vec![Near::PROTOCOL.into(), Starknet::PROTOCOL.into()].into(),
+            }),
         }
     }
 }

--- a/crates/context/config/src/client/env/config/mutate.rs
+++ b/crates/context/config/src/client/env/config/mutate.rs
@@ -84,6 +84,6 @@ impl<'a, T: Transport> ContextConfigMutateRequest<'a, T> {
             kind: self.kind,
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Write(request)).await
+        utils::send(&self.client, Operation::Write(request)).await
     }
 }

--- a/crates/context/config/src/client/env/config/query.rs
+++ b/crates/context/config/src/client/env/config/query.rs
@@ -28,7 +28,7 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
             context_id: Repr::new(context_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn application_revision(
@@ -39,7 +39,7 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
             context_id: Repr::new(context_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn members(
@@ -54,7 +54,7 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
             length,
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn has_member(
@@ -67,7 +67,7 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
             identity: Repr::new(identity),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn members_revision(
@@ -78,7 +78,7 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
             context_id: Repr::new(context_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn privileges(
@@ -88,7 +88,7 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
     ) -> Result<BTreeMap<SignerId, Vec<Capability>>, ClientError<T>> {
         let params = privileges::PrivilegesRequest::new(context_id, identities);
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn get_proxy_contract(
@@ -99,6 +99,6 @@ impl<'a, T: Transport> ContextConfigQuery<'a, T> {
             context_id: Repr::new(context_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 }

--- a/crates/context/config/src/client/env/proxy/mutate.rs
+++ b/crates/context/config/src/client/env/proxy/mutate.rs
@@ -77,6 +77,6 @@ impl<'a, T: Transport> ContextProxyMutateRequest<'a, T> {
             raw_request: self.raw_request,
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Write(request)).await
+        utils::send(&self.client, Operation::Write(request)).await
     }
 }

--- a/crates/context/config/src/client/env/proxy/query.rs
+++ b/crates/context/config/src/client/env/proxy/query.rs
@@ -32,7 +32,7 @@ impl<'a, T: Transport> ContextProxyQuery<'a, T> {
             offset,
             length: limit,
         };
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn proposal(
@@ -43,13 +43,13 @@ impl<'a, T: Transport> ContextProxyQuery<'a, T> {
             proposal_id: Repr::new(proposal_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn get_number_of_active_proposals(&self) -> Result<u16, ClientError<T>> {
         let params = ActiveProposalRequest;
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn get_number_of_proposal_approvals(
@@ -60,7 +60,7 @@ impl<'a, T: Transport> ContextProxyQuery<'a, T> {
             proposal_id: Repr::new(proposal_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 
     pub async fn get_proposal_approvers(
@@ -71,6 +71,6 @@ impl<'a, T: Transport> ContextProxyQuery<'a, T> {
             proposal_id: Repr::new(proposal_id),
         };
 
-        utils::send_near_or_starknet(&self.client, Operation::Read(params)).await
+        utils::send(&self.client, Operation::Read(params)).await
     }
 }

--- a/crates/context/config/src/client/protocol/near.rs
+++ b/crates/context/config/src/client/protocol/near.rs
@@ -26,7 +26,7 @@ use url::Url;
 
 use super::Protocol;
 use crate::client::transport::{
-    AssociatedTransport, Operation, Transport, TransportLike, TransportRequest,
+    AssociatedTransport, Operation, ProtocolTransport, TransportRequest,
 };
 
 #[derive(Copy, Clone, Debug)]
@@ -38,22 +38,6 @@ impl Protocol for Near {
 
 impl AssociatedTransport for NearTransport<'_> {
     type Protocol = Near;
-}
-
-impl TransportLike for NearTransport<'_> {
-    type Error = NearError;
-
-    async fn try_send(
-        &self,
-        request: TransportRequest<'_>,
-        payload: &Vec<u8>,
-    ) -> Option<Result<Vec<u8>, Self::Error>> {
-        if request.protocol == "near" {
-            Some(self.send(request, payload.to_vec()).await)
-        } else {
-            None
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -169,8 +153,6 @@ impl<'a> NearTransport<'a> {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum NearError {
-    #[error("unsupported protocol `{0}`")]
-    UnsupportedProtocol(String),
     #[error("unknown network `{0}`")]
     UnknownNetwork(String),
     #[error("invalid response from RPC while {operation}")]
@@ -203,7 +185,7 @@ pub enum ErrorOperation {
     FetchAccount,
 }
 
-impl Transport for NearTransport<'_> {
+impl ProtocolTransport for NearTransport<'_> {
     type Error = NearError;
 
     async fn send(
@@ -211,12 +193,6 @@ impl Transport for NearTransport<'_> {
         request: TransportRequest<'_>,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, Self::Error> {
-        if request.protocol != Near::PROTOCOL {
-            return Err(NearError::UnsupportedProtocol(
-                request.protocol.into_owned(),
-            ));
-        }
-
         let Some(network) = self.networks.get(&request.network_id) else {
             return Err(NearError::UnknownNetwork(request.network_id.into_owned()));
         };

--- a/crates/context/config/src/client/relayer.rs
+++ b/crates/context/config/src/client/relayer.rs
@@ -1,10 +1,13 @@
 use std::borrow::Cow;
 
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
-use super::transport::{Operation, Transport, TransportRequest};
+use super::transport::{
+    Operation, Transport, TransportArguments, TransportRequest, UnsupportedProtocol,
+};
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -48,40 +51,84 @@ pub enum RelayerError {
         "relayer response ({status}): {}",
         body.is_empty().then_some("<empty>").unwrap_or(body)
     )]
-    Response {
-        status: reqwest::StatusCode,
-        body: String,
+    Response { status: StatusCode, body: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+pub enum ServerError {
+    UnsupportedProtocol {
+        found: Cow<'static, str>,
+        expected: Cow<'static, [Cow<'static, str>]>,
     },
+}
+
+impl RelayerTransport {
+    async fn send<'a>(
+        &self,
+        args: TransportArguments<'a>,
+    ) -> Result<Result<Vec<u8>, UnsupportedProtocol<'a>>, RelayerError> {
+        let request = RelayRequest {
+            protocol: args.protocol,
+            network_id: args.request.network_id,
+            contract_id: args.request.contract_id,
+            operation: args.request.operation,
+            payload: args.payload,
+        };
+
+        let response = self
+            .client
+            .post(self.url.clone())
+            .json(&request)
+            .send()
+            .await?;
+
+        match response.status() {
+            status if status.is_success() => {
+                return response
+                    .bytes()
+                    .await
+                    .map(|v| Ok(v.into()))
+                    .map_err(|e| e.into());
+            }
+            status if status == StatusCode::BAD_REQUEST => {}
+            status => {
+                return Err(RelayerError::Response {
+                    status,
+                    body: response.text().await?,
+                })
+            }
+        }
+
+        let error = response.json::<ServerError>().await?;
+
+        match error {
+            ServerError::UnsupportedProtocol { found: _, expected } => {
+                let args = TransportArguments {
+                    protocol: request.protocol,
+                    request: TransportRequest {
+                        network_id: request.network_id,
+                        contract_id: request.contract_id,
+                        operation: request.operation,
+                    },
+                    payload: request.payload,
+                };
+
+                Ok(Err(UnsupportedProtocol { args, expected }))
+            }
+        }
+    }
 }
 
 impl Transport for RelayerTransport {
     type Error = RelayerError;
 
-    async fn send(
+    async fn try_send<'a>(
         &self,
-        request: TransportRequest<'_>,
-        payload: Vec<u8>,
-    ) -> Result<Vec<u8>, Self::Error> {
-        let response = self
-            .client
-            .post(self.url.clone())
-            .json(&RelayRequest {
-                protocol: request.protocol,
-                network_id: request.network_id,
-                contract_id: request.contract_id,
-                operation: request.operation,
-                payload,
-            })
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            return Err(RelayerError::Response {
-                status: response.status(),
-                body: response.text().await?,
-            });
-        }
-
-        response.bytes().await.map(Into::into).map_err(Into::into)
+        args: TransportArguments<'a>,
+    ) -> Result<Result<Vec<u8>, Self::Error>, UnsupportedProtocol<'a>> {
+        self.send(args)
+            .await
+            .map_or_else(|e| Ok(Err(e)), |v| v.map(Ok))
     }
 }

--- a/crates/context/config/src/client/utils.rs
+++ b/crates/context/config/src/client/utils.rs
@@ -17,8 +17,23 @@ where
             }
         }
 
-        write!(res, "{}", item).expect("infallible");
+        write!(res, "`{}`", item).expect("infallible");
     }
 
     res
+}
+
+#[test]
+fn test_humanize_iter() {
+    assert_eq!(
+        humanize_iter(&["near", "starknet", "ethereum", "solana"]),
+        "`near`, `starknet`, `ethereum` and `solana`"
+    );
+    assert_eq!(
+        humanize_iter(&["polkadot", "near", "icp"]),
+        "`polkadot`, `near` and `icp`"
+    );
+    assert_eq!(humanize_iter(&["this", "that"]), "`this` and `that`");
+    assert_eq!(humanize_iter(&["me"]), "`me`");
+    assert_eq!(humanize_iter::<[u8; 0]>([]), "");
 }

--- a/crates/context/config/src/client/utils.rs
+++ b/crates/context/config/src/client/utils.rs
@@ -1,0 +1,24 @@
+use core::fmt::{self, Write};
+
+pub fn humanize_iter<I>(iter: I) -> String
+where
+    I: IntoIterator<Item: fmt::Display>,
+{
+    let mut res = String::new();
+
+    let mut iter = iter.into_iter().peekable();
+
+    while let Some(item) = iter.next() {
+        if !res.is_empty() {
+            if iter.peek().is_some() {
+                res.push_str(", ");
+            } else {
+                res.push_str(" and ");
+            }
+        }
+
+        write!(res, "{}", item).expect("infallible");
+    }
+
+    res
+}


### PR DESCRIPTION
The goal is to further generalize the external client to support recursive nesting of structures like:

```rust
type All = Either<Relayer, Both<Near, Both<Starknet, Both<InternetComputer, Both<Ethereum, Solana>>>>>
```

or even

```rust
type NearAndStarknet =
    Both<Near, Starknet>;

type EthereumAndSolana =
    Both<Ethereum, Solana>;

type PolkadotAndInternetComputer =
    Both<Polkadot, InternetComputer>;

type NearAndStarknetOrEthereumAndSolana =
    Either<NearAndStarknet, EthereumAndSolana>;

type NearAndStarknetOrEthereumAndSolanaAndPolkadotAndInternetComputer =
    Both<NearAndStarknetOrEthereumAndSolana, PolkadotAndInternetComputer>;

type RelayerOrNearAndStarknetOrEthereumAndSolanaAndPolkadotAndInternetComputer =
    Either<Relayer, NearAndStarknetOrEthereumAndSolanaAndPolkadotAndInternetComputer>;
```

Which means we don't have to expand `Both` to contain more than 2 transports, or add new structures for each new accommodation.

This is an iteration of an earlier effort in #987.