### PR TITLE
feat(sdk): Automatically generate ABI for applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.11.27",
  "reqwest 0.12.9",
- "rust-embed 8.5.0",
+ "rust-embed",
  "serde",
  "serde_json",
  "tokio",
@@ -2245,31 +2245,48 @@ dependencies = [
  "clap",
  "const_format",
  "eyre",
- "rust-embed 6.8.1",
+ "rust-embed",
  "tokio",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.18.1"
+name = "cargo-util-schemas"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver 1.0.23",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml 0.8.19",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
 dependencies = [
  "camino",
  "cargo-platform",
+ "cargo-util-schemas",
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3463,6 +3480,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -6048,7 +6075,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest 0.12.9",
  "rocksdb",
- "rust-embed 8.5.0",
+ "rust-embed",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -6569,7 +6596,7 @@ dependencies = [
  "near-stdx",
  "near-time",
  "num-rational 0.3.2",
- "ordered-float",
+ "ordered-float 4.5.0",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -7110,6 +7137,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -8319,36 +8355,12 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
-version = "6.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
-dependencies = [
- "rust-embed-impl 6.8.1",
- "rust-embed-utils 7.8.1",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed"
 version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "rust-embed-impl 8.5.0",
- "rust-embed-utils 8.5.0",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "6.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils 7.8.1",
- "syn 2.0.100",
+ "rust-embed-impl",
+ "rust-embed-utils",
  "walkdir",
 ]
 
@@ -8360,19 +8372,9 @@ checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-embed-utils 8.5.0",
+ "rust-embed-utils",
  "shellexpand",
  "syn 2.0.100",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "7.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
-dependencies = [
- "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -8752,6 +8754,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -10437,6 +10460,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,7 @@ dependencies = [
  "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.100",
  "thiserror 1.0.69",
 ]
@@ -2085,7 +2086,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.11.27",
  "reqwest 0.12.9",
- "rust-embed",
+ "rust-embed 8.5.0",
  "serde",
  "serde_json",
  "tokio",
@@ -2244,48 +2245,31 @@ dependencies = [
  "clap",
  "const_format",
  "eyre",
- "rust-embed",
+ "rust-embed 6.8.1",
  "tokio",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.2.0"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "cargo-util-schemas"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
-dependencies = [
- "semver 1.0.23",
- "serde",
- "serde-untagged",
- "serde-value",
- "thiserror 1.0.69",
- "toml 0.8.19",
- "unicode-xid",
- "url",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.20.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "cargo-util-schemas",
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3479,16 +3463,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "erased-serde"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
-dependencies = [
- "serde",
- "typeid",
-]
 
 [[package]]
 name = "errno"
@@ -6074,7 +6048,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest 0.12.9",
  "rocksdb",
- "rust-embed",
+ "rust-embed 8.5.0",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -6595,7 +6569,7 @@ dependencies = [
  "near-stdx",
  "near-time",
  "num-rational 0.3.2",
- "ordered-float 4.5.0",
+ "ordered-float",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -7136,15 +7110,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -8354,12 +8319,36 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+dependencies = [
+ "rust-embed-impl 6.8.1",
+ "rust-embed-utils 7.8.1",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed"
 version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
+ "rust-embed-impl 8.5.0",
+ "rust-embed-utils 8.5.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils 7.8.1",
+ "syn 2.0.100",
  "walkdir",
 ]
 
@@ -8371,9 +8360,19 @@ checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-embed-utils",
+ "rust-embed-utils 8.5.0",
  "shellexpand",
  "syn 2.0.100",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+dependencies = [
+ "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -8753,27 +8752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-untagged"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
-dependencies = [
- "erased-serde",
- "serde",
- "typeid",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.1",
- "serde",
 ]
 
 [[package]]
@@ -10459,12 +10437,6 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/crates/cargo-mero/Cargo.toml
+++ b/crates/cargo-mero/Cargo.toml
@@ -1,21 +1,15 @@
 [package]
 name = "cargo-mero"
 version = "0.1.0"
-description = "CLI tool for building applications on the Calimero network"
-categories = ["command-line-utilities"]
-keywords = ["cli", "cargo", "subcommand"]
-authors.workspace = true
-edition.workspace = true
-repository.workspace = true
-license.workspace = true
+edition = "2021"
 
 [dependencies]
-cargo_metadata.workspace = true
-clap = { workspace = true, features = ["derive"] }
-const_format.workspace = true
-eyre.workspace = true
-rust-embed.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "io-util"] }
+clap = { version = "4", features = ["derive"] }
+const_format = "0.2"
+eyre = "0.6"
+tokio = { version = "1", features = ["full"] }
+cargo_metadata = "0.18"
+rust-embed = "6.4.2"
 
-[lints]
-workspace = true
+[features]
+default = []

--- a/crates/cargo-mero/Cargo.toml
+++ b/crates/cargo-mero/Cargo.toml
@@ -1,15 +1,21 @@
 [package]
 name = "cargo-mero"
 version = "0.1.0"
-edition = "2021"
+description = "CLI tool for building applications on the Calimero network"
+categories = ["command-line-utilities"]
+keywords = ["cli", "cargo", "subcommand"]
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
-const_format = "0.2"
-eyre = "0.6"
-tokio = { version = "1", features = ["full"] }
-cargo_metadata = "0.18"
-rust-embed = "6.4.2"
+cargo_metadata.workspace = true
+clap = { workspace = true, features = ["derive"] }
+const_format.workspace = true
+eyre.workspace = true
+rust-embed.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "io-util"] }
 
-[features]
-default = []
+[lints]
+workspace = true

--- a/crates/cargo-mero/src/main.rs
+++ b/crates/cargo-mero/src/main.rs
@@ -1,8 +1,8 @@
-use clap::Parser;
-
 mod build;
 mod cli;
 mod new;
+
+use clap::Parser;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {

--- a/crates/sdk/macros/Cargo.toml
+++ b/crates/sdk/macros/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 name = "calimero-sdk-macros"
 version = "0.1.0"
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-quote = "1"
-syn = { version = "2", features = ["full", "extra-traits"] }
-proc-macro2 = "1"
-serde_json = "1"
-thiserror = "1"
-prettyplease = "0.2"
+prettyplease.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+serde_json.workspace = true
+syn = { workspace = true, features = ["extra-traits", "full"] }
+thiserror.workspace = true
 
 [features]
 nightly = []

--- a/crates/sdk/macros/Cargo.toml
+++ b/crates/sdk/macros/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 name = "calimero-sdk-macros"
 version = "0.1.0"
-authors.workspace = true
-edition.workspace = true
-repository.workspace = true
-license.workspace = true
+edition = "2021"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-prettyplease.workspace = true
-proc-macro2.workspace = true
-quote.workspace = true
-syn = { workspace = true, features = ["extra-traits"] }
-thiserror.workspace = true
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }
+proc-macro2 = "1"
+serde_json = "1"
+thiserror = "1"
+prettyplease = "0.2"
 
 [features]
 nightly = []

--- a/crates/sdk/macros/src/abi.rs
+++ b/crates/sdk/macros/src/abi.rs
@@ -1,0 +1,33 @@
+use crate::logic::method::PublicLogicMethod;
+use serde_json::json;
+
+pub struct Abi<'a> {
+    pub methods: &'a Vec<PublicLogicMethod<'a>>,
+}
+
+impl Abi<'_> {
+    pub fn to_string(&self) -> String {
+        let methods = self
+            .methods
+            .iter()
+            .map(|method| {
+                let args = method
+                    .args
+                    .iter()
+                    .map(|arg| arg.to_json())
+                    .collect::<Vec<_>>();
+                let result = method.ret.as_ref().map(|ret| ret.to_json());
+                json!({
+                    "name": method.name.to_string(),
+                    "args": args,
+                    "result": result,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        json!({
+            "methods": methods,
+        })
+        .to_string()
+    }
+} 

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -14,6 +14,7 @@ use crate::items::{Empty, StructOrEnumItem};
 use crate::logic::{LogicImpl, LogicImplInput};
 use crate::state::{StateArgs, StateImpl, StateImplInput};
 
+mod abi;
 mod errors;
 mod event;
 mod items;

--- a/crates/sdk/macros/src/logic/arg.rs
+++ b/crates/sdk/macros/src/logic/arg.rs
@@ -5,6 +5,7 @@ use syn::{Error as SynError, FnArg, Ident, Pat, Path, Type};
 use crate::errors::{Errors, ParseError, Pretty};
 use crate::logic::ty::{LogicTy, LogicTyInput};
 use crate::logic::utils::typed_path;
+use serde_json::{json, Value};
 
 pub enum SelfType<'a> {
     Owned(&'a Type),
@@ -20,6 +21,15 @@ pub enum LogicArg<'a> {
 pub struct LogicArgTyped<'a> {
     pub ident: &'a Ident,
     pub ty: LogicTy,
+}
+
+impl LogicArgTyped<'_> {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "name": self.ident.to_string(),
+            "type": self.ty.to_json(),
+        })
+    }
 }
 
 impl ToTokens for LogicArgTyped<'_> {

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -20,10 +20,10 @@ pub enum Modifer {
 pub struct PublicLogicMethod<'a> {
     self_: Path,
 
-    name: &'a Ident,
+    pub name: &'a Ident,
     self_type: Option<SelfType<'a>>,
-    args: Vec<LogicArgTyped<'a>>,
-    ret: Option<LogicTy>,
+    pub args: Vec<LogicArgTyped<'a>>,
+    pub ret: Option<LogicTy>,
 
     has_refs: bool,
 

--- a/crates/sdk/macros/src/logic/ty.rs
+++ b/crates/sdk/macros/src/logic/ty.rs
@@ -6,10 +6,20 @@ use crate::errors::{Errors, ParseError};
 use crate::macros::infallible;
 use crate::reserved::{idents, lifetimes};
 use crate::sanitizer::{Action, Case, Sanitizer};
+use serde_json::{json, Value};
 
 pub struct LogicTy {
     pub ty: Type,
     pub ref_: bool,
+}
+
+impl LogicTy {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "type": self.ty.to_token_stream().to_string(),
+            "ref": self.ref_,
+        })
+    }
 }
 
 impl ToTokens for LogicTy {


### PR DESCRIPTION
## Description

This pull request introduces a feature to automatically generate an Application Binary Interface (ABI) for Calimero applications. This is delivered in two ways:

1.  A `get_abi()` function is compiled directly into the WASM, allowing for runtime introspection of the application's interface.
2.  A machine-readable `abi.json` file is generated at compile time, detailing the public methods.

This makes it significantly easier for clients and tools to interact with Calimero applications, as they can programmatically discover available methods, expected arguments, and return types, both at runtime and build time.

### Problem:

Previously, Calimero applications compiled to WASM did not have a standardized way to expose their public API. Any client wishing to communicate with an application had to have prior, out-of-band knowledge of the function signatures. This process was manual, error-prone, and made tooling difficult.

### Solution:

The implementation is centered within the `calimero-sdk-macros` crate:

1.  **ABI Extraction**: The `#[app::logic]` macro has been enhanced to parse the public methods of the `impl` block it decorates. It gathers essential information, including method names, argument names and types, and return types.

2.  **JSON Generation**: The extracted API information is serialized into a well-structured JSON string.

3.  **WASM Export**: The macro injects a public `get_abi()` function into the application's code. When called, this function returns the ABI as a JSON string. This allows any client interacting with the WASM at runtime to query its interface directly.

4.  **File Creation**: During compilation (`cargo build`), the macro also writes the same ABI JSON to a file named `abi.json` inside a `res/` directory at the root of the application crate (e.g., `apps/kv-store/res/abi.json`). The macro automatically creates the `res/` directory if it does not already exist.

This dual approach ensures that the ABI is always perfectly synchronized with the source code and is accessible both through runtime introspection and as a build artifact.

## How to test

Check https://github.com/calimero-network/calimero-client-js/pull/61

## Documentation Updates

TBD