### PR TITLE
[WIP] feat(product) Add ZKsync support

### DIFF
--- a/crates/context/config/src/client/env.rs
+++ b/crates/context/config/src/client/env.rs
@@ -21,6 +21,7 @@ mod utils {
     use crate::client::protocol::near::Near;
     use crate::client::protocol::starknet::Starknet;
     use crate::client::protocol::stellar::Stellar;
+    use crate::client::protocol::zk_sync::ZkSync;
     use crate::client::protocol::Protocol;
     use crate::client::transport::Transport;
     use crate::client::{CallClient, ClientError, Operation};
@@ -36,6 +37,7 @@ mod utils {
         M: Method<Icp, Returns = R>,
         M: Method<Stellar, Returns = R>,
         M: Method<Ethereum, Returns = R>,
+        M: Method<ZkSync, Returns = R>,
     {
         match &*client.protocol {
             Near::PROTOCOL => client.send::<Near, _>(params).await,
@@ -43,6 +45,7 @@ mod utils {
             Icp::PROTOCOL => client.send::<Icp, _>(params).await,
             Stellar::PROTOCOL => client.send::<Stellar, _>(params).await,
             Ethereum::PROTOCOL => client.send::<Ethereum, _>(params).await,
+            ZkSync::PROTOCOL => client.send::<ZkSync, _>(params).await,
             unsupported_protocol => Err(ClientError::UnsupportedProtocol {
                 found: unsupported_protocol.to_owned(),
                 expected: vec![
@@ -50,6 +53,8 @@ mod utils {
                     Starknet::PROTOCOL.into(),
                     Icp::PROTOCOL.into(),
                     Stellar::PROTOCOL.into(),
+                    Ethereum::PROTOCOL.into(),
+                    ZkSync::PROTOCOL.into(),
                 ]
                 .into(),
             }),

--- a/crates/context/config/src/client/protocol.rs
+++ b/crates/context/config/src/client/protocol.rs
@@ -3,6 +3,7 @@ pub mod icp;
 pub mod near;
 pub mod starknet;
 pub mod stellar;
+pub mod zksync;
 
 pub trait Protocol {
     const PROTOCOL: &'static str;

--- a/crates/context/config/src/client/protocol/zksync.rs
+++ b/crates/context/config/src/client/protocol/zksync.rs
@@ -130,9 +130,7 @@ impl ProtocolTransport for ZkSyncTransport<'_> {
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, Self::Error> {
         let Some(network) = self.networks.get(&request.network_id) else {
-            return Err(ZkSyncError::UnknownNetwork(
-                request.network_id.into_owned(),
-            ));
+            return Err(ZkSyncError::UnknownNetwork(request.network_id.into_owned()));
         };
 
         let contract_id = request.contract_id.into_owned();
@@ -242,4 +240,4 @@ impl Network {
 
         Ok(receipt.logs_bloom().as_slice().to_vec())
     }
-} 
+}

--- a/crates/context/config/src/client/protocol/zksync.rs
+++ b/crates/context/config/src/client/protocol/zksync.rs
@@ -1,0 +1,245 @@
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use alloy::eips::BlockId;
+use alloy::network::{Ethereum as EthereumNetwork, EthereumWallet, ReceiptResponse};
+use alloy::primitives::{keccak256, Address, Bytes};
+use alloy::providers::{DynProvider, Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::time::Duration;
+use url::Url;
+
+use super::Protocol;
+use crate::client::transport::{
+    AssociatedTransport, Operation, ProtocolTransport, TransportRequest,
+};
+
+#[derive(Copy, Clone, Debug)]
+pub enum ZkSync {}
+
+impl Protocol for ZkSync {
+    const PROTOCOL: &'static str = "zksync";
+}
+
+impl AssociatedTransport for ZkSyncTransport<'_> {
+    type Protocol = ZkSync;
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "serde_creds::Credentials")]
+pub struct Credentials {
+    pub account_id: String,
+    pub secret_key: String,
+}
+
+mod serde_creds {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Credentials {
+        account_id: String,
+        secret_key: String,
+    }
+
+    impl TryFrom<Credentials> for super::Credentials {
+        type Error = &'static str;
+
+        fn try_from(creds: Credentials) -> Result<Self, Self::Error> {
+            Ok(Self {
+                account_id: creds.account_id,
+                secret_key: creds.secret_key,
+            })
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct NetworkConfig {
+    pub rpc_url: Url,
+    pub account_id: String,
+    pub access_key: PrivateKeySigner,
+}
+
+#[derive(Debug)]
+pub struct ZkSyncConfig<'a> {
+    pub networks: BTreeMap<Cow<'a, str>, NetworkConfig>,
+}
+
+#[derive(Clone, Debug)]
+struct Network {
+    provider: DynProvider<EthereumNetwork>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ZkSyncTransport<'a> {
+    networks: BTreeMap<Cow<'a, str>, Network>,
+}
+
+impl<'a> ZkSyncTransport<'a> {
+    #[must_use]
+    pub fn new(config: &ZkSyncConfig<'a>) -> Self {
+        let mut networks = BTreeMap::new();
+
+        for (network_id, network_config) in &config.networks {
+            let wallet = EthereumWallet::from(network_config.access_key.clone());
+
+            let provider: DynProvider<EthereumNetwork> = ProviderBuilder::new()
+                .wallet(wallet)
+                .on_http(network_config.rpc_url.clone())
+                .erased();
+
+            let _ignored = networks.insert(network_id.clone(), Network { provider });
+        }
+
+        Self { networks }
+    }
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ZkSyncError {
+    #[error("unknown network `{0}`")]
+    UnknownNetwork(String),
+    #[error("invalid response from RPC while {operation}")]
+    InvalidResponse { operation: ErrorOperation },
+    #[error("error while {operation}: {reason}")]
+    Custom {
+        operation: ErrorOperation,
+        reason: String,
+    },
+}
+
+#[derive(Copy, Clone, Debug, Error)]
+#[non_exhaustive]
+pub enum ErrorOperation {
+    #[error("querying contract")]
+    Query,
+    #[error("mutating contract")]
+    Mutate,
+}
+
+impl ProtocolTransport for ZkSyncTransport<'_> {
+    type Error = ZkSyncError;
+
+    async fn send(
+        &self,
+        request: TransportRequest<'_>,
+        payload: Vec<u8>,
+    ) -> Result<Vec<u8>, Self::Error> {
+        let Some(network) = self.networks.get(&request.network_id) else {
+            return Err(ZkSyncError::UnknownNetwork(
+                request.network_id.into_owned(),
+            ));
+        };
+
+        let contract_id = request.contract_id.into_owned();
+
+        match request.operation {
+            Operation::Read { method } => {
+                network
+                    .query(contract_id, method.into_owned(), payload)
+                    .await
+            }
+            Operation::Write { method } => {
+                network
+                    .mutate(contract_id, method.into_owned(), payload)
+                    .await
+            }
+        }
+    }
+}
+
+impl Network {
+    async fn query(
+        &self,
+        contract_id: String,
+        method: String,
+        args: Vec<u8>,
+    ) -> Result<Vec<u8>, ZkSyncError> {
+        let address = contract_id
+            .parse::<Address>()
+            .map_err(|e| ZkSyncError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: e.to_string(),
+            })?;
+
+        let method_selector = &keccak256(method.as_bytes())[..4];
+
+        let call_data = [method_selector, &args].concat();
+
+        let request = TransactionRequest::default()
+            .to(address)
+            .input(Bytes::from(call_data).into());
+
+        let bytes = self
+            .provider
+            .call(&request)
+            .block(BlockId::latest())
+            .await
+            .map_err(|e| ZkSyncError::Custom {
+                operation: ErrorOperation::Query,
+                reason: format!("Failed to execute eth_call: {}", e),
+            })?;
+
+        Ok(bytes.into())
+    }
+
+    pub async fn mutate(
+        &self,
+        contract_id: String,
+        method: String,
+        args: Vec<u8>,
+    ) -> Result<Vec<u8>, ZkSyncError> {
+        let address = contract_id
+            .parse::<Address>()
+            .map_err(|e| ZkSyncError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: e.to_string(),
+            })?;
+
+        let method_selector = &keccak256(method.as_bytes());
+
+        let mut selector = [0u8; 4];
+        selector.copy_from_slice(&method_selector[0..4]);
+
+        let mut call_data = Vec::with_capacity(4 + args.len());
+        call_data.extend_from_slice(&selector);
+        call_data.extend_from_slice(&args);
+
+        let request = TransactionRequest::default()
+            .to(address)
+            .input(Bytes::from(call_data).into());
+
+        // Send the transaction, wait for it to be confirmed, and get the receipt
+        let tx = self
+            .provider
+            .send_transaction(request.clone())
+            .await
+            .map_err(|e| ZkSyncError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: format!("Failed to send transaction: {}", e),
+            })?;
+
+        let receipt = tx
+            .with_required_confirmations(1)
+            .with_timeout(Some(Duration::from_secs(60)))
+            .get_receipt()
+            .await
+            .map_err(|e| ZkSyncError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: format!("Failed to get transaction receipt: {}", e),
+            })?;
+
+        if !receipt.status() {
+            return Err(ZkSyncError::Custom {
+                operation: ErrorOperation::Mutate,
+                reason: "Transaction failed".to_owned(),
+            });
+        }
+
+        Ok(receipt.logs_bloom().as_slice().to_vec())
+    }
+} 

--- a/e2e-tests/src/config.rs
+++ b/e2e-tests/src/config.rs
@@ -6,6 +6,7 @@ use crate::protocol::ethereum::EthereumProtocolConfig;
 use crate::protocol::icp::IcpProtocolConfig;
 use crate::protocol::near::NearProtocolConfig;
 use crate::protocol::stellar::StellarProtocolConfig;
+use crate::protocol::zksync::ZkSyncProtocolConfig;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -38,4 +39,5 @@ pub enum ProtocolSandboxConfig {
     Icp(IcpProtocolConfig),
     Stellar(StellarProtocolConfig),
     Ethereum(EthereumProtocolConfig),
+    ZkSync(ZkSyncProtocolConfig),
 }

--- a/e2e-tests/src/protocol.rs
+++ b/e2e-tests/src/protocol.rs
@@ -3,11 +3,13 @@ use eyre::Result as EyreResult;
 use icp::IcpSandboxEnvironment;
 use near::NearSandboxEnvironment;
 use stellar::StellarSandboxEnvironment;
+use zksync::ZkSyncSandboxEnvironment;
 
 pub mod ethereum;
 pub mod icp;
 pub mod near;
 pub mod stellar;
+pub mod zksync;
 
 #[derive(Debug, Clone)]
 pub enum ProtocolSandboxEnvironment {
@@ -15,6 +17,7 @@ pub enum ProtocolSandboxEnvironment {
     Icp(IcpSandboxEnvironment),
     Stellar(StellarSandboxEnvironment),
     Ethereum(EthereumSandboxEnvironment),
+    ZkSync(ZkSyncSandboxEnvironment),
 }
 
 impl ProtocolSandboxEnvironment {
@@ -24,6 +27,7 @@ impl ProtocolSandboxEnvironment {
             Self::Icp(env) => Ok(env.node_args()),
             Self::Stellar(env) => Ok(env.node_args()),
             Self::Ethereum(env) => Ok(env.node_args()),
+            Self::ZkSync(env) => Ok(env.node_args()),
         }
     }
 
@@ -33,6 +37,7 @@ impl ProtocolSandboxEnvironment {
             Self::Icp(_) => "icp",
             Self::Stellar(_) => "stellar",
             Self::Ethereum(_) => "ethereum",
+            Self::ZkSync(_) => "zksync",
         }
     }
 
@@ -56,6 +61,10 @@ impl ProtocolSandboxEnvironment {
                     .await
             }
             Self::Ethereum(env) => {
+                env.verify_external_contract_state(contract_id, method_name, args)
+                    .await
+            }
+            Self::ZkSync(env) => {
                 env.verify_external_contract_state(contract_id, method_name, args)
                     .await
             }

--- a/e2e-tests/src/protocol/zksync.rs
+++ b/e2e-tests/src/protocol/zksync.rs
@@ -1,0 +1,153 @@
+use core::time::Duration;
+use std::net::TcpStream;
+
+use alloy::eips::BlockId;
+use alloy::network::EthereumWallet;
+use alloy::primitives::{keccak256, Address, Bytes};
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::sol_types::SolValue;
+use alloy::transports::http::reqwest::Url as AlloyUrl;
+use eyre::{bail, OptionExt, Result as EyreResult};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// Configuration for zkSync protocol sandbox environment
+/// Contains necessary parameters for connecting to and interacting with zkSync network
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZkSyncProtocolConfig {
+    /// Address of the deployed Context Config contract
+    pub context_config_contract_id: String,
+    /// URL of the zkSync RPC endpoint
+    pub rpc_url: String,
+    /// zkSync account address used for transactions
+    pub account_id: String,
+    /// Private key for signing transactions
+    pub secret_key: String,
+}
+
+/// Represents the zkSync sandbox environment for testing
+/// Handles contract interactions and state verification
+#[derive(Debug, Clone)]
+pub struct ZkSyncSandboxEnvironment {
+    config: ZkSyncProtocolConfig,
+}
+
+impl ZkSyncSandboxEnvironment {
+    /// Initialize a new zkSync sandbox environment
+    ///
+    /// # Arguments
+    /// * `config` - Configuration parameters for the zkSync environment
+    ///
+    /// # Returns
+    /// * `EyreResult<Self>` - New instance or error if connection fails
+    pub fn init(config: ZkSyncProtocolConfig) -> EyreResult<Self> {
+        // Parse and validate RPC URL
+        let rpc_url = Url::parse(&config.rpc_url)?;
+        let rpc_host = rpc_url
+            .host_str()
+            .ok_or_eyre("failed to get zksync rpc host from config")?;
+        let rpc_port = rpc_url
+            .port()
+            .ok_or_eyre("failed to get zksync rpc port from config")?;
+
+        // Test connection to RPC endpoint
+        if let Err(err) = TcpStream::connect_timeout(
+            &format!("{rpc_host}:{rpc_port}").parse()?,
+            Duration::from_secs(3),
+        ) {
+            bail!(
+                "Failed to connect to zksync rpc url '{}': {}",
+                &config.rpc_url,
+                err
+            );
+        }
+
+        Ok(Self { config })
+    }
+
+    /// Generate node configuration arguments for zkSync protocol
+    ///
+    /// # Returns
+    /// * `Vec<String>` - List of configuration arguments for the node
+    pub fn node_args(&self) -> Vec<String> {
+        vec![
+            // Protocol and network configuration
+            format!("context.config.zksync.protocol=\"{}\"", "zksync"),
+            format!("context.config.zksync.network=\"{}\"", "mainnet"),
+            format!(
+                "context.config.zksync.contract_id=\"{}\"",
+                self.config.context_config_contract_id
+            ),
+            // Signer configuration
+            format!("context.config.zksync.signer=\"{}\"", "self"),
+            format!(
+                "context.config.signer.self.zksync.mainnet.rpc_url=\"{}\"",
+                self.config.rpc_url
+            ),
+            format!(
+                "context.config.signer.self.zksync.mainnet.account_id=\"{}\"",
+                self.config.account_id
+            ),
+            format!(
+                "context.config.signer.self.zksync.mainnet.secret_key=\"{}\"",
+                self.config.secret_key
+            ),
+        ]
+    }
+
+    /// Verify the state of an external contract by calling a specified method
+    ///
+    /// # Arguments
+    /// * `contract_id` - Address of the contract to verify
+    /// * `method_name` - Name of the method to call
+    /// * `args` - Arguments to pass to the method
+    ///
+    /// # Returns
+    /// * `EyreResult<Option<String>>` - Result of the contract call or error
+    pub async fn verify_external_contract_state(
+        &self,
+        contract_id: &str,
+        method_name: &str,
+        args: &Vec<String>,
+    ) -> EyreResult<Option<String>> {
+        let access_key: PrivateKeySigner = PrivateKeySigner::from_str(&self.config.secret_key)
+            .wrap_err("failed to convert secret key to PrivateKeySigner")?;
+
+        let wallet = EthereumWallet::from(access_key);
+
+        let provider: DynProvider<EthereumNetwork> = ProviderBuilder::new()
+            .wallet(wallet)
+            .on_http(AlloyUrl::parse(&self.config.rpc_url)?)
+            .erased();
+
+        let address = contract_id
+            .parse::<Address>()
+            .wrap_err("failed to parse contract address")?;
+
+        let method_selector = &keccak256(method_name.as_bytes())[..4];
+
+        let mut call_data = Vec::with_capacity(4 + args.len() * 32);
+        call_data.extend_from_slice(method_selector);
+
+        for arg in args {
+            let bytes = hex::decode(arg.strip_prefix("0x").unwrap_or(arg))
+                .wrap_err("failed to decode argument")?;
+            call_data.extend_from_slice(&bytes);
+        }
+
+        let request = TransactionRequest::default()
+            .to(address)
+            .input(Bytes::from(call_data).into());
+
+        let bytes = provider
+            .call(&request)
+            .block(BlockId::latest())
+            .await
+            .wrap_err("failed to execute eth_call")?;
+
+        Ok(Some(format!("0x{}", hex::encode(bytes))))
+    }
+} 

--- a/e2e-tests/src/protocol/zksync.rs
+++ b/e2e-tests/src/protocol/zksync.rs
@@ -150,4 +150,4 @@ impl ZkSyncSandboxEnvironment {
 
         Ok(Some(format!("0x{}", hex::encode(bytes))))
     }
-} 
+}

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -18,6 +18,7 @@ export enum Network {
   ZK = 'ZK',
   STARKNET = 'STARKNET',
   ICP = 'ICP',
+  ZKSYNC = 'ZKSYNC',
 }
 
 export interface ContextClientKeysList {

--- a/node-ui/src/utils/ethWalletType.ts
+++ b/node-ui/src/utils/ethWalletType.ts
@@ -10,6 +10,8 @@ export const getNetworkType = (chainId: string): WalletType => {
       return WalletType.ETH({ chainId: 42161 });
     case '0x144':
       return WalletType.ETH({ chainId: 324 });
+    case '0x118':
+      return WalletType.ETH({ chainId: 280 });
     default:
       return WalletType.ETH({ chainId: 1 });
   }

--- a/node-ui/src/utils/rootkey.ts
+++ b/node-ui/src/utils/rootkey.ts
@@ -61,6 +61,8 @@ const getMetamaskType = (chainId: number): Network => {
       return Network.ARB;
     case 324:
       return Network.ZK;
+    case 280:
+      return Network.ZKSYNC;
     default:
       return Network.ETH;
   }


### PR DESCRIPTION
# [product] zkSync support

## Description

Start adding zkSync support by copying the Ethereum approach already executed by the team previously

Adding initial support for zkSync network by following the same patterns
used for Ethereum implementation. The changes include:

- Added zkSync protocol implementation with transport and network configuration
- Added zkSync support to the client environment
- Added e2e test support with zkSync sandbox environment
- Updated frontend to support zkSync network type and chain ID (280)
- Added zkSync to protocol sandbox configuration

The implementation reuses the Ethereum-compatible approach since zkSync is EVM-compatible,
with appropriate modifications for zkSync-specific configurations and network parameters.


## Test plan

Test the way a newly added network is tested (TBD).

## Documentation update

Add the corresponding "new network support" section in the docs.