### PR TITLE
fix(sync): broadcast-triggered sync should be mutually exclusive

### DIFF
--- a/crates/context/src/handlers/delete_context.rs
+++ b/crates/context/src/handlers/delete_context.rs
@@ -75,7 +75,7 @@ async fn delete_context(
     handle.delete(&key)?;
     handle.delete(&key::ContextConfig::new(context_id))?;
 
-    // fixme! store.handle() is prolematic here for lifetime reasons
+    // fixme! store.handle() is problematic here for lifetime reasons
     let mut datastore = handle.into_inner();
 
     delete_context_scoped::<key::ContextIdentity, 32>(&mut datastore, &context_id, [0; 32], None)?;

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -111,7 +111,7 @@ async fn join_context(
 
     node_client.subscribe(&context_id).await?;
 
-    node_client.sync(Some(&context_id)).await?;
+    node_client.sync(Some(&context_id), None).await?;
 
     Ok((context_id, invitee_id))
 }

--- a/crates/context/src/handlers/update_application.rs
+++ b/crates/context/src/handlers/update_application.rs
@@ -112,7 +112,7 @@ pub async fn update_application_id(
         ),
     )?;
 
-    node_client.sync(Some(&context_id)).await?;
+    node_client.sync(Some(&context_id), None).await?;
 
     Ok(application)
 }

--- a/crates/node/src/interactive_cli/context.rs
+++ b/crates/node/src/interactive_cli/context.rs
@@ -602,7 +602,7 @@ impl ContextCommand {
                 if all {
                     println!("{ind} Syncing all contexts...");
 
-                    node_client.sync(None).await?;
+                    node_client.sync(None, None).await?;
                 } else {
                     let context_id = node_client
                         .resolve_alias(context, None)?
@@ -613,7 +613,7 @@ impl ContextCommand {
                         pretty_alias(Some(context), &context_id)
                     );
 
-                    node_client.sync(Some(&context_id)).await?;
+                    node_client.sync(Some(&context_id), None).await?;
                 }
             }
         }

--- a/crates/server/src/admin/handlers/context/sync.rs
+++ b/crates/server/src/admin/handlers/context/sync.rs
@@ -15,7 +15,7 @@ pub async fn handler(
 ) -> impl IntoResponse {
     let context_id = context_id.map(|Path(c)| c);
 
-    let result = state.node_client.sync(context_id.as_ref()).await;
+    let result = state.node_client.sync(context_id.as_ref(), None).await;
 
     match result {
         Ok(()) => ApiResponse {


### PR DESCRIPTION
## Description

When applying a received state delta from a broadcast, certain conditions cause us to fall back to a sync with the peer instead of directly applying the received delta;

1. if the delta is more recent than what we expect
2. if we're missing the sender key and so can't decrypt the payload
3. if applying the delta doesn't produce the root hash they said it would

this last one (3) has been disabled, since we cannot guarantee the root hash will be consistent even if the data is guaranteed to be present on all nodes, further investigation can help us narrow it down, but #1389 tackes the main issue.

anyway, when doing this sync from delta application, and we determine that a sync is needed, it should be mutually exclusive with interval-triggered syncs to prevent both running at the same time.

When we make `SyncManager` a real actor, we can account for `handle_stream` also joining this mutually exclusive relationship.

## Test plan

--

## Documentation update

--