### PR TITLE
fix: Add missing e2e-tests directory in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY crates ./crates
 COPY contracts ./contracts
 COPY apps ./apps
 COPY node-ui ./node-ui
+COPY e2e-tests ./e2e-tests
 
 # Build the node UI
 WORKDIR /app/node-ui


### PR DESCRIPTION
This PR adds the ```COPY e2e-tests ./e2e-tests``` line to the Dockerfile, ensuring the e2e-tests directory (already referenced in Cargo.toml) is included in the build.