### PR TITLE
ci: run workflows on HEAD instead of implicit branch merged with master

### DIFF
--- a/.github/actions/contributions/action.yml
+++ b/.github/actions/contributions/action.yml
@@ -19,6 +19,8 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Apply Needs Attention Label
       uses: hramos/needs-attention@v2.0.0

--- a/.github/workflows/abi-guard.yml
+++ b/.github/workflows/abi-guard.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
         
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -60,4 +62,4 @@ jobs:
           
       - name: Run unit tests
         run: |
-          cargo test -p calimero-wasm-abi --test invariants 
+          cargo test -p calimero-wasm-abi --test invariants

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Apply Needs Attention Label
         id: needs-attention

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/new-issue-or-pr.yml
+++ b/.github/workflows/new-issue-or-pr.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Add Label to Issue or PR
         uses: actions/github-script@v7

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout core repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up git user

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get version info
         id: version_info
@@ -95,6 +97,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2
@@ -149,6 +153,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -181,6 +187,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Release
         uses: ./.github/actions/container-release
@@ -208,6 +216,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Release
         uses: ./.github/actions/container-release

--- a/.github/workflows/tidy-docker.yml
+++ b/.github/workflows/tidy-docker.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cleanup non-persistent images, except open PRs
         uses: dataaxiom/ghcr-cleanup-action@v1


### PR DESCRIPTION
# CI: run workflows on HEAD instead of implicit branch merged with `master`

## Description

The PR changes the default behavior of `actions/checkout` step in the CI workflows to run on the HEAD commit of PR instead of the commit, implicitly merged with `master`.

### Context: The Implicit Merge

When a workflow is triggered by a `pull_request` event, the `actions/checkout` step, by default, does not check out the HEAD of the PR branch. Instead, it checks out a special ephemeral reference created by GitHub: refs/pull/<PR-number>/merge.

This reference is a temporary, pre-merged commit that combines the latest commit from the target branch (master) with the HEAD of the PR branch. Our CI tests, therefore, run on the potential result of merging the PR.

Let's define some pros of having a default behavior (implicit merge commit):
* the code runs on up-to-date with `master` state.
* all the unit/integration tests are running on the state that will happen after the merge of PR, ensuring that there won't be failing workflows after the PR is merged.

However, there are some importants cons of a default behavior to consider:
* unit/integration tests become less deterministic - they can run successfully locally, but fail in CI. When a test fails, there's an ambiguity of whether a failure was caused by an incompatibility with recent changes to `master`, some different configuration of CI hosts, or the bug in PR.
* CI environment is not stable, possibly having a race condition: the workflows may start during the specific state of the `master`, but during the workflow execution, the `master` may be updated. Meaning that CI environment relies not only on the code in PR, but also the specific timing of running the workflow.


## Test plan

--

## Documentation update

--
