### PR TITLE
feat: bump node version rc28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.27"
+version = "0.10.0-rc.28"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.27"
+version = "0.10.0-rc.28"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# feat: bump node version rc28

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release metadata to rc.28.
> 
> - Bumps `calimero-version` to `0.10.0-rc.28` in `crates/version/Cargo.toml`
> - Syncs `Cargo.lock` to reflect the new version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1ab6b819640fff89e2e8f5464c98fbeb4161722. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->