### PR TITLE
fix: revert release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,8 +238,6 @@ jobs:
         with:
           shared-key: release
 
-      - name: Update dependencies
-        run: cargo update --workspace
       - name: Publish calimero-workspaces on crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -247,19 +245,13 @@ jobs:
         run: |
           set -x
 
-          # Update BOTH version fields in Cargo.toml
-          sed -i '0,/^version = "0\.0\.0"$/s//version = "'${VERSION}'"/' Cargo.toml
           sed -i 's/.*# crates_version/version = "'${VERSION}'" # crates_version/' Cargo.toml
 
-          # Verify the changes
-          grep -A2 "^\[workspace.package\]" Cargo.toml
-          grep "# crates_version" Cargo.toml
-
-          # Install the latest stable cargo-workspaces (better dependency resolution)
-          cargo install cargo-workspaces
-
-          # Publish with proper dependency ordering (remove --force to respect dependencies)
-          cargo ws publish --yes --allow-dirty \
+          # Install the specific version of cargo-workspaces that we know works
+          cargo install --git https://github.com/calimero-network/cargo-workspaces --tag v0.3.0 cargo-workspaces
+          # Publish all publishable crates from the workspace, skipping excluded packages
+          # Using --no-git flags to avoid git operations during publishing
+          cargo ws publish --yes --allow-dirty --force '*' \
               --no-git-commit --no-git-push --no-individual-tags --tag-prefix 'crates-' \
               -m $$'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}'
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.30"
+version = "0.10.0-rc.31"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.30"
+version = "0.10.0-rc.31"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# fix: revert release process

## Description
Reverted to [this](https://github.com/calimero-network/core/pull/1679/files) commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks crates publishing in release workflow and bumps version.
> 
> - Pin `cargo-workspaces` to `v0.3.0` from `calimero-network/cargo-workspaces`
> - Change publish step to use `cargo ws publish --yes --allow-dirty --force '*' --no-git-commit --no-git-push --no-individual-tags --tag-prefix 'crates-'`
> - Update `calimero-version` to `0.10.0-rc.31` in `crates/version/Cargo.toml` and `Cargo.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79fb720fa6e0cb911aa145d04272c8f23d6b7d78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->