### PR TITLE
ci: unify binary release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,32 +18,85 @@ on:
       - Cargo.toml
       - Cargo.lock
       - 'crates/**'
-      - .github/workflows/rust_binaries_release.yml
+      - .github/workflows/release.yml
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      is_release_candidate: ${{ steps.check_release_candidate.outputs.is_release_candidate }}
       binary_matrix: ${{ steps.setup_matrix.outputs.binary_matrix }}
+      version: ${{ steps.version_info.outputs.version }}
+      release_required: ${{ steps.version_info.outputs.release_required }}
+      build_required: ${{ steps.version_info.outputs.build_required }}
+      target_commit: ${{ steps.version_info.outputs.target_commit }}
+      prerelease: ${{ steps.version_info.outputs.prerelease }}
+      overwrite_release: ${{ steps.version_info.outputs.overwrite_release }}
     steps:
-      - name: Check if release candidate
-        id: check_release_candidate
-        run: |
-          # Additional checks for head_ref when PR because GH doesn't support that
-          if [ "${{ github.event_name }}" == "pull_request" ] && ! [[ "${{ github.head_ref }}" == prerelease/* ]]; then
-            echo 'is_release_candidate=false' >> "$GITHUB_OUTPUT"
-          else
-            echo 'is_release_candidate=true' >> "$GITHUB_OUTPUT"
-          fi
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Setup matrix
         id: setup_matrix
         run: |
           echo 'binary_matrix=["merod", "meroctl"]' >> "$GITHUB_OUTPUT"
 
+      - name: Get version info
+        id: version_info
+        shell: bash
+        run: |
+          echo "Validating binary versions"
+
+          version_candidate=""
+          for binary in $(echo '${{ steps.setup_matrix.outputs.binary_matrix }}' | jq -r '.[]'); do
+            binary_version=$(cargo metadata --format-version 1 --no-deps | jq -r --arg binary "$binary" '.packages[] | select(.name == $binary) | .version')
+            echo "  binary: $binary, version: $binary_version"
+
+            if [ -z "$version_candidate" ]; then
+              version_candidate="$binary_version"
+            elif [ "$version_candidate" != "$binary_version" ]; then
+              echo "Version mismatch between binaries"
+              echo "Make sure all binaries have the same version"
+              echo "All binaries: '${{ steps.setup_matrix.outputs.binary_matrix }}'"
+              exit 1
+            fi
+          done
+          echo "Valid version candidate: $version_candidate"
+
+          echo "target_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            version="$version_candidate"
+            echo "Master version: $version"
+
+            if gh release view "$version" --repo ${{ github.repository }} >/dev/null 2>&1; then
+              echo "Master release for this version already exists"
+              echo "release_required=false" >> $GITHUB_OUTPUT
+            else
+              echo "New master release required"
+              echo "release_required=true" >> $GITHUB_OUTPUT
+            fi
+
+            echo "build_required=true" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "overwrite_release=false">> $GITHUB_OUTPUT
+            echo "version=$version" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "pull_request" ] && [[ "${{ github.head_ref }}" == release/* ]]; then
+            version="prerelease-${{ github.event.number }}"
+            echo "Prerelease version: $version"
+
+            echo "build_required=true" >> $GITHUB_OUTPUT
+            echo "release_required=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "overwrite_release=true">> $GITHUB_OUTPUT
+            echo "version=$version" >> $GITHUB_OUTPUT
+          else
+            echo "This is not a master branch or a release PR"
+            echo "build_required=false" >> $GITHUB_OUTPUT
+            echo "release_required=false" >> $GITHUB_OUTPUT
+          fi
+
   build:
-    if: needs.prepare.outputs.is_release_candidate == 'true'
+    if: needs.prepare.outputs.build_required == 'true'
     strategy:
       matrix:
         include:
@@ -169,12 +222,9 @@ jobs:
           retention-days: 2
 
   release:
-    if: needs.prepare.outputs.is_release_candidate == 'true'
+    if: needs.prepare.outputs.release_required == 'true'
     runs-on: ubuntu-latest
     needs: [prepare, build]
-    strategy:
-      matrix:
-        binary: ${{ fromJSON(needs.prepare.outputs.binary_matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -185,73 +235,21 @@ jobs:
           path: artifacts/
           merge-multiple: true
 
-      - name: Get version info
-        id: version_info
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "target_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
-
-          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-            binary_version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "${{ matrix.binary }}") | .version')
-            version="${{ matrix.binary }}-$binary_version"
-            echo "Master version: $version"
-
-            if gh release view "$version" --repo ${{ github.repository }} >/dev/null 2>&1; then
-              echo "Master release for this version already exists"
-              echo "release_required=false" >> $GITHUB_OUTPUT
-            else
-              echo "New master release required"
-              echo "release_required=true" >> $GITHUB_OUTPUT
-            fi
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-            echo "overwrite=false">> $GITHUB_OUTPUT
-            echo "binary_version=$binary_version" >> $GITHUB_OUTPUT
-            echo "version=$version" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "pull_request" ] && [[ "${{ github.head_ref }}" == prerelease/* ]]; then
-            version="prerelease-${{ github.event.number }}"
-            echo "Prerelease version: $version"
-
-            echo "release_required=true" >> $GITHUB_OUTPUT
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-            echo "overwrite=true">> $GITHUB_OUTPUT
-            echo "version=$version" >> $GITHUB_OUTPUT
-          else
-            echo "This is not a master branch or a prerelease PR"
-            echo "release_required=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set release matrix outputs
-        uses: cloudposse/github-action-matrix-outputs-write@v1
-        with:
-          matrix-step-name: release
-          matrix-key: ${{ matrix.binary }}
-          outputs: |-
-            releaseRequired: ${{ steps.version_info.outputs.release_required }}
-            version: ${{ steps.version_info.outputs.binary_version }}
-
-      - name: Remove other binaries from artifacts
-        if: steps.version_info.outputs.release_required == 'true'
-        run: |
-          ls -al artifacts/
-          find artifacts/ -type f ! -name '${{ matrix.binary }}*' -exec rm {} +
-          ls -al artifacts/
-
       - name: Upload binaries to release
-        if: steps.version_info.outputs.release_required == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: artifacts/*
           file_glob: true
-          tag: ${{ steps.version_info.outputs.version }}
-          prerelease: ${{ steps.version_info.outputs.prerelease }}
-          overwrite: ${{ steps.version_info.outputs.overwrite }}
-          target_commit: ${{ steps.version_info.outputs.target_commit }}
+          tag: ${{ needs.prepare.outputs.version }}
+          prerelease: ${{ needs.prepare.outputs.prerelease }}
+          overwrite: ${{ needs.prepare.outputs.overwrite_release }}
+          target_commit: ${{ needs.prepare.outputs.target_commit }}
 
   brew-update:
-    if: needs.prepare.outputs.is_release_candidate == 'true' && github.ref == 'refs/heads/master'
+    if: |
+      needs.prepare.outputs.release_required == 'true' &&
+      github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [prepare, build, release]
     steps:
@@ -324,74 +322,3 @@ jobs:
           git push origin "${target_branch}"
 
           gh pr create -f || true
-
-  installation-script-update:
-    if: needs.prepare.outputs.is_release_candidate == 'true' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    needs: [prepare, build, release]
-    steps:
-      - name: Get release matrix outputs
-        id: release-matrix-outputs
-        uses: cloudposse/github-action-matrix-outputs-read@v1
-        with:
-          matrix-step-name: release
-
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Checkout core
-        uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
-
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure Git
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh auth setup-git
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-
-      - name: Process each binary and create PRs
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          for binary in $(echo '${{ needs.prepare.outputs.binary_matrix }}' | jq -r '.[]'); do
-            release_required=$(echo '${{ steps.release-matrix-outputs.outputs.result }}' | jq -r --arg key "${binary}" '.releaseRequired[$key]')
-            version=$(echo '${{ steps.release-matrix-outputs.outputs.result }}' | jq -r --arg key "${binary}" '.version[$key]')
-
-            if [ "${release_required}" == "true" ]; then
-              echo "Updating installation script for ${binary}, version: ${version}"
-
-              target_branch="chore/bump-${binary}-installation-script-to-v${version}"
-              git fetch origin "${target_branch}" || true
-              git checkout "${target_branch}" || git checkout -b "${target_branch}"
-              ./scripts/generate-installation-script.sh "${binary}" "${version}"
-
-              git add scripts/
-              git commit -m "chore: bump ${binary} installation script to v${version}" || true
-              git push origin "${target_branch}"
-
-              gh pr create \
-                --title "chore: bump ${binary} installation script to v${version}" \
-                --body "This PR updates the installation script for **${binary}** to version **${version}**." \
-                --head "${target_branch}" \
-                --base master \
-                -f || true
-
-            else
-              echo "No update required for ${binary}"
-            fi
-          done


### PR DESCRIPTION
Enforce that all binary crates have the same version and unify release artifacts into a single release. 

Example of the failed run due to mismatched binary versions: https://github.com/calimero-network/core/actions/runs/13075203029/job/36485590291
Example of prerelease release: https://github.com/calimero-network/core/releases/tag/prerelease-1089