### PR TITLE
feat: add tee verify-quote endpoint, make all tee endpoints public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1_der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2232,7 @@ dependencies = [
  "calimero-primitives",
  "calimero-storage",
  "calimero-sys",
+ "ed25519-dalek",
  "eyre",
  "fragile",
  "futures-util",
@@ -2299,6 +2306,7 @@ dependencies = [
  "calimero-store",
  "color-eyre",
  "configfs-tsm",
+ "dcap-qvl",
  "eyre",
  "futures-util",
  "hex",
@@ -2312,6 +2320,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "tdx-quote",
  "tdx_workload_attestation",
  "tokio",
  "tokio-stream",
@@ -2332,8 +2341,10 @@ dependencies = [
  "calimero-primitives",
  "camino",
  "eyre",
+ "hex",
  "serde",
  "serde_json",
+ "tdx-quote",
  "thiserror 1.0.69",
  "url",
 ]
@@ -2347,6 +2358,7 @@ dependencies = [
  "calimero-sdk",
  "calimero-storage-macros",
  "claims",
+ "ed25519-dalek",
  "eyre",
  "fixedstr",
  "hex",
@@ -2420,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.18"
+version = "0.10.0-rc.19"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",
@@ -3305,12 +3317,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcap-qvl"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435989ce7ba46ba3f837f9df3c8139469e72ae810e707893b19f8b6b370d14ef"
+dependencies = [
+ "anyhow",
+ "asn1_der",
+ "base64 0.22.1",
+ "borsh",
+ "byteorder",
+ "chrono",
+ "const-oid",
+ "dcap-qvl-webpki",
+ "der",
+ "futures",
+ "hex",
+ "log",
+ "parity-scale-codec",
+ "pem",
+ "reqwest 0.12.24",
+ "ring",
+ "rustls-webpki 0.102.8",
+ "scale-info",
+ "serde",
+ "serde-human-bytes",
+ "serde_json",
+ "tracing",
+ "urlencoding",
+ "wasm-bindgen-futures",
+ "x509-cert",
+]
+
+[[package]]
+name = "dcap-qvl-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ebdcd097c369fe3422cf3978540e0406148435ec0f4d8ecbbf201c746f19c9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -3327,6 +3385,17 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3376,11 +3445,31 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3992,6 +4081,12 @@ checksum = "cd7fe1d85100f2405b683f73d7f0c2bdb09bcea9e817c6a0e07755a83c35be8a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -5570,6 +5665,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-store-with-user-and-frozen-storage"
+version = "0.0.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+ "calimero-wasm-abi",
+ "hex",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lambdaworks-crypto"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5602,6 +5709,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -6124,7 +6234,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls",
- "rustls-webpki",
+ "rustls-webpki 0.103.7",
  "thiserror 2.0.17",
  "x509-parser",
  "yasna",
@@ -7317,6 +7427,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,6 +7744,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7784,6 +7935,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -8604,6 +8766,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.12",
+ "hickory-resolver",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -8615,6 +8778,7 @@ dependencies = [
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -8717,6 +8881,26 @@ checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8903,7 +9087,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.7",
  "subtle",
  "zeroize",
 ]
@@ -8925,6 +9109,17 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -8989,6 +9184,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -9234,6 +9454,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-human-bytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ef65cb41f3f9cef63c431193229067e8b98b53c4d4c4ed38a8ca87c4d07676"
+dependencies = [
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9301,6 +9531,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap 2.12.0",
  "itoa",
  "memchr",
  "ryu",
@@ -10141,6 +10372,20 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "tdx-quote"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f4ab4f38ef1537f0ccd0fbae769a5295a4b33f81a07b8d5b6267504594d80b"
+dependencies = [
+ "nom 7.1.3",
+ "p256",
+ "pem",
+ "sha2 0.10.9",
+ "spki",
+ "x509-verify",
+]
 
 [[package]]
 name = "tdx_workload_attestation"
@@ -10990,6 +11235,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -12116,6 +12367,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "x509-ocsp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e54e695a31f0fecb826cf59ae2093c941d7ef932a1f8508185dd23b29ce2e2e"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12130,6 +12404,28 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.17",
  "time",
+]
+
+[[package]]
+name = "x509-verify"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43a49bf845cd2f3aff9603a4276409dbf2b8fa4454d3e9501bf5b0028342964"
+dependencies = [
+ "const-oid",
+ "der",
+ "ecdsa",
+ "ed25519-dalek",
+ "k256",
+ "p256",
+ "p384",
+ "p521",
+ "rsa",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "x509-cert",
+ "x509-ocsp",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -38,6 +38,10 @@ calimero-server-primitives.workspace = true
 calimero-store = { workspace = true, features = ["serde"] }
 mero-auth = { path = "../auth" }
 
+# Quote verification dependencies (cross-platform)
+dcap-qvl.workspace = true
+tdx-quote.workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 configfs-tsm.workspace = true
 tdx_workload_attestation = { workspace = true, features = ["tdx-linux"] }

--- a/crates/server/primitives/Cargo.toml
+++ b/crates/server/primitives/Cargo.toml
@@ -11,9 +11,11 @@ publish = true
 [dependencies]
 camino = { workspace = true, features = ["serde1"] }
 eyre.workspace = true
+hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+tdx-quote.workspace = true
 url = { workspace = true, features = ["serde"] }
 
 calimero-context-config.workspace = true

--- a/crates/server/primitives/src/admin.rs
+++ b/crates/server/primitives/src/admin.rs
@@ -1092,6 +1092,205 @@ impl SyncContextResponse {
 
 // -------------------------------------------- TEE API --------------------------------------------
 
+// Serializable TDX Quote Types (mirrors tdx_quote::Quote structure)
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Quote {
+    pub header: QuoteHeader,
+    pub body: QuoteBody,
+    pub signature: String,
+    pub attestation_key: String,
+    pub certification_data: CertificationData,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteHeader {
+    pub version: u16,
+    pub attestation_key_type: u16,
+    pub tee_type: u32,
+    pub qe_vendor_id: String,
+    pub user_data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteBody {
+    /// TDX version
+    pub tdx_version: String,
+    /// TEE Trusted Computing Base Security Version Number (16 bytes)
+    pub tee_tcb_svn: String,
+    /// Measurement of SEAM module (48 bytes)
+    pub mrseam: String,
+    /// Measurement of SEAM signer (48 bytes)
+    pub mrsignerseam: String,
+    /// SEAM attributes (8 bytes)
+    pub seamattributes: String,
+    /// Trust Domain attributes (8 bytes)
+    pub tdattributes: String,
+    /// Extended features available mask (8 bytes)
+    pub xfam: String,
+    /// Measurement Register of Trust Domain (48 bytes) - hash of kernel + initrd + app
+    pub mrtd: String,
+    /// Measurement of configuration (48 bytes)
+    pub mrconfigid: String,
+    /// Measurement of owner (48 bytes)
+    pub mrowner: String,
+    /// Measurement of owner configuration (48 bytes)
+    pub mrownerconfig: String,
+    /// Runtime Measurement Register 0 (48 bytes)
+    pub rtmr0: String,
+    /// Runtime Measurement Register 1 (48 bytes)
+    pub rtmr1: String,
+    /// Runtime Measurement Register 2 (48 bytes)
+    pub rtmr2: String,
+    /// Runtime Measurement Register 3 (48 bytes)
+    pub rtmr3: String,
+    /// Report data (64 bytes): nonce[32] || app_hash[32]
+    pub reportdata: String,
+    /// Optional second TEE TCB SVN (16 bytes) - TDX 1.5+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tee_tcb_svn_2: Option<String>,
+    /// Optional measurement of service TD (48 bytes) - TDX 1.5+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mrservicetd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QeReportCertificationDataInfo {
+    /// QE report (384 bytes hex)
+    pub qe_report: String,
+    /// ECDSA signature (hex)
+    pub signature: String,
+    /// QE authentication data (hex)
+    pub qe_authentication_data: String,
+    /// Inner certification data type
+    pub certification_data_type: String,
+    /// Inner certification data (hex)
+    pub certification_data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "camelCase")]
+pub enum CertificationData {
+    #[serde(rename = "pckIdPpidPlainCpusvnPcesvn")]
+    PckIdPpidPlainCpusvnPcesvn(String),
+    #[serde(rename = "pckIdPpidRSA2048CpusvnPcesvn")]
+    PckIdPpidRSA2048CpusvnPcesvn(String),
+    #[serde(rename = "pckIdPpidRSA3072CpusvnPcesvn")]
+    PckIdPpidRSA3072CpusvnPcesvn(String),
+    #[serde(rename = "pckLeafCert")]
+    PckLeafCert(String),
+    #[serde(rename = "pckCertChain")]
+    PckCertChain(String),
+    #[serde(rename = "qeReportCertificationData")]
+    QeReportCertificationData(QeReportCertificationDataInfo),
+    #[serde(rename = "platformManifest")]
+    PlatformManifest(String),
+}
+
+// Conversion from tdx_quote::Quote to our serializable Quote type
+impl TryFrom<tdx_quote::Quote> for Quote {
+    type Error = String;
+
+    fn try_from(quote: tdx_quote::Quote) -> Result<Self, Self::Error> {
+        use tdx_quote::CertificationData as TdxCert;
+        use tdx_quote::CertificationDataInner;
+
+        // Extract method results first to avoid borrow issues
+        let mrtd = hex::encode(quote.mrtd());
+        let rtmr0 = hex::encode(quote.rtmr0());
+        let rtmr1 = hex::encode(quote.rtmr1());
+        let rtmr2 = hex::encode(quote.rtmr2());
+        let rtmr3 = hex::encode(quote.rtmr3());
+        let reportdata = hex::encode(quote.report_input_data());
+
+        Ok(Self {
+            header: QuoteHeader {
+                version: quote.header.version,
+                attestation_key_type: quote.header.attestation_key_type as u16,
+                tee_type: quote.header.tee_type as u32,
+                qe_vendor_id: hex::encode(&quote.header.qe_vendor_id),
+                user_data: hex::encode(&quote.header.user_data),
+            },
+            body: QuoteBody {
+                tdx_version: match quote.body.tdx_version {
+                    tdx_quote::TDXVersion::One => "1.0".to_string(),
+                    tdx_quote::TDXVersion::OnePointFive => "1.5".to_string(),
+                },
+                tee_tcb_svn: hex::encode(&quote.body.tee_tcb_svn),
+                mrseam: hex::encode(&quote.body.mrseam),
+                mrsignerseam: hex::encode(&quote.body.mrsignerseam),
+                seamattributes: hex::encode(&quote.body.seamattributes),
+                tdattributes: hex::encode(&quote.body.tdattributes),
+                xfam: hex::encode(&quote.body.xfam),
+                mrtd,
+                mrconfigid: hex::encode(&quote.body.mrconfigid),
+                mrowner: hex::encode(&quote.body.mrowner),
+                mrownerconfig: hex::encode(&quote.body.mrownerconfig),
+                rtmr0,
+                rtmr1,
+                rtmr2,
+                rtmr3,
+                reportdata,
+                tee_tcb_svn_2: quote.body.tee_tcb_svn_2.map(|v| hex::encode(&v)),
+                mrservicetd: quote.body.mrservicetd.map(|v| hex::encode(&v)),
+            },
+            signature: hex::encode(quote.signature.to_bytes()),
+            attestation_key: hex::encode(quote.attestation_key.to_sec1_bytes()),
+            certification_data: match quote.certification_data {
+                TdxCert::PckIdPpidPlainCpusvnPcesvn(data) => {
+                    CertificationData::PckIdPpidPlainCpusvnPcesvn(hex::encode(&data))
+                }
+                TdxCert::PckIdPpidRSA2048CpusvnPcesvn(data) => {
+                    CertificationData::PckIdPpidRSA2048CpusvnPcesvn(hex::encode(&data))
+                }
+                TdxCert::PckIdPpidRSA3072CpusvnPcesvn(data) => {
+                    CertificationData::PckIdPpidRSA3072CpusvnPcesvn(hex::encode(&data))
+                }
+                TdxCert::PckLeafCert(data) => CertificationData::PckLeafCert(hex::encode(&data)),
+                TdxCert::PckCertChain(data) => CertificationData::PckCertChain(hex::encode(&data)),
+                TdxCert::QeReportCertificationData(data) => {
+                    // Properly serialize the nested QeReportCertificationData structure
+                    let (cert_type, cert_data) = match &data.certification_data {
+                        CertificationDataInner::PckIdPpidPlainCpusvnPcesvn(d) => {
+                            ("PckIdPpidPlainCpusvnPcesvn", hex::encode(d))
+                        }
+                        CertificationDataInner::PckIdPpidRSA2048CpusvnPcesvn(d) => {
+                            ("PckIdPpidRSA2048CpusvnPcesvn", hex::encode(d))
+                        }
+                        CertificationDataInner::PckIdPpidRSA3072CpusvnPcesvn(d) => {
+                            ("PckIdPpidRSA3072CpusvnPcesvn", hex::encode(d))
+                        }
+                        CertificationDataInner::PckLeafCert(d) => ("PckLeafCert", hex::encode(d)),
+                        CertificationDataInner::PckCertChain(d) => ("PckCertChain", hex::encode(d)),
+                        CertificationDataInner::PlatformManifest(d) => {
+                            ("PlatformManifest", hex::encode(d))
+                        }
+                        // Return error for unknown inner certification data variants
+                        _ => return Err("Unknown CertificationDataInner variant encountered".to_string()),
+                    };
+
+                    CertificationData::QeReportCertificationData(QeReportCertificationDataInfo {
+                        qe_report: hex::encode(&data.qe_report),
+                        signature: hex::encode(data.signature.to_bytes()),
+                        qe_authentication_data: hex::encode(&data.qe_authentication_data),
+                        certification_data_type: cert_type.to_string(),
+                        certification_data: cert_data,
+                    })
+                }
+                TdxCert::PlatformManifest(data) => {
+                    CertificationData::PlatformManifest(hex::encode(&data))
+                }
+                // Return error for unknown certification data variants
+                _ => return Err("Unknown CertificationData variant encountered".to_string()),
+            },
+        })
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeeAttestRequest {
@@ -1146,6 +1345,8 @@ pub struct TeeAttestResponseData {
     /// Base64-encoded TDX quote
     /// The quote contains the report_data which the client must verify
     pub quote_b64: String,
+    /// Parsed TDX quote structure
+    pub quote: Quote,
 }
 
 #[derive(Debug, Serialize)]
@@ -1155,9 +1356,45 @@ pub struct TeeAttestResponse {
 }
 
 impl TeeAttestResponse {
-    pub fn new(quote_b64: String) -> Self {
+    pub fn new(quote_b64: String, quote: Quote) -> Self {
         Self {
-            data: TeeAttestResponseData { quote_b64 },
+            data: TeeAttestResponseData { quote_b64, quote },
         }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeeVerifyQuoteRequest {
+    /// Base64-encoded TDX quote to verify
+    pub quote_b64: String,
+    /// Client-provided nonce that should match report_data[0..32] (64 hex chars = 32 bytes)
+    pub nonce: String,
+    /// Optional expected application hash that should match report_data[32..64] (64 hex chars = 32 bytes)
+    pub expected_application_hash: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeeVerifyQuoteResponseData {
+    /// Whether the quote signature and certificate chain are valid
+    pub quote_verified: bool,
+    /// Whether the nonce matches report_data[0..32]
+    pub nonce_verified: bool,
+    /// Whether the application hash matches report_data[32..64] (if provided)
+    pub application_hash_verified: Option<bool>,
+    /// Parsed quote structure
+    pub quote: Quote,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeeVerifyQuoteResponse {
+    pub data: TeeVerifyQuoteResponseData,
+}
+
+impl TeeVerifyQuoteResponse {
+    pub fn new(data: TeeVerifyQuoteResponseData) -> Self {
+        Self { data }
     }
 }

--- a/crates/server/src/admin/handlers/tee.rs
+++ b/crates/server/src/admin/handlers/tee.rs
@@ -1,11 +1,13 @@
 use axum::routing::{get, post};
 use axum::Router;
 
-mod attestation;
+mod attest;
 mod info;
+mod verify_quote;
 
 pub fn service() -> Router {
     Router::new()
         .route("/info", get(info::handler))
-        .route("/attest", post(attestation::handler))
+        .route("/attest", post(attest::handler))
+        .route("/verify-quote", post(verify_quote::handler))
 }

--- a/crates/server/src/admin/handlers/tee/verify_quote.rs
+++ b/crates/server/src/admin/handlers/tee/verify_quote.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
+use calimero_server_primitives::admin::{
+    Quote, TeeVerifyQuoteRequest, TeeVerifyQuoteResponse, TeeVerifyQuoteResponseData,
+};
+use reqwest::StatusCode;
+use tracing::{error, info};
+
+use crate::admin::service::{ApiError, ApiResponse};
+use crate::AdminState;
+
+use dcap_qvl::collateral::get_collateral_from_pcs;
+use dcap_qvl::verify::verify;
+use tdx_quote::Quote as TdxQuote;
+
+pub async fn handler(
+    Extension(_state): Extension<Arc<AdminState>>,
+    Json(req): Json<TeeVerifyQuoteRequest>,
+) -> impl IntoResponse {
+    info!(
+        nonce=%req.nonce,
+        has_expected_hash=%req.expected_application_hash.is_some(),
+        "Verifying TDX quote"
+    );
+
+    match verify_quote(req).await {
+        Ok(response) => ApiResponse { payload: response }.into_response(),
+        Err(err) => err.into_response(),
+    }
+}
+
+async fn verify_quote(req: TeeVerifyQuoteRequest) -> Result<TeeVerifyQuoteResponse, ApiError> {
+    // 1. Validate and decode nonce
+    let nonce = hex::decode(&req.nonce).map_err(|_| {
+        error!("Invalid nonce format");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "Invalid nonce format (must be 64 hex characters)".to_owned(),
+        }
+    })?;
+
+    if nonce.len() != 32 {
+        error!(nonce_len=%nonce.len(), "Invalid nonce length");
+        return Err(ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "Nonce must be exactly 32 bytes (64 hex characters)".to_owned(),
+        });
+    }
+
+    // 2. Validate expected application hash if provided
+    let expected_app_hash = if let Some(hash_hex) = &req.expected_application_hash {
+        let h = hex::decode(hash_hex).map_err(|_| {
+            error!("Invalid application hash format");
+            ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "Invalid application hash format (must be 64 hex characters)".to_owned(),
+            }
+        })?;
+
+        if h.len() != 32 {
+            error!(hash_len=%h.len(), "Invalid application hash length");
+            return Err(ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "Application hash must be exactly 32 bytes (64 hex characters)".to_owned(),
+            });
+        }
+        Some(h)
+    } else {
+        None
+    };
+
+    // 3. Decode base64 quote
+    let quote_bytes = base64_engine.decode(&req.quote_b64).map_err(|err| {
+        error!(error=?err, "Failed to decode base64 quote");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: format!("Invalid base64 quote: {}", err),
+        }
+    })?;
+
+    info!(quote_size=%quote_bytes.len(), "Quote decoded successfully");
+
+    // 4. Parse TDX quote
+    let tdx_quote = TdxQuote::from_bytes(&quote_bytes).map_err(|err| {
+        error!(error=?err, "Failed to parse TDX quote");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: format!("Failed to parse TDX quote: {:?}", err),
+        }
+    })?;
+
+    info!("Quote parsed successfully");
+
+    // 5. Extract report data from quote
+    let report_data = tdx_quote.report_input_data();
+    let report_data_hex = hex::encode(report_data);
+
+    info!(report_data=%report_data_hex, "Extracted report data from quote");
+
+    // 6. Fetch collateral from Intel PCS
+    let collateral = get_collateral_from_pcs(&quote_bytes).await.map_err(|err| {
+        error!(error=?err, "Failed to fetch collateral from Intel PCS");
+        ApiError {
+            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            message: format!("Failed to fetch collateral from Intel PCS: {:?}", err),
+        }
+    })?;
+
+    info!("Collateral fetched from Intel PCS");
+
+    // 7. Verify quote signature and certificate chain
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|err| {
+            error!(error=?err, "Failed to get current time");
+            ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: format!("Failed to get current time: {}", err),
+            }
+        })?
+        .as_secs();
+
+    let quote_verified = match verify(&quote_bytes, &collateral, now) {
+        Ok(_) => {
+            info!("Quote cryptographic verification: PASSED");
+            true
+        }
+        Err(err) => {
+            error!(error=?err, "Quote cryptographic verification: FAILED");
+            // We don't return early here - we continue to check nonce and app hash
+            // and return all verification results
+            false
+        }
+    };
+
+    // 8. Verify nonce matches report_data[0..32]
+    let nonce_verified = &report_data[..32] == nonce.as_slice();
+    if nonce_verified {
+        info!("Nonce verification: PASSED");
+    } else {
+        error!(
+            expected=%hex::encode(&nonce),
+            actual=%hex::encode(&report_data[..32]),
+            "Nonce verification: FAILED"
+        );
+    }
+
+    // 9. Verify application hash if provided
+    let application_hash_verified = if let Some(expected_hash) = expected_app_hash {
+        let actual_hash = &report_data[32..64];
+        let verified = actual_hash == expected_hash.as_slice();
+        if verified {
+            info!("Application hash verification: PASSED");
+        } else {
+            error!(
+                expected=%hex::encode(&expected_hash),
+                actual=%hex::encode(actual_hash),
+                "Application hash verification: FAILED"
+            );
+        }
+        Some(verified)
+    } else {
+        None
+    };
+
+    // 10. Convert tdx_quote to our serializable Quote type
+    let quote = Quote::try_from(tdx_quote).map_err(|err| {
+        error!(error=%err, "Failed to convert TDX quote to serializable format");
+        ApiError {
+            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            message: format!("Failed to convert TDX quote: {}", err),
+        }
+    })?;
+
+    let response_data = TeeVerifyQuoteResponseData {
+        quote_verified,
+        nonce_verified,
+        application_hash_verified,
+        quote,
+    };
+
+    let overall_success =
+        quote_verified && nonce_verified && application_hash_verified.unwrap_or(true);
+
+    if overall_success {
+        info!("✓ Overall verification: PASSED");
+    } else {
+        error!("✗ Overall verification: FAILED");
+    }
+
+    Ok(TeeVerifyQuoteResponse::new(response_data))
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -218,8 +218,6 @@ pub(crate) fn setup(
         )
         // Alias management
         .nest("/alias", alias::service())
-        // TEE attestation
-        .nest("/tee", tee::service())
         .layer(Extension(Arc::clone(&shared_state)))
         .layer(session_layer.clone());
 
@@ -228,6 +226,8 @@ pub(crate) fn setup(
         // Dummy endpoint used to figure out if we are running behind auth or not
         .route("/is-authed", get(is_authed_handler))
         .route("/certificate", get(certificate_handler))
+        // TEE attestation (public endpoints)
+        .nest("/tee", tee::service())
         .layer(Extension(shared_state));
 
     Some((admin_path, protected_routes, public_routes))

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.18"
+version = "0.10.0-rc.19"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds public TEE endpoints including quote verification and enhances attestation to return parsed TDX quotes, with supporting primitives and deps.
> 
> - **Server API**:
>   - Expose TEE routes publicly under `admin-api/tee`: `POST /attest` (refactored) and new `POST /verify-quote`.
>   - `attest` now returns `quote_b64` plus parsed `quote` (TDX) structure.
> - **Handlers**:
>   - New `tee/verify_quote.rs`: decodes, parses, fetches PCS collateral via `dcap-qvl`, verifies quote, nonce, and optional app hash.
>   - `tee/attest.rs`: platform-gated TDX quote generation (Linux), parse via `tdx-quote`, serialize, base64-encode.
> - **Primitives**:
>   - Add serializable TDX `Quote` model + `TryFrom<tdx_quote::Quote>`; new request/response types for attest and verify.
> - **Dependencies**:
>   - Add `dcap-qvl`, `tdx-quote` (server, primitives); lockfile updates for crypto/x509/webpki.
> - **Version**:
>   - Bump `calimero-version` to `0.10.0-rc.19`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b045096e6f22c54df7d4351839a4215a020cf40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->