### PR TITLE
feat: accomodate consuming streams owned by the actor state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags 2.6.0",
+ "bytes 1.9.0",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite 0.2.15",
+ "smallvec",
+ "tokio 1.41.1",
+ "tokio-util 0.7.12",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
+dependencies = [
+ "futures-core",
+ "tokio 1.41.1",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1505,18 @@ dependencies = [
  "near-sdk",
  "near-workspaces",
  "tokio 1.41.1",
+]
+
+[[package]]
+name = "calimero-utils-actix"
+version = "0.1.0"
+dependencies = [
+ "actix",
+ "eyre",
+ "futures-util",
+ "paste",
+ "tokio 1.41.1",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -9044,9 +9112,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "./crates/storage-macros",
     "./crates/store",
     "./crates/store/blobs",
+    "./crates/utils/actix",
 
     "./apps/kv-store",
     "./apps/only-peers",
@@ -51,6 +52,7 @@ members = [
 ]
 
 [workspace.dependencies]
+actix = "0.13.5"
 assert-json-diff = "2.0.2"
 async-stream = "0.3.5"
 axum = "0.7.4"
@@ -101,6 +103,7 @@ notify = "6.1.1"
 ouroboros = "0.18.3"
 owo-colors = "3.5.0"
 parking_lot = "0.12.3"
+paste = "1.0.15"
 prettyplease = "0.2.17"
 proc-macro2 = "1.0"
 quote = "1.0.37"
@@ -134,6 +137,7 @@ tokio = "1.35.1"
 tokio-test = "0.4.4"
 tokio-tungstenite = "0.24.0"
 tokio-util = "0.7.11"
+tokio-stream = "0.1.17"
 toml = "0.8.9"
 toml_edit = "0.22.14"
 tower = "0.4.13"
@@ -175,6 +179,7 @@ calimero-storage-macros = { path = "./crates/storage-macros" }
 calimero-store = { path = "./crates/store" }
 calimero-blobstore = { path = "./crates/store/blobs" }
 e2e-tests = { path = "./e2e-tests" }
+calimero-utils-actix = { path = "./crates/utils/actix" }
 
 kv-store = { path = "./apps/kv-store" }
 only-peers = { path = "./apps/only-peers" }

--- a/crates/utils/actix/Cargo.toml
+++ b/crates/utils/actix/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "calimero-utils-actix"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+actix.workspace = true
+futures-util.workspace = true
+paste.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+
+[dev-dependencies]
+actix.workspace = true
+eyre.workspace = true
+tokio = { workspace = true, features = ["macros"] }
+tokio-stream = { workspace = true, features = ["time"] }
+
+[lints]
+workspace = true

--- a/crates/utils/actix/src/lib.rs
+++ b/crates/utils/actix/src/lib.rs
@@ -1,0 +1,2 @@
+#[doc(hidden)]
+pub mod macros;

--- a/crates/utils/actix/src/macros.rs
+++ b/crates/utils/actix/src/macros.rs
@@ -1,0 +1,142 @@
+#[cfg(test)]
+#[path = "macros_tests.rs"]
+mod macros_tests;
+
+#[doc(hidden)]
+pub mod __private {
+    #![allow(dead_code, unused_imports)]
+
+    pub use std::boxed::Box;
+    pub use std::ops::DerefMut;
+    pub use std::ptr;
+
+    pub use crate::spawn_actor;
+    pub use actix::{AsyncContext, Context, Handler, Message, StreamHandler};
+    pub use futures_util::{pin_mut, FutureExt, Stream, StreamExt};
+    pub use paste::paste;
+    pub use tokio::{select, task};
+
+    #[derive(Debug, Message)]
+    #[rtype("()")]
+    pub enum FromStreamInner<T> {
+        Started,
+        Finished,
+        Value(T),
+    }
+
+    impl FromStreamInner<()> {
+        pub const fn scoped_into<U, S>(this: FromStreamInner<U>, _: &S) -> FromStreamInner<U>
+        where
+            S: Stream<Item: Into<U>>,
+        {
+            this
+        }
+
+        pub const fn scoped_identity<S: Stream>(
+            this: FromStreamInner<S::Item>,
+            _: &S,
+        ) -> FromStreamInner<S::Item> {
+            this
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! spawn_actor {
+    (@$type:ident ? $($fn1:ident)::+ : $($fn2:ident)::+) => {
+        $($fn1)::+::<$type, _>
+    };
+    (@? $($fn1:ident)::+ : $($fn2:ident)::+) => {
+        $($fn2)::+
+    };
+    ($self:ident @ Self $($rest:tt),*) => {
+        compile_error!("`Self` is not allowed")
+    };
+    ($self:ident @ $actor:ident $(=> {$(.$stream:ident $(as $type:ident)?),+ $(,)?})?) => {{
+        use $crate::macros::__private::*;
+
+        paste! {
+            $($(
+                let [<stream_ $stream>] = {
+                    let stream = Box::deref_mut(&mut $self.$stream);
+                    unsafe { &mut *ptr::from_mut(stream) }
+                };
+            )+)?
+        }
+
+        let ctx = Context::new();
+
+        let addr = ctx.address();
+
+        let mut fut = ctx.into_future($self);
+
+        #[allow(non_local_definitions)]
+        impl<T> Handler<FromStreamInner<T>> for $actor
+        where
+            Self: StreamHandler<T>,
+        {
+            type Result = ();
+
+            fn handle(&mut self, msg: FromStreamInner<T>, ctx: &mut Context<Self>) -> Self::Result {
+                match msg {
+                    FromStreamInner::Started => StreamHandler::<T>::started(self, ctx),
+                    FromStreamInner::Finished => StreamHandler::<T>::finished(self, ctx),
+                    FromStreamInner::Value(value) => StreamHandler::<T>::handle(self, value, ctx),
+                }
+            }
+        }
+
+        let _ignored = task::spawn_local({
+            paste! {
+                $($(
+                    let [<task_ $stream>] = {
+                        let func = spawn_actor!(@ $($type)? ? FromStreamInner::scoped_into : FromStreamInner::scoped_identity);
+
+                        addr.do_send(func(FromStreamInner::Started, [<stream_ $stream>]));
+
+                        let addr = addr.downgrade();
+
+                        async move {
+                            loop {
+                                let item = [<stream_ $stream>].next().await;
+
+                                let Some(addr) = addr.upgrade() else {
+                                    break;
+                                };
+
+                                let Some(value) = item else {
+                                    addr.do_send(func(FromStreamInner::Finished, [<stream_ $stream>]));
+                                    break;
+                                };
+
+                                addr.do_send(func(FromStreamInner::Value(value.into()), [<stream_ $stream>]));
+                            }
+                        }
+                    };
+                )+)?
+            }
+
+            async move {
+                paste! {
+                    $($(
+                        pin_mut!([<task_ $stream>]);
+
+                        let mut [<task_ $stream>] = [<task_ $stream>].fuse();
+                    )+)?
+                }
+
+                loop {
+                    paste! {
+                        select! {
+                            biased;
+                            _ = &mut fut => { break },
+                            $($( _ = &mut [<task_ $stream>] => {} )+)?
+                        }
+                    }
+                }
+            }
+        });
+
+        addr
+    }};
+}

--- a/crates/utils/actix/src/macros_tests.rs
+++ b/crates/utils/actix/src/macros_tests.rs
@@ -1,0 +1,111 @@
+use std::array::IntoIter;
+
+use actix::{Actor, Addr, Context, Handler, Message, Response, StreamHandler};
+use futures_util::stream::{self, Iter, Repeat, StreamExt, Take, Zip};
+use tokio::time::{self, Instant};
+use tokio_stream::wrappers::IntervalStream;
+
+use crate::spawn_actor;
+
+struct MyActor {
+    total: usize,
+    stream1: Box<Take<Repeat<usize>>>,
+    current_name: &'static str,
+    stream2: Box<Zip<IntervalStream, Iter<IntoIter<&'static str, 26>>>>,
+}
+
+impl Actor for MyActor {
+    type Context = Context<Self>;
+
+    fn start(mut self) -> Addr<Self> {
+        spawn_actor!(self @ MyActor => {
+            .stream1,
+            .stream2 as Name,
+        })
+    }
+}
+
+impl StreamHandler<usize> for MyActor {
+    fn handle(&mut self, item: usize, _: &mut Context<Self>) {
+        self.total += item;
+    }
+
+    fn finished(&mut self, _ctx: &mut Self::Context) {}
+}
+
+struct Name {
+    name: &'static str,
+}
+
+impl From<(Instant, &'static str)> for Name {
+    fn from((_, name): (Instant, &'static str)) -> Self {
+        Self { name }
+    }
+}
+
+impl StreamHandler<Name> for MyActor {
+    fn handle(&mut self, item: Name, _: &mut Context<Self>) {
+        self.current_name = item.name;
+    }
+
+    fn finished(&mut self, _ctx: &mut Self::Context) {}
+}
+
+#[derive(Message)]
+#[rtype(usize)]
+struct GetTotal;
+
+impl Handler<GetTotal> for MyActor {
+    type Result = usize;
+
+    fn handle(&mut self, _: GetTotal, _: &mut Context<Self>) -> Self::Result {
+        self.total
+    }
+}
+
+#[derive(Message)]
+#[rtype("&'static str")]
+struct GetCurrentName;
+
+impl Handler<GetCurrentName> for MyActor {
+    type Result = Response<&'static str>;
+
+    fn handle(&mut self, _: GetCurrentName, _: &mut Context<Self>) -> Self::Result {
+        Response::reply(self.current_name)
+    }
+}
+
+#[actix::test]
+async fn test() -> eyre::Result<()> {
+    let names = stream::iter([
+        "Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Heidi", "Ivan", "Judy", "Kevin",
+        "Larry", "Mallory", "Nancy", "Olivia", "Peggy", "Quentin", "Ralph", "Steve", "Trent",
+        "Ursula", "Victor", "Walter", "Xavier", "Yvonne", "Zelda",
+    ]);
+
+    let interval = time::interval(time::Duration::from_millis(200));
+
+    let addr = MyActor {
+        total: 0,
+        stream1: Box::new(stream::repeat(10).take(5)),
+        current_name: "",
+        stream2: Box::new(IntervalStream::new(interval).zip(names)),
+    }
+    .start();
+
+    let mut interval = time::interval(time::Duration::from_secs(2));
+
+    let _ignored = interval.tick().await;
+
+    let total = addr.send(GetTotal).await?;
+
+    assert_eq!(50, total);
+
+    let _ignored = interval.tick().await;
+
+    let e = addr.send(GetCurrentName).await?;
+
+    assert_eq!("Judy", e);
+
+    Ok(())
+}


### PR DESCRIPTION
Sometimes, we may need to consume items from a stream, while maintaining ownership to it by the actor itself, for eventual mutation, or whatever other reason.

[`AsyncContext::add_stream`](https://docs.rs/actix/latest/actix/trait.AsyncContext.html#method.add_stream) is insufficient for this because it requires `Stream + 'static`.

I explored some options in https://github.com/miraclx/actors-test/tree/master/crates/experiments/self-stream#readme and extrapolated those learnings into a macro that can substitute the default actor start mechanism.

Key things to know:

1. The stream MUST be `Box`-ed.
2. `StreamHandler<T>::finished`'s default implementation WILL shutdown the actor. Not sure who thought that was a great idea, but that's what it is. This may be motivation enough to use our own traits, but we'll see.

Syntax:

1. This will trigger `StreamHandler<T>` where `Stream<Item = T>`

	```rust
	impl Actor for MyActor {
	    fn start(self) -> Addr<Self> {
	        spawn_actor!(self @ MyActor => { .stream })
	    }
	}
	```

2. This will trigger `StreamHandler<MyType>` where `Stream<Item: Into<MyType>>`

	```rust
	impl Actor for MyActor {
	    fn start(self) -> Addr<Self> {
	        spawn_actor!(self @ MyActor => { .stream as MyType })
	    }
	}
	```

3. Multiple streams are supported as well

	```rust
	impl Actor for MyActor {
	    fn start(self) -> Addr<Self> {
	        spawn_actor!(self @ MyActor => {
	            .stream1,
	            .stream2 as ItemType,
	        })
	    }
	}
	```

##### Example

```rust
use calimero_utils_actix::spawn_actor;

struct MyActor {
    repeating: Box<Repeat<usize>>,
    counting: Box<Iter<RangeFrom<usize>>>,
}

impl Actor for MyActor {
    type Context = Context<Self>;

    fn start(self) ->Addr<Self> {
        spawn_actor!(self @ MyActor => {
            .repeating,
            .counting as Count,
        })
    }
}

impl StreamHandler<usize> for MyActor {
    fn handle(&mut self, value: usize, _: &mut actix::Context<Self>) {
        println!("received a repeating number: {value}");
    }

    fn finished(&mut self, _ctx: &mut Self::Context) {}
}

struct Count(usize);

impl From<usize> for Count {
    fn from(value: usize) -> Self {
        Self(value)
    }
}

impl StreamHandler<Count> for MyActor {
    fn handle(&mut self, Count(value): Count, _: &mut actix::Context<Self>) {
        println!("received an incrementing number: {value}");
    }

    fn finished(&mut self, _ctx: &mut Self::Context) {}
}
```