### PR TITLE
fix(ci): specify download path for e2e-rust-apps-release artifacts 

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: e2e-rust-apps-release-build-artifacts
+          path: apps
 
       - name: Determine Docker image tag
         id: image-tag


### PR DESCRIPTION
# [ci] Fix e2e release workflow app path by extracting artifact into apps

## Description

The E2E Rust Apps (Released Image) workflow was failing on master after the build-apps job succeeded: the "Install application on node-1" step reported "Application path not found or not a file" for `apps/e2e-kv-store/res/e2e_kv_store.wasm` and `apps/xcall-example/res/xcall_example.wasm`.

Cause: `upload-artifact` uses the least common ancestor of the uploaded paths as the artifact root. With `apps/e2e-kv-store/res/*.wasm` and `apps/xcall-example/res/*.wasm`, that root is `apps/`, so the zip contains `e2e-kv-store/res/...` and `xcall-example/res/...` (no `apps/` prefix). The test job was downloading into the default `$GITHUB_WORKSPACE`, so files landed at `e2e-kv-store/res/` and `xcall-example/res/` instead of `apps/e2e-kv-store/res/` and `apps/xcall-example/res/`, while the workflow YAML resolves `path: res/e2e_kv_store.wasm` relative to the workflow file and expects `apps/e2e-kv-store/res/...`.

Fix: set `path: apps` on the download-artifact step so the artifact is extracted into the repo’s `apps/` directory. The extracted `e2e-kv-store/` and `xcall-example/` directories then sit under `apps/`, matching where the workflow runner looks for the WASM files.

No product/code changes; CI workflow only.

## Test plan

- `cargo check --workspace` (no code change).
- After merge, the workflow runs on push to `master` (or via workflow_dispatch). Confirm the "Run e2e-kv-store Workflow" and "Run xcall-example Workflow" steps pass and the install step no longer reports "Application path not found".
- Optionally trigger the workflow manually once to validate before/after.

## Documentation update

None. Change is limited to workflow configuration; AGENTS.md and README already describe the workflow at a high level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that affects CI artifact placement; low blast radius but could still break the e2e job if the path is incorrect.
> 
> **Overview**
> Fixes the `E2E - Rust Apps (Released Image)` workflow by setting `actions/download-artifact` to extract `e2e-rust-apps-release-build-artifacts` into the `apps/` directory, aligning the downloaded artifact layout with later steps that expect files under `apps/...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c522c0dc911aecdc34f301c3f90279f3a01939af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->