### PR TITLE
fix: rust fmt

### DIFF
--- a/crates/server/primitives/src/admin.rs
+++ b/crates/server/primitives/src/admin.rs
@@ -1270,7 +1270,11 @@ impl TryFrom<tdx_quote::Quote> for Quote {
                             ("PlatformManifest", hex::encode(d))
                         }
                         // Return error for unknown inner certification data variants
-                        _ => return Err("Unknown CertificationDataInner variant encountered".to_string()),
+                        _ => {
+                            return Err(
+                                "Unknown CertificationDataInner variant encountered".to_string()
+                            )
+                        }
                     };
 
                     CertificationData::QeReportCertificationData(QeReportCertificationDataInfo {


### PR DESCRIPTION
# Rust fmt fixes

## Description

Fixing the formatting errors after #1658.

## Test plan

--

## Documentation update
--

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reformats the fallback `_` match arm in `crates/server/primitives/src/admin.rs` to rustfmt-compliant multi-line style within the TDX quote certification data handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad6a6cc079e4d90cc9ea250a7cd74333e49e05a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->