### PR TITLE
fix(e2e): Increase consensus wait to 3s for key exchange completion

### DIFF
--- a/e2e-tests/config/protocols/ethereum/demo-blockchain-integrations.json
+++ b/e2e-tests/config/protocols/ethereum/demo-blockchain-integrations.json
@@ -26,10 +26,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },

--- a/e2e-tests/config/protocols/ethereum/kv-store-test.json
+++ b/e2e-tests/config/protocols/ethereum/kv-store-test.json
@@ -52,10 +52,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },

--- a/e2e-tests/config/protocols/icp/demo-blockchain-integrations.json
+++ b/e2e-tests/config/protocols/icp/demo-blockchain-integrations.json
@@ -26,10 +26,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },

--- a/e2e-tests/config/protocols/icp/kv-store-test.json
+++ b/e2e-tests/config/protocols/icp/kv-store-test.json
@@ -52,10 +52,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },

--- a/e2e-tests/config/protocols/kv-store/test.json
+++ b/e2e-tests/config/protocols/kv-store/test.json
@@ -52,10 +52,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },

--- a/e2e-tests/config/protocols/near/kv-store-with-handlers-test.json
+++ b/e2e-tests/config/protocols/near/kv-store-with-handlers-test.json
@@ -30,9 +30,9 @@
     },
     {
       "wait": {
-        "durationMs": 1000,
+        "durationMs": 3000,
         "for": "consensus",
-        "description": "Wait for nodes to join and reach consensus"
+        "description": "Wait for key exchange (2-3s) + gossipsub mesh formation + initial sync"
       }
     },
     {

--- a/e2e-tests/config/protocols/stellar/demo-blockchain-integrations.json
+++ b/e2e-tests/config/protocols/stellar/demo-blockchain-integrations.json
@@ -26,10 +26,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },

--- a/e2e-tests/config/protocols/stellar/kv-store-test.json
+++ b/e2e-tests/config/protocols/stellar/kv-store-test.json
@@ -52,10 +52,9 @@
     {
       "wait": {
         "for": "consensus",
-        "durationMs": 1000,
+        "durationMs": 3000,
         "description": [
-          "assuming it takes 5s to propagate we should",
-          "only need to wait 5 * ceil(log2(nodes)) seconds"
+          "Wait for key exchange (2-3s) + gossipsub mesh + initial sync"
         ]
       }
     },


### PR DESCRIPTION
## Root Cause Analysis (from logs)

Analyzed actual operation timings from e2e test failures:

### Measured Timings:
- Context initialization: ~2s
- Invite + Join: ~1-2s
- **Key exchange (full mesh)**: ~2-3s ← **Critical bottleneck**
- Gossipsub broadcast: ~4ms (instant)
- Initial state sync: ~1-2s

### The Race Condition:

In kv-store-with-handlers-test (NEAR):

**Problem**: Consensus wait was 1000ms base → 2s total (3 nodes)
**Reality**: Key exchange needs 2-3s to complete full mesh
**Result**: Broadcasts arrive before key exchange finishes → decrypt failures

### Impact:

1. **NEAR kv-store-with-handlers**: Handler count = 1 instead of 2
   - Node3 couldn't decrypt broadcast → handler didn't execute

2. **Ethereum kv-store-test**: Gets 'bar' instead of 'baz'
   - Similar timing issue preventing delta sync

### Fix:

Changed consensus wait: **1000ms → 3000ms base**

With 3 nodes: 3000ms * ceil(log2(3)) = **6 seconds total**

This ensures:
✅ Full mesh key exchange completes (2-3s)
✅ Gossipsub mesh forms properly
✅ Initial state sync finishes
✅ All nodes ready to decrypt broadcasts

## Files Updated:

- ethereum/kv-store-test.json
- ethereum/demo-blockchain-integrations.json
- icp/kv-store-test.json
- icp/demo-blockchain-integrations.json
- stellar/kv-store-test.json
- stellar/demo-blockchain-integrations.json
- kv-store/test.json
- near/kv-store-with-handlers-test.json

Note: NEAR tests (kv-store-test, open_invitation, demo-blockchain-integrations) already had 5000ms which is sufficient.

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
