### PR TITLE
feat(e2e-tests): single boot iteration

### DIFF
--- a/e2e-tests/src/merod.rs
+++ b/e2e-tests/src/merod.rs
@@ -43,7 +43,6 @@ impl Merod {
         server_port: u32,
         args: impl IntoIterator<Item = &'a str>,
     ) -> EyreResult<()> {
-        create_dir_all(&self.home_dir.join(&self.name)).await?;
         create_dir_all(&self.log_dir).await?;
 
         let mut child = self


### PR DESCRIPTION
With `--protocol` flag there is no need to stop, reconfigure, and start nodes for each protocol. This PR removes unnecessary steps from the e2e-test framework.