### PR TITLE
feat: bump core version + release logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-03-27
+- Added Ethereum integration
+- Decoupled contracts from core repository
+- Extended e2e tests to include proxy contract functionalities
+- Added autonat protocol
+
 ## [0.4.0] - 2025-02-18
 
 - Added Stellar integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@ Integrations:
 - Starknet: reached feature parity with the NEAR implementation, allowing
   contexts to be created in association with the Starknet protocol.
 
-[unreleased]: https://github.com/calimero-network/core/compare/0.4.0...HEAD
+[unreleased]: https://github.com/calimero-network/core/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/calimero-network/core/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/calimero-network/core/compare/merod-0.3.1...0.4.0
 [0.3.1]:
   https://github.com/calimero-network/core/compare/merod-0.3.0...merod-0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ## [0.5.0] - 2025-03-27
+
 - Added Ethereum integration
 - Decoupled contracts from core repository
 - Extended e2e tests to include proxy contract functionalities

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5892,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "meroctl"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-config",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "merod"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "axum",

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meroctl"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/merod/Cargo.toml
+++ b/crates/merod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merod"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description

Bump meroctl and merod to version 0.5.0 
Relase logs:
- Added Ethereum integration
- Decoupled contracts from core repository
- Extended e2e tests to include proxy contract functionalities
- Added autonat protocol

## Test plan

N/A

## Documentation update

Updated [here](https://github.com/calimero-network/calimero-network.github.io/commit/c470a6f97bc3fdc2d6d4c138c956cdc6fe469a79)
