### PR TITLE
fix: update output labels for application and context identifiers

### DIFF
--- a/crates/meroctl/src/cli/app.rs
+++ b/crates/meroctl/src/cli/app.rs
@@ -42,7 +42,7 @@ pub enum AppSubCommands {
 
 impl Report for Application {
     fn report(&self) {
-        println!("id: {}", self.id);
+        println!("application_id: {}", self.id);
         println!("size: {}", self.size);
         println!("blobId: {}", self.blob);
         println!("source: {}", self.source);

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -38,7 +38,7 @@ pub struct InstallCommand {
 
 impl Report for InstallApplicationResponse {
     fn report(&self) {
-        println!("id: {}", self.data.application_id);
+        println!("application_id: {}", self.data.application_id);
     }
 }
 

--- a/crates/meroctl/src/cli/context.rs
+++ b/crates/meroctl/src/cli/context.rs
@@ -68,7 +68,7 @@ pub enum ContextSubCommands {
 
 impl Report for Context {
     fn report(&self) {
-        println!("id: {}", self.id);
+        println!("context_id: {}", self.id);
         println!("application_id: {}", self.application_id);
         println!("root_hash: {}", self.root_hash);
     }

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -76,7 +76,7 @@ pub struct CreateCommand {
 
 impl Report for CreateContextResponse {
     fn report(&self) {
-        println!("id: {}", self.data.context_id);
+        println!("context_id: {}", self.data.context_id);
         println!("member_public_key: {}", self.data.member_public_key);
     }
 }


### PR DESCRIPTION
## Description
Changed generic "id" labels to more specific "context_id" and "application_id" in CLI output for better clarity. This improves user experience by clearly distinguishing between different types of identifiers. fix #1087

## Test plan
- Verified output format in all affected commands (create, list, get)
- Checked that context ID and application ID are correctly labeled

## Documentation update
-