### PR TITLE
fix: rustfmt code formatting

### DIFF
--- a/crates/server/src/admin/handlers/get_latest_version.rs
+++ b/crates/server/src/admin/handlers/get_latest_version.rs
@@ -23,10 +23,7 @@ pub async fn handler(
         Ok(Some((version, application_id))) => {
             info!(package=%package, %version, application_id=%application_id, "Latest version retrieved successfully");
             ApiResponse {
-                payload: GetLatestVersionResponse::new(
-                    Some(application_id),
-                    Some(version),
-                ),
+                payload: GetLatestVersionResponse::new(Some(application_id), Some(version)),
             }
             .into_response()
         }


### PR DESCRIPTION
# Fix rustfmt formatting in `get_latest_version` handler

## Description

This PR applies `rustfmt` formatting to the `GetLatestVersionResponse::new` call within the `get_latest_version` handler.
The change resolves a `rustfmt` error and ensures consistent code style.

## Test plan

This is a purely cosmetic formatting change; the functionality remains identical.
To verify, run `cargo fmt --check` on the affected file, `crates/server/src/admin/handlers/get_latest_version.rs`, which should now pass without issues.
No new end-to-end tests are required, and there are no UI changes.

## Documentation update

None.

---
<a href="https://cursor.com/background-agent?bcId=bc-28b9f7ba-d111-4da9-b77c-e7385609429d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28b9f7ba-d111-4da9-b77c-e7385609429d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change is purely formatting and does not alter control flow or data handling.
> 
> **Overview**
> Updates the admin `get_latest_version` handler to format the `GetLatestVersionResponse::new` invocation onto a single line to satisfy `rustfmt` and keep style consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d058d5b29e252e3ee5198c54a46d4a3bb3e134ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->