### PR TITLE
fix: race condition in JWT token rotation during refresh

### DIFF
--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::http::HeaderMap;
 use base64::Engine;
 use chrono::{Duration, Utc};
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};


### PR DESCRIPTION
# fix: Race condition in JWT token rotation during refresh

## Description

This PR addresses a race condition in the `refresh_token_pair()` method within `crates/auth/src/auth/token/jwt.rs`.

Previously, when rotating client tokens, a new key was stored *before* the new token pair was generated. If token generation subsequently failed, the original key might have already been removed, and cleanup of the newly stored key could also fail, potentially leaving the user locked out with no valid key.

The fix reorders these operations to ensure atomicity and a proper rollback strategy:
1.  **Generate the new access and refresh tokens first.** If this step fails, the function returns immediately, and no keys are modified, preserving the user's existing valid key.
2.  **Store the new client key** only after the tokens have been successfully generated. If this step fails, the user's old key is still valid, preventing lockout.
3.  **Delete the old client key** as the final step. This is now a non-critical cleanup; even if it fails, the new tokens and key are already in place.

This change prevents user lockout scenarios during token rotation failures.

## Test plan

The existing unit tests for token generation and refresh were run using `cargo test` and `cargo check` to ensure no regressions. The core change is a reordering of operations to prevent a specific failure mode, which is verified by the logical flow of the code.

To reproduce the original issue (which is difficult to reliably trigger in a test due to its race condition nature), one would need to simulate a failure in `generate_token` *after* `key_manager.set_key` for the new ID, but *before* `key_manager.delete_key` for the old ID. The current change ensures that `key_manager.set_key` for the new ID only happens *after* successful token generation, thus eliminating the problematic state.

No new end-to-end tests were added as this is a fix for an internal race condition.

## Documentation update

No public or internal documentation updates are required for this change, as it is an internal logic fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-49872735-bfcf-49b0-b670-f4f0259f3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49872735-bfcf-49b0-b670-f4f0259f3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token refresh/key-rotation flow in `jwt.rs`, so mistakes could break authentication for clients. Change is small and primarily reorders operations to avoid inconsistent key state on failures.
> 
> **Overview**
> Fixes a potential lockout/race scenario in `refresh_token_pair()` by **generating the new access/refresh tokens before mutating key storage**, then storing the new client key, and only finally attempting best-effort deletion of the old key.
> 
> Refactors token issuance by introducing `generate_raw_token_pair()` (token generation without key validation) and reusing it from both `generate_token_pair()` and `generate_mock_token_pair()` to reduce duplication and centralize expiry handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 142e8d41f955f7b2188dbbe5650de48873c3220b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->