### PR TITLE
fix: stabilize delta sync

### DIFF
--- a/crates/context/primitives/src/client.rs
+++ b/crates/context/primitives/src/client.rs
@@ -321,7 +321,7 @@ impl ContextClient {
         &self,
         context_id: &ContextId,
         public_key: &PublicKey,
-        height: NonZeroUsize,
+        height: &NonZeroUsize,
         delta: &[u8],
     ) -> eyre::Result<()> {
         let mut handle = self.datastore.handle();

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -290,7 +290,7 @@ async fn create_context(
 
     let height = NonZeroUsize::MIN;
 
-    context_client.put_state_delta(&context.id, &identity, height, &outcome.artifact)?;
+    context_client.put_state_delta(&context.id, &identity, &height, &outcome.artifact)?;
 
     context_client.set_delta_height(&context.id, &identity, height)?;
 

--- a/crates/context/src/handlers/delete_context.rs
+++ b/crates/context/src/handlers/delete_context.rs
@@ -82,6 +82,8 @@ async fn delete_context(
 
     delete_context_scoped::<key::ContextState, 32>(&mut datastore, &context_id, [0; 32], None)?;
 
+    delete_context_scoped::<key::ContextDelta, 40>(&mut datastore, &context_id, [0; 40], None)?;
+
     Ok(())
 }
 
@@ -100,7 +102,7 @@ where
     if context_id.len().saturating_add(N) != expected_length {
         bail!(
             "key length mismatch, expected: {}, got: {}",
-            Key::<K::Components>::len(),
+            Key::<K::Components>::len() - N,
             N
         )
     }

--- a/crates/context/src/handlers/execute.rs
+++ b/crates/context/src/handlers/execute.rs
@@ -425,7 +425,7 @@ async fn internal_execute(
                 context_client.put_state_delta(
                     &context.id,
                     &executor,
-                    delta_height,
+                    &delta_height,
                     &outcome.artifact,
                 )?;
 

--- a/crates/node/src/handlers/network_event.rs
+++ b/crates/node/src/handlers/network_event.rs
@@ -176,7 +176,9 @@ async fn handle_state_delta(
     if let Some(known_height) = context_client.get_delta_height(&context_id, &author_id)? {
         if known_height >= height || height.get() - known_height.get() > 1 {
             debug!(%author_id, %context_id, "Received state delta much further ahead than known height, syncing..");
-            return sync_manager.initiate_sync(context_id, source).await;
+
+            let _ignored = sync_manager.initiate_sync(context_id, source).await;
+            return Ok(());
         }
     }
 
@@ -186,7 +188,8 @@ async fn handle_state_delta(
     else {
         debug!(%author_id, %context_id, "Missing sender key, initiating sync");
 
-        return sync_manager.initiate_sync(context_id, source).await;
+        let _ignored = sync_manager.initiate_sync(context_id, source).await;
+        return Ok(());
     };
 
     let shared_key = SharedKey::from_sk(&sender_key);
@@ -194,7 +197,8 @@ async fn handle_state_delta(
     let Some(artifact) = shared_key.decrypt(artifact, nonce) else {
         debug!(%author_id, %context_id, "State delta decryption failed, initiating sync");
 
-        return sync_manager.initiate_sync(context_id, source).await;
+        let _ignored = sync_manager.initiate_sync(context_id, source).await;
+        return Ok(());
     };
 
     let identities = context_client.context_members(&context_id, Some(true));
@@ -203,8 +207,10 @@ async fn handle_state_delta(
         .await
         .transpose()?
     else {
-        bail!("no owned identities found for context: {}", context.id);
+        bail!("no owned identities found for context: {}", context_id);
     };
+
+    context_client.put_state_delta(&context_id, &author_id, &height, &artifact)?;
 
     let outcome = context_client
         .execute(
@@ -220,7 +226,16 @@ async fn handle_state_delta(
     context_client.set_delta_height(&context_id, &author_id, height)?;
 
     if outcome.root_hash != root_hash {
-        return sync_manager.initiate_sync(context_id, source).await;
+        debug!(
+            %context_id,
+            %author_id,
+            expected_root_hash = %root_hash,
+            current_root_hash = %outcome.root_hash,
+            "State delta application led to root hash mismatch, initiating sync"
+        );
+
+        let _ignored = sync_manager.initiate_sync(context_id, source).await;
+        return Ok(());
     }
 
     Ok(())

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -259,7 +259,7 @@ impl ContextDelta {
         height: usize,
     ) -> Self {
         let public_key = GenericArray::from(*public_key);
-        let height = GenericArray::from(height.to_le_bytes());
+        let height = GenericArray::from(height.to_be_bytes());
 
         let key = Key(GenericArray::from(*context_id)
             .concat(public_key)
@@ -292,7 +292,7 @@ impl ContextDelta {
 
         height.copy_from_slice(&AsRef::<[_; 72]>::as_ref(&self.0)[64..]);
 
-        usize::from_le_bytes(height)
+        usize::from_be_bytes(height)
     }
 }
 


### PR DESCRIPTION
## Description

1. Fix the delta ordering, we should be encoding the height in storage as big-endian instead of little-endian to take advantage of rocksdb's byte-wise lexicographical ordering
2. `context delete` should remove delta entries as well
3. When handling a broadcasted message;
	1. we should appropriately store the delta artifact
	2. if we sustain state variance post-delta application, the triggered sync should track time taken
4. When syncing deltas;
	- once we receive a delta entry, ensure it matches the one we requested in height and author, as a sanity check
	- ensure we never process out-of-sequence delta entries
	- ensure to store the delta entry as a product of the operation
	- log more of what happens during the sync process
	- add a guard check to ensure we never return more delta entries than are necessary

## Test plan

Tested locally with kv-store and curb chat apps, CI runs and passes

## What's left?

1. From some testing, it looks like the order of the delta applications matter, I'm investigating to what extend that is necessary, perhaps we can tweak some conditionals

2. We need to prioritize syncing the state of the context creator so we have the post-"init" state as a foundation, if fixing ^1 resolves this that'll be great, either way, still investigating

## Documentation update

None needed