### PR TITLE
chore: bump core version to rc19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.18"
+version = "0.10.0-rc.19"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.18"
+version = "0.10.0-rc.19"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `calimero-version` from `0.10.0-rc.18` to `0.10.0-rc.19` in `crates/version/Cargo.toml` and updates `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f5d039554a737d778a9793e4161dc8e75b9b4d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->