### PR TITLE
feat: implement specialized node invite protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,7 @@ name = "calimero-network-primitives"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "async-trait",
  "borsh",
  "bytes",
  "calimero-primitives",
@@ -2128,6 +2129,7 @@ dependencies = [
  "calimero-storage",
  "calimero-store",
  "calimero-store-rocksdb",
+ "calimero-tee-attestation",
  "calimero-utils-actix",
  "camino",
  "dashmap 6.1.0",
@@ -2164,6 +2166,7 @@ dependencies = [
  "calimero-store-rocksdb",
  "calimero-utils-actix",
  "camino",
+ "dashmap 6.1.0",
  "eyre",
  "flate2",
  "futures-util",
@@ -2293,9 +2296,8 @@ dependencies = [
  "calimero-primitives",
  "calimero-server-primitives",
  "calimero-store",
+ "calimero-tee-attestation",
  "color-eyre",
- "configfs-tsm",
- "dcap-qvl",
  "eyre",
  "futures-util",
  "hex",
@@ -2309,8 +2311,6 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "tdx-quote",
- "tdx_workload_attestation",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2402,6 +2402,22 @@ name = "calimero-sys"
 version = "0.0.0"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "calimero-tee-attestation"
+version = "0.0.0"
+dependencies = [
+ "base64 0.22.1",
+ "calimero-server-primitives",
+ "configfs-tsm",
+ "dcap-qvl",
+ "eyre",
+ "hex",
+ "reqwest 0.12.24",
+ "tdx-quote",
+ "tdx_workload_attestation",
+ "tracing",
 ]
 
 [[package]]
@@ -5670,6 +5686,7 @@ dependencies = [
  "libp2p-quic",
  "libp2p-relay",
  "libp2p-rendezvous",
+ "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "./crates/server/primitives",
     "./crates/storage",
     "./crates/storage-macros",
+    "./crates/tee-attestation",
 
     "./crates/store",
     "./crates/store/blobs",
@@ -230,6 +231,7 @@ calimero-storage-macros = { path = "./crates/storage-macros" }
 calimero-store = { path = "./crates/store" }
 calimero-store-rocksdb = { path = "./crates/store/impl/rocksdb" }
 calimero-sys = { path = "./crates/sys" }
+calimero-tee-attestation = { path = "./crates/tee-attestation" }
 calimero-utils-actix = { path = "./crates/utils/actix" }
 calimero-version = { path = "./crates/version" }
 calimero-wasm-abi = { path = "./crates/wasm-abi" }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -21,12 +21,12 @@ use calimero_server_primitives::admin::{
     GetContextResponse, GetContextStorageResponse, GetContextsResponse, GetLatestVersionResponse,
     GetPeersCountResponse, GetProposalApproversResponse, GetProposalResponse, GetProposalsResponse,
     GrantPermissionResponse, InstallApplicationRequest, InstallApplicationResponse,
-    InstallDevApplicationRequest, InviteToContextOpenInvitationRequest,
-    InviteToContextOpenInvitationResponse, InviteToContextRequest, InviteToContextResponse,
-    JoinContextByOpenInvitationRequest, JoinContextRequest, JoinContextResponse,
-    ListAliasesResponse, ListApplicationsResponse, ListPackagesResponse, ListVersionsResponse,
-    LookupAliasResponse, RevokePermissionResponse, SyncContextResponse,
-    UninstallApplicationResponse, UpdateContextApplicationRequest,
+    InstallDevApplicationRequest, InviteSpecializedNodeRequest, InviteSpecializedNodeResponse,
+    InviteToContextOpenInvitationRequest, InviteToContextOpenInvitationResponse,
+    InviteToContextRequest, InviteToContextResponse, JoinContextByOpenInvitationRequest,
+    JoinContextRequest, JoinContextResponse, ListAliasesResponse, ListApplicationsResponse,
+    ListPackagesResponse, ListVersionsResponse, LookupAliasResponse, RevokePermissionResponse,
+    SyncContextResponse, UninstallApplicationResponse, UpdateContextApplicationRequest,
     UpdateContextApplicationResponse,
 };
 use calimero_server_primitives::blob::{BlobDeleteResponse, BlobInfoResponse, BlobListResponse};
@@ -360,6 +360,21 @@ where
         let response = self
             .connection
             .post("admin-api/contexts/invite_by_open_invitation", request)
+            .await?;
+        Ok(response)
+    }
+
+    /// Invite specialized nodes (e.g., read-only TEE nodes) to join a context.
+    ///
+    /// This broadcasts a specialized node discovery request to the global invite topic.
+    /// Specialized nodes listening will respond with verification and receive invitations.
+    pub async fn invite_specialized_node(
+        &self,
+        request: InviteSpecializedNodeRequest,
+    ) -> Result<InviteSpecializedNodeResponse> {
+        let response = self
+            .connection
+            .post("admin-api/contexts/invite-specialized-node", request)
             .await?;
         Ok(response)
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -48,6 +48,33 @@ pub struct SyncConfig {
     pub frequency: Duration,
 }
 
+/// Configuration for specialized node functionality (e.g., read-only nodes).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct SpecializedNodeConfig {
+    /// Topic name for specialized node invite discovery messages.
+    #[serde(default = "default_specialized_node_invite_topic")]
+    pub invite_topic: String,
+
+    /// Whether to accept mock TEE attestation.
+    /// WARNING: Should only be true for testing. Never enable in production!
+    #[serde(default)]
+    pub accept_mock_tee: bool,
+}
+
+fn default_specialized_node_invite_topic() -> String {
+    "mero_specialized_node_invites".to_owned()
+}
+
+impl Default for SpecializedNodeConfig {
+    fn default() -> Self {
+        Self {
+            invite_topic: default_specialized_node_invite_topic(),
+            accept_mock_tee: false,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct NetworkConfig {
@@ -60,11 +87,15 @@ pub struct NetworkConfig {
 
     #[serde(default)]
     pub discovery: DiscoveryConfig,
+
+    /// Configuration for specialized nodes (read-only, etc.).
+    #[serde(default)]
+    pub specialized_node: SpecializedNodeConfig,
 }
 
 impl NetworkConfig {
     #[must_use]
-    pub const fn new(
+    pub fn new(
         swarm: SwarmConfig,
         bootstrap: BootstrapConfig,
         discovery: DiscoveryConfig,
@@ -75,6 +106,25 @@ impl NetworkConfig {
             server,
             bootstrap,
             discovery,
+            specialized_node: SpecializedNodeConfig::default(),
+        }
+    }
+
+    /// Create a new `NetworkConfig` with custom specialized node settings.
+    #[must_use]
+    pub fn with_specialized_node(
+        swarm: SwarmConfig,
+        bootstrap: BootstrapConfig,
+        discovery: DiscoveryConfig,
+        server: ServerConfig,
+        specialized_node: SpecializedNodeConfig,
+    ) -> Self {
+        Self {
+            swarm,
+            server,
+            bootstrap,
+            discovery,
+            specialized_node,
         }
     }
 }

--- a/crates/context/primitives/src/client/crypto.rs
+++ b/crates/context/primitives/src/client/crypto.rs
@@ -223,6 +223,7 @@ mod tests {
             node_manager,
             event_sender,
             ctx_sync_tx,
+            String::new(), // Not used in tests
         );
 
         // 5. Create a minimal, valid ClientConfig.

--- a/crates/context/primitives/tests/context_application_id.rs
+++ b/crates/context/primitives/tests/context_application_id.rs
@@ -55,6 +55,7 @@ async fn setup_test_context_client() -> (ContextClient, TempDir) {
         node_manager,
         event_sender,
         ctx_sync_tx,
+        String::new(), // Not used in tests
     );
 
     // 5. Setup ExternalClient

--- a/crates/meroctl/src/cli/context.rs
+++ b/crates/meroctl/src/cli/context.rs
@@ -11,6 +11,7 @@ pub mod get;
 pub mod identity;
 pub mod invite;
 pub mod invite_by_open_invitation;
+pub mod invite_specialized_node;
 pub mod join;
 pub mod join_by_open_invitation;
 pub mod list;
@@ -58,6 +59,7 @@ pub enum ContextSubCommands {
     Invite(invite::InviteCommand),
     #[command(alias = "invite-open")]
     InviteByOpenInvitation(invite_by_open_invitation::InviteByOpenInvitationCommand),
+    InviteSpecializedNode(invite_specialized_node::InviteSpecializedNodeCommand),
     Get(get::GetCommand),
     #[command(alias = "del")]
     Delete(delete::DeleteCommand),
@@ -81,6 +83,7 @@ impl ContextCommand {
             ContextSubCommands::InviteByOpenInvitation(open_invite) => {
                 open_invite.run(environment).await
             }
+            ContextSubCommands::InviteSpecializedNode(cmd) => cmd.run(environment).await,
             ContextSubCommands::Join(join) => join.run(environment).await,
             ContextSubCommands::JoinByOpenInvitation(join) => join.run(environment).await,
             ContextSubCommands::List(list) => list.run(environment).await,

--- a/crates/meroctl/src/cli/context/invite_specialized_node.rs
+++ b/crates/meroctl/src/cli/context/invite_specialized_node.rs
@@ -1,0 +1,66 @@
+//! CLI command for inviting specialized nodes (e.g., read-only TEE nodes) to a context.
+
+use calimero_primitives::alias::Alias;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use calimero_server_primitives::admin::InviteSpecializedNodeRequest;
+use clap::Parser;
+use eyre::{OptionExt, Result};
+
+use crate::cli::Environment;
+
+#[derive(Debug, Parser)]
+#[command(about = "Invite specialized nodes (e.g., read-only TEE nodes) to join a context")]
+pub struct InviteSpecializedNodeCommand {
+    #[clap(
+        long,
+        short,
+        value_name = "CONTEXT",
+        help = "The context to invite specialized nodes to",
+        default_value = "default"
+    )]
+    pub context: Alias<ContextId>,
+
+    #[clap(
+        long = "as",
+        value_name = "INVITER",
+        help = "The identifier of the inviter (defaults to context's default identity)"
+    )]
+    pub inviter: Option<Alias<PublicKey>>,
+}
+
+impl InviteSpecializedNodeCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?.clone();
+
+        // Resolve context alias
+        let context_id = client
+            .resolve_alias(self.context, None)
+            .await?
+            .value()
+            .cloned()
+            .ok_or_eyre("unable to resolve context alias")?;
+
+        // Resolve inviter alias if provided
+        let inviter_id = if let Some(inviter_alias) = self.inviter {
+            Some(
+                client
+                    .resolve_alias(inviter_alias, Some(context_id))
+                    .await?
+                    .value()
+                    .cloned()
+                    .ok_or_eyre("unable to resolve inviter alias")?,
+            )
+        } else {
+            None
+        };
+
+        let request = InviteSpecializedNodeRequest::new(context_id, inviter_id);
+
+        let response = client.invite_specialized_node(request).await?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/output/contexts.rs
+++ b/crates/meroctl/src/output/contexts.rs
@@ -2,8 +2,8 @@ use calimero_server_primitives::admin::{
     CreateContextResponse, DeleteContextResponse, GenerateContextIdentityResponse,
     GetContextClientKeysResponse, GetContextIdentitiesResponse, GetContextResponse,
     GetContextStorageResponse, GetContextUsersResponse, GetContextsResponse, GetPeersCountResponse,
-    GrantPermissionResponse, InviteToContextOpenInvitationResponse, InviteToContextResponse,
-    JoinContextResponse, RevokePermissionResponse, SyncContextResponse,
+    GrantPermissionResponse, InviteSpecializedNodeResponse, InviteToContextOpenInvitationResponse,
+    InviteToContextResponse, JoinContextResponse, RevokePermissionResponse, SyncContextResponse,
     UpdateContextApplicationResponse,
 };
 use calimero_server_primitives::jsonrpc::Response;
@@ -179,6 +179,21 @@ impl Report for InviteToContextOpenInvitationResponse {
         let mut table = Table::new();
         let _ = table.set_header(vec![Cell::new("Open Invitation Created").fg(Color::Green)]);
         let _ = table.add_row(vec!["Successfully created an open invitation"]);
+        println!("{table}");
+    }
+}
+
+impl Report for InviteSpecializedNodeResponse {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.set_header(vec![
+            Cell::new("Specialized Node Invite Discovery Broadcast").fg(Color::Green),
+            Cell::new("Nonce").fg(Color::Blue),
+        ]);
+        let _ = table.add_row(vec![
+            "Successfully broadcast specialized node invite discovery",
+            &self.data.nonce,
+        ]);
         println!("{table}");
     }
 }

--- a/crates/merod/src/cli.rs
+++ b/crates/merod/src/cli.rs
@@ -9,6 +9,7 @@ use crate::defaults;
 mod auth_mode;
 mod config;
 mod init;
+mod node_mode;
 mod run;
 
 use config::ConfigCommand;

--- a/crates/merod/src/cli/node_mode.rs
+++ b/crates/merod/src/cli/node_mode.rs
@@ -1,0 +1,20 @@
+use calimero_node::NodeMode;
+use clap::ValueEnum;
+
+#[derive(Copy, Clone, Debug, Default, ValueEnum)]
+pub enum NodeModeArg {
+    /// Standard mode - full node functionality with JSON-RPC execution
+    #[default]
+    Standard,
+    /// Read-only mode - disables JSON-RPC execution, used for TEE observer nodes
+    ReadOnly,
+}
+
+impl From<NodeModeArg> for NodeMode {
+    fn from(value: NodeModeArg) -> Self {
+        match value {
+            NodeModeArg::Standard => NodeMode::Standard,
+            NodeModeArg::ReadOnly => NodeMode::ReadOnly,
+        }
+    }
+}

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -29,6 +29,7 @@ libp2p = { workspace = true, features = [
     "quic",
     "rendezvous",
     "relay",
+    "request-response",
     "tokio",
     "tcp",
     "tls",

--- a/crates/network/primitives/Cargo.toml
+++ b/crates/network/primitives/Cargo.toml
@@ -10,18 +10,19 @@ publish = true
 
 [dependencies]
 actix.workspace = true
-borsh.workspace = true
+async-trait.workspace = true
+borsh = { workspace = true, features = ["derive"] }
 bytes.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
-libp2p = { workspace = true, features = ["gossipsub", "rendezvous"] }
+libp2p = { workspace = true, features = ["gossipsub", "rendezvous", "request-response"] }
 multiaddr.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["compat"] }
 
-calimero-primitives.workspace = true
+calimero-primitives = { workspace = true, features = ["borsh"] }
 calimero-utils-actix.workspace = true
 
 [dev-dependencies]

--- a/crates/network/primitives/src/lib.rs
+++ b/crates/network/primitives/src/lib.rs
@@ -2,4 +2,5 @@ pub mod blob_types;
 pub mod client;
 pub mod config;
 pub mod messages;
+pub mod specialized_node_invite;
 pub mod stream;

--- a/crates/network/primitives/src/specialized_node_invite.rs
+++ b/crates/network/primitives/src/specialized_node_invite.rs
@@ -1,0 +1,219 @@
+//! Specialized Node Invitation Protocol Types
+//!
+//! This module defines the request-response protocol types for specialized node invitation.
+//! The protocol allows specialized nodes (e.g., read-only TEE nodes) to receive context
+//! invitations after verification.
+
+use std::io;
+
+use async_trait::async_trait;
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_primitives::identity::PublicKey;
+use futures_util::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use libp2p::request_response::Codec;
+use libp2p::StreamProtocol;
+
+/// Protocol identifier for specialized node invitation request-response
+pub const CALIMERO_SPECIALIZED_NODE_INVITE_PROTOCOL: StreamProtocol =
+    StreamProtocol::new("/calimero/specialized-node-invite/1.0.0");
+
+/// Maximum size of a specialized node invite message (1MB should be sufficient for attestation + invitation)
+pub const MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE: u64 = 1024 * 1024;
+
+/// Type of specialized node being invited
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum SpecializedNodeType {
+    /// Read-only node - receives state updates but cannot execute transactions
+    ReadOnly,
+}
+
+/// Verification request sent by specialized node to inviting node
+///
+/// After receiving a discovery message via pubsub, the specialized node sends this
+/// request containing its verification data and public key.
+///
+/// Note: context_id is NOT included - the requesting node tracks it internally
+/// using the nonce as the lookup key.
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub enum VerificationRequest {
+    /// TEE attestation verification
+    TeeAttestation {
+        /// Nonce from the discovery message (binds attestation to request)
+        nonce: [u8; 32],
+        /// TDX/TEE attestation quote bytes
+        quote_bytes: Vec<u8>,
+        /// Specialized node's identity public key for invitation
+        public_key: PublicKey,
+    },
+    // Future variants:
+    // HardwareToken { ... },
+    // TrustedCertificate { ... },
+}
+
+impl VerificationRequest {
+    /// Get the nonce from the verification request
+    #[must_use]
+    pub fn nonce(&self) -> &[u8; 32] {
+        match self {
+            Self::TeeAttestation { nonce, .. } => nonce,
+        }
+    }
+
+    /// Get the public key from the verification request
+    #[must_use]
+    pub fn public_key(&self) -> &PublicKey {
+        match self {
+            Self::TeeAttestation { public_key, .. } => public_key,
+        }
+    }
+}
+
+/// Response sent by inviting node containing the invitation (or error)
+///
+/// After verifying the specialized node, the inviting node creates an invitation
+/// for the node's public key and sends it back.
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct SpecializedNodeInvitationResponse {
+    /// The nonce from the original request (for confirmation broadcast)
+    pub nonce: [u8; 32],
+    /// Serialized ContextInvitationPayload (if verification succeeded)
+    /// We use bytes here to avoid circular dependency with context-config crate
+    pub invitation_bytes: Option<Vec<u8>>,
+    /// Error message if verification failed
+    pub error: Option<String>,
+}
+
+impl SpecializedNodeInvitationResponse {
+    /// Create a successful response with an invitation
+    #[must_use]
+    pub fn success(nonce: [u8; 32], invitation_bytes: Vec<u8>) -> Self {
+        Self {
+            nonce,
+            invitation_bytes: Some(invitation_bytes),
+            error: None,
+        }
+    }
+
+    /// Create an error response
+    #[must_use]
+    pub fn error(nonce: [u8; 32], message: impl Into<String>) -> Self {
+        Self {
+            nonce,
+            invitation_bytes: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+/// Codec for specialized node invite request-response protocol
+#[derive(Debug, Clone, Default)]
+pub struct SpecializedNodeInviteCodec;
+
+#[async_trait]
+impl Codec for SpecializedNodeInviteCodec {
+    type Protocol = StreamProtocol;
+    type Request = VerificationRequest;
+    type Response = SpecializedNodeInvitationResponse;
+
+    async fn read_request<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        // Read length prefix (4 bytes, big endian)
+        let mut len_buf = [0u8; 4];
+        io.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+
+        if len as u64 > MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "request too large",
+            ));
+        }
+
+        // Read the message bytes
+        let mut buf = vec![0u8; len];
+        io.read_exact(&mut buf).await?;
+
+        // Deserialize
+        borsh::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        // Read length prefix (4 bytes, big endian)
+        let mut len_buf = [0u8; 4];
+        io.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+
+        if len as u64 > MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "response too large",
+            ));
+        }
+
+        // Read the message bytes
+        let mut buf = vec![0u8; len];
+        io.read_exact(&mut buf).await?;
+
+        // Deserialize
+        borsh::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+        req: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        // Serialize
+        let buf = borsh::to_vec(&req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        // Write length prefix
+        let len = buf.len() as u32;
+        io.write_all(&len.to_be_bytes()).await?;
+
+        // Write message
+        io.write_all(&buf).await?;
+        io.flush().await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+        res: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        // Serialize
+        let buf = borsh::to_vec(&res).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        // Write length prefix
+        let len = buf.len() as u32;
+        io.write_all(&len.to_be_bytes()).await?;
+
+        // Write message
+        io.write_all(&buf).await?;
+        io.flush().await?;
+
+        Ok(())
+    }
+}

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -1,7 +1,11 @@
 use core::time::Duration;
 
 use calimero_network_primitives::config::NetworkConfig;
+use calimero_network_primitives::specialized_node_invite::{
+    SpecializedNodeInviteCodec, CALIMERO_SPECIALIZED_NODE_INVITE_PROTOCOL,
+};
 use eyre::WrapErr;
+use libp2p::request_response::{self, ProtocolSupport};
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::swarm::{NetworkBehaviour, Swarm};
 use libp2p::{
@@ -32,6 +36,7 @@ pub struct Behaviour {
     pub relay: relay::client::Behaviour,
     pub rendezvous: rendezvous::client::Behaviour,
     pub stream: libp2p_stream::Behaviour,
+    pub specialized_node_invite: request_response::Behaviour<SpecializedNodeInviteCodec>,
 }
 
 impl Behaviour {
@@ -111,6 +116,13 @@ impl Behaviour {
                     rendezvous: rendezvous::client::Behaviour::new(key.clone()),
                     relay: relay_behaviour,
                     stream: libp2p_stream::Behaviour::new(),
+                    specialized_node_invite: request_response::Behaviour::new(
+                        [(
+                            CALIMERO_SPECIALIZED_NODE_INVITE_PROTOCOL,
+                            ProtocolSupport::Full,
+                        )],
+                        request_response::Config::default(),
+                    ),
                 };
 
                 Ok(behaviour)

--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -15,6 +15,8 @@ mod peer_count;
 mod publish;
 mod query_blob;
 mod request_blob;
+mod send_specialized_node_invitation_response;
+mod send_specialized_node_verification_request;
 mod subscribe;
 mod unsubscribe;
 
@@ -60,6 +62,12 @@ impl Handler<NetworkMessage> for NetworkManager {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::RequestBlob { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::SendSpecializedNodeVerificationRequest { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::SendSpecializedNodeInvitationResponse { request, outcome } => {
                 self.forward_handler(ctx, request, outcome);
             }
         }

--- a/crates/network/src/handlers/commands/send_specialized_node_invitation_response.rs
+++ b/crates/network/src/handlers/commands/send_specialized_node_invitation_response.rs
@@ -1,0 +1,23 @@
+use actix::{Context, Handler, Message};
+use calimero_network_primitives::messages::SendSpecializedNodeInvitationResponse;
+use eyre::eyre;
+
+use crate::NetworkManager;
+
+impl Handler<SendSpecializedNodeInvitationResponse> for NetworkManager {
+    type Result = <SendSpecializedNodeInvitationResponse as Message>::Result;
+
+    fn handle(
+        &mut self,
+        SendSpecializedNodeInvitationResponse { channel, response }: SendSpecializedNodeInvitationResponse,
+        _ctx: &mut Context<Self>,
+    ) -> Self::Result {
+        self.swarm
+            .behaviour_mut()
+            .specialized_node_invite
+            .send_response(channel, response)
+            .map_err(|_| {
+                eyre!("Failed to send specialized node invitation response - channel closed")
+            })
+    }
+}

--- a/crates/network/src/handlers/commands/send_specialized_node_verification_request.rs
+++ b/crates/network/src/handlers/commands/send_specialized_node_verification_request.rs
@@ -1,0 +1,22 @@
+use actix::{Context, Handler, Message};
+use calimero_network_primitives::messages::SendSpecializedNodeVerificationRequest;
+
+use crate::NetworkManager;
+
+impl Handler<SendSpecializedNodeVerificationRequest> for NetworkManager {
+    type Result = <SendSpecializedNodeVerificationRequest as Message>::Result;
+
+    fn handle(
+        &mut self,
+        SendSpecializedNodeVerificationRequest { peer_id, request }: SendSpecializedNodeVerificationRequest,
+        _ctx: &mut Context<Self>,
+    ) -> Self::Result {
+        let request_id = self
+            .swarm
+            .behaviour_mut()
+            .specialized_node_invite
+            .send_request(&peer_id, request);
+
+        Ok(request_id)
+    }
+}

--- a/crates/network/src/handlers/commands/subscribe.rs
+++ b/crates/network/src/handlers/commands/subscribe.rs
@@ -8,7 +8,6 @@ impl Handler<Subscribe> for NetworkManager {
 
     fn handle(&mut self, Subscribe(topic): Subscribe, _ctx: &mut Context<Self>) -> Self::Result {
         let _ignored = self.swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
-
         Ok(topic)
     }
 }

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -20,6 +20,7 @@ mod mdns;
 mod ping;
 mod relay;
 mod rendezvous;
+mod specialized_node_invite;
 
 pub trait EventHandler<E> {
     fn handle(&mut self, event: E);
@@ -54,6 +55,7 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                 BehaviourEvent::Relay(event) => EventHandler::handle(self, event),
                 BehaviourEvent::Rendezvous(event) => EventHandler::handle(self, event),
                 BehaviourEvent::Stream(()) => {}
+                BehaviourEvent::SpecializedNodeInvite(event) => EventHandler::handle(self, event),
             },
             SwarmEvent::NewListenAddr {
                 listener_id,

--- a/crates/network/src/handlers/stream/swarm/specialized_node_invite.rs
+++ b/crates/network/src/handlers/stream/swarm/specialized_node_invite.rs
@@ -1,0 +1,99 @@
+//! Specialized node invite request-response protocol event handler
+
+use calimero_network_primitives::messages::NetworkEvent;
+use calimero_network_primitives::specialized_node_invite::{
+    SpecializedNodeInvitationResponse, VerificationRequest,
+};
+use libp2p::request_response::Event;
+use owo_colors::OwoColorize;
+use tracing::debug;
+
+use super::{EventHandler, NetworkManager};
+
+impl EventHandler<Event<VerificationRequest, SpecializedNodeInvitationResponse>>
+    for NetworkManager
+{
+    fn handle(&mut self, event: Event<VerificationRequest, SpecializedNodeInvitationResponse>) {
+        debug!("{}: {:?}", "specialized_node_invite".yellow(), event);
+
+        match event {
+            Event::Message { peer, message, .. } => match message {
+                libp2p::request_response::Message::Request {
+                    request_id,
+                    request,
+                    channel,
+                } => {
+                    debug!(
+                        %peer,
+                        ?request_id,
+                        nonce = %hex::encode(request.nonce()),
+                        "Received specialized node verification request"
+                    );
+                    // Forward to NodeManager for handling
+                    self.event_recipient.do_send(
+                        NetworkEvent::SpecializedNodeVerificationRequest {
+                            peer_id: peer,
+                            request_id,
+                            request,
+                            channel,
+                        },
+                    );
+                }
+                libp2p::request_response::Message::Response {
+                    request_id,
+                    response,
+                } => {
+                    debug!(
+                        %peer,
+                        ?request_id,
+                        has_invitation = response.invitation_bytes.is_some(),
+                        has_error = response.error.is_some(),
+                        "Received specialized node invitation response"
+                    );
+                    // Forward to NodeManager for handling
+                    self.event_recipient
+                        .do_send(NetworkEvent::SpecializedNodeInvitationResponse {
+                            peer_id: peer,
+                            request_id,
+                            response,
+                        });
+                }
+            },
+            Event::OutboundFailure {
+                peer,
+                request_id,
+                error,
+                ..
+            } => {
+                debug!(
+                    %peer,
+                    ?request_id,
+                    %error,
+                    "Specialized node invite outbound failure"
+                );
+            }
+            Event::InboundFailure {
+                peer,
+                request_id,
+                error,
+                ..
+            } => {
+                debug!(
+                    %peer,
+                    ?request_id,
+                    %error,
+                    "Specialized node invite inbound failure"
+                );
+            }
+            Event::ResponseSent {
+                peer, request_id, ..
+            } => {
+                debug!(
+                    %peer,
+                    ?request_id,
+                    "Specialized node invite response sent"
+                );
+            }
+        }
+    }
+}

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -38,11 +38,12 @@ calimero-network.workspace = true
 dashmap.workspace = true
 calimero-network-primitives.workspace = true
 calimero-node-primitives.workspace = true
-calimero-primitives = { workspace = true, features = ["borsh"] }
+calimero-primitives = { workspace = true, features = ["borsh", "rand"] }
 calimero-server.workspace = true
 calimero-storage.workspace = true
 calimero-store = { workspace = true, features = ["datatypes"] }
 calimero-store-rocksdb.workspace = true
+calimero-tee-attestation.workspace = true
 calimero-utils-actix.workspace = true
 
 [dev-dependencies]

--- a/crates/node/primitives/Cargo.toml
+++ b/crates/node/primitives/Cargo.toml
@@ -13,6 +13,7 @@ actix.workspace = true
 async-stream.workspace = true
 borsh.workspace = true
 camino.workspace = true
+dashmap.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 infer.workspace = true

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -1,9 +1,30 @@
 use actix::Message;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
 use tokio::sync::oneshot;
 
 pub mod get_blob_bytes;
 
 use get_blob_bytes::GetBlobBytesRequest;
+
+/// Request to register a pending specialized node invite in the node's state.
+#[derive(Clone, Debug)]
+pub struct RegisterPendingSpecializedNodeInvite {
+    /// The nonce from the specialized node invite broadcast
+    pub nonce: [u8; 32],
+    /// The context to invite specialized nodes to
+    pub context_id: ContextId,
+    /// The identity performing the invitation
+    pub inviter_id: PublicKey,
+}
+
+/// Request to remove a pending specialized node invite from the node's state.
+/// Used to clean up if broadcast fails after registration.
+#[derive(Clone, Debug)]
+pub struct RemovePendingSpecializedNodeInvite {
+    /// The nonce to remove
+    pub nonce: [u8; 32],
+}
 
 #[derive(Debug, Message)]
 #[rtype("()")]
@@ -11,5 +32,11 @@ pub enum NodeMessage {
     GetBlobBytes {
         request: GetBlobBytesRequest,
         outcome: oneshot::Sender<<GetBlobBytesRequest as Message>::Result>,
+    },
+    RegisterPendingSpecializedNodeInvite {
+        request: RegisterPendingSpecializedNodeInvite,
+    },
+    RemovePendingSpecializedNodeInvite {
+        request: RemovePendingSpecializedNodeInvite,
     },
 }

--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_crypto::Nonce;
+use calimero_network_primitives::specialized_node_invite::SpecializedNodeType;
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::hash::Hash;
@@ -45,6 +46,30 @@ pub enum BroadcastMessage<'a> {
         root_hash: Hash,
         /// Current DAG head(s)
         dag_heads: Vec<[u8; 32]>,
+    },
+
+    /// Specialized node discovery request
+    ///
+    /// Broadcast by a node to discover and invite specialized nodes (e.g., read-only TEE nodes).
+    /// Specialized nodes receiving this will respond via request-response protocol
+    /// to the message source (available from gossipsub message).
+    ///
+    /// Note: context_id is NOT included - it's tracked internally by the requesting
+    /// node using the nonce as the lookup key.
+    SpecializedNodeDiscovery {
+        /// Random nonce to bind verification to this request
+        nonce: [u8; 32],
+        /// Type of specialized node being invited
+        node_type: SpecializedNodeType,
+    },
+
+    /// Confirmation that a specialized node has joined a context
+    ///
+    /// Broadcast by specialized nodes on the context topic after successfully joining.
+    /// The inviting node receives this and removes the pending invite entry.
+    SpecializedNodeJoinConfirmation {
+        /// The nonce from the original discovery request
+        nonce: [u8; 32],
     },
 }
 

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -128,6 +128,7 @@ async fn create_test_node_client() -> (NodeClient, TempDir, TempDir) {
         LazyRecipient::new(),
         event_sender,
         ctx_sync_tx,
+        String::new(), // Not used in tests
     );
 
     (node_client, data_dir, blob_dir)

--- a/crates/node/src/handlers.rs
+++ b/crates/node/src/handlers.rs
@@ -3,9 +3,13 @@
 //! **Purpose**: Handles incoming events from network layer and processes node-level requests.
 //! **Structure**: Each event type has its own focused file (SRP).
 
+use crate::specialized_node_invite_state::{
+    PendingSpecializedNodeInvite, SpecializedNodeInviteAction,
+};
 use actix::Handler;
 use calimero_node_primitives::messages::NodeMessage;
 use calimero_utils_actix::adapters::ActorExt;
+use tracing::debug;
 
 use crate::NodeManager;
 
@@ -13,6 +17,7 @@ use crate::NodeManager;
 mod blob_protocol;
 mod get_blob_bytes;
 mod network_event;
+mod specialized_node_invite;
 mod state_delta;
 mod stream_opened;
 
@@ -23,6 +28,32 @@ impl Handler<NodeMessage> for NodeManager {
         match msg {
             NodeMessage::GetBlobBytes { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
+            }
+            NodeMessage::RegisterPendingSpecializedNodeInvite { request } => {
+                let action = SpecializedNodeInviteAction::HandleContextInvite {
+                    context_id: request.context_id,
+                    inviter_id: request.inviter_id,
+                };
+                self.state
+                    .pending_specialized_node_invites
+                    .insert(request.nonce, PendingSpecializedNodeInvite::new(action));
+
+                debug!(
+                    context_id = %request.context_id,
+                    inviter_id = %request.inviter_id,
+                    nonce = %hex::encode(request.nonce),
+                    "Registered pending specialized node invite"
+                );
+            }
+            NodeMessage::RemovePendingSpecializedNodeInvite { request } => {
+                self.state
+                    .pending_specialized_node_invites
+                    .remove(&request.nonce);
+
+                debug!(
+                    nonce = %hex::encode(request.nonce),
+                    "Removed pending specialized node invite"
+                );
             }
         }
     }

--- a/crates/node/src/handlers/specialized_node_invite.rs
+++ b/crates/node/src/handlers/specialized_node_invite.rs
@@ -1,0 +1,445 @@
+//! Specialized Node Invite protocol handler
+//!
+//! This module handles the specialized node invitation protocol for nodes like
+//! read-only TEE nodes.
+//!
+//! ## Protocol Flow
+//!
+//! ### Standard Node (initiator)
+//! 1. User broadcasts `SpecializedNodeDiscovery` with nonce and node_type to global topic
+//! 2. Stores nonce -> {context_id, inviter_id, state: Pending} in `PendingSpecializedNodeInvites`
+//! 3. Receives `VerificationRequest` from specialized node (contains nonce, not context_id)
+//! 4. Atomically transitions state to AwaitingConfirmation (prevents race conditions)
+//! 5. Verifies the node (e.g., TEE attestation)
+//! 6. If valid, creates regular invitation and sends `SpecializedNodeInvitationResponse`
+//! 7. Waits for `SpecializedNodeJoinConfirmation` on context topic
+//! 8. If confirmation received, removes pending entry
+//! 9. If TTL expires (60s) without confirmation, resets to Pending for retry
+//!
+//! ### Specialized Node (e.g., Read-Only TEE Node)
+//! 1. Receives `SpecializedNodeDiscovery` broadcast (subscribed to global topic)
+//! 2. Generates verification data (e.g., TEE attestation with nonce)
+//! 3. Sends `VerificationRequest` via request-response (no context_id needed)
+//! 4. Receives `SpecializedNodeInvitationResponse` with ContextInvitationPayload
+//! 5. Joins context using the invitation payload
+//! 6. Broadcasts `SpecializedNodeJoinConfirmation` on context topic
+
+use crate::specialized_node_invite_state::{
+    InviteState, PendingSpecializedNodeInvites, SpecializedNodeInviteAction,
+};
+use calimero_context_primitives::client::ContextClient;
+use calimero_network_primitives::specialized_node_invite::{
+    SpecializedNodeInvitationResponse, VerificationRequest,
+};
+use calimero_primitives::context::{ContextId, ContextInvitationPayload};
+use calimero_primitives::identity::PublicKey;
+use calimero_tee_attestation::{
+    build_report_data, generate_attestation, is_mock_quote, verify_attestation,
+    verify_mock_attestation,
+};
+use libp2p::PeerId;
+use tracing::{debug, error, info, warn};
+
+/// Handle a specialized node discovery broadcast (for specialized nodes in read-only mode)
+///
+/// When a specialized node receives this broadcast, it:
+/// 1. Creates a new identity using `context_client.new_identity()` (stored in datastore)
+/// 2. Generates verification data (e.g., TEE attestation with report_data = nonce)
+/// 3. Returns request to send to the source peer with verification data + public key
+///
+/// The private key is securely stored in the datastore under `ContextId::zero()` (identity pool).
+/// When joining the context, `join_context` retrieves the identity from the pool automatically.
+pub fn handle_specialized_node_discovery(
+    nonce: [u8; 32],
+    source_peer: PeerId,
+    context_client: &ContextClient,
+) -> eyre::Result<VerificationRequest> {
+    info!(
+        %source_peer,
+        nonce = %hex::encode(nonce),
+        "Received specialized node discovery - generating verification"
+    );
+
+    // Create a new identity - this generates a keypair and stores the private key
+    // in the datastore under ContextId::zero() (identity pool)
+    let our_public_key = context_client.new_identity()?;
+
+    info!(
+        public_key = %our_public_key,
+        "Created identity for specialized node invitation (private key stored in datastore)"
+    );
+
+    // Build report_data: nonce || zeros
+    // The nonce alone provides replay protection - context_id is tracked by the requester
+    let report_data = build_report_data(&nonce, None);
+
+    // Generate attestation
+    let attestation_result = generate_attestation(report_data)?;
+
+    info!(
+        quote_len = attestation_result.quote_bytes.len(),
+        "TEE attestation generated successfully for specialized node verification"
+    );
+
+    // Create the verification request to send to the inviting node
+    let request = VerificationRequest::TeeAttestation {
+        nonce,
+        quote_bytes: attestation_result.quote_bytes,
+        public_key: our_public_key,
+    };
+
+    Ok(request)
+}
+
+/// Handle receiving a verification request (for standard/inviting nodes)
+///
+/// When an inviting node receives this request, it:
+/// 1. Atomically claims the nonce by transitioning state to AwaitingConfirmation
+/// 2. Verifies the specialized node (e.g., TEE attestation, supports mock for testing)
+/// 3. If valid, creates a regular invitation for the node's public key
+/// 4. Sends the invitation back via the response channel
+///
+/// State machine prevents race conditions:
+/// - Only one request can claim a Pending nonce at a time
+/// - If AwaitingConfirmation, check TTL before allowing retry
+/// - On failure, state is reset to Pending for retry
+pub async fn handle_verification_request(
+    peer_id: PeerId,
+    request: VerificationRequest,
+    pending_invites: &PendingSpecializedNodeInvites,
+    context_client: &ContextClient,
+    accept_mock_tee: bool,
+) -> SpecializedNodeInvitationResponse {
+    let nonce = *request.nonce();
+    let public_key = *request.public_key();
+
+    info!(
+        %peer_id,
+        public_key = %public_key,
+        nonce = %hex::encode(nonce),
+        "Received verification request - verifying specialized node"
+    );
+
+    // Atomically check and claim the pending invite.
+    // This prevents race conditions where multiple specialized nodes could
+    // all get invitations from a single broadcast.
+    let (context_id, inviter_id) = {
+        let mut entry = match pending_invites.get_mut(&nonce) {
+            Some(entry) => entry,
+            None => {
+                warn!(
+                    nonce = %hex::encode(nonce),
+                    "Received verification request for unknown nonce"
+                );
+                return SpecializedNodeInvitationResponse::error(
+                    nonce,
+                    "Unknown nonce - no pending invite request",
+                );
+            }
+        };
+
+        // Check if we can accept this request based on current state
+        if !entry.state.can_accept_request() {
+            // Already processing another request and TTL hasn't expired
+            if let InviteState::AwaitingConfirmation {
+                invitee_public_key, ..
+            } = &entry.state
+            {
+                warn!(
+                    nonce = %hex::encode(nonce),
+                    current_invitee = %invitee_public_key,
+                    new_requester = %public_key,
+                    "Nonce already claimed by another specialized node, TTL not expired"
+                );
+            }
+            return SpecializedNodeInvitationResponse::error(
+                nonce,
+                "Invite already in progress - please wait for TTL expiry",
+            );
+        }
+
+        // Extract context_id and inviter_id before transitioning state
+        let (context_id, inviter_id) = match &entry.action {
+            SpecializedNodeInviteAction::HandleContextInvite {
+                context_id,
+                inviter_id,
+            } => (*context_id, *inviter_id),
+        };
+
+        // Atomically transition to AwaitingConfirmation to claim this nonce
+        entry.transition_to_awaiting(public_key);
+
+        info!(
+            %peer_id,
+            %context_id,
+            %inviter_id,
+            "Claimed pending invite for nonce, transitioning to AwaitingConfirmation"
+        );
+
+        (context_id, inviter_id)
+    }; // Release the lock here
+
+    // Handle verification based on request type
+    match request {
+        VerificationRequest::TeeAttestation {
+            nonce,
+            quote_bytes,
+            public_key,
+        } => {
+            // Verify the attestation - detect mock vs real quotes
+            let is_mock = is_mock_quote(&quote_bytes);
+
+            // Reject mock attestation if not allowed
+            if is_mock && !accept_mock_tee {
+                warn!("Received mock TEE attestation but accept_mock_tee is disabled");
+                // Reset state to allow retry
+                reset_to_pending(pending_invites, &nonce);
+                return SpecializedNodeInvitationResponse::error(
+                    nonce,
+                    "Mock TEE attestation not accepted in this environment",
+                );
+            }
+
+            let verification_result = if is_mock {
+                // Mock attestation for development/testing
+                warn!("Verifying MOCK attestation - NOT FOR PRODUCTION USE");
+                match verify_mock_attestation(
+                    &quote_bytes,
+                    &nonce,
+                    None, // No app hash expected
+                ) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        error!(error = %err, "Failed to verify mock TEE attestation");
+                        // Reset state to allow retry
+                        reset_to_pending(pending_invites, &nonce);
+                        return SpecializedNodeInvitationResponse::error(
+                            nonce,
+                            format!("Mock attestation verification failed: {}", err),
+                        );
+                    }
+                }
+            } else {
+                // Real TDX attestation
+                match verify_attestation(
+                    &quote_bytes,
+                    &nonce,
+                    None, // No app hash expected - specialized node doesn't know context_id
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(err) => {
+                        error!(error = %err, "Failed to verify TEE attestation");
+                        // Reset state to allow retry
+                        reset_to_pending(pending_invites, &nonce);
+                        return SpecializedNodeInvitationResponse::error(
+                            nonce,
+                            format!("Attestation verification failed: {}", err),
+                        );
+                    }
+                }
+            };
+
+            if !verification_result.is_valid() {
+                warn!(
+                    quote_verified = verification_result.quote_verified,
+                    nonce_verified = verification_result.nonce_verified,
+                    app_hash_verified = ?verification_result.application_hash_verified,
+                    is_mock = is_mock,
+                    "TEE attestation verification failed"
+                );
+                // Reset state to allow retry
+                reset_to_pending(pending_invites, &nonce);
+                return SpecializedNodeInvitationResponse::error(
+                    nonce,
+                    "Attestation verification failed",
+                );
+            }
+
+            info!(
+                %peer_id,
+                %context_id,
+                %public_key,
+                is_mock = is_mock,
+                "TEE attestation verified successfully"
+            );
+
+            // Create invitation for the verified node
+            let response = create_invitation_response(
+                nonce,
+                context_client,
+                context_id,
+                inviter_id,
+                public_key,
+            )
+            .await;
+
+            // If invitation creation failed, reset state to allow retry
+            if response.invitation_bytes.is_none() {
+                reset_to_pending(pending_invites, &nonce);
+            }
+            // Note: We don't remove the entry here - it stays in AwaitingConfirmation
+            // until we receive a join confirmation or TTL expires
+
+            response
+        }
+    }
+}
+
+/// Reset a pending invite back to Pending state to allow retry
+fn reset_to_pending(pending_invites: &PendingSpecializedNodeInvites, nonce: &[u8; 32]) {
+    if let Some(mut entry) = pending_invites.get_mut(nonce) {
+        debug!(
+            nonce = %hex::encode(nonce),
+            "Resetting invite state to Pending for retry"
+        );
+        entry.reset_to_pending();
+    }
+}
+
+/// Handle a join confirmation from a specialized node
+///
+/// Called when a specialized node broadcasts `SpecializedNodeJoinConfirmation`
+/// on the context topic after successfully joining.
+pub fn handle_join_confirmation(pending_invites: &PendingSpecializedNodeInvites, nonce: [u8; 32]) {
+    if let Some((_, pending)) = pending_invites.remove(&nonce) {
+        let context_id = match &pending.action {
+            SpecializedNodeInviteAction::HandleContextInvite { context_id, .. } => context_id,
+        };
+        info!(
+            nonce = %hex::encode(nonce),
+            %context_id,
+            "Received join confirmation - specialized node successfully joined, removing pending invite"
+        );
+    } else {
+        debug!(
+            nonce = %hex::encode(nonce),
+            "Received join confirmation for unknown nonce (already removed or never existed)"
+        );
+    }
+}
+
+/// Create an invitation for a verified specialized node
+async fn create_invitation_response(
+    nonce: [u8; 32],
+    context_client: &ContextClient,
+    context_id: ContextId,
+    inviter_id: PublicKey,
+    invitee_public_key: PublicKey,
+) -> SpecializedNodeInvitationResponse {
+    // Create a regular invitation for the specialized node's public key
+    // This adds the node's public key as a member on-chain
+    let invitation_payload = match context_client
+        .invite_member(&context_id, &inviter_id, &invitee_public_key)
+        .await
+    {
+        Ok(Some(payload)) => payload,
+        Ok(None) => {
+            error!(%context_id, "Context configuration not found");
+            return SpecializedNodeInvitationResponse::error(
+                nonce,
+                "Context configuration not found",
+            );
+        }
+        Err(err) => {
+            error!(error = %err, %context_id, "Failed to create invitation for specialized node");
+            return SpecializedNodeInvitationResponse::error(
+                nonce,
+                format!("Failed to create invitation: {}", err),
+            );
+        }
+    };
+
+    info!(
+        %context_id,
+        %invitee_public_key,
+        "Created invitation for specialized node"
+    );
+
+    // Serialize the invitation payload
+    let invitation_bytes = invitation_payload.to_string().into_bytes();
+
+    SpecializedNodeInvitationResponse::success(nonce, invitation_bytes)
+}
+
+/// Handle receiving a specialized node invitation response (for specialized nodes)
+///
+/// When a specialized node receives this response, it:
+/// 1. Checks for errors in the response
+/// 2. If successful, deserializes the ContextInvitationPayload
+/// 3. Joins the context using the invitation
+/// 4. Returns the nonce and context_id for confirmation broadcast
+pub async fn handle_specialized_node_invitation_response(
+    peer_id: PeerId,
+    nonce: [u8; 32],
+    response: SpecializedNodeInvitationResponse,
+    context_client: &ContextClient,
+) -> eyre::Result<Option<ContextId>> {
+    if let Some(error) = &response.error {
+        warn!(
+            %peer_id,
+            %error,
+            "Specialized node invitation request was rejected"
+        );
+        return Ok(None);
+    }
+
+    let Some(invitation_bytes) = response.invitation_bytes else {
+        error!(%peer_id, "Specialized node invitation response missing both invitation and error");
+        return Ok(None);
+    };
+
+    info!(
+        %peer_id,
+        nonce = %hex::encode(nonce),
+        invitation_len = invitation_bytes.len(),
+        "Received specialized node invitation - joining context"
+    );
+
+    // Deserialize ContextInvitationPayload from the bytes
+    // The payload is serialized as a Base58-encoded string
+    let invitation_str = match String::from_utf8(invitation_bytes) {
+        Ok(s) => s,
+        Err(err) => {
+            error!(%peer_id, error = %err, "Failed to decode invitation bytes as UTF-8");
+            return Ok(None);
+        }
+    };
+
+    let invitation_payload: ContextInvitationPayload = match invitation_str.parse() {
+        Ok(payload) => payload,
+        Err(err) => {
+            error!(%peer_id, error = %err, "Failed to parse ContextInvitationPayload");
+            return Ok(None);
+        }
+    };
+
+    info!(
+        %peer_id,
+        invitation_len = invitation_str.len(),
+        "Joining context via specialized node invitation"
+    );
+
+    // Join the context using the invitation payload
+    match context_client.join_context(invitation_payload).await {
+        Ok(join_response) => {
+            info!(
+                %peer_id,
+                context_id = %join_response.context_id,
+                member_public_key = %join_response.member_public_key,
+                "Successfully joined context via specialized node invitation"
+            );
+            // Return the context_id so caller can broadcast confirmation
+            Ok(Some(join_response.context_id))
+        }
+        Err(err) => {
+            error!(
+                %peer_id,
+                error = %err,
+                "Failed to join context via specialized node invitation"
+            );
+            Ok(None)
+        }
+    }
+}

--- a/crates/node/src/specialized_node_invite_state.rs
+++ b/crates/node/src/specialized_node_invite_state.rs
@@ -1,0 +1,118 @@
+//! Pending specialized node invite request state tracking.
+//!
+//! This module provides state tracking for standard nodes to track pending invites
+//! by nonce when handling verification responses from specialized nodes.
+//!
+//! ## State Machine
+//!
+//! ```text
+//! Pending → AwaitingConfirmation → (confirmed) → Removed
+//!                 ↓
+//!           (TTL expired, 60s)
+//!                 ↓
+//!              Pending (retry allowed)
+//! ```
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use dashmap::DashMap;
+
+/// TTL for awaiting confirmation before allowing retry (60 seconds).
+pub const CONFIRMATION_TTL: Duration = Duration::from_secs(60);
+
+/// State of a pending specialized node invite.
+#[derive(Debug, Clone)]
+pub enum InviteState {
+    /// Waiting for a specialized node to send verification request.
+    Pending,
+    /// Invitation sent, waiting for join confirmation from specialized node.
+    AwaitingConfirmation {
+        /// When the invitation was sent.
+        invited_at: Instant,
+        /// The public key of the invited specialized node.
+        invitee_public_key: PublicKey,
+    },
+}
+
+impl InviteState {
+    /// Check if this state is expired (AwaitingConfirmation past TTL).
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        match self {
+            Self::Pending => false,
+            Self::AwaitingConfirmation { invited_at, .. } => {
+                invited_at.elapsed() > CONFIRMATION_TTL
+            }
+        }
+    }
+
+    /// Check if this state can accept a new verification request.
+    /// Returns true if Pending or if AwaitingConfirmation has expired.
+    #[must_use]
+    pub fn can_accept_request(&self) -> bool {
+        match self {
+            Self::Pending => true,
+            Self::AwaitingConfirmation { .. } => self.is_expired(),
+        }
+    }
+}
+
+/// Action to perform when a specialized node invitation response is received.
+#[derive(Debug, Clone)]
+pub enum SpecializedNodeInviteAction {
+    /// Create a regular invitation and send it to the specialized node.
+    HandleContextInvite {
+        /// The context to invite the specialized node to.
+        context_id: ContextId,
+        /// The identity of the user initiating the invite.
+        inviter_id: PublicKey,
+    },
+}
+
+/// State for a pending specialized node invite request (standard node side).
+#[derive(Debug, Clone)]
+pub struct PendingSpecializedNodeInvite {
+    /// Action to perform when response is received.
+    pub action: SpecializedNodeInviteAction,
+    /// Current state of this invite.
+    pub state: InviteState,
+}
+
+impl PendingSpecializedNodeInvite {
+    /// Create a new pending specialized node invite in Pending state.
+    #[must_use]
+    pub fn new(action: SpecializedNodeInviteAction) -> Self {
+        Self {
+            action,
+            state: InviteState::Pending,
+        }
+    }
+
+    /// Transition to AwaitingConfirmation state.
+    pub fn transition_to_awaiting(&mut self, invitee_public_key: PublicKey) {
+        self.state = InviteState::AwaitingConfirmation {
+            invited_at: Instant::now(),
+            invitee_public_key,
+        };
+    }
+
+    /// Reset to Pending state (e.g., after TTL expiry).
+    pub fn reset_to_pending(&mut self) {
+        self.state = InviteState::Pending;
+    }
+}
+
+/// Map of nonce -> pending action for specialized node invites (standard node side).
+///
+/// Uses DashMap for concurrent access since responses may arrive
+/// on different threads/actors.
+pub type PendingSpecializedNodeInvites = Arc<DashMap<[u8; 32], PendingSpecializedNodeInvite>>;
+
+/// Create a new empty pending specialized node invites map.
+#[must_use]
+pub fn new_pending_specialized_node_invites() -> PendingSpecializedNodeInvites {
+    Arc::new(DashMap::new())
+}

--- a/crates/node/src/sync/manager.rs
+++ b/crates/node/src/sync/manager.rs
@@ -15,7 +15,7 @@ use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage}
 use calimero_primitives::common::DIGEST_SIZE;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
-use eyre::{bail, eyre};
+use eyre::bail;
 use futures_util::stream::{self, FuturesUnordered};
 use futures_util::{FutureExt, StreamExt};
 use libp2p::gossipsub::TopicHash;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -36,15 +36,8 @@ calimero-node-primitives.workspace = true
 calimero-primitives.workspace = true
 calimero-server-primitives.workspace = true
 calimero-store = { workspace = true, features = ["serde"] }
+calimero-tee-attestation.workspace = true
 mero-auth = { path = "../auth" }
-
-# Quote verification dependencies (cross-platform)
-dcap-qvl.workspace = true
-tdx-quote.workspace = true
-
-[target.'cfg(target_os = "linux")'.dependencies]
-configfs-tsm.workspace = true
-tdx_workload_attestation = { workspace = true, features = ["tdx-linux"] }
 
 [dev-dependencies]
 color-eyre.workspace = true

--- a/crates/server/primitives/src/admin.rs
+++ b/crates/server/primitives/src/admin.rs
@@ -465,6 +465,45 @@ impl InviteToContextOpenInvitationResponse {
     }
 }
 
+/// Request to invite specialized nodes (e.g., read-only TEE nodes) to join a context
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InviteSpecializedNodeRequest {
+    pub context_id: ContextId,
+    /// Optional inviter identity - defaults to context's default identity if not provided
+    pub inviter_id: Option<PublicKey>,
+}
+
+impl InviteSpecializedNodeRequest {
+    pub const fn new(context_id: ContextId, inviter_id: Option<PublicKey>) -> Self {
+        Self {
+            context_id,
+            inviter_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InviteSpecializedNodeResponseData {
+    /// Hex-encoded nonce used for the specialized node invite discovery
+    pub nonce: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InviteSpecializedNodeResponse {
+    pub data: InviteSpecializedNodeResponseData,
+}
+
+impl InviteSpecializedNodeResponse {
+    pub fn new(nonce: String) -> Self {
+        Self {
+            data: InviteSpecializedNodeResponseData { nonce },
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JoinContextRequest {

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -7,6 +7,7 @@ pub mod get_context_storage;
 pub mod get_contexts_for_application;
 pub mod get_contexts_with_executors_for_application;
 pub mod grant_capabilities;
+pub mod invite_specialized_node;
 pub mod invite_to_context;
 pub mod invite_to_context_open_invitation;
 pub mod join_context;

--- a/crates/server/src/admin/handlers/context/invite_specialized_node.rs
+++ b/crates/server/src/admin/handlers/context/invite_specialized_node.rs
@@ -1,0 +1,81 @@
+//! Handler for specialized node invitation.
+//!
+//! This endpoint broadcasts a specialized node discovery request to the global invite topic,
+//! allowing specialized nodes (e.g., read-only TEE nodes) to respond with verification
+//! and receive invitations.
+
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use calimero_server_primitives::admin::{
+    InviteSpecializedNodeRequest, InviteSpecializedNodeResponse,
+};
+use futures_util::TryStreamExt;
+use tracing::{error, info};
+
+use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Extension(state): Extension<Arc<AdminState>>,
+    Json(req): Json<InviteSpecializedNodeRequest>,
+) -> impl IntoResponse {
+    info!(context_id=%req.context_id, "Initiating specialized node invitation");
+
+    // Resolve inviter_id - use provided or get default identity for context
+    let inviter_id = match req.inviter_id {
+        Some(id) => id,
+        None => {
+            // Get the first owned identity for this context
+            let stream = state
+                .ctx_client
+                .get_context_members(&req.context_id, Some(true)); // true = owned only
+
+            match stream.map_ok(|(id, _)| id).try_collect::<Vec<_>>().await {
+                Ok(identities) => {
+                    if let Some(first_identity) = identities.into_iter().next() {
+                        first_identity
+                    } else {
+                        error!(context_id=%req.context_id, "No owned identities found for context");
+                        return ApiError {
+                            status_code: axum::http::StatusCode::BAD_REQUEST,
+                            message: "No owned identities found for context".to_owned(),
+                        }
+                        .into_response();
+                    }
+                }
+                Err(err) => {
+                    error!(error=?err, "Failed to get context identities");
+                    return parse_api_error(err).into_response();
+                }
+            }
+        }
+    };
+
+    // Broadcast specialized node invite and register pending invite
+    let result = state
+        .node_client
+        .broadcast_specialized_node_invite(req.context_id, inviter_id)
+        .await;
+
+    match result {
+        Ok(nonce) => {
+            let nonce_hex = hex::encode(nonce);
+            info!(
+                context_id=%req.context_id,
+                %inviter_id,
+                %nonce_hex,
+                "Specialized node invite discovery broadcast successfully"
+            );
+            ApiResponse {
+                payload: InviteSpecializedNodeResponse::new(nonce_hex),
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(error=?err, "Failed to broadcast specialized node invite discovery");
+            parse_api_error(err).into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/handlers/tee/info.rs
+++ b/crates/server/src/admin/handlers/tee/info.rs
@@ -3,94 +3,35 @@ use std::sync::Arc;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_server_primitives::admin::TeeInfoResponse;
+use calimero_tee_attestation::get_tee_info;
 use reqwest::StatusCode;
 use tracing::{error, info};
 
 use crate::admin::service::{ApiError, ApiResponse};
 use crate::AdminState;
 
-#[cfg(target_os = "linux")]
-use tdx_workload_attestation::provider::AttestationProvider;
-#[cfg(target_os = "linux")]
-use tdx_workload_attestation::tdx::LinuxTdxProvider;
-
-struct HostInfo {
-    cloud_provider: String,
-    os_image: String,
-    mrtd: String,
-}
-
-#[cfg(target_os = "linux")]
-fn get_mrtd() -> eyre::Result<String> {
-    let provider = LinuxTdxProvider::new();
-    let mrtd = provider.get_launch_measurement()?;
-    Ok(hex::encode(mrtd))
-}
-
-#[cfg(not(target_os = "linux"))]
-fn get_mrtd() -> eyre::Result<String> {
-    // Mock MRTD for development on non-Linux platforms (e.g., macOS)
-    tracing::warn!("Running on non-Linux platform - using mock MRTD");
-    Ok("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_owned())
-}
-
-async fn detect_host_info() -> eyre::Result<HostInfo> {
-    // Get MRTD first
-    let mrtd = get_mrtd()?;
-
-    // Try to detect GCP
-    if let Ok(client) = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
-        .build()
-    {
-        if let Ok(response) = client
-            .get("http://metadata.google.internal/computeMetadata/v1/instance/image")
-            .header("Metadata-Flavor", "Google")
-            .send()
-            .await
-        {
-            if let Ok(image) = response.text().await {
-                let image_name = image.split('/').last().unwrap_or(&image).to_owned();
-
-                return Ok(HostInfo {
-                    cloud_provider: "gcp".to_owned(),
-                    os_image: image_name,
-                    mrtd,
-                });
-            }
-        }
-    }
-
-    // Fallback: Unknown platform
-    Ok(HostInfo {
-        cloud_provider: "unknown".to_owned(),
-        os_image: "unknown".to_owned(),
-        mrtd,
-    })
-}
-
 pub async fn handler(Extension(_state): Extension<Arc<AdminState>>) -> impl IntoResponse {
     info!("Getting TEE info");
 
-    match detect_host_info().await {
-        Ok(host_info) => {
+    match get_tee_info().await {
+        Ok(tee_info) => {
             info!(
-                cloud_provider=%host_info.cloud_provider,
-                os_image=%host_info.os_image,
+                cloud_provider=%tee_info.cloud_provider,
+                os_image=%tee_info.os_image,
                 "TEE info retrieved successfully"
             );
 
             ApiResponse {
                 payload: TeeInfoResponse::new(
-                    host_info.cloud_provider,
-                    host_info.os_image,
-                    host_info.mrtd,
+                    tee_info.cloud_provider,
+                    tee_info.os_image,
+                    tee_info.mrtd,
                 ),
             }
             .into_response()
         }
         Err(err) => {
-            error!(error=?err, "Failed to get TEE info");
+            error!(error=%err, "Failed to get TEE info");
 
             ApiError {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/server/src/admin/handlers/tee/verify_quote.rs
+++ b/crates/server/src/admin/handlers/tee/verify_quote.rs
@@ -4,17 +4,14 @@ use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
 use calimero_server_primitives::admin::{
-    Quote, TeeVerifyQuoteRequest, TeeVerifyQuoteResponse, TeeVerifyQuoteResponseData,
+    TeeVerifyQuoteRequest, TeeVerifyQuoteResponse, TeeVerifyQuoteResponseData,
 };
+use calimero_tee_attestation::{verify_attestation, AttestationError};
 use reqwest::StatusCode;
 use tracing::{error, info};
 
 use crate::admin::service::{ApiError, ApiResponse};
 use crate::AdminState;
-
-use dcap_qvl::collateral::get_collateral_from_pcs;
-use dcap_qvl::verify::verify;
-use tdx_quote::Quote as TdxQuote;
 
 pub async fn handler(
     Extension(_state): Extension<Arc<AdminState>>,
@@ -50,6 +47,8 @@ async fn verify_quote(req: TeeVerifyQuoteRequest) -> Result<TeeVerifyQuoteRespon
         });
     }
 
+    let nonce_array: [u8; 32] = nonce.try_into().expect("checked length above");
+
     // 2. Validate expected application hash if provided
     let expected_app_hash = if let Some(hash_hex) = &req.expected_application_hash {
         let h = hex::decode(hash_hex).map_err(|_| {
@@ -67,7 +66,9 @@ async fn verify_quote(req: TeeVerifyQuoteRequest) -> Result<TeeVerifyQuoteRespon
                 message: "Application hash must be exactly 32 bytes (64 hex characters)".to_owned(),
             });
         }
-        Some(h)
+
+        let hash_array: [u8; 32] = h.try_into().expect("checked length above");
+        Some(hash_array)
     } else {
         None
     };
@@ -83,109 +84,36 @@ async fn verify_quote(req: TeeVerifyQuoteRequest) -> Result<TeeVerifyQuoteRespon
 
     info!(quote_size=%quote_bytes.len(), "Quote decoded successfully");
 
-    // 4. Parse TDX quote
-    let tdx_quote = TdxQuote::from_bytes(&quote_bytes).map_err(|err| {
-        error!(error=?err, "Failed to parse TDX quote");
-        ApiError {
-            status_code: StatusCode::BAD_REQUEST,
-            message: format!("Failed to parse TDX quote: {:?}", err),
-        }
-    })?;
-
-    info!("Quote parsed successfully");
-
-    // 5. Extract report data from quote
-    let report_data = tdx_quote.report_input_data();
-    let report_data_hex = hex::encode(report_data);
-
-    info!(report_data=%report_data_hex, "Extracted report data from quote");
-
-    // 6. Fetch collateral from Intel PCS
-    let collateral = get_collateral_from_pcs(&quote_bytes).await.map_err(|err| {
-        error!(error=?err, "Failed to fetch collateral from Intel PCS");
-        ApiError {
-            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-            message: format!("Failed to fetch collateral from Intel PCS: {:?}", err),
-        }
-    })?;
-
-    info!("Collateral fetched from Intel PCS");
-
-    // 7. Verify quote signature and certificate chain
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    // 4. Verify using tee-attestation crate
+    let result = verify_attestation(&quote_bytes, &nonce_array, expected_app_hash.as_ref())
+        .await
         .map_err(|err| {
-            error!(error=?err, "Failed to get current time");
+            let (status_code, message) = match &err {
+                AttestationError::QuoteParsingFailed(_) => {
+                    (StatusCode::BAD_REQUEST, err.to_string())
+                }
+                AttestationError::CollateralFetchFailed(_) => {
+                    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+                }
+                _ => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+            };
+            error!(error=%err, "Attestation verification failed");
             ApiError {
-                status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                message: format!("Failed to get current time: {}", err),
+                status_code,
+                message,
             }
-        })?
-        .as_secs();
+        })?;
 
-    let quote_verified = match verify(&quote_bytes, &collateral, now) {
-        Ok(_) => {
-            info!("Quote cryptographic verification: PASSED");
-            true
-        }
-        Err(err) => {
-            error!(error=?err, "Quote cryptographic verification: FAILED");
-            // We don't return early here - we continue to check nonce and app hash
-            // and return all verification results
-            false
-        }
-    };
-
-    // 8. Verify nonce matches report_data[0..32]
-    let nonce_verified = &report_data[..32] == nonce.as_slice();
-    if nonce_verified {
-        info!("Nonce verification: PASSED");
-    } else {
-        error!(
-            expected=%hex::encode(&nonce),
-            actual=%hex::encode(&report_data[..32]),
-            "Nonce verification: FAILED"
-        );
-    }
-
-    // 9. Verify application hash if provided
-    let application_hash_verified = if let Some(expected_hash) = expected_app_hash {
-        let actual_hash = &report_data[32..64];
-        let verified = actual_hash == expected_hash.as_slice();
-        if verified {
-            info!("Application hash verification: PASSED");
-        } else {
-            error!(
-                expected=%hex::encode(&expected_hash),
-                actual=%hex::encode(actual_hash),
-                "Application hash verification: FAILED"
-            );
-        }
-        Some(verified)
-    } else {
-        None
-    };
-
-    // 10. Convert tdx_quote to our serializable Quote type
-    let quote = Quote::try_from(tdx_quote).map_err(|err| {
-        error!(error=%err, "Failed to convert TDX quote to serializable format");
-        ApiError {
-            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-            message: format!("Failed to convert TDX quote: {}", err),
-        }
-    })?;
+    let is_valid = result.is_valid();
 
     let response_data = TeeVerifyQuoteResponseData {
-        quote_verified,
-        nonce_verified,
-        application_hash_verified,
-        quote,
+        quote_verified: result.quote_verified,
+        nonce_verified: result.nonce_verified,
+        application_hash_verified: result.application_hash_verified,
+        quote: result.quote,
     };
 
-    let overall_success =
-        quote_verified && nonce_verified && application_hash_verified.unwrap_or(true);
-
-    if overall_success {
+    if is_valid {
         info!("✓ Overall verification: PASSED");
     } else {
         error!("✗ Overall verification: FAILED");

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -33,7 +33,7 @@ use crate::admin::handlers::applications::{
 use crate::admin::handlers::context::{
     create_context, delete_context, get_context, get_context_identities, get_context_ids,
     get_context_storage, get_contexts_for_application, get_contexts_with_executors_for_application,
-    invite_to_context, invite_to_context_open_invitation, join_context,
+    invite_specialized_node, invite_to_context, invite_to_context_open_invitation, join_context,
     join_context_open_invitation, sync, update_context_application,
 };
 use crate::admin::handlers::identity::generate_context_identity;
@@ -116,6 +116,7 @@ pub(crate) fn setup(
         )
         .route("/contexts/invite", post(invite_to_context::handler))
         .route("/contexts/invite_by_open_invitation", post(invite_to_context_open_invitation::handler))
+        .route("/contexts/invite-specialized-node", post(invite_specialized_node::handler))
         .route("/contexts/join", post(join_context::handler))
         .route("/contexts/join_by_open_invitation", post(join_context_open_invitation::handler))
         .route(

--- a/crates/server/src/jsonrpc.rs
+++ b/crates/server/src/jsonrpc.rs
@@ -36,6 +36,15 @@ pub(crate) fn service(
     config: &ServerConfig,
     ctx_client: ContextClient,
 ) -> Option<(String, Router)> {
+    // Check if JSON-RPC is configured and enabled
+    let _jsonrpc_config = match &config.jsonrpc {
+        Some(cfg) if cfg.enabled => cfg,
+        _ => {
+            info!("JSON RPC server is disabled");
+            return None;
+        }
+    };
+
     let base_path = "/jsonrpc";
 
     // Get the node prefix from env var

--- a/crates/tee-attestation/Cargo.toml
+++ b/crates/tee-attestation/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "calimero-tee-attestation"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+description = "TEE attestation generation and verification for Calimero"
+publish = true
+
+[dependencies]
+eyre.workspace = true
+hex.workspace = true
+tracing.workspace = true
+base64.workspace = true
+
+# Quote verification dependencies (cross-platform)
+dcap-qvl.workspace = true
+tdx-quote.workspace = true
+
+# Server primitives for Quote type
+calimero-server-primitives.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+configfs-tsm.workspace = true
+tdx_workload_attestation = { workspace = true, features = ["tdx-linux"] }
+reqwest.workspace = true
+

--- a/crates/tee-attestation/src/error.rs
+++ b/crates/tee-attestation/src/error.rs
@@ -1,0 +1,83 @@
+//! Error types for TEE attestation operations.
+
+use std::fmt;
+
+/// Error type for TEE attestation operations.
+#[derive(Debug)]
+pub enum AttestationError {
+    /// TEE attestation is not supported on this platform.
+    NotSupported,
+
+    /// Failed to generate TDX quote.
+    QuoteGenerationFailed(String),
+
+    /// Failed to parse TDX quote.
+    QuoteParsingFailed(String),
+
+    /// Failed to convert quote to serializable format.
+    QuoteConversionFailed(String),
+
+    /// Failed to verify quote signature.
+    QuoteVerificationFailed(String),
+
+    /// Failed to fetch collateral from Intel PCS.
+    CollateralFetchFailed(String),
+
+    /// Invalid nonce format or length.
+    InvalidNonce(String),
+
+    /// Invalid application hash format or length.
+    InvalidApplicationHash(String),
+
+    /// Nonce verification failed.
+    NonceMismatch { expected: String, actual: String },
+
+    /// Application hash verification failed.
+    ApplicationHashMismatch { expected: String, actual: String },
+
+    /// Failed to get TEE info.
+    InfoRetrievalFailed(String),
+
+    /// System time error.
+    SystemTimeError(String),
+}
+
+impl std::error::Error for AttestationError {}
+
+impl fmt::Display for AttestationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotSupported => {
+                write!(
+                    f,
+                    "TEE attestation is not supported on this platform (requires Linux with TDX)"
+                )
+            }
+            Self::QuoteGenerationFailed(msg) => write!(f, "Failed to generate TDX quote: {}", msg),
+            Self::QuoteParsingFailed(msg) => write!(f, "Failed to parse TDX quote: {}", msg),
+            Self::QuoteConversionFailed(msg) => {
+                write!(f, "Failed to convert quote to serializable format: {}", msg)
+            }
+            Self::QuoteVerificationFailed(msg) => {
+                write!(f, "Failed to verify quote signature: {}", msg)
+            }
+            Self::CollateralFetchFailed(msg) => {
+                write!(f, "Failed to fetch collateral from Intel PCS: {}", msg)
+            }
+            Self::InvalidNonce(msg) => write!(f, "Invalid nonce: {}", msg),
+            Self::InvalidApplicationHash(msg) => write!(f, "Invalid application hash: {}", msg),
+            Self::NonceMismatch { expected, actual } => {
+                write!(f, "Nonce mismatch: expected {}, got {}", expected, actual)
+            }
+            Self::ApplicationHashMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "Application hash mismatch: expected {}, got {}",
+                    expected, actual
+                )
+            }
+            Self::InfoRetrievalFailed(msg) => write!(f, "Failed to get TEE info: {}", msg),
+            Self::SystemTimeError(msg) => write!(f, "System time error: {}", msg),
+        }
+    }
+}

--- a/crates/tee-attestation/src/generate.rs
+++ b/crates/tee-attestation/src/generate.rs
@@ -1,0 +1,193 @@
+//! TDX quote generation (Linux) and mock attestation for non-Linux platforms.
+
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
+use calimero_server_primitives::admin::{
+    CertificationData, QeReportCertificationDataInfo, Quote, QuoteBody, QuoteHeader,
+};
+#[cfg(target_os = "linux")]
+use configfs_tsm::create_tdx_quote;
+#[cfg(target_os = "linux")]
+use tdx_quote::Quote as TdxQuote;
+#[cfg(target_os = "linux")]
+use tracing::error;
+use tracing::warn;
+
+use crate::error::AttestationError;
+
+/// Magic header for mock quotes - used to identify mock attestations.
+pub const MOCK_QUOTE_HEADER: &[u8] = b"MOCK_TDX_QUOTE_V1";
+
+/// Result of generating a TEE attestation.
+#[derive(Debug, Clone)]
+pub struct AttestationResult {
+    /// Raw quote bytes.
+    pub quote_bytes: Vec<u8>,
+    /// Base64-encoded quote string.
+    pub quote_b64: String,
+    /// Parsed and serializable quote structure.
+    pub quote: Quote,
+    /// Whether this is a mock attestation (for development/testing).
+    pub is_mock: bool,
+}
+
+/// Generate a TDX attestation with the given report data.
+///
+/// The report data is typically constructed as: `nonce[32] || app_hash[32]`
+///
+/// # Arguments
+/// * `report_data` - 64 bytes of data to include in the attestation.
+///
+/// # Returns
+/// An `AttestationResult` containing the quote bytes, base64 encoding, and parsed quote.
+///
+/// # Errors
+/// Returns an error if quote generation fails.
+///
+/// # Platform Behavior
+/// - On Linux with TDX: Generates a real TDX attestation quote.
+/// - On non-Linux platforms: Returns a mock attestation for development/testing.
+#[cfg(target_os = "linux")]
+pub fn generate_attestation(report_data: [u8; 64]) -> Result<AttestationResult, AttestationError> {
+    // Generate TDX quote using configfs-tsm
+    let quote_bytes = create_tdx_quote(report_data).map_err(|err| {
+        error!(error=?err, "Failed to generate TDX quote");
+        AttestationError::QuoteGenerationFailed(format!("{:?}", err))
+    })?;
+
+    // Parse the generated quote
+    let tdx_quote = TdxQuote::from_bytes(&quote_bytes).map_err(|err| {
+        error!(error=?err, "Failed to parse generated TDX quote");
+        AttestationError::QuoteParsingFailed(format!("{:?}", err))
+    })?;
+
+    // Convert to serializable format
+    let quote = Quote::try_from(tdx_quote).map_err(|err| {
+        error!(error=%err, "Failed to convert TDX quote to serializable format");
+        AttestationError::QuoteConversionFailed(err.to_string())
+    })?;
+
+    let quote_b64 = base64_engine.encode(&quote_bytes);
+
+    Ok(AttestationResult {
+        quote_bytes,
+        quote_b64,
+        quote,
+        is_mock: false,
+    })
+}
+
+/// Generate a mock TEE attestation on non-Linux platforms.
+///
+/// This function creates a syntactically valid but cryptographically unverifiable
+/// attestation for development and testing purposes.
+///
+/// # Security Warning
+/// Mock attestations bypass all TEE security guarantees. The quote signature is
+/// invalid and will fail cryptographic verification. This is only suitable for
+/// testing attestation protocol flow on non-TEE platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn generate_attestation(report_data: [u8; 64]) -> Result<AttestationResult, AttestationError> {
+    warn!("Generating MOCK attestation on non-Linux platform - NOT FOR PRODUCTION USE");
+
+    // Create mock quote structure with placeholder values
+    let quote = create_mock_quote(&report_data);
+
+    // Create mock "quote bytes" with marker + report_data
+    let mut quote_bytes = Vec::with_capacity(128);
+
+    // Mock quote header marker (identifies this as mock)
+    quote_bytes.extend_from_slice(MOCK_QUOTE_HEADER);
+
+    // Include the report data so it can be extracted during mock verification
+    quote_bytes.extend_from_slice(&report_data);
+
+    // Pad to reasonable size (real quotes are ~4-6KB)
+    quote_bytes.resize(256, 0);
+
+    let quote_b64 = base64_engine.encode(&quote_bytes);
+
+    Ok(AttestationResult {
+        quote_bytes,
+        quote_b64,
+        quote,
+        is_mock: true,
+    })
+}
+
+/// Check if the given quote bytes represent a mock attestation.
+pub fn is_mock_quote(quote_bytes: &[u8]) -> bool {
+    quote_bytes.len() >= MOCK_QUOTE_HEADER.len()
+        && &quote_bytes[..MOCK_QUOTE_HEADER.len()] == MOCK_QUOTE_HEADER
+}
+
+/// Create a mock Quote structure with the given report data.
+pub fn create_mock_quote(report_data: &[u8; 64]) -> Quote {
+    // Standard mock values - 48-byte measurements as hex (96 chars)
+    let mock_measurement_48 =
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    // 16-byte values as hex (32 chars)
+    let mock_16_bytes = "00000000000000000000000000000000";
+    // 8-byte values as hex (16 chars)
+    let mock_8_bytes = "0000000000000000";
+
+    Quote {
+        header: QuoteHeader {
+            version: 4,
+            attestation_key_type: 2, // ECDSA-256-with-P-256
+            tee_type: 0x81,          // TDX
+            qe_vendor_id: "939a7233f79c4ca9940a0db3957f0607".to_owned(), // Intel QE vendor ID
+            user_data: "00000000000000000000000000000000".to_owned(), // 16 bytes of zeros
+        },
+        body: QuoteBody {
+            tdx_version: "1.0".to_owned(),
+            tee_tcb_svn: mock_16_bytes.to_owned(),
+            mrseam: mock_measurement_48.to_owned(),
+            mrsignerseam: mock_measurement_48.to_owned(),
+            seamattributes: mock_8_bytes.to_owned(),
+            tdattributes: mock_8_bytes.to_owned(),
+            xfam: mock_8_bytes.to_owned(),
+            mrtd: mock_measurement_48.to_owned(),
+            mrconfigid: mock_measurement_48.to_owned(),
+            mrowner: mock_measurement_48.to_owned(),
+            mrownerconfig: mock_measurement_48.to_owned(),
+            rtmr0: mock_measurement_48.to_owned(),
+            rtmr1: mock_measurement_48.to_owned(),
+            rtmr2: mock_measurement_48.to_owned(),
+            rtmr3: mock_measurement_48.to_owned(),
+            reportdata: hex::encode(report_data), // 64 bytes = 128 hex chars
+            tee_tcb_svn_2: None,
+            mrservicetd: None,
+        },
+        // Mock signature (64 bytes for ECDSA-256)
+        signature: "0".repeat(128),
+        // Mock attestation key (65 bytes for uncompressed P-256 public key)
+        attestation_key: "04".to_owned() + &"0".repeat(128),
+        // Mock certification data
+        certification_data: CertificationData::QeReportCertificationData(
+            QeReportCertificationDataInfo {
+                qe_report: "0".repeat(768),             // 384 bytes
+                signature: "0".repeat(128),             // 64 bytes
+                qe_authentication_data: "0".repeat(64), // 32 bytes
+                certification_data_type: "PckCertChain".to_owned(),
+                certification_data: "0".repeat(200), // Placeholder
+            },
+        ),
+    }
+}
+
+/// Build report data from nonce and optional application hash.
+///
+/// # Arguments
+/// * `nonce` - 32-byte nonce value.
+/// * `app_hash` - Optional 32-byte application bytecode hash.
+///
+/// # Returns
+/// A 64-byte array suitable for use as TDX report data.
+pub fn build_report_data(nonce: &[u8; 32], app_hash: Option<&[u8; 32]>) -> [u8; 64] {
+    let mut report_data = [0u8; 64];
+    report_data[..32].copy_from_slice(nonce);
+    if let Some(hash) = app_hash {
+        report_data[32..].copy_from_slice(hash);
+    }
+    report_data
+}

--- a/crates/tee-attestation/src/info.rs
+++ b/crates/tee-attestation/src/info.rs
@@ -1,0 +1,97 @@
+//! TEE host information retrieval.
+
+use tracing::{error, warn};
+
+use crate::error::AttestationError;
+
+/// Information about the TEE host environment.
+#[derive(Debug, Clone)]
+pub struct TeeInfo {
+    /// Cloud provider (e.g., "gcp", "azure", "unknown").
+    pub cloud_provider: String,
+    /// OS image name.
+    pub os_image: String,
+    /// MRTD (Measurement of the TDX module) - hex encoded.
+    pub mrtd: String,
+}
+
+/// Get the MRTD (launch measurement) from TDX.
+#[cfg(target_os = "linux")]
+fn get_mrtd() -> eyre::Result<String> {
+    use tdx_workload_attestation::provider::AttestationProvider;
+    use tdx_workload_attestation::tdx::LinuxTdxProvider;
+
+    let provider = LinuxTdxProvider::new();
+    let mrtd = provider.get_launch_measurement()?;
+    Ok(hex::encode(mrtd))
+}
+
+/// Get the MRTD (mock for non-Linux platforms).
+#[cfg(not(target_os = "linux"))]
+fn get_mrtd() -> eyre::Result<String> {
+    warn!("Running on non-Linux platform - using mock MRTD");
+    Ok("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        .to_owned())
+}
+
+/// Detect host information including cloud provider and OS image.
+#[cfg(target_os = "linux")]
+async fn detect_host_info() -> eyre::Result<TeeInfo> {
+    // Get MRTD first
+    let mrtd = get_mrtd()?;
+
+    // Try to detect GCP
+    if let Ok(client) = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+    {
+        if let Ok(response) = client
+            .get("http://metadata.google.internal/computeMetadata/v1/instance/image")
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await
+        {
+            if let Ok(image) = response.text().await {
+                let image_name = image.split('/').last().unwrap_or(&image).to_owned();
+
+                return Ok(TeeInfo {
+                    cloud_provider: "gcp".to_owned(),
+                    os_image: image_name,
+                    mrtd,
+                });
+            }
+        }
+    }
+
+    // Fallback: Unknown platform
+    Ok(TeeInfo {
+        cloud_provider: "unknown".to_owned(),
+        os_image: "unknown".to_owned(),
+        mrtd,
+    })
+}
+
+/// Detect host information (non-Linux fallback).
+#[cfg(not(target_os = "linux"))]
+async fn detect_host_info() -> eyre::Result<TeeInfo> {
+    let mrtd = get_mrtd()?;
+    Ok(TeeInfo {
+        cloud_provider: "unknown".to_owned(),
+        os_image: "unknown".to_owned(),
+        mrtd,
+    })
+}
+
+/// Get information about the TEE environment.
+///
+/// # Returns
+/// A `TeeInfo` struct containing cloud provider, OS image, and MRTD.
+///
+/// # Errors
+/// Returns an error if TEE information cannot be retrieved.
+pub async fn get_tee_info() -> Result<TeeInfo, AttestationError> {
+    detect_host_info().await.map_err(|err| {
+        error!(error=?err, "Failed to get TEE info");
+        AttestationError::InfoRetrievalFailed(err.to_string())
+    })
+}

--- a/crates/tee-attestation/src/lib.rs
+++ b/crates/tee-attestation/src/lib.rs
@@ -1,0 +1,51 @@
+//! TEE attestation generation and verification for Calimero.
+//!
+//! This crate provides platform-agnostic interfaces for:
+//! - Generating TDX attestation quotes (Linux with TDX)
+//! - Mock attestation generation (non-Linux platforms, for development)
+//! - Verifying TDX attestation quotes (cross-platform)
+//! - Retrieving TEE host information
+//!
+//! # Example
+//!
+//! ```ignore
+//! use calimero_tee_attestation::{generate_attestation, verify_attestation, build_report_data};
+//!
+//! // Generate an attestation
+//! let nonce = [0u8; 32];
+//! let report_data = build_report_data(&nonce, None);
+//! let result = generate_attestation(report_data)?;
+//!
+//! // On non-Linux, result.is_mock will be true
+//! if result.is_mock {
+//!     println!("Generated mock attestation for development");
+//! }
+//!
+//! // Verify an attestation (use verify_mock_attestation for mock quotes)
+//! let verification = if result.is_mock {
+//!     verify_mock_attestation(&result.quote_bytes, &nonce, None)?
+//! } else {
+//!     verify_attestation(&result.quote_bytes, &nonce, None).await?
+//! };
+//! assert!(verification.is_valid());
+//! ```
+//!
+//! # Platform Behavior
+//!
+//! - **Linux with TDX**: Generates real TDX attestation quotes that can be
+//!   cryptographically verified.
+//! - **Non-Linux platforms**: Generates mock attestations (`is_mock = true`)
+//!   for development and testing. These are NOT cryptographically valid.
+//!
+//! **Warning**: Mock attestations bypass all TEE security guarantees and should
+//! never be trusted in production environments.
+
+mod error;
+mod generate;
+mod info;
+mod verify;
+
+pub use error::AttestationError;
+pub use generate::{build_report_data, generate_attestation, is_mock_quote, AttestationResult};
+pub use info::{get_tee_info, TeeInfo};
+pub use verify::{verify_attestation, verify_mock_attestation, VerificationResult};

--- a/crates/tee-attestation/src/verify.rs
+++ b/crates/tee-attestation/src/verify.rs
@@ -1,0 +1,234 @@
+//! TDX quote verification.
+
+use calimero_server_primitives::admin::Quote;
+use dcap_qvl::collateral::get_collateral_from_pcs;
+use dcap_qvl::verify::verify;
+use tdx_quote::Quote as TdxQuote;
+use tracing::{error, info, warn};
+
+use crate::error::AttestationError;
+use crate::generate::{is_mock_quote, MOCK_QUOTE_HEADER};
+
+/// Result of verifying a TEE attestation.
+#[derive(Debug, Clone)]
+pub struct VerificationResult {
+    /// Whether the quote's cryptographic signature is valid.
+    pub quote_verified: bool,
+    /// Whether the nonce in the report data matches the expected value.
+    pub nonce_verified: bool,
+    /// Whether the application hash matches (if an expected hash was provided).
+    pub application_hash_verified: Option<bool>,
+    /// The parsed quote structure.
+    pub quote: Quote,
+}
+
+impl VerificationResult {
+    /// Check if all verification checks passed.
+    pub fn is_valid(&self) -> bool {
+        self.quote_verified && self.nonce_verified && self.application_hash_verified.unwrap_or(true)
+    }
+}
+
+/// Verify a TDX attestation quote.
+///
+/// # Arguments
+/// * `quote_bytes` - Raw quote bytes to verify.
+/// * `nonce` - Expected 32-byte nonce that should be in report_data[0..32].
+/// * `expected_app_hash` - Optional expected 32-byte app hash that should be in report_data[32..64].
+///
+/// # Returns
+/// A `VerificationResult` with the verification status for each check.
+///
+/// # Errors
+/// Returns an error if the quote cannot be parsed or if collateral fetch fails.
+pub async fn verify_attestation(
+    quote_bytes: &[u8],
+    nonce: &[u8; 32],
+    expected_app_hash: Option<&[u8; 32]>,
+) -> Result<VerificationResult, AttestationError> {
+    // Parse TDX quote
+    let tdx_quote = TdxQuote::from_bytes(quote_bytes).map_err(|err| {
+        error!(error=?err, "Failed to parse TDX quote");
+        AttestationError::QuoteParsingFailed(format!("{:?}", err))
+    })?;
+
+    info!("Quote parsed successfully");
+
+    // Extract report data from quote
+    let report_data = tdx_quote.report_input_data();
+    let report_data_hex = hex::encode(report_data);
+    info!(report_data=%report_data_hex, "Extracted report data from quote");
+
+    // Fetch collateral from Intel PCS
+    let collateral = get_collateral_from_pcs(quote_bytes).await.map_err(|err| {
+        error!(error=?err, "Failed to fetch collateral from Intel PCS");
+        AttestationError::CollateralFetchFailed(format!("{:?}", err))
+    })?;
+
+    info!("Collateral fetched from Intel PCS");
+
+    // Verify quote signature and certificate chain
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|err| {
+            error!(error=?err, "Failed to get current time");
+            AttestationError::SystemTimeError(err.to_string())
+        })?
+        .as_secs();
+
+    let quote_verified = match verify(quote_bytes, &collateral, now) {
+        Ok(_verified_report) => {
+            info!("Quote cryptographic verification: PASSED");
+            true
+        }
+        Err(err) => {
+            error!(error=?err, "Quote cryptographic verification: FAILED");
+            false
+        }
+    };
+
+    // Verify nonce matches report_data[0..32]
+    let nonce_verified = &report_data[..32] == nonce;
+    if nonce_verified {
+        info!("Nonce verification: PASSED");
+    } else {
+        error!(
+            expected=%hex::encode(nonce),
+            actual=%hex::encode(&report_data[..32]),
+            "Nonce verification: FAILED"
+        );
+    }
+
+    // Verify application hash if provided
+    let application_hash_verified = expected_app_hash.map(|expected_hash| {
+        let actual_hash = &report_data[32..64];
+        let verified = actual_hash == expected_hash;
+        if verified {
+            info!("Application hash verification: PASSED");
+        } else {
+            error!(
+                expected=%hex::encode(expected_hash),
+                actual=%hex::encode(actual_hash),
+                "Application hash verification: FAILED"
+            );
+        }
+        verified
+    });
+
+    // Convert tdx_quote to our serializable Quote type
+    let quote = Quote::try_from(tdx_quote).map_err(|err| {
+        error!(error=%err, "Failed to convert TDX quote to serializable format");
+        AttestationError::QuoteConversionFailed(err.to_string())
+    })?;
+
+    let result = VerificationResult {
+        quote_verified,
+        nonce_verified,
+        application_hash_verified,
+        quote,
+    };
+
+    if result.is_valid() {
+        info!("Overall verification: PASSED");
+    } else {
+        error!("Overall verification: FAILED");
+    }
+
+    Ok(result)
+}
+
+/// Verify a mock TEE attestation for development/testing.
+///
+/// This function verifies mock attestations generated on non-Linux platforms.
+/// It extracts the report data from the mock quote format and verifies the nonce
+/// and optional application hash match.
+///
+/// # Arguments
+/// * `quote_bytes` - Raw mock quote bytes.
+/// * `nonce` - Expected 32-byte nonce.
+/// * `expected_app_hash` - Optional expected 32-byte app hash.
+///
+/// # Returns
+/// A `VerificationResult` where `quote_verified` is always `true` for mock quotes
+/// (since there's no cryptographic signature to verify).
+///
+/// # Security Warning
+/// This function bypasses all cryptographic verification. It should ONLY be used
+/// for development and testing purposes.
+pub fn verify_mock_attestation(
+    quote_bytes: &[u8],
+    nonce: &[u8; 32],
+    expected_app_hash: Option<&[u8; 32]>,
+) -> Result<VerificationResult, AttestationError> {
+    use crate::generate::create_mock_quote;
+
+    warn!("Verifying MOCK attestation - NOT FOR PRODUCTION USE");
+
+    // Verify this is actually a mock quote
+    if !is_mock_quote(quote_bytes) {
+        return Err(AttestationError::QuoteParsingFailed(
+            "Not a valid mock quote - missing MOCK_TDX_QUOTE_V1 header".to_owned(),
+        ));
+    }
+
+    // Extract report data from mock quote
+    // Format: MOCK_TDX_QUOTE_V1 (17 bytes) || report_data (64 bytes) || padding
+    let header_len = MOCK_QUOTE_HEADER.len();
+    if quote_bytes.len() < header_len + 64 {
+        return Err(AttestationError::QuoteParsingFailed(
+            "Mock quote too short to contain report data".to_owned(),
+        ));
+    }
+
+    let report_data = &quote_bytes[header_len..header_len + 64];
+    let report_data_hex = hex::encode(report_data);
+    info!(report_data=%report_data_hex, "Extracted report data from mock quote");
+
+    // Verify nonce matches report_data[0..32]
+    let nonce_verified = &report_data[..32] == nonce;
+    if nonce_verified {
+        info!("Nonce verification: PASSED");
+    } else {
+        error!(
+            expected=%hex::encode(nonce),
+            actual=%hex::encode(&report_data[..32]),
+            "Nonce verification: FAILED"
+        );
+    }
+
+    // Verify application hash if provided
+    let application_hash_verified = expected_app_hash.map(|expected_hash| {
+        let actual_hash = &report_data[32..64];
+        let verified = actual_hash == expected_hash;
+        if verified {
+            info!("Application hash verification: PASSED");
+        } else {
+            error!(
+                expected=%hex::encode(expected_hash),
+                actual=%hex::encode(actual_hash),
+                "Application hash verification: FAILED"
+            );
+        }
+        verified
+    });
+
+    // Create a mock quote structure with the report data
+    let mut mock_report_data = [0u8; 64];
+    mock_report_data.copy_from_slice(report_data);
+    let quote = create_mock_quote(&mock_report_data);
+
+    let result = VerificationResult {
+        quote_verified: true, // Mock quotes always pass signature verification
+        nonce_verified,
+        application_hash_verified,
+        quote,
+    };
+
+    if result.is_valid() {
+        info!("Overall mock verification: PASSED");
+    } else {
+        warn!("Overall mock verification: FAILED (nonce or app_hash mismatch)");
+    }
+
+    Ok(result)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements specialized-node discovery/invite over libp2p request-response, adds TEE attestation crate, read-only node mode, server/CLI endpoints, and supporting config/state.
> 
> - **Protocol & Networking**:
>   - Introduce specialized-node invite protocol with libp2p `request-response` (codec, messages, events) in `calimero-network[-primitives]`; enable `request-response` feature.
>   - Handlers to send/receive verification requests and invitation responses; swarm behaviour wired.
> - **Node**:
>   - Add `NodeMode` with `ReadOnly`; disable JSON-RPC when read-only.
>   - Implement discovery broadcast, pending-invite state machine, verification handling, invitation creation, and join confirmation flow (`node/*`, `node/primitives`).
>   - `NodeClient::new` gains `specialized_node_invite_topic` and `broadcast_specialized_node_invite`.
> - **Config**:
>   - Add `SpecializedNodeConfig` to `NetworkConfig` (invite topic, `accept_mock_tee`); plumbed through `merod run` to `NodeConfig`.
> - **Server**:
>   - New admin endpoint `POST admin-api/contexts/invite-specialized-node`.
>   - Refactor TEE attest/info/verify to new crate APIs and improved responses; JSON-RPC service respects disabled config.
> - **TEE Attestation**:
>   - New crate `calimero-tee-attestation` providing quote generation (Linux), mock support, verification, and host info.
> - **CLI & Client**:
>   - `meroctl`: add `context invite-specialized-node` command and output formatting.
>   - `client`: add `invite_specialized_node` method.
> - **Misc/Test Updates**:
>   - Adjust constructors in tests to pass invite topic; minor dependency and feature additions in Cargo files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb22766d051b1bd02f99e8bb31b543ac98ec7d46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->