### PR TITLE
feat(e2e): introduce an optimized wait step for the best case

### DIFF
--- a/e2e-tests/config/scenarios/kv-store/test.json
+++ b/e2e-tests/config/scenarios/kv-store/test.json
@@ -34,13 +34,29 @@
       "contextInviteJoin": null
     },
     {
+      "wait": {
+        "for": "consensus",
+        "durationMs": 5000,
+        "description": [
+          "assuming it takes 5s to propagate we should",
+          "only need to wait 5 * ceil(log2(nodes)) seconds"
+        ]
+      }
+    },
+    {
       "call": {
         "methodName": "get",
         "argsJson": { "key": "foo" },
         "expectedResultJson": "bar",
         "target": "allMembers",
-        "retries": 5,
-        "intervalMs": 35000
+        "retries": 20,
+        "intervalMs": 5000,
+        "description": [
+          "if we don't reach consensus in the ideal case",
+          "wait 5 seconds for nodes that have not yet synced",
+          "in the worst case, wait 20 * 5s for nodes that uselessly",
+          "keep syncing with themselves without having the state"
+        ]
       }
     },
     {
@@ -52,13 +68,24 @@
       }
     },
     {
+      "wait": {
+        "for": "broadcast",
+        "durationMs": 5000,
+        "description": ["wait exactly 5s for the broadcast to propagate"]
+      }
+    },
+    {
       "call": {
         "methodName": "get",
         "argsJson": { "key": "foo" },
         "expectedResultJson": "baz",
         "target": "allMembers",
-        "retries": 1,
-        "intervalMs": 5000
+        "retries": 5,
+        "intervalMs": 5000,
+        "description": [
+          "if a node still hasn't received the broadcast",
+          "try 5 more times in 5 seconds, but no more"
+        ]
       }
     }
   ]

--- a/e2e-tests/src/steps.rs
+++ b/e2e-tests/src/steps.rs
@@ -5,6 +5,7 @@ use context_invite_join::ContextInviteJoinStep;
 use eyre::Result as EyreResult;
 use jsonrpc_call::CallStep;
 use serde::{Deserialize, Serialize};
+use wait::WaitStep;
 
 use crate::driver::{Test, TestContext};
 
@@ -13,6 +14,7 @@ mod context_create;
 mod context_create_alias;
 mod context_invite_join;
 mod jsonrpc_call;
+mod wait;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -28,6 +30,7 @@ pub enum TestStep {
     ContextCreateAlias(ContextCreateAliasStep),
     ContextInviteJoin(ContextInviteJoinStep),
     Call(CallStep),
+    Wait(WaitStep),
 }
 
 impl Test for TestStep {
@@ -38,6 +41,7 @@ impl Test for TestStep {
             Self::ContextCreateAlias(step) => step.display_name(),
             Self::ContextInviteJoin(step) => step.display_name(),
             Self::Call(step) => step.display_name(),
+            Self::Wait(step) => step.display_name(),
         }
     }
 
@@ -48,6 +52,7 @@ impl Test for TestStep {
             Self::ContextCreateAlias(step) => step.run_assert(ctx).await,
             Self::ContextInviteJoin(step) => step.run_assert(ctx).await,
             Self::Call(step) => step.run_assert(ctx).await,
+            Self::Wait(step) => step.run_assert(ctx).await,
         }
     }
 }

--- a/e2e-tests/src/steps/wait.rs
+++ b/e2e-tests/src/steps/wait.rs
@@ -1,0 +1,96 @@
+use std::time::Duration;
+
+use eyre::Result as EyreResult;
+use serde::{Deserialize, Serialize};
+use tokio::time;
+
+use crate::driver::{Test, TestContext};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaitStep {
+    #[serde(rename = "durationMs", with = "serde_duration")]
+    pub duration: Duration,
+    pub r#for: WaitFor,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WaitFor {
+    #[default]
+    Broadcast,
+    /// Wait the minimum amount of time for consensus to be reached.
+    ///
+    /// In the ideal case, this should only take ceil(log2(nodes)).
+    ///
+    /// For example, with 4 nodes:
+    ///
+    /// sync 1:
+    ///   Node 1 => Node2
+    /// sync 2:
+    ///   Node 1 => Node3
+    ///   Node 2 => Node4
+    ///
+    /// Or with 8 nodes:
+    ///
+    /// sync 1:
+    ///   Node 1 => Node2
+    /// sync 2:
+    ///   Node 1 => Node3
+    ///   Node 2 => Node4
+    /// sync 3:
+    ///   Node 1 => Node5
+    ///   Node 2 => Node6
+    ///   Node 3 => Node7
+    ///   Node 4 => Node8
+    Consensus,
+}
+
+mod serde_duration {
+    use core::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(duration.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        u64::deserialize(deserializer).map(Duration::from_millis)
+    }
+}
+
+impl Test for WaitStep {
+    fn display_name(&self) -> String {
+        format!("wait ({:?})", self.r#for)
+    }
+
+    async fn run_assert(&self, ctx: &mut TestContext<'_>) -> EyreResult<()> {
+        let mut extra = String::new();
+
+        let factor = match self.r#for {
+            WaitFor::Consensus => {
+                let nodes = (ctx.invitees.len() + 1) as f64;
+                let pairs = nodes.log2().ceil() as u32;
+                extra = format!(" (assuming we reach consensus in {} rounds)", pairs);
+                pairs
+            }
+            _ => 1,
+        };
+
+        let duration = self.duration * factor;
+
+        ctx.output_writer
+            .write_str(&format!("Waiting for {} ms{extra}", duration.as_millis()));
+
+        time::sleep(duration).await;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
In the best case, consensus should be reached in `ceil(log2(nodes))` sync rounds.

Assuming we sync for 5s, we can alleviate the previously enforced wait duration of 40s.

And when a node doesn't sync in that period, in the worst case we retry 20 times. Hoping in a 100s period the sync happens. 🙂