### PR TITLE
fix(node): init for apps

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -465,9 +465,10 @@ impl Node {
             return Err(CallError::ContextNotFound);
         };
 
-        if method != "init" && &*context.root_hash == &[0; 32] {
-            return Err(CallError::Uninitialized);
-        }
+        // TODO: remove this once we have a logic init method
+        // if method != "init" && &*context.root_hash == &[0; 32] {
+        //     return Err(CallError::Uninitialized);
+        // }
 
         if !self
             .ctx_manager


### PR DESCRIPTION
# fix(node): init for apps

## Description

On installation of new apps which don't have any changes, throws error for all methods and unable to fix from UI / sdk.
![Screenshot 2025-05-20 at 11 43 45](https://github.com/user-attachments/assets/cf6e22fd-6eaf-4293-a2a8-64868ff6affa)

cc @miraclx propose other solutions if known please.

## Test plan
Can do set and get methods from apps

![Screenshot 2025-05-20 at 11 43 59](https://github.com/user-attachments/assets/4ee7c139-1e2f-4be2-81e6-e3fc98fc2b3c)


## Documentation update
-
