### PR TITLE
ci: include mero-auth container in the release workflow

### DIFF
--- a/.github/actions/release/container.yml
+++ b/.github/actions/release/container.yml
@@ -1,0 +1,113 @@
+name: Container release
+description: "Release container based on prebuilt binaries"
+runs-on: ubuntu-latest
+timeout-minutes: 120
+
+inputs:
+  binaries:
+    description: "List of binaries to include in the container"
+    required: true
+  dockerfile:
+    description: "Path to the Dockerfile to use for building the container"
+    required: true
+  conatiner_name:
+    description: "Name of the container to build and push"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download built binaries
+      uses: actions/download-artifact@v4
+      with:
+        path: binaries/
+        merge-multiple: true
+
+    - name: Extract Linux binaries
+      shell: bash
+      run: |
+        mkdir -p ./bin/amd64 ./bin/arm64
+
+        readarray -t binaries <<< "${{ inputs.binaries }}"
+
+        for binary in ${binaries[@]}; do
+          echo "Extracting ${binary} binaries"
+
+          tar -xzf binaries/${binary}_x86_64-unknown-linux-gnu.tar.gz -C ./bin/amd64 --no-same-owner
+          tar -xzf binaries/${binary}_aarch64-unknown-linux-gnu.tar.gz -C ./bin/arm64 --no-same-owner
+        done
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare Docker Cache parameters
+      shell: bash
+      id: prepare
+      run: |
+        MASTER_SCOPE="${{ github.repository_owner }}-docker-master"
+        DEV_SCOPE="${{ github.repository_owner }}-docker-dev"
+
+        if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+          echo "cache_from=type=gha,scope=${MASTER_SCOPE}" >> $GITHUB_OUTPUT
+          echo "cache_to=type=gha,scope=${MASTER_SCOPE},mode=max" >> $GITHUB_OUTPUT
+        else
+          echo "cache_from=type=gha,scope=${MASTER_SCOPE} type=gha,scope=${DEV_SCOPE}" >> $GITHUB_OUTPUT
+          echo "cache_to=type=gha,scope=${DEV_SCOPE},mode=max" >> $GITHUB_OUTPUT
+        fi
+
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "docker_source=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
+        else
+          echo "docker_source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Extract metadata
+      id: metadata
+      uses: docker/metadata-action@v5
+      env:
+        LABELS: |
+          org.opencontainers.image.description=Calimero Node
+          org.opencontainers.image.source=${{ steps.prepare.outputs.docker_source }}
+          org.opencontainers.image.licenses=MIT OR Apache-2.0
+          org.opencontainers.image.authors=Calimero Limited <info@calimero.network>
+          org.opencontainers.image.url=https://calimero.network
+        DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        DOCKER_METADATA_PR_HEAD_SHA: true
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.container_name }}
+        tags: |
+          type=edge
+          type=ref,prefix=pr-,event=pr
+          type=sha,prefix=,format=short
+          type=raw,value=${{ needs.prepare.outputs.version }},enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' }}
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' && needs.prepare.outputs.prerelease == 'false' }}
+        labels: ${{ env.LABELS }}
+        annotations: ${{ env.LABELS }}
+
+    - name: Build and push image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: .github/workflows/deps/prebuilt.Dockerfile
+        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.metadata.outputs.tags }}
+        labels: ${{ steps.metadata.outputs.labels }}
+        annotations: ${{ steps.metadata.outputs.annotations }}
+        cache-from: ${{ steps.prepare.outputs.cache_from }}
+        cache-to: ${{ steps.prepare.outputs.cache_to }}
+        provenance: false
+        sbom: false

--- a/.github/workflows/deps/prebuilt.auth.Dockerfile
+++ b/.github/workflows/deps/prebuilt.auth.Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# Dockerfile for prebuilt binaries
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG UID=10001
+RUN useradd \
+    --home-dir "/user" \
+    --create-home \
+    --shell "/sbin/nologin" \
+    --uid "${UID}" \
+    user
+
+ARG TARGETARCH
+
+# Copy the prebuilt binary from the CI workflow artifacts
+COPY \
+    bin/${TARGETARCH}/mero-auth \
+    /usr/local/bin/
+COPY crates/auth/config/config.toml /etc/calimero/auth.toml
+
+RUN chmod +x /usr/local/bin/mero-auth
+
+USER user
+WORKDIR /data
+
+VOLUME /data
+EXPOSE 3001
+
+ENTRYPOINT mero-auth --config /etc/calimero/auth.toml --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,111 +165,35 @@ jobs:
           prerelease: ${{ needs.prepare.outputs.prerelease }}
           target_commit: ${{ needs.prepare.outputs.target_commit }}
 
-  build-docker:
-    name: Build Docker Image
+  release-merod-container:
+    name: Release Merod container
     needs: [prepare, build-binaries]
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ needs.prepare.outputs.version }}
       cancel-in-progress: true
     permissions:
       contents: read
       packages: write
+    uses: ./.github/actions/release/container.yml
+    with:
+      binaries: $BINARIES
+      dockerfile: .github/workflows/deps/prebuilt.Dockerfile
+      container_name: merod
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Download built binaries
-        uses: actions/download-artifact@v4
-        with:
-          path: binaries/
-          merge-multiple: true
-
-      - name: Extract Linux binaries
-        run: |
-          mkdir -p ./bin/amd64 ./bin/arm64
-
-          readarray -t binaries <<< "$BINARIES"
-
-          for binary in ${binaries[@]}; do
-            echo "Extracting ${binary} binaries"
-
-            tar -xzf binaries/${binary}_x86_64-unknown-linux-gnu.tar.gz -C ./bin/amd64 --no-same-owner
-            tar -xzf binaries/${binary}_aarch64-unknown-linux-gnu.tar.gz -C ./bin/arm64 --no-same-owner
-          done
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare Docker Cache parameters
-        id: prepare
-        run: |
-          MASTER_SCOPE="${{ github.repository_owner }}-docker-master"
-          DEV_SCOPE="${{ github.repository_owner }}-docker-dev"
-
-          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-            echo "cache_from=type=gha,scope=${MASTER_SCOPE}" >> $GITHUB_OUTPUT
-            echo "cache_to=type=gha,scope=${MASTER_SCOPE},mode=max" >> $GITHUB_OUTPUT
-          else
-            echo "cache_from=type=gha,scope=${MASTER_SCOPE} type=gha,scope=${DEV_SCOPE}" >> $GITHUB_OUTPUT
-            echo "cache_to=type=gha,scope=${DEV_SCOPE},mode=max" >> $GITHUB_OUTPUT
-          fi
-
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "docker_source=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
-          else
-            echo "docker_source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Extract metadata
-        id: metadata
-        uses: docker/metadata-action@v5
-        env:
-          LABELS: |
-            org.opencontainers.image.description=Calimero Node
-            org.opencontainers.image.source=${{ steps.prepare.outputs.docker_source }}
-            org.opencontainers.image.licenses=MIT OR Apache-2.0
-            org.opencontainers.image.authors=Calimero Limited <info@calimero.network>
-            org.opencontainers.image.url=https://calimero.network
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-          DOCKER_METADATA_PR_HEAD_SHA: true
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/merod
-          tags: |
-            type=edge
-            type=ref,prefix=pr-,event=pr
-            type=sha,prefix=,format=short
-            type=raw,value=${{ needs.prepare.outputs.version }},enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' && needs.prepare.outputs.docker_release == 'true' && needs.prepare.outputs.prerelease == 'false' }}
-          labels: ${{ env.LABELS }}
-          annotations: ${{ env.LABELS }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: .github/workflows/deps/prebuilt.Dockerfile
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          annotations: ${{ steps.metadata.outputs.annotations }}
-          cache-from: ${{ steps.prepare.outputs.cache_from }}
-          cache-to: ${{ steps.prepare.outputs.cache_to }}
-          provenance: false
-          sbom: false
+  release-mero-auth-container:
+    name: Release Mero Auth container
+    needs: [prepare, build-binaries]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ needs.prepare.outputs.version }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/actions/release/container.yml
+    with:
+      binaries: $AUTH_BINARIES
+      dockerfile: .github/workflows/deps/prebuilt.auth.Dockerfile
+      container_name: mero-auth
 
   brew-update:
     name: Update Homebrew Tap


### PR DESCRIPTION
## Description
Include mero-auth docker release in the workflow in a similar fashion as merod container.
Extract `release-container` into action so it is reusable.  

## Test Plan
n/a

## Documentation Update
n/a
