### PR TITLE
fix: remove private key exposure

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1610,4 +1610,41 @@ impl ContextManager {
 
         Ok(aliases)
     }
+
+    /// Stores a ContextIdentity value directly.
+    /// Used internally and potentially by admin handlers for pre-storing keys.
+    pub fn store_identity_value(
+        &self,
+        context_id: ContextId,
+        public_key: PublicKey,
+        value: ContextIdentityValue,
+    ) -> EyreResult<()> {
+        let key = ContextIdentityKey::new(context_id, public_key);
+        let mut handle = self.store.handle();
+        handle.put(&key, &value)?;
+        Ok(())
+    }
+
+    /// Retrieves a complete ContextIdentity value.
+    pub fn get_identity_value(
+        &self,
+        context_id: ContextId,
+        public_key: PublicKey,
+    ) -> EyreResult<Option<ContextIdentityValue>> {
+        let key = ContextIdentityKey::new(context_id, public_key);
+        let handle = self.store.handle();
+        handle.get(&key).map_err(eyre::Report::from)
+    }
+
+    /// Deletes a ContextIdentity value.
+    pub fn delete_identity_value(
+        &self,
+        context_id: ContextId,
+        public_key: PublicKey,
+    ) -> EyreResult<()> {
+        let key = ContextIdentityKey::new(context_id, public_key);
+        let mut handle = self.store.handle();
+        handle.delete(&key)?;
+        Ok(())
+    }
 }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1611,8 +1611,6 @@ impl ContextManager {
         Ok(aliases)
     }
 
-    /// Stores a ContextIdentity value directly.
-    /// Used internally and potentially by admin handlers for pre-storing keys.
     pub fn store_identity_value(
         &self,
         context_id: ContextId,
@@ -1625,7 +1623,6 @@ impl ContextManager {
         Ok(())
     }
 
-    /// Retrieves a complete ContextIdentity value.
     pub fn get_identity_value(
         &self,
         context_id: ContextId,
@@ -1636,7 +1633,6 @@ impl ContextManager {
         handle.get(&key).map_err(eyre::Report::from)
     }
 
-    /// Deletes a ContextIdentity value.
     pub fn delete_identity_value(
         &self,
         context_id: ContextId,

--- a/crates/meroctl/src/cli/context/identity/generate.rs
+++ b/crates/meroctl/src/cli/context/identity/generate.rs
@@ -13,14 +13,13 @@ pub struct GenerateCommand;
 impl Report for GenerateContextIdentityResponse {
     fn report(&self) {
         println!("public_key: {}", self.data.public_key);
-        println!("private_key: {}", self.data.private_key);
     }
 }
 
 impl GenerateCommand {
     pub async fn run(self, environment: &Environment) -> EyreResult<()> {
         let private_key = PrivateKey::random(&mut rand::thread_rng());
-        let response = GenerateContextIdentityResponse::new(private_key.public_key(), private_key);
+        let response = GenerateContextIdentityResponse::new(private_key.public_key());
         environment.output.write(&response);
 
         Ok(())

--- a/crates/server-primitives/src/admin.rs
+++ b/crates/server-primitives/src/admin.rs
@@ -5,7 +5,7 @@ use calimero_primitives::alias::Alias;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextId, ContextInvitationPayload};
 use calimero_primitives::hash::Hash;
-use calimero_primitives::identity::{ClientKey, ContextUser, PrivateKey, PublicKey, WalletType};
+use calimero_primitives::identity::{ClientKey, ContextUser, PublicKey, WalletType};
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -346,17 +346,14 @@ impl InviteToContextResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JoinContextRequest {
-    pub private_key: PrivateKey,
+    pub public_key: PublicKey,
     pub invitation_payload: ContextInvitationPayload,
 }
 
 impl JoinContextRequest {
-    pub const fn new(
-        private_key: PrivateKey,
-        invitation_payload: ContextInvitationPayload,
-    ) -> Self {
+    pub const fn new(public_key: PublicKey, invitation_payload: ContextInvitationPayload) -> Self {
         Self {
-            private_key,
+            public_key,
             invitation_payload,
         }
     }
@@ -419,7 +416,6 @@ impl UpdateContextApplicationResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GenerateContextIdentityResponseData {
     pub public_key: PublicKey,
-    pub private_key: PrivateKey,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -429,12 +425,9 @@ pub struct GenerateContextIdentityResponse {
 }
 
 impl GenerateContextIdentityResponse {
-    pub const fn new(public_key: PublicKey, private_key: PrivateKey) -> Self {
+    pub const fn new(public_key: PublicKey) -> Self {
         Self {
-            data: GenerateContextIdentityResponseData {
-                public_key,
-                private_key,
-            },
+            data: GenerateContextIdentityResponseData { public_key },
         }
     }
 }

--- a/crates/server/src/admin/handlers/context/join_context.rs
+++ b/crates/server/src/admin/handlers/context/join_context.rs
@@ -1,19 +1,96 @@
 use std::sync::Arc;
 
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
+use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::{JoinContextRequest, JoinContextResponse};
+use tracing::error;
 
-use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
+
+// Placeholder Context ID used for storing unassigned keys
+const PLACEHOLDER_CONTEXT_ID_BYTES: [u8; 32] = [0; 32];
 
 pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
     Json(JoinContextRequest {
-        private_key,
+        public_key,
         invitation_payload,
     }): Json<JoinContextRequest>,
 ) -> impl IntoResponse {
+    // 1. Extract invitee_id from payload and verify it matches the provided public_key
+    let invitee_id_result = invitation_payload.parts().map(|(_, id, _, _, _)| id);
+    let _invitee_id = match invitee_id_result {
+        Ok(id) => {
+            if id != public_key {
+                error!("Public key in request does not match invitee ID in payload");
+                return ApiError {
+                    status_code: StatusCode::BAD_REQUEST,
+                    message: "Public key mismatch".into(),
+                }
+                .into_response();
+            }
+            id
+        }
+        Err(e) => {
+            error!("Failed to parse invitation payload: {}", e);
+            return ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "Invalid invitation payload".into(),
+            }
+            .into_response();
+        }
+    };
+
+    // 2. Retrieve the pre-stored private key using the ContextManager method
+    let private_key_result = (|| {
+        let placeholder_context_id = ContextId::from(PLACEHOLDER_CONTEXT_ID_BYTES);
+
+        let stored_identity = state
+            .ctx_manager
+            .get_identity_value(placeholder_context_id, public_key)?
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "Pre-stored private key not found for public key: {}",
+                    public_key
+                )
+            })?;
+
+        let private_key = stored_identity
+            .private_key
+            .ok_or_else(|| eyre::eyre!("Stored identity value is missing private key"))?;
+
+        // 3. Delete the temporary entry using the ContextManager method
+        state
+            .ctx_manager
+            .delete_identity_value(placeholder_context_id, public_key)?;
+
+        Ok::<_, eyre::Report>(private_key.into())
+    })();
+
+    let private_key = match private_key_result {
+        Ok(pk) => pk,
+        Err(e) => {
+            error!("Failed to retrieve or delete pre-stored key: {}", e);
+            // Use a specific error or a generic one
+            let api_error = if e.to_string().contains("Pre-stored private key not found") {
+                ApiError {
+                    status_code: StatusCode::BAD_REQUEST, // Or NOT_FOUND?
+                    message: "Identity generation process not completed or key expired".into(),
+                }
+            } else {
+                ApiError {
+                    status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: "Failed to process join request".into(),
+                }
+            };
+            return api_error.into_response();
+        }
+    };
+
+    // 4. Call the actual join context logic with the retrieved private key
     let result = state
         .ctx_manager
         .join_context(private_key, invitation_payload)

--- a/crates/server/src/admin/handlers/identity/generate_context_identity.rs
+++ b/crates/server/src/admin/handlers/identity/generate_context_identity.rs
@@ -1,17 +1,51 @@
 use std::sync::Arc;
 
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
+use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::GenerateContextIdentityResponse;
+use calimero_store::types::ContextIdentity as ContextIdentityValue;
+use tracing::error;
 
-use crate::admin::service::ApiResponse;
+use crate::admin::service::{ApiError, ApiResponse};
 use crate::AdminState;
+
+// Placeholder Context ID for storing unassigned keys
+const PLACEHOLDER_CONTEXT_ID_BYTES: [u8; 32] = [0; 32];
 
 pub async fn handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {
     let private_key = state.ctx_manager.new_private_key();
+    let public_key = private_key.public_key();
 
-    ApiResponse {
-        payload: GenerateContextIdentityResponse::new(private_key.public_key(), private_key),
+    // Store the private key temporarily associated with a placeholder context ID
+    let store_result = (|| {
+        let placeholder_context_id = ContextId::from(PLACEHOLDER_CONTEXT_ID_BYTES);
+        // Note: Setting sender_key to None initially. It will be generated and stored
+        // during the actual context join process if needed.
+        let value = ContextIdentityValue {
+            private_key: Some(*private_key),
+            sender_key: None,
+        };
+        // Use the new public method on ContextManager
+        state
+            .ctx_manager
+            .store_identity_value(placeholder_context_id, public_key, value)?;
+        Ok::<(), eyre::Report>(())
+    })();
+
+    match store_result {
+        Ok(_) => ApiResponse {
+            payload: GenerateContextIdentityResponse::new(public_key),
+        }
+        .into_response(),
+        Err(e) => {
+            error!("Failed to store temporary context identity key: {}", e);
+            ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Failed to generate context identity".into(),
+            }
+            .into_response()
+        }
     }
-    .into_response()
 }

--- a/crates/server/src/admin/handlers/identity/generate_context_identity.rs
+++ b/crates/server/src/admin/handlers/identity/generate_context_identity.rs
@@ -11,23 +11,18 @@ use tracing::error;
 use crate::admin::service::{ApiError, ApiResponse};
 use crate::AdminState;
 
-// Placeholder Context ID for storing unassigned keys
 const PLACEHOLDER_CONTEXT_ID_BYTES: [u8; 32] = [0; 32];
 
 pub async fn handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {
     let private_key = state.ctx_manager.new_private_key();
     let public_key = private_key.public_key();
 
-    // Store the private key temporarily associated with a placeholder context ID
     let store_result = (|| {
         let placeholder_context_id = ContextId::from(PLACEHOLDER_CONTEXT_ID_BYTES);
-        // Note: Setting sender_key to None initially. It will be generated and stored
-        // during the actual context join process if needed.
         let value = ContextIdentityValue {
             private_key: Some(*private_key),
             sender_key: None,
         };
-        // Use the new public method on ContextManager
         state
             .ctx_manager
             .store_identity_value(placeholder_context_id, public_key, value)?;


### PR DESCRIPTION
# [Core] Server-Side Private Key Management for Context Join

## Description

Refactors context identity generation and joining. A new endpoint generates keys, temporarily stores the private key server-side, and returns only the public key. The `join_context` endpoint now takes this public key to retrieve the stored private key for joining, then deletes it. This enhances security by not requiring clients to handle private keys for joining.

## Test plan



## Documentation update


Fixes: #919