### PR TITLE
Update meroctl commands

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -784,7 +784,7 @@ impl ContextManager {
         Ok(handle.has(&ContextIdentityKey::new(context_id, public_key))?)
     }
 
-    fn get_context_identities(
+    pub fn get_context_identities(
         &self,
         context_id: ContextId,
         only_owned_identities: bool,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1487,4 +1487,8 @@ impl ContextManager {
 
         Ok(proxy_contract)
     }
+
+    pub async fn get_peers_count(&self) -> usize {
+        self.network_client.peer_count().await
+    }
 }

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -16,12 +16,14 @@ mod bootstrap;
 mod call;
 mod context;
 mod identity;
+mod peers;
 mod proxy;
 
 use app::AppCommand;
 use call::CallCommand;
 use context::ContextCommand;
 use identity::IdentityCommand;
+use peers::PeersCommand;
 use proxy::ProxyCommand;
 
 pub const EXAMPLES: &str = r"
@@ -56,6 +58,7 @@ pub enum SubCommands {
     Proxy(ProxyCommand),
     Call(CallCommand),
     Bootstrap(BootstrapCommand),
+    Peers(PeersCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -106,6 +109,7 @@ impl RootCommand {
             SubCommands::Proxy(proxy) => proxy.run(&environment).await,
             SubCommands::Call(call) => call.run(&environment).await,
             SubCommands::Bootstrap(call) => call.run(&environment).await,
+            SubCommands::Peers(peers) => peers.run(&environment).await,
         };
 
         if let Err(err) = result {

--- a/crates/meroctl/src/cli/context/get.rs
+++ b/crates/meroctl/src/cli/context/get.rs
@@ -2,7 +2,7 @@ use calimero_server_primitives::admin::{
     GetContextClientKeysResponse, GetContextIdentitiesResponse, GetContextResponse,
     GetContextStorageResponse, GetContextUsersResponse,
 };
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use eyre::Result as EyreResult;
 use libp2p::identity::Keypair;
 use libp2p::Multiaddr;
@@ -17,20 +17,32 @@ use crate::output::Report;
 #[derive(Parser, Debug)]
 #[command(about = "Fetch details about the context")]
 pub struct GetCommand {
-    #[arg(value_name = "METHOD", help = "Method to fetch details", value_enum)]
-    pub method: GetRequest,
+    #[command(subcommand)]
+    pub command: GetSubcommand,
 
     #[arg(value_name = "CONTEXT_ID", help = "context_id of the context")]
     pub context_id: String,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
-pub enum GetRequest {
+#[derive(Debug, Parser)]
+pub enum GetSubcommand {
+    #[command(about = "Get context details")]
     Context,
+
+    #[command(about = "Get context users")]
     Users,
+
+    #[command(about = "Get client keys")]
     ClientKeys,
+
+    #[command(about = "Get storage information")]
     Storage,
-    Identities,
+
+    #[command(about = "Get identities")]
+    Identities {
+        #[arg(long, help = "Show only owned identities")]
+        owned: bool,
+    },
 }
 
 impl Report for GetContextResponse {
@@ -72,25 +84,25 @@ impl GetCommand {
         let multiaddr = fetch_multiaddr(&config)?;
         let client = Client::new();
 
-        match self.method {
-            GetRequest::Context => {
+        match self.command {
+            GetSubcommand::Context => {
                 self.get_context(environment, multiaddr, &client, &config.identity)
                     .await
             }
-            GetRequest::Users => {
+            GetSubcommand::Users => {
                 self.get_users(environment, multiaddr, &client, &config.identity)
                     .await
             }
-            GetRequest::ClientKeys => {
+            GetSubcommand::ClientKeys => {
                 self.get_client_keys(environment, multiaddr, &client, &config.identity)
                     .await
             }
-            GetRequest::Storage => {
+            GetSubcommand::Storage => {
                 self.get_storage(environment, multiaddr, &client, &config.identity)
                     .await
             }
-            GetRequest::Identities => {
-                self.get_identities(environment, multiaddr, &client, &config.identity)
+            GetSubcommand::Identities { owned } => {
+                self.get_identities(environment, multiaddr, &client, &config.identity, owned)
                     .await
             }
         }
@@ -162,11 +174,17 @@ impl GetCommand {
         multiaddr: &Multiaddr,
         client: &Client,
         keypair: &Keypair,
+        owned: bool,
     ) -> EyreResult<()> {
-        let url = multiaddr_to_url(
-            multiaddr,
-            &format!("admin-api/dev/contexts/{}/identities", self.context_id),
-        )?;
+        let endpoint = if owned {
+            format!(
+                "admin-api/dev/contexts/{}/identities-owned",
+                self.context_id
+            )
+        } else {
+            format!("admin-api/dev/contexts/{}/identities", self.context_id)
+        };
+        let url = multiaddr_to_url(multiaddr, &endpoint)?;
         self.make_request::<GetContextIdentitiesResponse>(environment, client, url, keypair)
             .await
     }

--- a/crates/meroctl/src/cli/peers.rs
+++ b/crates/meroctl/src/cli/peers.rs
@@ -1,0 +1,36 @@
+use calimero_server_primitives::admin::GetPeersCountResponse;
+use clap::Parser;
+use eyre::Result as EyreResult;
+use reqwest::Client;
+
+use crate::cli::Environment;
+use crate::common::{do_request, fetch_multiaddr, load_config, multiaddr_to_url, RequestType};
+use crate::output::Report;
+
+#[derive(Debug, Parser)]
+pub struct PeersCommand;
+
+impl Report for GetPeersCountResponse {
+    fn report(&self) {
+        println!("{}", self.count);
+    }
+}
+
+impl PeersCommand {
+    pub async fn run(&self, environment: &Environment) -> EyreResult<()> {
+        let config = load_config(&environment.args.home, &environment.args.node_name)?;
+
+        let response: GetPeersCountResponse = do_request(
+            &Client::new(),
+            multiaddr_to_url(fetch_multiaddr(&config)?, "admin-api/dev/peers")?,
+            None::<()>,
+            &config.identity,
+            RequestType::Get,
+        )
+        .await?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -448,6 +448,21 @@ impl GenerateContextIdentityResponse {
 }
 
 // -------------------------------------------- Misc API --------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetPeersCountResponse {
+    pub count: usize,
+}
+
+impl GetPeersCountResponse {
+    #[must_use]
+    pub fn new(count: usize) -> Self {
+        Self { count }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]

--- a/crates/server/src/admin/handlers.rs
+++ b/crates/server/src/admin/handlers.rs
@@ -4,5 +4,6 @@ pub mod challenge;
 pub mod context;
 pub mod did;
 pub mod identity;
+pub mod peers;
 pub mod proposals;
 pub mod root_keys;

--- a/crates/server/src/admin/handlers/context/get_context_identities.rs
+++ b/crates/server/src/admin/handlers/context/get_context_identities.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::extract::Path;
+use axum::extract::{Path, Request};
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_primitives::context::ContextId;
@@ -13,6 +13,7 @@ use crate::AdminState;
 pub async fn handler(
     Path(context_id): Path<ContextId>,
     Extension(state): Extension<Arc<AdminState>>,
+    req: Request,
 ) -> impl IntoResponse {
     let context = state
         .ctx_manager
@@ -35,9 +36,11 @@ pub async fn handler(
         }
     };
 
+    let owned = req.uri().path().ends_with("identities-owned");
+
     let context_identities = state
         .ctx_manager
-        .get_context_owned_identities(context.id)
+        .get_context_identities(context.id, owned)
         .map_err(|err| parse_api_error(err).into_response());
 
     match context_identities {

--- a/crates/server/src/admin/handlers/peers.rs
+++ b/crates/server/src/admin/handlers/peers.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_server_primitives::admin::GetPeersCountResponse;
+
+use crate::admin::service::ApiResponse;
+use crate::AdminState;
+
+pub async fn get_peers_count_handler(
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let peer_count = state.ctx_manager.get_peers_count().await;
+
+    ApiResponse {
+        payload: GetPeersCountResponse::new(peer_count),
+    }
+    .into_response()
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -129,6 +129,10 @@ pub(crate) fn setup(
             "/contexts/:context_id/identities",
             get(get_context_identities::handler),
         )
+        .route(
+            "/contexts/:context_id/identities-owned",
+            get(get_context_identities::handler),
+        )
         .route("/contexts/invite", post(invite_to_context::handler))
         .route("/contexts/join", post(join_context::handler))
         .route("/contexts", get(get_contexts::handler))
@@ -223,6 +227,10 @@ pub(crate) fn setup(
         )
         .route(
             "/dev/contexts/:context_id/identities",
+            get(get_context_identities::handler),
+        )
+        .route(
+            "/dev/contexts/:context_id/identities-owned",
             get(get_context_identities::handler),
         )
         .route("/dev/contexts/:context_id", delete(delete_context::handler))

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -41,6 +41,7 @@ use crate::admin::handlers::context::{
 };
 use crate::admin::handlers::did::fetch_did_handler;
 use crate::admin::handlers::identity::generate_context_identity;
+use crate::admin::handlers::peers::get_peers_count_handler;
 use crate::admin::handlers::root_keys::{create_root_key_handler, delete_auth_keys_handler};
 use crate::config::ServerConfig;
 use crate::middleware::auth::AuthSignatureLayer;
@@ -142,6 +143,7 @@ pub(crate) fn setup(
         )
         .route("/identity/keys", delete(delete_auth_keys_handler))
         .route("/generate-jwt-token", post(generate_jwt_token_handler))
+        .route("/peers", get(get_peers_count_handler))
         .layer(AuthSignatureLayer::new(store))
         .layer(Extension(Arc::clone(&shared_state)));
 
@@ -258,6 +260,7 @@ pub(crate) fn setup(
             "/dev/contexts/:context_id/proposals/:proposal_id",
             get(get_proposal_handler),
         )
+        .route("/dev/peers", get(get_peers_count_handler))
         .route_layer(from_fn(dev_mode_auth));
 
     let admin_router = Router::new()


### PR DESCRIPTION
# PR short description

Now all the functionalities from the` interactive cli` are included in the `meroctl`.
Updates from this PR include:

1.  `context get identities` (`--owned`) command - list all the identities in a context, the `--owned` command is to show only the owned identities
2. `peers` command - show the number of connected peers

## Test plan

`get identities` tested by creating a context, inviting one other peer and then verifying the output of the `identities` and `identities --owned` commands.
`peers` command tested by creating three nodes, and verifying that the output is `3`

## Documentation update

No documentation update is necessary right now, although when we move form interactive cli to meroctl in our public docs it should be mentioned
