### PR TITLE
fix: don't truncate and log if bigger than 4kb in server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "tower 0.4.13",
  "tower-http 0.5.2",
  "tower-sessions",
  "tracing",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tower.workspace = true
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 tower-sessions = { workspace = true, optional = true }
 tracing.workspace = true


### PR DESCRIPTION

## Description

responses and requests bigger than 4kb don't work due to truncation

## Test plan
tested locally to ensure it doesn't happen again

## Documentation update
n/a