### PR TITLE
fix: late join tests and fix, release rc.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.15"
+version = "0.10.0-rc.16"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/dag/readme/architecture.md
+++ b/crates/dag/readme/architecture.md
@@ -238,8 +238,8 @@ pub fn get_missing_parents(&self) -> Vec<[u8; 32]> {
     
     for pending in self.pending.values() {
         for parent in &pending.delta.parents {
-            // Not applied yet = missing (includes both not-in-DAG and pending)
-            if !self.applied.contains(parent) {
+            // Not in deltas map at all = missing
+            if !self.deltas.contains_key(parent) {
                 missing.insert(*parent);
             }
         }

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.15"
+version = "0.10.0-rc.16"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/e2e-tests/config/protocols/near/kv-store-late-join-test.json
+++ b/e2e-tests/config/protocols/near/kv-store-late-join-test.json
@@ -1,0 +1,291 @@
+{
+  "steps": [
+    {
+      "applicationInstall": {
+        "application": {
+          "localFile": "./apps/kv-store/res/kv_store.wasm"
+        },
+        "target": "allMembers"
+      }
+    },
+    {
+      "contextCreate": null
+    },
+    {
+      "contextCreateAlias": {
+        "aliasName": "my_context_late_join"
+      }
+    },
+    {
+      "wait": {
+        "for": "broadcast",
+        "durationMs": 500,
+        "description": [
+          "Wait for context creation to propagate"
+        ]
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key0",
+          "value": "value0"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key0"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key1",
+          "value": "value1"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key1"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key2",
+          "value": "value2"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key2"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key3",
+          "value": "value3"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key3"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key4",
+          "value": "value4"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key4"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key5",
+          "value": "value5"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key5"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key6",
+          "value": "value6"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key6"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key7",
+          "value": "value7"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key7"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key8",
+          "value": "value8"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key8"
+      }
+    },
+    {
+      "call": {
+        "methodName": "set",
+        "argsJson": {
+          "key": "key9",
+          "value": "value9"
+        },
+        "target": "inviter",
+        "description": "Inviter sets key9"
+      }
+    },
+    {
+      "wait": {
+        "for": "broadcast",
+        "durationMs": 500,
+        "description": [
+          "Wait for all 10 set operations to be persisted"
+        ]
+      }
+    },
+    {
+      "call": {
+        "methodName": "len",
+        "argsJson": {},
+        "expectedResultJson": 10,
+        "target": "inviter",
+        "description": "Inviter should have all 10 keys before invitee joins"
+      }
+    },
+    {
+      "contextInviteJoin": null
+    },
+    {
+      "wait": {
+        "durationMs": 2000,
+        "for": "consensus",
+        "description": [
+          "Wait for invitee to sync full state history via DAG catchup"
+        ]
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key0"
+        },
+        "expectedResultJson": "value0",
+        "target": "allMembers",
+        "description": "Both nodes should have key0",
+        "retryCount": 10,
+        "retryDelayMs": 1000
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key1"
+        },
+        "expectedResultJson": "value1",
+        "target": "allMembers",
+        "description": "Both nodes should have key1"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key2"
+        },
+        "expectedResultJson": "value2",
+        "target": "allMembers",
+        "description": "Both nodes should have key2"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key3"
+        },
+        "expectedResultJson": "value3",
+        "target": "allMembers",
+        "description": "Both nodes should have key3"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key4"
+        },
+        "expectedResultJson": "value4",
+        "target": "allMembers",
+        "description": "Both nodes should have key4"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key5"
+        },
+        "expectedResultJson": "value5",
+        "target": "allMembers",
+        "description": "Both nodes should have key5"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key6"
+        },
+        "expectedResultJson": "value6",
+        "target": "allMembers",
+        "description": "Both nodes should have key6"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key7"
+        },
+        "expectedResultJson": "value7",
+        "target": "allMembers",
+        "description": "Both nodes should have key7"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key8"
+        },
+        "expectedResultJson": "value8",
+        "target": "allMembers",
+        "description": "Both nodes should have key8"
+      }
+    },
+    {
+      "call": {
+        "methodName": "get",
+        "argsJson": {
+          "key": "key9"
+        },
+        "expectedResultJson": "value9",
+        "target": "allMembers",
+        "description": "Both nodes should have key9"
+      }
+    },
+    {
+      "call": {
+        "methodName": "len",
+        "argsJson": {},
+        "expectedResultJson": 10,
+        "target": "allMembers",
+        "description": "Both nodes should have all 10 keys after sync"
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens DAG missing-parent detection to only unseen parents, adds a late-join KV-store e2e test, and bumps version to rc.16.
> 
> - **DAG**:
>   - Update `get_missing_parents` to return only parents absent from `deltas` (not merely unapplied), with revised docs/comments.
> - **E2E Tests**:
>   - Add `e2e-tests/config/protocols/near/kv-store-late-join-test.json` to validate late-join state sync (10 key set/get and length checks across members).
> - **Versioning**:
>   - Bump `calimero-version` to `0.10.0-rc.16` in `crates/version/Cargo.toml` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7287bf48421557865d16f594d9bfec506a31efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->