### PR TITLE
feat: added cargo deny check licenses and sources with the deny.toml

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           cargo test
 
+      - name: Cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses sources
+
   nodejs:
     name: NodeJS
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+[graph]
+targets = []
+
+[bans]
+multiple-versions = "warn"  # Warn about duplicate dependency versions
+
+# Skip specific crates that might need multiple versions
+[[bans.skip]]
+name = "ring"
+version = "*"
+
+[[bans.skip]]
+name = "tokio"
+version = "*"
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "OpenSSL",
+    "CC0-1.0",
+    "BSL-1.0",
+    "MPL-2.0",
+    "AGPL-3.0",
+    "GPL-3.0",
+    "LGPL-3.0",
+    "0BSD",
+    "Unlicense",
+    "Apache-2.0 WITH LLVM-exception",
+]
+
+# Add exceptions for packages with complex licensing
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "ISC OR OpenSSL OR MIT"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/xJonathanLEI/starknet-rs"]
+


### PR DESCRIPTION
added cargo deny check licenses and sources with the deny.toml

## Description
 added cargo deny check licenses and sources with the deny.toml, for now ignore all the issues, but revisit them later and clean them up one by one

also added the cleanup as subtask to https://github.com/calimero-network/core/issues/265

## Test plan
CI should run the check and pass.

## Documentation update
N/A
