### PR TITLE
fix: default to relayer for stellar signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,8 @@ jobs:
               echo "Master release for this version already exists"
               echo "release_required=false" >> $GITHUB_OUTPUT
             else
-              if [ "$version" == "0.3.1" ]; then
-                echo "Version 0.3.1 already exists in a legacy release format, skipping"
-                echo "release_required=false" >> $GITHUB_OUTPUT
-              else
-                echo "New master release required"
-                echo "release_required=true" >> $GITHUB_OUTPUT
-              fi
+              echo "New master release required"
+              echo "release_required=true" >> $GITHUB_OUTPUT
             fi
 
             echo "build_required=true" >> $GITHUB_OUTPUT

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -302,7 +302,7 @@ impl InitCommand {
                     protocol: "stellar".into(),
                     contract_id: "CDZ25SJ65YRXTCWMJNLTNZXPFPBGHOOB7BUBYQE7W3PU7I357BTX6QZY"
                         .parse()?,
-                    signer: ClientSelectedSigner::Local,
+                    signer: ClientSelectedSigner::Relayer,
                 },
             );
 
@@ -330,6 +330,7 @@ impl InitCommand {
                 .protocols
                 .insert("stellar".to_owned(), local_config);
         }
+
         let relayer = self
             .relayer_url
             .unwrap_or_else(defaults::default_relayer_url);


### PR DESCRIPTION
`signer = "self"` for stellar will almost certainly fail unless the node admin funds the testnet account.

This patch changes it to use relayer instead.