### PR TITLE
chore(near): nonce migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,7 @@ name = "calimero-context-config-near"
 version = "0.1.0"
 dependencies = [
  "calimero-context-config",
+ "cfg-if 1.0.0",
  "ed25519-dalek",
  "eyre",
  "near-crypto",

--- a/contracts/near/context-config/Cargo.toml
+++ b/contracts/near/context-config/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
+cfg-if.workspace = true
 near-sdk = { workspace = true, features = ["unstable"] }
 calimero-context-config.workspace = true
 
@@ -24,3 +25,12 @@ tokio.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+default = []
+
+migrations = []
+## migrations (mutually exclusive) ##
+01_guard_revisions = []
+02_nonces = []
+## migrations (mutually exclusive) ##

--- a/contracts/near/context-config/build.sh
+++ b/contracts/near/context-config/build.sh
@@ -7,7 +7,12 @@ TARGET="${CARGO_TARGET_DIR:-../../../target}"
 
 rustup target add wasm32-unknown-unknown
 
-cargo build --target wasm32-unknown-unknown --profile app-release
+if [ "$1" = "--migration" ]; then
+  selected_migration=$2
+  extra_args="--features migrations,$selected_migration"
+fi
+
+cargo build --target wasm32-unknown-unknown --profile app-release $extra_args
 
 mkdir -p res
 

--- a/contracts/near/context-config/src/lib.rs
+++ b/contracts/near/context-config/src/lib.rs
@@ -6,8 +6,10 @@
 
 use calimero_context_config::types::{Application, ContextId, ContextIdentity};
 use calimero_context_config::Timestamp;
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::store::{IterableMap, IterableSet, LazyOption};
 use near_sdk::{near, AccountId, BorshStorageKey};
+
 mod guard;
 mod mutate;
 mod query;
@@ -41,13 +43,15 @@ struct Context {
     pub proxy: Guard<AccountId>,
 }
 
-#[derive(Copy, Clone, Debug, BorshStorageKey)]
-#[near(serializers = [borsh])]
+#[derive(Copy, Clone, Debug, BorshSerialize, BorshDeserialize, BorshStorageKey)]
+#[borsh(crate = "::near_sdk::borsh", use_discriminant = true)]
+#[repr(u8)]
 enum Prefix {
-    Contexts,
-    Members(ContextId),
-    Privileges(PrivilegeScope),
-    ProxyCode,
+    Contexts = 1,
+    Members(ContextId) = 2,
+    Privileges(PrivilegeScope) = 3,
+    ProxyCode = 4,
+    MemberNonces(ContextId) = 5,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/contracts/near/context-config/src/mutate.rs
+++ b/contracts/near/context-config/src/mutate.rs
@@ -100,6 +100,9 @@ impl ContextConfigs {
         let mut members = IterableSet::new(Prefix::Members(*context_id));
         let _ignored = members.insert(*author_id);
 
+        let mut member_nonces = IterableMap::new(Prefix::MemberNonces(*context_id));
+        let _ignored = member_nonces.insert(*author_id, 0);
+
         // Create incremental account ID
         let account_id: AccountId = format!("{}.{}", self.next_proxy_id, env::current_account_id())
             .parse()
@@ -130,7 +133,7 @@ impl ContextConfigs {
                 author_id.rt().expect("infallible conversion"),
                 members,
             ),
-            member_nonces: IterableMap::new(b"n"),
+            member_nonces,
             proxy: Guard::new(
                 Prefix::Privileges(PrivilegeScope::Context(
                     *context_id,

--- a/contracts/near/context-config/src/sys.rs
+++ b/contracts/near/context-config/src/sys.rs
@@ -1,13 +1,11 @@
 use core::time;
-use std::io;
 
-use calimero_context_config::repr::Repr;
-use calimero_context_config::types::{Application, ContextId, ContextIdentity, SignerId};
 use calimero_context_config::{SystemRequest, Timestamp};
-use near_sdk::store::{IterableMap, IterableSet};
 use near_sdk::{env, near, Gas, NearToken, Promise};
 
-use crate::{parse_input, Config, ContextConfigs, ContextConfigsExt};
+use crate::{parse_input, ContextConfigs, ContextConfigsExt};
+
+mod migrations;
 
 const MIN_VALIDITY_THRESHOLD_MS: Timestamp = 5_000;
 
@@ -54,46 +52,6 @@ impl ContextConfigs {
             "Post-erase storage usage: {}",
             env::storage_usage()
         ));
-    }
-
-    #[private]
-    pub fn migrate() {
-        // IterableMap doesn't support raw access to the underlying storage
-        // Which hinders migration of the data, so we have to employ this trick
-
-        #[derive(Debug)]
-        #[near(serializers = [borsh])]
-        pub struct OldContextConfigs {
-            contexts: IterableMap<ContextId, OldContext>,
-            config: Config,
-        }
-
-        #[derive(Debug)]
-        #[near(serializers = [borsh])]
-        struct OldContext {
-            pub application: OldGuard<Application<'static>>,
-            pub members: OldGuard<IterableSet<ContextIdentity>>,
-        }
-
-        #[derive(Debug)]
-        #[near(serializers = [borsh])]
-        pub struct OldGuard<T> {
-            inner: T,
-            #[borsh(deserialize_with = "skipped")]
-            revision: u64,
-            priviledged: IterableSet<SignerId>,
-        }
-
-        #[expect(clippy::unnecessary_wraps, reason = "borsh needs this")]
-        pub fn skipped<R: io::Read>(_reader: &mut R) -> Result<u64, io::Error> {
-            Ok(Default::default())
-        }
-
-        let mut state = env::state_read::<OldContextConfigs>().expect("failed to read state");
-
-        for (context_id, _) in state.contexts.iter_mut() {
-            env::log_str(&format!("Migrating context `{}`", Repr::new(*context_id)));
-        }
     }
 
     #[private]

--- a/contracts/near/context-config/src/sys/migrations.rs
+++ b/contracts/near/context-config/src/sys/migrations.rs
@@ -1,0 +1,54 @@
+use cfg_if::cfg_if;
+
+#[cfg(feature = "migrations")]
+const _: () = {
+    use near_sdk::near;
+
+    use crate::{ContextConfigs, ContextConfigsExt};
+
+    #[near]
+    impl ContextConfigs {
+        #[private]
+        pub fn migrate() {
+            directive::migrate();
+        }
+    }
+};
+
+migrations! {
+    "01_guard_revisions" => "migrations/01_guard_revisions.rs",
+    "02_nonces"         => "migrations/02_nonces.rs",
+}
+
+// ---
+
+macro_rules! _migrations {
+    ($($migration:literal => $path:literal,)+) => {
+        $(
+            #[cfg(feature = $migration)]
+            #[path = $path]
+            mod directive; /* migrations are exclusive */
+
+            #[cfg(all(feature = $migration, not(feature = "migrations")))]
+            compile_error!("migration selected without migrations enabled");
+        )+
+
+        cfg_if! {
+            if #[cfg(not(feature = "migrations"))] {}
+            $(
+                else if #[cfg(feature = $migration)] {}
+            )+
+            else {
+                mod directive {
+                    pub fn migrate() {
+                        /* no op */
+                    }
+                }
+
+                compile_error!("migrations enabled, but no migration selected");
+            }
+        }
+    };
+}
+
+use _migrations as migrations;

--- a/contracts/near/context-config/src/sys/migrations/01_guard_revisions.rs
+++ b/contracts/near/context-config/src/sys/migrations/01_guard_revisions.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+use calimero_context_config::repr::Repr;
+use calimero_context_config::types::{Application, ContextId, ContextIdentity, SignerId};
+use near_sdk::store::{IterableMap, IterableSet};
+use near_sdk::{env, near};
+
+use crate::Config;
+
+#[derive(Debug)]
+#[near(serializers = [borsh])]
+pub struct OldContextConfigs {
+    contexts: IterableMap<ContextId, OldContext>,
+    config: Config,
+}
+
+#[derive(Debug)]
+#[near(serializers = [borsh])]
+struct OldContext {
+    pub application: OldGuard<Application<'static>>,
+    pub members: OldGuard<IterableSet<ContextIdentity>>,
+}
+
+#[derive(Debug)]
+#[near(serializers = [borsh])]
+pub struct OldGuard<T> {
+    inner: T,
+    #[borsh(deserialize_with = "skipped")]
+    revision: u64,
+    priviledged: IterableSet<SignerId>,
+}
+
+#[expect(clippy::unnecessary_wraps, reason = "borsh needs this")]
+pub fn skipped<R: io::Read>(_reader: &mut R) -> Result<u64, io::Error> {
+    Ok(Default::default())
+}
+
+pub fn migrate() {
+    // IterableMap doesn't support raw access to the underlying storage
+    // Which hinders migration of the data, so we have to employ this trick
+
+    let mut state = env::state_read::<OldContextConfigs>().expect("failed to read state");
+
+    for (context_id, _) in state.contexts.iter_mut() {
+        env::log_str(&format!("Migrating context `{}`", Repr::new(*context_id)));
+    }
+}

--- a/contracts/near/context-config/src/sys/migrations/02_nonces.rs
+++ b/contracts/near/context-config/src/sys/migrations/02_nonces.rs
@@ -1,0 +1,49 @@
+use std::io;
+
+use calimero_context_config::repr::Repr;
+use calimero_context_config::types::{Application, ContextId, ContextIdentity};
+use near_sdk::store::{IterableMap, IterableSet, LazyOption};
+use near_sdk::{env, near, AccountId};
+
+use crate::guard::Guard;
+use crate::{Config, Prefix};
+
+#[derive(Debug)]
+#[near(serializers = [borsh])]
+pub struct OldContextConfigs {
+    contexts: IterableMap<ContextId, OldContext>,
+    config: Config,
+    proxy_code: LazyOption<Vec<u8>>,
+    next_proxy_id: u64,
+}
+
+#[derive(Debug)]
+#[near(serializers = [borsh])]
+struct OldContext {
+    pub application: Guard<Application<'static>>,
+    pub members: Guard<IterableSet<ContextIdentity>>,
+    #[borsh(deserialize_with = "skipped")]
+    pub member_nonces: IterableMap<ContextIdentity, u64>,
+    pub proxy: Guard<AccountId>,
+}
+
+#[expect(clippy::unnecessary_wraps, reason = "borsh needs this")]
+pub fn skipped<R: io::Read>(
+    _reader: &mut R,
+) -> Result<IterableMap<ContextIdentity, u64>, io::Error> {
+    Ok(IterableMap::new(&[13; 37][..]))
+}
+
+pub fn migrate() {
+    let mut state = env::state_read::<OldContextConfigs>().expect("failed to read state");
+
+    for (context_id, context) in state.contexts.iter_mut() {
+        env::log_str(&format!("Migrating context `{}`", Repr::new(*context_id)));
+
+        context.member_nonces = IterableMap::new(Prefix::MemberNonces(*context_id));
+
+        for member in context.members.iter() {
+            let _ignored = context.member_nonces.insert(*member, 0);
+        }
+    }
+}

--- a/contracts/near/context-config/tests/migrations.rs
+++ b/contracts/near/context-config/tests/migrations.rs
@@ -1,0 +1,367 @@
+#![allow(unused_crate_dependencies)]
+
+use std::time;
+
+use calimero_context_config::repr::{Repr, ReprTransmute};
+use calimero_context_config::types::{Application, Signed, SignerId};
+use calimero_context_config::{ContextRequest, ContextRequestKind, Request, RequestKind};
+use ed25519_dalek::{Signer, SigningKey};
+use near_sdk::serde::Serialize;
+use near_sdk::NearToken;
+use rand::Rng;
+use serde_json::json;
+use tokio::fs;
+
+#[cfg_attr(not(feature = "01_guard_revisions"), ignore)]
+#[tokio::test]
+async fn migration_revision_guard() -> eyre::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+
+    let wasm_v0 =
+        fs::read("res/calimero_context_config_near_migration_revision_guard_pre.wasm").await?;
+    let wasm_v1 =
+        fs::read("res/calimero_context_config_near_migration_revision_guard_post.wasm").await?;
+
+    let mut rng = rand::thread_rng();
+
+    let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
+
+    let context_proxy_blob =
+        fs::read("../context-proxy/res/calimero_context_proxy_near.wasm").await?;
+
+    let _ignored = contract_v0
+        .call("set_proxy_code")
+        .args(context_proxy_blob)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    let root_account = worker.root_account()?;
+
+    let node1 = root_account
+        .create_subaccount("node1")
+        .initial_balance(NearToken::from_near(1))
+        .transact()
+        .await?
+        .into_result()?;
+
+    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let alice_cx_pk = alice_cx_sk.verifying_key();
+    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+    let context_secret = SigningKey::from_bytes(&rng.gen());
+    let context_public = context_secret.verifying_key();
+    let context_id = context_public.to_bytes().rt()?;
+
+    let application_id = rng.gen::<[_; 32]>().rt()?;
+    let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    let res = node1
+        .call(contract_v0.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(context_id.rt()?, kind, 0)
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert!(
+        res.logs()
+            .contains(&format!("Context `{}` added", context_id).as_str()),
+        "{:?}",
+        res.logs()
+    );
+
+    let res = contract_v0
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.size, 0);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let contract_v1 = contract_v0
+        .as_account()
+        .deploy(&wasm_v1)
+        .await?
+        .into_result()?;
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await
+        .expect_err("should've failed");
+
+    {
+        let err = format!("{:?}", res);
+        assert!(err.contains("Cannot deserialize element"), "{}", err);
+    }
+
+    let migration = contract_v1
+        .call("migrate")
+        .transact()
+        .await?
+        .into_result()?;
+
+    dbg!(migration.logs());
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.size, 0);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    Ok(())
+}
+
+#[cfg_attr(not(feature = "02_nonces"), ignore)]
+#[tokio::test]
+async fn migration_member_nonces() -> eyre::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+
+    // testnet block 185_028_495
+    let wasm_v0 =
+        fs::read("res/calimero_context_config_near_migration_member_nonces_pre.wasm").await?;
+    let wasm_v1 =
+        fs::read("res/calimero_context_config_near_migration_member_nonces_post.wasm").await?;
+
+    let mut rng = rand::thread_rng();
+
+    let contract_v0 = worker.dev_deploy(&wasm_v0).await?;
+
+    let context_proxy_blob =
+        fs::read("../context-proxy/res/calimero_context_proxy_near.wasm").await?;
+
+    let _ignored = contract_v0
+        .call("set_proxy_code")
+        .args(context_proxy_blob)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    let root_account = worker.root_account()?;
+
+    let node1 = root_account
+        .create_subaccount("node1")
+        .initial_balance(NearToken::from_near(1))
+        .transact()
+        .await?
+        .into_result()?;
+
+    let alice_cx_sk = SigningKey::from_bytes(&rng.gen());
+    let alice_cx_pk = alice_cx_sk.verifying_key();
+    let alice_cx_id = alice_cx_pk.to_bytes().rt()?;
+
+    let context_secret = SigningKey::from_bytes(&rng.gen());
+    let context_public = context_secret.verifying_key();
+    let context_id = context_public.to_bytes().rt()?;
+
+    let application_id = rng.gen::<[_; 32]>().rt()?;
+    let blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    #[derive(Debug, Serialize)]
+    #[serde(crate = "near_sdk::serde")]
+    #[serde(rename_all = "camelCase")]
+    struct OldRequest<'a> {
+        signer_id: Repr<SignerId>,
+        timestamp_ms: u64,
+
+        #[serde(flatten)]
+        kind: RequestKind<'a>,
+    }
+
+    let res = node1
+        .call(contract_v0.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::Add {
+                        author_id: alice_cx_id,
+                        application: Application::new(
+                            application_id,
+                            blob_id,
+                            0,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                OldRequest {
+                    kind,
+                    signer_id: context_id.rt()?,
+                    timestamp_ms: time::SystemTime::now()
+                        .duration_since(time::UNIX_EPOCH)
+                        .expect("system time is before epoch?")
+                        .as_millis() as _,
+                }
+            },
+            |p| context_secret.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert!(
+        res.logs()
+            .contains(&format!("Context `{}` added", context_id).as_str()),
+        "{:?}",
+        res.logs()
+    );
+
+    let res = contract_v0
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let contract_v1 = contract_v0
+        .as_account()
+        .deploy(&wasm_v1)
+        .await?
+        .into_result()?;
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await
+        .expect_err("should've failed");
+
+    {
+        let err = format!("{:?}", res);
+        assert!(err.contains("Cannot deserialize element"), "{}", err);
+    }
+
+    let migration = contract_v1
+        .call("migrate")
+        .transact()
+        .await?
+        .into_result()?;
+
+    dbg!(migration.logs());
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, application_id);
+    assert_eq!(res.blob, blob_id);
+    assert_eq!(res.size, 0);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let res: Option<u64> = contract_v1
+        .view("fetch_nonce")
+        .args_json(json!({ "context_id": context_id, "member_id": alice_cx_id }))
+        .await?
+        .json()?;
+
+    let nonce = res.expect("nonce not found");
+
+    assert_eq!(nonce, 0);
+
+    let new_application_id = rng.gen::<[_; 32]>().rt()?;
+    let new_blob_id = rng.gen::<[_; 32]>().rt()?;
+
+    let res = node1
+        .call(contract_v1.id(), "mutate")
+        .args_json(Signed::new(
+            &{
+                let kind = RequestKind::Context(ContextRequest::new(
+                    context_id,
+                    ContextRequestKind::UpdateApplication {
+                        application: Application::new(
+                            new_application_id,
+                            new_blob_id,
+                            1,
+                            Default::default(),
+                            Default::default(),
+                        ),
+                    },
+                ));
+
+                Request::new(alice_cx_id.rt()?, kind, nonce)
+            },
+            |p| alice_cx_sk.sign(p),
+        )?)
+        .max_gas()
+        .transact()
+        .await?
+        .into_result()?;
+
+    assert_eq!(
+        res.logs(),
+        [format!(
+            "Updated application for context `{}` from `{}` to `{}`",
+            context_id, application_id, new_application_id
+        )]
+    );
+
+    let res = contract_v1
+        .view("application")
+        .args_json(json!({ "context_id": context_id }))
+        .await?;
+
+    let res: Application<'_> = serde_json::from_slice(&res.result)?;
+
+    assert_eq!(res.id, new_application_id);
+    assert_eq!(res.blob, new_blob_id);
+    assert_eq!(res.size, 1);
+    assert_eq!(res.source, Default::default());
+    assert_eq!(res.metadata, Default::default());
+
+    let res: Option<u64> = contract_v1
+        .view("fetch_nonce")
+        .args_json(json!({ "context_id": context_id, "member_id": alice_cx_id }))
+        .await?
+        .json()?;
+
+    let nonce = res.expect("nonce not found");
+
+    assert_eq!(nonce, 1);
+
+    Ok(())
+}

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(single_use_lifetimes, reason = "False positive")]
 
 use std::borrow::Cow;
-use std::time;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -23,29 +22,18 @@ pub type Timestamp = u64;
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Request<'a> {
+    pub signer_id: Repr<SignerId>,
+    pub nonce: u64,
+
     #[serde(borrow, flatten)]
     pub kind: RequestKind<'a>,
-
-    pub signer_id: Repr<SignerId>,
-    pub timestamp_ms: Timestamp,
-    pub nonce: u64,
 }
 
 impl<'a> Request<'a> {
     #[must_use]
     pub fn new(signer_id: SignerId, kind: RequestKind<'a>, nonce: u64) -> Self {
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "This is never expected to overflow"
-        )]
-        let timestamp_ms = time::SystemTime::now()
-            .duration_since(time::UNIX_EPOCH)
-            .expect("system time is before epoch?")
-            .as_millis() as u64;
-
         Request {
             signer_id: Repr::new(signer_id),
-            timestamp_ms,
             kind,
             nonce,
         }


### PR DESCRIPTION
Add migrations for moving to nonces from timestamps in the near contract.

Defines an organized structure for managing migrations.

### Test Plan

Pull the wasm blob of `calimero-context-config.testnet` at block `185_028_495`.

```console
near contract download-wasm calimero-context-config.testnet to-folder . network-config testnet at-block-height 185028495
```

Move that to `res/calimero_context_config_near_migration_member_nonces_pre.wasm`

```console
mv contract_calimero-context-config_testnet.wasm ./contracts/near/context-config/res/calimero_context_config_near_migration_member_nonces_pre.wasm
```

Then with this branch checked out, and run:

```console
./contracts/near/context-config/build.sh --migration 02_nonces
```

and copy the built wasm to `res/calimero_context_config_near_migration_member_nonces_post.wasm`

```console
cp ./contracts/near/context-config/res/calimero_context_config_near.wasm ./contracts/near/context-config/res/calimero_context_config_near_migration_member_nonces_post.wasm
```

then run

```console
cargo test -p calimero-context-config-near --features migrations,02_nonces -- migration_member_nonces
```