### PR TITLE
feat(node-ui): update identity api endpoint

### DIFF
--- a/node-ui/build/index.html
+++ b/node-ui/build/index.html
@@ -36,7 +36,7 @@
       })(window.location);
     </script>
     <!-- End Single Page Apps for GitHub Pages -->
-    <script type="module" crossorigin src="/admin-dashboard/assets/main-BxzzjMgG.js"></script>
+    <script type="module" crossorigin src="/admin-dashboard/assets/main-C0yi8Iu3.js"></script>
     <link rel="stylesheet" crossorigin href="/admin-dashboard/assets/main-BesWMiQO.css">
   </head>
   <body>

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -651,7 +651,7 @@ export class NodeDataSource implements NodeApi {
     }
 
     return await this.client.get<ContextIdentitiesResponse>(
-      `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities`,
+      `${getAppEndpointKey()}/admin-api/contexts/${contextId}/identities-owned`,
       headers,
     );
   }


### PR DESCRIPTION
# feat(node-ui): update identity api endpoint

Identity endpoint was split into two new endpoints so this change is needed so admin dashboard only displays owned context identities.

## Test plan

<img width="501" alt="Screenshot 2025-02-12 at 15 01 32" src="https://github.com/user-attachments/assets/d526ea6d-b4a7-49d3-b8d9-2f55c77a3cf7" />
<img width="438" alt="Screenshot 2025-02-12 at 15 01 38" src="https://github.com/user-attachments/assets/469b3b74-ca04-413d-9113-448c276d912d" />


## Documentation update

No updates