### PR TITLE
fix: skip the next steps and exit gracefully in the publish crate workflow if nothing to publish

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,6 +30,7 @@ jobs:
         run: rustc --version
 
       - name: Check if version is already published
+        id: version-check
         run: |
           # Extract package name and version from workspace metadata
           VERSION=$(cargo metadata --format-version 1 | jq -r '.metadata.workspaces.version // empty' 2>/dev/null || echo "")
@@ -60,13 +61,15 @@ jobs:
           echo "Published version: $PUBLISHED" 
           
           if [ "$PUBLISHED" = "$VERSION" ]; then
-            echo "Version $VERSION is already published. Exiting."
-            exit 1
+            echo "Version $VERSION is already published. Skipping publish steps."
+            echo "skip_publish=true" >> $GITHUB_OUTPUT
           else
             echo "Version $VERSION is not yet published. Proceeding with publish."
+            echo "skip_publish=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish calimero-workspaces on crates.io
+        if: steps.version-check.outputs.skip_publish != 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
@@ -80,6 +83,7 @@ jobs:
               --tag-msg $$'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}'
 
       - name: Create tag on https://github.com/calimero-network/core
+        if: steps.version-check.outputs.skip_publish != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -44,7 +44,7 @@ jobs:
           # Extract package name from workspace metadata
           
           # Check if version is already published
-          CRATES_RESPONSE=$(curl -s "https://crates.io/api/v1/crates/calimero-primitives/versions")
+          CRATES_RESPONSE=$(curl -s  --user-agent "calimero-publish-workflow" "https://crates.io/api/v1/crates/calimero-primitives/versions")
           echo "API Response preview: $(echo "$CRATES_RESPONSE" | head -c 200)..."
           
           # Check if API response contains errors


### PR DESCRIPTION
fix: skip the next steps and exit gracefully in the publish crate workflow if nothing to publish

## Description
^^

## Test plan
doesn't fail on ci master

## Documentation update
N/A
