### PR TITLE
feat(store): Configure RocksDB with 128MB block cache for better perf…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11883,6 +11883,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcall-example"
+version = "0.0.0"
+dependencies = [
+ "bs58 0.5.1",
+ "calimero-sdk",
+ "calimero-storage",
+ "calimero-wasm-abi",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/store/impl/rocksdb/src/lib.rs
+++ b/crates/store/impl/rocksdb/src/lib.rs
@@ -36,6 +36,15 @@ impl Database<'_> for RocksDB {
         options.create_if_missing(true);
         options.create_missing_column_families(true);
 
+        // Configure block cache for better performance
+        // Default: 128MB LRU cache for frequently accessed blocks
+        const DEFAULT_BLOCK_CACHE_SIZE: usize = 128 * 1024 * 1024; // 128MB
+
+        let cache = rocksdb::Cache::new_lru_cache(DEFAULT_BLOCK_CACHE_SIZE);
+        let mut block_opts = rocksdb::BlockBasedOptions::default();
+        block_opts.set_block_cache(&cache);
+        options.set_block_based_table_factory(&block_opts);
+
         Ok(Self {
             db: DB::open_cf(&options, &config.path, Column::iter())?,
         })


### PR DESCRIPTION
…ormance

## Description
- Increase block cache from default 8MB to 128MB
- Uses LRU eviction policy for frequently accessed blocks
- Improves read performance for hot data (compiled WASM modules)
- Simple one-line configuration change with no code complexity


## Test plan
ci

## Documentation update
N/A