### PR TITLE
feat: update default boot-node and relayer IPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.23"
+version = "0.10.0-rc.24"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/merod/src/defaults.rs
+++ b/crates/merod/src/defaults.rs
@@ -3,7 +3,7 @@ use dirs::home_dir;
 use url::Url;
 
 pub const DEFAULT_CALIMERO_HOME: &str = ".calimero";
-pub const DEFAULT_RELAYER_URL: &str = "http://3.125.79.112:63529";
+pub const DEFAULT_RELAYER_URL: &str = "http://63.179.161.75:63529";
 
 pub fn default_node_dir() -> Utf8PathBuf {
     if let Some(home) = home_dir() {

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -20,8 +20,8 @@ pub const IPFS_BOOT_NODES: &[&str] = &[
 ];
 
 pub const CALIMERO_DEV_BOOT_NODES: &[&str] = &[
-    "/ip4/18.156.18.6/udp/4001/quic-v1/p2p/12D3KooWMgoF9xzyeKJHtRvrYwdomheRbHPELagWZwTLmXb6bCVC",
-    "/ip4/18.156.18.6/tcp/4001/p2p/12D3KooWMgoF9xzyeKJHtRvrYwdomheRbHPELagWZwTLmXb6bCVC",
+    "/ip4/63.181.86.34/udp/4001/quic-v1/p2p/12D3KooWMgoF9xzyeKJHtRvrYwdomheRbHPELagWZwTLmXb6bCVC",
+    "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooWMgoF9xzyeKJHtRvrYwdomheRbHPELagWZwTLmXb6bCVC",
 ];
 
 #[derive(Debug)]

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.23"
+version = "0.10.0-rc.24"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates default relayer URL and dev boot-node IPs; bumps calimero-version to 0.10.0-rc.24.
> 
> - **Networking**:
>   - **Defaults**: Update `DEFAULT_RELAYER_URL` in `crates/merod/src/defaults.rs` to `http://63.179.161.75:63529`.
>   - **Dev boot nodes**: Replace IP in `CALIMERO_DEV_BOOT_NODES` (both `udp` and `tcp`) in `crates/network/primitives/src/config.rs` to `63.181.86.34`.
> - **Versioning**:
>   - Bump `calimero-version` to `0.10.0-rc.24` in `crates/version/Cargo.toml` and `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 802340a5027e75a6bbdb0c224c5a7c7c575ff345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->