### PR TITLE
fix: release workflow clean changes after creating PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,6 +375,7 @@ jobs:
             if [ "${release_required}" == "true" ]; then
               echo "Updating installation script for ${binary}, version: ${version}"
 
+              git checkout master
               target_branch="chore/bump-${binary}-installation-script-to-v${version}"
               git fetch origin "${target_branch}" || true
               git checkout "${target_branch}" || git checkout -b "${target_branch}"


### PR DESCRIPTION
# [product] short description
Clean state after PR is created for installation scripts so each loop does not use changes from previous loop.

## Test plan
-

## Documentation update
None
