### PR TITLE
fix(core): stellar rpc mutate function + types update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-client",
+ "soroban-env-common",
  "soroban-sdk",
  "starknet",
  "starknet-crypto 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ serde = "1.0.196"
 serde_json = "1.0.113"
 serde_with = "3.9.0"
 soroban-env-common = "22.1.3"
-soroban-sdk = { version = "22.0.5" }
+soroban-sdk = { version = "22.0.5", features = ["alloc"] }
 starknet = "0.12.0"
 starknet-crypto = "0.7.1"
 starknet-types-core = "0.1.7"

--- a/crates/context/config/Cargo.toml
+++ b/crates/context/config/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 soroban-sdk = { workspace = true, optional = true }
+soroban-env-common = { workspace = true, optional = true }
 starknet = { workspace = true, optional = true }
 starknet-crypto = { workspace = true, optional = true }
 starknet-types-core = { workspace = true, optional = true }
@@ -71,7 +72,7 @@ starknet_client = [
   "dep:starknet-types-core",
 ]
 
-stellar = ["soroban-sdk"]
+stellar = ["soroban-sdk", "soroban-env-common"]
 
 stellar_client = [
   "stellar",

--- a/crates/context/config/src/client/env/config/mutate.rs
+++ b/crates/context/config/src/client/env/config/mutate.rs
@@ -180,15 +180,12 @@ impl<'a> Method<Stellar> for Mutate<'a> {
         let signer_sk = SigningKey::from_bytes(&self.signing_key);
 
         let request = StellarRequest::new(
-          signer_sk.verifying_key().rt()?,
-          StellarRequestKind::from_with_env(self.kind, &env),
-          self.nonce,
+            signer_sk.verifying_key().rt()?,
+            StellarRequestKind::from_with_env(self.kind, &env),
+            self.nonce,
         );
-        let signed_request = StellarSignedRequest::new(
-            &env,
-            request,
-            |b| Ok(signer_sk.sign(b))
-        ).map_err(|e| eyre::eyre!("Failed to sign request: {:?}", e))?;
+        let signed_request = StellarSignedRequest::new(&env, request, |b| Ok(signer_sk.sign(b)))
+            .map_err(|e| eyre::eyre!("Failed to sign request: {:?}", e))?;
 
         let bytes: Vec<u8> = signed_request.to_xdr(&env).into_iter().collect();
 

--- a/crates/context/config/src/client/env/config/mutate.rs
+++ b/crates/context/config/src/client/env/config/mutate.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use ed25519_dalek::{Signer, SigningKey};
 use soroban_sdk::xdr::ToXdr;
-use soroban_sdk::{Bytes, BytesN, Env, IntoVal};
+use soroban_sdk::Env;
 use starknet::core::codec::Encode as StarknetEncode;
 use starknet::signers::SigningKey as StarknetSigningKey;
 use starknet_crypto::{poseidon_hash_many, Felt};
@@ -17,12 +17,9 @@ use crate::client::transport::Transport;
 use crate::client::{CallClient, ClientError, Operation};
 use crate::icp::types::{ICRequest, ICSigned};
 use crate::repr::{Repr, ReprTransmute};
-use crate::stellar::stellar_types::{
-    StellarApplication, StellarContextRequest, StellarContextRequestKind, StellarRequest,
-    StellarRequestKind, StellarSignedRequest,
-};
+use crate::stellar::stellar_types::{StellarRequest, StellarRequestKind, StellarSignedRequest};
 use crate::types::Signed;
-use crate::{ContextIdentity, ContextRequestKind, Request, RequestKind};
+use crate::{ContextIdentity, Request, RequestKind};
 pub mod methods;
 
 use crate::stellar::stellar_types::FromWithEnv;
@@ -192,8 +189,8 @@ impl<'a> Method<Stellar> for Mutate<'a> {
         Ok(bytes)
     }
 
-    fn decode(response: Vec<u8>) -> eyre::Result<Self::Returns> {
-        todo!()
+    fn decode(_response: Vec<u8>) -> eyre::Result<Self::Returns> {
+        Ok(())
     }
 }
 

--- a/crates/context/config/src/client/protocol/stellar.rs
+++ b/crates/context/config/src/client/protocol/stellar.rs
@@ -18,9 +18,9 @@ use soroban_client::soroban_rpc::{
 };
 use soroban_client::transaction::{TransactionBehavior, TransactionBuilder};
 use soroban_client::transaction_builder::TransactionBuilderBehavior;
-use soroban_sdk::{Bytes, Env, Val, xdr::FromXdr, TryIntoVal};
 use soroban_client::xdr::{ScBytes, ScVal};
-
+use soroban_sdk::xdr::FromXdr;
+use soroban_sdk::{Bytes, Env, TryIntoVal, Val};
 use stellar_baselib::xdr::{self, ReadXdr};
 use thiserror::Error;
 use url::Url;
@@ -284,15 +284,19 @@ impl Network {
         } else {
             let env = Env::default();
             let env_bytes = Bytes::from_slice(&env, &args);
-            let signed_request = StellarSignedRequest::from_xdr(&env, &env_bytes).map_err(|e| StellarError::Custom {
-                operation: ErrorOperation::Mutate,
-                reason: "Failed to deserialize signed request".to_owned(),
+            let signed_request = StellarSignedRequest::from_xdr(&env, &env_bytes).map_err(|e| {
+                StellarError::Custom {
+                    operation: ErrorOperation::Mutate,
+                    reason: "Failed to deserialize signed request".to_owned(),
+                }
             })?;
             // Convert StellarSignedRequest to ScVal
-            let val: Val = signed_request.try_into_val(&env).map_err(|e| StellarError::Custom {
-                operation: ErrorOperation::Mutate,
-                reason: "Failed to convert to Val".to_owned(),
-            })?;
+            let val: Val = signed_request
+                .try_into_val(&env)
+                .map_err(|e| StellarError::Custom {
+                    operation: ErrorOperation::Mutate,
+                    reason: "Failed to convert to Val".to_owned(),
+                })?;
             let sc_val: ScVal = val.try_into_val(&env).map_err(|e| StellarError::Custom {
                 operation: ErrorOperation::Mutate,
                 reason: "Failed to convert to ScVal".to_owned(),
@@ -308,14 +312,15 @@ impl Network {
             .build();
 
         // First simulate the transaction to get proper values
-        let simulation_result = self.client
+        let simulation_result = self
+            .client
             .simulate_transaction(transaction.clone(), None)
             .await;
 
-            match simulation_result {
+        match simulation_result {
             Ok(sim_response) => {
                 println!("Simulation successful: {:?}", sim_response);
-            },
+            }
             Err(e) => {
                 println!("Simulation failed: {:?}", e);
                 return Err(StellarError::Custom {

--- a/crates/context/config/src/client/protocol/stellar.rs
+++ b/crates/context/config/src/client/protocol/stellar.rs
@@ -18,7 +18,9 @@ use soroban_client::soroban_rpc::{
 };
 use soroban_client::transaction::{TransactionBehavior, TransactionBuilder};
 use soroban_client::transaction_builder::TransactionBuilderBehavior;
+use soroban_sdk::{Bytes, Env, Val, xdr::FromXdr, TryIntoVal};
 use soroban_client::xdr::{ScBytes, ScVal};
+
 use stellar_baselib::xdr::{self, ReadXdr};
 use thiserror::Error;
 use url::Url;
@@ -27,6 +29,7 @@ use super::Protocol;
 use crate::client::transport::{
     AssociatedTransport, Operation, ProtocolTransport, TransportRequest,
 };
+use crate::stellar::stellar_types::StellarSignedRequest;
 
 #[derive(Copy, Clone, Debug)]
 pub enum Stellar {}
@@ -276,16 +279,25 @@ impl Network {
             })?;
 
         let source_account = Rc::new(RefCell::new(account));
-
         let args = if args.is_empty() {
             None
         } else {
-            let sc_bytes = ScBytes::try_from(args).map_err(|e| StellarError::Custom {
+            let env = Env::default();
+            let env_bytes = Bytes::from_slice(&env, &args);
+            let signed_request = StellarSignedRequest::from_xdr(&env, &env_bytes).map_err(|e| StellarError::Custom {
                 operation: ErrorOperation::Mutate,
-                reason: e.to_string(),
+                reason: "Failed to deserialize signed request".to_owned(),
             })?;
-            let scval_bytes = ScVal::Bytes(sc_bytes);
-            Some(vec![scval_bytes])
+            // Convert StellarSignedRequest to ScVal
+            let val: Val = signed_request.try_into_val(&env).map_err(|e| StellarError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: "Failed to convert to Val".to_owned(),
+            })?;
+            let sc_val: ScVal = val.try_into_val(&env).map_err(|e| StellarError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: "Failed to convert to ScVal".to_owned(),
+            })?;
+            Some(vec![sc_val])
         };
 
         let transaction = TransactionBuilder::new(source_account, self.network.as_str(), None)
@@ -294,6 +306,24 @@ impl Network {
             .set_timeout(15)
             .expect("Transaction timeout")
             .build();
+
+        // First simulate the transaction to get proper values
+        let simulation_result = self.client
+            .simulate_transaction(transaction.clone(), None)
+            .await;
+
+            match simulation_result {
+            Ok(sim_response) => {
+                println!("Simulation successful: {:?}", sim_response);
+            },
+            Err(e) => {
+                println!("Simulation failed: {:?}", e);
+                return Err(StellarError::Custom {
+                    operation: ErrorOperation::Mutate,
+                    reason: format!("Simulation failed: {:?}", e),
+                });
+            }
+        }
 
         let signed_tx = {
             let prepared_tx = self

--- a/crates/context/config/src/stellar/stellar_types.rs
+++ b/crates/context/config/src/stellar/stellar_types.rs
@@ -40,11 +40,15 @@ impl<'a> FromWithEnv<Application<'a>> for StellarApplication {
 
 impl<'a> From<StellarApplication> for Application<'a> {
     fn from(value: StellarApplication) -> Self {
+        let mut bytes = vec![0u8; value.source.len() as usize];
+        value.source.copy_into_slice(&mut bytes);
+        let std_string = std::string::String::from_utf8(bytes).expect("valid utf8");
+
         Application::new(
             value.id.rt().expect("infallible conversion"),
             value.blob.rt().expect("infallible conversion"),
             value.size,
-            ApplicationSource(Cow::Owned(value.source.to_string())),
+            ApplicationSource(Cow::Owned(std_string)),
             ApplicationMetadata(Repr::new(Cow::Owned(value.metadata.to_alloc_vec()))),
         )
     }

--- a/crates/context/config/src/stellar/stellar_types.rs
+++ b/crates/context/config/src/stellar/stellar_types.rs
@@ -32,25 +32,20 @@ impl<'a> FromWithEnv<Application<'a>> for StellarApplication {
             id: BytesN::from_array(env, &value.id.rt().expect("infallible conversion")),
             blob: BytesN::from_array(env, &value.blob.rt().expect("infallible conversion")),
             size: value.size,
-            source: String::from_str(env, &value.source.0.into_owned()),
-            metadata: Bytes::from_slice(env, &value.metadata.0.as_bytes().to_vec()),
+            source: String::from_str(env, &value.source.0),
+            metadata: Bytes::from_slice(env, &value.metadata.0),
         }
     }
 }
 
 impl<'a> From<StellarApplication> for Application<'a> {
     fn from(value: StellarApplication) -> Self {
-        // Convert Soroban String to std::String
-        let mut bytes = vec![0u8; value.source.len() as usize];
-        value.source.copy_into_slice(&mut bytes);
-        let std_string = std::string::String::from_utf8(bytes).expect("valid utf8");
-
         Application::new(
             value.id.rt().expect("infallible conversion"),
             value.blob.rt().expect("infallible conversion"),
             value.size,
-            ApplicationSource(Cow::Owned(std_string)),
-            ApplicationMetadata(Repr::new(Cow::Owned(value.metadata.into_iter().collect()))),
+            ApplicationSource(Cow::Owned(value.source.to_string())),
+            ApplicationMetadata(Repr::new(Cow::Owned(value.metadata.to_alloc_vec()))),
         )
     }
 }

--- a/crates/context/config/src/stellar/stellar_types.rs
+++ b/crates/context/config/src/stellar/stellar_types.rs
@@ -26,7 +26,6 @@ pub struct StellarApplication {
     pub metadata: Bytes,
 }
 
-//TODO, fix metadata cast
 impl<'a> FromWithEnv<Application<'a>> for StellarApplication {
     fn from_with_env(value: Application<'a>, env: &Env) -> Self {
         StellarApplication {
@@ -34,11 +33,11 @@ impl<'a> FromWithEnv<Application<'a>> for StellarApplication {
             blob: BytesN::from_array(env, &value.blob.rt().expect("infallible conversion")),
             size: value.size,
             source: String::from_str(env, &value.source.0.into_owned()),
-            metadata: Bytes::new(env),
+            metadata: Bytes::from_slice(env, &value.metadata.0.as_bytes().to_vec()),
         }
     }
 }
-//TODO, check if this is optimized way
+
 impl<'a> From<StellarApplication> for Application<'a> {
     fn from(value: StellarApplication) -> Self {
         // Convert Soroban String to std::String
@@ -133,25 +132,25 @@ impl FromWithEnv<ContextRequestKind<'_>> for StellarContextRequestKind {
                 ))
             }
             ContextRequestKind::AddMembers { members } => {
-                let mut vec = Vec::new(&Env::default());
+                let mut vec = Vec::new(&env);
                 for member in members.into_owned() {
-                    vec.push_back(BytesN::from_array(&Env::default(), &member.as_bytes()));
+                    vec.push_back(BytesN::from_array(&env, &member.as_bytes()));
                 }
                 StellarContextRequestKind::AddMembers(vec)
             }
             ContextRequestKind::RemoveMembers { members } => {
-                let mut vec = Vec::new(&Env::default());
+                let mut vec = Vec::new(&env);
                 for member in members.into_owned() {
-                    vec.push_back(BytesN::from_array(&Env::default(), &member.as_bytes()));
+                    vec.push_back(BytesN::from_array(&env, &member.as_bytes()));
                 }
                 StellarContextRequestKind::RemoveMembers(vec)
             }
             ContextRequestKind::Grant { capabilities } => {
-                let mut vec = Vec::new(&Env::default());
+                let mut vec = Vec::new(&env);
                 for (id, cap) in capabilities.into_owned() {
                     vec.push_back((
                         BytesN::from_array(
-                            &Env::default(),
+                            &env,
                             &id.rt::<BytesN<32>>()
                                 .expect("infallible conversion")
                                 .as_bytes(),
@@ -162,11 +161,11 @@ impl FromWithEnv<ContextRequestKind<'_>> for StellarContextRequestKind {
                 StellarContextRequestKind::Grant(vec)
             }
             ContextRequestKind::Revoke { capabilities } => {
-                let mut vec = Vec::new(&Env::default());
+                let mut vec = Vec::new(&env);
                 for (id, cap) in capabilities.into_owned() {
                     vec.push_back((
                         BytesN::from_array(
-                            &Env::default(),
+                            &env,
                             &id.rt::<BytesN<32>>()
                                 .expect("infallible conversion")
                                 .as_bytes(),
@@ -200,7 +199,6 @@ impl<'a> FromWithEnv<RequestKind<'a>> for StellarRequestKind {
     }
 }
 
-// TODO implement new method
 #[derive(Clone, Debug)]
 #[contracttype]
 pub struct StellarRequest {

--- a/crates/context/config/src/stellar/stellar_types.rs
+++ b/crates/context/config/src/stellar/stellar_types.rs
@@ -4,9 +4,7 @@ use alloc::vec::Vec as StdVec;
 
 use bs58;
 use soroban_sdk::xdr::ToXdr;
-use soroban_sdk::{
-    contracterror, contracttype, Bytes, BytesN, Env, String, Vec,
-};
+use soroban_sdk::{contracterror, contracttype, Bytes, BytesN, Env, String, Vec};
 
 use crate::repr::{Repr, ReprBytes, ReprError, ReprTransmute};
 use crate::types::{Application, ApplicationMetadata, ApplicationSource, Capability};
@@ -14,7 +12,7 @@ use crate::{ContextRequest, ContextRequestKind, RequestKind};
 
 // Trait for environment-aware conversion
 pub trait FromWithEnv<T> {
-  fn from_with_env(value: T, env: &Env) -> Self;
+    fn from_with_env(value: T, env: &Env) -> Self;
 }
 
 // Core types for Application
@@ -30,32 +28,32 @@ pub struct StellarApplication {
 
 //TODO, fix metadata cast
 impl<'a> FromWithEnv<Application<'a>> for StellarApplication {
-  fn from_with_env(value: Application<'a>, env: &Env) -> Self {
-      StellarApplication {
-        id: BytesN::from_array(env, &value.id.rt().expect("infallible conversion")),
-        blob: BytesN::from_array(env, &value.blob.rt().expect("infallible conversion")),
-        size: value.size,
-        source: String::from_str(env, &value.source.0.into_owned()),
-        metadata: Bytes::new(env),
-      }
-  }
+    fn from_with_env(value: Application<'a>, env: &Env) -> Self {
+        StellarApplication {
+            id: BytesN::from_array(env, &value.id.rt().expect("infallible conversion")),
+            blob: BytesN::from_array(env, &value.blob.rt().expect("infallible conversion")),
+            size: value.size,
+            source: String::from_str(env, &value.source.0.into_owned()),
+            metadata: Bytes::new(env),
+        }
+    }
 }
 //TODO, check if this is optimized way
 impl<'a> From<StellarApplication> for Application<'a> {
-  fn from(value: StellarApplication) -> Self {
-      // Convert Soroban String to std::String
-      let mut bytes = vec![0u8; value.source.len() as usize];
-      value.source.copy_into_slice(&mut bytes);
-      let std_string = std::string::String::from_utf8(bytes).expect("valid utf8");
+    fn from(value: StellarApplication) -> Self {
+        // Convert Soroban String to std::String
+        let mut bytes = vec![0u8; value.source.len() as usize];
+        value.source.copy_into_slice(&mut bytes);
+        let std_string = std::string::String::from_utf8(bytes).expect("valid utf8");
 
-      Application::new(
-          value.id.rt().expect("infallible conversion"),
-          value.blob.rt().expect("infallible conversion"),
-          value.size,
-          ApplicationSource(Cow::Owned(std_string)),
-          ApplicationMetadata(Repr::new(Cow::Owned(value.metadata.into_iter().collect()))),
-      )
-  }
+        Application::new(
+            value.id.rt().expect("infallible conversion"),
+            value.blob.rt().expect("infallible conversion"),
+            value.size,
+            ApplicationSource(Cow::Owned(std_string)),
+            ApplicationMetadata(Repr::new(Cow::Owned(value.metadata.into_iter().collect()))),
+        )
+    }
 }
 
 // Request structures
@@ -68,7 +66,8 @@ pub struct StellarContextRequest {
 
 impl<'a> FromWithEnv<ContextRequest<'a>> for StellarContextRequest {
     fn from_with_env(value: ContextRequest<'a>, env: &Env) -> Self {
-        let context_id = BytesN::from_array(env, &value.context_id.rt().expect("infallible conversion"));
+        let context_id =
+            BytesN::from_array(env, &value.context_id.rt().expect("infallible conversion"));
         let kind = StellarContextRequestKind::from_with_env(value.kind, env);
         Self { context_id, kind }
     }
@@ -83,23 +82,23 @@ pub enum StellarCapability {
 }
 
 impl From<Capability> for StellarCapability {
-  fn from(value: Capability) -> Self {
-      match value {
-          Capability::ManageApplication => StellarCapability::ManageApplication,
-          Capability::ManageMembers => StellarCapability::ManageMembers,
-          Capability::Proxy => StellarCapability::Proxy,
-      }
-  }
+    fn from(value: Capability) -> Self {
+        match value {
+            Capability::ManageApplication => StellarCapability::ManageApplication,
+            Capability::ManageMembers => StellarCapability::ManageMembers,
+            Capability::Proxy => StellarCapability::Proxy,
+        }
+    }
 }
 
 impl From<StellarCapability> for Capability {
-  fn from(value: StellarCapability) -> Self {
-      match value {
-          StellarCapability::ManageApplication => Capability::ManageApplication,
-          StellarCapability::ManageMembers => Capability::ManageMembers,
-          StellarCapability::Proxy => Capability::Proxy,
-      }
-  }
+    fn from(value: StellarCapability) -> Self {
+        match value {
+            StellarCapability::ManageApplication => Capability::ManageApplication,
+            StellarCapability::ManageMembers => Capability::ManageMembers,
+            StellarCapability::Proxy => Capability::Proxy,
+        }
+    }
 }
 
 // Request types without named fields in enum variants
@@ -118,13 +117,20 @@ pub enum StellarContextRequestKind {
 impl FromWithEnv<ContextRequestKind<'_>> for StellarContextRequestKind {
     fn from_with_env(value: ContextRequestKind<'_>, env: &Env) -> Self {
         match value {
-            ContextRequestKind::Add { author_id, application } => {
-                let author_id = BytesN::from_array(env, &author_id.rt().expect("infallible conversion"));
+            ContextRequestKind::Add {
+                author_id,
+                application,
+            } => {
+                let author_id =
+                    BytesN::from_array(env, &author_id.rt().expect("infallible conversion"));
                 let stellar_app = StellarApplication::from_with_env(application, env);
                 StellarContextRequestKind::Add(author_id, stellar_app)
             }
             ContextRequestKind::UpdateApplication { application } => {
-                StellarContextRequestKind::UpdateApplication(StellarApplication::from_with_env(application, env))
+                StellarContextRequestKind::UpdateApplication(StellarApplication::from_with_env(
+                    application,
+                    env,
+                ))
             }
             ContextRequestKind::AddMembers { members } => {
                 let mut vec = Vec::new(&Env::default());

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -250,8 +250,6 @@ impl ContextManager {
                 .send(*context_secret, 0)
                 .await?;
 
-            println!("Got to proxy contract");
-
             let proxy_contract = this
                 .config_client
                 .query::<ContextConfigEnv>(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -250,6 +250,8 @@ impl ContextManager {
                 .send(*context_secret, 0)
                 .await?;
 
+            println!("Got to proxy contract");
+
             let proxy_contract = this
                 .config_client
                 .query::<ContextConfigEnv>(


### PR DESCRIPTION
# fix(core): stellar rpc mutate function + types update

Fixing mutate encode function to properly pass byte arguments to context config contract.
Updating stellar types for proper casting from Stellar struct to Calimero types.

## Test plan
Setup node from docs and run following
```
application install file <path>
> application_id
context create <application_id> --protocol stellar
> should get error in different place and its regarding proxy which is WIP in other pr
context ls
> context should be create
```

## Documentation update

-
