### PR TITLE
fix(network): remove hardcoded Kademlia server mode

### DIFF
--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -96,8 +96,6 @@ impl Behaviour {
                             kad_config,
                         );
 
-                        kad.set_mode(Some(kad::Mode::Server));
-
                         for (peer_id, addr) in bootstrap_peers {
                             let _ = kad.add_address(&peer_id, addr);
                         }


### PR DESCRIPTION
# [network] remove hardcoded Kademlia server mode

## Description
Short description: Remove the unconditional Kademlia server mode override so the mode is determined by configuration/auto.
Issue fixed: Kademlia was forced into server mode regardless of node role, preventing auto/client behavior (no issue ID linked).
Motivation/context: Aligns Kademlia behavior with libp2p defaults and lets role-specific config control whether the node acts as server or client.
Dependencies: None.

## Test plan
Tested with different network configurations. On average with default configuration it takes about 70s for a node to switch from default client mode to server.

## Documentation update
Docs: None. If there is a networking/Kademlia behavior doc, ensure it reflects that server mode is no longer forced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove forced Kademlia server mode so Kademlia mode is determined by defaults/config.
> 
> - **Networking**
>   - **Kademlia behaviour (`crates/network/src/behaviour.rs`)**:
>     - Remove `kad.set_mode(Some(kad::Mode::Server))`, allowing mode to be determined by defaults/config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d6bf2addd123f2fd29b12500ea7b4c9afcdc919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->