### PR TITLE
feat(sync): 003 - Sync Handshake Protocol Messages

### DIFF
--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -64,7 +64,7 @@ pub enum SyncProtocol {
     /// Best for: Large trees with small diff (<10% divergence).
     BloomFilter {
         /// Size of the bloom filter in bits.
-        filter_size: usize,
+        filter_size: u64,
         /// Expected false positive rate (0.0 to 1.0).
         false_positive_rate: f64,
     },
@@ -82,7 +82,7 @@ pub enum SyncProtocol {
     /// Best for: Trees with depth ≤ 2 and many children.
     LevelWise {
         /// Maximum depth to sync.
-        max_depth: usize,
+        max_depth: u32,
     },
 }
 
@@ -100,7 +100,7 @@ pub struct SyncCapabilities {
     /// Whether compression is supported.
     pub supports_compression: bool,
     /// Maximum entities per batch transfer.
-    pub max_batch_size: usize,
+    pub max_batch_size: u64,
     /// Protocols this node supports (ordered by preference).
     pub supported_protocols: Vec<SyncProtocol>,
 }
@@ -140,9 +140,9 @@ pub struct SyncHandshake {
     /// Current Merkle root hash.
     pub root_hash: [u8; 32],
     /// Number of entities in the tree.
-    pub entity_count: usize,
+    pub entity_count: u64,
     /// Maximum depth of the Merkle tree.
-    pub max_depth: usize,
+    pub max_depth: u32,
     /// Current DAG heads (latest delta IDs).
     pub dag_heads: Vec<[u8; 32]>,
     /// Whether this node has any state.
@@ -156,8 +156,8 @@ impl SyncHandshake {
     #[must_use]
     pub fn new(
         root_hash: [u8; 32],
-        entity_count: usize,
-        max_depth: usize,
+        entity_count: u64,
+        max_depth: u32,
         dag_heads: Vec<[u8; 32]>,
     ) -> Self {
         let has_state = root_hash != [0; 32];
@@ -203,7 +203,7 @@ pub struct SyncHandshakeResponse {
     /// Responder's current root hash.
     pub root_hash: [u8; 32],
     /// Responder's entity count.
-    pub entity_count: usize,
+    pub entity_count: u64,
     /// Responder's capabilities.
     pub capabilities: SyncCapabilities,
 }
@@ -211,7 +211,7 @@ pub struct SyncHandshakeResponse {
 impl SyncHandshakeResponse {
     /// Create a response indicating no sync is needed.
     #[must_use]
-    pub fn already_synced(root_hash: [u8; 32], entity_count: usize) -> Self {
+    pub fn already_synced(root_hash: [u8; 32], entity_count: u64) -> Self {
         Self {
             selected_protocol: SyncProtocol::None,
             root_hash,
@@ -225,7 +225,7 @@ impl SyncHandshakeResponse {
     pub fn with_protocol(
         selected_protocol: SyncProtocol,
         root_hash: [u8; 32],
-        entity_count: usize,
+        entity_count: u64,
     ) -> Self {
         Self {
             selected_protocol,


### PR DESCRIPTION
## Summary

Implements issue #1770 - **Sync Handshake Protocol Messages** from the Sync Protocol series (CIP §2).

This is a **foundation issue** that defines the wire protocol types for sync negotiation between peers.

## Changes

### New Types in `crates/node/primitives/src/sync.rs`

| Type | Description |
|------|-------------|
| `SYNC_PROTOCOL_VERSION` | Wire protocol version constant (v1) |
| `SyncProtocol` | 7-variant enum for sync strategies |
| `SyncCapabilities` | Peer capabilities for negotiation |
| `SyncHandshake` | Initiator → Responder message |
| `SyncHandshakeResponse` | Responder → Initiator message |

### SyncProtocol Variants

- `None` - Already in sync
- `DeltaSync` - DAG-based delta transfer
- `HashComparison` - Merkle tree comparison
- `Snapshot` - Full state transfer (fresh nodes only, per I5)
- `BloomFilter` - Probabilistic diff detection
- `SubtreePrefetch` - Deep localized changes
- `LevelWise` - Wide shallow trees

## Tests

8 unit tests for serialization roundtrip and helper methods:
- `test_sync_protocol_roundtrip`
- `test_sync_capabilities_roundtrip`
- `test_sync_handshake_roundtrip`
- `test_sync_handshake_response_roundtrip`
- `test_sync_handshake_version_compatibility`
- `test_sync_handshake_in_sync_detection`
- `test_sync_handshake_fresh_node`
- `test_sync_handshake_response_already_synced`

## What's NOT in this PR

- Wire integration (`InitPayload`/`MessagePayload`) - deferred to #1771
- Protocol selection algorithm - deferred to #1771
- Actual sync flow changes

## CIP Reference

- §2 - Sync Handshake Protocol
- Invariant I5 (No Silent Data Loss) - documented in Snapshot variant
- Invariant I11 (Protocol Honesty) - enabled by SyncCapabilities

## Checklist

- [x] Handshake messages serialize/deserialize correctly
- [x] Version mismatch detection
- [x] Unit tests for all message types
- [x] Doc comments with CIP references

Closes #1770

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new public, Borsh-serialized primitives that other nodes/components will depend on, so any future changes are wire-compatibility sensitive; however this PR doesn’t alter runtime sync behavior yet.
> 
> **Overview**
> Defines the *CIP §2 sync handshake wire format* in `crates/node/primitives/src/sync.rs`, adding `SYNC_PROTOCOL_VERSION`, the `SyncProtocol` strategy enum, `SyncCapabilities`, and the initiator/responder messages `SyncHandshake` and `SyncHandshakeResponse` with small helper constructors/checks.
> 
> Adds unit tests to validate Borsh serialization roundtrips and basic helpers (version compatibility, in-sync detection, fresh-node detection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3b891ef74ab36c8fcbe8ce53e3c637514910669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->