### PR TITLE
fix(Context): Don't install application from path on initial context sync

### DIFF
--- a/crates/context/primitives/src/client/sync.rs
+++ b/crates/context/primitives/src/client/sync.rs
@@ -107,12 +107,12 @@ impl ContextClient {
                             .install_application_from_url(source, metadata, None)
                             .await?
                     }
-                    _ => {
-                        // fixme! we shouldn't assume both nodes run on the same machine
-                        self.node_client
-                            .install_application_from_path(source.path().into(), metadata)
-                            .await?
-                    }
+                    _ => self.node_client.install_application(
+                        &application.blob.bytecode,
+                        application.size,
+                        &source.into(),
+                        metadata,
+                    )?,
                 };
 
                 if application.id != derived_application_id {

--- a/crates/context/primitives/src/client/sync.rs
+++ b/crates/context/primitives/src/client/sync.rs
@@ -103,9 +103,19 @@ impl ContextClient {
 
                 let derived_application_id = match source.scheme() {
                     "http" | "https" => {
-                        self.node_client
-                            .install_application_from_url(source, metadata, None)
-                            .await?
+                        match self
+                            .node_client
+                            .install_application_from_url(source.clone(), metadata.clone(), None)
+                            .await
+                        {
+                            Ok(app_id) => app_id,
+                            Err(_) => self.node_client.install_application(
+                                &application.blob.bytecode,
+                                application.size,
+                                &source.into(),
+                                metadata,
+                            )?,
+                        }
                     }
                     _ => self.node_client.install_application(
                         &application.blob.bytecode,

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -74,7 +74,7 @@ impl NodeClient {
         Ok(false)
     }
 
-    fn install_application(
+    pub fn install_application(
         &self,
         blob_id: &BlobId,
         size: u64,


### PR DESCRIPTION
# [Context] short description

## Description

Don't try to install the application in initial context sync if the path is a local path. 
Instead, create a reference in the storage and download the application on periodical context sync.

## Test plan

Run 2 nodes, install the application using local path on 1st node, create a context and invite the 2nd node to it. 
Run command `application ls` on the 2nd node and notice installed flag in the output. 
After the sync run the command again and you will see that the application is installed.

## Documentation update

N/A
