### PR TITLE
feat(cli): set default proposals limit to 1

### DIFF
--- a/crates/meroctl/src/cli/context/proposals.rs
+++ b/crates/meroctl/src/cli/context/proposals.rs
@@ -38,7 +38,7 @@ pub enum ProposalsSubcommand {
         #[arg(
             long,
             help = "Maximum number of proposals to display in results",
-            default_value = "20"
+            default_value = "1"
         )]
         limit: usize,
     },


### PR DESCRIPTION
# [meroctl] set default proposals limit to 1

## Description
This PR updates the default value for the `--limit` argument in the `proposals list` command from 20 to 1. 
This aligns with the requirements specified in issue #1108.

**Recovery Note:**
I apologize for the previous messy PRs (#1813). I realized that relying on the GitHub web editor introduced unnecessary merge commits and unintentional scope creep. 
I've switched to a clean local CLI workflow. This is a surgical, single-commit fix with no merge commits and no server-side changes.

## Test plan
I've verified the change locally by inspecting the CLI argument defaults.
Reproduction:
1. Run `meroctl proposals list --help`
2. Verify that `[default: 1]` is shown for the `--limit` option.

## Documentation update
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI-only behavior change; it only alters the default pagination size for `meroctl proposals list` and does not affect server-side logic or data handling.
> 
> **Overview**
> Changes the default value of the `--limit` argument for `meroctl proposals list` from `20` to `1`, reducing the number of proposals shown when the flag is omitted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3229c21a9a8e29b508a1a719b5b29a44582d1574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->