### PR TITLE
fix: add `GH_TOKEN` for gh command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Get version info
         id: version_info
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Validating binary versions"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,6 @@ jobs:
 
           echo "target_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
 
-          if gh release view "$version_candidate" --repo ${{ github.repository }} >/dev/null 2>&1; then
-            echo "works"
-          else
-            echo "doesn't work"
-          fi
-
           if [ "${{ github.ref }}" == "refs/heads/master" ]; then
             version="$version_candidate"
             echo "Master version: $version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
 
           echo "target_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
 
+          if gh release view "$version_candidate" --repo ${{ github.repository }} >/dev/null 2>&1; then
+            echo "works"
+          else
+            echo "doesn't work"
+          fi
+
           if [ "${{ github.ref }}" == "refs/heads/master" ]; then
             version="$version_candidate"
             echo "Master version: $version"


### PR DESCRIPTION
`gh release view` needs a token, causes master to fail: https://github.com/calimero-network/core/actions/runs/13497216832/job/37707846721