### PR TITLE
fix: peers and context invitation should resolve correctly

### DIFF
--- a/crates/node/src/interactive_cli/context.rs
+++ b/crates/node/src/interactive_cli/context.rs
@@ -241,7 +241,7 @@ impl ContextCommand {
                     .ok_or_eyre("unable to resolve")?;
                 let inviter_id = node
                     .ctx_manager
-                    .resolve_alias(inviter, None)?
+                    .resolve_alias(inviter, Some(context_id))?
                     .ok_or_eyre("unable to resolve")?;
 
                 if let Some(invitation_payload) = node

--- a/crates/node/src/interactive_cli/peers.rs
+++ b/crates/node/src/interactive_cli/peers.rs
@@ -1,7 +1,7 @@
 use calimero_primitives::alias::Alias;
 use calimero_primitives::context::ContextId;
 use clap::Parser;
-use eyre::{OptionExt, Result as EyreResult};
+use eyre::Result as EyreResult;
 use libp2p::gossipsub::TopicHash;
 use owo_colors::OwoColorize;
 
@@ -26,7 +26,7 @@ impl PeersCommand {
             .context
             .map(|context| node.ctx_manager.resolve_alias(context, None))
             .transpose()?
-            .ok_or_eyre("unable to resolve")?;
+            .flatten();
 
         if let Some(context_id) = context_id {
             let topic = TopicHash::from_raw(context_id);


### PR DESCRIPTION
The logic in `peers` would've always failed when no context is provided as an argument, this is now fixed.
And context invitation wasn't resolving the inviter identity under the context scope, also fixed.
