### PR TITLE
chore(CI): fix docker push condition

### DIFF
--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -50,3 +50,8 @@ jobs:
 
       - name: und das?
         run: echo "[${{ github.event.ref == "" }}]"
+
+      - name: und das?
+        env:
+          BRO: ${{ toJson(github) }}
+        run: echo "$BRO"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -50,8 +50,3 @@ jobs:
 
       - name: und das?
         run: echo "[${{ github.event.ref == "" }}]"
-
-      - name: und das?
-        env:
-          THING: ${{ github.ref }}
-        run: echo "[$THING]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -55,7 +55,7 @@ jobs:
           BRO: ${{ toJson(github) }}
         run: jq <<< "$BRO"
 
-      - name: und das?
-        env:
-          T: ${{ github.event.ref == "" }}
-        run: echo "[$T]"
+      # - name: und das?
+      #   env:
+      #     T: ${{ github.event.ref == "" }}
+      #   run: echo "[$T]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -52,4 +52,6 @@ jobs:
         run: echo "[${{ github.event.ref == "" }}]"
 
       - name: und das?
-        run: echo "[${{ github.ref }}]"
+        env:
+          THING: ${{ github.ref }}
+        run: echo "[$THING]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -55,5 +55,7 @@ jobs:
           BRO: ${{ toJson(github) }}
         run: jq <<< "$BRO"
 
-      # - name: und das?
-      #   run: echo "[${{ github.event.ref == "" }}]"
+      - name: und das?
+        env:
+          T: ${{ github.event.ref == "" }}
+        run: echo "[$T]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -56,12 +56,4 @@ jobs:
         run: jq <<< "$BRO"
 
       - name: und das?
-        if: ${{ github.event && github.event.ref == "" }}
-        run: echo "forkkkkkk"
-
-      - name: und das?
-        if: ${{ github.event && github.event.ref != "" }}
-        run: echo "base"
-
-      - name: und das?
         run: echo "${{ github.event.pull_request && github.event.pull_request.head.repo.fork || !github.event.pull_request }}"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -58,4 +58,4 @@ jobs:
       - name: und das?
         env:
           IS_FORK: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
-        run: echo "${{ !env.IS_FORK }}"
+        run: echo "${{ env.IS_FORK == 'false' }}

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -32,4 +32,6 @@ jobs:
       - run: echo "Ignored"
 
       - name: Thing
-        run: ${{ toJson(github.event) }}
+        env:
+          BRO: ${{ toJson(github.event) }}
+        run: echo "$BRO"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -62,3 +62,6 @@ jobs:
       - name: und das?
         if: ${{ github.event && github.event.ref != "" }}
         run: echo "base"
+
+      - name: und das?
+        run: echo "${{ github.event.pull_request && github.event.pull_request.head.repo.fork || !github.event.pull_request }}"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -52,6 +52,4 @@ jobs:
         run: echo "[${{ github.event.ref == "" }}]"
 
       - name: und das?
-        env:
-          BRO: ${{ toJson(github) }}
-        run: echo "$BRO"
+        run: echo "[${{ github.event }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -55,7 +55,10 @@ jobs:
           BRO: ${{ toJson(github) }}
         run: jq <<< "$BRO"
 
-      # - name: und das?
-      #   env:
-      #     T: ${{ github.event.ref == "" }}
-      #   run: echo "[$T]"
+      - name: und das?
+        if: ${{ github.event.ref == "" }}
+        run: echo "forkkkkkk"
+
+      - name: und das?
+        if: ${{ github.event.ref != "" }}
+        run: echo "base"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -58,4 +58,4 @@ jobs:
       - name: und das?
         env:
           IS_FORK: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
-        run: echo "${{ env.IS_FORK == 'false' }}
+        run: echo "${{ env.IS_FORK == 'false' }}"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -43,4 +43,4 @@ jobs:
         run: echo "[${{ github.event.repository.fork }}]"
 
       - name: und das?
-        run: echo "[${{ github.event.repository.fork == true }}]"
+        run: echo "[${{ github.event.repository.fork == false }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -32,21 +32,3 @@ jobs:
         env:
           BRO: ${{ toJson(github.event) }}
         run: echo "$BRO"
-
-      - name: und das?
-        run: echo "[${{github.event.pull_request.head.repo.full_name}}]"
-
-      - name: und das?
-        run: echo "[${{ github.event.pull_request.head.repo.fork }}]"
-
-      - name: und das?
-        run: echo "[${{ github.event.repository.fork }}]"
-
-      - name: und das?
-        run: echo "[${{ github.event.repository.fork == false }}]"
-
-      - name: und das?
-        run: echo "[${{ github.event.ref }}]"
-
-      - name: und das?
-        run: echo "[${{ github.event.ref == "" }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -3,6 +3,9 @@ name: Stub (Release)
 # without the release workflow being run as it is a required check.
 
 on:
+  push:
+    branches:
+      - miraclx/test
   pull_request:
     paths-ignore:
       - Cargo.toml
@@ -27,3 +30,6 @@ jobs:
 
     steps:
       - run: echo "Ignored"
+
+      - name: Thing
+        run: ${{ toJson(github.event) }}

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -3,9 +3,6 @@ name: Stub (Release)
 # without the release workflow being run as it is a required check.
 
 on:
-  push:
-    branches:
-      - miraclx/test
   pull_request:
     paths-ignore:
       - Cargo.toml

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -56,4 +56,4 @@ jobs:
         run: jq <<< "$BRO"
 
       - name: und das?
-        run: echo "${{ github.event.pull_request && github.event.pull_request.head.repo.fork || !github.event.pull_request }}"
+        run: echo "${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -50,5 +50,5 @@ jobs:
           BRO: ${{ toJson(github.event) }}
         run: jq <<< "$BRO" .ref
 
-      - name: und das?
-        run: echo "[${{ github.event.ref == "" }}]"
+      # - name: und das?
+      #   run: echo "[${{ github.event.ref == "" }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -57,5 +57,5 @@ jobs:
 
       - name: und das?
         env:
-          IS_FORK: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
-        run: echo "${{ env.IS_FORK == 'false' }}"
+          RELEASE: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
+        run: echo "${{ env.RELEASE == 'true' }}"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -32,3 +32,23 @@ jobs:
         env:
           BRO: ${{ toJson(github.event) }}
         run: echo "$BRO"
+
+      - name: und das?
+        run: echo "[${{github.event.pull_request.head.repo.full_name}}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.pull_request.head.repo.fork }}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.repository.fork }}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.repository.fork == false }}]"
+
+      - name: und das?
+        env:
+          BRO: ${{ toJson(github.event) }}
+        run: jq <<< "$BRO" .ref
+
+      - name: und das?
+        run: echo "[${{ github.event.ref == "" }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -56,4 +56,6 @@ jobs:
         run: jq <<< "$BRO"
 
       - name: und das?
-        run: echo "${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}"
+        env:
+          IS_FORK: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
+        run: echo "${{ !env.IS_FORK }}"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -3,6 +3,9 @@ name: Stub (Release)
 # without the release workflow being run as it is a required check.
 
 on:
+  push:
+    branches:
+      - miraclx/test
   pull_request:
     paths-ignore:
       - Cargo.toml

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           BRO: ${{ toJson(github.event) }}
         run: echo "$BRO"
+
+      - name: und das?
+        env:
+          BRO: ${{ toJson(github.event) }}
+        run: echo "[${{github.event.pull_request.head.repo.full_name}}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -50,5 +50,10 @@ jobs:
           BRO: ${{ toJson(github.event) }}
         run: jq <<< "$BRO" .ref
 
+      - name: und das?
+        env:
+          BRO: ${{ toJson(github) }}
+        run: jq <<< "$BRO"
+
       # - name: und das?
       #   run: echo "[${{ github.event.ref == "" }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -37,7 +37,16 @@ jobs:
         run: echo "[${{github.event.pull_request.head.repo.full_name}}]"
 
       - name: und das?
+        run: echo "[${{ github.event.pull_request.head.repo.fork }}]"
+
+      - name: und das?
         run: echo "[${{ github.event.repository.fork }}]"
 
       - name: und das?
         run: echo "[${{ github.event.repository.fork == false }}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.ref }}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.ref == "" }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -56,9 +56,9 @@ jobs:
         run: jq <<< "$BRO"
 
       - name: und das?
-        if: ${{ github.event.ref == "" }}
+        if: ${{ github.event && github.event.ref == "" }}
         run: echo "forkkkkkk"
 
       - name: und das?
-        if: ${{ github.event.ref != "" }}
+        if: ${{ github.event && github.event.ref != "" }}
         run: echo "base"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -52,4 +52,4 @@ jobs:
         run: echo "[${{ github.event.ref == "" }}]"
 
       - name: und das?
-        run: echo "[${{ github.event }}]"
+        run: echo "[${{ github.ref }}]"

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -37,6 +37,10 @@ jobs:
         run: echo "$BRO"
 
       - name: und das?
-        env:
-          BRO: ${{ toJson(github.event) }}
         run: echo "[${{github.event.pull_request.head.repo.full_name}}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.repository.fork }}]"
+
+      - name: und das?
+        run: echo "[${{ github.event.repository.fork == true }}]"


### PR DESCRIPTION
## Description

small oversight: `github.event.pull_request.head.repo.full_name` evaluates to `false` on `master`

we need something more general than that, I noticed the `github.event.repository` object has a `fork` field, I'm testing to see if that holds up as we expect

Observations:

1. `github.event.repository` represents the base repo, not the fork
2. `github.event.head.repo` also has a `fork` field, which is `true` when we're a fork, great

## Test plan

--

## Documentation update

--