### PR TITLE
chore: Cleanup build warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,16 +1728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "calimero-abi"
-version = "0.0.0"
-dependencies = [
- "clap",
- "eyre",
- "serde_json",
- "wasmparser 0.118.2",
-]
-
-[[package]]
 name = "calimero-blobstore"
 version = "0.0.0"
 dependencies = [
@@ -6036,6 +6026,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mero-abi"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "eyre",
+ "serde_json",
+ "wasmparser 0.118.2",
 ]
 
 [[package]]

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 /// An enum representing a handle to a blob, which can be for reading or writing.
+#[derive(Debug)]
 pub enum BlobHandle {
     /// A handle for writing data to a blob.
     Write(BlobWriteHandle),
@@ -41,6 +42,17 @@ pub struct BlobReadHandle {
     current_chunk_cursor: Option<Cursor<Vec<u8>>>,
     /// The current reading position within the blob.
     position: u64,
+}
+
+impl std::fmt::Debug for BlobReadHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobReadHandle")
+            .field("blob_id", &self.blob_id)
+            .field("stream", &"<stream>")
+            .field("current_chunk_cursor", &self.current_chunk_cursor)
+            .field("position", &self.position)
+            .finish()
+    }
 }
 
 impl VMHostFunctions<'_> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,6 +1,8 @@
 use core::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
+use tower as _;
+
 use axum::body::{to_bytes, Body};
 use axum::http::Method;
 use axum::middleware::{from_fn, Next};


### PR DESCRIPTION
Nothing much, updated the crate name + cleaned up some `cargo build` warnings.

## Description

na

## Test plan

na

## Documentation update

na