### PR TITLE
fix: version flag issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,8 +252,7 @@ jobs:
           # Publish all publishable crates from the workspace, skipping excluded packages
           # Using --no-git flags to avoid git operations during publishing
           cargo ws publish --yes --allow-dirty --force '*' \
-              --no-git-commit --no-git-push --no-individual-tags --tag-prefix 'crates-' \
-              -m $$'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}'
+              --no-git-commit --no-git-push --no-individual-tags --tag-prefix 'crates-'
 
   release-merod-container:
     name: Release Merod container

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.31"
+version = "0.10.0-rc.32"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.31"
+version = "0.10.0-rc.32"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# fix: version flag issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release pipeline and versioning.
> 
> - Bumps `calimero-version` to `0.10.0-rc.32` in `crates/version/Cargo.toml` and `Cargo.lock`
> - Simplifies crates publish step in `.github/workflows/release.yml` by removing the custom `-m` message from `cargo ws publish`, keeping `--no-git-*` flags and `--tag-prefix 'crates-'`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed4a911b1c873e7d512bd8ea9814efbc677f7a96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->