### PR TITLE
chore(merod, meroctl): release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Allowed the specification of all protocol's default context configuration
 - Exposed, and enabled functionality for context proxy storage
 - Introduced bootstrap command for quick development as a demo
+- Added additional REST endpoints for easier access and information retrieval
 
 ## [0.2.0] - 2024-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.3.0] - 2025-01-16
+
+- Introduced ICP integrations, achieving full feature parity with NEAR and
+  Starknet
+- Improved replay protection on external interactions, fixing spurious failures
+  from expired requests
+- Moved protocol selection to context creation, and out of the config
+- Allowed the specification of all protocol's default context configuration
+- Exposed, and enabled functionality for context proxy storage
+- Introduced bootstrap command for quick development as a demo
+
 ## [0.2.0] - 2024-12-05
 
 Rust SDK:
 
 - env::executor_id() for fetching the runtime identity (no arbitrary signing,
-  however.
+  however).
 - env::context_id() for fetching the context ID.
 - calimero_storage::collections::{Unordered{Map,Set},Vector} for conflict-free
   operations
@@ -31,3 +44,9 @@ Integrations:
   every created context, which facilitates context representation on the network
 - Starknet: reached feature parity with the NEAR implementation, allowing
   contexts to be created in association with the Starknet protocol.
+
+[unreleased]:
+  https://github.com/calimero-network/core/compare/merod-0.3.0...HEAD
+[0.3.0]:
+  https://github.com/calimero-network/core/compare/merod-0.2.0...merod-0.3.0
+[0.2.0]: https://github.com/calimero-network/core/releases/tag/merod-0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4942,7 +4942,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "meroctl"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-config",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "merod"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "calimero-blobstore",

--- a/contracts/near/context-config/src/sys/migrations.rs
+++ b/contracts/near/context-config/src/sys/migrations.rs
@@ -17,7 +17,7 @@ const _: () = {
 
 migrations! {
     "01_guard_revisions" => "migrations/01_guard_revisions.rs",
-    "02_nonces"         => "migrations/02_nonces.rs",
+    "02_nonces"          => "migrations/02_nonces.rs",
 }
 
 // ---

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meroctl"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/merod/Cargo.toml
+++ b/crates/merod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merod"
-version = "0.2.1"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Notable changes:

- Introduced ICP integrations, achieving full feature parity with NEAR and Starknet
- Improved replay protection on external interactions, fixing spurious failures from expired requests
- Moved protocol selection to context creation, and out of the config
- Allowed the specification of all protocol's default context configuration
- Exposed, and enabled functionality for context proxy storage
- Introduced bootstrap command for quick development as a demo