### PR TITLE
feat: Introduced workflow for publishing merod and meroctl docker images

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,0 +1,164 @@
+name: Build and Publish Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - 'crates/**'
+      - 'core/Dockerfile'
+      - '.github/workflows/publish-docker-images.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - 'crates/**'
+      - 'core/Dockerfile'
+      - '.github/workflows/publish-docker-images.yml'
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+
+jobs:
+  prepare:
+    name: Prepare Docker Build
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' || 
+      github.event_name == 'push' || 
+      github.event_name == 'pull_request' || 
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    outputs:
+      version: ${{ steps.version_info.outputs.version }}
+      should_build: ${{ steps.version_info.outputs.should_build }}
+      prerelease: ${{ steps.version_info.outputs.prerelease }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get version info
+        id: version_info
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Default values
+          echo "should_build=false" >> $GITHUB_OUTPUT
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+          
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            # Extract version from the triggering workflow (Release)
+            latest_release=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
+            if [ -n "$latest_release" ]; then
+              echo "Using latest release version: $latest_release"
+              echo "version=$latest_release" >> $GITHUB_OUTPUT
+              echo "should_build=true" >> $GITHUB_OUTPUT
+            else
+              echo "No release version found"
+              exit 0
+            fi
+          else
+            # Similar logic to the release workflow
+            if [ -f "Cargo.toml" ]; then
+              version_candidate=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "merod") | .version')
+              echo "Version from Cargo: $version_candidate"
+              
+              if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+                echo "On master branch"
+                echo "version=$version_candidate" >> $GITHUB_OUTPUT
+                echo "should_build=true" >> $GITHUB_OUTPUT
+              elif [ "${{ github.event_name }}" == "pull_request" ] && [[ "${{ github.head_ref }}" == release/* ]]; then
+                echo "On release PR"
+                echo "version=prerelease-${{ github.event.number }}" >> $GITHUB_OUTPUT
+                echo "should_build=true" >> $GITHUB_OUTPUT
+                echo "prerelease=true" >> $GITHUB_OUTPUT
+              elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+                echo "Manual trigger"
+                echo "version=$version_candidate" >> $GITHUB_OUTPUT
+                echo "should_build=true" >> $GITHUB_OUTPUT
+              else
+                echo "Not building for this branch/PR"
+              fi
+            else
+              echo "No Cargo.toml found"
+            fi
+          fi
+
+  build-and-push:
+    name: Build and Push Docker Images
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata for merod
+        id: meta-merod
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/merod
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+
+      - name: Extract metadata for meroctl
+        id: meta-meroctl
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/meroctl
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+      
+      - name: Build and push merod image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./core/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          target: merod
+          tags: ${{ steps.meta-merod.outputs.tags }}
+          labels: ${{ steps.meta-merod.outputs.labels }}
+          annotations: |
+            org.opencontainers.image.description=Merod container image
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+      
+      - name: Build and push meroctl image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./core/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          target: meroctl
+          tags: ${{ steps.meta-meroctl.outputs.tags }}
+          labels: ${{ steps.meta-meroctl.outputs.labels }}
+          annotations: |
+            org.opencontainers.image.description=Meroctl container image
+            org.opencontainers.image.source=https://github.com/${{ github.repository }} 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,10 @@ RUN --mount=type=cache,target=/app/target/ \
 # Create a minimal runner stage for merod
 FROM debian:bookworm-slim AS merod
 
+# Add labels for container metadata
+LABEL org.opencontainers.image.description="Merod daemon"
+LABEL org.opencontainers.image.licenses="MIT"
+
 # Install only the essential runtime dependencies
 RUN apt-get update && apt-get install -y \
     libssl3 \
@@ -98,6 +102,10 @@ CMD ["--help"]
 ################################################################################
 # Create a minimal runner stage for meroctl
 FROM debian:bookworm-slim AS meroctl
+
+# Add labels for container metadata
+LABEL org.opencontainers.image.description="Meroctl - Control tool for Merod daemon"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # Install only the essential runtime dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
# [product] short description

## Description

Implemented workflow file for automatic release of `merod` and `meroctl` Docker images to GitHub Container Registry.

Key features:
- Follows the same rules for triggering as the binary release workflow
- Automatically builds when:
  - New releases are created
  - Changes to Cargo.toml, Cargo.lock, or crates/** on master branch
  - Pull requests with the release/* prefix
  - Manual trigger via GitHub Actions UI
- Creates multi-architecture images (amd64 and arm64)
- Images are tagged with proper version numbers from Cargo.toml
- Images include proper metadata and license information
- Container images are minimal, secure, and run as non-root users

## Test plan

- Manually trigger the workflow from GitHub Actions UI
- Check that correct Docker images were built and published to ghcr.io
- Pull images from ghcr.io/calimero-network/merod:latest
- Pull images from ghcr.io/calimero-network/meroctl:latest
- Run basic commands with both images

## Documentation update

N/A