### PR TITLE
chore: docker & cargo patches for cleanup and consistency

### DIFF
--- a/.github/workflows/deps/prebuilt.Dockerfile
+++ b/.github/workflows/deps/prebuilt.Dockerfile
@@ -9,10 +9,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG UID=10001
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/user" \
+RUN useradd \
+    --home-dir "/user" \
+    --create-home \
     --shell "/sbin/nologin" \
     --uid "${UID}" \
     user

--- a/.github/workflows/deps/prebuilt.Dockerfile
+++ b/.github/workflows/deps/prebuilt.Dockerfile
@@ -2,10 +2,9 @@
 
 # Dockerfile for prebuilt binaries
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y \
-    libssl3 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -19,7 +18,6 @@ RUN adduser \
     user
 
 ARG TARGETARCH
-ARG BINARY_NAME
 
 # Copy the prebuilt binary from the CI workflow artifacts
 COPY \
@@ -33,5 +31,8 @@ USER user
 WORKDIR /data
 ENV CALIMERO_HOME=/data
 
-ENTRYPOINT ["/usr/local/bin/merod"]
+VOLUME /data
+EXPOSE 2428 2528
+
+ENTRYPOINT ["merod"]
 CMD ["--help"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ dependencies = [
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
- "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
@@ -189,8 +188,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
 ]
 
 [[package]]
@@ -218,7 +215,6 @@ dependencies = [
  "auto_impl",
  "c-kzg",
  "derive_more 1.0.0",
- "k256",
  "serde",
 ]
 
@@ -248,7 +244,6 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-provider",
- "alloy-pubsub",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
@@ -318,7 +313,6 @@ checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "k256",
  "serde",
  "thiserror 2.0.11",
 ]
@@ -460,18 +454,11 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
- "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -489,25 +476,6 @@ dependencies = [
  "tracing",
  "url",
  "wasmtimer",
-]
-
-[[package]]
-name = "alloy-pubsub"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a68996f193f542f9e29c88dfa8ed1369d6ee04fa764c1bf23dc11b2f9e4a2"
-dependencies = [
- "alloy-json-rpc",
- "alloy-primitives",
- "alloy-transport",
- "bimap",
- "futures",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower 0.5.2",
- "tracing",
 ]
 
 [[package]]
@@ -540,11 +508,8 @@ checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
  "futures",
  "pin-project",
  "reqwest 0.12.9",
@@ -565,22 +530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-anvil"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d06300df4a87d960add35909240fc72da355dd2ac926fa6999f9efafbdc5a7"
-dependencies = [
- "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -595,32 +544,6 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-debug"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834b7012054cb2f90ee9893b7cc97702edca340ec1ef386c30c42e55e6cd691"
-dependencies = [
- "alloy-primitives",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83dde9fcf1ccb9b815cc0c89bba26bbbbaae5150a53ae624ed0fc63cb3676c1"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 1.0.0",
- "serde",
- "strum 0.26.3",
 ]
 
 [[package]]
@@ -641,32 +564,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.11",
-]
-
-[[package]]
-name = "alloy-rpc-types-trace"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd951155515fa452a2ca4b5434d4b3ab742bcd3d1d1b9a91704bcef5b8d2604"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
- "serde_json",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "alloy-rpc-types-txpool"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8dd5bd94993eda3d56a8c4c0d693548183a35462523ffc4385c0b020d3b0c"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -817,44 +714,6 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-transport-ipc"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e88304aa8b796204e5e2500dfe235933ed692745e3effd94c3733643db6d218"
-dependencies = [
- "alloy-json-rpc",
- "alloy-pubsub",
- "alloy-transport",
- "bytes",
- "futures",
- "interprocess",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "alloy-transport-ws"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9653ea9aa06d0e02fcbe2f04f1c47f35a85c378ccefa98e54ae85210bc8bbfa"
-dependencies = [
- "alloy-pubsub",
- "alloy-transport",
- "futures",
- "http 1.1.0",
- "rustls 0.23.19",
- "serde_json",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "tracing",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -1316,17 +1175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version 0.4.1",
-]
-
-[[package]]
 name = "asynchronous-codec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,7 +1266,7 @@ dependencies = [
  "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -1989,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-config"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-context",
@@ -2163,7 +2011,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "webbrowser 1.0.4",
+ "webbrowser",
 ]
 
 [[package]]
@@ -2502,16 +2350,6 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
-]
-
-[[package]]
-name = "chat-app"
-version = "0.1.0"
-dependencies = [
- "bs58 0.5.1",
- "calimero-sdk",
- "calimero-storage",
- "flate2",
 ]
 
 [[package]]
@@ -3295,7 +3133,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3395,12 +3232,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "doctest-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "downcast"
@@ -5108,21 +4939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6144,15 +5960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6230,10 +6037,10 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "toml 0.8.19",
  "url",
- "webbrowser 0.8.15",
+ "webbrowser",
 ]
 
 [[package]]
@@ -7131,15 +6938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7490,16 +7288,6 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -8066,12 +7854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
-name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8111,12 +7893,6 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
-
-[[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -8874,12 +8650,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -10259,23 +10029,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.23.19",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.0",
- "tungstenite 0.26.2",
- "webpki-roots 0.26.7",
+ "tungstenite",
 ]
 
 [[package]]
@@ -10581,25 +10335,6 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.1.0",
- "httparse",
- "log",
- "rand 0.9.0",
- "rustls 0.23.19",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.11",
  "utf-8",
 ]
 
@@ -11322,23 +11057,6 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
-dependencies = [
- "core-foundation 0.9.4",
- "home",
- "jni",
- "log",
- "ndk-context",
- "objc",
- "raw-window-handle",
- "url",
- "web-sys",
-]
-
-[[package]]
-name = "webbrowser"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
@@ -11779,25 +11497,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version 0.4.1",
- "send_wrapper",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ authors = ["Calimero Limited <info@calimero.network>"]
 edition = "2021"
 repository = "https://github.com/calimero-network/core"
 license = "MIT OR Apache-2.0"
-license-file = "LICENSE.md"
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ members = [
     "./crates/storage",
     "./crates/storage/macros",
     "./crates/store",
-    "./crates/store/impl/rocksdb",
     "./crates/store/blobs",
+    "./crates/store/impl/rocksdb",
     "./crates/utils/actix",
     "./crates/version",
 
@@ -42,13 +42,12 @@ members = [
 
 [workspace.dependencies]
 actix = "0.13.5"
-alloy = { version = "0.11.1", features = ["full"] }
+alloy = "0.11.1"
 alloy-sol-types = "0.8.22"
 assert-json-diff = "2.0.2"
 async-stream = "0.3.5"
 axum = "0.7.4"
 base64 = "0.22.0"
-bincode = "1.3.3"
 borsh = "1.3.1"
 bs58 = "0.5.0"
 bytes = "1.6.0"
@@ -64,8 +63,8 @@ comfy-table = "7.0"
 const_format = "0.2.32"
 curve25519-dalek = "4.1.3"
 dirs = "5.0.1"
-ed25519-dalek = "2.1.1"
 ed25519-consensus = "2.1.0"
+ed25519-dalek = "2.1.1"
 either = "1.13.0"
 ethabi = "18.0.0"
 eyre = "0.6.12"
@@ -74,17 +73,13 @@ fragile = "2.0.0"
 futures-util = "0.3.30"
 generic-array = "1.0.0"
 hex = "0.4.3"
-http = "1.1.0"
-http-serde = "2.1.1"
 ic-agent = "0.39.1"
-ic-canister-sig-creation = "1.1"
-ic-signature-verification = "0.2"
 indexmap = "2.6.0"
 itertools = "0.14.0"
 jsonwebtoken = "9.3.0"
 libp2p = "0.53.2"
-libp2p-stream = "0.1.0-alpha.1"
 libp2p-identity = "0.2.9"
+libp2p-stream = "0.1.0-alpha.1"
 memchr = "2"
 multiaddr = "0.18.1"
 near-account-id = "1.0.0"
@@ -92,7 +87,6 @@ near-crypto = "0.27.0"
 near-jsonrpc-client = "0.14.0"
 near-jsonrpc-primitives = "0.27.0"
 near-primitives = "0.27.0"
-near-sdk = "5.5.0"
 near-workspaces = "0.15.0"
 notify = "6.1.1"
 ouroboros = "0.18.5"
@@ -107,29 +101,27 @@ reqwest = "0.12.2"
 ring = "0.17.8"
 rocksdb = "0.22.0"
 rust-embed = "8.5.0"
-sha2 = "0.10.8"
-sha3 = "0.10.8"
+rustc_version = "0.4"
 semver = "1.0.22"
 serde = "1.0.196"
 serde_json = "1.0.113"
 serde_with = "3.9.0"
-soroban-sdk = { version = "22.0.5", features = ["alloc"] }
+sha2 = "0.10.8"
+soroban-client = "0.3.7"
+soroban-sdk = "22.0.5"
 starknet = "0.12.0"
 starknet-crypto = "0.7.1"
 starknet-types-core = "0.1.7"
-stellar-baselib = "0.4.6"
 strum = "0.26.2"
-soroban-client = "0.3.7"
 syn = "2.0"
 tempdir = "0.3.7"
-tempfile = "3.12.0"
 thiserror = "1.0.56"
 thunderdome = "0.6.1"
 tokio = "1.35.1"
+tokio-stream = "0.1.17"
 tokio-test = "0.4.4"
 tokio-tungstenite = "0.24.0"
 tokio-util = "0.7.11"
-tokio-stream = "0.1.17"
 toml = "0.8.9"
 toml_edit = "0.22.14"
 tower = "0.4.13"
@@ -143,48 +135,36 @@ url = "2.5.2"
 velcro = "0.5.4"
 wasmer = "4.2.5"
 wasmer-types = "4.2.5"
-webbrowser = "1.0.4"
 web3 = "0.19.0"
-x509-parser = "0.16.0"
+webbrowser = "1.0.4"
 
-calimero-config = { path = "./crates/config" }
-calimero-context = { path = "./crates/context" }
-calimero-context-config = { path = "./crates/context/config" }
-calimero-context-primitives = { path = "./crates/context/primitives" }
-calimero-crypto = { path = "./crates/crypto" }
-meroctl = { path = "./crates/meroctl" }
-merod = { path = "./crates/merod" }
-calimero-network = { path = "./crates/network" }
-calimero-network-primitives = { path = "./crates/network/primitives" }
-calimero-node = { path = "./crates/node" }
-calimero-node-primitives = { path = "./crates/node/primitives" }
-calimero-primitives = { path = "./crates/primitives" }
-calimero-runtime = { path = "./crates/runtime" }
-calimero-sdk = { path = "./crates/sdk" }
-calimero-sdk-near = { path = "./crates/sdk/libs/near" }
-calimero-sdk-macros = { path = "./crates/sdk/macros" }
-calimero-server = { path = "./crates/server" }
-calimero-server-primitives = { path = "./crates/server/primitives" }
-calimero-storage = { path = "./crates/storage" }
-calimero-storage-macros = { path = "./crates/storage/macros" }
-calimero-store = { path = "./crates/store" }
-calimero-store-rocksdb = { path = "./crates/store/impl/rocksdb" }
-calimero-blobstore = { path = "./crates/store/blobs" }
-e2e-tests = { path = "./e2e-tests" }
-calimero-utils-actix = { path = "./crates/utils/actix" }
-calimero-version = { path = "./crates/version" }
-
-kv-store = { path = "./apps/kv-store" }
-
-calimero-registry = { path = "./contracts/near/registry" }
-calimero-context-config-near = { path = "./contracts/near/context-config" }
-calimero-context-proxy-near = { path = "./contracts/near/context-proxy" }
-calimero-test-counter-near = { path = "./contracts/near/test-counter" }
-
-calimero-context-contract-icp = { path = "./contracts/icp/context-config" }
-calimero-proxy-contract-icp = { path = "./contracts/icp/context-proxy" }
-calimero-mock-ledger-icp = { path = "./contracts/icp/context-proxy/mock/ledger" }
-calimero-mock-external-icp = { path = "./contracts/icp/context-proxy/mock/external" }
+calimero-blobstore.path = "./crates/store/blobs"
+calimero-config.path = "./crates/config"
+calimero-context.path = "./crates/context"
+calimero-context-config.path = "./crates/context/config"
+calimero-context-primitives.path = "./crates/context/primitives"
+calimero-crypto.path = "./crates/crypto"
+calimero-network.path = "./crates/network"
+calimero-network-primitives.path = "./crates/network/primitives"
+calimero-node.path = "./crates/node"
+calimero-node-primitives.path = "./crates/node/primitives"
+calimero-primitives.path = "./crates/primitives"
+calimero-runtime.path = "./crates/runtime"
+calimero-sdk.path = "./crates/sdk"
+calimero-sdk-macros.path = "./crates/sdk/macros"
+calimero-sdk-near.path = "./crates/sdk/libs/near"
+calimero-server.path = "./crates/server"
+calimero-server-primitives.path = "./crates/server/primitives"
+calimero-storage.path = "./crates/storage"
+calimero-storage-macros.path = "./crates/storage/macros"
+calimero-store.path = "./crates/store"
+calimero-store-rocksdb.path = "./crates/store/impl/rocksdb"
+calimero-utils-actix.path = "./crates/utils/actix"
+calimero-version.path = "./crates/version"
+e2e-tests.path = "./e2e-tests"
+kv-store.path = "./apps/kv-store"
+meroctl.path = "./crates/meroctl"
+merod.path = "./crates/merod"
 
 [profile.release]
 strip = "symbols"

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -1,43 +1,59 @@
-# syntax=docker/dockerfile:1.6
+# syntax=docker/dockerfile:1
 
 ARG RUST_VERSION=1.85.0
+# ^~~ keep this in sync with rust-toolchain.toml
+
 ARG APP_NAME=calimero-auth
 
 ################################################################################
-# Build Stage - compile the binary
 FROM rust:${RUST_VERSION}-slim-bookworm AS build
 ARG APP_NAME
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
     pkg-config \
     libssl-dev \
-    clang \
-    libclang-dev \
-    libzstd-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Copy source code
-COPY . .
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+COPY apps ./apps
+COPY e2e-tests ./e2e-tests
 
-# Build the release binary
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
+ARG CALIMERO_AUTH_FRONTEND_SRC
+ARG CALIMERO_AUTH_FRONTEND_REPO
+ARG CALIMERO_AUTH_FRONTEND_VERSION
+ARG CALIMERO_AUTH_FRONTEND_FETCH
+
+# ^~~ docker build
+#        --build-arg CALIMERO_AUTH_FRONTEND_FETCH=1
+#   env: --secret id=gh-token,env=CALIMERO_AUTH_FRONTEND_FETCH_TOKEN
+#  file: --secret id=gh-token,src=./gh_token.txt
+
+RUN --mount=type=cache,target=/app/target \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/app/target \
-    cargo build --release --bin ${APP_NAME} && \
-    cp target/release/${APP_NAME} /bin/server
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=secret,id=gh-token,env=CALIMERO_AUTH_FRONTEND_FETCH_TOKEN \
+    [ -n "$CALIMERO_AUTH_FRONTEND_FETCH_TOKEN" ] || unset CALIMERO_AUTH_FRONTEND_FETCH_TOKEN && \
+    cargo build --locked --release -p ${APP_NAME} && \
+    cp target/release/${APP_NAME} /usr/local/bin/
 
 ################################################################################
-# Final Production Stage
-FROM debian:bookworm-slim AS final
+FROM debian:bookworm-slim AS runtime
+ARG APP_NAME
 
-# Add labels for container metadata
-LABEL org.opencontainers.image.description="Calimero Authentication Service"
-LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.description="Calimero Authentication Service" \
+    org.opencontainers.image.licenses="MIT OR Apache-2.0" \
+    org.opencontainers.image.authors="Calimero Limited <info@calimero.network>" \
+    org.opencontainers.image.source="https://github.com/calimero-network/core" \
+    org.opencontainers.image.url="https://calimero.network"
 
-# Create a non-privileged user
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 ARG UID=10001
 RUN adduser \
     --disabled-password \
@@ -47,27 +63,16 @@ RUN adduser \
     --uid "${UID}" \
     user
 
-# Install runtime dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates libssl-dev libsnappy1v5 liblz4-1 libzstd1 curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy the executable and configs
-COPY --from=build /bin/server /usr/local/bin/calimero-auth
+COPY --from=build \
+    /usr/local/bin/${APP_NAME} \
+    /usr/local/bin/
 COPY crates/auth/config/config.toml /etc/calimero/auth.toml
 
-# Create data directory and set permissions
-RUN mkdir -p /data/auth_db && \
-    chown -R user:user /data
-
-# Switch to non-root user
 USER user
 WORKDIR /data
-ENV CALIMERO_HOME=/data
 
-VOLUME ["/data"]
+VOLUME /data
 EXPOSE 3001
 
-ENTRYPOINT ["calimero-auth"]
+ENTRYPOINT ["${APP_NAME}"]
 CMD ["--config", "/etc/calimero/auth.toml", "--verbose"]

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -74,5 +74,6 @@ WORKDIR /data
 VOLUME /data
 EXPOSE 3001
 
-ENTRYPOINT ["${APP_NAME}"]
+ENV APP_NAME=${APP_NAME}
+ENTRYPOINT $APP_NAME
 CMD ["--config", "/etc/calimero/auth.toml", "--verbose"]

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,56 +1,57 @@
 [package]
 name = "calimero-auth"
 version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/calimero-network/core"
+authors.workspace = true
+edition.workspace = true
 description = "Forward Authentication Service for Calimero Network"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 aes-gcm = "0.10.3"
 async-trait = "0.1.88"
 axum = { workspace = true, features = ["macros"] }
 axum-extra = { version = "0.10.1", features = ["cookie", "cookie-signed", "cookie-private"] }
-base64 = { workspace = true }
-borsh = { workspace = true }
-bs58 = { workspace = true }
+base64.workspace = true
+borsh.workspace = true
+bs58.workspace = true
 calimero-primitives = { path = "../primitives" }
 calimero-store = { path = "../store" }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
 config = { version = "0.13", features = ["yaml"] }
 ctor = "0.1"
-dashmap = "5.5.3"  # Fast concurrent HashMap
+dashmap = "5.5.3"
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 eyre.workspace = true
-hex = { workspace = true }
+hex.workspace = true
 ic-agent = { workspace = true, optional = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken.workspace = true
 lazy_static = "1.4"
-near-crypto = { workspace = true }
-near-jsonrpc-client = { workspace = true }
-near-primitives = { workspace = true }
-parking_lot = { workspace = true }
-rand = { workspace = true }
+near-crypto.workspace = true
+near-jsonrpc-client.workspace = true
+near-primitives.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
 regex = "1.10.2"
-rocksdb = { workspace = true }
+rocksdb.workspace = true
 rust-embed = { workspace = true, features = ["mime-guess", "interpolate-folder-path"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-sha2 = { workspace = true }
-starknet = { workspace = true }
+serde_json.workspace = true
+sha2.workspace = true
+starknet.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-toml = "0.8"
+toml.workspace = true
 tower = { workspace = true, features = ["util", "limit"] }
 tower-http = { workspace = true, features = ["cors", "trace", "catch-panic", "limit", "set-header"] }
 tower-sessions.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-url = "2.4"
+url.workspace = true
 uuid = { version = "1.6", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
-web3 = { workspace = true }
+web3.workspace = true
 
 [dev-dependencies]
 mockall = "0.11"
@@ -59,11 +60,11 @@ tempfile = "3.8"
 tokio-test = "0.4"
 
 [build-dependencies]
-bytes = { workspace = true }
-cached-path = { workspace = true }
-eyre = { workspace = true }
+bytes.workspace = true
+cached-path.workspace = true
+eyre.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 # cached-path compat
 reqwest-compat = { version = "0.11", package = "reqwest", features = ["blocking"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-config"
-version = "0.1.1"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.7", features = ["http1"] }
+axum = { workspace = true, features = ["http1"] }
 camino = { workspace = true, features = ["serde1"] }
 clap = { workspace = true, features = ["env", "derive"] }
 color-eyre.workspace = true
@@ -30,7 +30,7 @@ tokio = { workspace = true, features = ["io-std", "macros", "fs", "net", "rt-mul
 tokio-tungstenite.workspace = true
 toml.workspace = true
 url = { workspace = true, features = ["serde"] }
-webbrowser = "0.8"
+webbrowser.workspace = true
 
 calimero-config.workspace = true
 calimero-context-config.workspace = true

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 license.workspace = true
 
 [build-dependencies]
-eyre = "0.6"
-rustc_version = "0.4"
+eyre.workspace = true
+rustc_version.workspace = true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,11 +3,17 @@ x-node-defaults: &node-defaults
     context: .
     dockerfile: Dockerfile
     target: runtime
+    secrets:
+      - gh-token
   user: root
   volumes:
     - calimero_auth_node:/calimero
   healthcheck:
-    test: ["CMD-SHELL", "curl -f http://localhost:$${NODE_PORT}/admin-api/peers || exit 0"]
+    test:
+      [
+        "CMD-SHELL",
+        "curl -f http://localhost:$${NODE_PORT}/admin-api/peers || exit 0",
+      ]
     interval: 10s
     timeout: 5s
     retries: 5
@@ -70,7 +76,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.auth
-      target: final
+      target: runtime
+      secrets:
+        - gh-token
     volumes:
       - calimero_auth_data:/data
     environment:
@@ -90,7 +98,7 @@ services:
         max-file: "3"
     labels:
       - "traefik.enable=true"
-      
+
       # Public Routes (No Auth)
       - "traefik.http.routers.auth-public.rule=PathPrefix(`/auth/`) || PathPrefix(`/admin/`)"
       - "traefik.http.routers.auth-public.entrypoints=web"
@@ -142,3 +150,7 @@ volumes:
     driver: local
   calimero_auth_data:
     driver: local
+
+secrets:
+  gh-token:
+    environment: GH_TOKEN


### PR DESCRIPTION
## Description

1. remove unreferenced dependencies in the root manifest
2. `calimero-auth` doesn't follow the convention of `.workspace = true` (I updated the already existing dependencies, and left the ones only used by `calimero–auth`)
3. `license-file = LICENSE.md` is the default, it doesn't have to be stated
4. https://github.com/calimero-network/core/issues/1328 - GitHub's CI runner's use glibc 2.39, which we build on, and therefore link to. But `debian:bookwork-slim` had `2.36-9`, failing at runtime. Reverted to use `ubuntu:24.04` at runtime.
5. stop installing unneeded packages for the rust build in docker
6. https://github.com/calimero-network/core/issues/1335 - build arguments for the webui and auth ui should be specifiable in  docker builds

## Test Plan

- docker build locally passes, permuting all situations we care about
- docker build in CI passes, same
- cargo build passes
- CI docker image from this PR works as expected:
  ```console
  # Before
  $ docker run -it --rm ghcr.io/calimero-network/merod:0.7.0
  /usr/local/bin/merod: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/bin/merod)
  /usr/local/bin/merod: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/merod)

  # After
  $ docker run -it --rm ghcr.io/calimero-network/merod:pr-1338
  Usage: merod [OPTIONS] --node-name <NAME> <COMMAND>
  <..snip..>
  ```
- Fresh build for both node and auth passes, and environment vars are passed through:
  ```console
  # envs
  $ docker build -t merod:head . --build-arg CALIMERO_WEBUI_VERSION=latest
  <..snip..>

  # secrets
  $ GH_TOKEN="<token>" docker build -t merod:head . --secret id=gh-token,env=GH_TOKEN
  <..snip..>

  # auth via compose
  $ GH_TOKEN="<token>" docker compose -f docker-compose.prod.yml build auth
  <..snip..>
  ```

## Documentation Update

None needed