### PR TITLE
feat!: remove primitive Mergeable - prevent state divergence at compi…

### DIFF
--- a/apps/kv-store-init/src/lib.rs
+++ b/apps/kv-store-init/src/lib.rs
@@ -5,14 +5,14 @@ use std::collections::BTreeMap;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_storage::collections::UnorderedMap;
+use calimero_storage::collections::{LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct KvStoreInit {
-    items: UnorderedMap<String, String>,
+    items: UnorderedMap<String, LwwRegister<String>>,
 }
 
 #[app::event]
@@ -44,15 +44,18 @@ impl KvStoreInit {
         // Add some initial data during initialization
         store
             .items
-            .insert("init_key_1".to_owned(), "Initial value 1".to_owned())
+            .insert("init_key_1".to_owned(), "Initial value 1".to_owned().into())
             .expect("Failed to insert init_key_1");
         store
             .items
-            .insert("init_key_2".to_owned(), "Initial value 2".to_owned())
+            .insert("init_key_2".to_owned(), "Initial value 2".to_owned().into())
             .expect("Failed to insert init_key_2");
         store
             .items
-            .insert("welcome".to_owned(), "Welcome to KvStoreInit!".to_owned())
+            .insert(
+                "welcome".to_owned(),
+                "Welcome to KvStoreInit!".to_owned().into(),
+            )
             .expect("Failed to insert welcome");
 
         app::log!("KvStoreInit initialized with 3 default items");
@@ -75,7 +78,7 @@ impl KvStoreInit {
             });
         }
 
-        self.items.insert(key, value)?;
+        self.items.insert(key, value.into())?;
 
         Ok(())
     }
@@ -83,7 +86,11 @@ impl KvStoreInit {
     pub fn entries(&self) -> app::Result<BTreeMap<String, String>> {
         app::log!("Getting all entries");
 
-        Ok(self.items.entries()?.collect())
+        Ok(self
+            .items
+            .entries()?
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
     }
 
     pub fn len(&self) -> app::Result<usize> {
@@ -95,14 +102,14 @@ impl KvStoreInit {
     pub fn get(&self, key: &str) -> app::Result<Option<String>> {
         app::log!("Getting key: {:?}", key);
 
-        self.items.get(key).map_err(Into::into)
+        Ok(self.items.get(key)?.map(|v| v.get().clone()))
     }
 
     pub fn get_unchecked(&self, key: &str) -> app::Result<String> {
         app::log!("Getting key without checking: {:?}", key);
 
         // this panics, which we do not recommend
-        Ok(self.items.get(key)?.expect("key not found"))
+        Ok(self.items.get(key)?.expect("key not found").get().clone())
     }
 
     pub fn get_result(&self, key: &str) -> app::Result<String> {
@@ -120,7 +127,7 @@ impl KvStoreInit {
 
         app::emit!(Event::Removed { key });
 
-        self.items.remove(key).map_err(Into::into)
+        Ok(self.items.remove(key)?.map(|v| v.get().clone()))
     }
 
     pub fn clear(&mut self) -> app::Result<()> {

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -27,7 +27,7 @@ pub struct NestedCrdtTest {
     pub registers: UnorderedMap<String, LwwRegister<String>>,
 
     /// Nested maps - field-level merge
-    pub metadata: UnorderedMap<String, UnorderedMap<String, String>>,
+    pub metadata: UnorderedMap<String, UnorderedMap<String, LwwRegister<String>>>,
 
     /// Vector of counters - element-wise merge
     pub metrics: Vector<Counter>,
@@ -152,7 +152,7 @@ impl NestedCrdtTest {
 
         drop(
             inner_map
-                .insert(inner_key.clone(), value.clone())
+                .insert(inner_key.clone(), value.clone().into())
                 .map_err(|e| format!("Inner insert failed: {:?}", e))?,
         );
 
@@ -179,6 +179,7 @@ impl NestedCrdtTest {
             .get(&inner_key)
             .map_err(|e| format!("Inner get failed: {:?}", e))?
             .ok_or_else(|| "Inner key not found".to_owned())
+            .map(|v| v.get().clone())
     }
 
     // ===== Vector Operations =====

--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -6,7 +6,7 @@ use bs58;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_storage::collections::UnorderedMap;
+use calimero_storage::collections::{LwwRegister, UnorderedMap};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
@@ -15,7 +15,7 @@ use thiserror::Error;
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct SecretGame {
     /// Mapping of game_id -> sha256(secret) hex
-    games: UnorderedMap<String, String>,
+    games: UnorderedMap<String, LwwRegister<String>>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
@@ -23,6 +23,7 @@ pub struct SecretGame {
 #[app::private]
 pub struct Secrets {
     /// Private mapping of game_id -> secret
+    /// Note: Private data is node-local and NOT synchronized, so we can use String directly
     secrets: UnorderedMap<String, String>,
 }
 
@@ -77,7 +78,7 @@ impl SecretGame {
         // Save public hash for guess verification in games map
         let hash = Sha256::digest(secret.as_bytes());
         let hash_hex = hex::encode(hash);
-        self.games.insert(game_id.clone(), hash_hex)?;
+        self.games.insert(game_id.clone(), hash_hex.into())?;
         app::emit!(Event::SecretSet { game_id: &game_id });
         Ok(())
     }
@@ -85,7 +86,7 @@ impl SecretGame {
     /// Allow a user to guess the secret; returns true if the guess matches the stored hash.
     /// `who` is derived from the executor identity rather than passed as an argument.
     pub fn add_guess(&self, game_id: &str, guess: String) -> app::Result<bool> {
-        let Some(public_hash_hex) = self.games.get(game_id)? else {
+        let Some(public_hash_hex) = self.games.get(game_id)?.map(|v| v.get().clone()) else {
             app::bail!(Error::NoHash);
         };
         let guess_hash = Sha256::digest(guess.as_bytes());
@@ -110,6 +111,10 @@ impl SecretGame {
 
     /// Get all public games and their secret hashes.
     pub fn games(&self) -> app::Result<BTreeMap<String, String>> {
-        Ok(self.games.entries()?.collect())
+        Ok(self
+            .games
+            .entries()?
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
     }
 }

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -273,6 +273,35 @@ fn normalize_generic_type(
                 ));
             }
         }
+        // CRDT types - unwrap to inner type for ABI
+        "LwwRegister" | "Counter" | "ReplicatedGrowableArray" | "Vector" | "UnorderedSet" => {
+            // These CRDT wrappers unwrap to their inner type for ABI purposes
+            // LwwRegister<T> -> T, Counter -> u64, etc.
+
+            if ident_str == "Counter" || ident_str == "ReplicatedGrowableArray" {
+                // Counter and RGA don't have generic args (or are opaque)
+                // Counter -> u64, RGA -> string
+                if ident_str == "Counter" {
+                    return Ok(TypeRef::Scalar(ScalarType::U64));
+                } else {
+                    return Ok(TypeRef::Scalar(ScalarType::String));
+                }
+            }
+
+            // LwwRegister<T>, Vector<T>, UnorderedSet<T> -> unwrap T
+            if args.args.is_empty() {
+                return Err(NormalizeError::TypePathError(format!(
+                    "invalid {ident_str} type - expected 1 type argument"
+                )));
+            }
+            let arg = &args.args[0];
+            let GenericArgument::Type(ty) = arg else {
+                return Err(NormalizeError::TypePathError(
+                    "invalid CRDT argument".to_owned(),
+                ));
+            };
+            normalize_type(ty, wasm32, resolver)
+        }
         _ => Err(NormalizeError::TypePathError(format!(
             "unknown generic type: {ident}"
         ))),


### PR DESCRIPTION
…le time

BREAKING CHANGE: Primitive types (String, u64, bool, etc.) no longer implement Mergeable. Users MUST use LwwRegister<T> for synchronized state fields.

Why this change:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Primitive merge (*self = other) is NOT commutative:
  • merge(A,B) ≠ merge(B,A)
  • Causes permanent state divergence where nodes never converge
  • Violates fundamental CRDT convergence property
  • Silent failures in distributed applications

Example of divergence:
  Node A: name="Alice", receives "Bob" → "Bob"
  Node B: name="Bob", receives "Alice" → "Alice"
  Result: Nodes NEVER converge! ❌

Changes in this commit:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Core:
  • Removed impl_mergeable_lww! macro invocation
  • Added comprehensive comment explaining why
  • Updated UnorderedMap/Vector examples to use LwwRegister<T>

Tests:
  • Fixed all storage tests to use LwwRegister<String>
  • All 279 tests passing ✅

Example Apps (updated to LwwRegister):
  • kv-store: UnorderedMap<String, LwwRegister<String>>
  • kv-store-init: Same pattern + auto-casting with .into()
  • kv-store-with-handlers: Both items and handlers_called maps
  • collaborative-editor: metadata map uses LwwRegister
  • nested-crdt-test: Nested map values use LwwRegister
  • private_data: Public games use LwwRegister, private secrets use String (OK - node-local)

WASM ABI:
  • Added LwwRegister, Counter, RGA, Vector, UnorderedSet support
  • LwwRegister<T> unwraps to T for ABI (like Option<T>)
  • Counter → u64, RGA → string in generated ABI

Documentation:
  • Updated README with compile-time safety explanation
  • Added comprehensive Mergeable implementation guide
  • Showed derive macro vs manual implementation
  • Added examples with custom validation, logging, conditional merge
  • Updated all code examples to use LwwRegister
  • Clarified when primitives CAN be used (private data, atomic structs)

Migration path:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Before:
  pub struct App { name: String }  // ❌ Won't compile

After:
  pub struct App { name: LwwRegister<String> }  // ✅ Works

Usage (nearly identical thanks to ergonomic traits):
  app.name = "Alice".to_owned().into();  // .into() auto-casts
  let s: &str = &*app.name;                // Deref
  process(app.name.as_ref());               // AsRef

Benefits:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ✅ No state divergence possible - compile-time guarantee ✅ Clear compiler errors guide users to correct solution ✅ Production-safe by default
✅ Deterministic conflict resolution via timestamps ✅ All tests passing (279/279)

Related: Previous commit added LwwRegister ergonomic traits (Deref, AsRef, From, Borrow)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `Mergeable` for primitives, migrates app/state maps to `LwwRegister<T>` values, adds CRDT-aware ABI normalization, and updates docs/tests accordingly.
> 
> - **BREAKING**:
>   - Remove `Mergeable` impls for primitives (`String`, `u64`, etc.); require `LwwRegister<T>` for synchronized fields.
> - **Storage/Core**:
>   - Delete primitive LWW merge macro; keep `Option<T: Mergeable>` support.
>   - Clarify docs in `crdt_impls.rs` about non-mergeable primitives.
> - **WASM ABI**:
>   - Normalize CRDTs: unwrap `LwwRegister<T>` to `T`; map `Counter`→`u64`, `ReplicatedGrowableArray`→`string`; handle `Vector<T>`, `UnorderedSet<T>` generics.
> - **Apps**:
>   - `collaborative-editor`: `metadata` now `UnorderedMap<String, LwwRegister<String>>`; inserts use `.into()`; reads use `.get().clone()`.
>   - `kv-store`, `kv-store-init`, `kv-store-with-handlers`: `items` and handler maps use `UnorderedMap<String, LwwRegister<String>>`; adapt inserts/gets.
>   - `nested-crdt-test`: nested `metadata` values use `LwwRegister<String>`; adjust set/get.
>   - `private_data`: public `games` map uses `LwwRegister<String>`; private `Secrets` remains primitive `String`.
> - **Tests**:
>   - Update integration tests to use `LwwRegister<String>` in maps and adjust expectations.
> - **Docs**:
>   - Revise README and collections guide: compile-time safety, migration to `LwwRegister`, derive vs manual `Mergeable`, examples updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b985a03b262114cfd18d273c630b3ef62b5211a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->