### PR TITLE
chore: `meroctl` should not depend on `calimero-server`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
 name = "calimero-server-primitives"
 version = "0.1.0"
 dependencies = [
+ "calimero-context-config",
  "calimero-node-primitives",
  "calimero-primitives",
  "camino",
@@ -5187,7 +5188,6 @@ dependencies = [
  "bs58 0.5.1",
  "calimero-config",
  "calimero-primitives",
- "calimero-server",
  "calimero-server-primitives",
  "camino",
  "chrono",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 toml.workspace = true
 
 calimero-context.workspace = true
-calimero-server = { workspace = true, features = ["admin"] }
+calimero-server = { workspace = true, features = ["admin", "jsonrpc", "websocket"] }
 calimero-network.workspace = true
 
 [lints]

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -31,7 +31,6 @@ url = { workspace = true, features = ["serde"] }
 
 calimero-config.workspace = true
 calimero-primitives.workspace = true
-calimero-server = { workspace = true, features = ["jsonrpc", "websocket", "admin"] }
 calimero-server-primitives.workspace = true
 
 [lints]

--- a/crates/meroctl/src/cli/proxy.rs
+++ b/crates/meroctl/src/cli/proxy.rs
@@ -1,9 +1,7 @@
-use calimero_server::admin::handlers::proposals::Proposal;
 use clap::{Parser, Subcommand};
 use eyre::Result as EyreResult;
 
 use super::Environment;
-use crate::output::Report;
 
 mod get;
 use get::GetCommand;
@@ -18,15 +16,6 @@ pub struct ProxyCommand {
 #[derive(Debug, Subcommand)]
 pub enum ProxySubCommands {
     Get(GetCommand),
-}
-
-impl Report for Proposal {
-    fn report(&self) {
-        println!("{}", self.id);
-        println!("{:#?}", self.author);
-        println!("{}", self.title);
-        println!("{}", self.description);
-    }
 }
 
 impl ProxyCommand {

--- a/crates/meroctl/src/cli/proxy/get.rs
+++ b/crates/meroctl/src/cli/proxy/get.rs
@@ -1,7 +1,7 @@
 use calimero_primitives::alias::Alias;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::hash::Hash;
-use calimero_server::admin::handlers::proposals::{
+use calimero_server_primitives::admin::{
     GetNumberOfActiveProposalsResponse, GetNumberOfProposalApprovalsResponse,
     GetProposalApproversResponse, GetProposalResponse, GetProposalsResponse,
 };

--- a/crates/meroctl/src/main.rs
+++ b/crates/meroctl/src/main.rs
@@ -1,6 +1,5 @@
 use std::process::ExitCode;
 
-use calimero_server as _;
 use clap::Parser;
 
 use crate::cli::RootCommand;

--- a/crates/server-primitives/Cargo.toml
+++ b/crates/server-primitives/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 url = { workspace = true, features = ["serde"] }
 
+calimero-context-config.workspace = true
 calimero-node-primitives.workspace = true
 calimero-primitives.workspace = true
 

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -1,3 +1,6 @@
+use calimero_context_config::repr::Repr;
+use calimero_context_config::types::{ContextIdentity, ContextStorageEntry};
+use calimero_context_config::{Proposal, ProposalWithApprovals};
 use calimero_primitives::alias::Alias;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
@@ -764,4 +767,72 @@ impl NodeChallengeMessage {
             timestamp,
         }
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProposalsResponse {
+    pub data: Vec<Proposal>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProposalResponse {
+    pub data: Proposal,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProxyContractResponse {
+    pub data: String,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProposalsRequest {
+    pub offset: usize,
+    pub limit: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetContextValueRequest {
+    pub key: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GetContextStorageEntriesRequest {
+    pub offset: usize,
+    pub limit: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetContextValueResponse {
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetContextStorageEntriesResponse {
+    pub data: Vec<ContextStorageEntry>,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetNumberOfActiveProposalsResponse {
+    pub data: u16,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProposalApproversResponse {
+    pub data: Vec<Repr<ContextIdentity>>,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetNumberOfProposalApprovalsResponse {
+    pub data: ProposalWithApprovals,
 }


### PR DESCRIPTION
`meroctl` has no business depending on `calimero-server`

Following this patch, it only transitively depends on it via `calimero-config`

We need to extract all the configs of `calimero-context`, `calimero-server` and `calimero-network` into light weight crates to ease that relationship.