### PR TITLE
fix(sync-sim): bug fixes, optimizations, and agent documentation

### DIFF
--- a/.cursor/rules/sync-protocol-testing.mdc
+++ b/.cursor/rules/sync-protocol-testing.mdc
@@ -1,0 +1,65 @@
+# Sync Protocol Testing Requirements
+
+## Scope
+
+This rule applies when working on sync protocol issues #1768 through #1785.
+
+## Mandatory Simulation Tests
+
+When implementing any sync protocol issue, you MUST:
+
+1. **Write simulation tests** using the sync_sim framework
+2. **Place tests in the correct location:**
+   - Protocol behavior tests → `crates/node/tests/sync_scenarios/`
+   - Compliance tests (issue #1785) → `crates/node/tests/sync_compliance/`
+3. **Read the agent guide first:** `crates/node/tests/sync_sim/AGENT_GUIDE.md`
+
+## Test Requirements
+
+Each sync protocol change MUST have tests that verify:
+
+1. **Happy path**: Normal operation converges correctly
+2. **Fault tolerance**: Behavior under message loss, latency, reorder
+3. **Partition tolerance**: Behavior during and after network partitions
+4. **Edge cases**: Empty state, single node, maximum load
+
+## Example Test Structure
+
+```rust
+#[test]
+fn test_issue_NNNN_feature_name() {
+    let mut rt = SimRuntime::with_seed(42);
+    
+    // Setup scenario relevant to the issue
+    let scenario = Scenario::...;
+    rt.apply_scenario(scenario);
+    
+    // Trigger the specific behavior being tested
+    // ...
+    
+    // Run simulation
+    rt.run();
+    
+    // Assert expected outcomes
+    assert_converged!(rt);
+}
+```
+
+## PR Checklist
+
+Before submitting a PR for sync protocol issues:
+
+- [ ] Simulation tests added in `sync_scenarios/` or `sync_compliance/`
+- [ ] Tests cover happy path and at least one fault scenario
+- [ ] Tests are deterministic (use fixed seeds)
+- [ ] All existing simulation tests pass (`cargo test --test sync_sim`)
+- [ ] Referenced CIP section in test comments
+
+## Framework Documentation
+
+Full framework documentation: `crates/node/tests/sync_sim/AGENT_GUIDE.md`
+
+Key imports:
+```rust
+use crate::sync_sim::prelude::*;
+```

--- a/crates/node/tests/sync_compliance/mod.rs
+++ b/crates/node/tests/sync_compliance/mod.rs
@@ -1,0 +1,19 @@
+//! Sync Protocol Compliance Test Suite
+//!
+//! This module implements the compliance test suite defined in issue #1785.
+//! Tests verify that the sync protocol implementation meets all CIP requirements.
+//!
+//! ## Categories (from issue #1785)
+//!
+//! - Negotiation compliance
+//! - Buffering compliance  
+//! - CRDT merge compliance
+//! - Convergence compliance
+//! - Security compliance
+//!
+//! ## Adding Tests
+//!
+//! See `../sync_sim/AGENT_GUIDE.md` for framework usage.
+//! Each test should reference the specific CIP section it validates.
+
+// Compliance tests will be added when implementing issue #1785

--- a/crates/node/tests/sync_scenarios/mod.rs
+++ b/crates/node/tests/sync_scenarios/mod.rs
@@ -1,0 +1,19 @@
+//! Sync Protocol Scenario Tests
+//!
+//! This module contains simulation-based tests for sync protocol behavior.
+//! Each test validates specific protocol scenarios using the sync_sim framework.
+//!
+//! ## Adding New Tests
+//!
+//! See `../sync_sim/AGENT_GUIDE.md` for detailed instructions.
+//!
+//! ## Test Categories
+//!
+//! - `negotiation.rs` - Protocol negotiation tests
+//! - `snapshot.rs` - Snapshot sync path tests
+//! - `hash_compare.rs` - Hash comparison sync tests
+//! - `delta.rs` - Delta exchange tests
+//! - `partitions.rs` - Network partition tests
+//! - `failures.rs` - Fault tolerance tests
+
+// Tests will be added as sync protocol issues are implemented

--- a/crates/node/tests/sync_sim.rs
+++ b/crates/node/tests/sync_sim.rs
@@ -199,18 +199,16 @@ mod tests {
         let a = rt.add_node("alice");
         let b = rt.add_node("bob");
 
-        // All messages should be lost
-        rt.inject_message(
-            a,
-            b,
-            SyncMessage::SyncComplete { success: true },
-            SimDuration::from_millis(10),
-        )
-        .expect("sender node should exist");
+        // Send message through network router (with fault injection)
+        rt.send_message(a, b, SyncMessage::SyncComplete { success: true })
+            .expect("sender node should exist");
 
-        // Queue should be empty (message lost at send time)
-        // Note: The inject_message uses node's next_message_id, then routes through network
-        // But with 100% loss, message is dropped
+        // Verify message was dropped due to loss
+        assert_eq!(
+            rt.network().metrics.messages_dropped_loss,
+            1,
+            "Message should have been dropped due to 100% loss rate"
+        );
     }
 
     // =========================================================================

--- a/crates/node/tests/sync_sim/AGENT_GUIDE.md
+++ b/crates/node/tests/sync_sim/AGENT_GUIDE.md
@@ -1,0 +1,221 @@
+# Sync Protocol Simulation Framework - Agent Guide
+
+This guide is for AI agents working on the Calimero sync protocol implementation.
+
+## Framework Location
+
+```
+crates/node/tests/
+├── sync_sim/              # Simulation framework (DO NOT MODIFY without review)
+│   ├── mod.rs             # Main module, prelude exports
+│   ├── actions.rs         # SyncMessage, SyncActions (effects model)
+│   ├── types.rs           # NodeId, MessageId, EntityId, etc.
+│   ├── runtime/           # SimClock, SimRng, EventQueue
+│   ├── network/           # NetworkRouter, FaultConfig, PartitionManager
+│   ├── node/              # SimNode state machine
+│   ├── scenarios/         # Deterministic and random scenario generators
+│   ├── convergence.rs     # Convergence checking (C1-C5 properties)
+│   ├── digest.rs          # StateDigest computation
+│   ├── metrics.rs         # SimMetrics collection
+│   └── assertions.rs      # Test assertion macros
+├── sync_sim.rs            # Framework unit tests
+├── sync_scenarios/        # Protocol behavior tests (ADD NEW TESTS HERE)
+└── sync_compliance/       # Compliance suite for issue #1785
+```
+
+## Quick Start
+
+```rust
+use crate::sync_sim::prelude::*;
+
+#[test]
+fn test_example() {
+    // Create runtime with seed for reproducibility
+    let mut rt = SimRuntime::with_seed(42);
+    
+    // Add nodes with a scenario
+    let scenario = Scenario::n_nodes_synced(3, 10); // 3 nodes, 10 shared entities
+    let nodes = rt.apply_scenario(scenario);
+    
+    // Run until convergence or timeout
+    let result = rt.run();
+    
+    // Assert convergence
+    assert_converged!(rt);
+    assert_eq!(result, StopCondition::Converged);
+}
+```
+
+## Key Concepts
+
+### SimRuntime
+The orchestrator. Manages clock, event queue, nodes, and network.
+
+```rust
+let mut rt = SimRuntime::with_seed(42);           // Basic
+let mut rt = SimRuntime::with_config(config);     // With custom config
+
+rt.add_node("alice");                              // Add empty node
+rt.apply_scenario(scenario);                       // Add nodes with state
+rt.run();                                          // Run to completion
+rt.run_until(|rt| rt.clock().now() > 1000.into()); // Run with predicate
+rt.step();                                         // Single event step
+```
+
+### Scenarios
+
+**Deterministic** (for specific test cases):
+```rust
+Scenario::n_nodes_synced(n, entities)      // All nodes have same state
+Scenario::n_nodes_diverged(n, entities)    // Each node has unique state
+Scenario::partial_overlap(n, shared, unique) // Mix of shared/unique
+Scenario::force_snapshot()                 // Forces snapshot sync path
+Scenario::force_none()                     // Empty nodes
+```
+
+**Random** (for property-based testing):
+```rust
+let config = RandomScenarioConfig::new(seed)
+    .with_node_count(3, 5)
+    .with_entity_count(10, 100)
+    .with_divergence(0.3);
+let scenario = RandomScenario::generate(&config);
+```
+
+### Fault Injection
+
+```rust
+let config = SimConfig::with_seed(42)
+    .with_faults(FaultConfig::default()
+        .with_loss(0.1)              // 10% message loss
+        .with_latency(50, 10)        // 50ms base, 10ms jitter
+        .with_reorder_window(100)    // 100ms reorder window
+        .with_duplicate(0.05));      // 5% duplication
+
+// Network partitions
+rt.partition_bidirectional(&alice, &bob, None);           // Permanent
+rt.partition_bidirectional(&alice, &bob, Some(1000.into())); // Temporary
+rt.heal_partition(&alice, &bob);
+```
+
+### Assertions
+
+```rust
+assert_converged!(rt);                    // All nodes converged
+assert_not_converged!(rt);                // Not converged
+assert_entity_count!(rt, "alice", 10);    // Node has N entities
+assert_has_entity!(rt, "alice", entity_id); // Node has specific entity
+assert_idle!(rt, "alice");                // Node is idle (no pending work)
+assert_buffer_empty!(rt, "alice");        // Delta buffer is empty
+```
+
+### Metrics
+
+```rust
+let metrics = rt.metrics();
+metrics.protocol.messages_sent;
+metrics.protocol.bytes_sent;
+metrics.effects.messages_dropped;
+metrics.convergence.converged;
+metrics.convergence.time_to_converge;
+```
+
+## Writing Tests
+
+### Where to Put Tests
+
+| Test Type | Location | When to Use |
+|-----------|----------|-------------|
+| Framework tests | `sync_sim.rs` | Testing the framework itself |
+| Protocol scenarios | `sync_scenarios/*.rs` | Testing sync protocol behavior |
+| Compliance tests | `sync_compliance/*.rs` | Issue #1785 compliance suite |
+
+### Test Patterns
+
+**Basic convergence test:**
+```rust
+#[test]
+fn test_two_nodes_converge() {
+    let mut rt = SimRuntime::with_seed(42);
+    let scenario = Scenario::n_nodes_diverged(2, 10);
+    rt.apply_scenario(scenario);
+    
+    rt.run();
+    
+    assert_converged!(rt);
+}
+```
+
+**Fault tolerance test:**
+```rust
+#[test]
+fn test_convergence_with_packet_loss() {
+    let config = SimConfig::with_seed(42)
+        .with_faults(FaultConfig::default().with_loss(0.2));
+    let mut rt = SimRuntime::with_config(config);
+    
+    // ... setup and run
+    
+    assert_converged!(rt);
+}
+```
+
+**Partition healing test:**
+```rust
+#[test]
+fn test_partition_healing() {
+    let mut rt = SimRuntime::with_seed(42);
+    let [a, b] = rt.apply_scenario(Scenario::n_nodes_diverged(2, 5));
+    
+    // Partition for 1000 ticks
+    rt.partition_bidirectional(&a, &b, Some(1000.into()));
+    
+    rt.run();
+    
+    assert_converged!(rt); // Should converge after partition heals
+}
+```
+
+**Property-based test:**
+```rust
+#[test]
+fn test_random_scenarios_converge() {
+    for seed in 0..100 {
+        let config = RandomScenarioConfig::new(seed)
+            .with_node_count(2, 5)
+            .with_entity_count(5, 20);
+        
+        let mut rt = SimRuntime::with_seed(seed);
+        rt.apply_scenario(RandomScenario::generate(&config));
+        
+        let result = rt.run();
+        
+        assert!(
+            matches!(result, StopCondition::Converged),
+            "Seed {} failed to converge", seed
+        );
+    }
+}
+```
+
+## Invariants (DO NOT BREAK)
+
+1. **Determinism**: Same seed MUST produce identical results
+2. **No silent drops**: All message drops must be recorded in metrics
+3. **Convergence properties C1-C5**: See `convergence.rs` for formal definitions
+4. **Time monotonicity**: SimClock never goes backwards
+
+## Debugging Failures
+
+1. **Get the seed**: All random tests should log their seed
+2. **Reproduce locally**: `SimRuntime::with_seed(failing_seed)`
+3. **Step through**: Use `rt.step()` instead of `rt.run()`
+4. **Check metrics**: `rt.metrics()` shows what happened
+5. **Check convergence**: `rt.check_convergence()` returns detailed status
+
+## Common Mistakes
+
+- **Forgetting seed**: Always use deterministic seeds for reproducibility
+- **Not checking StopCondition**: `run()` returns why it stopped
+- **Ignoring metrics**: Metrics reveal silent failures
+- **Hardcoding time**: Use `SimTime` and `SimDuration`, not raw numbers

--- a/crates/node/tests/sync_sim/digest.rs
+++ b/crates/node/tests/sync_sim/digest.rs
@@ -14,6 +14,8 @@ pub fn hash_metadata(metadata: &EntityMetadata) -> [u8; 32] {
     let mut hasher = Sha256::new();
 
     // CrdtType discriminant
+    // IMPORTANT: These discriminant values must remain stable for digest compatibility.
+    // Changing them will cause different digests for the same data across versions.
     match &metadata.crdt_type {
         calimero_primitives::crdt::CrdtType::LwwRegister => hasher.update([0u8]),
         calimero_primitives::crdt::CrdtType::GCounter => hasher.update([1u8]),


### PR DESCRIPTION
## Summary

Follow-up fixes and documentation for the sync simulation framework (after #1943 was merged).

### Bug Fixes
- Add `send_message` helper for proper fault injection testing
- Use `estimated_size()` for accurate message size metrics (heap-aware)
- Remove incorrect reorder metric counting (delay ≠ actual reorder)
- Add partition drops to effect metrics (`record_drop` in `should_deliver`)
- Fix deadlock detection in `run_until()` (was returning `Manual`)
- Change `drain_inbox_per_tick` to `assert` (not `debug_assert`)
- Document CRDT discriminant stability requirement

### Performance
- Cache `check_convergence()` result to avoid redundant computation

### Documentation
- Add `AGENT_GUIDE.md` for AI agents working on sync protocol
- Create `sync_scenarios/` directory for protocol behavior tests  
- Create `sync_compliance/` directory for issue #1785 compliance suite
- Add cursor rule requiring simulation tests for issues #1768-#1785

## Files Changed

| File | Change |
|------|--------|
| `sync_sim/AGENT_GUIDE.md` | New - framework usage guide for agents |
| `sync_scenarios/mod.rs` | New - placeholder for protocol tests |
| `sync_compliance/mod.rs` | New - placeholder for #1785 compliance |
| `.cursor/rules/sync-protocol-testing.mdc` | New - rule for sync issues |
| `sync_sim/actions.rs` | Add `estimated_size()` method |
| `sync_sim/network/router.rs` | Use `estimated_size()`, fix reorder metric |
| `sync_sim/sim_runtime.rs` | Fix `run_until()`, cache convergence, add `send_message` |
| `sync_sim/digest.rs` | Document discriminant stability |
| `sync_sim.rs` | Update `test_fault_injection_loss` to use `send_message` |

## Test Plan

- [x] All 131 sync_sim tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core simulation runtime/network semantics and metrics accounting (stop conditions, message sizing, drop/reorder counting), which could affect many existing tests and any consumers relying on these metrics or termination behavior.
> 
> **Overview**
> Improves the sync simulation framework’s correctness and observability by routing test messages through the fault-injecting network path, recording partition drops in effect metrics, and fixing `run()`/`run_until()` empty-queue handling so simulations end as `Converged`/`Deadlock`/`Diverged` instead of falling back to `Manual`.
> 
> Protocol/network byte metrics are made heap-aware via a new `SyncMessage::estimated_size()` that is computed once and passed into `NetworkRouter::route_message`, and reorder metrics are no longer incremented just for applying random delay (since delay doesn’t imply actual reordering). This also adds scaffolding/docs for upcoming sync-protocol work: `sync_scenarios/` and `sync_compliance/` test modules, a detailed `sync_sim/AGENT_GUIDE.md`, and a `.cursor` rule requiring deterministic simulation tests for issues #1768–#1785.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d4b94047e85344596bb444508ff759b80abf9a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->