### PR TITLE
chore: bump core version to rc33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.32"
+version = "0.10.0-rc.33"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.32"
+version = "0.10.0-rc.33"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Bumps core version from rc32 to rc33 following the feat-bump-core-version pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates version metadata only.
> 
> - Bumps `calimero-version` crate to `0.10.0-rc.33` in `crates/version/Cargo.toml`
> - Synchronizes `Cargo.lock` to reflect the new version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 551fb72abf5698f36d14a0e10b41a5435b68f63e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->