### PR TITLE
fix: calimero boot node peer id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.24"
+version = "0.10.0-rc.25"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -20,8 +20,8 @@ pub const IPFS_BOOT_NODES: &[&str] = &[
 ];
 
 pub const CALIMERO_DEV_BOOT_NODES: &[&str] = &[
-    "/ip4/63.181.86.34/udp/4001/quic-v1/p2p/12D3KooWMgoF9xzyeKJHtRvrYwdomheRbHPELagWZwTLmXb6bCVC",
-    "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooWMgoF9xzyeKJHtRvrYwdomheRbHPELagWZwTLmXb6bCVC",
+    "/ip4/63.181.86.34/udp/4001/quic-v1/p2p/12D3KooWR5V4zmisVtVdGE6i8jfFwtgRNq5t8eDGxfckKuhXu7Eh",
+    "/ip4/63.181.86.34/tcp/4001/p2p/12D3KooWR5V4zmisVtVdGE6i8jfFwtgRNq5t8eDGxfckKuhXu7Eh",
 ];
 
 #[derive(Debug)]

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.24"
+version = "0.10.0-rc.25"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Calimero dev boot node peer ID and bump `calimero-version` to rc.25.
> 
> - **Networking**:
>   - Update `CALIMERO_DEV_BOOT_NODES` peer ID (both `udp/quic-v1` and `tcp`) in `crates/network/primitives/src/config.rs`.
> - **Versioning**:
>   - Bump `calimero-version` to `0.10.0-rc.25` and update `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2512a767a644af5b52a30351c7ed341c91fd0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->