### PR TITLE
fix: integrate all app examples into workspace properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ description = "Core Calimero infrastructure and tools"
 version = "0.0.0" # crates_version
 exclude = [
     "./apps/abi_conformance",
+    "./apps/blobs",
     "./apps/kv-store",
     "./apps/kv-store-with-handlers",
+    "./apps/private_data",
     "./apps/xcall-example",
     "./e2e-tests",
     "./crates/merod",
@@ -64,6 +66,7 @@ members = [
     "./apps/private_data",
     "./apps/blobs",
     "./apps/abi_conformance",
+    "./apps/xcall-example",
 
     "./e2e-tests",
     "./tools/calimero-abi",
@@ -207,6 +210,7 @@ e2e-tests = { path = "./e2e-tests" }
 kv-store = { path = "./apps/kv-store" }
 meroctl = { path = "./crates/meroctl" }
 merod = { path = "./crates/merod" }
+xcall-example = { path = "./apps/xcall-example" }
 
 [profile.release]
 strip = "symbols"

--- a/apps/xcall-example/Cargo.toml
+++ b/apps/xcall-example/Cargo.toml
@@ -1,10 +1,10 @@
-[workspace]
-
 [package]
 name = "xcall-example"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
@@ -12,18 +12,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bs58 = { version = "0.5", default-features = false, features = ["alloc"] }
-calimero-sdk = { path = "../../crates/sdk" }
-calimero-storage = { path = "../../crates/storage" }
-thiserror = { version = "2", default-features = false }
+calimero-sdk.workspace = true
+calimero-storage.workspace = true
+thiserror.workspace = true
 
 [build-dependencies]
-calimero-wasm-abi = { path = "../../crates/wasm-abi" }
-serde_json = "1"
+calimero-wasm-abi.workspace = true
+serde_json.workspace = true
 
-[profile.release]
-debug = false
-lto = true
-opt-level = "s"
-panic = "abort"
-strip = "symbols"
+[package.metadata.workspaces]
+independent = true
 


### PR DESCRIPTION
Make xcall-example consistent with other example apps (kv-store, blobs):
- Remove [workspace] declaration (was a separate workspace)
- Use workspace settings (version, edition, license, etc.)
- Use workspace dependencies (calimero-sdk, calimero-storage, etc.)
- Add to [workspace.members] list
- Add to exclude list to prevent publishing
- Add to [workspace.dependencies] for path reference

This fixes cargo-workspaces error:
  'excluded member patterns matched no packages: ./apps/xcall-example'

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
