### PR TITLE
ci: add commit lint workflow

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -2,7 +2,7 @@ name: PR Comment
 
 on:
   workflow_run:
-    workflows: ['e2e-tests', 'PR Description']
+    workflows: ['e2e-tests', 'PR Description', 'PR Title']
     types:
       - completed
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,55 @@
+name: PR Title
+# ^~~ if changed, update comment.yml as well
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ERR_MSG: |-
+        The PR title `${{ github.event.pull_request.title }}` does not follow the Calimero-Network Commit Message Convention
+        https://github.com/calimero-network/core/blob/master/CONTRIBUTING.md#commit-message-style
+
+        Our PR title should have the following structure:
+
+          <type>(<scope>): <subject>
+
+        Common errors to avoid:
+        1. The commit header <type>(<scope>): <subject> must be in lower case.
+        2. Allowed type values are: build, ci, docs, feat, fix, perf, refactor, test.
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+
+      - name: Create PR Comment Payload
+        if: ${{ !cancelled() }}
+        run: >-
+          jq -n
+          --arg pr '${{ github.event.number }}'
+          --arg tag pr-lint-check
+          --arg mode "${{ steps.lint_pr_title.outputs.error_message != null && 'recreate' || 'delete' }}"
+          --arg message "${{ env.ERR_MSG }}"
+          '{pr: $pr, tag: $tag, mode: $mode, message: $message}' | tee payload.json
+
+      - name: Upload Comment
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment-payload
+          path: payload.json


### PR DESCRIPTION
# [CI] Validate PR follows calimero-network commit message style fixes https://github.com/calimero-network/core/issues/1286

## Description

[Ensures PRs follows conventional commit messaging style](https://www.conventionalcommits.org/en/v1.0.0/)

## Test plan

Tested in my personal repository to ensure PRs title follow conventional commit

## Documentation update

We comment on users PR if the workflow fails on how to follow our commit message rule.
