### PR TITLE
chore: remove meroctl cli dead code

### DIFF
--- a/crates/meroctl/src/cli/validation.rs
+++ b/crates/meroctl/src/cli/validation.rs
@@ -40,24 +40,6 @@ pub fn validate_file_exists(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Validates that a directory exists.
-///
-/// # Arguments
-/// * `path` - The directory path to validate
-///
-/// # Errors
-/// Returns an error if the directory doesn't exist or is not a directory.
-#[allow(dead_code)]
-pub fn validate_directory_exists(path: &Path) -> Result<()> {
-    if !path.exists() {
-        bail!("Directory not found: '{}'", path.display());
-    }
-    if !path.is_dir() {
-        bail!("Path is not a directory: '{}'", path.display());
-    }
-    Ok(())
-}
-
 /// Validates that a parent directory exists and is a directory.
 ///
 /// # Arguments
@@ -80,51 +62,6 @@ pub fn validate_parent_directory_exists(path: &Path) -> Result<()> {
 
     if !parent.is_dir() {
         bail!("Parent path is not a directory: '{}'", parent.display());
-    }
-
-    Ok(())
-}
-
-/// Validates that a URL string is well-formed.
-///
-/// # Arguments
-/// * `url_str` - The URL string to validate
-///
-/// # Errors
-/// Returns an error if the URL is malformed.
-#[allow(dead_code)]
-pub fn validate_url(url_str: &str) -> Result<url::Url> {
-    url::Url::parse(url_str).map_err(|e| {
-        eyre::eyre!(
-            "Invalid URL '{}': {}. Expected format: http(s)://hostname[:port][/path]",
-            url_str,
-            e
-        )
-    })
-}
-
-/// Validates a node name.
-///
-/// Node names must be non-empty and contain only alphanumeric characters,
-/// hyphens, and underscores.
-///
-/// # Arguments
-/// * `name` - The node name to validate
-///
-/// # Errors
-/// Returns an error if the node name is invalid.
-#[allow(dead_code)]
-pub fn validate_node_name(name: &str) -> Result<()> {
-    validate_non_empty(name, "Node name")?;
-
-    if !name
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-    {
-        bail!(
-            "Node name '{}' contains invalid characters. Only alphanumeric characters, hyphens (-), and underscores (_) are allowed",
-            name
-        );
     }
 
     Ok(())
@@ -222,34 +159,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_directory_exists_valid() {
-        let temp_dir = tempdir().unwrap();
-        assert!(validate_directory_exists(temp_dir.path()).is_ok());
-    }
-
-    #[test]
-    fn test_validate_directory_exists_not_found() {
-        let path = Path::new("/nonexistent/directory/path");
-        let result = validate_directory_exists(path);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Directory not found"));
-    }
-
-    #[test]
-    fn test_validate_directory_exists_not_directory() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let result = validate_directory_exists(temp_file.path());
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Path is not a directory"));
-    }
-
-    #[test]
     fn test_validate_parent_directory_exists_valid() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("output.txt");
@@ -278,47 +187,6 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Parent path is not a directory"));
-    }
-
-    #[test]
-    fn test_validate_url_valid() {
-        assert!(validate_url("http://localhost:8080").is_ok());
-        assert!(validate_url("https://example.com/path").is_ok());
-        assert!(validate_url("http://127.0.0.1:2528").is_ok());
-    }
-
-    #[test]
-    fn test_validate_url_invalid() {
-        let result = validate_url("not-a-url");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid URL"));
-    }
-
-    #[test]
-    fn test_validate_node_name_valid() {
-        assert!(validate_node_name("node1").is_ok());
-        assert!(validate_node_name("my-node").is_ok());
-        assert!(validate_node_name("my_node_123").is_ok());
-        assert!(validate_node_name("Node-1").is_ok());
-    }
-
-    #[test]
-    fn test_validate_node_name_empty() {
-        assert!(validate_node_name("").is_err());
-        assert!(validate_node_name("   ").is_err());
-    }
-
-    #[test]
-    fn test_validate_node_name_invalid_chars() {
-        let result = validate_node_name("node@1");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("invalid characters"));
-
-        assert!(validate_node_name("node.name").is_err());
-        assert!(validate_node_name("node name").is_err());
     }
 
     #[test]


### PR DESCRIPTION
# meroctl: Remove dead code from validation module

## Description

Removed unused validation helper functions (`validate_directory_exists`, `validate_url`, `validate_node_name`) and their corresponding tests from `crates/meroctl/src/cli/validation.rs`. These functions were marked with `#[allow(dead_code)]` and were not called anywhere in the codebase.

This change improves code hygiene by removing dead code.

## Test plan

The removed functions were previously marked as dead code and had no callers. Their associated unit tests were also removed. Existing tests in the module continue to pass, ensuring no regressions in the remaining validation logic.

## Documentation update

None.

---
<a href="https://cursor.com/background-agent?bcId=bc-708819e9-3be5-4a39-a29f-6e6b664a23b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-708819e9-3be5-4a39-a29f-6e6b664a23b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only deletes `#[allow(dead_code)]` helpers and corresponding tests with no remaining callers or behavioral changes to active validation paths.
> 
> **Overview**
> **Cleans up `meroctl` CLI validation** by removing dead helper functions (`validate_directory_exists`, `validate_url`, `validate_node_name`) and deleting their associated unit tests.
> 
> No functional changes to the remaining validation/parsers; the module now only retains the validations that are still exercised by tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b72130a83d478e59efab33051184d0dd400615df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->