### PR TITLE
fix(e2e-tests): ensure ports are available before running merod

### DIFF
--- a/e2e-tests/config/config.json
+++ b/e2e-tests/config/config.json
@@ -2,6 +2,7 @@
   "network": {
     "nodeCount": 2,
     "swarmHost": "0.0.0.0",
+    "serverHost": "127.0.0.1",
     "startSwarmPort": 2427,
     "startServerPort": 2527
   },

--- a/e2e-tests/src/config.rs
+++ b/e2e-tests/src/config.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::icp::IcpProtocolConfig;
@@ -16,9 +18,10 @@ pub struct Config {
 #[serde(rename_all = "camelCase")]
 pub struct Network {
     pub node_count: u32,
-    pub swarm_host: String,
-    pub start_swarm_port: u32,
-    pub start_server_port: u32,
+    pub swarm_host: IpAddr,
+    pub server_host: IpAddr,
+    pub start_swarm_port: u16,
+    pub start_server_port: u16,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/e2e-tests/src/driver.rs
+++ b/e2e-tests/src/driver.rs
@@ -1,7 +1,7 @@
 use core::fmt::Write;
-use core::time::Duration;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 
 use camino::Utf8PathBuf;
@@ -9,7 +9,8 @@ use eyre::{bail, OptionExt, Result as EyreResult};
 use rand::seq::IteratorRandom;
 use serde_json::from_slice;
 use tokio::fs::{read, read_dir, write};
-use tokio::time::sleep;
+use tokio::net::{TcpListener, TcpSocket};
+use tokio::{time, try_join};
 
 use crate::config::{Config, ProtocolSandboxConfig};
 use crate::meroctl::Meroctl;
@@ -159,6 +160,12 @@ impl Driver {
 
         let mut merods = HashMap::new();
 
+        let swarm_host = self.config.network.swarm_host.to_string();
+        let mut swarm_port = self.config.network.start_swarm_port;
+
+        let server_host = self.config.network.server_host.to_string();
+        let mut server_port = self.config.network.start_server_port;
+
         for i in 0..self.config.network.node_count {
             let node_name = format!("node{}", i + 1);
             if let Entry::Vacant(e) = merods.entry(node_name.clone()) {
@@ -182,23 +189,39 @@ impl Driver {
                     self.environment.output_writer,
                 );
 
+                let swarm_port =
+                    PortBinding::next_available(self.config.network.swarm_host, &mut swarm_port)
+                        .await?;
+
+                let server_port =
+                    PortBinding::next_available(self.config.network.server_host, &mut server_port)
+                        .await?;
+
                 merod
                     .init(
-                        &self.config.network.swarm_host,
-                        self.config.network.start_swarm_port + i,
-                        self.config.network.start_server_port + i,
+                        &swarm_host,
+                        &server_host,
+                        swarm_port.port(),
+                        server_port.port(),
                         config_args.map(String::as_str),
                     )
                     .await?;
 
+                let swarm_addr = swarm_port.into_socket_addr();
+                let server_addr = server_port.into_socket_addr();
+
                 merod.run().await?;
 
                 let _ = e.insert(merod);
+
+                while let Err(_) = try_join!(
+                    TcpSocket::new_v4()?.connect(swarm_addr),
+                    TcpSocket::new_v4()?.connect(server_addr)
+                ) {
+                    time::sleep(time::Duration::from_secs(1)).await;
+                }
             }
         }
-
-        // TODO: Implement health check?
-        sleep(Duration::from_secs(10)).await;
 
         Ok(Mero {
             ctl: Meroctl::new(
@@ -460,4 +483,41 @@ impl TestScenarioReport {
 struct TestStepReport {
     step_name: String,
     result: Option<EyreResult<()>>,
+}
+
+struct PortBinding {
+    address: SocketAddr,
+    listener: TcpListener,
+}
+
+impl PortBinding {
+    fn port(&self) -> u16 {
+        self.address.port()
+    }
+
+    /// Drop the binding, returning the bound address.
+    fn into_socket_addr(self) -> SocketAddr {
+        drop(self.listener);
+        self.address
+    }
+
+    async fn next_available(host: IpAddr, port: &mut u16) -> EyreResult<PortBinding> {
+        for _ in 0..100 {
+            let address = (host, *port).into();
+
+            let res = TcpListener::bind(address).await;
+
+            *port += 1;
+
+            if let Ok(listener) = res {
+                return Ok(PortBinding { address, listener });
+            }
+        }
+
+        bail!(
+            "unable to select a port in range {}..={}",
+            *port - 100,
+            *port - 1
+        );
+    }
 }

--- a/e2e-tests/src/merod.rs
+++ b/e2e-tests/src/merod.rs
@@ -39,8 +39,9 @@ impl Merod {
     pub async fn init<'a>(
         &'a self,
         swarm_host: &str,
-        swarm_port: u32,
-        server_port: u32,
+        server_host: &str,
+        swarm_port: u16,
+        server_port: u16,
         args: impl IntoIterator<Item = &'a str>,
     ) -> EyreResult<()> {
         create_dir_all(&self.log_dir).await?;
@@ -51,6 +52,8 @@ impl Merod {
                     "init",
                     "--swarm-host",
                     swarm_host,
+                    "--server-host",
+                    server_host,
                     "--swarm-port",
                     swarm_port.to_string().as_str(),
                     "--server-port",


### PR DESCRIPTION
We cannot account for pre-used ports in CI environments, patch e2e tests to attempt to find at least one unused port in 100 attempts, incrementing by one each time.

Should fix https://github.com/calimero-network/core/actions/runs/13939669570/job/39014375346