### PR TITLE
feat: expand possible inputs to `app::bail!`

### DIFF
--- a/apps/only-peers/src/lib.rs
+++ b/apps/only-peers/src/lib.rs
@@ -1,6 +1,5 @@
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_sdk::types::Error;
 use calimero_sdk::{app, env};
 use calimero_storage::collections::Vector;
 
@@ -50,23 +49,24 @@ impl OnlyPeers {
         OnlyPeers::default()
     }
 
-    pub fn post(&self, id: usize) -> Result<Option<Post>, Error> {
-        env::log(&format!("Getting post with id: {:?}", id));
+    pub fn post(&self, id: usize) -> app::Result<Option<Post>> {
+        app::log!("Getting post with id: {:?}", id);
 
         Ok(self.posts.get(id)?)
     }
 
-    pub fn posts(&self) -> Result<Vec<Post>, Error> {
-        env::log("Getting all posts");
+    pub fn posts(&self) -> app::Result<Vec<Post>> {
+        app::log!("Getting all posts");
 
-        Ok(self.posts.entries()?.collect())
+        Ok(self.posts.iter()?.collect())
     }
 
-    pub fn create_post(&mut self, title: String, content: String) -> Result<Post, Error> {
-        env::log(&format!(
+    pub fn create_post(&mut self, title: String, content: String) -> app::Result<Post> {
+        app::log!(
             "Creating post with title: {:?} and content: {:?}",
-            title, content
-        ));
+            title,
+            content
+        );
 
         app::emit!(Event::PostCreated {
             id: self.posts.len()?,
@@ -93,11 +93,13 @@ impl OnlyPeers {
         post_id: usize,
         user: String, // todo! expose executor identity to app context
         text: String,
-    ) -> Result<Option<Comment>, Error> {
-        env::log(&format!(
+    ) -> app::Result<Option<Comment>> {
+        app::log!(
             "Creating comment under post with id: {:?} as user: {:?} with text: {:?}",
-            post_id, user, text
-        ));
+            post_id,
+            user,
+            text
+        );
 
         let Some(mut post) = self.posts.get(post_id)? else {
             return Ok(None);

--- a/apps/visited/src/lib.rs
+++ b/apps/visited/src/lib.rs
@@ -1,10 +1,7 @@
 #![allow(clippy::len_without_is_empty)]
 
-use std::result::Result;
-
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use calimero_sdk::types::Error;
 use calimero_storage::collections::{UnorderedMap, UnorderedSet};
 
 #[app::state]
@@ -23,15 +20,15 @@ impl VisitedCities {
         }
     }
 
-    pub fn add_person(&mut self, person: String) -> Result<bool, Error> {
+    pub fn add_person(&mut self, person: String) -> app::Result<bool> {
         Ok(self.visited.insert(person, UnorderedSet::new())?.is_some())
     }
 
-    pub fn add_visited_city(&mut self, person: String, city: String) -> Result<bool, Error> {
+    pub fn add_visited_city(&mut self, person: String, city: String) -> app::Result<bool> {
         Ok(self.visited.get(&person)?.unwrap().insert(city)?)
     }
 
-    pub fn get_person_with_most_cities_visited(&self) -> Result<String, Error> {
+    pub fn get_person_with_most_cities_visited(&self) -> app::Result<String> {
         let mut max = 0;
         let mut person = String::new();
 
@@ -42,6 +39,7 @@ impl VisitedCities {
                 person = person_key.clone();
             }
         }
+
         Ok(person)
     }
 }

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -5,6 +5,7 @@
 
 use macros::parse_macro_input;
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{Expr, ItemImpl};
 
@@ -86,4 +87,11 @@ pub fn emit(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Expr);
 
     quote!(::calimero_sdk::event::emit(#input)).into()
+}
+
+#[proc_macro]
+pub fn bail(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TokenStream2);
+
+    quote!(::calimero_sdk::__bail__!(#input)).into()
 }

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -90,6 +90,13 @@ pub fn emit(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
+pub fn err(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TokenStream2);
+
+    quote!(::calimero_sdk::__err__!(#input)).into()
+}
+
+#[proc_macro]
 pub fn bail(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as TokenStream2);
 

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -92,17 +92,13 @@ pub fn emit(input: TokenStream) -> TokenStream {
 pub fn bail(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Expr);
 
-    if let Expr::Lit(lit) = &input {
-        if let syn::Lit::Str(str) = &lit.lit {
-            return quote! {
-                return Err(::calimero_sdk::types::Error::msg(#str));
-            }
-            .into();
-        }
-    }
+    quote! {{
+        let wrapped = ::calimero_sdk::types::__private::Wrap(#input);
 
-    quote! {
-        return Err(::calimero_sdk::types::Error::from(#input));
-    }
+        {
+            use ::calimero_sdk::types::__private::*;
+            return ::core::result::Result::Err(wrapped.into_error());
+        }
+    }}
     .into()
 }

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -87,18 +87,3 @@ pub fn emit(input: TokenStream) -> TokenStream {
 
     quote!(::calimero_sdk::event::emit(#input)).into()
 }
-
-#[proc_macro]
-pub fn bail(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as Expr);
-
-    quote! {{
-        let wrapped = ::calimero_sdk::types::__private::Wrap(#input);
-
-        {
-            use ::calimero_sdk::types::__private::*;
-            return ::core::result::Result::Err(wrapped.into_error());
-        }
-    }}
-    .into()
-}

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -102,3 +102,10 @@ pub fn bail(input: TokenStream) -> TokenStream {
 
     quote!(::calimero_sdk::__bail__!(#input)).into()
 }
+
+#[proc_macro]
+pub fn log(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TokenStream2);
+
+    quote!(::calimero_sdk::__log__!(#input)).into()
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -13,7 +13,7 @@ pub mod app {
 
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-    pub use calimero_sdk_macros::{bail, destroy, emit, event, init, logic, state};
+    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, logic, state};
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -13,7 +13,7 @@ pub mod app {
 
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, logic, state};
+    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, log, logic, state};
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -13,9 +13,7 @@ pub mod app {
 
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-    pub use calimero_sdk_macros::{destroy, emit, event, init, logic, state};
-
-    pub use super::__bail as bail;
+    pub use calimero_sdk_macros::{bail, destroy, emit, event, init, logic, state};
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -2,6 +2,7 @@ pub use {borsh, serde, serde_json};
 
 pub mod env;
 pub mod event;
+mod macros;
 mod returns;
 pub mod state;
 mod sys;
@@ -12,7 +13,9 @@ pub mod app {
 
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-    pub use calimero_sdk_macros::{bail, destroy, emit, event, init, logic, state};
+    pub use calimero_sdk_macros::{destroy, emit, event, init, logic, state};
+
+    pub use super::__bail as bail;
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -28,3 +28,19 @@ macro_rules! __bail__ {
         return ::core::result::Result::Err($crate::__err__!($fmt, $($arg)*));
     };
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log__ {
+    ($fmt:literal $(,)?) => {
+        match ::std::format_args!($fmt) {
+            args => match args.as_str() {
+                Some(msg) => $crate::env::log(msg),
+                None => $crate::env::log(&::std::fmt::format(args)),
+            },
+        }
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::env::log(&::std::format!($fmt, $($arg)*))
+    };
+}

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -1,7 +1,7 @@
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __bail {
-    ($msg:literal) => {{
+macro_rules! __bail__ {
+    ($msg:literal $(,)?) => {{
         use $crate::types::__private::*;
         return Err((&&&&$crate::types::__private::Wrap(::std::format_args!($msg))).into_error());
     }};

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -1,17 +1,30 @@
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __bail__ {
+macro_rules! __err__ {
     ($msg:literal $(,)?) => {{
         use $crate::types::__private::*;
-        return Err((&&&&$crate::types::__private::Wrap(::std::format_args!($msg))).into_error());
+        (&&&&$crate::types::__private::Wrap(::std::format_args!($msg))).into_error()
     }};
-    ($msg:expr $(,)?) => {{
+    ($err:expr $(,)?) => {{
         #[allow(unused_imports, reason = "if expanding the next line fails, it reports this as unused")]
         use $crate::types::__private::*;
-        return Err((&&&&$crate::types::__private::Wrap($msg)).into_error());
+        (&&&&$crate::types::__private::Wrap($err)).into_error()
     }};
     ($fmt:expr, $($arg:tt)*) => {{
         use $crate::types::__private::*;
-        return Err((&&&&$crate::types::__private::Wrap(&::std::format!($fmt, $($arg)*))).into_error());
+        (&&&&$crate::types::__private::Wrap(&::std::format!($fmt, $($arg)*))).into_error()
     }};
+}
+
+#[macro_export]
+macro_rules! __bail__ {
+    ($msg:literal $(,)?) => {
+        return ::core::result::Result::Err($crate::__err__!($msg));
+    };
+    ($err:expr $(,)?) => {
+        return ::core::result::Result::Err($crate::__err__!($err));
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        return ::core::result::Result::Err($crate::__err__!($fmt, $($arg)*));
+    };
 }

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -1,0 +1,17 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __bail {
+    ($msg:literal) => {{
+        use $crate::types::__private::*;
+        return Err((&&&&$crate::types::__private::Wrap(::std::format_args!($msg))).into_error());
+    }};
+    ($msg:expr $(,)?) => {{
+        #[allow(unused_imports, reason = "if expanding the next line fails, it reports this as unused")]
+        use $crate::types::__private::*;
+        return Err((&&&&$crate::types::__private::Wrap($msg)).into_error());
+    }};
+    ($fmt:expr, $($arg:tt)*) => {{
+        use $crate::types::__private::*;
+        return Err((&&&&$crate::types::__private::Wrap(&::std::format!($fmt, $($arg)*))).into_error());
+    }};
+}

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -127,18 +127,18 @@ pub mod __private {
 mod tests {
     use super::__private::*;
     use super::*;
-    use crate::app;
+    use crate::{__bail__ as bail, app};
 
     fn _case1() -> app::Result<()> {
-        app::bail!("something happened");
+        bail!("something happened");
     }
 
     fn _case2() -> app::Result<()> {
-        app::bail!(Errorlike);
+        bail!(Errorlike);
     }
 
     fn _case3() -> app::Result<()> {
-        app::bail!(SerializableError {
+        bail!(SerializableError {
             name: "something happened".to_string()
         });
     }
@@ -146,11 +146,11 @@ mod tests {
     fn _case4() -> app::Result<()> {
         let arg = "happened";
 
-        app::bail!(format_args!("something {arg}"));
+        bail!(format_args!("something {arg}"));
     }
 
     // fn _case5() -> app::Result<()> {
-    //     app::bail!(Displayable("something happened"));
+    //     bail!(Displayable("something happened"));
     // }
 
     macro_rules! into_error {

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -1,33 +1,189 @@
-use core::error::Error as CoreError;
-use std::fmt::{Debug, Display};
+use std::fmt;
 
-use serde::{Serialize, Serializer};
+use serde::Serialize;
+use serde_json::Value;
 
 #[derive(Debug, Serialize)]
-pub struct Error(#[serde(serialize_with = "error_string")] Box<dyn CoreError>);
-
-fn error_string<S>(error: &impl AsRef<dyn CoreError>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&error.as_ref().to_string())
+pub struct Error {
+    error: Value,
+    #[cfg(test)]
+    flag: u8,
 }
 
 impl Error {
     #[must_use]
     pub fn msg<M>(msg: M) -> Self
     where
-        M: Display,
+        M: fmt::Display,
     {
-        Self(msg.to_string().into())
+        Self {
+            error: msg.to_string().into(),
+            #[cfg(test)]
+            flag: u8::MAX,
+        }
     }
 }
 
 impl<T> From<T> for Error
 where
-    T: CoreError + 'static,
+    T: core::error::Error,
 {
     fn from(error: T) -> Self {
-        Self(Box::new(error))
+        Self::msg(error)
+    }
+}
+
+#[doc(hidden)]
+pub mod __private {
+    use serde::Serialize;
+
+    use super::Error;
+
+    #[derive(Debug)]
+    pub struct Wrap<T>(pub T);
+
+    pub trait ViaStr {
+        fn into_error(&self) -> Error;
+    }
+
+    impl ViaStr for &&&Wrap<&str> {
+        fn into_error(&self) -> Error {
+            let Wrap(value) = self;
+            Error {
+                error: (*value).into(),
+                #[cfg(test)]
+                flag: 0,
+            }
+        }
+    }
+
+    pub trait ViaSerialize {
+        fn into_error(&self) -> Error;
+    }
+
+    impl<T> ViaSerialize for &&Wrap<T>
+    where
+        T: Serialize,
+    {
+        fn into_error(&self) -> Error {
+            let Wrap(value) = self;
+            Error {
+                error: serde_json::json!(value),
+                #[cfg(test)]
+                flag: 1,
+            }
+        }
+    }
+
+    pub trait ViaError {
+        fn into_error(&self) -> Error;
+    }
+
+    impl<T> ViaError for &Wrap<T>
+    where
+        T: core::error::Error,
+    {
+        fn into_error(&self) -> Error {
+            let Wrap(value) = self;
+            Error {
+                error: value.to_string().into(),
+                #[cfg(test)]
+                flag: 2,
+            }
+        }
+    }
+
+    pub trait ViaDisplay {
+        fn into_error(&self) -> Error;
+    }
+
+    impl<T> ViaDisplay for Wrap<T>
+    where
+        T: std::fmt::Display,
+    {
+        fn into_error(&self) -> Error {
+            let Wrap(value) = self;
+            Error {
+                error: value.to_string().into(),
+                #[cfg(test)]
+                flag: 3,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::__private::*;
+    use super::*;
+
+    macro_rules! into_error {
+        ($err:expr) => {
+            (&&&&Wrap($err)).into_error()
+        };
+    }
+
+    #[test]
+    fn test_specialization() {
+        let err = "beltalowda";
+
+        let error = into_error!(err);
+
+        dbg!(&error);
+        assert_eq!(error.flag, 0); // used `ViaStr`
+
+        struct Displayable;
+
+        impl fmt::Display for Displayable {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "Displayable")
+            }
+        }
+
+        let err = Displayable;
+
+        let error = into_error!(err);
+
+        dbg!(&error);
+        assert_eq!(error.flag, 3); // used `ViaDisplay`
+
+        #[derive(Debug)]
+        struct Errorlike;
+
+        impl core::error::Error for Errorlike {}
+
+        impl fmt::Display for Errorlike {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "Errorlike")
+            }
+        }
+
+        let err = Errorlike;
+
+        let error = into_error!(err);
+
+        dbg!(&error);
+        assert_eq!(error.flag, 2); // used `ViaError`
+
+        #[derive(Debug, Serialize)]
+        struct SerializableError {
+            name: String,
+        }
+
+        impl core::error::Error for SerializableError {}
+        impl fmt::Display for SerializableError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "SerializableError")
+            }
+        }
+
+        let err = SerializableError {
+            name: "felota".to_string(),
+        };
+
+        let error = into_error!(err);
+
+        dbg!(&error);
+        assert_eq!(error.flag, 1); // used `ViaSerialize`
     }
 }

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -4,9 +4,11 @@ use serde::Serialize;
 use serde_json::Value;
 
 #[derive(Debug, Serialize)]
+#[serde(transparent)]
 pub struct Error {
     error: Value,
     #[cfg(test)]
+    #[serde(skip)]
     flag: u8,
 }
 


### PR DESCRIPTION
## Description

Iterations on https://github.com/calimero-network/core/pull/1195.

The initial impl would always `Display` serializable errors, which isn't the best if you intend to parse it at the caller.

This patch uses [some](https://www.reddit.com/r/rust/comments/rnn32g/rust_already_has_specialization/) [rust-trickery](https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html), different from what we [previously](https://github.com/calimero-network/core/blob/0588c5e4cc0f9db2a83d76e4ce4c4a942d813e40/crates/sdk/macros/src/logic/method.rs#L136-L148) [had](https://github.com/calimero-network/core/blob/0588c5e4cc0f9db2a83d76e4ce4c4a942d813e40/crates/sdk/src/returns.rs) for return type serialization due to needing more than 2 overrides, but it essentially exploits related language features to enable this.

Now this expands possible inputs to `app::bail!` to the following:

```rust
// literal string (as before)
app::bail("unauthorized");

// Serialize if `MyError: Serialize` otherwise, `Display` if `MyError: Error`.
app::bail(MyError::Unauthorized);
```

## Test plan

tests are included, and they pass, plus apps are updated in #1199 and they compile

## Documentation update

after the hackathon