### PR TITLE
feat: added a simple bash script to run the localnet

### DIFF
--- a/crates/merod/run_localnet.sh
+++ b/crates/merod/run_localnet.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+# Set default NODE_HOME 
+: ${NODE_HOME:="$HOME/.calimero"}
+
+# Check if an argument was provided
+if [ $# -eq 0 ]; then
+  echo "Please provide the number of local nodes argument."
+  exit 1
+fi
+
+# Get the first command line argument
+N=$1
+
+# Array to store PIDs of running nodes
+declare -a NODE_PIDS
+
+# Function to cleanup on exit
+cleanup() {
+    echo -e "\n\x1b[1;36m(i)\x1b[39m Cleaning up..."
+    for pid in "${NODE_PIDS[@]}"; do
+        if ps -p "$pid" > /dev/null; then
+            echo -e " \x1b[1;36m|\x1b[0m Stopping node with PID: $pid"
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    echo -e " \x1b[1;32m✔\x1b[39m Cleanup complete.\x1b[0m"
+}
+
+# Set up trap to ensure cleanup runs on script exit
+trap cleanup EXIT
+
+cargo build --bin merod
+
+echo -e "\x1b[1;36m(i)\x1b[39m Starting $N local nodes...\x1b[0m"
+
+# Start each node in the background
+for ((i = 1; i <= N; i++)); do
+    node_home="$HOME/.calimero/"
+    echo -e " \x1b[1;36m|\x1b[0m Starting Node $i..."
+    
+    # Start the node in the background and capture its PID
+    ./target/debug/merod --home "$node_home" --node-name "node$i" run > "$node_home/node.log" 2>&1 &
+    NODE_PIDS[$i]=$!
+    
+    # Wait a bit to ensure the node has time to start
+    sleep 2
+    
+    # Check if the process is still running
+    if ! ps -p "${NODE_PIDS[$i]}" > /dev/null; then
+        echo -e " \x1b[1;31m✖\x1b[39m \x1b[33mNode $i\x1b[39m failed to start. Check $node_home/node.log for details.\x1b[0m"
+        exit 1
+    fi
+    
+    echo -e " \x1b[1;32m✔\x1b[39m \x1b[33mNode $i\x1b[39m started with PID: ${NODE_PIDS[$i]}\x1b[0m"
+done
+
+echo -e "\x1b[1;32m✔\x1b[39m All $N nodes started successfully.\x1b[0m"
+echo -e "\x1b[1;36m(i)\x1b[39m Press Ctrl+C to stop all nodes.\x1b[0m"
+
+# Keep the script running and wait for Ctrl+C
+while true; do
+    sleep 1
+done 


### PR DESCRIPTION
Added a simple script to run a set of nodes locally.

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

```
chefsale@chefsale-X670-GAMING-X-AX-V2:~/workspace/core$ ./crates/merod/gen_localnet_configs.sh 3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s
(i) Initializing Node 1 at /home/chefsale/.calimero/node1
 |  2025-04-11T11:14:55.406356Z  INFO merod::cli::init: Generated identity: PeerId("12D3KooWAvGTnP5EFu3gnSEhmSHpYV4jfP3FvWyUee4C5pRtaPrh")
 |  2025-04-11T11:14:55.464922Z  INFO merod::cli::init: Initialized a node in "/home/chefsale/.calimero/node1"
 ✔ Node 1 initialized.
(i) Initializing Node 2 at /home/chefsale/.calimero/node2
 |  2025-04-11T11:14:55.482611Z  INFO merod::cli::init: Generated identity: PeerId("12D3KooWPq6RVXnzxmdJqnAu8LKhhZFEDwGJrYFzh5DCka1KNNxp")
 |  2025-04-11T11:14:55.534917Z  INFO merod::cli::init: Initialized a node in "/home/chefsale/.calimero/node2"
 ✔ Node 2 initialized.
(i) Initializing Node 3 at /home/chefsale/.calimero/node3
 |  2025-04-11T11:14:55.552674Z  INFO merod::cli::init: Generated identity: PeerId("12D3KooWD9Dhqd271Nvw8kGkAtzrt2wqsQEkmezT7aGtYycM1RaD")
 |  2025-04-11T11:14:55.607013Z  INFO merod::cli::init: Initialized a node in "/home/chefsale/.calimero/node3"
 ✔ Node 3 initialized.
chefsale@chefsale-X670-GAMING-X-AX-V2:~/workspace/core$ ./crates/merod/run_localnet.sh 
Please provide the number of local nodes argument.
chefsale@chefsale-X670-GAMING-X-AX-V2:~/workspace/core$ ./crates/merod/run_localnet.sh 3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
(i) Starting 3 local nodes...
 | Starting Node 1...
 ✔ Node 1 started with PID: 79696
 | Starting Node 2...
 ✔ Node 2 started with PID: 79874
 | Starting Node 3...
 ✔ Node 3 started with PID: 80052
✔ All 3 nodes started successfully.
(i) Press Ctrl+C to stop all nodes.
```