### PR TITLE
chore(CI): clean up post-CI debugging

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -13,11 +13,6 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
 
     steps:
-      - name: Debug Workflow Run Payload
-        env:
-          PD: ${{ toJson(github.event.workflow_run) }}
-        run: echo "$PD"
-
       - name: Download artifact
         id: download
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
 
     env:
       CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

1. https://github.com/calimero-network/core/pull/1354 introduced a log line to visualize the workflow_run payload, from which I've observed everything to be working as expected, so we can now take it out
2. `mero-auth` is built in the release workflow, for some reason.. and so we have to pass the GH_TOKEN to mitigate the rate limiting

## Test plan

maybe the tests are the friends we met along the way

## Documentation update

--