### PR TITLE
fix: add mero-auth to workspace dependencies for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,7 @@ calimero-tee-attestation = { path = "./crates/tee-attestation" }
 calimero-utils-actix = { path = "./crates/utils/actix" }
 calimero-version = { path = "./crates/version" }
 calimero-wasm-abi = { path = "./crates/wasm-abi" }
+mero-auth = { path = "./crates/auth" }
 kv-store = { path = "./apps/kv-store" }
 xcall-example = { path = "./apps/xcall-example" }
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -24,4 +24,4 @@ calimero-context.workspace = true
 calimero-node-primitives.workspace = true
 calimero-server = { workspace = true }
 calimero-network-primitives.workspace = true
-mero-auth = { path = "../auth" }
+mero-auth.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -37,7 +37,7 @@ calimero-primitives.workspace = true
 calimero-server-primitives.workspace = true
 calimero-store = { workspace = true, features = ["serde"] }
 calimero-tee-attestation.workspace = true
-mero-auth = { path = "../auth" }
+mero-auth.workspace = true
 
 [dev-dependencies]
 color-eyre.workspace = true


### PR DESCRIPTION
## Problem

When publishing crates to crates.io,  was failing with:
```
error: all dependencies must have a version specified when publishing.
dependency `mero-auth` does not specify a version
```

## Solution

- Added `mero-auth` to `workspace.dependencies` in `Cargo.toml`
- Updated `calimero-server` and `calimero-config` to use `mero-auth.workspace = true` instead of path dependencies

This ensures that when publishing, Cargo can resolve the version from the workspace dependency configuration.

## Changes

- `core/Cargo.toml`: Added `mero-auth` to workspace dependencies
- `core/crates/server/Cargo.toml`: Changed from path to workspace dependency
- `core/crates/config/Cargo.toml`: Changed from path to workspace dependency

Fixes publishing error for `calimero-server` and `calimero-config`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `mero-auth` is resolved via workspace for publishing.
> 
> - Add `mero-auth` to `[workspace.dependencies]` in `Cargo.toml`
> - Update `crates/config/Cargo.toml` and `crates/server/Cargo.toml` to use `mero-auth.workspace = true` instead of a path dependency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30e1a371864ed0b2d1f43062f28416b4a582cfe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->