### PR TITLE
chore: restore cargo deny rules, with alternative patch

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "miraclx/thing"]
   pull_request:
     paths:
       - Cargo.toml

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -56,32 +56,8 @@ jobs:
 
           cargo test -- --nocapture
 
-      # TODO: Cargo deny check temporarily disabled due to unresolved license compliance issue
-      # 
-      # ISSUE: The nacl crate (dependency of stellar-baselib -> soroban-client) uses a deprecated
-      # license format "LGPL-3.0+" which is not recognized by newer versions of cargo-deny (0.18.x).
-      # 
-      # ATTEMPTS MADE:
-      # - licenses.exceptions with allow = ["LGPL-3.0"] - failed in CI
-      # - licenses.clarify with expression = "LGPL-3.0" - failed in CI (deprecated identifier)
-      # - licenses.clarify with expression = "LGPL-3.0-or-later" - failed in CI (invalid format)
-      # - Adding LGPL-3.0-or-later to allowed licenses - failed in CI (invalid format)
-      # 
-      # ROOT CAUSE: The newer cargo-deny version used by EmbarkStudios/cargo-deny-action@v2
-      # is much stricter about license formats and considers even basic GNU licenses as deprecated.
-      # 
-      # ALTERNATIVES CONSIDERED:
-      # - Pinning cargo-deny to older version - would require custom action setup
-      # - Removing Stellar support - would require major refactoring of codebase
-      # - Finding alternative Stellar library - would require significant changes
-      # 
-      # TEMPORARY SOLUTION: Disable cargo-deny check until nacl license issue can be resolved
-      # or until a compatible version of cargo-deny is available.
-      #
-      # - name: Cargo deny
-      #   if: ${{ !cancelled() }}
-      #   uses: EmbarkStudios/cargo-deny-action@v2
-      #   with:
-      #     command: check licenses sources
-      #     arguments: --all-features
-      #     log-level: warn
+      - name: Cargo deny
+        if: ${{ !cancelled() }}
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses sources

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["master", "miraclx/thing"]
+    branches: ["master"]
   pull_request:
     paths:
       - Cargo.toml

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 targets = []
 
 [bans]
-multiple-versions = "warn"  # Warn about duplicate dependency versions
+multiple-versions = "warn" # Warn about duplicate dependency versions
 
 # Skip specific crates that might need multiple versions
 [[bans.skip]]
@@ -30,7 +30,7 @@ allow = [
     "MPL-2.0",
     "AGPL-3.0",
     "GPL-3.0",
-    "LGPL-3.0",
+    "LGPL-3.0-or-later",
     "0BSD",
     "Unlicense",
     "Apache-2.0 WITH LLVM-exception",

--- a/deny.toml
+++ b/deny.toml
@@ -45,14 +45,6 @@ license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
-[[licenses.clarify]]
-name = "nacl"
-version = "*"
-expression = "LGPL-3.0-or-later"
-license-files = [
-    { path = "LICENSE", hash = 0x0 }
-]
-
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"


### PR DESCRIPTION
## Description

Adding `LGPL-3.0-or-later` works fine, and in CI too it [appears](https://github.com/calimero-network/core/actions/runs/17117285922/job/48550750021)

## Test plan

--

## Documentation update

--
