### PR TITLE
fix: revert docker changes

### DIFF
--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -52,6 +52,7 @@ LABEL org.opencontainers.image.description="Calimero Authentication Service" \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 ARG UID=10001

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -76,5 +76,4 @@ VOLUME /data
 EXPOSE 3001
 
 ENV APP_NAME=${APP_NAME}
-ENTRYPOINT $APP_NAME
-CMD ["--config", "/etc/calimero/auth.toml", "--verbose"]
+ENTRYPOINT ${APP_NAME} --config /etc/calimero/auth.toml --verbose

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,8 +5,6 @@ x-node-defaults: &node-defaults
     target: runtime
     secrets:
       - gh-token
-    args:
-      - CALIMERO_WEBUI_FETCH=1
   user: root
   volumes:
     - calimero_auth_node:/calimero
@@ -81,18 +79,14 @@ services:
       target: runtime
       secrets:
         - gh-token
-      args:
-        - CALIMERO_AUTH_FRONTEND_FETCH=1
     volumes:
       - calimero_auth_data:/data
-    user: root
     environment:
       - RUST_LOG=debug
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/auth/health"]
       interval: 30s
       timeout: 10s
-    entrypoint: ["calimero-auth", "--config", "/etc/calimero/auth.toml", "--verbose"]
     networks:
       - internal
       - web

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,8 @@ x-node-defaults: &node-defaults
     target: runtime
     secrets:
       - gh-token
+    args:
+      - CALIMERO_WEBUI_FETCH=1
   user: root
   volumes:
     - calimero_auth_node:/calimero
@@ -79,14 +81,18 @@ services:
       target: runtime
       secrets:
         - gh-token
+      args:
+        - CALIMERO_AUTH_FRONTEND_FETCH=1
     volumes:
       - calimero_auth_data:/data
+    user: root
     environment:
       - RUST_LOG=debug
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/auth/health"]
       interval: 30s
       timeout: 10s
+    entrypoint: ["calimero-auth", "--config", "/etc/calimero/auth.toml", "--verbose"]
     networks:
       - internal
       - web


### PR DESCRIPTION
## Description
A few things required in the services were unitentionally removed during the optimization. This PR brings them back:

## Test Plan
`docker-compose -f docker-compose.prod.yml up`

## Documentation Update
Complete flow will be added to the next docs version