### PR TITLE
feat: introduce `app::log!` convenience macro

### DIFF
--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -102,3 +102,10 @@ pub fn bail(input: TokenStream) -> TokenStream {
 
     quote!(::calimero_sdk::__bail__!(#input)).into()
 }
+
+#[proc_macro]
+pub fn log(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TokenStream2);
+
+    quote!(::calimero_sdk::__log__!(#input)).into()
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -13,7 +13,7 @@ pub mod app {
 
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, logic, state};
+    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, log, logic, state};
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -28,3 +28,19 @@ macro_rules! __bail__ {
         return ::core::result::Result::Err($crate::__err__!($fmt, $($arg)*));
     };
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log__ {
+    ($fmt:literal $(,)?) => {
+        match ::std::format_args!($fmt) {
+            args => match args.as_str() {
+                Some(msg) => $crate::env::log(msg),
+                None => $crate::env::log(&::std::fmt::format(args)),
+            },
+        }
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::env::log(&::std::format!($fmt, $($arg)*))
+    };
+}


### PR DESCRIPTION
## Description

Add an `app::log!` macro which is behaviourally equivalent to the standard library's `println!`.

## Test plan

Tested locally, and in a secondary PR - #1199, I update the apps to use the `bail!` and `log!` macros.

## Documentation update

After the hackathon