### PR TITLE
fix: jscounter not initialized error for collections

### DIFF
--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -42,6 +42,23 @@ impl JsUnorderedMap {
         }
     }
 
+    /// Rehydrates a map using a known identifier.
+    ///
+    /// This is primarily used when deserialising contract state: the wasm side
+    /// only stores the map id, so when the state is reconstructed we need a
+    /// `JsUnorderedMap` that shares the same identifier. Merely allocating the
+    /// wrapper is not enough – the collection still has to be attached to the
+    /// storage index so subsequent reads do not fail with "map not found".  
+    /// Callers are expected to invoke [`save`](Self::save) after creating the
+    /// wrapper (the runtime loaders already do this).
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            map: UnorderedMap::default(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
     /// Returns the unique identifier of this collection.
     #[must_use]
     pub fn id(&self) -> Id {
@@ -173,6 +190,18 @@ impl JsVector {
         }
     }
 
+    /// Equivalent to [`new`](Self::new) but ensures the wrapper reports the
+    /// provided identifier.  The runtime persists the freshly created instance
+    /// immediately so that subsequent loads succeed even if the original vector
+    /// was missing from storage.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            vector: Vector::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
     #[must_use]
     pub fn id(&self) -> Id {
         self.storage.id()
@@ -272,6 +301,18 @@ impl JsUnorderedSet {
         Self {
             set: UnorderedSet::new(),
             storage: Element::new(None),
+        }
+    }
+
+    /// Creates a set wrapper that reuses an existing identifier.  Just like the
+    /// map/vector variants this is paired with an eager `save` on the runtime
+    /// side to guarantee that the collection is registered in the storage
+    /// index before it is accessed.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            set: UnorderedSet::new(),
+            storage: Element::new(Some(id)),
         }
     }
 
@@ -375,6 +416,18 @@ impl JsLwwRegister {
         Self {
             register: StorageLwwRegister::new(None),
             storage: Element::new(None),
+        }
+    }
+
+    /// Recreates a register wrapper for an existing identifier.  Used when state
+    /// is deserialised and we only have the register id; the runtime will
+    /// persist the newly constructed wrapper before it is accessed to avoid
+    /// "register not found" errors.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            register: StorageLwwRegister::new(None),
+            storage: Element::new(Some(id)),
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Automatically rehydrate and persist missing JS CRDT collection instances (map/vector/set/LWW register/counter) by id and add debug/warn tracing to avoid "not found" errors.
> 
> - **Runtime (`crates/runtime/src/logic/host_functions/js_collections.rs`)**
>   - Add debug/warn tracing for JS CRDT operations (`map`, `vector`, `set`, `lww_register`, `counter`).
>   - When a collection load returns `None`, recreate with same `id` via `new_with_id(...)`, persist/attach to root, and proceed.
>   - `JsCounter`:
>     - Log creation, load, save, attach, and increment; warn on increment failure.
>   - Import `tracing::{debug, warn}`.
> - **Storage (`crates/storage/src/js.rs`)**
>   - Add `new_with_id(id: Id)` constructors for `JsUnorderedMap`, `JsVector`, `JsUnorderedSet`, `JsLwwRegister`, and `JsCounter` to rehydrate wrappers with known IDs.
>   - No API behavior changes beyond enabling rehydration; existing save/load methods unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa715a7f90c019e352a3c14a97297268e5ca2264. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->