### PR TITLE
feat: on-demand context sync

### DIFF
--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -111,5 +111,7 @@ async fn join_context(
 
     node_client.subscribe(&context_id).await?;
 
+    node_client.sync(Some(&context_id)).await?;
+
     Ok((context_id, invitee_id))
 }

--- a/crates/context/src/handlers/update_application.rs
+++ b/crates/context/src/handlers/update_application.rs
@@ -89,5 +89,7 @@ pub async fn update_application_id(
         .update_application(&context_id, &application_id, &public_key)
         .await?;
 
+    node_client.sync(Some(&context_id)).await?;
+
     Ok(application)
 }

--- a/crates/meroctl/src/cli/context.rs
+++ b/crates/meroctl/src/cli/context.rs
@@ -16,6 +16,7 @@ pub mod invite;
 pub mod join;
 pub mod list;
 pub mod proposals;
+pub mod sync;
 pub mod update;
 pub mod watch;
 
@@ -64,6 +65,7 @@ pub enum ContextSubCommands {
     Alias(alias::ContextAliasCommand),
     Use(alias::UseCommand),
     Proposals(proposals::ProposalsCommand),
+    Sync(sync::SyncCommand),
 }
 
 impl Report for Context {
@@ -99,6 +101,7 @@ impl ContextCommand {
             ContextSubCommands::Alias(alias) => alias.run(environment).await,
             ContextSubCommands::Use(use_cmd) => use_cmd.run(environment).await,
             ContextSubCommands::Proposals(proposals) => proposals.run(environment).await,
+            ContextSubCommands::Sync(sync) => sync.run(environment).await,
         }
     }
 }

--- a/crates/meroctl/src/cli/context/sync.rs
+++ b/crates/meroctl/src/cli/context/sync.rs
@@ -44,11 +44,7 @@ impl SyncCommand {
             format!("/admin-api/contexts/sync/{context_id}").into()
         };
 
-        let e = connection.post(&url, ()).await;
-
-        dbg!(&e);
-
-        let response: SyncContextResponse = e?;
+        let response: SyncContextResponse = connection.post(&url, ()).await?;
 
         environment.output.write(&response);
 

--- a/crates/meroctl/src/cli/context/sync.rs
+++ b/crates/meroctl/src/cli/context/sync.rs
@@ -1,0 +1,57 @@
+use std::borrow::Cow;
+
+use calimero_primitives::alias::Alias;
+use calimero_primitives::context::ContextId;
+use calimero_server_primitives::admin::SyncContextResponse;
+use clap::Parser;
+use eyre::{OptionExt, Result};
+
+use crate::cli::Environment;
+use crate::common::resolve_alias;
+use crate::output::Report;
+
+#[derive(Copy, Clone, Debug, Parser)]
+#[command(about = "Explicitly request a sync")]
+pub struct SyncCommand {
+    #[clap(long, short, help = "The context to sync", default_value = "default")]
+    context: Alias<ContextId>,
+
+    #[clap(long, short, help = "Sync all contexts", conflicts_with = "context")]
+    all: bool,
+}
+
+impl Report for SyncContextResponse {
+    fn report(&self) {
+        let mut table = comfy_table::Table::new();
+        let _ = table.add_row(["Sync requested"]);
+        println!("{table}");
+    }
+}
+
+impl SyncCommand {
+    pub async fn run(self, environment: &Environment) -> Result<()> {
+        let connection = environment.connection()?;
+
+        let url = if self.all {
+            Cow::from("/admin-api/contexts/sync")
+        } else {
+            let context_id = resolve_alias(connection, self.context, None)
+                .await?
+                .value()
+                .copied()
+                .ok_or_eyre("unable to resolve")?;
+
+            format!("/admin-api/contexts/sync/{context_id}").into()
+        };
+
+        let e = connection.post(&url, ()).await;
+
+        dbg!(&e);
+
+        let response: SyncContextResponse = e?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}

--- a/crates/node/src/interactive_cli/peers.rs
+++ b/crates/node/src/interactive_cli/peers.rs
@@ -37,7 +37,7 @@ impl PeersCommand {
             println!(
                 "{ind} Peers (Session) for Topic {}: {:#?}",
                 topic.clone(),
-                node_client.get_peers_count(Some(context_id)).await.cyan()
+                node_client.get_peers_count(Some(&context_id)).await.cyan()
             );
         }
 

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -109,12 +109,15 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
 
     let (event_sender, _) = broadcast::channel(32);
 
+    let (ctx_sync_tx, ctx_sync_rx) = mpsc::channel(16);
+
     let node_client = NodeClient::new(
         datastore.clone(),
         blobstore.clone(),
         network_client.clone(),
         node_recipient.clone(),
         event_sender,
+        ctx_sync_tx,
     );
 
     let external_client = ExternalClient::from_config(&config.context.client);
@@ -143,6 +146,7 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
         node_client.clone(),
         context_client.clone(),
         network_client.clone(),
+        ctx_sync_rx,
     );
 
     let node_manager = NodeManager::new(

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -153,10 +153,10 @@ impl SyncManager {
                 Some(()) = async {
                     loop { advance(&mut futs, &mut state).await? }
                 } => {},
-                Some(res) = ctx_sync_rx.recv() => {
-                    debug!(?res, "Received an explicit sync request");
+                Some(ctx) = ctx_sync_rx.recv() => {
+                    debug!(?ctx, "Received an explicit sync request");
 
-                    requested_ctx = res;
+                    requested_ctx = ctx;
                 }
             }
 

--- a/crates/server/primitives/src/admin.rs
+++ b/crates/server/primitives/src/admin.rs
@@ -904,3 +904,15 @@ impl RevokePermissionResponse {
         Self { data: Empty {} }
     }
 }
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncContextResponse {
+    pub data: Empty,
+}
+
+impl SyncContextResponse {
+    pub const fn new() -> Self {
+        Self { data: Empty {} }
+    }
+}

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -8,4 +8,5 @@ pub mod grant_capabilities;
 pub mod invite_to_context;
 pub mod join_context;
 pub mod revoke_capabilities;
+pub mod sync;
 pub mod update_context_application;

--- a/crates/server/src/admin/handlers/context/sync.rs
+++ b/crates/server/src/admin/handlers/context/sync.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_primitives::context::ContextId;
+use calimero_server_primitives::admin::SyncContextResponse;
+
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Extension(state): Extension<Arc<AdminState>>,
+    context_id: Option<Path<ContextId>>,
+) -> impl IntoResponse {
+    let context_id = context_id.map(|Path(c)| c);
+
+    let result = state.node_client.sync(context_id.as_ref()).await;
+
+    match result {
+        Ok(()) => ApiResponse {
+            payload: SyncContextResponse::new(),
+        }
+        .into_response(),
+        Err(err) => parse_api_error(err).into_response(),
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -31,7 +31,7 @@ use crate::admin::handlers::applications::{
 };
 use crate::admin::handlers::context::{
     create_context, delete_context, get_context, get_context_identities, get_context_storage,
-    get_contexts, invite_to_context, join_context, update_context_application,
+    get_contexts, invite_to_context, join_context, sync, update_context_application,
 };
 use crate::admin::handlers::identity::generate_context_identity;
 use crate::admin::handlers::peers::get_peers_count_handler;
@@ -171,6 +171,12 @@ pub(crate) fn setup(
         .route(
             "/contexts/:context_id/proxy-contract",
             get(get_proxy_contract_handler),
+        )
+        .nest(
+            "/contexts/sync",
+            Router::new()
+                .route("/", post(sync::handler))
+                .route("/:context_id", post(sync::handler)),
         )
         // Network info
         .route("/peers", get(get_peers_count_handler))


### PR DESCRIPTION
## Description

Sync contexts when explicitly requested.

This also means we can explicitly request a sync after joining a context. As well as after updating the application.

This is also made available both via merod's interactive CLI, the APIs and also meroctl.

```
context sync
  (sync the default context)
context sync -c <context-id>
  (sync the context specifically)
context sync -a
  (sync all contexts)
```

## Test plan

Tested locally

## Documentation update

--