### PR TITLE
fix: release workflow clean changes after creating PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,6 +391,9 @@ jobs:
                 --base master \
                 -f || true
 
+              # Reset the repository to a clean state
+              git reset --hard HEAD
+
             else
               echo "No update required for ${binary}"
             fi


### PR DESCRIPTION
# [product] short description
Clean state after PR is created for installation scripts so each loop does not use changes from previous loop.

## Test plan
-

## Documentation update
None
