### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-15
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
Mac is deprecated, upgrade.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the x86_64 macOS build matrix target from macos-13 to macos-15 in release workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f8c90407365ab396854b9051558ed8c3024eb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->