### PR TITLE
chore: qol improvements

### DIFF
--- a/crates/meroctl/src/cli/call.rs
+++ b/crates/meroctl/src/cli/call.rs
@@ -75,7 +75,7 @@ impl Report for Response {
                     if let Some(output) = &result.output {
                         let _ = table.add_row(vec![format!("Output: {:#}", output)]);
                     } else {
-                        let _ = table.add_row(vec!["<no output>".to_string()]);
+                        let _ = table.add_row(vec!["<no output>".to_owned()]);
                     }
                 } else {
                     let _ = table.add_row(vec![format!("Result: {:#}", result)]);

--- a/crates/node/src/handlers/network_event.rs
+++ b/crates/node/src/handlers/network_event.rs
@@ -10,6 +10,7 @@ use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use eyre::bail;
 use libp2p::PeerId;
+use owo_colors::OwoColorize;
 use tracing::{debug, info, warn};
 
 use crate::sync::SyncManager;
@@ -46,7 +47,8 @@ impl Handler<NetworkEvent> for NodeManager {
 
                 info!(
                     "Peer '{}' subscribed to context '{}'",
-                    their_peer_id, context_id
+                    their_peer_id.cyan(),
+                    context_id.cyan()
                 );
             }
             NetworkEvent::Unsubscribed {

--- a/crates/node/src/interactive_cli/context.rs
+++ b/crates/node/src/interactive_cli/context.rs
@@ -77,7 +77,7 @@ enum Commands {
         #[clap(long, short, default_value = "default")]
         context: Alias<ContextId>,
         /// The identity inviting the other
-        #[clap(long = "as")]
+        #[clap(long = "as", default_value = "default")]
         inviter: Alias<PublicKey>,
         /// The name for the invitee
         #[clap(long)]
@@ -105,7 +105,6 @@ enum Commands {
     /// Delete a context
     Delete {
         /// The context to delete
-        #[clap(long, short)]
         context: Alias<ContextId>,
     },
     /// Update the proxy for a context
@@ -319,7 +318,8 @@ impl ContextCommand {
 
                 println!(
                     "{ind} Joined context '{}' as '{}', syncing state...",
-                    response.context_id, response.member_public_key
+                    response.context_id.cyan(),
+                    response.member_public_key.cyan()
                 );
             }
 
@@ -390,8 +390,9 @@ impl ContextCommand {
                         }
 
                         println!(
-                            "{ind} Created context {} with identity {}",
-                            response.context_id, response.identity
+                            "{ind} Created context '{}' with identity '{}'",
+                            response.context_id.cyan(),
+                            response.identity.cyan()
                         );
                     }
                     Err(err) => {
@@ -424,7 +425,7 @@ impl ContextCommand {
                         pretty_alias(name, &invitee_id),
                         pretty_alias(Some(context), &context_id)
                     );
-                    println!("{ind} Invitation Payload: {invitation_payload}");
+                    println!("{ind} Invitation Payload: '{}'", invitation_payload.cyan());
                 } else {
                     println!(
                         "{ind} Unable to invite '{}' to context '{}'",
@@ -574,11 +575,13 @@ impl ContextCommand {
 
                 if context.as_str() != context_id.as_str() {
                     println!(
-                        "{} Default context set to: {} (from alias '{}')",
-                        ind, context_id, context
+                        "{} Default context set to '{}' (from alias '{}')",
+                        ind,
+                        context_id.cyan(),
+                        context.cyan()
                     );
                 } else {
-                    println!("{} Default context set to: {}", ind, context_id);
+                    println!("{} Default context set to '{}'", ind, context_id.cyan());
                 }
             }
             Commands::Identity(identity) => identity.run(node_client, ctx_client).await?,

--- a/crates/server/primitives/src/jsonrpc.rs
+++ b/crates/server/primitives/src/jsonrpc.rs
@@ -5,12 +5,13 @@ use calimero_primitives::identity::PublicKey;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum RequestId {
     String(String),
     Number(u64),
+    #[default]
     Null,
 }
 
@@ -51,14 +52,14 @@ impl<'de> Deserialize<'de> for Version {
 #[non_exhaustive]
 pub struct Request<P> {
     pub jsonrpc: Version,
-    pub id: Option<RequestId>,
+    pub id: RequestId,
     #[serde(flatten)]
     pub payload: P,
 }
 
 impl Request<RequestPayload> {
     #[must_use]
-    pub const fn new(jsonrpc: Version, id: Option<RequestId>, payload: RequestPayload) -> Self {
+    pub const fn new(jsonrpc: Version, id: RequestId, payload: RequestPayload) -> Self {
         Self {
             jsonrpc,
             id,
@@ -78,14 +79,14 @@ pub enum RequestPayload {
 #[non_exhaustive]
 pub struct Response {
     pub jsonrpc: Version,
-    pub id: Option<RequestId>,
+    pub id: RequestId,
     #[serde(flatten)]
     pub body: ResponseBody,
 }
 
 impl Response {
     #[must_use]
-    pub const fn new(jsonrpc: Version, id: Option<RequestId>, body: ResponseBody) -> Self {
+    pub const fn new(jsonrpc: Version, id: RequestId, body: ResponseBody) -> Self {
         Self { jsonrpc, id, body }
     }
 }

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# temp setup to test stuff
+# you may need to modify
+# the TCONTRACT, TRPC vars
+# to match your environment
+
 set -e
 
 cd "$(dirname $0)"


### PR DESCRIPTION
## Description

- Better output representation for `meroctl call`
- `ContextId`, `ApplicationId` and `PublicKey` with the colored representation should be consistent.
- `context delete <ctx-id>` instead of `context delete -c <ctx-id>`

## Test plan

--

## Documentation update

--