### PR TITLE
fix: mero-khm-phala ci fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ env:
     mero-kms-phala
   AUTH_BINARIES: |-
     mero-auth
+  # Binaries to publish to Homebrew (excludes specialized components like mero-kms-phala)
+  HOMEBREW_BINARIES: |-
+    merod
+    meroctl
+    mero-relayer
+    mero-abi
 
 jobs:
   prepare:
@@ -447,10 +453,10 @@ jobs:
           git fetch origin "${target_branch}" || true
           git checkout "${target_branch}" || git checkout -b "${target_branch}"
 
-          readarray -t binaries <<< "$BINARIES"
+          readarray -t binaries <<< "$HOMEBREW_BINARIES"
 
           for binary in "${binaries[@]}"; do
-            echo "Updating formula for ${binary}, version: ${version}"
+            echo "Updating formula for ${binary}, version: ${{ needs.prepare.outputs.version }}"
             ./generate-formula.sh "${binary}" "${{ needs.prepare.outputs.version }}"
           done
 


### PR DESCRIPTION
# fix: mero-khm-phala ci fail

## Description
Issue here -> [CI](https://github.com/calimero-network/core/actions/runs/21594084956/job/62226220206)

Added HOMEBREW_BINARIES - Contains only the binaries that should be published to Homebrew, excluding mero-kms-phala which is a specialized TEE component.

The mero-kms-phala binary will still be built and released to GitHub releases and Docker, but won't be pushed to Homebrew tap since it's a specialized Phala TEE component not meant for general distribution via package managers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the release GitHub Actions workflow to change which binaries are iterated for Homebrew updates; build/release artifacts for other targets remain unaffected.
> 
> **Overview**
> Updates the release workflow to **separate “binaries we build/release” from “binaries we publish to Homebrew”** by introducing `HOMEBREW_BINARIES` (excluding `mero-kms-phala`).
> 
> The Homebrew tap update job now iterates over `HOMEBREW_BINARIES` instead of `BINARIES`, preventing formula generation/publish attempts for the specialized `mero-kms-phala` binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32f4a2f559883cacbac52afc31a152a186d833b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->