### PR TITLE
feat: cargo mero cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-mero"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "const_format",
+ "eyre",
+ "rust-embed",
+ "tokio",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
+name = "app-template"
+version = "0.1.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "./crates/version",
 
     "./apps/kv-store",
+    "./apps/app-template",
 
     "./e2e-tests",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "./crates/crypto",
     "./crates/meroctl",
     "./crates/merod",
+    "./crates/cargo-mero",
     "./crates/network",
     "./crates/network/primitives",
     "./crates/node",

--- a/apps/app-template/Cargo.toml
+++ b/apps/app-template/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "app-template"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+license-file.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+thiserror.workspace = true
+calimero-sdk.workspace = true
+calimero-storage.workspace = true
+
+[lints]
+workspace = true

--- a/apps/app-template/src/lib.rs
+++ b/apps/app-template/src/lib.rs
@@ -1,0 +1,61 @@
+#![allow(clippy::len_without_is_empty)]
+
+use calimero_sdk::app;
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::serde::Serialize;
+use calimero_storage::collections::UnorderedMap;
+use thiserror::Error;
+
+#[app::state(emits = Event)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
+pub struct SampleApp {
+    balances: UnorderedMap<String, usize>,
+}
+
+#[derive(Debug)]
+#[app::event]
+pub enum Event {
+    BalanceUpdated { account: String, value: usize },
+    BalanceSet { account: String, value: usize },
+}
+
+#[derive(Debug, Error, Serialize)]
+#[serde(crate = "calimero_sdk::serde")]
+#[serde(tag = "kind", content = "data")]
+pub enum Error<'a> {
+    #[error("Account not found: {0}")]
+    NotFound(&'a str),
+}
+
+#[app::logic]
+impl SampleApp {
+    #[app::init]
+    pub fn init() -> SampleApp {
+        SampleApp {
+            balances: UnorderedMap::new(),
+        }
+    }
+
+    pub fn set(&mut self, account: String, value: usize) -> app::Result<()> {
+        app::log!("Setting the account balance of {} ", account);
+
+        if let Some(balance) = self.balances.insert(account.clone(), value)? {
+            app::emit!(Event::BalanceUpdated {
+                account,
+                value: balance
+            });
+        } else {
+            app::emit!(Event::BalanceSet { account, value });
+        }
+
+        Ok(())
+    }
+
+    pub fn get(&self, account: &str) -> app::Result<usize> {
+        if let Some(balance) = self.balances.get(account)? {
+            return Ok(balance);
+        }
+        app::bail!(Error::NotFound(account));
+    }
+}

--- a/crates/cargo-mero/Cargo.toml
+++ b/crates/cargo-mero/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cargo-mero"
+version = "0.1.0"
+description = "CLI tool for building applications on the Calimero network"
+categories = ["command-line-utilities"]
+keywords = ["cli", "cargo", "subcommand"]
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+license-file.workspace = true
+
+[dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+eyre.workspace = true
+clap = { workspace = true, features = ["derive"] }
+const_format.workspace = true
+rust-embed.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cargo-mero/src/abi.rs
+++ b/crates/cargo-mero/src/abi.rs
@@ -1,0 +1,3 @@
+pub async fn run() -> eyre::Result<()> {
+    Ok(())
+}

--- a/crates/cargo-mero/src/build.rs
+++ b/crates/cargo-mero/src/build.rs
@@ -1,0 +1,3 @@
+pub async fn run() -> eyre::Result<()> {
+    Ok(())
+}

--- a/crates/cargo-mero/src/cli.rs
+++ b/crates/cargo-mero/src/cli.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use const_format::concatcp;
+
+use crate::{abi, build, new};
+
+pub const EXAMPLES: &str = r"
+  # Create a new application
+  $ cargo mero new --name gitter
+
+  # Build app
+  $ cargo mero build
+
+  # Generate ABI
+  $ cargo mero abi
+
+  # Publish app
+  $ cargo mero publish
+";
+
+#[derive(Debug, Parser)]
+#[command(name = "mero")]
+#[command(bin_name = "cargo mero")]
+#[command(after_help = concatcp!("Examples: ", EXAMPLES))]
+pub struct RootCommand {
+    #[command(subcommand)]
+    command: SubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum SubCommands {
+    New(NewCommand),
+    Build,
+    Abi,
+}
+
+#[derive(Debug, Parser)]
+pub struct NewCommand {
+    #[arg(long)]
+    pub name: PathBuf,
+}
+
+impl RootCommand {
+    pub async fn run(self) -> eyre::Result<()> {
+        match self.command {
+            SubCommands::Abi => abi::run().await,
+            SubCommands::New(args) => new::run(args).await,
+            SubCommands::Build => build::run().await,
+        }
+    }
+}

--- a/crates/cargo-mero/src/main.rs
+++ b/crates/cargo-mero/src/main.rs
@@ -1,0 +1,19 @@
+use clap::Parser;
+
+mod abi;
+mod build;
+mod cli;
+mod new;
+
+async fn init() -> eyre::Result<()> {
+    let command = cli::RootCommand::parse();
+
+    command.run().await
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    init().await?;
+
+    Ok(())
+}

--- a/crates/cargo-mero/src/new.rs
+++ b/crates/cargo-mero/src/new.rs
@@ -1,0 +1,36 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::{env, fs};
+
+use rust_embed::RustEmbed;
+
+use crate::cli::NewCommand;
+
+#[derive(RustEmbed)]
+#[folder = "../../apps/app-template/"]
+struct AppTemplate;
+
+pub async fn run(args: NewCommand) -> eyre::Result<()> {
+    println!("Creating a new project {:?} from template...", args.name);
+    let path = args.name;
+
+    fs::create_dir_all(&path)?;
+    env::set_current_dir(path)?;
+
+    for file in AppTemplate::iter() {
+        let path = Path::new(&*file);
+
+        // Create directories if needed
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut file_handle = File::create(path)?;
+        if let Some(file_content) = AppTemplate::get(&file) {
+            file_handle.write_all(&file_content.data)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Introduces  a new `cargo mero` cli to facilitate creating, building, publishing & ABI generation of Calimero apps.

### Usage

#### Create a new application
```sh
 $ cargo mero new --name gitter
```
#### Build app
```sh 
$ cargo mero build
```

#### Generate ABI
```sh
$ cargo mero abi
```

#### Publish app
```sh
$ cargo mero publish
```

### Todo

- [x] - Create
- [ ] - Build
- [ ] - ABI
- [ ] - Publish
