### PR TITLE
chore(ci): pin cargo deny to the version with is compatible with Rust 1.88.0

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Cargo deny
         if: ${{ !cancelled() }}
         run: |
-          cargo install cargo-deny
+          # Pin cargo-deny to 0.16.3 for compatibility with Rust 1.88.0 (from rust-toolchain.toml)
+          cargo install cargo-deny --version 0.16.3 --locked
           cargo deny check licenses sources
 
 


### PR DESCRIPTION
^^^

## Description
It would install version on Rust 1.89.0 which doesnt work.

## Test plan
ci should pass master should be green

## Documentation update
N/A
