### PR TITLE
Flaky tests analysis

### DIFF
--- a/.github/workflows/merobox-e2e.yml
+++ b/.github/workflows/merobox-e2e.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Run merobox workflow examples
         run: |
           set -euo pipefail
+          export PATH="$GITHUB_WORKSPACE/target/debug:$PATH"
+          cd merobox
           merobox --version
 
           workflows=(
@@ -77,7 +79,7 @@ jobs:
 
           for workflow in "${workflows[@]}"; do
             echo "Running workflow: $workflow"
-            if ! merobox bootstrap run "merobox/${workflow}" \
+            if ! merobox bootstrap run "${workflow}" \
               --no-docker \
               --binary-path "$GITHUB_WORKSPACE/target/debug/merod" \
               --e2e-mode \
@@ -96,7 +98,7 @@ jobs:
 
             still_failed=()
             for workflow in "${failed_workflows[@]}"; do
-              if ! merobox bootstrap run "merobox/${workflow}" \
+              if ! merobox bootstrap run "${workflow}" \
                 --no-docker \
                 --binary-path "$GITHUB_WORKSPACE/target/debug/merod" \
                 --e2e-mode \


### PR DESCRIPTION
# Merobox E2E Workflows for Core CI

## Description

This PR introduces a new GitHub Actions workflow, `.github/workflows/merobox-e2e.yml`, to the `calimero-network/core` repository.

The motivation for this change is to address consistently failing, flaky E2E tests in the `merobox` repository's CI, specifically `workflow-open-invitation-example.yml` and `workflow-propagation-monitoring.yml`. These failures indicate potential eventual consistency or state propagation issues within `core`.

Currently, `merobox` CI uses an older, pinned `merod` binary and runs these specific E2E tests, which `core`'s CI does not. This discrepancy means `core` PRs pass while `merobox` CI fails, masking underlying `core` bugs.

By integrating these critical E2E tests directly into `core`'s CI, we aim to:
1.  Ensure `core` PRs are tested against the exact scenarios that expose these flaky behaviors.
2.  Enable direct debugging and fixing of the underlying `core` issues causing propagation failures, using the `merod` binary built from the PR branch.

The new workflow builds `merod` from the current PR and executes the two identified flaky merobox workflows with retries.

## Test plan

This PR itself introduces new E2E tests. The success or failure of the new `merobox-e2e` workflow on subsequent `core` PRs will serve as the validation. The workflow is configured to run on `push` and `pull_request` events to `master` affecting `crates/**`, `apps/**`, or the workflow file itself. No user interface changes are involved.

## Documentation update

No immediate public documentation update is required. Internal CI documentation might need to be updated to reflect the addition of this new workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bbd43b8-5b8b-436a-bceb-a7c8cd4beac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0bbd43b8-5b8b-436a-bceb-a7c8cd4beac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

