### PR TITLE
Revert "fix: core builds speedup"

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   rust:
     name: Rust
-    runs-on: big-machine
+    runs-on: ubuntu-24.04-8cpu
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ env:
     mero-kms-phala
   AUTH_BINARIES: |-
     mero-auth
-  PROFILING_BINARIES: |-
-    merod
-    meroctl
   # Binaries to publish to Homebrew (excludes specialized components like mero-kms-phala)
   HOMEBREW_BINARIES: |-
     merod
@@ -50,7 +47,6 @@ jobs:
       binary_release: ${{ steps.version_info.outputs.binary_release }}
       crate_release: ${{ steps.version_info.outputs.crate_release }}
       docker_release: ${{ steps.version_info.outputs.docker_release }}
-      build_binaries: ${{ steps.version_info.outputs.build_binaries }}
       docker_push: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork || !github.event.pull_request }}
       prerelease: ${{ steps.version_info.outputs.prerelease }}
       target_commit: ${{ steps.version_info.outputs.target_commit }}
@@ -88,43 +84,26 @@ jobs:
             docker_release=true
           fi
 
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            build_binaries=$(cat <<'EOF'
-          merod
-          meroctl
-          mero-relayer
-          mero-kms-phala
-          mero-auth
-          EOF
-            )
-          else
-            build_binaries=$(printf "%s\n%s\n" "$BINARIES" "$AUTH_BINARIES")
-          fi
-
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "prerelease=$prerelease" >> $GITHUB_OUTPUT
           echo "binary_release=$binary_release" >> $GITHUB_OUTPUT
           echo "crate_release=$crate_release" >> $GITHUB_OUTPUT
           echo "docker_release=$docker_release" >> $GITHUB_OUTPUT
-          echo "build_binaries<<EOF" >> $GITHUB_OUTPUT
-          echo "$build_binaries" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
   build-binaries:
     name: Build Binaries
     needs: prepare
-    if: ${{ github.event_name != 'pull_request' || matrix.target != 'aarch64-apple-darwin' }}
     strategy:
       matrix:
         include:
-          - runs-on: big-machine
+          - os: ubuntu-24.04-8cpu
             target: x86_64-unknown-linux-gnu
-          - runs-on: ubuntu-24.04-arm
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - runs-on: macos-latest
+          - os: macos-latest
             target: aarch64-apple-darwin
       fail-fast: false
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.os }}
 
     env:
       CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,12 +121,15 @@ jobs:
           key: release
 
       - name: Update Bash
-        if: ${{ matrix.target == 'aarch64-apple-darwin' }}
+        if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-latest' }}
         run: brew install bash
 
       - name: Build binaries
         run: |
-          readarray -t binaries <<< "${{ needs.prepare.outputs.build_binaries }}"
+          readarray -t binaries <<< "$BINARIES"
+          readarray -t auth_binaries <<< "$AUTH_BINARIES"
+
+          binaries+=("${auth_binaries[@]}")
 
           binaries=$(printf -- '-p %s ' "${binaries[@]}")
 
@@ -157,27 +139,30 @@ jobs:
         run: |
           mkdir -p artifacts
 
-          readarray -t binaries <<< "${{ needs.prepare.outputs.build_binaries }}"
+          readarray -t binaries <<< "$BINARIES"
+          readarray -t auth_binaries <<< "$AUTH_BINARIES"
+
+          binaries+=("${auth_binaries[@]}")
 
           for binary in "${binaries[@]}"; do
             tar -czf artifacts/"$binary"_${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release "$binary"
           done
 
       - name: Build profiling binaries (with frame pointers and debug symbols)
-        if: ${{ github.event_name != 'pull_request' && (matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu') }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
-          readarray -t binaries <<< "$PROFILING_BINARIES"
+          readarray -t binaries <<< "$BINARIES"
           binaries=$(printf -- '-p %s ' "${binaries[@]}")
 
           # Build with frame pointers and enable Wasmer PerfMap profiling feature
           RUSTFLAGS="-C force-frame-pointers=yes" cargo build $binaries --profile profiling --target ${{ matrix.target }} --features calimero-context/profiling
 
       - name: Compress profiling artifacts using gzip
-        if: ${{ github.event_name != 'pull_request' && (matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu') }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           mkdir -p artifacts-profiling
 
-          readarray -t binaries <<< "$PROFILING_BINARIES"
+          readarray -t binaries <<< "$BINARIES"
 
           for binary in "${binaries[@]}"; do
             tar -czf artifacts-profiling/"$binary"_${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/profiling "$binary"
@@ -191,7 +176,7 @@ jobs:
           retention-days: 2
 
       - name: Upload profiling artifacts
-        if: ${{ github.event_name != 'pull_request' && (matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu') }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu' }}
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-profiling-${{ matrix.target }}
@@ -300,9 +285,7 @@ jobs:
           release: ${{ needs.prepare.outputs.docker_release }}
           prerelease: ${{ needs.prepare.outputs.prerelease }}
           push: ${{ needs.prepare.outputs.docker_push }}
-          binaries: |-
-            merod
-            meroctl
+          binaries: ${{ env.BINARIES }}
           dockerfile: .github/workflows/deps/prebuilt.Dockerfile
           container_name: merod
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -331,7 +314,7 @@ jobs:
           release: ${{ needs.prepare.outputs.docker_release }}
           prerelease: ${{ needs.prepare.outputs.prerelease }}
           push: ${{ needs.prepare.outputs.docker_push }}
-          binaries: mero-auth
+          binaries: ${{ env.AUTH_BINARIES }}
           dockerfile: .github/workflows/deps/prebuilt.auth.Dockerfile
           container_name: mero-auth
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -360,7 +343,7 @@ jobs:
           release: ${{ needs.prepare.outputs.docker_release }}
           prerelease: ${{ needs.prepare.outputs.prerelease }}
           push: ${{ needs.prepare.outputs.docker_push }}
-          binaries: mero-kms-phala
+          binaries: ${{ env.BINARIES }}
           dockerfile: .github/workflows/deps/prebuilt.mero-kms-phala.Dockerfile
           container_name: mero-kms-phala
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -397,7 +380,6 @@ jobs:
   release-merod-profiling-container:
     name: Release Merod Profiling container
     needs: [prepare, build-binaries]
-    if: ${{ github.event_name != 'pull_request' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-merod-profiling-${{ needs.prepare.outputs.version }}
       cancel-in-progress: true
@@ -419,7 +401,7 @@ jobs:
           release: ${{ needs.prepare.outputs.docker_release }}
           prerelease: ${{ needs.prepare.outputs.prerelease }}
           push: ${{ needs.prepare.outputs.docker_push }}
-          binaries: ${{ env.PROFILING_BINARIES }}
+          binaries: ${{ env.BINARIES }}
           dockerfile: .github/workflows/deps/prebuilt.profiling.Dockerfile
           container_name: merod
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts calimero-network/core#1812

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI/release execution environments and which binaries are built/packaged (including profiling artifacts), which can break releases or produce unexpected container contents.
> 
> **Overview**
> **CI and release workflows are reverted/simplified around runners and binary lists.** CI `rust` job now runs on `ubuntu-24.04-8cpu` instead of the custom `big-machine` runner.
> 
> In `release.yml`, binary selection logic via a `prepare` output is removed; build steps always derive binaries from `BINARIES` + `AUTH_BINARIES`, and the build matrix is normalized to an `os` key. Profiling builds/uploads and the `release-merod-profiling-container` job are no longer gated to non-PR events, and container release steps now take their `binaries` input from the workflow env (expanding some containers from single-binary inputs to `BINARIES`/`AUTH_BINARIES`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef86dfa2aebb23ff22e7b4889b9c1bbc43e5421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->