### PR TITLE
chore(runtime): fixes, minor improvements. Add doc comments

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -40,6 +40,13 @@ pub type VMLogicResult<T, E = VMLogicError> = Result<T, E>;
 /// The digest is used everywhere: for context, public key, proposals, etc.
 const DIGEST_SIZE: usize = 32;
 
+// The constant for one kibibyte for a better readability and less error-prone approach on usage.
+const ONE_KIB: u32 = 1024;
+// The constant for one mibibyte for a better readability and less error-prone approach on usage.
+const ONE_MIB: u32 = ONE_KIB * 1024;
+// The constant for one gibibyte for a better readability and less error-prone approach on usage.
+const ONE_GIB: u32 = ONE_MIB * 1024;
+
 /// Encapsulates the context for a single VM execution.
 ///
 /// This struct holds all the necessary information about the current execution environment,
@@ -123,20 +130,20 @@ impl Default for VMLimits {
         }
 
         Self {
-            max_memory_pages: 1 << 10,                               // 1 KiB (64 KiB?)
-            max_stack_size: 200 << 10,                               // 200 KiB
-            max_registers: 100,                                      //
-            max_register_size: is_valid((100 << 20).validate()),     // 100 MiB
-            max_registers_capacity: 1 << 30,                         // 1 GiB
-            max_logs: 100,                                           //
-            max_log_size: 16 << 10,                                  // 16 KiB
-            max_events: 100,                                         //
-            max_event_kind_size: 100,                                //
-            max_event_data_size: 16 << 10,                           // 16 KiB
-            max_storage_key_size: is_valid((1 << 20).try_into()),    // 1 MiB
-            max_storage_value_size: is_valid((10 << 20).try_into()), // 10 MiB
-            max_blob_handles: 100,
-            max_blob_chunk_size: 10 << 20, // 10 MiB
+            max_memory_pages: ONE_KIB,                                          // 1 KiB
+            max_stack_size: 200 * ONE_KIB as usize,                             // 200 KiB
+            max_registers: 100,                                                 //
+            max_register_size: is_valid((100 * ONE_MIB as u64).validate()),     // 100 MiB
+            max_registers_capacity: ONE_GIB as u64,                             // 1 GiB
+            max_logs: 100,                                                      //
+            max_log_size: 16 * ONE_KIB as u64,                                  // 16 KiB
+            max_events: 100,                                                    //
+            max_event_kind_size: 100,                                           //
+            max_event_data_size: 16 * ONE_KIB as u64,                           // 16 KiB
+            max_storage_key_size: is_valid((ONE_MIB as u64).try_into()),        // 1 MiB
+            max_storage_value_size: is_valid((10 * ONE_MIB as u64).try_into()), // 10 MiB
+            max_blob_handles: 100,                                              //
+            max_blob_chunk_size: 10 * ONE_MIB as u64,                           // 10 MiB
         }
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -13,8 +13,7 @@ thread_local! {
     static HOST_CTX: AtomicBool = const { AtomicBool::new(false) };
 }
 
-impl<'a> VMLogic<'a> {
-    #[expect(clippy::too_many_arguments, reason = "Acceptable here")]
+impl VMLogic<'_> {
     pub fn imports(&mut self, store: &mut Store) -> Imports {
         imports! {
             store;

--- a/crates/runtime/src/logic/registers.rs
+++ b/crates/runtime/src/logic/registers.rs
@@ -63,7 +63,7 @@ impl Registers {
             Entry::Vacant(entry) => {
                 let _ = entry.insert(data.into());
             }
-        };
+        }
 
         Ok(())
     }


### PR DESCRIPTION
# Runtime: fixes, minor improvements. Improve readability and add doc comments

## Description

Before, all the runtime functions, host functions, and other helpers used for host-guest interaction were not properly documented, and the readability was misleading in some places. This resulted into adding some bugs and regression during the implementation of other features recently (e.g. "storage collections bug"). Moreover, during the fixes for the aforementioned bugs, some new dangerous and non-idiomatic changes were introduced (e.g. implicitly allowing mutable access to guest memory even if it's not intended).

This PR addresses many of these concerns, targeting to reduce the error-prone approach, improve the documentation coverage, improve the code readability, and increase the maintainability of the code in general. The rest of the fixes will be addressed in the follow up PRs.

The more detailed changes are described below. These could be also used for a detailed description in the merge commit.

* Change `read_slice()` mutability to immutable.
* Add `read_guest_memory_slice_mut()` function.
* Change host functions to properly handle the input/output
  (immutable/mutable).
* Rename `read_slice()` -> `read_guest_memory_slice()`.
* Rename `read_str()` -> `read_guest_memory_str()`.
* Use `DIGEST_SIZE` const instead of hardcoded `32` values.
* Use KiB/MiB/GiB constants for setting VM Limits.
* Add doc comments.
* Add more tests.
* Other minor improvements.
* Fix several clippy warnings.

## Test plan

The existing unit tests should pass, also some new tests were added.

## Documentation update

--
