### PR TITLE
Clean up credentials parsing from config

### DIFF
--- a/crates/context/config/src/client/config.rs
+++ b/crates/context/config/src/client/config.rs
@@ -8,6 +8,7 @@ use crate::client::protocol::ethereum::Credentials as EthereumCredentials;
 use crate::client::protocol::icp::Credentials as IcpCredentials;
 use crate::client::protocol::near::Credentials as NearCredentials;
 use crate::client::protocol::starknet::Credentials as StarknetCredentials;
+use crate::client::protocol::stellar::Credentials as StellarCredentials;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ClientConfig {
@@ -61,19 +62,19 @@ pub struct ClientRelayerSigner {
 pub struct ClientLocalSigner {
     pub rpc_url: Url,
     #[serde(flatten)]
-    pub credentials: Credentials,
+    pub near_credentials: Option<NearCredentials>, 
+    #[serde(flatten)]
+    pub starknet_credentials: Option<StarknetCredentials>,
+    #[serde(flatten)]
+    pub ethereum_credentials: Option<EthereumCredentials>,
+    #[serde(flatten)]
+    pub icp_credentials:Option<IcpCredentials>,
+    #[serde(flatten)]
+    pub stellar_credentials:Option<StellarCredentials>,
+    
 }
 
-#[non_exhaustive]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum Credentials {
-    Near(NearCredentials),
-    Starknet(StarknetCredentials),
-    Icp(IcpCredentials),
-    Ethereum(EthereumCredentials),
-    Raw(RawCredentials),
-}
+
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RawCredentials {

--- a/crates/context/config/src/client/protocol/ethereum.rs
+++ b/crates/context/config/src/client/protocol/ethereum.rs
@@ -60,6 +60,7 @@ pub struct NetworkConfig {
     pub rpc_url: Url,
     pub account_id: String,
     pub access_key: PrivateKeySigner,
+    pub public_key: String,
 }
 
 #[derive(Debug)]

--- a/crates/context/config/src/client/protocol/icp.rs
+++ b/crates/context/config/src/client/protocol/icp.rs
@@ -31,6 +31,7 @@ pub struct Credentials {
     pub account_id: Principal,
     pub public_key: String,
     pub secret_key: String,
+    
 }
 
 mod serde_creds {

--- a/crates/context/config/src/client/protocol/near.rs
+++ b/crates/context/config/src/client/protocol/near.rs
@@ -112,6 +112,7 @@ pub struct NetworkConfig {
     pub rpc_url: Url,
     pub account_id: AccountId,
     pub access_key: SecretKey,
+    pub public_key: Option<String>
 }
 
 #[derive(Debug)]

--- a/crates/context/config/src/client/protocol/starknet.rs
+++ b/crates/context/config/src/client/protocol/starknet.rs
@@ -95,6 +95,7 @@ pub struct NetworkConfig {
     pub rpc_url: Url,
     pub account_id: Felt,
     pub access_key: Felt,
+    pub public_key: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/context/config/src/client/protocol/stellar.rs
+++ b/crates/context/config/src/client/protocol/stellar.rs
@@ -52,6 +52,7 @@ pub struct NetworkConfig {
     pub network: String,
     pub public_key: String,
     pub secret_key: String,
+    
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR solves issue #1135

## Description

This PR introduces the following changes:

Skip public_key: For any protocol where the account_id is exactly the same as the public_key (e.g., NEAR, StarkNet), we no longer include the public_key in the wallet creation payload. This avoids redundancy and aligns with protocol expectations.

Fix signer resolution logic: Corrects the logic used when parsing protocol configuration. Previously, it selected context.config.<protocol> only if at least one context.config.signer.self.<protocol>.<network> entry existed. This allowed unexpected fallback to relayer mode, even when signer == "local" but no credentials were configured. Now, the logic ensures that:

If signer == "local", valid local credentials must be present.

If not, fallback to relayer does not occur unexpectedly.

Remove Credentials enum fallback: Eliminates the fallback-based parsing approach where the Credentials enum attempted to parse credentials for multiple protocols in sequence. This approach was error-prone:

Parsing ambiguity between protocols with similar credential constraints (e.g., same key types).

Risk of mistakenly parsing N+1 protocol credentials as a valid format for N.

Strict parsing per protocol is now enforced explicitly.



