### PR TITLE
fix: update application

### DIFF
--- a/crates/context/primitives/src/client/sync.rs
+++ b/crates/context/primitives/src/client/sync.rs
@@ -1,9 +1,12 @@
 use calimero_primitives::context::{Context, ContextConfigParams, ContextId};
 use calimero_primitives::hash::Hash;
 use calimero_store::{key, types};
+use tokio::sync::oneshot;
 use url::Url;
 
 use super::ContextClient;
+use crate::messages::sync::SyncRequest;
+use crate::messages::ContextMessage;
 
 impl ContextClient {
     pub async fn sync_context_config(
@@ -164,11 +167,25 @@ impl ContextClient {
         );
 
         if should_save {
-            // todo! if the application_id changed, we need to notify ContextManager
             handle.put(
                 &key::ContextMeta::new(context_id),
                 &types::ContextMeta::new(key::ApplicationMeta::new(application_id), *root_hash),
             )?;
+
+            let (sender, receiver) = oneshot::channel();
+
+            self.context_manager
+                .send(ContextMessage::Sync {
+                    request: SyncRequest {
+                        context_id,
+                        application_id,
+                    },
+                    outcome: sender,
+                })
+                .await
+                .expect("Mailbox not to be dropped");
+
+            receiver.await.expect("Mailbox not to be dropped")
         }
 
         let context = Context::new(context_id, application_id, root_hash);

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -5,12 +5,14 @@ pub mod create_context;
 pub mod delete_context;
 pub mod execute;
 pub mod join_context;
+pub mod sync;
 pub mod update_application;
 
 use create_context::CreateContextRequest;
 use delete_context::DeleteContextRequest;
 use execute::ExecuteRequest;
 use join_context::JoinContextRequest;
+use sync::SyncRequest;
 use update_application::UpdateApplicationRequest;
 
 #[derive(Debug, Message)]
@@ -35,5 +37,9 @@ pub enum ContextMessage {
     UpdateApplication {
         request: UpdateApplicationRequest,
         outcome: oneshot::Sender<<UpdateApplicationRequest as Message>::Result>,
+    },
+    Sync {
+        request: SyncRequest,
+        outcome: oneshot::Sender<<SyncRequest as Message>::Result>,
     },
 }

--- a/crates/context/primitives/src/messages/sync.rs
+++ b/crates/context/primitives/src/messages/sync.rs
@@ -1,0 +1,13 @@
+use actix::Message;
+use calimero_primitives::application::ApplicationId;
+use calimero_primitives::context::ContextId;
+
+#[derive(Copy, Clone, Debug)]
+pub struct SyncRequest {
+    pub context_id: ContextId,
+    pub application_id: ApplicationId,
+}
+
+impl Message for SyncRequest {
+    type Result = ();
+}

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -8,6 +8,7 @@ pub mod create_context;
 pub mod delete_context;
 pub mod execute;
 pub mod join_context;
+pub mod sync;
 pub mod update_application;
 
 impl Handler<ContextMessage> for ContextManager {
@@ -28,6 +29,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::JoinContext { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::Sync { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
         }

--- a/crates/context/src/handlers/sync.rs
+++ b/crates/context/src/handlers/sync.rs
@@ -1,0 +1,21 @@
+use actix::{Handler, Message};
+use calimero_context_primitives::messages::sync::SyncRequest;
+
+use crate::ContextManager;
+
+impl Handler<SyncRequest> for ContextManager {
+    type Result = <SyncRequest as Message>::Result;
+
+    fn handle(
+        &mut self,
+        SyncRequest {
+            context_id,
+            application_id,
+        }: SyncRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        if let Some(context) = self.contexts.get_mut(&context_id) {
+            context.meta.application_id = application_id;
+        }
+    }
+}


### PR DESCRIPTION
## Description

A couple of things here:

1. The `UpdateApplication` handler, after updating the application on the context config contract, was calling into `update_application` on the `ContextClient`, which in turn led to the `UpdateApplication` handler to be triggered, culminating essentially in infinite recursion.
2. The context meta cache on `ContextManager` needs to be updated when a context config sync causes us to be made aware of an application update.

## Test plan

Local testing

## Documentation update

--