### PR TITLE
ci: compress and include mero-auth binaries in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
           mkdir -p artifacts
 
           readarray -t binaries <<< "$BINARIES"
+          readarray -t auth_binaries <<< "$AUTH_BINARIES"
+
+          binaries+=("${auth_binaries[@]}")
 
           for binary in "${binaries[@]}"; do
             tar -czf artifacts/"$binary"_${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release "$binary"


### PR DESCRIPTION
## Description
Missed it in the previous [PR](https://github.com/calimero-network/core/pull/1355)

## Test Plan
n/a

## Documentation Update
n/a