### PR TITLE
Stuck GitHub actions jobs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   rust:
     name: Rust
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (CodeQL)
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -49,7 +49,7 @@ env:
 jobs:
   build:
     name: Build Apps
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     outputs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
@@ -113,7 +113,7 @@ jobs:
   fuzzy-test-kv-store:
     name: Run KV Store Fuzzy Test with Profiling
     needs: build
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     outputs:
       test_passed: ${{ steps.set-result.outputs.passed }}
@@ -331,7 +331,7 @@ jobs:
   fuzzy-test-handlers:
     name: Run KV Store with Handlers Fuzzy Test with Profiling
     needs: build
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     outputs:
       test_passed: ${{ steps.set-result-handlers.outputs.passed }}

--- a/.github/workflows/merobox-proposals.yml
+++ b/.github/workflows/merobox-proposals.yml
@@ -58,7 +58,7 @@ jobs:
 
   download-contracts:
     name: Download Contracts
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
   near:
     name: Test NEAR Proposals
     needs: [determine-image-tag, download-contracts]
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -163,7 +163,7 @@ jobs:
   icp:
     name: Test ICP Proposals
     needs: [determine-image-tag, download-contracts]
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -256,7 +256,7 @@ jobs:
   ethereum:
     name: Test Ethereum Proposals
     needs: [determine-image-tag, download-contracts]
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/merobox-workflows.yml
+++ b/.github/workflows/merobox-workflows.yml
@@ -32,7 +32,7 @@ env:
 jobs:
     build-apps:
         name: Build Apps
-        runs-on: ubuntu-24.04-8cpu
+        runs-on: ubuntu-24.04
         outputs:
             cache-key: ${{ steps.cache-key.outputs.key }}
         steps:
@@ -74,7 +74,7 @@ jobs:
     test:
         name: Run All Merobox Workflows
         needs: build-apps
-        runs-on: ubuntu-24.04-8cpu
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/release-ignored.yml
+++ b/.github/workflows/release-ignored.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-24.04-8cpu
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   prepare:
     name: Prepare
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version_info.outputs.version }}
       binary_release: ${{ steps.version_info.outputs.binary_release }}
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-24.04-8cpu
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
@@ -186,7 +186,7 @@ jobs:
   release-binaries:
     name: Release Binaries
     if: needs.prepare.outputs.binary_release == 'true'
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     needs: [prepare, build-binaries]
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-${{ needs.prepare.outputs.version }}
@@ -270,7 +270,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -299,7 +299,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -328,7 +328,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -357,7 +357,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -386,7 +386,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -409,7 +409,7 @@ jobs:
   brew-update:
     name: Update Homebrew Tap
     if: needs.prepare.outputs.binary_release == 'true'
-    runs-on: ubuntu-24.04-8cpu
+    runs-on: ubuntu-24.04
     needs: [prepare, release-binaries]
     permissions:
       id-token: write

--- a/.github/workflows/test-sdk-js.yml
+++ b/.github/workflows/test-sdk-js.yml
@@ -31,7 +31,7 @@ env:
 jobs:
     test-sdk-js:
         name: Test SDK JS with Core Binary
-        runs-on: ubuntu-24.04-8cpu
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout Core code
               uses: actions/checkout@v4


### PR DESCRIPTION
# CI: Switch to standard GitHub Actions runners

## Description

This PR fixes an issue where GitHub Actions jobs were stuck in a queued state. The root cause was that workflows were configured to use the `ubuntu-24.04-8cpu` runner label, but no runners with this label were available or had capacity.

This change updates all GitHub Actions workflows to use the standard `ubuntu-24.04` GitHub-hosted runner label, allowing jobs to be picked up and executed.

Affected workflows include: `ci-checks`, `codeql`, `fuzzy-load-test`, `merobox-proposals`, `merobox-workflows`, `release-ignored`, `release`, and `test-sdk-js`.

## Test plan

To verify this change, re-run any of the affected GitHub Actions workflows. The jobs should now be picked up by standard GitHub-hosted runners and proceed with execution instead of remaining in a queued state.

## Documentation update

None.

---
<a href="https://cursor.com/background-agent?bcId=bc-db520db4-3436-4d72-81bd-377797ab9305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db520db4-3436-4d72-81bd-377797ab9305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

