### PR TITLE
chore: update the apps in core to use the new sdk macros

### DIFF
--- a/apps/only-peers/src/lib.rs
+++ b/apps/only-peers/src/lib.rs
@@ -1,6 +1,5 @@
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_sdk::types::Error;
 use calimero_sdk::{app, env};
 use calimero_storage::collections::Vector;
 
@@ -50,23 +49,24 @@ impl OnlyPeers {
         OnlyPeers::default()
     }
 
-    pub fn post(&self, id: usize) -> Result<Option<Post>, Error> {
-        env::log(&format!("Getting post with id: {:?}", id));
+    pub fn post(&self, id: usize) -> app::Result<Option<Post>> {
+        app::log!("Getting post with id: {:?}", id);
 
         Ok(self.posts.get(id)?)
     }
 
-    pub fn posts(&self) -> Result<Vec<Post>, Error> {
-        env::log("Getting all posts");
+    pub fn posts(&self) -> app::Result<Vec<Post>> {
+        app::log!("Getting all posts");
 
         Ok(self.posts.entries()?.collect())
     }
 
-    pub fn create_post(&mut self, title: String, content: String) -> Result<Post, Error> {
-        env::log(&format!(
+    pub fn create_post(&mut self, title: String, content: String) -> app::Result<Post> {
+        app::log!(
             "Creating post with title: {:?} and content: {:?}",
-            title, content
-        ));
+            title,
+            content
+        );
 
         app::emit!(Event::PostCreated {
             id: self.posts.len()?,
@@ -93,11 +93,13 @@ impl OnlyPeers {
         post_id: usize,
         user: String, // todo! expose executor identity to app context
         text: String,
-    ) -> Result<Option<Comment>, Error> {
-        env::log(&format!(
+    ) -> app::Result<Option<Comment>> {
+        app::log!(
             "Creating comment under post with id: {:?} as user: {:?} with text: {:?}",
-            post_id, user, text
-        ));
+            post_id,
+            user,
+            text
+        );
 
         let Some(mut post) = self.posts.get(post_id)? else {
             return Ok(None);

--- a/apps/only-peers/src/lib.rs
+++ b/apps/only-peers/src/lib.rs
@@ -58,7 +58,7 @@ impl OnlyPeers {
     pub fn posts(&self) -> app::Result<Vec<Post>> {
         app::log!("Getting all posts");
 
-        Ok(self.posts.entries()?.collect())
+        Ok(self.posts.iter()?.collect())
     }
 
     pub fn create_post(&mut self, title: String, content: String) -> app::Result<Post> {

--- a/apps/visited/src/lib.rs
+++ b/apps/visited/src/lib.rs
@@ -1,10 +1,7 @@
 #![allow(clippy::len_without_is_empty)]
 
-use std::result::Result;
-
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use calimero_sdk::types::Error;
 use calimero_storage::collections::{UnorderedMap, UnorderedSet};
 
 #[app::state]
@@ -23,15 +20,15 @@ impl VisitedCities {
         }
     }
 
-    pub fn add_person(&mut self, person: String) -> Result<bool, Error> {
+    pub fn add_person(&mut self, person: String) -> app::Result<bool> {
         Ok(self.visited.insert(person, UnorderedSet::new())?.is_some())
     }
 
-    pub fn add_visited_city(&mut self, person: String, city: String) -> Result<bool, Error> {
+    pub fn add_visited_city(&mut self, person: String, city: String) -> app::Result<bool> {
         Ok(self.visited.get(&person)?.unwrap().insert(city)?)
     }
 
-    pub fn get_person_with_most_cities_visited(&self) -> Result<String, Error> {
+    pub fn get_person_with_most_cities_visited(&self) -> app::Result<String> {
         let mut max = 0;
         let mut person = String::new();
 
@@ -42,6 +39,7 @@ impl VisitedCities {
                 person = person_key.clone();
             }
         }
+
         Ok(person)
     }
 }

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -102,3 +102,10 @@ pub fn bail(input: TokenStream) -> TokenStream {
 
     quote!(::calimero_sdk::__bail__!(#input)).into()
 }
+
+#[proc_macro]
+pub fn log(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TokenStream2);
+
+    quote!(::calimero_sdk::__log__!(#input)).into()
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -13,7 +13,7 @@ pub mod app {
 
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, logic, state};
+    pub use calimero_sdk_macros::{bail, destroy, emit, err, event, init, log, logic, state};
 }
 
 #[doc(hidden)]

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -28,3 +28,19 @@ macro_rules! __bail__ {
         return ::core::result::Result::Err($crate::__err__!($fmt, $($arg)*));
     };
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log__ {
+    ($fmt:literal $(,)?) => {
+        match ::std::format_args!($fmt) {
+            args => match args.as_str() {
+                Some(msg) => $crate::env::log(msg),
+                None => $crate::env::log(&::std::fmt::format(args)),
+            },
+        }
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::env::log(&::std::format!($fmt, $($arg)*))
+    };
+}


### PR DESCRIPTION
## Description

Update the apps in core to use the `app::bail!` (https://github.com/calimero-network/core/pull/1195 + https://github.com/calimero-network/core/pull/1197) and `app::log!` (https://github.com/calimero-network/core/pull/1198) macros.

## Test plan

It compiles

## Documentation update

After the hackathon