### PR TITLE
chore(store, primitives): minor refactoring and clippy warn fixes

### DIFF
--- a/crates/primitives/src/alias.rs
+++ b/crates/primitives/src/alias.rs
@@ -3,9 +3,10 @@
 mod tests;
 
 use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::str::FromStr;
+use core::cmp::Ordering as CmpOrdering;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::str::{from_utf8, from_utf8_unchecked, FromStr};
 
 use serde::{de, ser, Deserialize, Serialize};
 use thiserror::Error;
@@ -14,10 +15,16 @@ use crate::application::ApplicationId;
 use crate::context::ContextId;
 use crate::identity::PublicKey;
 
-const MAX_LENGTH: usize = 50;
-const _: [(); { (usize::BITS - MAX_LENGTH.leading_zeros()) > 8 } as usize] = [
-    /* MAX_LENGTH must be a 8-bit number */
-];
+const MAX_ALIAS_LEN: usize = 50;
+
+// Compile time assertion to ensure that the `MAX_ALIAS_LEN` fits within `u8`.
+const _: () = {
+    // Assert that MAX_ALIAS_LEN can fit within an 8-bit unsigned integer (0-255).
+    if MAX_ALIAS_LEN > u8::MAX as usize {
+        // This panic will trigger a compilation error with the provided message.
+        panic!("MAX_ALIAS_LEN must be a value that fits in 8 bits.");
+    }
+};
 
 pub trait ScopedAlias {
     type Scope;
@@ -36,7 +43,7 @@ impl ScopedAlias for ApplicationId {
 }
 
 pub struct Alias<T> {
-    str: [u8; MAX_LENGTH],
+    str: [u8; MAX_ALIAS_LEN],
     len: u8,
     _pd: PhantomData<T>,
 }
@@ -51,7 +58,7 @@ impl<T> Clone for Alias<T> {
 #[derive(Copy, Clone, Debug, Error)]
 #[error("invalid alias: {}")]
 pub enum InvalidAlias {
-    #[error("exceeds maximum length of {} characters", MAX_LENGTH)]
+    #[error("exceeds maximum length of {} characters", MAX_ALIAS_LEN)]
     TooLong,
 }
 
@@ -59,7 +66,7 @@ impl<T> Alias<T> {
     #[must_use]
     pub fn as_str(&self) -> &str {
         let bytes = &self.str[..self.len as usize];
-        unsafe { std::str::from_utf8_unchecked(bytes) }
+        unsafe { from_utf8_unchecked(bytes) }
     }
 }
 
@@ -73,17 +80,20 @@ impl<T> FromStr for Alias<T> {
     type Err = InvalidAlias;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > MAX_LENGTH {
+        if s.len() > MAX_ALIAS_LEN {
             return Err(InvalidAlias::TooLong);
         }
 
-        let mut str = [0; MAX_LENGTH];
+        let mut str = [0; MAX_ALIAS_LEN];
         str[..s.len()].copy_from_slice(s.as_bytes());
+
+        // NOTE: This conversion should never return an error because the assert above
+        // ensures `s.len()` is less than `MAX_ALIAS_LEN` (50), which always fits in a u8.
+        let len_u8 = u8::try_from(s.len()).map_err(|_| InvalidAlias::TooLong)?;
 
         Ok(Self {
             str,
-            // safety: we guarantee this is 8-bit, where MAX_LENGTH is defined
-            len: s.len() as u8,
+            len: len_u8,
             _pd: PhantomData,
         })
     }
@@ -110,13 +120,13 @@ impl<T> PartialEq for Alias<T> {
 }
 
 impl<T> Ord for Alias<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
         self.str.cmp(&other.str)
     }
 }
 
 impl<T> PartialOrd for Alias<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
         Some(self.cmp(other))
     }
 }
@@ -141,7 +151,7 @@ impl<'de, T> Deserialize<'de> for Alias<T> {
             type Value = Alias<T>;
 
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "an alias of at most {} characters", MAX_LENGTH)
+                write!(f, "an alias of at most {MAX_ALIAS_LEN} characters")
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -155,7 +165,7 @@ impl<'de, T> Deserialize<'de> for Alias<T> {
             where
                 E: de::Error,
             {
-                let Ok(s) = std::str::from_utf8(v) else {
+                let Ok(s) = from_utf8(v) else {
                     return Err(de::Error::invalid_value(de::Unexpected::Bytes(v), &self));
                 };
 

--- a/crates/primitives/src/reflect.rs
+++ b/crates/primitives/src/reflect.rs
@@ -103,6 +103,7 @@ pub trait ReflectExt: Reflect {
         self.type_id() == non_static_type_id::<T>()
     }
 
+    #[must_use]
     fn type_id() -> TypeId {
         non_static_type_id::<Self>()
     }
@@ -124,7 +125,7 @@ pub trait ReflectExt: Reflect {
     }
 
     fn downcast_box<T: Reflect>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        if (&*self).is::<T>() {
+        if (*self).is::<T>() {
             return Ok(unsafe { Box::from_raw(Box::into_raw(self).cast()) });
         }
 
@@ -132,7 +133,7 @@ pub trait ReflectExt: Reflect {
     }
 
     fn downcast_rc<T: Reflect>(self: Rc<Self>) -> Result<Rc<T>, Rc<Self>> {
-        if (&*self).is::<T>() {
+        if (*self).is::<T>() {
             return Ok(unsafe { Rc::from_raw(Rc::into_raw(self).cast()) });
         }
 
@@ -140,7 +141,7 @@ pub trait ReflectExt: Reflect {
     }
 
     fn downcast_arc<T: Reflect>(self: Arc<Self>) -> Result<Arc<T>, Arc<Self>> {
-        if (&*self).is::<T>() {
+        if (*self).is::<T>() {
             return Ok(unsafe { Arc::from_raw(Arc::into_raw(self).cast()) });
         }
 

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -1,6 +1,28 @@
-use std::iter;
+use core::iter;
 
+/// Creates an iterator that finds and compacts segments of a Rust type name.
+///
+/// This function scans a path, discarding segments that do not contain generic
+/// parameters (`<` or `>`). For segments that do, it truncates them after the
+/// last `<` or `>` character.
+/// Creates an iterator that splits a Rust-style path by `"::"`.
+///
+/// ## Examples
+///
+/// ```
+/// use calimero_primitives::utils::compact_path;
+///
+/// let path = "path::to::Struct<path::to::OtherStruct<Option<Vec<module::Thing<T>>>, U>>";
+/// let captures = compact_path(path).collect::<Vec<_>>();
+/// assert_eq!(
+///     captures,
+///     ["Struct<", "OtherStruct<Option<Vec<", "Thing<T>>>, U>>"]
+/// );
+/// ```
 pub fn compact_path(path: &str) -> impl Iterator<Item = &str> {
+    const PATH_SEPARATOR: &str = "::";
+    const PATH_SEPARATOR_END: &str = ">::";
+
     let mut path = path;
 
     iter::from_fn(move || {
@@ -8,8 +30,9 @@ pub fn compact_path(path: &str) -> impl Iterator<Item = &str> {
             return None;
         }
 
+        // TODO: refactor the function to improve the readability.
         loop {
-            let idx = path.find("::").map_or(path.len(), |idx| idx + 2);
+            let idx = path.find(PATH_SEPARATOR).map_or(path.len(), |idx| idx + PATH_SEPARATOR.len());
             let (segment, rest) = path.split_at(idx);
 
             path = rest;
@@ -18,11 +41,11 @@ pub fn compact_path(path: &str) -> impl Iterator<Item = &str> {
                 break Some(segment);
             }
 
-            if segment.ends_with(">::") {
+            if segment.ends_with(PATH_SEPARATOR_END) {
                 break Some(segment);
             }
 
-            let Some(idx) = segment.rfind(&['<', '>']) else {
+            let Some(idx) = segment.rfind(['<', '>']) else {
                 continue;
             };
 

--- a/crates/store/src/layer/temporal.rs
+++ b/crates/store/src/layer/temporal.rs
@@ -152,7 +152,7 @@ impl<'a, K: AsKeyParts + FromKeyParts> DBIter for TemporalIterator<'a, '_, K> {
     fn read(&self) -> EyreResult<Slice<'_>> {
         if let Some(value) = &self.value {
             return Ok(value.into());
-        };
+        }
 
         self.inner.read()
     }

--- a/crates/store/src/slice.rs
+++ b/crates/store/src/slice.rs
@@ -26,9 +26,9 @@ trait BufRef: Reflect + Send + Sync {
     fn buf(&self) -> &[u8];
 }
 
-impl<'a, T> BufRef for T
+impl<T> BufRef for T
 where
-    T: AsRef<[u8]> + Send + Sync + 'a,
+    T: AsRef<[u8]> + Send + Sync,
 {
     fn buf(&self) -> &[u8] {
         self.as_ref()
@@ -53,6 +53,7 @@ impl<'a> Slice<'a> {
         }
     }
 
+    #[must_use]
     pub fn into_boxed(self) -> Box<[u8]> {
         let ref_boxed = match self.inner {
             SliceInner::Ref(inner) => return inner.into(),
@@ -85,7 +86,7 @@ impl<'a> Slice<'a> {
                     inner: SliceInner::Any(inner),
                 }),
             };
-        };
+        }
 
         Err(self)
     }

--- a/crates/store/src/tx.rs
+++ b/crates/store/src/tx.rs
@@ -18,6 +18,7 @@ pub enum Operation<'a> {
 }
 
 impl<'a> Transaction<'a> {
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.cols.is_empty()
     }
@@ -61,6 +62,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    #[must_use]
     pub fn iter(&self) -> Iter<'_, 'a> {
         Iter {
             iter: self.cols.iter(),
@@ -100,10 +102,12 @@ pub struct Entry<'a> {
 }
 
 impl<'a> Entry<'a> {
+    #[must_use]
     pub const fn key(&self) -> &'a [u8] {
         self.key
     }
 
+    #[must_use]
     pub const fn column(&self) -> Column {
         self.column
     }


### PR DESCRIPTION
# Store and Primitives crates: minor refactoring and clippy warning fixes.

## Description

Minor refactoring was done to `calimero-store` and `calimero-primitives` crates to:
* Slightly improve code readability;
* Use Rust-idiomatic conversions;
* Add doc comments and some extra tests/examples;
* Add consts instead of magic numbers;
* Don't use non-readable black magic stuff without a reason;
* Fix several clippy warnings.

## Test plan

--

## Documentation update

--
