### PR TITLE
feat(storage): add timestamp drifting verification

### DIFF
--- a/crates/storage/src/constants.rs
+++ b/crates/storage/src/constants.rs
@@ -26,6 +26,14 @@ pub const FULL_RESYNC_THRESHOLD_NANOS: u64 = 172_800_000_000_000;
 /// Value: 43,200,000,000,000 nanoseconds = 12 hours
 pub const GC_INTERVAL_NANOS: u64 = 43_200_000_000_000;
 
+/// Drift tolerance in nanoseconds (5 seconds).
+///
+/// Actions with timestamps further in the future than this tolerance
+/// are rejected to prevent Time Drift attacks.
+///
+/// Value: 5,000,000,000 nanoseconds = 5 seconds
+pub const DRIFT_TOLERANCE_NANOS: u64 = 5_000_000_000;
+
 /// Helper: Convert days to nanoseconds.
 #[inline]
 #[must_use]

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -36,7 +36,11 @@ pub enum StorageError {
     #[error("Invalid data: {0}")]
     InvalidData(String),
 
-    /// [NEW] The provided signature for an action is invalid.
+    /// The provided timestamp for an action is invalid (too far in the future).
+    #[error("Invalid timestamp {0} for an action, too far in the future (local time: {1}).")]
+    InvalidTimestamp(u64, u64),
+
+    /// The provided signature for an action is invalid.
     #[error("Invalid signature for user-owned data")]
     InvalidSignature,
 
@@ -75,6 +79,10 @@ impl Serialize for StorageError {
             | Self::IndexNotFound(id)
             | Self::UnexpectedId(id)
             | Self::NotFound(id) => serializer.serialize_str(&id.to_string()),
+            Self::InvalidTimestamp(timestamp, local_time) => serializer.serialize_str(&format!(
+                "Invalid timestamp {} for an action, too far in the future (local time: {}).",
+                timestamp, local_time
+            )),
             Self::InvalidData(ref msg) => serializer.serialize_str(msg),
             Self::InvalidSignature => serializer.serialize_str("Invalid signature"),
             Self::NonceReplay(ref data) => {


### PR DESCRIPTION
# Storage: add timestamp drifting verification

## Description

Storage: add timestamp drifting verification for incoming actions to ensure the actions have proper timestamps.

## Test plan

New tests are added.

## Documentation update
--

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `Interface::apply_action` validation to reject remote actions whose timestamps are too far in the future, which can cause sync failures if node clocks are skewed or timestamps are produced incorrectly.
> 
> **Overview**
> Adds a configurable **timestamp drift tolerance** (`DRIFT_TOLERANCE_NANOS`, 5s) and enforces it in `Interface::apply_action` by rejecting `Add`/`Update` actions with `metadata.updated_at()` and `DeleteRef` actions with `deleted_at` that are too far ahead of local time.
> 
> Introduces `StorageError::InvalidTimestamp` for this failure mode and expands CRDT tests to cover accept/reject behavior for near-future, far-future, and past timestamps (including delete actions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d415e5dccc6046eddcc7fc1395c9cabd22da238c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->