### PR TITLE
chore: bump node version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.22"
+version = "0.10.0-rc.23"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.22"
+version = "0.10.0-rc.23"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# chore: bump node version

## Description
Testing new release flow check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps the calimero-version crate to 0.10.0-rc.23 and updates Cargo.lock accordingly.
> 
> - **Versioning**:
>   - Update `calimero-version` from `0.10.0-rc.22` to `0.10.0-rc.23` in `crates/version/Cargo.toml` and `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b542c33ddb38c39a2f3bc709954ee7bb4ac7663a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->