### PR TITLE
chore: bump version to rc40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.39"
+version = "0.10.0-rc.40"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.39"
+version = "0.10.0-rc.40"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# chore: bump version to rc40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure version metadata bump with no functional code changes; low risk aside from standard release/version propagation impacts.
> 
> **Overview**
> Bumps the `calimero-version` crate version from `0.10.0-rc.39` to `0.10.0-rc.40`, updating both `crates/version/Cargo.toml` and the `Cargo.lock` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c64476da69915e6ba5e202b4adbd780576d85fc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->