### PR TITLE
ci: properly format error messages when pull request title don't follow commit convention

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -40,14 +40,11 @@ jobs:
       - name: Create PR Comment Payload
         if: ${{ !cancelled() }}
         run: |
-          # Some commit messages may contain single quotes, which can break the JSON format.
-          echo "$ERR_MSG" > error_msg.md
-
           jq -n \
             --arg pr '${{ github.event.number }}' \
             --arg tag pr-lint-check \
             --arg mode "${{ steps.lint_pr_title.outputs.error_message != null && 'recreate' || 'delete' }}" \
-            --rawfile message error_msg.md \
+            --arg message '${{ env.ERR_MSG }}' \
             '{pr: $pr, tag: $tag, mode: $mode, message: $message}' | tee payload.json
 
       - name: Upload Comment


### PR DESCRIPTION
# [product] Properly format error messages

## Description

Handle string formatting when sending PR comment on invalid PR title

## Test plan

I used a bad PR title in the open PR to confirm that the correct message is being sent

## Documentation update

<img width="970" alt="Screenshot 2025-07-08 at 6 09 25 PM" src="https://github.com/user-attachments/assets/0fc96b11-5d44-4e1b-83cd-039e567cf886" />

