### PR TITLE
feat(meroctl): Add event-triggered command execution to context watch

### DIFF
--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -1,10 +1,11 @@
+use std::process::Command;
+
 use calimero_primitives::alias::Alias;
 use calimero_primitives::context::ContextId;
 use calimero_server_primitives::ws::{Request, RequestPayload, Response, SubscribeRequest};
 use clap::Parser;
 use eyre::{OptionExt, Result as EyreResult};
 use futures_util::{SinkExt, StreamExt};
-use std::process::Command;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
@@ -77,7 +78,7 @@ impl WatchCommand {
         environment
             .output
             .write(&InfoLine(&format!("Subscribed to context {}", context_id)));
-        
+
         if let Some(cmd) = &self.exec {
             environment
                 .output
@@ -101,14 +102,14 @@ impl WatchCommand {
                     if let WsMessage::Text(text) = msg {
                         let response = serde_json::from_str::<Response>(&text)?;
                         environment.output.write(&response);
-                        
+
                         if let Some(cmd) = &self.exec {
                             let output = Command::new("sh")
                                 .arg("-c")
                                 .arg(cmd)
                                 .output()
                                 .map_err(|e| eyre::eyre!("Failed to execute command: {}", e))?;
-                            
+
                             if !output.status.success() {
                                 environment.output.write(&ErrorLine(&format!(
                                     "Command failed: {}",
@@ -121,14 +122,14 @@ impl WatchCommand {
                                 )));
                             }
                         }
-                        
+
                         event_count += 1;
                     }
                 }
                 Err(err) => {
-                    environment.output.write(&ErrorLine(&format!(
-                        "Error receiving message: {err}"
-                    )));
+                    environment
+                        .output
+                        .write(&ErrorLine(&format!("Error receiving message: {err}")));
                 }
             }
         }

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -1,11 +1,10 @@
-use std::process::Command;
-
 use calimero_primitives::alias::Alias;
 use calimero_primitives::context::ContextId;
 use calimero_server_primitives::ws::{Request, RequestPayload, Response, SubscribeRequest};
 use clap::Parser;
 use eyre::{OptionExt, Result as EyreResult};
 use futures_util::{SinkExt, StreamExt};
+use tokio::process::Command;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
@@ -108,6 +107,7 @@ impl WatchCommand {
                                 .arg("-c")
                                 .arg(cmd)
                                 .output()
+                                .await
                                 .map_err(|e| eyre::eyre!("Failed to execute command: {}", e))?;
 
                             if !output.status.success() {


### PR DESCRIPTION
## Description

Resolves https://github.com/calimero-network/core/issues/1072

I implemented a new meroctl command that listens for context events and triggers shell commands in response

## Test plan
Basic event watching (existing functionality)
`meroctl context watch`

Command execution
`meroctl context watch -x "echo 'Event received'"`

Event count limiting
`meroctl context watch -x "date" -c 3`


## Documentation update


