### PR TITLE
fix: `state-schema-conformance` app build script

### DIFF
--- a/apps/state-schema-conformance/build.sh
+++ b/apps/state-schema-conformance/build.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cd "$(dirname $0)"
+
 # Add WASM target if not present
 rustup target add wasm32-unknown-unknown >/dev/null 2>&1 || true
+
+TARGET="${CARGO_TARGET_DIR:-../../target}"
 
 # Build with release optimizations
 echo "Building state-schema-conformance..."
@@ -10,13 +14,13 @@ cargo build -p state-schema-conformance --target wasm32-unknown-unknown --profil
 
 # Copy WASM file to res directory
 mkdir -p res
-cp target/wasm32-unknown-unknown/app-release/state_schema_conformance.wasm res/state-schema-conformance.wasm
+cp $TARGET/wasm32-unknown-unknown/app-release/state_schema_conformance.wasm ./res/
 
 # Optimize with wasm-opt if available
 if command -v wasm-opt &> /dev/null; then
     echo "Optimizing WASM with wasm-opt..."
-    wasm-opt -Os res/state-schema-conformance.wasm -o res/state-schema-conformance.wasm
+    wasm-opt -Os res/state_schema_conformance.wasm -o ./res/state_schema_conformance.wasm
 fi
 
-echo "Build complete: res/state-schema-conformance.wasm"
+echo "Build complete: res/state_schema_conformance.wasm"
 


### PR DESCRIPTION
# Fix `state-schema-conformance` app build script

## Description

Fix `state-schema-conformance` app build script:
* fix the target directory;
* fix the binary name.

## Test plan

--

## Documentation update

--

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the build script to produce and handle the correct WASM artifact reliably.
> 
> - Run from the script directory to stabilize relative paths (`cd "$(dirname $0)"`)
> - Respect `CARGO_TARGET_DIR` via `TARGET` fallback to `../../target`
> - Use the correct artifact name `state_schema_conformance.wasm` (underscores)
> - Update copy path to `$TARGET/wasm32-unknown-unknown/app-release/...` and output to `./res/`
> - Align `wasm-opt` invocation and final echo with the corrected filename
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 117f3e7be7a07f2db1bf69e7470c51a6c645a84f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->