### PR TITLE
feat(e2e): add testing aliases to e2e tests

### DIFF
--- a/contracts/icp/context-config/deploy_devnet.sh
+++ b/contracts/icp/context-config/deploy_devnet.sh
@@ -96,7 +96,7 @@ CONTEXT_ID=$(dfx canister id context_contract)
 WALLET_ID=$(dfx identity get-wallet)
 
 # abricate cycles for the wallet
-dfx ledger fabricate-cycles --canister $WALLET_ID --amount 200000
+dfx ledger fabricate-cycles --canister $WALLET_ID --amount 2000000
 
 # Transfer cycles from wallet to context contract
 dfx canister deposit-cycles 1000000000000000000 $CONTEXT_ID

--- a/e2e-tests/config/scenarios/kv-store/test.json
+++ b/e2e-tests/config/scenarios/kv-store/test.json
@@ -10,6 +10,11 @@
       "contextCreate": null
     },
     {
+      "contextCreateAlias": {
+        "aliasName": "my_context"
+      }
+    },
+    {
       "call": {
         "methodName": "set",
         "argsJson": { "key": "foo", "value": "bar" },

--- a/e2e-tests/src/driver.rs
+++ b/e2e-tests/src/driver.rs
@@ -32,6 +32,7 @@ pub struct TestContext<'a> {
     pub invitees_public_keys: HashMap<String, String>,
     pub protocol_name: &'a str,
     pub output_writer: OutputWriter,
+    pub context_alias: Option<String>,
 }
 
 pub trait Test {
@@ -57,6 +58,7 @@ impl<'a> TestContext<'a> {
             inviter_public_key: None,
             invitees_public_keys: HashMap::new(),
             output_writer,
+            context_alias: None,
         }
     }
 }

--- a/e2e-tests/src/meroctl.rs
+++ b/e2e-tests/src/meroctl.rs
@@ -76,6 +76,30 @@ impl Meroctl {
         Ok((context_id, member_public_key))
     }
 
+    pub async fn context_create_alias(
+        &self,
+        node_name: &str,
+        context_id: &str,
+        alias: &str,
+    ) -> EyreResult<()> {
+        drop(
+            self.run_cmd(node_name, ["context", "alias", "add", alias, context_id])
+                .await?,
+        );
+        Ok(())
+    }
+
+    pub async fn context_get_alias(&self, node_name: &str, alias: &str) -> EyreResult<String> {
+        let json = self
+            .run_cmd(node_name, ["context", "alias", "get", alias])
+            .await?;
+
+        let data = self.remove_value_from_object(json, "data")?;
+        let context_id = self.get_string_from_object(&data, "value")?;
+
+        Ok(context_id)
+    }
+
     pub async fn context_invite(
         &self,
         node_name: &str,

--- a/e2e-tests/src/steps.rs
+++ b/e2e-tests/src/steps.rs
@@ -1,5 +1,6 @@
 use application_install::ApplicationInstallStep;
 use context_create::ContextCreateStep;
+use context_create_alias::ContextCreateAliasStep;
 use context_invite_join::ContextInviteJoinStep;
 use eyre::Result as EyreResult;
 use jsonrpc_call::CallStep;
@@ -9,6 +10,7 @@ use crate::driver::{Test, TestContext};
 
 mod application_install;
 mod context_create;
+mod context_create_alias;
 mod context_invite_join;
 mod jsonrpc_call;
 
@@ -23,6 +25,7 @@ pub struct TestScenario {
 pub enum TestStep {
     ApplicationInstall(ApplicationInstallStep),
     ContextCreate(ContextCreateStep),
+    ContextCreateAlias(ContextCreateAliasStep),
     ContextInviteJoin(ContextInviteJoinStep),
     Call(CallStep),
 }
@@ -32,6 +35,7 @@ impl Test for TestStep {
         match self {
             Self::ApplicationInstall(step) => step.display_name(),
             Self::ContextCreate(step) => step.display_name(),
+            Self::ContextCreateAlias(step) => step.display_name(),
             Self::ContextInviteJoin(step) => step.display_name(),
             Self::Call(step) => step.display_name(),
         }
@@ -41,6 +45,7 @@ impl Test for TestStep {
         match self {
             Self::ApplicationInstall(step) => step.run_assert(ctx).await,
             Self::ContextCreate(step) => step.run_assert(ctx).await,
+            Self::ContextCreateAlias(step) => step.run_assert(ctx).await,
             Self::ContextInviteJoin(step) => step.run_assert(ctx).await,
             Self::Call(step) => step.run_assert(ctx).await,
         }

--- a/e2e-tests/src/steps/context_create_alias.rs
+++ b/e2e-tests/src/steps/context_create_alias.rs
@@ -1,0 +1,45 @@
+use eyre::{bail, Result as EyreResult};
+use serde::{Deserialize, Serialize};
+
+use crate::driver::{Test, TestContext};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextCreateAliasStep {
+    pub alias_name: String,
+}
+
+impl Test for ContextCreateAliasStep {
+    async fn run_assert(&self, ctx: &mut TestContext<'_>) -> EyreResult<()> {
+        let Some(ref context_id) = ctx.context_id else {
+            bail!("To create an alias we need a context id")
+        };
+
+        let _ = ctx
+            .meroctl
+            .context_create_alias(&ctx.inviter, context_id, &self.alias_name)
+            .await?;
+
+        ctx.output_writer.write_str(&format!(
+            "Created alias {} for context {}",
+            self.alias_name, context_id
+        ));
+
+        let alias_context_id = ctx
+            .meroctl
+            .context_get_alias(&ctx.inviter, &self.alias_name)
+            .await?;
+
+        if alias_context_id != *context_id {
+            bail!("Creating alias for context failed");
+        }
+
+        ctx.context_alias = Some(self.alias_name.clone());
+
+        Ok(())
+    }
+
+    fn display_name(&self) -> String {
+        "alias create".to_owned()
+    }
+}

--- a/e2e-tests/src/steps/jsonrpc_call.rs
+++ b/e2e-tests/src/steps/jsonrpc_call.rs
@@ -27,11 +27,7 @@ impl Test for CallStep {
     }
 
     async fn run_assert(&self, ctx: &mut TestContext<'_>) -> EyreResult<()> {
-        let mut context_id = if let Some(ref alias) = ctx.context_alias {
-            alias
-        } else {
-            bail!("Context ID or Alias is required for JsonRpcExecuteStep");
-        };
+        let context_id;
 
         let mut public_keys = HashMap::new();
         if let Some(ref inviter_public_key) = ctx.inviter_public_key {
@@ -41,7 +37,13 @@ impl Test for CallStep {
         }
 
         match self.target {
-            CallTarget::Inviter => {}
+            CallTarget::Inviter => {
+                if let Some(ref alias) = ctx.context_alias {
+                    context_id = alias;
+                } else {
+                    bail!("Alias is required for JsonRpcExecuteStep on the Inviter node");
+                };
+            }
             CallTarget::AllMembers => {
                 if let Some(ref id) = ctx.context_id {
                     context_id = id;


### PR DESCRIPTION
# Add e2e test for testing context aliases

Create an alias for a context on the inviter node named `my_context`, and use that alias instead of a `contextId` in subsequent jsonrpc calls.

## Test plan

## Documentation update

N/A