### PR TITLE
docs: Explain why RocksDB doesn't need external connection pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6703,6 +6703,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",

--- a/crates/server/src/admin/handlers/get_latest_version.rs
+++ b/crates/server/src/admin/handlers/get_latest_version.rs
@@ -23,10 +23,7 @@ pub async fn handler(
         Ok(Some((version, application_id))) => {
             info!(package=%package, %version, application_id=%application_id, "Latest version retrieved successfully");
             ApiResponse {
-                payload: GetLatestVersionResponse::new(
-                    Some(application_id),
-                    Some(version),
-                ),
+                payload: GetLatestVersionResponse::new(Some(application_id), Some(version)),
             }
             .into_response()
         }


### PR DESCRIPTION
^^^

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the RocksDB `Database::open` configuration, which can affect runtime file-descriptor usage and performance characteristics. Other changes are documentation/tests and a small handler formatting tweak.
> 
> **Overview**
> **RocksDB backend:** Adds extensive module/docs comments explaining why RocksDB doesn’t need external connection pooling, and makes resource defaults explicit via new constants; `Database::open` now sets `max_open_files` (256) in addition to the existing block-cache configuration.
> 
> **Tests/odds & ends:** Adds a new RocksDB test that verifies data persists across open/close cycles, includes a small formatting-only change in `get_latest_version` handler response construction, and updates `Cargo.lock` to include `tempfile`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a833220ca18ab18885fe6754be056ea2236da8a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->