### PR TITLE
feat: added basic debug request/response server logging to the crate

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -10,6 +10,7 @@ publish = true
 
 [dependencies]
 axum = { workspace = true, features = ["multipart"] }
+bytes.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 hex.workspace = true
@@ -23,7 +24,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-tower-http = { workspace = true, features = ["cors", "fs"] }
+tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 tower-sessions = { workspace = true, optional = true }
 tracing.workspace = true
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,11 +1,11 @@
 use core::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
-use axum::http::Method;
-use axum::Router;
-use axum::response::Response;
-use axum::middleware::{from_fn, Next};
 use axum::body::{to_bytes, Body};
+use axum::http::Method;
+use axum::middleware::{from_fn, Next};
+use axum::response::Response;
+use axum::Router;
 use calimero_context_primitives::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
 use calimero_store::Store;
@@ -17,8 +17,8 @@ use tokio::net::TcpListener;
 use tokio::task::JoinSet;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
-use tracing::Level;
 use tracing::warn;
+use tracing::Level;
 
 use crate::admin::service::{setup, site};
 
@@ -193,14 +193,18 @@ pub async fn start(
                     "incoming request"
                 );
             })
-            .on_response(|response: &axum::http::Response<_>, latency: std::time::Duration, _span: &tracing::Span| {
-                tracing::debug!(
-                    target: "server::http",
-                    status = %response.status(),
-                    elapsed_ms = latency.as_millis() as u64,
-                    "response sent"
-                );
-            }),
+            .on_response(
+                |response: &axum::http::Response<_>,
+                 latency: std::time::Duration,
+                 _span: &tracing::Span| {
+                    tracing::debug!(
+                        target: "server::http",
+                        status = %response.status(),
+                        elapsed_ms = latency.as_millis() as u64,
+                        "response sent"
+                    );
+                },
+            ),
     );
 
     // Log response bodies (capped) after handlers run

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 
 use axum::http::Method;
 use axum::Router;
+use axum::response::Response;
+use axum::middleware::{from_fn, Next};
+use axum::body::{to_bytes, Body};
 use calimero_context_primitives::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
 use calimero_store::Store;
@@ -13,6 +16,8 @@ use prometheus_client::registry::Registry;
 use tokio::net::TcpListener;
 use tokio::task::JoinSet;
 use tower_http::cors::{Any, CorsLayer};
+use tower_http::trace::TraceLayer;
+use tracing::Level;
 use tracing::warn;
 
 use crate::admin::service::{setup, site};
@@ -160,6 +165,47 @@ pub async fn start(
             .allow_private_network(true),
     );
 
+    // Middleware to log small JSON request bodies (without impacting handlers)
+    app = app.layer(from_fn(log_request_body));
+
+    // Global structured request/response tracing for all server routes
+    app = app.layer(
+        TraceLayer::new_for_http()
+            .make_span_with(|request: &axum::http::Request<_>| {
+                tracing::span!(
+                    Level::DEBUG,
+                    "http_request",
+                    method = %request.method(),
+                    path = %request.uri().path()
+                )
+            })
+            .on_request(|request: &axum::http::Request<_>, _span: &tracing::Span| {
+                let content_type = request
+                    .headers()
+                    .get(axum::http::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                tracing::debug!(
+                    target: "server::http",
+                    method = %request.method(),
+                    path = %request.uri().path(),
+                    content_type,
+                    "incoming request"
+                );
+            })
+            .on_response(|response: &axum::http::Response<_>, latency: std::time::Duration, _span: &tracing::Span| {
+                tracing::debug!(
+                    target: "server::http",
+                    status = %response.status(),
+                    elapsed_ms = latency.as_millis() as u64,
+                    "response sent"
+                );
+            }),
+    );
+
+    // Log response bodies (capped) after handlers run
+    app = app.layer(from_fn(log_response_body));
+
     let mut set = JoinSet::new();
 
     for listener in listeners {
@@ -174,7 +220,59 @@ pub async fn start(
     Ok(())
 }
 
+// Log request body if it is small (cap to avoid huge payloads), then restore the body for downstream handlers
+async fn log_request_body(mut req: axum::http::Request<Body>, next: Next) -> Response {
+    const MAX_LOG_BYTES: usize = 4096;
+
+    // Read and buffer the body (with a size cap)
+    let (parts, body) = req.into_parts();
+    match to_bytes(body, MAX_LOG_BYTES).await {
+        Ok(bytes) => {
+            if let Ok(text) = std::str::from_utf8(&bytes) {
+                let truncated = bytes.len() >= MAX_LOG_BYTES;
+                tracing::debug!(target: "server::http", truncated, body = %text, "request body");
+            } else {
+                tracing::debug!(target: "server::http", size = bytes.len(), "request body (non-utf8)");
+            }
+            // Reconstruct the request with the buffered body for downstream
+            let req_restored = axum::http::Request::from_parts(parts, Body::from(bytes));
+            next.run(req_restored).await
+        }
+        Err(err) => {
+            tracing::debug!(target: "server::http", error = %err, "failed to read request body");
+            // Fall through and pass the original request (with empty body) to downstream
+            let req_restored = axum::http::Request::from_parts(parts, Body::empty());
+            next.run(req_restored).await
+        }
+    }
+}
+
 #[cfg(test)]
 mod integration_tests_package_usage {
     use {color_eyre as _, tracing_subscriber as _};
+}
+
+// Log response body if it is small (cap to avoid huge payloads) and then restore the body
+async fn log_response_body(req: axum::http::Request<Body>, next: Next) -> Response {
+    const MAX_LOG_BYTES: usize = 4096;
+
+    // Run the rest of the stack first
+    let res = next.run(req).await;
+
+    let (parts, body) = res.into_parts();
+    match to_bytes(body, MAX_LOG_BYTES).await {
+        Ok(bytes) => {
+            if let Ok(text) = std::str::from_utf8(&bytes) {
+                let truncated = bytes.len() >= MAX_LOG_BYTES;
+                tracing::debug!(target: "server::http", truncated, body = %text, "response body");
+            } else {
+                tracing::debug!(target: "server::http", size = bytes.len(), "response body (non-utf8)");
+            }
+            Response::from_parts(parts, Body::from(bytes))
+        }
+        Err(err) => {
+            tracing::debug!(target: "server::http", error = %err, "failed to read response body");
+            Response::from_parts(parts, Body::empty())
+        }
+    }
 }


### PR DESCRIPTION
Basic logging to unblock debugging 

## Description
We are currently fully in the dark, this adds basic debug logging of the requests and responses to help triaging. First version, probably can be improved.

## Test plan

Run it locally and you get the nice request/response logs with debug enabled.
```
42-2025-09-08T08:31:12.871436Z DEBUG server::http: request body truncated=false body={"path":"/Users/chefsale/workspace/calimero/core/apps/kv-store/res/kv_store.wasm","metadata":[]}
43-2025-09-08T08:31:12.894820Z DEBUG server::http: response sent status=200 OK elapsed_ms=23
44:2025-09-08T08:31:12.894883Z DEBUG server::http: response body truncated=false body={"data":{"applicationId":"Es8ShuWDKipNv3ZjkxsAjCaerL9u5sqKBX7Q6cvkuGwj"}}
45-2025-09-08T08:31:12.913840Z DEBUG server::http: incoming request method=GET path=/admin-api/applications/Es8ShuWDKipNv3ZjkxsAjCaerL9u5sqKBX7Q6cvkuGwj content_type=""
46-2025-09-08T08:31:12.913917Z DEBUG server::http: request body truncated=false body=
47-2025-09-08T08:31:12.914221Z DEBUG server::http: response sent status=200 OK elapsed_ms=0
48:2025-09-08T08:31:12.914247Z DEBUG server::http: response body truncated=false body={"data":{"application":{"id":"Es8ShuWDKipNv3ZjkxsAjCaerL9u5sqKBX7Q6cvkuGwj","blob":{"bytecode":"56NvDrFaVWJf7H4E41TQF1yLon3WHk6pcTuPnPjDmnpu","compiled":"11111111111111111111111111111111"},"size":276033,"source":"file:///Users/chefsale/workspace/calimero/core/apps/kv-store/res/kv_store.wasm","metadata":[]}}}
52-2025-09-08T08:31:15.604747Z DEBUG server::http: request body truncated=false body={"path":"/private/tmp/app.wasm","metadata":[]}
53-2025-09-08T08:31:15.629540Z DEBUG server::http: response sent status=200 OK elapsed_ms=24
54:2025-09-08T08:31:15.629564Z DEBUG server::http: response body truncated=false body={"data":{"applicationId":"FdezNku2gyR7U6CQufbKnu5unSSQif7Ydd2Vg9McU7xq"}}
55-2025-09-08T08:31:15.647846Z DEBUG server::http: incoming request method=GET path=/admin-api/applications/FdezNku2gyR7U6CQufbKnu5unSSQif7Ydd2Vg9McU7xq content_type=""
56-2025-09-08T08:31:15.647887Z DEBUG server::http: request body truncated=false body=
57-2025-09-08T08:31:15.648108Z DEBUG server::http: response sent status=200 OK elapsed_ms=0
58:2025-09-08T08:31:15.648127Z DEBUG server::http: response body truncated=false body={"data":{"application":{"id":"FdezNku2gyR7U6CQufbKnu5unSSQif7Ydd2Vg9McU7xq","blob":{"bytecode":"FYL7uvEBuCj2YgsNqM9w2irms51HN3kGcydXpzJZXxhs","compiled":"11111111111111111111111111111111"},"size":250577,"source":"file:///private/tmp/app.wasm","metadata":[]}}}
```

## Documentation update
N/A