### PR TITLE
chore(release): bump the packages to 0.2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Core Calimero infrastructure and tools"
 
 [workspace.metadata.workspaces]
 # Shared version of all public crates in the workspace.
-version = "0.2.4"
+version = "0.2.5"
 exclude = [
     "./apps/abi_conformance",
     "./apps/kv-store", 


### PR DESCRIPTION
New version without stellar.

## Description
^^^

## Test plan
ci should release on master.

## Documentation update
N/A
