### PR TITLE
chore(storage): iron out some kinks

### DIFF
--- a/apps/only-peers/src/lib.rs
+++ b/apps/only-peers/src/lib.rs
@@ -58,7 +58,7 @@ impl OnlyPeers {
     pub fn posts(&self) -> app::Result<Vec<Post>> {
         app::log!("Getting all posts");
 
-        Ok(self.posts.entries()?.collect())
+        Ok(self.posts.iter()?.collect())
     }
 
     pub fn create_post(&mut self, title: String, content: String) -> app::Result<Post> {

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -1,15 +1,15 @@
 //! High-level data structures for storage.
 
-use core::fmt;
-use std::cell::RefCell;
+use core::cell::RefCell;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::{fmt, ptr};
 use std::collections::BTreeMap;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
-use std::ptr;
 use std::sync::LazyLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use indexmap::IndexSet;
+use sha2::{Digest, Sha256};
 
 pub mod unordered_map;
 pub use unordered_map::UnorderedMap;
@@ -30,6 +30,14 @@ use crate::entities::{ChildInfo, Data, Element};
 use crate::interface::{Interface, StorageError};
 use crate::store::{MainStorage, StorageAdaptor};
 use crate::{AtomicUnit, Collection};
+
+/// Compute the ID for a key.
+fn compute_id(parent: Id, key: &[u8]) -> Id {
+    let mut hasher = Sha256::new();
+    hasher.update(parent.as_bytes());
+    hasher.update(key);
+    Id::new(hasher.finalize().into())
+}
 
 mod compat {
     use std::collections::BTreeMap;
@@ -161,6 +169,10 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         let entry = <Interface<S>>::find_by_id::<Entry<_>>(id)?;
 
         Ok(entry.map(|entry| entry.item))
+    }
+
+    fn contains(&self, id: Id) -> StoreResult<bool> {
+        Ok(self.children_cache()?.contains(&id))
     }
 
     fn get_mut(&mut self, id: Id) -> StoreResult<Option<EntryMut<'_, T, S>>> {
@@ -408,5 +420,36 @@ impl<T: PartialOrd + BorshSerialize + BorshDeserialize, S: StorageAdaptor> Parti
         let r = other.entries().ok()?.flatten();
 
         l.partial_cmp(r)
+    }
+}
+
+impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Extend<(Option<Id>, T)>
+    for Collection<T, S>
+{
+    fn extend<I: IntoIterator<Item = (Option<Id>, T)>>(&mut self, iter: I) {
+        let path = self.path();
+
+        let mut collection = CollectionMut::new(self);
+
+        for (id, item) in iter {
+            let mut entry = Entry {
+                item,
+                storage: Element::new(&path, id),
+            };
+
+            collection
+                .insert(&mut entry)
+                .expect("collection extension failed");
+        }
+    }
+}
+
+impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> FromIterator<(Option<Id>, T)>
+    for Collection<T, S>
+{
+    fn from_iter<I: IntoIterator<Item = (Option<Id>, T)>>(iter: I) -> Self {
+        let mut collection = Collection::new(None);
+        collection.extend(iter);
+        collection
     }
 }

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -426,6 +426,7 @@ impl<T: PartialOrd + BorshSerialize + BorshDeserialize, S: StorageAdaptor> Parti
 impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Extend<(Option<Id>, T)>
     for Collection<T, S>
 {
+    #[expect(clippy::expect_used, reason = "fatal error if it happens")]
     fn extend<I: IntoIterator<Item = (Option<Id>, T)>>(&mut self, iter: I) {
         let path = self.path();
 


### PR DESCRIPTION
## Description

Patched some things that were notably absent, behaviorally inefficient or inappropriately named.

1. Should be able to create / extend;
	- an `UnorderedMap` from an iterator of `(K, V)`
	- an `UnorderedSet` from an iterator of `V`
	- a `Vector` from an iterator of `V`
2. `UnorderedMap<K, V>: Default` doesn't need `K: Default, V: Default`
3. Checking if the collection contains some key for `Unordered{Map,Set}` shouldn't need to read `V` from storage.

## Test plan

Apps compile, and it works locally

## Documentation update

The relevant bits are documented in-code, can triage to see if any external bits need to be updated but I doubt it