### PR TITLE
fix: Avoid GitHub API for webui download in CI

### DIFF
--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -25,7 +25,8 @@ const FRESHNESS_LIFETIME: u64 = 60 * 60 * 24 * 7; // 1 week
 const CALIMERO_WEBUI_REPO: &str = "calimero-network/admin-dashboard";
 const CALIMERO_WEBUI_VERSION: &str = "latest";
 const CALIMERO_WEBUI_DEFAULT_ASSET: &str = "admin-dashboard-build.zip";
-const CALIMERO_WEBUI_RELEASE_API_URL: &str = "https://api.github.com/repos/{repo}/releases/{version}";
+const CALIMERO_WEBUI_RELEASE_API_URL: &str =
+    "https://api.github.com/repos/{repo}/releases/{version}";
 const CALIMERO_WEBUI_RELEASE_DOWNLOAD_LATEST_URL: &str =
     "https://github.com/{repo}/releases/latest/download/{asset}";
 const CALIMERO_WEBUI_RELEASE_DOWNLOAD_TAG_URL: &str =

--- a/crates/server/src/admin/handlers/get_latest_version.rs
+++ b/crates/server/src/admin/handlers/get_latest_version.rs
@@ -23,10 +23,7 @@ pub async fn handler(
         Ok(Some((version, application_id))) => {
             info!(package=%package, %version, application_id=%application_id, "Latest version retrieved successfully");
             ApiResponse {
-                payload: GetLatestVersionResponse::new(
-                    Some(application_id),
-                    Some(version),
-                ),
+                payload: GetLatestVersionResponse::new(Some(application_id), Some(version)),
             }
             .into_response()
         }


### PR DESCRIPTION
# Fix: Avoid GitHub API for webui download in CI

## Description

This PR fixes CI failures caused by GitHub API rate limit exhaustion when `crates/server/build.rs` attempts to resolve the `admin-dashboard` asset.

The `build.rs` script now prioritizes direct download URLs for the `admin-dashboard` asset, bypassing the GitHub API for common scenarios. This prevents `secrets.GITHUB_TOKEN` from hitting its shared rate limit during concurrent PR builds.

The GitHub API is now only used as a fallback when a non-default repository is specified and no `CALIMERO_WEBUI_ASSET` environment variable is provided.

## Test plan

The fix addresses CI stability. Verification involves observing successful CI runs on pull requests, which previously failed due to the described rate limit issue. No specific new tests were run as part of this change.

## Documentation update

No public documentation update is required. For internal reference, if the `admin-dashboard` asset name changes or a custom repository is used, the `CALIMERO_WEBUI_ASSET` environment variable can be set in the workflow to specify the asset name and avoid API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-8278c8a8-00e0-4e55-8c98-fb7816ec25ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8278c8a8-00e0-4e55-8c98-fb7816ec25ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and limited to build-time WebUI fetching logic; main risk is misconfiguration or asset-name mismatches causing build failures when using non-default repos/versions.
> 
> **Overview**
> Build-time WebUI fetching now **prefers direct GitHub release download URLs** (using a new default asset `admin-dashboard-build.zip` and `release_download_url()`), reducing reliance on the GitHub Releases API and avoiding CI rate-limit issues.
> 
> The GitHub API lookup is now only used as a fallback when a **non-default repo** is configured *and* no `CALIMERO_WEBUI_ASSET` is provided; otherwise the script constructs the download URL directly. Also includes a small formatting-only change in `get_latest_version` handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3564d75a27a336f0c14bee252ec6392b3c2bc2db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->