### PR TITLE
chore: update default context config contract ID for NEAR

### DIFF
--- a/DOCKER-RELAYER.md
+++ b/DOCKER-RELAYER.md
@@ -48,7 +48,7 @@ The relayer supports the following environment variables:
 #### Near Protocol
 - `NEAR_NETWORK`: Network name (default: `testnet`)
 - `NEAR_RPC_URL`: RPC endpoint (default: `https://rpc.testnet.near.org`)
-- `NEAR_CONTRACT_ID`: Contract address (default: `calimero-context-config.testnet`)
+- `NEAR_CONTRACT_ID`: Contract address (default: `v0-6.config.calimero-context.testnet`)
 - `NEAR_ACCOUNT_ID`: Account ID (custom credentials)
 - `NEAR_PUBLIC_KEY`: Public key (custom credentials)
 - `NEAR_SECRET_KEY`: Secret key (custom credentials)
@@ -341,7 +341,7 @@ curl -X POST http://localhost:63529/ \
   -d '{
     "protocol": "near",
     "network_id": "testnet", 
-    "contract_id": "calimero-context-config.testnet",
+    "contract_id": "v0-6.config.calimero-context.testnet",
     "operation": "Read",
     "payload": "{\"method_name\":\"get_context_ids\"}"
   }'

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -64,7 +64,7 @@ const PROTOCOL_CONFIGS: &[ProtocolConfig<'static>] = &[
     ProtocolConfig {
         name: "near",
         default_network: "testnet",
-        default_contract: "calimero-context-config.testnet",
+        default_contract: "v0-6.config.calimero-context.testnet",
         signer_type: ClientSelectedSigner::Relayer,
         networks: &[
             ("mainnet", "https://rpc.mainnet.near.org"),

--- a/crates/relayer/README.md
+++ b/crates/relayer/README.md
@@ -69,7 +69,7 @@ export RELAYER_LISTEN_URL="0.0.0.0:63529"
 export ENABLE_NEAR=true
 export NEAR_NETWORK="testnet"
 export NEAR_RPC_URL="https://rpc.testnet.near.org"
-export NEAR_CONTRACT_ID="calimero-context-config.testnet"
+export NEAR_CONTRACT_ID="v0-6.config.calimero-context.testnet"
 export NEAR_ACCOUNT_ID="<PUT_YOUR_ACCOUNT_ID_HERE>"
 export NEAR_PUBLIC_KEY="<PUT_YOUR_PUBLIC_KEY_HERE>"
 export NEAR_SECRET_KEY="<PUT_YOUR_SECRET_KEY_HERE>"
@@ -112,7 +112,7 @@ listen = "0.0.0.0:63529"
 [protocols.near]
 network = "testnet"
 rpc_url = "https://rpc.testnet.near.org"
-contract_id = "calimero-context-config.testnet"
+contract_id = "v0-6.config.calimero-context.testnet"
 
 [protocols.near.credentials]
 type = "near"

--- a/crates/relayer/src/constants.rs
+++ b/crates/relayer/src/constants.rs
@@ -19,7 +19,7 @@ pub mod protocols {
         pub const NAME: &str = "near";
         pub const DEFAULT_NETWORK: &str = "testnet";
         pub const DEFAULT_RPC_URL: &str = "https://rpc.testnet.near.org";
-        pub const DEFAULT_CONTRACT_ID: &str = "calimero-context-config.testnet";
+        pub const DEFAULT_CONTRACT_ID: &str = "v0-6.config.calimero-context.testnet";
         // Note: All credentials must be provided via environment variables
     }
 


### PR DESCRIPTION
# Update default context config contract ID for NEAR

## Description

Update default context config contract ID for NEAR to `v0-6.config.calimero-context.testnet`.

## Test plan

--

## Documentation update

--
