### PR TITLE
fix(node): subscribe to meta_topic after network is started

### DIFF
--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -19,6 +19,7 @@ use calimero_utils_actix::LazyRecipient;
 use camino::Utf8PathBuf;
 use eyre::{OptionExt, WrapErr};
 use futures_util::{stream, StreamExt};
+use libp2p::gossipsub::IdentTopic;
 use libp2p::identity::Keypair;
 use prometheus_client::registry::Registry;
 use tokio::sync::{broadcast, mpsc};
@@ -109,6 +110,10 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
         assert!(network_recipient.init(ctx), "failed to initialize");
         network_manager
     });
+
+    let _ignored = network_client
+        .subscribe(IdentTopic::new("meta_topic".to_owned()))
+        .await?;
 
     let (event_sender, _) = broadcast::channel(32);
 


### PR DESCRIPTION
## Description
Adding back `meta_topic` subscription for all nodes.
Introduced here: https://github.com/calimero-network/core/pull/521/files
Removed here: https://github.com/calimero-network/core/pull/1263/files#diff-d0587fc4eae7ba1fdbb1011adef223aae8df6025fb4429d9cac9044d35467565

## Test Plan
Run 2 nodes locally with a custom rendezvous namespace for a while and check that they have an equal number of connections which must be `>=` 2 .

## Documentation Update
n/a