### PR TITLE
chore: `e2e-tests` should run on PRs that don't target `master`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,8 +12,6 @@ on:
       - 'e2e-tests/**'
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - master
     paths:
       - Cargo.toml
       - Cargo.lock


### PR DESCRIPTION
## Description

`e2e-tests` in PRs that are transitively based on master should run as well.

## Test plan

hopes and prayers

## Documentation update

none needed