### PR TITLE
fix: increase auth service rate limit and remove unused burst configuration

### DIFF
--- a/crates/auth/config/config.toml
+++ b/crates/auth/config/config.toml
@@ -30,8 +30,7 @@ max_body_size = 1048576          # 1MB default request body size limit
 
 # Rate limiting settings
 [security.rate_limit]
-rate_limit_rpm = 300             # Requests per minute (increased from 50)
-rate_limit_burst = 50            # Burst size for rate limiting (increased from 20)
+rate_limit_rpm = 2000            # Requests per minute (increased from 1000)
 
 # Security headers configuration
 [security.headers]

--- a/crates/auth/src/config.rs
+++ b/crates/auth/src/config.rs
@@ -201,10 +201,6 @@ pub struct RateLimitConfig {
     /// Requests per minute
     #[serde(default = "default_rate_limit_rpm")]
     pub rate_limit_rpm: u32,
-
-    /// Burst size for rate limiting
-    #[serde(default = "default_rate_limit_burst")]
-    pub rate_limit_burst: u32,
 }
 
 /// Security headers configuration
@@ -273,7 +269,6 @@ impl Default for RateLimitConfig {
     fn default() -> Self {
         Self {
             rate_limit_rpm: default_rate_limit_rpm(),
-            rate_limit_burst: default_rate_limit_burst(),
         }
     }
 }
@@ -308,11 +303,7 @@ fn default_true() -> bool {
 }
 
 fn default_rate_limit_rpm() -> u32 {
-    100 // 100 requests per minute
-}
-
-fn default_rate_limit_burst() -> u32 {
-    10 // Burst size of 10
+    1000 // 1000 requests per minute
 }
 
 fn default_max_body_size() -> usize {

--- a/crates/auth/src/main.rs
+++ b/crates/auth/src/main.rs
@@ -51,8 +51,7 @@ fn create_default_config() -> AuthConfig {
         cors: Default::default(),
         security: SecurityConfig {
             rate_limit: RateLimitConfig {
-                rate_limit_rpm: 100,
-                rate_limit_burst: 10,
+                rate_limit_rpm: 1000,
             },
             max_body_size: 1024 * 1024, // 1MB
             headers: SecurityHeadersConfig {


### PR DESCRIPTION
## Summary

This PR increases the auth service rate limits and removes unused burst configuration that was not implemented in the actual rate limiting logic.

## Changes

### Rate Limit Increases
- Config file: Increased from 300 to 2000 requests per minute
- Default fallback: Increased from 100 to 1000 requests per minute
- Hardcoded fallback: Increased from 100 to 1000 requests per minute

### Code Cleanup
- Removed unused rate_limit_burst field from RateLimitConfig struct
- Removed default_rate_limit_burst function
- Simplified configuration to only include the parameter that's actually used
- Updated all references to remove burst size configuration

## Impact

- Higher throughput: Auth service now supports up to 2000 requests per minute
- Cleaner code: Removed unused configuration that was confusing
- Better maintainability: Configuration now matches actual implementation

## Testing

The rate limiting implementation uses a simple sliding window approach that resets every 60 seconds, so the new limits will allow:
- Up to 2000 requests in any 60-second window (when using config file)
- Up to 1000 requests in any 60-second window (when using defaults)

This provides significantly more headroom for high-traffic scenarios while maintaining protection against abuse.