### PR TITLE
feat(build): fetch pre-built admin dashboard from release assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,9 +804,9 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -2083,7 +2083,6 @@ dependencies = [
  "libp2p",
  "multiaddr",
  "rand 0.8.5",
- "reqwest 0.11.27",
  "reqwest 0.12.9",
  "rust-embed",
  "serde",
@@ -2829,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -3093,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -41,8 +41,6 @@ bytes.workspace = true
 cached-path.workspace = true
 eyre.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
-# cached-path compat
-reqwest-compat = { version = "0.11", package = "reqwest", features = ["blocking"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -83,23 +83,10 @@ fn try_main() -> eyre::Result<()> {
         }
     };
 
-    let mut builder = reqwest_compat::blocking::Client::builder().user_agent(USER_AGENT);
-
-    if let Some(token) = token {
-        let headers = [(
-            reqwest_compat::header::AUTHORIZATION,
-            format!("Bearer {token}").try_into()?,
-        )]
-        .into_iter();
-
-        builder = builder.default_headers(headers.collect());
-    }
-
     let webui_dir = if is_local_dir {
         Cow::from(Path::new(&*src))
     } else {
         let cache = Cache::builder()
-            .client_builder(builder)
             .freshness_lifetime(FRESHNESS_LIFETIME)
             .dir(target_dir()?.join("cache"))
             .build()?;

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -72,16 +72,14 @@ fn try_main() -> eyre::Result<()> {
                 other => bail!("expected json response, got: {:?}", other),
             };
 
-            let zipball_url = release
+            let build_url = release
                 .assets
                 .into_iter()
                 .find(|asset| asset.name == "admin-dashboard-build.zip")
                 .map(|asset| asset.browser_download_url)
                 .ok_or_eyre("missing `admin-dashboard-build.zip` asset")?;
 
-            println!("zipball_url: {}", zipball_url);
-
-            zipball_url.into()
+            build_url.into()
         }
     };
 
@@ -117,15 +115,7 @@ fn try_main() -> eyre::Result<()> {
 
         let workdir = cache.cached_path_with_options(&*src, &options)?;
 
-        if src.ends_with(".zip") {
-            Cow::from(workdir)
-        } else {
-            let repo = fs::read_dir(&workdir)?
-                .filter_map(Result::ok)
-                .find(|entry| entry.path().is_dir())
-                .ok_or_eyre("no extracted directory found")?;
-            Cow::from(repo.path().join("build"))
-        }
+        workdir.into()
     };
 
     println!("cargo:rerun-if-changed={}", webui_dir.display());


### PR DESCRIPTION
## Description

This PR updates the build process to fetch a pre-built admin dashboard artifact from the GitHub release assets, rather than downloading the entire source code. This change improves build efficiency and aligns with the new semantic-release workflow.

## Test plan

 CALIMERO_WEBUI_FETCH=1 cargo run -p merod -- --node-name node1 run
 Navigate to http://localhost:2428/admin-dashboard/

## Documentation update
N/A transparent for the user
