### PR TITLE
feat: update proposal handling to include author and actions fields

### DIFF
--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -103,7 +103,18 @@ impl From<[u8; 32]> for Identity {
 }
 
 #[derive(
-    Eq, Ord, Copy, Debug, Clone, PartialEq, PartialOrd, BorshSerialize, BorshDeserialize, Hash,
+    Eq,
+    Ord,
+    Copy,
+    Debug,
+    Clone,
+    PartialEq,
+    PartialOrd,
+    BorshSerialize,
+    BorshDeserialize,
+    Hash,
+    Serialize,
+    Deserialize,
 )]
 pub struct SignerId(Identity);
 

--- a/crates/server/primitives/src/admin.rs
+++ b/crates/server/primitives/src/admin.rs
@@ -965,7 +965,8 @@ impl RevokePermissionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct CreateAndApproveProposalRequest {
     pub signer_id: PublicKey,
-    pub proposal: Proposal,
+    pub author_id: calimero_context_config::types::SignerId,
+    pub actions: Vec<calimero_context_config::ProposalAction>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
# [server] Add proposal creation and approval API endpoints

## Description

Exposes two new HTTP endpoints for creating and approving blockchain proposals via the admin API. The server now generates `ProposalId` internally and signs transactions using context identities before forwarding to the proxy contract.

**Changes:**
- Refactored proposal creation to use author public key and actions directly
- Updated `CreateAndApproveProposalRequest` to include `author_id` and `actions` instead of full `Proposal`
- Introduced `generate_proposal_id()` function for server-side ID generation
- Implemented `Serialize`/`Deserialize` for `ProposalId` and `SignerId` types
- Added meroctl CLI commands: `context proposals create-and-approve` and `approve`

This enables external clients to interact with proposals without managing signing keys directly, following NEAR-first implementation.

## Test plan

**Prerequisites:**
- Context must be created with blockchain integration (`--protocol near`)
**Test steps:**

1. Create actions file:
```bash
cat > actions.json << 'EOF'
[{
  "scope": "ExternalFunctionCall",
  "params": {
    "receiver_id": "mock-external.test.near",
    "method_name": "increment",
    "args": "{}",
    "deposit": 0
  }
}]
EOF
```

2. Get context identity:
```bash
meroctl --node node1 context identity list --context <context-id>
```

3. Create and approve proposal:
```bash
meroctl --node node1 context proposals create-and-approve \
  --signer <identity> \
  --author <identity> \
  --actions-file actions.json \
  --context <context-id>
```

4. Verify proposal was created:
```bash
meroctl --node node1 context proposals list --context <context-id>
```

**Known issue:** Currently returns 422 error, likely due to identity/signing or proxy contract configuration. Requires server logs debugging.

## Documentation update

- API documentation: Add new endpoints to admin API reference
  - Request/response schemas for `create-and-approve` and `approve`
  - Explain `signerId` vs `authorId` parameters
- meroctl documentation: Add examples for new proposal commands
- Update proposal workflow guide to include server API option alongside SDK