### PR TITLE
fix: disabled case in which users could delete other users proposals

### DIFF
--- a/contracts/icp/context-proxy/src/mutate.rs
+++ b/contracts/icp/context-proxy/src/mutate.rs
@@ -186,12 +186,12 @@ async fn internal_create_proposal(
             // Get the proposal to be deleted
             let to_delete = with_state(|contract| contract.proposals.get(proposal_id).cloned())
                 .ok_or("Proposal to delete does not exist")?;
-            
+
             // Check if the current user is the author of the proposal to be deleted
             if to_delete.author_id != proposal.author_id {
                 return Err("Only the proposal author can delete their proposals".to_string());
             }
-            
+
             remove_proposal(proposal_id);
             return Ok(None);
         }

--- a/contracts/icp/context-proxy/src/mutate.rs
+++ b/contracts/icp/context-proxy/src/mutate.rs
@@ -183,6 +183,15 @@ async fn internal_create_proposal(
     // Check if the proposal contains a delete action
     for action in &proposal.actions {
         if let ICProposalAction::DeleteProposal { proposal_id } = action {
+            // Get the proposal to be deleted
+            let to_delete = with_state(|contract| contract.proposals.get(proposal_id).cloned())
+                .ok_or("Proposal to delete does not exist")?;
+            
+            // Check if the current user is the author of the proposal to be deleted
+            if to_delete.author_id != proposal.author_id {
+                return Err("Only the proposal author can delete their proposals".to_string());
+            }
+            
             remove_proposal(proposal_id);
             return Ok(None);
         }

--- a/contracts/near/context-proxy/src/mutate.rs
+++ b/contracts/near/context-proxy/src/mutate.rs
@@ -282,6 +282,15 @@ impl ProxyContract {
 
         // If this is a delete proposal, execute it immediately
         if let Some(ProposalAction::DeleteProposal { proposal_id }) = proposal.actions.first() {
+            let existing_proposal = self
+                .proposals
+                .get(proposal_id)
+                .expect("Proposal to delete does not exist");
+            require!(
+                existing_proposal.author_id == proposal.author_id,
+                "Can only delete own proposals"
+            );
+
             self.remove_proposal(*proposal_id);
             return Promise::new(env::current_account_id());
         }


### PR DESCRIPTION
Fixed case in which users could delete other users proposals for NEAR and ICP