### PR TITLE
feat(meroctl): support creating alias on context join and invite

### DIFF
--- a/crates/meroctl/src/cli/bootstrap/start.rs
+++ b/crates/meroctl/src/cli/bootstrap/start.rs
@@ -216,7 +216,7 @@ impl StartBootstrapCommand {
         let join_command = JoinCommand {
             private_key: invitee_private_key,
             invitation_payload,
-            name: None,
+            context: None,
             identity: None,
         };
         join_command.run(invitee_environment).await?;

--- a/crates/meroctl/src/cli/bootstrap/start.rs
+++ b/crates/meroctl/src/cli/bootstrap/start.rs
@@ -199,6 +199,7 @@ impl StartBootstrapCommand {
             context: context_id.as_str().parse()?,
             inviter: inviter_public_key.as_str().parse()?,
             invitee_id: invitee_private_key.public_key(),
+            name: None,
         };
         let invitation_payload = invite_command.invite(invitor_environment).await?;
 
@@ -215,6 +216,8 @@ impl StartBootstrapCommand {
         let join_command = JoinCommand {
             private_key: invitee_private_key,
             invitation_payload,
+            name: None,
+            identity: None,
         };
         join_command.run(invitee_environment).await?;
         println!(
@@ -306,6 +309,7 @@ impl StartBootstrapCommand {
             None,
             &config.identity,
             protocol,
+            None,
             None,
         )
         .await?;

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -21,7 +21,9 @@ use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
 use crate::cli::Environment;
-use crate::common::{do_request, fetch_multiaddr, load_config, multiaddr_to_url, RequestType};
+use crate::common::{
+    create_alias, do_request, fetch_multiaddr, load_config, multiaddr_to_url, RequestType,
+};
 use crate::output::{ErrorLine, InfoLine, Report};
 
 #[derive(Debug, Parser)]
@@ -67,6 +69,9 @@ pub struct CreateCommand {
 
     #[clap(long = "as", help = "Create an alias for the context identity")]
     identity: Option<Alias<PublicKey>>,
+
+    #[clap(long = "name", help = "Create an alias for the context")]
+    name: Option<Alias<ContextId>>,
 }
 
 impl Report for CreateContextResponse {
@@ -97,6 +102,7 @@ impl CreateCommand {
                 params,
                 protocol,
                 identity,
+                name,
             } => {
                 let _ = create_context(
                     environment,
@@ -108,6 +114,7 @@ impl CreateCommand {
                     &config.identity,
                     protocol,
                     identity,
+                    name,
                 )
                 .await?;
             }
@@ -119,6 +126,7 @@ impl CreateCommand {
                 params,
                 protocol,
                 identity,
+                name,
             } => {
                 let path = path.canonicalize_utf8()?;
                 let metadata = metadata.map(String::into_bytes);
@@ -142,6 +150,7 @@ impl CreateCommand {
                     &config.identity,
                     protocol,
                     identity,
+                    name,
                 )
                 .await?;
 
@@ -174,6 +183,7 @@ pub async fn create_context(
     keypair: &Keypair,
     protocol: String,
     identity: Option<Alias<PublicKey>>,
+    name: Option<Alias<ContextId>>,
 ) -> EyreResult<(ContextId, PublicKey)> {
     if !app_installed(base_multiaddr, &application_id, client, keypair).await? {
         bail!("Application is not installed on node.")
@@ -219,7 +229,17 @@ pub async fn create_context(
 
         environment.output.write(&alias_response);
     }
-
+    if let Some(name_alias) = name {
+        let res = create_alias(
+            base_multiaddr,
+            keypair,
+            name_alias,
+            None,
+            response.data.context_id,
+        )
+        .await?;
+        environment.output.write(&res);
+    }
     Ok((response.data.context_id, response.data.member_public_key))
 }
 

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -71,7 +71,7 @@ pub struct CreateCommand {
     identity: Option<Alias<PublicKey>>,
 
     #[clap(long = "name", help = "Create an alias for the context")]
-    name: Option<Alias<ContextId>>,
+    context: Option<Alias<ContextId>>,
 }
 
 impl Report for CreateContextResponse {
@@ -102,7 +102,7 @@ impl CreateCommand {
                 params,
                 protocol,
                 identity,
-                name,
+                context,
             } => {
                 let _ = create_context(
                     environment,
@@ -114,7 +114,7 @@ impl CreateCommand {
                     &config.identity,
                     protocol,
                     identity,
-                    name,
+                    context,
                 )
                 .await?;
             }
@@ -126,7 +126,7 @@ impl CreateCommand {
                 params,
                 protocol,
                 identity,
-                name,
+                context,
             } => {
                 let path = path.canonicalize_utf8()?;
                 let metadata = metadata.map(String::into_bytes);
@@ -150,7 +150,7 @@ impl CreateCommand {
                     &config.identity,
                     protocol,
                     identity,
-                    name,
+                    context,
                 )
                 .await?;
 
@@ -183,7 +183,7 @@ pub async fn create_context(
     keypair: &Keypair,
     protocol: String,
     identity: Option<Alias<PublicKey>>,
-    name: Option<Alias<ContextId>>,
+    context: Option<Alias<ContextId>>,
 ) -> EyreResult<(ContextId, PublicKey)> {
     if !app_installed(base_multiaddr, &application_id, client, keypair).await? {
         bail!("Application is not installed on node.")
@@ -229,11 +229,11 @@ pub async fn create_context(
 
         environment.output.write(&alias_response);
     }
-    if let Some(name_alias) = name {
+    if let Some(context_alias) = context {
         let res = create_alias(
             base_multiaddr,
             keypair,
-            name_alias,
+            context_alias,
             None,
             response.data.context_id,
         )

--- a/crates/meroctl/src/cli/context/invite.rs
+++ b/crates/meroctl/src/cli/context/invite.rs
@@ -8,7 +8,8 @@ use reqwest::Client;
 
 use crate::cli::Environment;
 use crate::common::{
-    do_request, fetch_multiaddr, load_config, multiaddr_to_url, resolve_alias, RequestType,
+    create_alias, do_request, fetch_multiaddr, load_config, multiaddr_to_url, resolve_alias,
+    RequestType,
 };
 use crate::output::Report;
 
@@ -30,6 +31,9 @@ pub struct InviteCommand {
 
     #[clap(value_name = "INVITEE", help = "The identifier of the invitee")]
     pub invitee_id: PublicKey,
+
+    #[clap(value_name = "ALIAS", help = "The alias for the invitee")]
+    pub name: Option<Alias<PublicKey>>,
 }
 
 impl Report for InviteToContextResponse {
@@ -84,6 +88,18 @@ impl InviteCommand {
         let invitation_payload = response
             .data
             .ok_or_else(|| eyre::eyre!("No invitation payload found in the response"))?;
+
+        if let Some(name) = self.name {
+            let res = create_alias(
+                multiaddr,
+                &config.identity,
+                name,
+                Some(context_id),
+                self.invitee_id,
+            )
+            .await?;
+            environment.output.write(&res);
+        }
 
         Ok(invitation_payload)
     }

--- a/crates/meroctl/src/cli/context/join.rs
+++ b/crates/meroctl/src/cli/context/join.rs
@@ -1,12 +1,15 @@
-use calimero_primitives::context::ContextInvitationPayload;
-use calimero_primitives::identity::PrivateKey;
+use calimero_primitives::alias::Alias;
+use calimero_primitives::context::{ContextId, ContextInvitationPayload};
+use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_server_primitives::admin::{JoinContextRequest, JoinContextResponse};
 use clap::Parser;
 use eyre::Result as EyreResult;
 use reqwest::Client;
 
 use crate::cli::Environment;
-use crate::common::{do_request, fetch_multiaddr, load_config, multiaddr_to_url, RequestType};
+use crate::common::{
+    create_alias, do_request, fetch_multiaddr, load_config, multiaddr_to_url, RequestType,
+};
 use crate::output::Report;
 
 #[derive(Debug, Parser)]
@@ -21,7 +24,12 @@ pub struct JoinCommand {
         value_name = "INVITE",
         help = "The invitation payload for joining the context"
     )]
+    // Is it any useful here?
+    #[clap(long = "name", help = "The alias for the context")]
+    pub name: Option<Alias<ContextId>>,
     pub invitation_payload: ContextInvitationPayload,
+    #[clap(long = "as", help = "The alias for the invitee")]
+    pub identity: Option<Alias<PublicKey>>,
 }
 
 impl Report for JoinContextResponse {
@@ -39,10 +47,11 @@ impl Report for JoinContextResponse {
 impl JoinCommand {
     pub async fn run(self, environment: &Environment) -> EyreResult<()> {
         let config = load_config(&environment.args.home, &environment.args.node_name)?;
+        let multiaddr = fetch_multiaddr(&config)?;
 
         let response: JoinContextResponse = do_request(
             &Client::new(),
-            multiaddr_to_url(fetch_multiaddr(&config)?, "admin-api/dev/contexts/join")?,
+            multiaddr_to_url(multiaddr, "admin-api/dev/contexts/join")?,
             Some(JoinContextRequest::new(
                 self.private_key,
                 self.invitation_payload,
@@ -53,6 +62,23 @@ impl JoinCommand {
         .await?;
 
         environment.output.write(&response);
+
+        if let Some(ref payload) = response.data {
+            if let Some(identity) = self.identity {
+                let context_id = payload.context_id;
+                let public_key = payload.member_public_key;
+
+                let res = create_alias(
+                    multiaddr,
+                    &config.identity,
+                    identity,
+                    Some(context_id),
+                    public_key,
+                )
+                .await?;
+                environment.output.write(&res);
+            }
+        }
 
         Ok(())
     }

--- a/crates/meroctl/src/cli/context/join.rs
+++ b/crates/meroctl/src/cli/context/join.rs
@@ -24,10 +24,9 @@ pub struct JoinCommand {
         value_name = "INVITE",
         help = "The invitation payload for joining the context"
     )]
-    // Is it any useful here?
-    #[clap(long = "name", help = "The alias for the context")]
-    pub name: Option<Alias<ContextId>>,
     pub invitation_payload: ContextInvitationPayload,
+    #[clap(long = "name", help = "The alias for the context")]
+    pub context: Option<Alias<ContextId>>,
     #[clap(long = "as", help = "The alias for the invitee")]
     pub identity: Option<Alias<PublicKey>>,
 }
@@ -64,6 +63,12 @@ impl JoinCommand {
         environment.output.write(&response);
 
         if let Some(ref payload) = response.data {
+            if let Some(context) = self.context {
+                let context_id = payload.context_id;
+                let res =
+                    create_alias(multiaddr, &config.identity, context, None, context_id).await?;
+                environment.output.write(&res);
+            }
             if let Some(identity) = self.identity {
                 let context_id = payload.context_id;
                 let public_key = payload.member_public_key;


### PR DESCRIPTION
## Support alias creation on context join and identity invite in meroctl

This PR fixes #1179 by adding alias support to meroctl while creating a new context, inviting new users to a context and when a new user joins.