### PR TITLE
feat: bump to rc39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.38"
+version = "0.10.0-rc.39"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.38"
+version = "0.10.0-rc.39"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# feat: bump to rc39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only bump with no logic changes; impact is limited to downstream consumers expecting the previous pre-release version string.
> 
> **Overview**
> Bumps the `calimero-version` crate version from `0.10.0-rc.38` to `0.10.0-rc.39`, updating `Cargo.toml` and the corresponding entry in `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf6c28edb6568d5a828532081b0af2475cd9e6de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->