### PR TITLE
chore(CI): restore disk space maximization

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -7,12 +7,37 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_HOME: ''
+  RUSTUP_HOME: ''
+  ALT_HOME: ''
+  STAGE_DIR: ''
 
 jobs:
   rust:
     name: Rust
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare
+        run: |
+          export STAGE_DIR="$(dirname $GITHUB_WORKSPACE)"
+          echo "STAGE_DIR=$STAGE_DIR" >> $GITHUB_ENV
+          export ALT_HOME="$STAGE_DIR/.home"
+          echo "ALT_HOME=$ALT_HOME" >> $GITHUB_ENV
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          build-mount-path: ${{ env.STAGE_DIR }}
+          root-reserve-mb: 8192
+
+      - name: Relocate environment
+        run: |
+          echo "CARGO_HOME=$ALT_HOME/.cargo" >> $GITHUB_ENV
+          echo "RUSTUP_HOME=$ALT_HOME/.rustup" >> $GITHUB_ENV
+          mkdir $ALT_HOME
+          mv ~/.cargo $ALT_HOME
+          mv ~/.rustup $ALT_HOME
+          echo "$ALT_HOME/.cargo/bin" | cat - $GITHUB_PATH > temp && mv temp $GITHUB_PATH
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

from time to time, our disk usage grows beyond the free disk space available on the root fs in the GHA runner, however there are other filesystems available to the runner with much more space

https://github.com/calimero-network/core/pull/909 looked into this and was able to combine all of them into a new volume

after a while, our build disk usage dropped, enough to fit within the root disk, after which https://github.com/calimero-network/core/pull/1145 removed this accomodation

Building https://github.com/calimero-network/core/pull/1268 just seemed to trigger that issue [once again](https://github.com/calimero-network/core/actions/runs/15299718513/job/43037046120?pr=1268#step:8:909), leading to this patch reintroducing it.

## Test plan

cherry-picked into https://github.com/calimero-network/core/pull/1268 at 0aac299, if the run passes there and here, we're good to go

## Documentation update

None needed