### PR TITLE
added versioning of creates via central workspace version

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,63 @@
+name: Calimero Crates Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        required: true
+        description: Branch name or tag to publish crates from
+
+jobs:
+  publish-cargo-crates:
+    name: "Publish calimero-workspaces on crates.io"
+    runs-on: ubuntu-latest
+    environment: deploy
+    permissions:
+      contents: write # required for crates push
+    timeout-minutes: 30 
+    
+    steps:
+      - name: Checkout core's ${{ github.event.inputs.branch }} branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Checkout core repository
+        if: ${{ github.event_name != 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up git user
+        uses: fregante/setup-git-user@v2
+
+      - name: Check if version is already published
+        run: |
+          PACKAGE_NAME="calimero-primitives"
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.metadata.workspaces.version')
+          PUBLISHED=$(curl -s https://crates.io/api/v1/crates/$PACKAGE_NAME/versions | jq -r '.versions[] | select(.num=="'"$VERSION"'") | .num')
+          if [ "$PUBLISHED" == "$VERSION" ]; then
+            echo "Version $VERSION of $PACKAGE_NAME is already published."
+            exit 1
+          fi
+
+      - name: Publish calimero-workspaces on crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -x
+          cargo install --git https://github.com/miraclx/cargo-workspaces --tag v0.3.0 cargo-workspaces
+          cargo ws publish --yes --allow-dirty --force '*' \
+              --no-git-commit --no-git-push --no-individual-tags --tag-prefix 'crates-' \
+              --tag-msg $$'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}'
+
+      - name: Create tag on https://github.com/calimero-network/core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push --no-follow-tags https://github.com/calimero-network/core.git tag 'crates-*'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "abi_conformance"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bs58 0.5.1",
  "calimero-sdk",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-abi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-blobstore"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-stream",
  "calimero-primitives",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bs58 0.5.1",
  "calimero-context",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "borsh",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy",
  "alloy-sol-types",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-primitives"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "async-stream",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-crypto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calimero-primitives",
  "curve25519-dalek",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-network-primitives"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "bytes",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "borsh",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-node-primitives"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "async-stream",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert-json-diff",
  "borsh",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "bs58 0.5.1",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-sdk-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prettyplease 0.2.25",
  "proc-macro2",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-sdk-near"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calimero-primitives",
  "calimero-sdk",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum 0.7.9",
  "bytes",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-server-primitives"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calimero-context-config",
  "calimero-context-primitives",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "calimero-sdk",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-storage-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "calimero-sdk",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "calimero-primitives",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-store-rocksdb"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calimero-store",
  "eyre",
@@ -2249,14 +2249,14 @@ dependencies = [
 
 [[package]]
 name = "calimero-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "calimero-utils-actix"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "async-stream",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-mero"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3364,7 +3364,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "e2e-tests"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy",
  "async-compression",
@@ -5358,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "kv-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "mero-auth"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ repository = "https://github.com/calimero-network/core"
 license = "MIT OR Apache-2.0"
 description = "Core Calimero infrastructure and tools"
 
+[workspace.metadata.workspaces]
+# Shared version of all public crates in the workspace.
+version = "0.1.1"
+exclude = ["merod", "meroctl", "calimero-abi", "kv-store", "abi_conformance", "e2e-tests"]
+
 [workspace]
 resolver = "2"
 members = [

--- a/README.mdx
+++ b/README.mdx
@@ -159,6 +159,39 @@ flowchart TD
     node --> Network & runtime["Runtime"] & net & ctx & Blobstore
 ```
 
+## Version Management
+
+Calimero Core uses centralized version management (same as NEAR Protocol) where all crates share a single version number. This ensures consistent versioning across the entire workspace.
+
+### Quick Commands
+
+```bash
+# Install cargo-workspaces (same version as NEAR)
+cargo install --git https://github.com/miraclx/cargo-workspaces --tag v0.3.0 cargo-workspaces
+
+# Show all crate versions
+cargo ws list
+
+# Update all versions to 0.1.1
+cargo ws version custom 0.1.1 --yes
+
+# Publish all crates to crates.io
+cargo ws publish --yes --allow-dirty --force '*'
+```
+
+### How It Works
+
+- **Workspace version**: Set in `Cargo.toml` under `[workspace.metadata.workspaces].version`
+- **Crate versions**: Use `version.workspace = true` to inherit the workspace version
+- **Excluded crates**: Internal tools and examples are excluded from publishing
+- **Automated publishing**: GitHub Actions workflow handles crates.io publishing
+
+### Current Status
+
+- **Workspace version**: 0.1.1
+- **Using workspace versioning**: `calimero-primitives`, `calimero-client`, `calimero-network`
+- **Manual versions**: Most other crates (can be migrated)
+
 ## Contributing
 
 Calimero is Open Source under the [Apache License 2.0](LICENSE), and is the

--- a/apps/abi_conformance/Cargo.toml
+++ b/apps/abi_conformance/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "abi_conformance"
 description = "Calimero ABI conformance test application"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/apps/kv-store/Cargo.toml
+++ b/apps/kv-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-store"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mero-auth"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 description = "Forward Authentication Service for Calimero Network"

--- a/crates/cargo-mero/Cargo.toml
+++ b/crates/cargo-mero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mero"
-version = "0.1.0"
+version.workspace = true
 description = "CLI tool for building applications on the Calimero network"
 categories = ["command-line-utilities"]
 keywords = ["cli", "cargo", "subcommand"]

--- a/crates/cargo-mero/app-template/Cargo.toml
+++ b/crates/cargo-mero/app-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app-template"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [lib]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-config"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/context/config/Cargo.toml
+++ b/crates/context/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-config"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/context/primitives/Cargo.toml
+++ b/crates/context/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-primitives"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-crypto"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/network/primitives/Cargo.toml
+++ b/crates/network/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-network-primitives"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-node"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/node/primitives/Cargo.toml
+++ b/crates/node/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-node-primitives"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-runtime"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-sdk"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/sdk/libs/near/Cargo.toml
+++ b/crates/sdk/libs/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-sdk-near"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/sdk/macros/Cargo.toml
+++ b/crates/sdk/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-sdk-macros"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-server"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/server/primitives/Cargo.toml
+++ b/crates/server/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-server-primitives"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-storage"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/storage/macros/Cargo.toml
+++ b/crates/storage/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-storage-macros"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-store"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/store/blobs/Cargo.toml
+++ b/crates/store/blobs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-blobstore"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/store/impl/rocksdb/Cargo.toml
+++ b/crates/store/impl/rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-store-rocksdb"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-sys"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/utils/actix/Cargo.toml
+++ b/crates/utils/actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-utils-actix"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e-tests"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tools/calimero-abi/Cargo.toml
+++ b/tools/calimero-abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "calimero-abi"
 description = "CLI tool for extracting Calimero WASM ABI"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
not meant for versioning binaries, just packages for external use.

## Description
^^^
needed for python-bindings or any other tool somebody wants to build using our crates. also, we should have proper versioning of packages for a certain binary release - ideally the binary release having the same version as crates.

## Test plan
YOLO - it runs the ci and publishes the packages.

## Documentation update
N/A
