### PR TITLE
fix(cli): prevent wasted cycles when executing non-interactively

### DIFF
--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -191,11 +191,7 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
             _ = &mut sync => {},
             res = &mut server => res??,
             res = &mut system => break res?,
-            line = lines.recv() => {
-                let Some(line) = line else {
-                    continue;
-                };
-
+            Some(line) = lines.recv() => {
                 let it = handle_line(
                     context_client.clone(),
                     node_client.clone(),


### PR DESCRIPTION
## Description

The previous logic assumed we were always going to execute interactively, which is not the case in docker, or when spawned as a child process etc.

The result of that was `lines.recv()` always returning `None`, which was handled as a `continue`ation of the loop, causing the observed 100% utilization.

We patch this by telling tokio to select the branch only on the `Some` variant.

## Test plan

- run a calimero node before this patch (with docker preferably)
- run `docker stats`, see the ~100% util on idle
- run a calimero node after this patch
- run `docker stats`, observe the util drops well under 10%

## Documentation update

None needed