### PR TITLE
feat(meroctl): implement --latest flag for proposals and fix default limits

### DIFF
--- a/crates/meroctl/src/cli/context/proposals.rs
+++ b/crates/meroctl/src/cli/context/proposals.rs
@@ -41,6 +41,10 @@ pub enum ProposalsSubcommand {
             default_value = "20"
         )]
         limit: usize,
+
+        /// Display the latest proposal only (shorthand for --limit 1)
+        #[arg(long, short, help = "Display the latest proposal only")]
+        latest: bool,
     },
     #[command(about = "Create a proposal and immediately approve it")]
     CreateAndApprove {
@@ -88,8 +92,12 @@ impl ProposalsCommand {
             ProposalsSubcommand::List {
                 context,
                 offset,
-                limit,
+                mut limit,
+                latest,
             } => {
+                if latest {
+                    limit = 1;
+                }
                 let client = environment.client()?;
 
                 let context_id = client


### PR DESCRIPTION
# meroctl: add --latest flag to proposals and restore default limits

## Description

Following the discussion in #1843, I've updated the implementation to satisfy both the unconventional default concern and the original requirement in #1108.

- Restored standard default limit of 20 for consistency.
- Introduced `--latest` / `-l` flag which overrides the limit to 1. 
- Cleaned up the help text.

Fixes #1108

## Test plan

- Verified that `meroctl proposals list` defaults to 20 results using the standard CLI argument parsing.
- Verified that `meroctl proposals list --latest` (or `-l`) correctly overrides the limit to 1 in the logic.
- Checked help text formatting with `meroctl proposals list --help`.
- Validated code style and formatting with `cargo fmt --check`.

## Documentation update