### PR TITLE
ci: implement update homebrew formula job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Rust binaries release
+name: Release
 
 on:
   push:
@@ -193,8 +193,8 @@ jobs:
           echo "target_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
 
           if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-            version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "${{ matrix.binary }}") | .version')
-            version="${{ matrix.binary }}-$version"
+            binary_version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "${{ matrix.binary }}") | .version')
+            version="${{ matrix.binary }}-$binary_version"
             echo "Master version: $version"
 
             if gh release view "$version" --repo ${{ github.repository }} >/dev/null 2>&1; then
@@ -206,6 +206,7 @@ jobs:
             fi
             echo "prerelease=false" >> $GITHUB_OUTPUT
             echo "overwrite=false">> $GITHUB_OUTPUT
+            echo "binary_version=$binary_version" >> $GITHUB_OUTPUT
             echo "version=$version" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "pull_request" ] && [[ "${{ github.head_ref }}" == prerelease/* ]]; then
             version="prerelease-${{ github.event.number }}"
@@ -219,6 +220,15 @@ jobs:
             echo "This is not a master branch or a prerelease PR"
             echo "release_required=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set release matrix outputs
+        uses: cloudposse/github-action-matrix-outputs-write@v1
+        with:
+          matrix-step-name: release
+          matrix-key: ${{ matrix.binary }}
+          outputs: |-
+            releaseRequired: ${{ steps.version_info.outputs.release_required }}
+            version: ${{ steps.version_info.outputs.binary_version }}
 
       - name: Remove other binaries from artifacts
         if: steps.version_info.outputs.release_required == 'true'
@@ -238,3 +248,78 @@ jobs:
           prerelease: ${{ steps.version_info.outputs.prerelease }}
           overwrite: ${{ steps.version_info.outputs.overwrite }}
           target_commit: ${{ steps.version_info.outputs.target_commit }}
+
+  brew-update:
+    if: needs.prepare.outputs.is_release_candidate == 'true' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: [prepare, build, release]
+    steps:
+      - name: Get release matrix outputs
+        id: release-matrix-outputs
+        uses: cloudposse/github-action-matrix-outputs-read@v1
+        with:
+          matrix-step-name: release
+
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            homebrew-tap
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/homebrew-tap
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure Git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh auth setup-git
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Update Formula
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          target_branch="chore/bump-formulas-version"
+          git fetch origin "${target_branch}" || true
+          git checkout "${target_branch}" || git checkout -b "${target_branch}"
+
+          for binary in $(echo '${{ needs.prepare.outputs.binary_matrix }}' | jq -r '.[]'); do
+            release_required=$(echo '${{ steps.release-matrix-outputs.outputs.result }}' | jq -r --arg key "${binary}" '.releaseRequired[$key]')
+            version=$(echo '${{ steps.release-matrix-outputs.outputs.result }}' | jq -r --arg key "${binary}" '.version[$key]')
+
+            if [ "${release_required}" == "true" ]; then
+              echo "Updating formula for ${binary}, version: ${version}"
+              ./generate-formula.sh "${binary}" "${version}"
+            else
+              echo "No formula update required for ${binary}"
+            fi
+          done
+
+          git status
+
+          if git diff-index --quiet HEAD --; then
+            echo "There are no changes to commit"
+            exit 0
+          fi
+
+          git add Formula/
+          git commit -m "chore: bump formulas version"
+          git push origin "${target_branch}"
+
+          gh pr create -f || true


### PR DESCRIPTION
Update homebrew formulas once all binaries have been released. 

Example of a PR (usually only one commit): https://github.com/calimero-network/homebrew-tap/pull/7