### PR TITLE
fix: Implement WASM module size limits

### DIFF
--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -47,7 +47,7 @@ pub enum FunctionCallError {
     HostError(HostError),
     #[error("the method call returned an error: {0:?}")]
     ExecutionError(Vec<u8>),
-    #[error("module size limit (max_module_size) exceeded: size {size} bytes exceeds maximum {max} bytes")]
+    #[error("module size limit (max_module_size) exceeded: {size} bytes > {max} bytes limit")]
     ModuleSizeLimitExceeded { size: u64, max: u64 },
 }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -441,9 +441,9 @@ mod integration_tests_package_usage {
     use {eyre as _, owo_colors as _, rand as _, wat as _};
 }
 
-/// Integration tests for WASM execution with panic handling
+/// Integration tests for WASM execution (panic handling, size limits, compilation)
 #[cfg(test)]
-mod wasm_panic_integration_tests {
+mod wasm_integration_tests {
     use super::*;
     use crate::store::InMemoryStorage;
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -162,6 +162,10 @@ pub struct VMLimits {
     /// The maximum size of a WASM module in bytes before compilation.
     /// This limit prevents memory exhaustion attacks from large malicious modules.
     /// Setting this to 0 will reject all non-empty modules.
+    ///
+    /// **Configuration guidance**: Typical WASM modules range from 100 KiB to a few MiB.
+    /// The default of 10 MiB accommodates most applications while preventing memory
+    /// exhaustion. Consider reducing for memory-constrained environments.
     pub max_module_size: u64,
 }
 


### PR DESCRIPTION
# fix: Implement WASM module size limits

## Description

This PR implements a configurable maximum size limit for WASM modules before compilation. This addresses a security vulnerability where a large malicious module could exhaust memory during the compilation process.

The `Engine::compile` method now performs a size check against `self.limits.max_module_size`. If the module exceeds this limit, a `FunctionCallError::ModuleSizeLimitExceeded` error is returned. A default maximum module size of 10 MiB has been added to `VMLimits`.

This change fixes the bounty: "Implement WASM module size limits".

## Test plan

The following tests were added to `crates/runtime/src/lib.rs` to verify the changes:

-   `test_wasm_module_size_limit`: Ensures that modules exceeding the configured size limit are rejected with the appropriate error.
-   `test_wasm_module_within_size_limit`: Confirms that modules within the size limit compile successfully.
-   `test_default_engine_module_size_limit`: Verifies that the `VMLimits::default()` sets the `max_module_size` to the expected 10 MiB.

To reproduce, run `cargo test` in the `crates/runtime` directory. All existing tests, including the new ones, should pass.

It is possible to add an end-to-end test that attempts to deploy an oversized WASM module and asserts the failure, but this PR focuses on the minimal runtime change.

## Documentation update

No public or internal documentation updates are required for this change.

---
<a href="https://cursor.com/background-agent?bcId=bc-287b8081-2d94-4398-a78a-5564d2db0421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-287b8081-2d94-4398-a78a-5564d2db0421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a public API change (`Engine::compile` now returns `FunctionCallError`) and new early-reject behavior that can affect module deployment/execution flows if limits are misconfigured.
> 
> **Overview**
> Adds a **pre-compilation WASM size check** in `Engine::compile`, rejecting oversized binaries to mitigate memory-exhaustion during compilation and emitting `FunctionCallError::ModuleSizeLimitExceeded`.
> 
> Introduces `VMLimits::max_module_size` (default **10 MiB**) and expands integration tests to cover size-limit rejection, boundary conditions, and that normal compilation errors are still propagated; `from_precompiled` gains explicit safety/security documentation about skipping size checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2d242f42aed88d31545fc9a9d1463a280679ee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->