### PR TITLE
feat: bump node version rc38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.37"
+version = "0.10.0-rc.38"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.37"
+version = "0.10.0-rc.38"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# feat: bump node version rc38


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump only; no functional or behavioral code changes beyond propagating the updated crate version through the lockfile.
> 
> **Overview**
> Bumps the `calimero-version` crate from `0.10.0-rc.37` to `0.10.0-rc.38`, updating both `crates/version/Cargo.toml` and `Cargo.lock` to reflect the new release candidate version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8819d64c9be5c6faef16b178354e37d045f6cce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->