### PR TITLE
fix(js): fix the register js export

### DIFF
--- a/crates/node/src/handlers/state_delta.rs
+++ b/crates/node/src/handlers/state_delta.rs
@@ -366,13 +366,15 @@ pub async fn handle_state_delta(
     // to avoid infinite loops and ensure proper distributed execution.
     if applied && !handlers_already_executed {
         if let Some(ref payload) = events_payload {
-            if author_id != our_identity {
-                info!(
-                    %context_id,
-                    %author_id,
-                    %our_identity,
-                    "Executing event handlers (delta applied, we are a receiving node)"
-                );
+            let is_author = author_id == our_identity;
+            info!(
+                %context_id,
+                %author_id,
+                %our_identity,
+                is_author,
+                "Evaluating event handler execution for applied delta"
+            );
+            if !is_author {
                 execute_event_handlers_parsed(
                     &node_clients.context,
                     &context_id,

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -38,6 +38,7 @@ impl VMLogic<'_> {
             fn xcall(xcall_ptr: u64);
 
             fn commit(root_hash_ptr: u64, artifact_ptr: u64);
+            fn flush_delta() -> i32;
 
             fn storage_write(
                 key_ptr: u64,

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -185,7 +185,7 @@ impl JsVector {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            vector: Vector::new(),
+            vector: Vector::default(),
             storage: Element::new(None),
         }
     }
@@ -197,7 +197,7 @@ impl JsVector {
     #[must_use]
     pub fn new_with_id(id: Id) -> Self {
         Self {
-            vector: Vector::new(),
+            vector: Vector::default(),
             storage: Element::new(Some(id)),
         }
     }
@@ -299,7 +299,7 @@ impl JsUnorderedSet {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            set: UnorderedSet::new(),
+            set: UnorderedSet::default(),
             storage: Element::new(None),
         }
     }
@@ -311,7 +311,7 @@ impl JsUnorderedSet {
     #[must_use]
     pub fn new_with_id(id: Id) -> Self {
         Self {
-            set: UnorderedSet::new(),
+            set: UnorderedSet::default(),
             storage: Element::new(Some(id)),
         }
     }
@@ -437,6 +437,7 @@ impl JsLwwRegister {
     }
 
     pub fn set(&mut self, value: Option<&[u8]>) {
+        self.storage.update();
         match value {
             Some(bytes) => self.register.set(Some(bytes.to_vec())),
             None => self.register.set(None),
@@ -445,6 +446,11 @@ impl JsLwwRegister {
 
     pub fn get(&self) -> Option<Vec<u8>> {
         self.register.get().clone()
+    }
+
+    pub fn clear(&mut self) {
+        self.storage.update();
+        self.register.set(None);
     }
 
     pub fn timestamp(&self) -> crate::logical_clock::HybridTimestamp {
@@ -494,6 +500,7 @@ impl JsCounter {
         }
     }
 
+    /// Rehydrates a counter using a known identifier.
     #[must_use]
     pub fn new_with_id(id: Id) -> Self {
         Self {


### PR DESCRIPTION
^^^^

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `flush_delta()` host import to emit pending CRDT deltas, updates JS storage wrappers (defaults, LWW register update/clear), and refines node event handler logging/author check.
> 
> - **Runtime**:
>   - **Host Function**: Add `flush_delta()` in `logic/host_functions/system.rs` and expose it in `logic/imports.rs`; commits pending CRDT actions as a causal delta and returns 1/0.
> - **Storage (JS wrappers)**:
>   - Use `Vector::default()`/`UnorderedSet::default()` in `JsVector`/`JsUnorderedSet` constructors.
>   - `JsLwwRegister`:
>     - Call `storage.update()` in `set()`.
>     - Add `clear()` method (with `storage.update()`).
>   - Minor docs for `JsCounter::new_with_id`.
> - **Node**:
>   - `handlers/state_delta.rs`: Refine event handler execution decision with `is_author` flag and improved logging; skip execution on author node.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ece002e03869eb1b9e7b06e0179af0c3b69e03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->