### PR TITLE
feat: Implement fine-grained permissions for context invitations

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -14,8 +14,7 @@ use calimero_context_config::client::utils::humanize_iter;
 use calimero_context_config::client::{AnyTransport, Client as ExternalClient};
 use calimero_context_config::repr::{Repr, ReprBytes, ReprTransmute};
 use calimero_context_config::types::{
-    Application as ApplicationConfig, ApplicationMetadata as ApplicationMetadataConfig,
-    ApplicationSource as ApplicationSourceConfig, ContextIdentity, ContextStorageEntry, ProposalId,
+    Application as ApplicationConfig, ApplicationMetadata as ApplicationMetadataConfig, ApplicationSource as ApplicationSourceConfig, Capability, ContextIdentity, ContextStorageEntry, ProposalId
 };
 use calimero_context_config::{Proposal, ProposalAction, ProposalWithApprovals};
 use calimero_network::client::NetworkClient;
@@ -1610,4 +1609,138 @@ impl ContextManager {
 
         Ok(aliases)
     }
+
+    pub async fn has_invite_permission(
+        &self,
+        context_id: ContextId,
+        public_key: PublicKey,
+    ) -> EyreResult<bool> {
+        let handle = self.store.handle();
+        
+        let Some(context_config) = handle.get(&ContextConfigKey::new(context_id))? else {
+            return Ok(false);
+        };
+
+        // Check if user has ManageMembers capability
+        let privileges = self
+            .config_client
+            .query::<ContextConfigEnv>(
+                context_config.protocol.as_ref().into(),
+                context_config.network.as_ref().into(),
+                context_config.contract.as_ref().into(),
+            )
+            .privileges(
+                context_id.rt().expect("infallible conversion"),
+                &[public_key.rt().expect("infallible conversion")],
+            )
+            .await?;
+
+        Ok(privileges
+            .values()
+            .flatten()
+            .any(|cap| *cap == Capability::ManageMembers))
+    }
+
+    pub async fn grant_permission(
+        &self,
+        context_id: ContextId,
+        granter_id: PublicKey,
+        grantee_id: PublicKey,
+        capability: Capability,
+    ) -> EyreResult<()> {
+        let handle = self.store.handle();
+
+        let Some(context_config) = handle.get(&ContextConfigKey::new(context_id))? else {
+            bail!("Context not found");
+        };
+
+        let Some(ContextIdentityValue {
+            private_key: Some(signing_key),
+            ..
+        }) = handle.get(&ContextIdentityKey::new(context_id, granter_id))?
+        else {
+            bail!("No private key found for granter");
+        };
+
+        let nonce = self
+            .config_client
+            .query::<ContextConfigEnv>(
+                context_config.protocol.as_ref().into(),
+                context_config.network.as_ref().into(),
+                context_config.contract.as_ref().into(),
+            )
+            .fetch_nonce(
+                context_id.rt().expect("infallible conversion"),
+                granter_id.rt().expect("infallible conversion"),
+            )
+            .await?
+            .ok_or_eyre("Granter is not a member")?;
+
+        self.config_client
+            .mutate::<ContextConfigEnv>(
+                context_config.protocol.as_ref().into(),
+                context_config.network.as_ref().into(),
+                context_config.contract.as_ref().into(),
+            )
+            .grant(
+                context_id.rt().expect("infallible conversion"),
+                &[(grantee_id.rt().expect("infallible conversion"), capability)],
+            )
+            .send(signing_key, nonce)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn revoke_permission(
+        &self,
+        context_id: ContextId,
+        revoker_id: PublicKey,
+        revokee_id: PublicKey,
+        capability: Capability,
+    ) -> EyreResult<()> {
+        let handle = self.store.handle();
+
+        let Some(context_config) = handle.get(&ContextConfigKey::new(context_id))? else {
+            bail!("Context not found");
+        };
+
+        let Some(ContextIdentityValue {
+            private_key: Some(signing_key),
+            ..
+        }) = handle.get(&ContextIdentityKey::new(context_id, revoker_id))?
+        else {
+            bail!("No private key found for revoker");
+        };
+
+        let nonce = self
+            .config_client
+            .query::<ContextConfigEnv>(
+                context_config.protocol.as_ref().into(),
+                context_config.network.as_ref().into(),
+                context_config.contract.as_ref().into(),
+            )
+            .fetch_nonce(
+                context_id.rt().expect("infallible conversion"),
+                revoker_id.rt().expect("infallible conversion"),
+            )
+            .await?
+            .ok_or_eyre("Revoker is not a member")?;
+
+        self.config_client
+            .mutate::<ContextConfigEnv>(
+                context_config.protocol.as_ref().into(),
+                context_config.network.as_ref().into(),
+                context_config.contract.as_ref().into(),
+            )
+            .revoke(
+                context_id.rt().expect("infallible conversion"),
+                &[(revokee_id.rt().expect("infallible conversion"), capability)],
+            )
+            .send(signing_key, nonce)
+            .await?;
+
+        Ok(())
+    }
+
 }

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -1,5 +1,5 @@
 use calimero_context_config::repr::Repr;
-use calimero_context_config::types::{ContextIdentity, ContextStorageEntry};
+use calimero_context_config::types::{Capability, ContextIdentity, ContextStorageEntry};
 use calimero_context_config::{Proposal, ProposalWithApprovals};
 use calimero_primitives::alias::Alias;
 use calimero_primitives::application::{Application, ApplicationId};
@@ -835,4 +835,81 @@ pub struct GetProposalApproversResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GetNumberOfProposalApprovalsResponse {
     pub data: ProposalWithApprovals,
+}
+
+
+// Add near the other request/response types in the Context API section
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrantPermissionRequest {
+    pub context_id: ContextId,
+    pub granter_id: PublicKey,
+    pub grantee_id: PublicKey,
+    pub capability: Capability,
+}
+
+impl GrantPermissionRequest {
+    pub const fn new(
+        context_id: ContextId,
+        granter_id: PublicKey,
+        grantee_id: PublicKey,
+        capability: Capability,
+    ) -> Self {
+        Self {
+            context_id,
+            granter_id,
+            grantee_id,
+            capability,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrantPermissionResponse {
+    pub data: Empty,
+}
+
+impl GrantPermissionResponse {
+    pub const fn new() -> Self {
+        Self { data: Empty {} }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokePermissionRequest {
+    pub context_id: ContextId,
+    pub revoker_id: PublicKey,
+    pub revokee_id: PublicKey,
+    pub capability: Capability,
+}
+
+impl RevokePermissionRequest {
+    pub const fn new(
+        context_id: ContextId,
+        revoker_id: PublicKey,
+        revokee_id: PublicKey,
+        capability: Capability,
+    ) -> Self {
+        Self {
+            context_id,
+            revoker_id,
+            revokee_id,
+            capability,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokePermissionResponse {
+    pub data: Empty,
+}
+
+impl RevokePermissionResponse {
+    pub const fn new() -> Self {
+        Self { data: Empty {} }
+    }
 }

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -8,3 +8,5 @@ pub mod get_contexts;
 pub mod invite_to_context;
 pub mod join_context;
 pub mod update_context_application;
+pub mod grant_permission;
+pub mod revoke_permission;

--- a/crates/server/src/admin/handlers/context/grant_permission.rs
+++ b/crates/server/src/admin/handlers/context/grant_permission.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use calimero_server_primitives::admin::{GrantPermissionRequest, GrantPermissionResponse};
+
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Extension(state): Extension<Arc<AdminState>>,
+    Json(req): Json<GrantPermissionRequest>,
+) -> impl IntoResponse {
+    let result = state
+        .ctx_manager
+        .grant_permission(
+            req.context_id,
+            req.granter_id,
+            req.grantee_id,
+            req.capability,
+        )
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(()) => ApiResponse {
+            payload: GrantPermissionResponse::new(),
+        }
+        .into_response(),
+        Err(err) => err.into_response(),
+    }
+}

--- a/crates/server/src/admin/handlers/context/invite_to_context.rs
+++ b/crates/server/src/admin/handlers/context/invite_to_context.rs
@@ -3,25 +3,45 @@ use std::sync::Arc;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use calimero_server_primitives::admin::{InviteToContextRequest, InviteToContextResponse};
+use reqwest::StatusCode;
 
-use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
     Json(req): Json<InviteToContextRequest>,
 ) -> impl IntoResponse {
-    let result = state
-        .ctx_manager
-        .invite_to_context(req.context_id, req.inviter_id, req.invitee_id)
-        .await
-        .map_err(parse_api_error);
+      // Check if inviter has permission to invite
+      let has_permission = state
+      .ctx_manager
+      .has_invite_permission(req.context_id, req.inviter_id)
+      .await
+      .map_err(parse_api_error);
 
-    match result {
-        Ok(invitation_payload) => ApiResponse {
-            payload: InviteToContextResponse::new(invitation_payload),
-        }
-        .into_response(),
-        Err(err) => err.into_response(),
-    }
+  match has_permission {
+      Ok(false) => {
+          return ApiError {
+              status_code: StatusCode::FORBIDDEN,
+              message: "User does not have permission to invite".to_string(),
+          }
+          .into_response()
+      }
+      Err(err) => return err.into_response(),
+      _ => (),
+  }
+
+  let result = state
+      .ctx_manager
+      .invite_to_context(req.context_id, req.inviter_id, req.invitee_id)
+      .await
+      .map_err(parse_api_error);
+
+  match result {
+      Ok(invitation_payload) => ApiResponse {
+          payload: InviteToContextResponse::new(invitation_payload),
+      }
+      .into_response(),
+      Err(err) => err.into_response(),
+  }
 }

--- a/crates/server/src/admin/handlers/context/revoke_permission.rs
+++ b/crates/server/src/admin/handlers/context/revoke_permission.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use calimero_server_primitives::admin::{RevokePermissionRequest, RevokePermissionResponse};
+
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Extension(state): Extension<Arc<AdminState>>,
+    Json(req): Json<RevokePermissionRequest>,
+) -> impl IntoResponse {
+    let result = state
+        .ctx_manager
+        .revoke_permission(
+            req.context_id,
+            req.revoker_id,
+            req.revokee_id,
+            req.capability,
+        )
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(()) => ApiResponse {
+            payload: RevokePermissionResponse::new(),
+        }
+        .into_response(),
+        Err(err) => err.into_response(),
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -37,7 +37,7 @@ use crate::admin::handlers::applications::{
 use crate::admin::handlers::challenge::request_challenge_handler;
 use crate::admin::handlers::context::{
     create_context, delete_context, get_context, get_context_client_keys, get_context_identities,
-    get_context_storage, get_contexts, invite_to_context, join_context, update_context_application,
+    get_context_storage, get_contexts, invite_to_context, join_context, update_context_application, revoke_permission, grant_permission,
 };
 use crate::admin::handlers::did::fetch_did_handler;
 use crate::admin::handlers::identity::generate_context_identity;
@@ -106,6 +106,8 @@ pub(crate) fn setup(
     let protected_router = Router::new()
         .route("/root-key", post(create_root_key_handler))
         .route("/install-application", post(install_application::handler))
+        .route("/contexts/grant-permission", post(grant_permission::handler))
+        .route("/contexts/revoke-permission", post(revoke_permission::handler))
         .route(
             "/uninstall-application",
             post(uninstall_application::handler),


### PR DESCRIPTION
## Description

Implemented a permission system for context invitations with:

- Permission verification before allowing invites

- New API endpoints for managing capabilities:

- POST /contexts/grant-permission

- POST /contexts/revoke-permission

Capability-based access control:

- Requires ManageMembers capability to invite users

- Maintains backward compatibility



## Test plan


## Documentation update

