### PR TITLE
fix: key sync encryption issues & make e2e tests more resilient

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -535,7 +535,7 @@ impl ContextManager {
                             &key,
                             &ContextIdentityValue {
                                 private_key: None,
-                                sender_key: Some(*self.new_private_key()),
+                                sender_key: None,
                             },
                         )?;
                     }

--- a/crates/merod/src/main.rs
+++ b/crates/merod/src/main.rs
@@ -22,7 +22,10 @@ async fn main() -> EyreResult<()> {
 
 fn setup() -> EyreResult<()> {
     registry()
-        .with(EnvFilter::builder().parse(format!("info,{}", var("RUST_LOG").unwrap_or_default()))?)
+        .with(EnvFilter::builder().parse(format!(
+            "merod=info,calimero_=info,{}",
+            var("RUST_LOG").unwrap_or_default()
+        ))?)
         .with(layer())
         .init();
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -451,9 +451,9 @@ impl Node {
             return Err(CallError::ContextNotFound);
         };
 
-        // if method != "init" && &*context.root_hash == &[0; 32] {
-        //     return Err(CallError::Uninitialized);
-        // }
+        if method != "init" && &*context.root_hash == &[0; 32] {
+            return Err(CallError::Uninitialized);
+        }
 
         if !self
             .ctx_manager

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -467,7 +467,7 @@ impl Node {
         }
 
         let outcome_option = self
-            .execute(&mut context, method, payload.clone(), executor_public_key)
+            .execute(&mut context, method, payload, executor_public_key)
             .await
             .map_err(|e| {
                 error!(%e, "Failed to execute query call.");

--- a/crates/node/src/sync/state.rs
+++ b/crates/node/src/sync/state.rs
@@ -139,6 +139,7 @@ impl Node {
             Some((shared_key, our_nonce)),
         )
         .await?;
+
         self.bidirectional_sync(
             context,
             our_identity,
@@ -149,9 +150,7 @@ impl Node {
             our_new_nonce,
             their_nonce,
         )
-        .await?;
-
-        Ok(())
+        .await
     }
 
     pub(super) async fn handle_state_sync_request(
@@ -255,8 +254,6 @@ impl Node {
             their_nonce,
         )
         .await
-
-        // should we compare root hashes again?
     }
 
     async fn bidirectional_sync(
@@ -345,6 +342,8 @@ impl Node {
 
             our_nonce = our_new_nonce;
         }
+
+        // eventually compare that both nodes arrive at the same state
 
         debug!(
             context_id=%context.id,

--- a/e2e-tests/config/config.json
+++ b/e2e-tests/config/config.json
@@ -1,6 +1,6 @@
 {
   "network": {
-    "nodeCount": 2,
+    "nodeCount": 3,
     "swarmHost": "0.0.0.0",
     "startSwarmPort": 2427,
     "startServerPort": 2527

--- a/e2e-tests/config/scenarios/kv-store/test.json
+++ b/e2e-tests/config/scenarios/kv-store/test.json
@@ -38,7 +38,27 @@
         "methodName": "get",
         "argsJson": { "key": "foo" },
         "expectedResultJson": "bar",
-        "target": "allMembers"
+        "target": "allMembers",
+        "retries": 5,
+        "intervalMs": 35000
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": { "key": "foo", "value": "baz" },
+        "expectedResultJson": null,
+        "target": "inviter"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": { "key": "foo" },
+        "expectedResultJson": "baz",
+        "target": "allMembers",
+        "retries": 1,
+        "intervalMs": 5000
       }
     }
   ]

--- a/e2e-tests/src/meroctl.rs
+++ b/e2e-tests/src/meroctl.rs
@@ -158,9 +158,7 @@ impl Meroctl {
 
         Ok((public_key, private_key))
     }
-}
 
-impl Meroctl {
     pub fn json_rpc_execute(
         &self,
         node_name: &str,

--- a/e2e-tests/src/steps/context_invite_join.rs
+++ b/e2e-tests/src/steps/context_invite_join.rs
@@ -1,8 +1,5 @@
-use core::time::Duration;
-
 use eyre::{bail, Result as EyreResult};
 use serde::{Deserialize, Serialize};
-use tokio::time::sleep;
 
 use crate::driver::{Test, TestContext};
 
@@ -63,9 +60,6 @@ impl Test for ContextInviteJoinStep {
                 ctx.invitees_public_keys
                     .insert(invitee.clone(), invitee_public_key),
             );
-
-            // Sync period is 30s, but in GHA we have some timeout issues
-            sleep(Duration::from_secs(40)).await;
 
             ctx.output_writer
                 .write_str(&format!("Report: Node '{invitee}' joined the context"));


### PR DESCRIPTION
Alen noticed some weird behaviour with encryption, turned out we were assigning a default key to peers we've never directly synced with, that was wrong.

And when the sender key is unable to decrypt a state delta, we should assume the sender key was invalid and trigger a sync (which should fetch us the latest key and the updated state).

Restored the uninitialized guard for execution.

Increased the number of nodes in e2e tests to 3.

Made the jsonrpc step retriable, in case, for example, node 1 has the state, and node2 & 3 waste their 30s sync allowance doing a pointless sync with one other. Should reduce the odds of ever failing in this process by a lot.