### PR TITLE
feat(relayer): add support for API key authentication via Authorizati…

### DIFF
--- a/crates/context/config/src/client.rs
+++ b/crates/context/config/src/client.rs
@@ -60,6 +60,7 @@ impl Client<AnyTransport> {
     pub fn from_config(config: &ClientConfig) -> Self {
         let relayer = relayer::RelayerTransport::new(&relayer::RelayerConfig {
             url: config.signer.relayer.url.clone(),
+            api_key: config.signer.relayer.api_key.clone(),
         });
 
         let local = Self::from_local_config(&config).expect("validation error");

--- a/crates/context/config/src/client/config.rs
+++ b/crates/context/config/src/client/config.rs
@@ -54,6 +54,8 @@ pub struct ClientLocalConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ClientRelayerSigner {
     pub url: Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -94,6 +94,10 @@ pub struct InitCommand {
     #[clap(long, value_name = "URL")]
     pub relayer_url: Option<Url>,
 
+    /// API key for the relayer (if required for authentication)
+    #[clap(long, value_name = "API_KEY")]
+    pub relayer_api_key: Option<String>,
+
     /// Name of protocol
     #[clap(long, value_name = "PROTOCOL", default_value = "near")]
     #[clap(value_enum)]
@@ -392,7 +396,10 @@ impl InitCommand {
 
         let client_config = ClientConfig {
             signer: ClientSigner {
-                relayer: ClientRelayerSigner { url: relayer },
+                relayer: ClientRelayerSigner {
+                    url: relayer,
+                    api_key: self.relayer_api_key,
+                },
                 local: local_signers,
             },
             params: client_params,


### PR DESCRIPTION
…on header

# [relayer] Add optional api_key field to RelayerConfig and ClientRelayerSigner

## Description

This PR adds support for API key authentication in the relayer transport layer to support paid RPC providers like FastNear that require authentication via the Authorization header.

**Issue**: The relayer currently only supports unauthenticated RPC endpoints, but we're moving to a paid RPC provider (FastNear) that requires an API key for authentication.

**Motivation**: FastNear requires either an `apiKey` query parameter or an `Authorization: Bearer {api_key}` header for all RPC requests. This change implements the header-based authentication method for better security and follows standard HTTP authentication practices.

**Context**: The relayer is used to forward blockchain transactions and queries to external RPC endpoints. With the move to paid providers, authentication is now required.

**Dependencies**: No new dependencies required. Uses existing `reqwest` HTTP client capabilities.

## Test plan

**Tests run to verify changes:**
1. **Compilation tests**: Verified that both `calimero-context-config` and `merod` packages compile successfully
   ```bash
   cargo check --package calimero-context-config
   cargo check --package merod
   ```

2. **Code structure verification**: Confirmed that:
   - `RelayerConfig` now accepts optional `api_key` field
   - `RelayerTransport` properly stores and uses the API key
   - `ClientRelayerSigner` configuration supports the new field
   - CLI initialization accepts `--relayer-api-key` argument

**Reproduction instructions:**
1. Checkout the feature branch: `git checkout feat/relayer-api-key-support`
2. Verify compilation: `cargo check --package calimero-context-config`
3. Test CLI argument parsing: `cargo run --bin merod -- init --help | grep relayer-api-key`

**End-to-end test possibility**: Yes, this can be tested in end-to-end tests by:
1. Setting up a test relayer endpoint that requires authentication
2. Initializing a node with `--relayer-api-key` 
3. Verifying that requests include the proper Authorization header
4. Testing backward compatibility by initializing without the API key

## Documentation update

**Public documentation updates required:**
1. **CLI documentation**: Update `merod init --help` output to document the new `--relayer-api-key` argument
2. **Configuration guide**: Document how to configure API keys for paid RPC providers in the node setup documentation
3. **Relayer configuration**: Update any relayer configuration examples to show the new `api_key` field

**Internal documentation updates required:**
1. **Developer guide**: Document the new authentication flow in the relayer transport implementation
2. **API reference**: Update internal API documentation for `RelayerConfig` and `ClientRelayerSigner` structs

**Timeline**: Documentation updates must be completed within one day of PR merge.