### PR TITLE
fix: remove timestamp from contracts

### DIFF
--- a/contracts/icp/context-config/src/mutate.rs
+++ b/contracts/icp/context-config/src/mutate.rs
@@ -21,16 +21,6 @@ pub async fn mutate(signed_request: ICSigned<ICRequest>) -> Result<(), String> {
         .parse(|r| *r.signer_id)
         .map_err(|e| format!("Failed to verify signature: {}", e))?;
 
-    // Add debug logging
-    let current_time = ic_cdk::api::time() / 1_000_000;
-    let time_diff = current_time.saturating_sub(request.timestamp_ms);
-    if time_diff > 1000 * 5 {
-        return Err(format!(
-            "request expired: diff={}ms, current={}, request={}",
-            time_diff, current_time, request.timestamp_ms
-        ));
-    }
-
     match request.kind {
         ICRequestKind::Context(ICContextRequest { context_id, kind }) => match kind {
             ICContextRequestKind::Add {

--- a/contracts/icp/context-proxy/src/query.rs
+++ b/contracts/icp/context-proxy/src/query.rs
@@ -72,7 +72,6 @@ pub fn get_proposal_approvals_with_signer(
                 .map(|signer_id| ICProposalApprovalWithSigner {
                     proposal_id: proposal_id.clone(),
                     signer_id: signer_id.clone(),
-                    added_timestamp: 0, // TODO: We need to store approval timestamps
                 })
                 .collect()
         } else {

--- a/contracts/icp/context-proxy/tests/integration.rs
+++ b/contracts/icp/context-proxy/tests/integration.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::time::UNIX_EPOCH;
 
 use calimero_context_config::icp::repr::ICRepr;
 use calimero_context_config::icp::types::{
@@ -35,13 +34,6 @@ fn create_signed_context_request(
     request: ICRequest,
 ) -> ICSigned<ICRequest> {
     ICSigned::new(request, |bytes| signer_key.sign(bytes)).expect("Failed to create signed request")
-}
-
-fn get_time_nanos(pic: &PocketIc) -> u64 {
-    pic.get_time()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_nanos() as u64
 }
 
 // Helper function to create a proposal and verify response
@@ -196,7 +188,6 @@ fn create_context_with_proxy(
             },
         }),
         signer_id: context_id.rt().expect("infallible conversion"),
-        timestamp_ms: get_time_nanos(pic),
         nonce: 0,
     };
 
@@ -254,7 +245,6 @@ fn add_members_to_context(
             kind: ICContextRequestKind::AddMembers { members },
         }),
         signer_id: author_pk.rt().expect("infallible conversion"),
-        timestamp_ms: get_time_nanos(pic),
         nonce: 0,
     };
 
@@ -346,7 +336,6 @@ fn test_update_proxy_contract() {
             kind: ICContextRequestKind::UpdateProxyContract,
         }),
         signer_id: author_pk.rt().expect("infallible conversion"),
-        timestamp_ms: get_time_nanos(&pic),
         nonce: 0,
     };
 
@@ -639,7 +628,6 @@ fn test_approve_own_proposal() {
     let approval = ICProposalApprovalWithSigner {
         signer_id: author_id,
         proposal_id,
-        added_timestamp: get_time_nanos(&pic),
     };
 
     let request = ICProxyMutateRequest::Approve { approval };
@@ -683,7 +671,6 @@ fn test_approve_non_existent_proposal() {
     let approval = ICProposalApprovalWithSigner {
         signer_id,
         proposal_id,
-        added_timestamp: get_time_nanos(&pic),
     };
 
     let request = ICProxyMutateRequest::Approve { approval };
@@ -878,7 +865,6 @@ fn test_proposal_execution_transfer() {
         let approval = ICProposalApprovalWithSigner {
             signer_id,
             proposal_id,
-            added_timestamp: get_time_nanos(&pic),
         };
 
         let request = ICProxyMutateRequest::Approve { approval };
@@ -1023,7 +1009,6 @@ fn test_proposal_execution_external_call() {
         let approval = ICProposalApprovalWithSigner {
             signer_id,
             proposal_id,
-            added_timestamp: get_time_nanos(&pic),
         };
 
         let request = ICProxyMutateRequest::Approve { approval };
@@ -1164,7 +1149,6 @@ fn test_proposal_execution_external_call_with_deposit() {
         let approval = ICProposalApprovalWithSigner {
             signer_id,
             proposal_id,
-            added_timestamp: get_time_nanos(&pic),
         };
 
         let request = ICProxyMutateRequest::Approve { approval };

--- a/contracts/near/context-config/src/mutate.rs
+++ b/contracts/near/context-config/src/mutate.rs
@@ -23,12 +23,6 @@ impl ContextConfigs {
             .parse(|i| *i.signer_id)
             .expect("failed to parse input");
 
-        require!(
-            env::block_timestamp_ms().saturating_sub(request.timestamp_ms)
-                <= self.config.validity_threshold_ms,
-            "request expired"
-        );
-
         match request.kind {
             RequestKind::Context(ContextRequest {
                 context_id, kind, ..

--- a/crates/context/config/src/icp.rs
+++ b/crates/context/config/src/icp.rs
@@ -161,7 +161,6 @@ impl From<ICProposalWithApprovals> for ProposalWithApprovals {
 pub struct ICProposalApprovalWithSigner {
     pub proposal_id: ICRepr<ProposalId>,
     pub signer_id: ICRepr<SignerId>,
-    pub added_timestamp: u64,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -194,7 +193,6 @@ impl TryFrom<ProxyMutateRequest> for ICProxyMutateRequest {
                 approval: ICProposalApprovalWithSigner {
                     proposal_id: approval.proposal_id.rt().map_err(|e| e.to_string())?,
                     signer_id: approval.signer_id.rt().map_err(|e| e.to_string())?,
-                    added_timestamp: approval.added_timestamp,
                 },
             },
         };

--- a/crates/context/config/src/icp/types.rs
+++ b/crates/context/config/src/icp/types.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use candid::CandidType;
 use ed25519_dalek::{Verifier, VerifyingKey};
@@ -160,7 +159,6 @@ impl<'a> From<RequestKind<'a>> for ICRequestKind {
 pub struct ICRequest {
     pub kind: ICRequestKind,
     pub signer_id: ICRepr<SignerId>,
-    pub timestamp_ms: u64,
     pub nonce: u64,
 }
 
@@ -169,10 +167,6 @@ impl ICRequest {
         Self {
             signer_id: ICRepr::new(signer_id),
             kind,
-            timestamp_ms: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
-                .as_millis() as u64,
             nonce,
         }
     }


### PR DESCRIPTION
# fix: remove timestamp from contracts

## Summary
Timestamp removed from contracts as they now use nonce
