### PR TITLE
fix: e2e report PR number determination

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -295,11 +295,11 @@ jobs:
             --repo ${{ github.repository }} \
             --state open \
             --head "${GH_REF#refs/heads/}" \
-            --base master \
             --json number \
             -q '.[0].number')" >> $GITHUB_OUTPUT
       - name: Update pull request comment
         uses: thollander/actions-comment-pull-request@v3
+        if: steps.pr_number.outputs.PR_NUMBER != ''
         with:
           file-path: ./combined_report.md
           pr-number: ${{ steps.pr_number.outputs.PR_NUMBER }}


### PR DESCRIPTION
https://github.com/calimero-network/core/commit/cce742b1744e993193fcf73318cccbb75a49b0f1#r152680837 was leading to [`Error: No issue/pull request in input neither in current context.`](https://github.com/calimero-network/core/actions/runs/13369736224/job/37335851687#step:5:9) because `PR_NUMBER` was undefined.

I've also removed the `--base` branch filter, to allow for branches that don't immediately target master. As is the case with https://github.com/calimero-network/core/pull/1115.