### PR TITLE
chore(CI): prevent eager exit on error, patch concurrency rules

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -37,9 +37,11 @@ jobs:
           cargo +nightly fmt -- --check
 
       - name: Cargo clippy
+        if: ${{ !cancelled() }}
         run: cargo clippy -- -A warnings
 
       - name: Cargo test
+        if: ${{ !cancelled() }}
         run: |
           FIRST_HOST=$(ifconfig | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | head -n 1)
 
@@ -49,6 +51,7 @@ jobs:
           cargo test -- --nocapture
 
       - name: Cargo deny
+        if: ${{ !cancelled() }}
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check licenses sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   BINARIES: |-
     merod
@@ -139,6 +135,9 @@ jobs:
     if: needs.prepare.outputs.binary_release == 'true'
     runs-on: ubuntu-latest
     needs: [prepare, build-binaries]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ needs.prepare.outputs.version }}
+      cancel-in-progress: true
     permissions:
       contents: write
     steps:
@@ -168,6 +167,9 @@ jobs:
     needs: [prepare, build-binaries]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ needs.prepare.outputs.version }}
+      cancel-in-progress: true
     permissions:
       contents: read
       packages: write
@@ -247,7 +249,7 @@ jobs:
             type=ref,prefix=pr-,event=pr
             type=sha,prefix=,format=short
             type=raw,value=${{ needs.prepare.outputs.version }},enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' && needs.prepare.outputs.prerelease == 'false' }}
           labels: ${{ env.LABELS }}
           annotations: ${{ env.LABELS }}
 


### PR DESCRIPTION
## Description

1. if `cargo fmt` fails, don't exit immediately, test clippy, run tests and do the license check and show all the failures not just the first one.
2. if a second release run begins, don't immediatly cancel the build of an existing one, let the build pass, and only cancel if;
	1. a GH release is happening at the same time
	2. a docker release is happening at the same time
	- both of which are trivially retryable, so that's great
3. the `latest` docker tag shouldn't apply to pre-releases at all

## Test plan

--

## Documentation update

--