### PR TITLE
fix: SHA-tagged images should be HEAD, not merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - "crates/**"
+      - .github/workflows/release.yml
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
       - Cargo.toml
       - Cargo.lock
       - "crates/**"
-      - .github/workflows/release.yml
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,7 @@ jobs:
             org.opencontainers.image.authors=Calimero Limited <info@calimero.network>
             org.opencontainers.image.url=https://calimero.network
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_PR_HEAD_SHA: true
         with:
           images: ghcr.io/${{ github.repository_owner }}/merod
           tags: |


### PR DESCRIPTION
## Description

SHA-tagged images from PRs by default use the merge commit sha as opposed to the PRs HEAD.

<img src="https://github.com/user-attachments/assets/88ede0b3-6f65-4f3c-a6a6-89db5f8548e8" width="50%" />

![CleanShot 2025-06-13 at 14 22 04@2x](https://github.com/user-attachments/assets/8ae73486-43c3-45f6-ab9d-7f0fdb8a563e)


## Test plan

my eyes

## Documentation update

--