### PR TITLE
ci(release): fix PR matrix gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,16 +113,8 @@ jobs:
   build-binaries:
     name: Build Binaries
     needs: prepare
-    if: ${{ github.event_name != 'pull_request' || matrix.target != 'aarch64-apple-darwin' }}
     strategy:
-      matrix:
-        include:
-          - runs-on: big-machine
-            target: x86_64-unknown-linux-gnu
-          - runs-on: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-          - runs-on: macos-latest
-            target: aarch64-apple-darwin
+      matrix: ${{ fromJSON(github.event_name == 'pull_request' && '{"include":[{"runs-on":"big-machine","target":"x86_64-unknown-linux-gnu"},{"runs-on":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"}]}' || '{"include":[{"runs-on":"big-machine","target":"x86_64-unknown-linux-gnu"},{"runs-on":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"},{"runs-on":"macos-latest","target":"aarch64-apple-darwin"}]}' ) }}
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adjusts which runner/targets are built on PRs vs non-PR runs, without affecting production code.
> 
> **Overview**
> Adjusts `.github/workflows/release.yml` so `build-binaries` uses a conditional `fromJSON` matrix: PRs build only Linux targets, while non-PR runs also include the macOS `aarch64-apple-darwin` target.
> 
> This removes the previous job-level `if` that skipped the macOS matrix entry, preventing PR workflows from scheduling an unused macOS build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1c69760808b9f7a7ea57241cdcbf863a821306c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->