### PR TITLE
Feat/capability management

### DIFF
--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -156,7 +156,19 @@ pub struct ContextStorageEntry {
     pub value: Vec<u8>,
 }
 
-#[derive(Eq, Ord, Copy, Debug, Clone, PartialEq, PartialOrd, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Eq,
+    Ord,
+    Copy,
+    Debug,
+    Clone,
+    PartialEq,
+    PartialOrd,
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
+)]
 pub struct ContextIdentity(Identity);
 
 impl ReprBytes for ContextIdentity {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -15,7 +15,8 @@ use calimero_context_config::client::{AnyTransport, Client as ExternalClient};
 use calimero_context_config::repr::{Repr, ReprBytes, ReprTransmute};
 use calimero_context_config::types::{
     Application as ApplicationConfig, ApplicationMetadata as ApplicationMetadataConfig,
-    ApplicationSource as ApplicationSourceConfig, Capability, ContextIdentity, ContextStorageEntry, ProposalId,
+    ApplicationSource as ApplicationSourceConfig, Capability, ContextIdentity, ContextStorageEntry,
+    ProposalId,
 };
 use calimero_context_config::{Proposal, ProposalAction, ProposalWithApprovals};
 use calimero_network::client::NetworkClient;
@@ -1624,7 +1625,10 @@ impl ContextManager {
         let Some(ContextIdentityValue {
             private_key: Some(signing_key),
             ..
-        }) = handle.get(&ContextIdentityKey::new(context_id, signing_key.public_key()))?
+        }) = handle.get(&ContextIdentityKey::new(
+            context_id,
+            signing_key.public_key(),
+        ))?
         else {
             bail!("No private key found for signer");
         };
@@ -1638,7 +1642,10 @@ impl ContextManager {
             )
             .fetch_nonce(
                 context_id.rt().expect("infallible conversion"),
-                signing_key.public_key().rt().expect("infallible conversion"),
+                signing_key
+                    .public_key()
+                    .rt()
+                    .expect("infallible conversion"),
             )
             .await?
             .ok_or_eyre("Not a member")?;
@@ -1649,7 +1656,10 @@ impl ContextManager {
                 context_config.network.as_ref().into(),
                 context_config.contract.as_ref().into(),
             )
-            .grant(context_id.rt().expect("infallible conversion"), capabilities)
+            .grant(
+                context_id.rt().expect("infallible conversion"),
+                capabilities,
+            )
             .send(signing_key, nonce)
             .await?;
 
@@ -1670,7 +1680,10 @@ impl ContextManager {
         let Some(ContextIdentityValue {
             private_key: Some(signing_key),
             ..
-        }) = handle.get(&ContextIdentityKey::new(context_id, signing_key.public_key()))?
+        }) = handle.get(&ContextIdentityKey::new(
+            context_id,
+            signing_key.public_key(),
+        ))?
         else {
             bail!("No private key found for signer");
         };
@@ -1684,7 +1697,10 @@ impl ContextManager {
             )
             .fetch_nonce(
                 context_id.rt().expect("infallible conversion"),
-                signing_key.public_key().rt().expect("infallible conversion"),
+                signing_key
+                    .public_key()
+                    .rt()
+                    .expect("infallible conversion"),
             )
             .await?
             .ok_or_eyre("Not a member")?;
@@ -1695,7 +1711,10 @@ impl ContextManager {
                 context_config.network.as_ref().into(),
                 context_config.contract.as_ref().into(),
             )
-            .revoke(context_id.rt().expect("infallible conversion"), capabilities)
+            .revoke(
+                context_id.rt().expect("infallible conversion"),
+                capabilities,
+            )
             .send(signing_key, nonce)
             .await?;
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1614,6 +1614,7 @@ impl ContextManager {
     pub async fn grant_capabilities(
         &self,
         context_id: ContextId,
+        signer_id: PublicKey,
         capabilities: &[(ContextIdentity, Capability)],
     ) -> EyreResult<()> {
         let handle = self.store.handle();
@@ -1625,10 +1626,7 @@ impl ContextManager {
         let Some(ContextIdentityValue {
             private_key: Some(signing_key),
             ..
-        }) = handle.get(&ContextIdentityKey::new(
-            context_id,
-            signing_key.public_key(),
-        ))?
+        }) = handle.get(&ContextIdentityKey::new(context_id, signer_id))?
         else {
             bail!("No private key found for signer");
         };
@@ -1642,10 +1640,7 @@ impl ContextManager {
             )
             .fetch_nonce(
                 context_id.rt().expect("infallible conversion"),
-                signing_key
-                    .public_key()
-                    .rt()
-                    .expect("infallible conversion"),
+                signer_id.rt().expect("infallible conversion"),
             )
             .await?
             .ok_or_eyre("Not a member")?;
@@ -1669,6 +1664,7 @@ impl ContextManager {
     pub async fn revoke_capabilities(
         &self,
         context_id: ContextId,
+        signer_id: PublicKey,
         capabilities: &[(ContextIdentity, Capability)],
     ) -> EyreResult<()> {
         let handle = self.store.handle();
@@ -1680,10 +1676,7 @@ impl ContextManager {
         let Some(ContextIdentityValue {
             private_key: Some(signing_key),
             ..
-        }) = handle.get(&ContextIdentityKey::new(
-            context_id,
-            signing_key.public_key(),
-        ))?
+        }) = handle.get(&ContextIdentityKey::new(context_id, signer_id))?
         else {
             bail!("No private key found for signer");
         };
@@ -1697,10 +1690,7 @@ impl ContextManager {
             )
             .fetch_nonce(
                 context_id.rt().expect("infallible conversion"),
-                signing_key
-                    .public_key()
-                    .rt()
-                    .expect("infallible conversion"),
+                signer_id.rt().expect("infallible conversion"),
             )
             .await?
             .ok_or_eyre("Not a member")?;

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -5,6 +5,8 @@ pub mod get_context_client_keys;
 pub mod get_context_identities;
 pub mod get_context_storage;
 pub mod get_contexts;
+pub mod grant_capabilities;
 pub mod invite_to_context;
 pub mod join_context;
+pub mod revoke_capabilities;
 pub mod update_context_application;

--- a/crates/server/src/admin/handlers/context/grant_capabilities.rs
+++ b/crates/server/src/admin/handlers/context/grant_capabilities.rs
@@ -30,8 +30,12 @@ pub async fn handler(
         }
     };
 
-    match state.ctx_manager.grant_capabilities(context.id, &request.capabilities).await {
+    match state
+        .ctx_manager
+        .grant_capabilities(context.id, &request.capabilities)
+        .await
+    {
         Ok(_) => ApiResponse { payload: () }.into_response(),
         Err(err) => parse_api_error(err).into_response(),
     }
-} 
+}

--- a/crates/server/src/admin/handlers/context/grant_capabilities.rs
+++ b/crates/server/src/admin/handlers/context/grant_capabilities.rs
@@ -5,14 +5,16 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context_config::types::{Capability, ContextIdentity};
 use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
 use serde::Deserialize;
 
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct GrantCapabilitiesRequest {
     pub capabilities: Vec<(ContextIdentity, Capability)>,
+    pub signer_id: PublicKey,
 }
 
 pub async fn handler(
@@ -32,7 +34,7 @@ pub async fn handler(
 
     match state
         .ctx_manager
-        .grant_capabilities(context.id, &request.capabilities)
+        .grant_capabilities(context.id, request.signer_id, &request.capabilities)
         .await
     {
         Ok(_) => ApiResponse { payload: () }.into_response(),

--- a/crates/server/src/admin/handlers/context/grant_capabilities.rs
+++ b/crates/server/src/admin/handlers/context/grant_capabilities.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use axum::extract::{Json, Path};
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_config::types::{Capability, ContextIdentity};
+use calimero_primitives::context::ContextId;
+use serde::Deserialize;
+
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+#[derive(Deserialize)]
+pub struct GrantCapabilitiesRequest {
+    pub capabilities: Vec<(ContextIdentity, Capability)>,
+}
+
+pub async fn handler(
+    Path(context_id): Path<ContextId>,
+    Extension(state): Extension<Arc<AdminState>>,
+    Json(request): Json<GrantCapabilitiesRequest>,
+) -> impl IntoResponse {
+    let context = match state.ctx_manager.get_context(&context_id) {
+        Ok(Some(context)) => context,
+        Ok(None) => {
+            return parse_api_error(eyre::eyre!("Context not found")).into_response();
+        }
+        Err(err) => {
+            return parse_api_error(err).into_response();
+        }
+    };
+
+    match state.ctx_manager.grant_capabilities(context.id, &request.capabilities).await {
+        Ok(_) => ApiResponse { payload: () }.into_response(),
+        Err(err) => parse_api_error(err).into_response(),
+    }
+} 

--- a/crates/server/src/admin/handlers/context/revoke_capabilities.rs
+++ b/crates/server/src/admin/handlers/context/revoke_capabilities.rs
@@ -30,7 +30,11 @@ pub async fn handler(
         }
     };
 
-    match state.ctx_manager.revoke_capabilities(context.id, &request.capabilities).await {
+    match state
+        .ctx_manager
+        .revoke_capabilities(context.id, &request.capabilities)
+        .await
+    {
         Ok(_) => ApiResponse { payload: () }.into_response(),
         Err(err) => parse_api_error(err).into_response(),
     }

--- a/crates/server/src/admin/handlers/context/revoke_capabilities.rs
+++ b/crates/server/src/admin/handlers/context/revoke_capabilities.rs
@@ -5,14 +5,16 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context_config::types::{Capability, ContextIdentity};
 use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
 use serde::Deserialize;
 
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct RevokeCapabilitiesRequest {
     pub capabilities: Vec<(ContextIdentity, Capability)>,
+    pub signer_id: PublicKey,
 }
 
 pub async fn handler(
@@ -32,7 +34,7 @@ pub async fn handler(
 
     match state
         .ctx_manager
-        .revoke_capabilities(context.id, &request.capabilities)
+        .revoke_capabilities(context.id, request.signer_id, &request.capabilities)
         .await
     {
         Ok(_) => ApiResponse { payload: () }.into_response(),

--- a/crates/server/src/admin/handlers/context/revoke_capabilities.rs
+++ b/crates/server/src/admin/handlers/context/revoke_capabilities.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use axum::extract::{Json, Path};
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_config::types::{Capability, ContextIdentity};
+use calimero_primitives::context::ContextId;
+use serde::Deserialize;
+
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+#[derive(Deserialize)]
+pub struct RevokeCapabilitiesRequest {
+    pub capabilities: Vec<(ContextIdentity, Capability)>,
+}
+
+pub async fn handler(
+    Path(context_id): Path<ContextId>,
+    Extension(state): Extension<Arc<AdminState>>,
+    Json(request): Json<RevokeCapabilitiesRequest>,
+) -> impl IntoResponse {
+    let context = match state.ctx_manager.get_context(&context_id) {
+        Ok(Some(context)) => context,
+        Ok(None) => {
+            return parse_api_error(eyre::eyre!("Context not found")).into_response();
+        }
+        Err(err) => {
+            return parse_api_error(err).into_response();
+        }
+    };
+
+    match state.ctx_manager.revoke_capabilities(context.id, &request.capabilities).await {
+        Ok(_) => ApiResponse { payload: () }.into_response(),
+        Err(err) => parse_api_error(err).into_response(),
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -19,6 +19,7 @@ use tower_sessions::{MemoryStore, SessionManagerLayer};
 use tracing::info;
 
 use super::handlers::alias;
+use super::handlers::context::{grant_capabilities, revoke_capabilities};
 use super::handlers::did::delete_did_handler;
 use super::handlers::proposals::{
     get_context_storage_entries_handler, get_context_value_handler,
@@ -134,6 +135,14 @@ pub(crate) fn setup(
         .route(
             "/contexts/:context_id/identities-owned",
             get(get_context_identities::handler),
+        )
+        .route(
+            "/contexts/:context_id/capabilities/grant",
+            post(grant_capabilities::handler),
+        )
+        .route(
+            "/contexts/:context_id/capabilities/revoke",
+            post(revoke_capabilities::handler),
         )
         .route("/contexts/invite", post(invite_to_context::handler))
         .route("/contexts/join", post(join_context::handler))

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -303,6 +303,10 @@ export interface CreateTokenResponse {
   data: JsonWebToken;
 }
 
+export interface CapabilitiesRequest {
+  capabilities: Array<[string, string]>; // [ContextIdentity, Capability]
+}
+
 export class NodeDataSource implements NodeApi {
   private client: HttpClient;
 
@@ -674,5 +678,55 @@ export class NodeDataSource implements NodeApi {
       },
       headers,
     );
+  }
+
+  async grantCapabilities(
+    contextId: string,
+    request: CapabilitiesRequest,
+  ): ApiResponse<void> {
+    try {
+      const headers: Header | null = await createAuthHeader(
+        contextId,
+        getNearEnvironment(),
+      );
+      if (!headers) {
+        return { error: { code: 401, message: t.unauthorizedErrorMessage } };
+      }
+
+      await this.client.post<void>(
+        `${getAppEndpointKey()}/admin-api/contexts/${contextId}/capabilities/grant`,
+        request,
+        headers,
+      );
+      return { data: undefined };
+    } catch (error) {
+      console.error('Error granting capabilities:', error);
+      return { error: { code: 500, message: 'Failed to grant capabilities.' } };
+    }
+  }
+
+  async revokeCapabilities(
+    contextId: string,
+    request: CapabilitiesRequest,
+  ): ApiResponse<void> {
+    try {
+      const headers: Header | null = await createAuthHeader(
+        contextId,
+        getNearEnvironment(),
+      );
+      if (!headers) {
+        return { error: { code: 401, message: t.unauthorizedErrorMessage } };
+      }
+
+      await this.client.post<void>(
+        `${getAppEndpointKey()}/admin-api/contexts/${contextId}/capabilities/revoke`,
+        request,
+        headers,
+      );
+      return { data: undefined };
+    } catch (error) {
+      console.error('Error revoking capabilities:', error);
+      return { error: { code: 500, message: 'Failed to revoke capabilities.' } };
+    }
   }
 }

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -305,6 +305,7 @@ export interface CreateTokenResponse {
 
 export interface CapabilitiesRequest {
   capabilities: Array<[string, string]>; // [ContextIdentity, Capability]
+  signer_id: string;
 }
 
 export class NodeDataSource implements NodeApi {
@@ -693,9 +694,14 @@ export class NodeDataSource implements NodeApi {
         return { error: { code: 401, message: t.unauthorizedErrorMessage } };
       }
 
+      const data = {
+        capabilities: request.capabilities,
+        signer_id: request.signer_id,
+      };
+      const url = `/contexts/${contextId}/capabilities/grant`;
       await this.client.post<void>(
-        `${getAppEndpointKey()}/admin-api/contexts/${contextId}/capabilities/grant`,
-        request,
+        `${getAppEndpointKey()}/admin-api${url}`,
+        data,
         headers,
       );
       return { data: undefined };
@@ -718,9 +724,14 @@ export class NodeDataSource implements NodeApi {
         return { error: { code: 401, message: t.unauthorizedErrorMessage } };
       }
 
+      const data = {
+        capabilities: request.capabilities,
+        signer_id: request.signer_id,
+      };
+      const url = `/contexts/${contextId}/capabilities/revoke`;
       await this.client.post<void>(
-        `${getAppEndpointKey()}/admin-api/contexts/${contextId}/capabilities/revoke`,
-        request,
+        `${getAppEndpointKey()}/admin-api${url}`,
+        data,
         headers,
       );
       return { data: undefined };

--- a/node-ui/src/api/dataSource/NodeDataSource.ts
+++ b/node-ui/src/api/dataSource/NodeDataSource.ts
@@ -726,7 +726,9 @@ export class NodeDataSource implements NodeApi {
       return { data: undefined };
     } catch (error) {
       console.error('Error revoking capabilities:', error);
-      return { error: { code: 500, message: 'Failed to revoke capabilities.' } };
+      return {
+        error: { code: 500, message: 'Failed to revoke capabilities.' },
+      };
     }
   }
 }

--- a/node-ui/src/api/nodeApi.ts
+++ b/node-ui/src/api/nodeApi.ts
@@ -20,6 +20,7 @@ import {
   CreateContextResponse,
   GetContextsResponse,
   Context,
+  CapabilitiesRequest,
 } from './dataSource/NodeDataSource';
 import { ApiResponse } from './response';
 
@@ -59,4 +60,12 @@ export interface NodeApi {
   uninstallApplication(
     applicationId: string,
   ): ApiResponse<UninstallApplicationResponse>;
+  grantCapabilities(
+    contextId: string,
+    request: CapabilitiesRequest,
+  ): ApiResponse<void>;
+  revokeCapabilities(
+    contextId: string,
+    request: CapabilitiesRequest,
+  ): ApiResponse<void>;
 }


### PR DESCRIPTION
# [core-node] Expose context capability management (grant/revoke) via API

## Description

This PR exposes the existing `grant` and `revoke` functionality, available in the context configuration contracts, through the node's admin API. This allows administrators or authorized identities to manage permissions within a context programmatically.

It introduces two new API endpoints:

*   `POST /admin-api/contexts/:context_id/capabilities/grant`
*   `POST /admin-api/contexts/:context_id/capabilities/revoke`

Both endpoints require a request body containing:
*   `capabilities`: An array of tuples `[ContextIdentity, Capability]`, where `ContextIdentity` is the base58 encoded public key string of the target identity and `Capability` is the permission being granted/revoked (e.g., "ManageMembers", "ManageApplication", "Proxy").
*   `signer_id`: The base58 encoded public key string of the identity performing and signing the action. This identity must have the necessary permissions to manage capabilities and must be owned by the node (i.e., the node must possess the corresponding private key).

This PR includes:
*   Addition of `grant_capabilities` and `revoke_capabilities` methods in `ContextManager` (`crates/context/src/lib.rs`).
*   Creation of corresponding API handlers (`crates/server/src/admin/handlers/context/grant_capabilities.rs` and `revoke_capabilities.rs`).
*   Updates to API service routing (`crates/server/src/admin/service.rs`).
*   Updates to the frontend API interface and data source (`node-ui/src/api/nodeApi.ts` and `node-ui/src/api/dataSource/NodeDataSource.ts`) to support calling these new endpoints.
*   Fixes for compilation errors by deriving `Serialize`, `Deserialize`, and `Debug` for necessary types (`ContextIdentity`, `GrantCapabilitiesRequest`, `RevokeCapabilitiesRequest`).

Fixes: #1070.