### PR TITLE
ci(e2e-tests): set serverHost to 0.0.0.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -174,6 +174,9 @@ jobs:
         run: |
           echo "Running e2e tests for ${{ matrix.protocol }}"
 
+          jq '.network.serverHost = "0.0.0.0"' \
+            e2e-tests/config/config.json > tmp.json && mv tmp.json e2e-tests/config/config.json
+
           ./target/debug/e2e-tests \
             --input-dir ./e2e-tests/config \
             --output-dir ./e2e-tests/corpus \


### PR DESCRIPTION
## Description
Attempt to fix `addr already in use` issue. Run the server on the same host as the swarm.
## Test plan
N/A
## Documentation update
N/A