### PR TITLE
fix(meroctl): Fix error handling

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1557,8 +1557,10 @@ impl ContextManager {
     where
         T: Aliasable<Scope: StoreScopeCompat> + From<Hash> + FromStr<Err: Into<eyre::Report>>,
     {
-        if let Some(value) = self.lookup_alias(alias, scope)? {
-            return Ok(Some(value));
+        if let Ok(potential_alias) = self.lookup_alias(alias, scope) {
+            if let Some(value) = potential_alias {
+                return Ok(Some(value));
+            }
         }
 
         Ok(alias.as_str().parse().ok())

--- a/crates/meroctl/src/cli/context/invite.rs
+++ b/crates/meroctl/src/cli/context/invite.rs
@@ -36,7 +36,7 @@ impl Report for InviteToContextResponse {
     fn report(&self) {
         match self.data {
             Some(ref payload) => {
-                println!("{:?}", payload)
+                println!("Invitation payload: {}", payload)
             }
             None => println!("No invitation payload"),
         }

--- a/crates/meroctl/src/cli/context/join.rs
+++ b/crates/meroctl/src/cli/context/join.rs
@@ -28,8 +28,8 @@ impl Report for JoinContextResponse {
     fn report(&self) {
         match self.data {
             Some(ref payload) => {
-                print!("context_id {}", payload.context_id);
-                print!("member_public_key: {}", payload.member_public_key);
+                println!("context_id {}", payload.context_id);
+                println!("member_public_key: {}", payload.member_public_key);
             }
             None => todo!(),
         }

--- a/crates/node/src/interactive_cli/peers.rs
+++ b/crates/node/src/interactive_cli/peers.rs
@@ -1,7 +1,7 @@
 use calimero_primitives::alias::Alias;
 use calimero_primitives::context::ContextId;
 use clap::Parser;
-use eyre::{OptionExt, Result as EyreResult};
+use eyre::Result as EyreResult;
 use libp2p::gossipsub::TopicHash;
 use owo_colors::OwoColorize;
 
@@ -25,16 +25,17 @@ impl PeersCommand {
         let context_id = self
             .context
             .map(|context| node.ctx_manager.resolve_alias(context, None))
-            .transpose()?
-            .ok_or_eyre("unable to resolve")?;
+            .transpose()?;
 
-        if let Some(context_id) = context_id {
-            let topic = TopicHash::from_raw(context_id);
-            println!(
-                "{ind} Peers (Session) for Topic {}: {:#?}",
-                topic.clone(),
-                node.network_client.mesh_peer_count(topic).await.cyan()
-            );
+        if let Some(potential_context_id) = context_id {
+            if let Some(context_id) = potential_context_id {
+                let topic = TopicHash::from_raw(context_id);
+                println!(
+                    "{ind} Peers (Session) for Topic {}: {:#?}",
+                    topic.clone(),
+                    node.network_client.mesh_peer_count(topic).await.cyan()
+                );
+            }
         }
 
         Ok(())


### PR DESCRIPTION
# Meroctl error handling fix

Regarding last PRs on Aliases, there were some cases of returning `Errors` too soon, which would cause problems if the user didn't provide an alias.
They are now fixed, and also some formating enhancements on `meroctl`.

## Test plan

Tested the `peers` command in interactive cli.
Tested one "round" of creating a context, inviting and joining with two nodes both on the interactive cli and meroctl.

## Documentation update

No need.
