### PR TITLE
chore(CI): fix docker push condition

### DIFF
--- a/.github/actions/container-release/action.yml
+++ b/.github/actions/container-release/action.yml
@@ -109,7 +109,7 @@ runs:
       with:
         context: .
         file: ${{ inputs.dockerfile }}
-        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        push: ${{ inputs.release == 'true' }}
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.metadata.outputs.tags }}
         labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
             if ! gh release view "$version" --repo ${{ github.repository }} >/dev/null 2>&1; then
               binary_release=true
-              docker_release=true
+              docker_release=${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
             fi
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             docker_release=true


### PR DESCRIPTION
## Description

small oversight: `github.event.pull_request.head.repo.full_name` evaluates to `false` on `master`

we need something more general than that, I noticed the `github.event.repository` object has a `fork` field, I'm testing to see if that holds up as we expect

Observations:

1. `github.event.repository` represents the base repo, not the fork
2. `github.event.head.repo` also has a `fork` field, which is `true` when we're a fork, great

## Test plan

Tested pushes from a [fork](https://github.com/calimero-network/core/pull/1379), pushes to a branch (simulating master) and pushes to a [PR](https://github.com/calimero-network/core/pull/1380) within the repo.

Everything works as we expect.

## Documentation update

--