### PR TITLE
chore: release 0.10.0-rc.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.35"
+version = "0.10.0-rc.36"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.35"
+version = "0.10.0-rc.36"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prepares release `0.10.0-rc.36`.
> 
> - Bumps `calimero-version` from `0.10.0-rc.35` to `0.10.0-rc.36` in `crates/version/Cargo.toml`
> - Updates `Cargo.lock` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94a722cda9e592e3af9c67fc2e278ac1e63a7dd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->