### PR TITLE
fix(storage): permit out-of-order delta application

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -338,6 +338,15 @@ impl<S: StorageAdaptor> Index<S> {
         }
     }
 
+    /// Checks if an index exists for a given entity ID.
+    ///
+    /// # Parameters
+    ///
+    /// * `id` - The [`Id`] of the entity to check for an index.
+    pub(crate) fn has_index(id: Id) -> bool {
+        S::storage_read(Key::Index(id)).is_some()
+    }
+
     /// Retrieves the ID of the parent of a given entity.
     ///
     /// # Parameters

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -433,7 +433,28 @@ impl<S: StorageAdaptor> Interface<S> {
                 ancestors,
                 metadata,
             } => {
-                if let Some(parent) = ancestors.first() {
+                let mut parent = None;
+                for this in ancestors.iter().rev() {
+                    let parent = parent.replace(this);
+
+                    if <Index<S>>::has_index(this.id()) {
+                        continue;
+                    }
+
+                    let Some(parent) = parent else {
+                        <Index<S>>::add_root(*this)?;
+
+                        continue;
+                    };
+
+                    <Index<S>>::add_child_to(
+                        parent.id(),
+                        "no collection, remove this nonsense",
+                        *this,
+                    )?;
+                }
+
+                if let Some(parent) = parent {
                     let own_hash = Sha256::digest(&data).into();
 
                     <Index<S>>::add_child_to(


### PR DESCRIPTION
## Description

Permit out-of-order application, that is if a.b.c is recieved before a or a.b exists locally, go ahead to create sparse entries for a and a.b, when we eventually receive the entries for a and a.b, we can fill them

## Test plan

```console
cargo test -p calimero-storage -- apply_action__sparse
```

## Documentation update

--