### PR TITLE
fix(meroctl): `meroctl watch` should work correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6270,7 +6270,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -8303,6 +8303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8511,6 +8523,19 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -9948,7 +9973,11 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.19",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.0",
  "tungstenite 0.24.0",
 ]
 
@@ -10254,6 +10283,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.23.19",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -14,7 +14,7 @@ camino = { workspace = true, features = ["serde1"] }
 chrono.workspace = true
 clap = { workspace = true, features = ["env", "derive"] }
 color-eyre.workspace = true
-comfy-table.workspace = true 
+comfy-table.workspace = true
 const_format.workspace = true
 dirs.workspace = true
 eyre.workspace = true
@@ -28,7 +28,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-std", "macros"] }
-tokio-tungstenite.workspace = true
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 toml.workspace = true
 url = { workspace = true, features = ["serde"] }
 

--- a/crates/meroctl/src/cli/context/list.rs
+++ b/crates/meroctl/src/cli/context/list.rs
@@ -14,8 +14,7 @@ impl Report for GetContextsResponse {
     fn report(&self) {
         let mut table = Table::new();
         let _ = table.set_header(vec![
-            Cell::new("Contexts").fg(Color::Blue),
-            Cell::new("ID").fg(Color::Blue),
+            Cell::new("Context ID").fg(Color::Blue),
             Cell::new("Application ID").fg(Color::Blue),
         ]);
 

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -1,10 +1,17 @@
+use std::borrow::Cow;
+use std::process::Stdio;
+
 use calimero_primitives::alias::Alias;
 use calimero_primitives::context::ContextId;
-use calimero_server_primitives::ws::{Request, RequestPayload, Response, SubscribeRequest};
+use calimero_server_primitives::ws::{
+    Request, RequestPayload, Response, ResponseBody, SubscribeRequest,
+};
 use clap::Parser;
 use comfy_table::{Cell, Color, Table};
 use eyre::{OptionExt, Result as EyreResult};
 use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
@@ -52,8 +59,39 @@ impl Report for Response {
     fn report(&self) {
         let mut table = Table::new();
         let _ = table.set_header(vec![Cell::new("WebSocket Response").fg(Color::Blue)]);
+
         let _ = table.add_row(vec![format!("ID: {:?}", self.id)]);
-        let _ = table.add_row(vec![format!("Payload: {:#?}", self.body)]);
+
+        match &self.body {
+            ResponseBody::Result(value) => {
+                let _ = table.add_row(vec![format!("Result: {:#}", value)]);
+            }
+            ResponseBody::Error(error) => {
+                let _ = table.add_row(vec![format!("Error: {:?}", error)]);
+            }
+        }
+
+        println!("{table}");
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ExecutionOutput<'a> {
+    #[serde(borrow)]
+    cmd: Cow<'a, [String]>,
+    status: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+impl Report for ExecutionOutput<'_> {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.add_row(vec![format!("Command: {}", self.cmd.join(" "))]);
+        let _ = table.add_row(vec![format!("Status: {:?}", self.status)]);
+        let _ = table.add_row(vec![format!("Stdout: {}", self.stdout)]);
+        let _ = table.add_row(vec![format!("Stderr: {}", self.stderr)]);
+
         println!("{table}");
     }
 }
@@ -73,7 +111,13 @@ impl WatchCommand {
             .ok_or_eyre("Failed to resolve context: no value found")?;
 
         let mut url = connection.api_url.clone();
-        url.set_scheme("ws")
+
+        let scheme = match url.scheme() {
+            "https" => "wss",
+            "http" | _ => "ws",
+        };
+
+        url.set_scheme(scheme)
             .map_err(|()| eyre::eyre!("Failed to set URL scheme"))?;
         url.set_path("ws");
 
@@ -125,23 +169,42 @@ impl WatchCommand {
                                 }
                             }
 
-                            let output = Command::new(&cmd[0])
+                            let mut child = Command::new(&cmd[0])
                                 .args(&cmd[1..])
-                                .output()
+                                .stdin(Stdio::piped())
+                                .spawn()?;
+
+                            let stdin = child.stdin.take();
+
+                            let stdin = tokio::spawn(async {
+                                let Some(mut stdin) = stdin else {
+                                    return Ok(());
+                                };
+
+                                if let ResponseBody::Result(result) = response.body {
+                                    let result = result.to_string();
+
+                                    return stdin.write_all(result.as_bytes()).await;
+                                }
+
+                                Ok(())
+                            });
+
+                            let output = child
+                                .wait_with_output()
                                 .await
                                 .map_err(|e| eyre::eyre!("Failed to execute command: {}", e))?;
 
-                            if !output.status.success() {
-                                environment.output.write(&ErrorLine(&format!(
-                                    "Command failed: {}",
-                                    String::from_utf8_lossy(&output.stderr)
-                                )));
-                            } else {
-                                environment.output.write(&InfoLine(&format!(
-                                    "Command output: {}",
-                                    String::from_utf8_lossy(&output.stdout)
-                                )));
-                            }
+                            stdin.await??;
+
+                            let outcome = ExecutionOutput {
+                                cmd: cmd.into(),
+                                status: output.status.code(),
+                                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                            };
+
+                            environment.output.write(&outcome);
                         }
 
                         event_count += 1;


### PR DESCRIPTION
## Description

This patches `meroctl context watch` to;

1. support `https` node urls
2. show the execution output in a structured format, which supports `--output-format json`
3. actually pass the event emitted to the executed command, surprised this wasn't the case already
4. support executing command with flags, for example `sh -c "cat"`, `xargs -I{} echo {}`

## Test plan

Works in local testing

## Documentation update

--