### PR TITLE
chore: release 0.10.0-rc.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.25"
+version = "0.10.0-rc.26"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.25"
+version = "0.10.0-rc.26"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Release bump**
> 
> - Update `crates/version/Cargo.toml` to `version = 0.10.0-rc.26`
> - Refresh `Cargo.lock` to reflect the new `calimero-version`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45837b47bc2086bea82db3efd4a4cb353344e2af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->