### PR TITLE
chore: rename apierror to clienterror and move to seperate crate to p…

### DIFF
--- a/crates/meroctl/src/connection.rs
+++ b/crates/meroctl/src/connection.rs
@@ -8,8 +8,8 @@ use url::Url;
 
 use crate::cli::auth::authenticate;
 use crate::cli::storage::{get_session_cache, JwtToken};
-use crate::cli::ApiError;
 use crate::common::RequestType;
+use crate::errors::ClientError;
 use crate::output::Output;
 
 #[derive(Debug)]
@@ -179,7 +179,7 @@ impl ConnectionInfo {
             }
 
             if !response.status().is_success() {
-                bail!(ApiError {
+                bail!(ClientError {
                     status_code: response.status().as_u16(),
                     message: response
                         .text()

--- a/crates/meroctl/src/errors.rs
+++ b/crates/meroctl/src/errors.rs
@@ -1,0 +1,10 @@
+use serde::Serialize;
+use thiserror::Error;
+
+/// Client-specific error type for HTTP responses
+#[derive(Debug, Serialize, Error)]
+#[error("{status_code}: {message}")]
+pub struct ClientError {
+    pub status_code: u16,
+    pub message: String,
+}

--- a/crates/meroctl/src/main.rs
+++ b/crates/meroctl/src/main.rs
@@ -8,6 +8,7 @@ mod common;
 mod config;
 mod connection;
 mod defaults;
+mod errors;
 mod output;
 mod version;
 


### PR DESCRIPTION
…repare for extraction

## Description
Moving errors into seperate file to fix dependency hell of moving the client.

## Test plan
E2E

## Documentation update
N/A
