### PR TITLE
feat: setup is-authed endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "eyre",
  "rustc_version 0.4.1",

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -190,8 +190,9 @@ pub(crate) fn setup(
         )
         // Alias management
         .nest("/alias", alias::service())
-        // Health endpoints (previously unprotected)
         .route("/health", get(health_check_handler))
+        // Dummy endpoint used to figure out if we are running behind auth or not
+        .route("/is-authed", get(is_authed_handler))
         .route("/certificate", get(certificate_handler))
         .layer(Extension(Arc::clone(&shared_state)));
 
@@ -383,6 +384,10 @@ async fn health_check_handler() -> impl IntoResponse {
         },
     }
     .into_response()
+}
+
+async fn is_authed_handler() -> impl IntoResponse {
+    ApiResponse { payload: {} }.into_response()
 }
 
 async fn certificate_handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description
Add a dedicated dummy endpoint for checking if we are running behind auth or not. The health endpoint should be public most of the time. 

## Test Plan
n/a

## Documentation Update
n/a