### PR TITLE
feat(node): set ICP init config

### DIFF
--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -222,7 +222,11 @@ impl InitCommand {
             ContextConfig {
                 client: ClientConfig {
                     signer: ClientSigner {
-                        selected: ClientSelectedSigner::Relayer,
+                        selected: match self.protocol {
+                            ConfigProtocol::Near => ClientSelectedSigner::Relayer,
+                            ConfigProtocol::Starknet => ClientSelectedSigner::Relayer,
+                            ConfigProtocol::Icp => ClientSelectedSigner::Local,
+                        },
                         relayer: ClientRelayerSigner { url: relayer },
                         local: LocalConfig {
                             near: [
@@ -286,7 +290,7 @@ impl InitCommand {
                         network: match self.protocol {
                             ConfigProtocol::Near => "testnet".into(),
                             ConfigProtocol::Starknet => "sepolia".into(),
-                            ConfigProtocol::Icp => "ic".into(),
+                            ConfigProtocol::Icp => "local".into(),
                         },
                         protocol: self.protocol.as_str().to_owned(),
                         contract_id: match self.protocol {


### PR DESCRIPTION
# feat: set ICP init config

## Summary
Set default values for ICP as local network and self signer. This is because we decided not to go with the relayer solution for now

<img width="426" alt="Screenshot 2024-12-20 at 15 38 34" src="https://github.com/user-attachments/assets/84d3f114-9a06-47fa-881a-b77afff1f7e9" />
