### PR TITLE
chore: release 0.10.0-rc.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.36"
+version = "0.10.0-rc.37"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.36"
+version = "0.10.0-rc.37"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Release version bump**
> 
> - Updates `calimero-version` crate from `0.10.0-rc.36` to `0.10.0-rc.37`
> - Syncs `Cargo.lock` and `crates/version/Cargo.toml` to the new version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6e47c0e7b8d596bb886f4d544def2afb83562de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->