### PR TITLE
test(sync): I5 protection and CIP §2.3 negotiation compliance tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,6 +2243,7 @@ dependencies = [
  "lz4_flex",
  "prometheus-client",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -51,3 +51,4 @@ calimero-utils-actix.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 calimero-dag = { workspace = true, features = ["testing"] }
+rand_chacha = "0.3"

--- a/crates/node/tests/sync_compliance/mod.rs
+++ b/crates/node/tests/sync_compliance/mod.rs
@@ -1,0 +1,19 @@
+//! Sync Protocol Compliance Test Suite
+//!
+//! This module implements the compliance test suite defined in issue #1785.
+//! Tests verify that the sync protocol implementation meets all CIP requirements.
+//!
+//! ## Categories (from issue #1785)
+//!
+//! - `negotiation.rs` - Protocol negotiation compliance (CIP §2.3)
+//! - `buffering.rs` - Delta buffering compliance (TODO)
+//! - `crdt_merge.rs` - CRDT merge compliance (TODO)
+//! - `convergence.rs` - Convergence compliance (TODO)  
+//! - `security.rs` - Security compliance (TODO)
+//!
+//! ## Adding Tests
+//!
+//! See `../sync_sim/AGENT_GUIDE.md` for framework usage.
+//! Each test should reference the specific CIP section it validates.
+
+pub mod negotiation;

--- a/crates/node/tests/sync_compliance/negotiation.rs
+++ b/crates/node/tests/sync_compliance/negotiation.rs
@@ -1,0 +1,519 @@
+//! Protocol Negotiation Compliance Tests (CIP §2.3)
+//!
+//! These tests verify that protocol selection conforms to CIP §2.3 decision table.
+//! Each test forces specific conditions to trigger a deterministic protocol selection.
+//!
+//! # Decision Table (CIP §2.3)
+//!
+//! | # | Condition | Selected Protocol |
+//! |---|-----------|-------------------|
+//! | 1 | `root_hash` match | `None` |
+//! | 2 | `!has_state` (fresh node) | `Snapshot` |
+//! | 3 | `has_state` AND divergence >50% | `HashComparison` |
+//! | 4 | `max_depth` >3 AND divergence <20% | `SubtreePrefetch` |
+//! | 5 | `entity_count` >50 AND divergence <10% | `BloomFilter` |
+//! | 6 | `max_depth` 1-2 AND avg children/level >10 | `LevelWise` |
+//! | 7 | (default) | `HashComparison` |
+
+use calimero_node_primitives::sync::handshake::SyncHandshake;
+use calimero_node_primitives::sync::protocol::{select_protocol, SyncProtocol};
+
+use crate::sync_sim::prelude::*;
+
+// =============================================================================
+// Rule 1: Same root hash → None
+// =============================================================================
+
+/// CIP-2.3-R1: Same root hash results in protocol None.
+#[test]
+fn test_cip23_rule1_same_root_hash() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Precondition: same root hash
+    assert_eq!(
+        hs_a.root_hash, hs_b.root_hash,
+        "Precondition: same root hash"
+    );
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "CIP §2.3 R1 VIOLATION: Same root hash should select None, got {:?}",
+        selection.protocol
+    );
+}
+
+/// CIP-2.3-R1: Verify symmetry - both directions give None.
+#[test]
+fn test_cip23_rule1_symmetric() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    let sel_ab = select_protocol(&hs_a, &hs_b);
+    let sel_ba = select_protocol(&hs_b, &hs_a);
+
+    assert!(matches!(sel_ab.protocol, SyncProtocol::None));
+    assert!(matches!(sel_ba.protocol, SyncProtocol::None));
+}
+
+// =============================================================================
+// Rule 2: Fresh node → Snapshot
+// =============================================================================
+
+/// CIP-2.3-R2: Fresh node bootstrap uses Snapshot.
+#[test]
+fn test_cip23_rule2_fresh_node_snapshot() {
+    let (mut fresh, mut source) = Scenario::force_snapshot();
+
+    let hs_fresh = fresh.build_handshake();
+    let hs_source = source.build_handshake();
+
+    // Preconditions
+    assert!(!hs_fresh.has_state, "Precondition: fresh node has no state");
+    assert!(hs_source.has_state, "Precondition: source has state");
+
+    let selection = select_protocol(&hs_fresh, &hs_source);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "CIP §2.3 R2 VIOLATION: Fresh node should use Snapshot, got {:?}",
+        selection.protocol
+    );
+}
+
+/// CIP-2.3-R2: Fresh node with empty source still returns None (both empty).
+#[test]
+fn test_cip23_rule2_both_fresh_nodes() {
+    let fresh_a = SimNode::new("fresh_a");
+    let fresh_b = SimNode::new("fresh_b");
+
+    let mut a = fresh_a;
+    let mut b = fresh_b;
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Both empty - same root hash (zeros)
+    assert_eq!(hs_a.root_hash, hs_b.root_hash);
+    assert_eq!(hs_a.root_hash, [0; 32]);
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    // Same hash = None (Rule 1 takes precedence)
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "Both empty nodes should match and select None, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 3: High divergence (>50%) → HashComparison
+// =============================================================================
+
+/// CIP-2.3-R3: High divergence triggers HashComparison.
+#[test]
+fn test_cip23_rule3_high_divergence_hash_comparison() {
+    let (mut a, mut b) = Scenario::force_hash_high_divergence();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Preconditions
+    assert!(hs_a.has_state);
+    assert!(hs_b.has_state);
+    // Calculate divergence
+    let max_count = hs_a.entity_count.max(hs_b.entity_count) as f64;
+    let min_count = hs_a.entity_count.min(hs_b.entity_count) as f64;
+    let divergence = if max_count > 0.0 {
+        1.0 - (min_count / max_count)
+    } else {
+        0.0
+    };
+    assert!(
+        divergence > 0.5,
+        "Precondition: divergence > 50%, got {:.2}%",
+        divergence * 100.0
+    );
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "CIP §2.3 R3 VIOLATION: High divergence should use HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+/// CIP-2.3-R3: Verify 51% divergence triggers HashComparison.
+#[test]
+fn test_cip23_rule3_boundary_51_percent() {
+    // Create scenario with exactly ~51% divergence
+    // Local: 49 entities, Remote: 100 entities → 51% divergence
+    let hs_local = SyncHandshake::new([1; 32], 49, 3, vec![]);
+    let hs_remote = SyncHandshake::new([2; 32], 100, 3, vec![]);
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "51% divergence should use HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 4: Deep tree + low divergence → SubtreePrefetch
+// =============================================================================
+
+/// CIP-2.3-R4: Deep tree with localized changes uses SubtreePrefetch.
+#[test]
+fn test_cip23_rule4_deep_tree_subtree_prefetch() {
+    let (mut a, mut b) = Scenario::force_subtree_prefetch();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Preconditions
+    assert!(hs_a.has_state);
+    assert!(hs_b.has_state);
+    // max_depth > 3
+    assert!(
+        hs_b.max_depth > 3,
+        "Precondition: max_depth > 3, got {}",
+        hs_b.max_depth
+    );
+    // divergence < 20%
+    let max_count = hs_a.entity_count.max(hs_b.entity_count) as f64;
+    let min_count = hs_a.entity_count.min(hs_b.entity_count) as f64;
+    let divergence = if max_count > 0.0 {
+        1.0 - (min_count / max_count)
+    } else {
+        0.0
+    };
+    assert!(
+        divergence < 0.2,
+        "Precondition: divergence < 20%, got {:.2}%",
+        divergence * 100.0
+    );
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::SubtreePrefetch { .. }),
+        "CIP §2.3 R4 VIOLATION: Deep tree + low divergence should use SubtreePrefetch, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 5: Large tree + small diff → BloomFilter
+// =============================================================================
+
+/// CIP-2.3-R5: Large tree with tiny diff uses BloomFilter.
+///
+/// Requirements: entity_count > 50 AND divergence < 10% AND NOT (max_depth > 3)
+/// (R4 SubtreePrefetch takes precedence when depth > 3)
+#[test]
+fn test_cip23_rule5_large_tree_bloom_filter() {
+    // Construct handshakes that precisely meet R5 conditions:
+    // - entity_count > 50: yes (100)
+    // - divergence < 10%: yes (~5%)
+    // - max_depth <= 3: yes (3) - to avoid R4 SubtreePrefetch
+    let hs_local = SyncHandshake::new([1; 32], 95, 3, vec![]); // 95 entities, depth 3
+    let hs_remote = SyncHandshake::new([2; 32], 100, 3, vec![]); // 100 entities, depth 3
+
+    // Verify preconditions
+    assert!(
+        hs_remote.entity_count > 50,
+        "Precondition: entity_count > 50"
+    );
+    let divergence = 1.0 - (95.0 / 100.0);
+    assert!(divergence < 0.1, "Precondition: divergence < 10%");
+    assert!(
+        hs_remote.max_depth <= 3,
+        "Precondition: max_depth <= 3 to avoid R4"
+    );
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::BloomFilter { .. }),
+        "CIP §2.3 R5 VIOLATION: Large tree + tiny diff should use BloomFilter, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 6: Wide shallow tree → LevelWise
+// =============================================================================
+
+/// CIP-2.3-R6: Wide shallow tree uses LevelWise.
+///
+/// Requirements: max_depth 1-2 AND avg_children/level > 10 AND divergence <= 50%
+#[test]
+fn test_cip23_rule6_wide_shallow_levelwise() {
+    // Construct handshakes that precisely meet R6 conditions:
+    // - max_depth 1-2: yes (2)
+    // - avg_children/level > 10: yes (50 entities / 2 depth = 25 avg)
+    // - divergence <= 50%: yes (~20%)
+    let hs_local = SyncHandshake::new([1; 32], 40, 2, vec![]); // 40 entities, depth 2
+    let hs_remote = SyncHandshake::new([2; 32], 50, 2, vec![]); // 50 entities, depth 2
+
+    // Verify preconditions
+    assert!(hs_remote.has_state);
+    assert!(
+        hs_remote.max_depth >= 1 && hs_remote.max_depth <= 2,
+        "Precondition: max_depth 1-2, got {}",
+        hs_remote.max_depth
+    );
+    let avg_children = hs_remote.entity_count / u64::from(hs_remote.max_depth);
+    assert!(
+        avg_children > 10,
+        "Precondition: avg_children > 10, got {}",
+        avg_children
+    );
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::LevelWise { .. }),
+        "CIP §2.3 R6 VIOLATION: Wide shallow tree should use LevelWise, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 7: Default → HashComparison
+// =============================================================================
+
+/// CIP-2.3-R7: Default fallback is HashComparison.
+#[test]
+fn test_cip23_rule7_default_hash_comparison() {
+    // Create a scenario that doesn't match any specific rule
+    // Medium divergence, medium depth, medium entity count
+    let hs_local = SyncHandshake::new([1; 32], 30, 3, vec![]); // 30 entities, depth 3
+    let hs_remote = SyncHandshake::new([2; 32], 40, 3, vec![]); // 40 entities, depth 3
+
+    // Divergence: ~25% (doesn't match R3 >50%, R4 <20%, R5 <10%)
+    // Depth: 3 (doesn't match R6 depth 1-2)
+    // Entity count: 40 (doesn't match R5 >50)
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "CIP §2.3 R7: Default should use HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Version Compatibility Tests
+// =============================================================================
+
+/// CIP-2.3: Version mismatch falls back to HashComparison.
+#[test]
+fn test_cip23_version_mismatch_fallback() {
+    let mut hs_local = SyncHandshake::new([1; 32], 50, 3, vec![]);
+    let mut hs_remote = SyncHandshake::new([2; 32], 50, 3, vec![]);
+
+    // Force version mismatch
+    hs_local.version = 1;
+    hs_remote.version = 999;
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "Version mismatch should fall back to HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Edge Cases and Priority Tests
+// =============================================================================
+
+/// Rule priority: R1 (same hash) takes precedence over everything.
+#[test]
+fn test_cip23_rule1_priority() {
+    // Even if other conditions would trigger different protocols,
+    // same hash = None
+    let hs = SyncHandshake::new([42; 32], 1000, 10, vec![]);
+
+    let selection = select_protocol(&hs, &hs);
+
+    assert!(matches!(selection.protocol, SyncProtocol::None));
+}
+
+/// Rule priority: R2 (fresh node) takes precedence over R3-R7.
+#[test]
+fn test_cip23_rule2_priority_over_divergence() {
+    // Fresh node with 100% divergence should still use Snapshot
+    let hs_fresh = SyncHandshake::new([0; 32], 0, 0, vec![]);
+    let hs_full = SyncHandshake::new([1; 32], 10000, 20, vec![]);
+
+    // This would be 100% divergence, but fresh node takes precedence
+    let selection = select_protocol(&hs_fresh, &hs_full);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "Fresh node should use Snapshot regardless of divergence, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Rule priority: R3 (high divergence) takes precedence over R4-R6.
+#[test]
+fn test_cip23_rule3_priority_over_optimization() {
+    // High divergence with deep tree should use HashComparison, not SubtreePrefetch
+    let hs_local = SyncHandshake::new([1; 32], 20, 10, vec![]); // 20 entities, depth 10
+    let hs_remote = SyncHandshake::new([2; 32], 100, 10, vec![]); // 100 entities, depth 10
+                                                                  // Divergence: 80%
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "High divergence should use HashComparison even with deep tree, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Sweep Tests
+// =============================================================================
+
+/// Sweep test: verify all rules are reachable.
+#[test]
+fn test_cip23_all_rules_reachable() {
+    let mut rules_hit = [false; 7]; // R1-R7
+
+    // R1: Same hash
+    {
+        let (mut a, mut b) = Scenario::force_none();
+        let hs_a = a.build_handshake();
+        let hs_b = b.build_handshake();
+        if matches!(select_protocol(&hs_a, &hs_b).protocol, SyncProtocol::None) {
+            rules_hit[0] = true;
+        }
+    }
+
+    // R2: Fresh node
+    {
+        let (mut fresh, mut source) = Scenario::force_snapshot();
+        let hs_f = fresh.build_handshake();
+        let hs_s = source.build_handshake();
+        if matches!(
+            select_protocol(&hs_f, &hs_s).protocol,
+            SyncProtocol::Snapshot { .. }
+        ) {
+            rules_hit[1] = true;
+        }
+    }
+
+    // R3: High divergence
+    {
+        let (mut a, mut b) = Scenario::force_hash_high_divergence();
+        let hs_a = a.build_handshake();
+        let hs_b = b.build_handshake();
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::HashComparison { .. }
+        ) {
+            // Only count as R3 if divergence > 50%
+            let max = hs_a.entity_count.max(hs_b.entity_count) as f64;
+            let min = hs_a.entity_count.min(hs_b.entity_count) as f64;
+            let div = 1.0 - (min / max);
+            if div > 0.5 {
+                rules_hit[2] = true;
+            }
+        }
+    }
+
+    // R4: SubtreePrefetch
+    {
+        let (mut a, mut b) = Scenario::force_subtree_prefetch();
+        let hs_a = a.build_handshake();
+        let hs_b = b.build_handshake();
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::SubtreePrefetch { .. }
+        ) {
+            rules_hit[3] = true;
+        }
+    }
+
+    // R5: BloomFilter - use direct handshake construction for precise control
+    // Requires: entity_count > 50, divergence < 10%, max_depth <= 3 (to avoid R4)
+    {
+        let hs_a = SyncHandshake::new([1; 32], 95, 3, vec![]);
+        let hs_b = SyncHandshake::new([2; 32], 100, 3, vec![]);
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::BloomFilter { .. }
+        ) {
+            rules_hit[4] = true;
+        }
+    }
+
+    // R6: LevelWise - use direct handshake construction for precise control
+    // Requires: max_depth 1-2, avg_children/level > 10
+    {
+        let hs_a = SyncHandshake::new([1; 32], 40, 2, vec![]);
+        let hs_b = SyncHandshake::new([2; 32], 50, 2, vec![]);
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::LevelWise { .. }
+        ) {
+            rules_hit[5] = true;
+        }
+    }
+
+    // R7: Default HashComparison
+    {
+        let hs_a = SyncHandshake::new([1; 32], 30, 3, vec![]);
+        let hs_b = SyncHandshake::new([2; 32], 40, 3, vec![]);
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::HashComparison { .. }
+        ) {
+            rules_hit[6] = true;
+        }
+    }
+
+    // Verify all rules were hit
+    for (i, hit) in rules_hit.iter().enumerate() {
+        assert!(
+            *hit,
+            "CIP §2.3 Rule {} was never triggered by any scenario!",
+            i + 1
+        );
+    }
+}
+
+/// Determinism test: same inputs = same outputs across 1000 runs.
+#[test]
+fn test_cip23_deterministic_selection() {
+    let hs_a = SyncHandshake::new([1; 32], 100, 5, vec![[1; 32]]);
+    let hs_b = SyncHandshake::new([2; 32], 80, 5, vec![[2; 32]]);
+
+    let baseline = select_protocol(&hs_a, &hs_b);
+
+    for i in 0..1000 {
+        let result = select_protocol(&hs_a, &hs_b);
+        assert_eq!(
+            std::mem::discriminant(&result.protocol),
+            std::mem::discriminant(&baseline.protocol),
+            "Protocol selection changed on iteration {}!",
+            i
+        );
+    }
+}

--- a/crates/node/tests/sync_scenarios/mod.rs
+++ b/crates/node/tests/sync_scenarios/mod.rs
@@ -1,0 +1,20 @@
+//! Sync Protocol Scenario Tests
+//!
+//! This module contains simulation-based tests for sync protocol behavior.
+//! Each test validates specific protocol scenarios using the sync_sim framework.
+//!
+//! ## Adding New Tests
+//!
+//! See `../sync_sim/AGENT_GUIDE.md` for detailed instructions.
+//!
+//! ## Test Categories
+//!
+//! - `snapshot_merge_protection.rs` - Ensures Snapshot never overwrites initialized nodes (I5)
+//! - `negotiation.rs` - Protocol negotiation tests (TODO)
+//! - `snapshot.rs` - Snapshot sync path tests (TODO)
+//! - `hash_compare.rs` - Hash comparison sync tests (TODO)
+//! - `delta.rs` - Delta exchange tests (TODO)
+//! - `partitions.rs` - Network partition tests (TODO)
+//! - `failures.rs` - Fault tolerance tests (TODO)
+
+pub mod snapshot_merge_protection;

--- a/crates/node/tests/sync_scenarios/snapshot_merge_protection.rs
+++ b/crates/node/tests/sync_scenarios/snapshot_merge_protection.rs
@@ -1,0 +1,400 @@
+//! Snapshot Merge Protection Tests
+//!
+//! # Invariant I5: No Silent Data Loss
+//!
+//! > "State-based sync on initialized nodes MUST use CRDT merge.
+//! >  LWW overwrite is ONLY permitted when local value is absent (fresh node bootstrap)."
+//!
+//! This is one of the most critical safety invariants in the Calimero Sync Protocol.
+//!
+//! # Why This Matters
+//!
+//! When syncing, **Snapshot** means "copy all state, replacing local state entirely".
+//! If a node already has data and receives a Snapshot, all its local data would be
+//! **silently deleted** and replaced. This violates CRDT semantics where concurrent
+//! changes should be merged, not overwritten.
+//!
+//! ```text
+//! Example of what I5 prevents:
+//!
+//!   Node A: has entities [1, 2, 3]
+//!   Node B: has entities [4, 5, 6]
+//!
+//!   WITHOUT I5 protection:
+//!     B syncs from A using Snapshot
+//!     B now has: [1, 2, 3]  ← entities 4, 5, 6 LOST FOREVER!
+//!
+//!   WITH I5 protection:
+//!     Protocol selector sees B.has_state = true
+//!     Forces HashComparison instead of Snapshot
+//!     B now has: [1, 2, 3, 4, 5, 6]  ← All data preserved via CRDT merge
+//! ```
+//!
+//! **Rule**: Snapshot is ONLY allowed for fresh (empty) nodes. Initialized nodes
+//! MUST use CRDT-merge protocols (HashComparison, BloomFilter, SubtreePrefetch, etc.).
+//!
+//! # CIP Reference
+//! - CIP §6.3 - Snapshot Usage Constraints
+//! - CIP §2.3 - Protocol Selection Rules (Rule 2 is the ONLY case for Snapshot)
+//!
+//! # Test Categories
+//! - Protocol selection layer (automatic protection)
+//! - Simulation-based tests (runtime verification)
+//! - Edge cases (single entity, version mismatch, etc.)
+
+use calimero_node_primitives::sync::handshake::SyncHandshake;
+use calimero_node_primitives::sync::protocol::{select_protocol, SyncProtocol};
+
+use crate::sync_sim::prelude::*;
+use crate::sync_sim::scenarios::deterministic::Scenario;
+
+// =============================================================================
+// Protocol Selection Layer Tests (CIP §2.3)
+// =============================================================================
+
+/// Protocol selection NEVER returns Snapshot when local node has state.
+///
+/// This is the primary protection layer. The `select_protocol` function
+/// must return a state-based protocol (HashComparison, etc.) when `has_state = true`.
+#[test]
+fn test_initialized_node_never_gets_snapshot() {
+    // Test with both_initialized scenario
+    let (mut a, mut b) = Scenario::both_initialized();
+
+    let local_hs = build_handshake(&mut a);
+    let remote_hs = build_handshake(&mut b);
+
+    // Verify preconditions
+    assert!(local_hs.has_state, "Local must have state for this test");
+    assert!(remote_hs.has_state, "Remote must have state for this test");
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Snapshot selected for initialized node!\n\
+         Local has_state: {}\n\
+         Remote has_state: {}\n\
+         Selected: {:?}\n\
+         Reason: {}",
+        local_hs.has_state,
+        remote_hs.has_state,
+        selection.protocol,
+        selection.reason
+    );
+}
+
+/// Even with extreme divergence (60%+), Snapshot must NOT be selected
+/// for initialized nodes - uses HashComparison instead.
+#[test]
+fn test_high_divergence_uses_hash_comparison_not_snapshot() {
+    let (mut a, mut b) = Scenario::force_hash_high_divergence();
+
+    let local_hs = build_handshake(&mut a);
+    let remote_hs = build_handshake(&mut b);
+
+    // This scenario has ~60% divergence
+    assert!(local_hs.has_state);
+    assert!(remote_hs.has_state);
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Snapshot selected despite high divergence!\n\
+         Expected: HashComparison (or similar state-based protocol)\n\
+         Got: {:?}",
+        selection.protocol
+    );
+
+    // Should use HashComparison for high divergence
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "Expected HashComparison for high divergence, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Verify Snapshot IS selected for fresh (empty) nodes - the valid case.
+///
+/// This confirms that Snapshot works correctly when it SHOULD be used.
+#[test]
+fn test_fresh_node_allowed_to_use_snapshot() {
+    let (mut fresh, mut source) = Scenario::force_snapshot();
+
+    let local_hs = build_handshake(&mut fresh);
+    let remote_hs = build_handshake(&mut source);
+
+    // Verify preconditions
+    assert!(!local_hs.has_state, "Fresh node must have has_state=false");
+    assert!(remote_hs.has_state, "Source must have state");
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "Snapshot should be selected for fresh node, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Property test - protection holds regardless of entity counts or divergence levels.
+#[test]
+fn test_protection_holds_across_entity_count_combinations() {
+    // Test various entity count combinations where both have state
+    let test_cases = [
+        (1, 1),       // Minimal
+        (1, 100),     // Asymmetric
+        (100, 1),     // Asymmetric reversed
+        (50, 50),     // Balanced
+        (1000, 1000), // Large
+        (1, 10000),   // Extreme asymmetric
+    ];
+
+    for (local_count, remote_count) in test_cases {
+        let local_hs = SyncHandshake::new(
+            [1; 32], // Non-zero hash (has state)
+            local_count,
+            3,
+            vec![],
+        );
+
+        let remote_hs = SyncHandshake::new(
+            [2; 32], // Different hash
+            remote_count,
+            3,
+            vec![],
+        );
+
+        assert!(local_hs.has_state);
+        assert!(remote_hs.has_state);
+
+        let selection = select_protocol(&local_hs, &remote_hs);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION at counts ({}, {}): {:?}",
+            local_count,
+            remote_count,
+            selection.protocol
+        );
+    }
+}
+
+/// All deterministic scenarios with initialized nodes must not use Snapshot.
+#[test]
+fn test_all_initialized_scenarios_avoid_snapshot() {
+    let scenarios: Vec<(&str, (SimNode, SimNode))> = vec![
+        ("both_initialized", Scenario::both_initialized()),
+        ("partial_overlap", Scenario::partial_overlap()),
+        (
+            "force_hash_high_div",
+            Scenario::force_hash_high_divergence(),
+        ),
+        ("force_subtree_prefetch", Scenario::force_subtree_prefetch()),
+        ("force_bloom_filter", Scenario::force_bloom_filter()),
+        ("force_levelwise", Scenario::force_levelwise()),
+        ("force_delta_sync", Scenario::force_delta_sync()),
+    ];
+
+    for (name, (mut a, mut b)) in scenarios {
+        let local_hs = build_handshake(&mut a);
+        let remote_hs = build_handshake(&mut b);
+
+        // Skip if local doesn't have state (e.g., force_snapshot)
+        if !local_hs.has_state {
+            continue;
+        }
+
+        let selection = select_protocol(&local_hs, &remote_hs);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION in scenario '{}': Snapshot selected!\n\
+             Local entities: {}, Remote entities: {}\n\
+             Protocol: {:?}",
+            name,
+            local_hs.entity_count,
+            remote_hs.entity_count,
+            selection.protocol
+        );
+    }
+}
+
+// =============================================================================
+// Simulation-Based Tests
+// =============================================================================
+
+/// Verify protocol negotiation in simulation runtime.
+#[test]
+fn test_simulation_runtime_negotiation() {
+    let mut rt = SimRuntime::new(42);
+
+    // Add two initialized nodes
+    let (node_a, node_b) = Scenario::both_initialized();
+    let a = rt.add_existing_node(node_a);
+    let b = rt.add_existing_node(node_b);
+
+    // Build handshakes
+    let hs_a = rt.node_mut(&a).unwrap().build_handshake();
+    let hs_b = rt.node_mut(&b).unwrap().build_handshake();
+
+    // Negotiate
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION in simulation: {:?}",
+        selection.protocol
+    );
+}
+
+/// Protection holds across 100 random seeds.
+#[test]
+fn test_protection_holds_across_random_seeds() {
+    for seed in 0..100 {
+        let mut rt = SimRuntime::new(seed);
+
+        // Create two diverged nodes (both have state)
+        let nodes = Scenario::n_nodes_diverged(2);
+        let a = rt.add_existing_node(nodes.into_iter().next().unwrap());
+        let b_node = Scenario::n_nodes_diverged(2).into_iter().nth(1).unwrap();
+        let b = rt.add_existing_node(b_node);
+
+        let hs_a = rt.node_mut(&a).unwrap().build_handshake();
+        let hs_b = rt.node_mut(&b).unwrap().build_handshake();
+
+        // Both should have state
+        if !hs_a.has_state || !hs_b.has_state {
+            continue;
+        }
+
+        let selection = select_protocol(&hs_a, &hs_b);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION at seed {}: {:?}",
+            seed,
+            selection.protocol
+        );
+    }
+}
+
+/// Three-node topology - all pairwise negotiations avoid Snapshot.
+#[test]
+fn test_three_node_pairwise_negotiations() {
+    let (mut a, mut b, mut c) = Scenario::three_nodes_one_diverged();
+
+    let hs_a = build_handshake(&mut a);
+    let hs_b = build_handshake(&mut b);
+    let hs_c = build_handshake(&mut c);
+
+    // All nodes have state
+    assert!(hs_a.has_state);
+    assert!(hs_b.has_state);
+    assert!(hs_c.has_state);
+
+    // Test all pairs
+    let pairs = [
+        ("a→b", &hs_a, &hs_b),
+        ("a→c", &hs_a, &hs_c),
+        ("b→a", &hs_b, &hs_a),
+        ("b→c", &hs_b, &hs_c),
+        ("c→a", &hs_c, &hs_a),
+        ("c→b", &hs_c, &hs_b),
+    ];
+
+    for (label, local, remote) in pairs {
+        let selection = select_protocol(local, remote);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION in pair {}: {:?}",
+            label,
+            selection.protocol
+        );
+    }
+}
+
+// =============================================================================
+// Edge Case Tests
+// =============================================================================
+
+/// Even a single entity should prevent Snapshot (no data loss tolerance).
+#[test]
+fn test_single_entity_still_prevents_snapshot() {
+    // Local has just 1 entity, remote has 1000
+    let local_hs = SyncHandshake::new([1; 32], 1, 1, vec![]);
+    let remote_hs = SyncHandshake::new([2; 32], 1000, 10, vec![]);
+
+    assert!(local_hs.has_state);
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Even 1 entity should prevent Snapshot!\n\
+         Got: {:?}",
+        selection.protocol
+    );
+}
+
+/// Version mismatch falls back to HashComparison, not Snapshot.
+#[test]
+fn test_version_mismatch_uses_safe_fallback() {
+    let mut local_hs = SyncHandshake::new([1; 32], 50, 3, vec![]);
+    let mut remote_hs = SyncHandshake::new([2; 32], 50, 3, vec![]);
+
+    // Force version mismatch
+    local_hs.version = 1;
+    remote_hs.version = 2;
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    // Should fall back to HashComparison
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "Version mismatch should fall back to HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Same root hash means no sync needed - nodes already in sync.
+#[test]
+fn test_same_hash_means_no_sync_needed() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let hs_a = build_handshake(&mut a);
+    let hs_b = build_handshake(&mut b);
+
+    assert_eq!(hs_a.root_hash, hs_b.root_hash);
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "Same root hash should select None, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Build a SyncHandshake from a SimNode.
+fn build_handshake(node: &mut SimNode) -> SyncHandshake {
+    node.build_handshake()
+}
+
+#[cfg(test)]
+mod compile_check {
+    //! Ensure all tests compile and types are correct.
+    use super::*;
+
+    #[test]
+    fn types_compile() {
+        let _ = Scenario::both_initialized();
+        let _ = Scenario::force_snapshot();
+    }
+}

--- a/crates/node/tests/sync_sim.rs
+++ b/crates/node/tests/sync_sim.rs
@@ -1,0 +1,334 @@
+//! Sync Protocol Simulation Test Entry Point
+//!
+//! This module provides the test harness for the sync protocol simulation framework.
+//!
+//! # Running Tests
+//!
+//! ```bash
+//! cargo test -p calimero-node --test sync_sim
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use sync_sim::prelude::*;
+//!
+//! #[test]
+//! fn test_basic_convergence() {
+//!     let mut rt = SimRuntime::new(42);
+//!     
+//!     // Use a deterministic scenario
+//!     let (a, b) = Scenario::force_none();
+//!     rt.add_existing_node(a);
+//!     rt.add_existing_node(b);
+//!     
+//!     // Already synced - should converge immediately
+//!     assert!(rt.check_convergence().is_converged());
+//! }
+//! ```
+
+#[macro_use]
+#[path = "sync_sim/mod.rs"]
+pub mod sync_sim;
+
+// Protocol scenario tests using the simulation framework
+#[path = "sync_scenarios/mod.rs"]
+pub mod sync_scenarios;
+
+// Compliance tests (CIP conformance)
+#[path = "sync_compliance/mod.rs"]
+pub mod sync_compliance;
+
+// Re-export prelude for convenience
+pub use sync_sim::prelude::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use calimero_primitives::crdt::CrdtType;
+
+    // =========================================================================
+    // Basic Tests
+    // =========================================================================
+
+    #[test]
+    fn test_empty_runtime() {
+        let mut rt = SimRuntime::new(42);
+        assert!(rt.check_convergence().is_converged());
+    }
+
+    #[test]
+    fn test_single_node() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+
+        rt.node_mut(&a).unwrap().insert_entity(
+            EntityId::from_u64(1),
+            vec![1, 2, 3],
+            CrdtType::LwwRegister,
+        );
+
+        assert!(rt.check_convergence().is_converged());
+    }
+
+    #[test]
+    fn test_two_nodes_same_state() {
+        let mut rt = SimRuntime::new(42);
+
+        let (a, b) = Scenario::force_none();
+        let _a_id = rt.add_existing_node(a);
+        let _b_id = rt.add_existing_node(b);
+
+        assert!(rt.check_convergence().is_converged());
+    }
+
+    #[test]
+    fn test_two_nodes_different_state() {
+        let mut rt = SimRuntime::new(42);
+
+        let (a, b) = Scenario::force_hash_high_divergence();
+        rt.add_existing_node(a);
+        rt.add_existing_node(b);
+
+        assert!(rt.check_convergence().is_diverged());
+    }
+
+    // =========================================================================
+    // Scenario Tests
+    // =========================================================================
+
+    #[test]
+    fn test_scenario_force_none() {
+        let (mut a, mut b) = Scenario::force_none();
+        assert_eq!(a.root_hash(), b.root_hash());
+    }
+
+    #[test]
+    fn test_scenario_force_snapshot() {
+        let (fresh, source) = Scenario::force_snapshot();
+        assert!(!fresh.has_any_state());
+        assert!(source.has_any_state());
+    }
+
+    #[test]
+    fn test_scenario_partial_overlap() {
+        let (a, b) = Scenario::partial_overlap();
+        assert_eq!(a.entity_count(), 75);
+        assert_eq!(b.entity_count(), 75);
+    }
+
+    #[test]
+    fn test_scenario_both_initialized() {
+        let (a, b) = Scenario::both_initialized();
+        assert!(a.has_any_state());
+        assert!(b.has_any_state());
+    }
+
+    // =========================================================================
+    // Convergence Tests
+    // =========================================================================
+
+    #[test]
+    fn test_convergence_pending_messages() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        // Before any messages, system should be converged (empty state)
+        assert!(
+            rt.check_convergence().is_converged(),
+            "Empty system should be converged"
+        );
+
+        // Inject message with longer delay
+        rt.inject_message(
+            a,
+            b,
+            SyncMessage::SyncComplete { success: true },
+            SimDuration::from_millis(100),
+        )
+        .expect("sender node should exist");
+
+        // With a message in flight, system should NOT be converged (C1 violated)
+        assert!(
+            !rt.check_convergence().is_converged(),
+            "System with in-flight message should not be converged"
+        );
+        assert_eq!(
+            rt.network().in_flight_count(),
+            1,
+            "Should have 1 message in flight"
+        );
+
+        // After processing the message, system should be converged again
+        rt.step();
+        assert!(
+            rt.check_convergence().is_converged(),
+            "System should be converged after message delivered"
+        );
+    }
+
+    // =========================================================================
+    // Network Tests
+    // =========================================================================
+
+    #[test]
+    fn test_partition_blocks_messages() {
+        let mut rt =
+            SimRuntime::with_config(SimConfig::with_seed(42).with_faults(FaultConfig::none()));
+
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        // Create partition immediately
+        rt.schedule_partition(vec![vec![a.clone()], vec![b.clone()]], SimDuration::ZERO);
+        rt.step(); // Process partition
+
+        // Message should be dropped
+        rt.inject_message(
+            a,
+            b,
+            SyncMessage::SyncComplete { success: true },
+            SimDuration::from_millis(10),
+        )
+        .expect("sender node should exist");
+        rt.step(); // Process message
+
+        // Message was dropped
+        assert_eq!(rt.network().metrics.messages_dropped_partition, 1);
+    }
+
+    #[test]
+    fn test_fault_injection_loss() {
+        let mut rt = SimRuntime::with_config(
+            SimConfig::with_seed(42).with_faults(FaultConfig::none().with_loss(1.0)),
+        );
+
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        // Send message through network router (with fault injection)
+        rt.send_message(a, b, SyncMessage::SyncComplete { success: true })
+            .expect("sender node should exist");
+
+        // Verify message was dropped due to loss
+        assert_eq!(
+            rt.network().metrics.messages_dropped_loss,
+            1,
+            "Message should have been dropped due to 100% loss rate"
+        );
+    }
+
+    // =========================================================================
+    // Crash/Restart Tests
+    // =========================================================================
+
+    #[test]
+    fn test_crash_preserves_storage() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+
+        // Add entity
+        rt.node_mut(&a).unwrap().insert_entity(
+            EntityId::from_u64(1),
+            vec![1],
+            CrdtType::LwwRegister,
+        );
+
+        // Crash
+        rt.schedule_crash(a.clone(), SimDuration::ZERO);
+        rt.step();
+
+        // Storage preserved
+        assert_eq!(rt.node(&a).unwrap().entity_count(), 1);
+    }
+
+    #[test]
+    fn test_restart_increments_session() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+
+        assert_eq!(rt.node(&a).unwrap().session, 0);
+
+        rt.schedule_crash(a.clone(), SimDuration::ZERO);
+        rt.schedule_restart(a.clone(), SimDuration::from_millis(10));
+
+        rt.step(); // crash
+        rt.step(); // restart
+
+        assert_eq!(rt.node(&a).unwrap().session, 1);
+    }
+
+    // =========================================================================
+    // Random Scenario Tests
+    // =========================================================================
+
+    #[test]
+    fn test_random_scenario_deterministic() {
+        let nodes1 = RandomScenario::two_nodes_random(42);
+        let nodes2 = RandomScenario::two_nodes_random(42);
+
+        assert_eq!(nodes1.len(), nodes2.len());
+
+        for (n1, n2) in nodes1.iter().zip(nodes2.iter()) {
+            assert_eq!(n1.entity_count(), n2.entity_count());
+        }
+    }
+
+    #[test]
+    fn test_random_scenario_mesh() {
+        let nodes = RandomScenario::mesh_random(42, 5);
+        assert_eq!(nodes.len(), 5);
+    }
+
+    // =========================================================================
+    // Metrics Tests
+    // =========================================================================
+
+    #[test]
+    fn test_metrics_crash_counted() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+
+        rt.schedule_crash(a, SimDuration::ZERO);
+        rt.step();
+
+        assert_eq!(rt.metrics().effects.node_crashes, 1);
+    }
+
+    #[test]
+    fn test_metrics_partition_counted() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        rt.schedule_partition(vec![vec![a], vec![b]], SimDuration::ZERO);
+        rt.step();
+
+        assert_eq!(rt.metrics().effects.partitions, 1);
+    }
+
+    // =========================================================================
+    // Assertion Macro Tests
+    // =========================================================================
+
+    #[test]
+    fn test_assert_macros() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Empty nodes converged
+        assert_converged!(a, b);
+
+        // Add different entities
+        a.insert_entity(EntityId::from_u64(1), vec![1], CrdtType::LwwRegister);
+        b.insert_entity(EntityId::from_u64(2), vec![2], CrdtType::LwwRegister);
+
+        assert_not_converged!(a, b);
+        assert_entity_count!(a, 1);
+        assert_has_entity!(a, EntityId::from_u64(1));
+        assert_no_entity!(a, EntityId::from_u64(2));
+        assert_idle!(a);
+        assert_buffer_empty!(a);
+    }
+}

--- a/crates/node/tests/sync_sim/AGENT_GUIDE.md
+++ b/crates/node/tests/sync_sim/AGENT_GUIDE.md
@@ -1,0 +1,221 @@
+# Sync Protocol Simulation Framework - Agent Guide
+
+This guide is for AI agents working on the Calimero sync protocol implementation.
+
+## Framework Location
+
+```
+crates/node/tests/
+├── sync_sim/              # Simulation framework (DO NOT MODIFY without review)
+│   ├── mod.rs             # Main module, prelude exports
+│   ├── actions.rs         # SyncMessage, SyncActions (effects model)
+│   ├── types.rs           # NodeId, MessageId, EntityId, etc.
+│   ├── runtime/           # SimClock, SimRng, EventQueue
+│   ├── network/           # NetworkRouter, FaultConfig, PartitionManager
+│   ├── node/              # SimNode state machine
+│   ├── scenarios/         # Deterministic and random scenario generators
+│   ├── convergence.rs     # Convergence checking (C1-C5 properties)
+│   ├── digest.rs          # StateDigest computation
+│   ├── metrics.rs         # SimMetrics collection
+│   └── assertions.rs      # Test assertion macros
+├── sync_sim.rs            # Framework unit tests
+├── sync_scenarios/        # Protocol behavior tests (ADD NEW TESTS HERE)
+└── sync_compliance/       # Compliance suite for issue #1785
+```
+
+## Quick Start
+
+```rust
+use crate::sync_sim::prelude::*;
+
+#[test]
+fn test_example() {
+    // Create runtime with seed for reproducibility
+    let mut rt = SimRuntime::with_seed(42);
+    
+    // Add nodes with a scenario
+    let scenario = Scenario::n_nodes_synced(3, 10); // 3 nodes, 10 shared entities
+    let nodes = rt.apply_scenario(scenario);
+    
+    // Run until convergence or timeout
+    let result = rt.run();
+    
+    // Assert convergence
+    assert_converged!(rt);
+    assert_eq!(result, StopCondition::Converged);
+}
+```
+
+## Key Concepts
+
+### SimRuntime
+The orchestrator. Manages clock, event queue, nodes, and network.
+
+```rust
+let mut rt = SimRuntime::with_seed(42);           // Basic
+let mut rt = SimRuntime::with_config(config);     // With custom config
+
+rt.add_node("alice");                              // Add empty node
+rt.apply_scenario(scenario);                       // Add nodes with state
+rt.run();                                          // Run to completion
+rt.run_until(|rt| rt.clock().now() > 1000.into()); // Run with predicate
+rt.step();                                         // Single event step
+```
+
+### Scenarios
+
+**Deterministic** (for specific test cases):
+```rust
+Scenario::n_nodes_synced(n, entities)      // All nodes have same state
+Scenario::n_nodes_diverged(n, entities)    // Each node has unique state
+Scenario::partial_overlap(n, shared, unique) // Mix of shared/unique
+Scenario::force_snapshot()                 // Forces snapshot sync path
+Scenario::force_none()                     // Empty nodes
+```
+
+**Random** (for property-based testing):
+```rust
+let config = RandomScenarioConfig::new(seed)
+    .with_node_count(3, 5)
+    .with_entity_count(10, 100)
+    .with_divergence(0.3);
+let scenario = RandomScenario::generate(&config);
+```
+
+### Fault Injection
+
+```rust
+let config = SimConfig::with_seed(42)
+    .with_faults(FaultConfig::default()
+        .with_loss(0.1)              // 10% message loss
+        .with_latency(50, 10)        // 50ms base, 10ms jitter
+        .with_reorder_window(100)    // 100ms reorder window
+        .with_duplicate(0.05));      // 5% duplication
+
+// Network partitions
+rt.partition_bidirectional(&alice, &bob, None);           // Permanent
+rt.partition_bidirectional(&alice, &bob, Some(1000.into())); // Temporary
+rt.heal_partition(&alice, &bob);
+```
+
+### Assertions
+
+```rust
+assert_converged!(rt);                    // All nodes converged
+assert_not_converged!(rt);                // Not converged
+assert_entity_count!(rt, "alice", 10);    // Node has N entities
+assert_has_entity!(rt, "alice", entity_id); // Node has specific entity
+assert_idle!(rt, "alice");                // Node is idle (no pending work)
+assert_buffer_empty!(rt, "alice");        // Delta buffer is empty
+```
+
+### Metrics
+
+```rust
+let metrics = rt.metrics();
+metrics.protocol.messages_sent;
+metrics.protocol.bytes_sent;
+metrics.effects.messages_dropped;
+metrics.convergence.converged;
+metrics.convergence.time_to_converge;
+```
+
+## Writing Tests
+
+### Where to Put Tests
+
+| Test Type | Location | When to Use |
+|-----------|----------|-------------|
+| Framework tests | `sync_sim.rs` | Testing the framework itself |
+| Protocol scenarios | `sync_scenarios/*.rs` | Testing sync protocol behavior |
+| Compliance tests | `sync_compliance/*.rs` | Issue #1785 compliance suite |
+
+### Test Patterns
+
+**Basic convergence test:**
+```rust
+#[test]
+fn test_two_nodes_converge() {
+    let mut rt = SimRuntime::with_seed(42);
+    let scenario = Scenario::n_nodes_diverged(2, 10);
+    rt.apply_scenario(scenario);
+    
+    rt.run();
+    
+    assert_converged!(rt);
+}
+```
+
+**Fault tolerance test:**
+```rust
+#[test]
+fn test_convergence_with_packet_loss() {
+    let config = SimConfig::with_seed(42)
+        .with_faults(FaultConfig::default().with_loss(0.2));
+    let mut rt = SimRuntime::with_config(config);
+    
+    // ... setup and run
+    
+    assert_converged!(rt);
+}
+```
+
+**Partition healing test:**
+```rust
+#[test]
+fn test_partition_healing() {
+    let mut rt = SimRuntime::with_seed(42);
+    let [a, b] = rt.apply_scenario(Scenario::n_nodes_diverged(2, 5));
+    
+    // Partition for 1000 ticks
+    rt.partition_bidirectional(&a, &b, Some(1000.into()));
+    
+    rt.run();
+    
+    assert_converged!(rt); // Should converge after partition heals
+}
+```
+
+**Property-based test:**
+```rust
+#[test]
+fn test_random_scenarios_converge() {
+    for seed in 0..100 {
+        let config = RandomScenarioConfig::new(seed)
+            .with_node_count(2, 5)
+            .with_entity_count(5, 20);
+        
+        let mut rt = SimRuntime::with_seed(seed);
+        rt.apply_scenario(RandomScenario::generate(&config));
+        
+        let result = rt.run();
+        
+        assert!(
+            matches!(result, StopCondition::Converged),
+            "Seed {} failed to converge", seed
+        );
+    }
+}
+```
+
+## Invariants (DO NOT BREAK)
+
+1. **Determinism**: Same seed MUST produce identical results
+2. **No silent drops**: All message drops must be recorded in metrics
+3. **Convergence properties C1-C5**: See `convergence.rs` for formal definitions
+4. **Time monotonicity**: SimClock never goes backwards
+
+## Debugging Failures
+
+1. **Get the seed**: All random tests should log their seed
+2. **Reproduce locally**: `SimRuntime::with_seed(failing_seed)`
+3. **Step through**: Use `rt.step()` instead of `rt.run()`
+4. **Check metrics**: `rt.metrics()` shows what happened
+5. **Check convergence**: `rt.check_convergence()` returns detailed status
+
+## Common Mistakes
+
+- **Forgetting seed**: Always use deterministic seeds for reproducibility
+- **Not checking StopCondition**: `run()` returns why it stopped
+- **Ignoring metrics**: Metrics reveal silent failures
+- **Hardcoding time**: Use `SimTime` and `SimDuration`, not raw numbers

--- a/crates/node/tests/sync_sim/actions.rs
+++ b/crates/node/tests/sync_sim/actions.rs
@@ -1,0 +1,409 @@
+//! Side-effect model for sync state machines.
+//!
+//! Protocol state machines return `SyncActions` effects. The runtime applies them.
+//! See spec §3 - Side-Effect Model.
+
+use calimero_primitives::crdt::CrdtType;
+
+use super::runtime::SimDuration;
+use super::types::{DeltaId, EntityId, MessageId, NodeId, TimerId, TimerKind};
+
+/// Effects returned by state machine — runtime applies these.
+#[derive(Debug, Default)]
+pub struct SyncActions {
+    /// Messages to send.
+    pub messages: Vec<OutgoingMessage>,
+    /// Storage operations to apply.
+    pub storage_ops: Vec<StorageOp>,
+    /// Timer operations.
+    pub timer_ops: Vec<TimerOp>,
+}
+
+impl SyncActions {
+    /// Create empty actions.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check if there are any actions.
+    pub fn is_empty(&self) -> bool {
+        self.messages.is_empty() && self.storage_ops.is_empty() && self.timer_ops.is_empty()
+    }
+
+    /// Add a message to send.
+    pub fn send(&mut self, to: NodeId, msg: SyncMessage, msg_id: MessageId) {
+        self.messages.push(OutgoingMessage { to, msg, msg_id });
+    }
+
+    /// Add a storage operation.
+    pub fn storage(&mut self, op: StorageOp) {
+        self.storage_ops.push(op);
+    }
+
+    /// Set a timer.
+    pub fn set_timer(&mut self, id: TimerId, delay: SimDuration, kind: TimerKind) {
+        self.timer_ops.push(TimerOp::Set { id, delay, kind });
+    }
+
+    /// Cancel a timer.
+    pub fn cancel_timer(&mut self, id: TimerId) {
+        self.timer_ops.push(TimerOp::Cancel { id });
+    }
+
+    /// Merge actions from another SyncActions.
+    pub fn merge(&mut self, other: SyncActions) {
+        self.messages.extend(other.messages);
+        self.storage_ops.extend(other.storage_ops);
+        self.timer_ops.extend(other.timer_ops);
+    }
+}
+
+/// Outgoing message with routing info.
+#[derive(Debug, Clone)]
+pub struct OutgoingMessage {
+    /// Destination node.
+    pub to: NodeId,
+    /// The message payload.
+    pub msg: SyncMessage,
+    /// Unique ID for deduplication (assigned by SM).
+    pub msg_id: MessageId,
+}
+
+/// Storage operations.
+#[derive(Debug, Clone)]
+pub enum StorageOp {
+    /// Insert a new entity.
+    Insert {
+        id: EntityId,
+        data: Vec<u8>,
+        metadata: EntityMetadata,
+    },
+    /// Update an existing entity.
+    Update {
+        id: EntityId,
+        data: Vec<u8>,
+        metadata: EntityMetadata,
+    },
+    /// Remove an entity (hard delete).
+    Remove { id: EntityId },
+}
+
+/// Entity metadata for storage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityMetadata {
+    /// CRDT type for merge semantics.
+    pub crdt_type: CrdtType,
+    /// HLC timestamp.
+    pub hlc_timestamp: u64,
+    /// Version counter.
+    pub version: u32,
+    /// Collection ID (for grouping).
+    pub collection_id: [u8; 32],
+}
+
+impl Default for EntityMetadata {
+    fn default() -> Self {
+        Self {
+            crdt_type: CrdtType::LwwRegister,
+            hlc_timestamp: 0,
+            version: 1,
+            collection_id: [0; 32],
+        }
+    }
+}
+
+impl EntityMetadata {
+    /// Create new metadata with specified CRDT type and timestamp.
+    pub fn new(crdt_type: CrdtType, hlc_timestamp: u64) -> Self {
+        Self {
+            crdt_type,
+            hlc_timestamp,
+            version: 1,
+            collection_id: [0; 32],
+        }
+    }
+}
+
+/// Timer operations.
+#[derive(Debug, Clone)]
+pub enum TimerOp {
+    /// Set a new timer.
+    Set {
+        id: TimerId,
+        delay: SimDuration,
+        kind: TimerKind,
+    },
+    /// Cancel an existing timer.
+    Cancel { id: TimerId },
+}
+
+/// Sync protocol messages.
+///
+/// These are the wire-format messages exchanged between nodes during sync.
+#[derive(Debug, Clone)]
+pub enum SyncMessage {
+    // =========================================================================
+    // Handshake
+    // =========================================================================
+    /// Initial handshake from initiator.
+    Handshake(HandshakeRequest),
+    /// Response to handshake.
+    HandshakeResponse(HandshakeResponse),
+
+    // =========================================================================
+    // Snapshot Protocol
+    // =========================================================================
+    /// Request next snapshot page.
+    SnapshotRequest { page: u32 },
+    /// Snapshot page data.
+    SnapshotPage {
+        page: u32,
+        entities: Vec<EntityTransfer>,
+        has_more: bool,
+        total_pages: u32,
+    },
+    /// Snapshot complete acknowledgment.
+    SnapshotComplete {
+        success: bool,
+        error: Option<String>,
+    },
+
+    // =========================================================================
+    // HashComparison Protocol
+    // =========================================================================
+    /// Request children of a Merkle node.
+    HashCompareRequest { node_hash: [u8; 32], level: u32 },
+    /// Children hashes response.
+    HashCompareResponse {
+        node_hash: [u8; 32],
+        children: Vec<([u8; 32], bool)>, // (hash, is_leaf)
+        has_more: bool,
+    },
+    /// Request entity data by ID.
+    EntityRequest { ids: Vec<EntityId> },
+    /// Entity data response.
+    EntityResponse { entities: Vec<EntityTransfer> },
+
+    // =========================================================================
+    // DeltaSync Protocol
+    // =========================================================================
+    /// Advertise DAG heads.
+    DeltaHeads { heads: Vec<DeltaId> },
+    /// Request missing deltas.
+    DeltaRequest { ids: Vec<DeltaId> },
+    /// Delta data response.
+    DeltaResponse { deltas: Vec<DeltaTransfer> },
+
+    // =========================================================================
+    // Common
+    // =========================================================================
+    /// Sync complete (from either side).
+    SyncComplete { success: bool },
+    /// Error during sync.
+    SyncError { code: u32, message: String },
+}
+
+impl SyncMessage {
+    /// Estimate the total size of this message including heap allocations.
+    ///
+    /// This provides a rough approximation of the wire-format size for metrics.
+    pub fn estimated_size(&self) -> usize {
+        use std::mem::size_of;
+
+        // Base stack size of the enum
+        let base = size_of::<Self>();
+
+        // Add heap allocation sizes for each variant
+        let heap_size = match self {
+            SyncMessage::Handshake(req) => req.dag_heads.len() * size_of::<DeltaId>(),
+            SyncMessage::HandshakeResponse(resp) => resp.reason.len(),
+            SyncMessage::SnapshotRequest { .. } => 0,
+            SyncMessage::SnapshotPage { entities, .. } => entities
+                .iter()
+                .map(|e| e.data.len() + size_of::<EntityTransfer>())
+                .sum(),
+            SyncMessage::SnapshotComplete { error, .. } => {
+                error.as_ref().map(|s| s.len()).unwrap_or(0)
+            }
+            SyncMessage::HashCompareRequest { .. } => 0,
+            SyncMessage::HashCompareResponse { children, .. } => {
+                children.len() * size_of::<([u8; 32], bool)>()
+            }
+            SyncMessage::EntityRequest { ids } => ids.len() * size_of::<EntityId>(),
+            SyncMessage::EntityResponse { entities } => entities
+                .iter()
+                .map(|e| e.data.len() + size_of::<EntityTransfer>())
+                .sum(),
+            SyncMessage::DeltaHeads { heads } => heads.len() * size_of::<DeltaId>(),
+            SyncMessage::DeltaRequest { ids } => ids.len() * size_of::<DeltaId>(),
+            SyncMessage::DeltaResponse { deltas } => deltas
+                .iter()
+                .map(|d| {
+                    d.parents.len() * size_of::<DeltaId>()
+                        + d.operations
+                            .iter()
+                            .map(|op| match op {
+                                StorageOp::Insert { data, .. } | StorageOp::Update { data, .. } => {
+                                    data.len() + size_of::<StorageOp>()
+                                }
+                                StorageOp::Remove { .. } => size_of::<StorageOp>(),
+                            })
+                            .sum::<usize>()
+                        + size_of::<DeltaTransfer>()
+                })
+                .sum(),
+            SyncMessage::SyncComplete { .. } => 0,
+            SyncMessage::SyncError { message, .. } => message.len(),
+        };
+
+        base + heap_size
+    }
+}
+
+/// Handshake request (initiator → responder).
+#[derive(Debug, Clone)]
+pub struct HandshakeRequest {
+    /// Protocol version.
+    pub version: u32,
+    /// Current Merkle root hash.
+    pub root_hash: [u8; 32],
+    /// Number of entities.
+    pub entity_count: u64,
+    /// Maximum tree depth.
+    pub max_depth: u32,
+    /// Current DAG heads.
+    pub dag_heads: Vec<DeltaId>,
+    /// Whether this node has any state.
+    pub has_state: bool,
+}
+
+/// Handshake response (responder → initiator).
+#[derive(Debug, Clone)]
+pub struct HandshakeResponse {
+    /// Selected protocol.
+    pub protocol: SelectedProtocol,
+    /// Responder's root hash.
+    pub root_hash: [u8; 32],
+    /// Responder's entity count.
+    pub entity_count: u64,
+    /// Reason for protocol selection (for debugging).
+    pub reason: String,
+}
+
+/// Selected sync protocol.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SelectedProtocol {
+    /// No sync needed.
+    None,
+    /// Full snapshot transfer.
+    Snapshot { compressed: bool },
+    /// Hash-based comparison.
+    HashComparison,
+    /// Delta-based sync.
+    DeltaSync { missing_count: usize },
+    /// Bloom filter sync.
+    BloomFilter { filter_size: u64 },
+    /// Subtree prefetch.
+    SubtreePrefetch,
+    /// Level-wise sync.
+    LevelWise { max_depth: u32 },
+}
+
+/// Entity data for transfer.
+#[derive(Debug, Clone)]
+pub struct EntityTransfer {
+    /// Entity ID.
+    pub id: EntityId,
+    /// Entity data.
+    pub data: Vec<u8>,
+    /// Entity metadata.
+    pub metadata: EntityMetadata,
+}
+
+/// Delta data for transfer.
+#[derive(Debug, Clone)]
+pub struct DeltaTransfer {
+    /// Delta ID.
+    pub id: DeltaId,
+    /// Parent delta IDs.
+    pub parents: Vec<DeltaId>,
+    /// Operations in this delta.
+    pub operations: Vec<StorageOp>,
+    /// HLC timestamp.
+    pub hlc_timestamp: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sync_actions_empty() {
+        let actions = SyncActions::new();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_sync_actions_send() {
+        let mut actions = SyncActions::new();
+
+        actions.send(
+            NodeId::new("bob"),
+            SyncMessage::SyncComplete { success: true },
+            MessageId::new("alice", 1, 1),
+        );
+
+        assert!(!actions.is_empty());
+        assert_eq!(actions.messages.len(), 1);
+        assert_eq!(actions.messages[0].to.as_str(), "bob");
+    }
+
+    #[test]
+    fn test_sync_actions_storage() {
+        let mut actions = SyncActions::new();
+
+        actions.storage(StorageOp::Insert {
+            id: EntityId::from_u64(1),
+            data: vec![1, 2, 3],
+            metadata: EntityMetadata::default(),
+        });
+
+        assert!(!actions.is_empty());
+        assert_eq!(actions.storage_ops.len(), 1);
+    }
+
+    #[test]
+    fn test_sync_actions_timer() {
+        let mut actions = SyncActions::new();
+
+        actions.set_timer(
+            TimerId::new(1),
+            SimDuration::from_millis(100),
+            TimerKind::Sync,
+        );
+        actions.cancel_timer(TimerId::new(2));
+
+        assert!(!actions.is_empty());
+        assert_eq!(actions.timer_ops.len(), 2);
+    }
+
+    #[test]
+    fn test_sync_actions_merge() {
+        let mut a = SyncActions::new();
+        a.send(
+            NodeId::new("bob"),
+            SyncMessage::SyncComplete { success: true },
+            MessageId::new("alice", 1, 1),
+        );
+
+        let mut b = SyncActions::new();
+        b.storage(StorageOp::Remove {
+            id: EntityId::from_u64(1),
+        });
+
+        a.merge(b);
+
+        assert_eq!(a.messages.len(), 1);
+        assert_eq!(a.storage_ops.len(), 1);
+    }
+}

--- a/crates/node/tests/sync_sim/assertions.rs
+++ b/crates/node/tests/sync_sim/assertions.rs
@@ -1,0 +1,329 @@
+//! Test assertion macros and helpers.
+
+use crate::sync_sim::node::SimNode;
+use crate::sync_sim::types::StateDigest;
+
+/// Check if two nodes have converged (same state digest).
+pub fn nodes_converged(a: &mut SimNode, b: &mut SimNode) -> bool {
+    a.state_digest() == b.state_digest()
+}
+
+/// Check if all nodes have the same state digest.
+pub fn all_converged(nodes: &mut [SimNode]) -> bool {
+    if nodes.is_empty() {
+        return true;
+    }
+
+    let first = nodes[0].state_digest();
+    nodes.iter_mut().all(|n| n.state_digest() == first)
+}
+
+/// Get the majority digest from nodes.
+///
+/// Uses deterministic tiebreaker (lexicographic digest ordering) to match
+/// the implementation in convergence.rs.
+pub fn majority_digest(nodes: &mut [SimNode]) -> Option<StateDigest> {
+    use std::collections::HashMap;
+
+    let mut counts: HashMap<StateDigest, usize> = HashMap::new();
+    for node in nodes.iter_mut() {
+        *counts.entry(node.state_digest()).or_default() += 1;
+    }
+
+    counts
+        .iter()
+        .max_by(|(d1, c1), (d2, c2)| {
+            c1.cmp(c2).then_with(|| {
+                // On count tie, use lexicographic ordering of digest bytes for determinism
+                d1.0.cmp(&d2.0)
+            })
+        })
+        .map(|(digest, _)| *digest)
+}
+
+/// Compute divergence percentage between two nodes.
+///
+/// Entities are considered "shared" only if they have the same ID AND
+/// the same content (data + metadata). This catches cases where both nodes
+/// have an entity with the same ID but different values.
+pub fn divergence_percentage(a: &SimNode, b: &SimNode) -> f64 {
+    let a_count = a.entity_count();
+    let b_count = b.entity_count();
+
+    if a_count == 0 && b_count == 0 {
+        return 0.0;
+    }
+
+    // Count truly shared entities (same ID AND same content)
+    let mut shared = 0;
+    for entity_a in a.storage.iter() {
+        if let Some(entity_b) = b.storage.get(&entity_a.id) {
+            // Only count as shared if data and all metadata fields match
+            if entity_a.data == entity_b.data && entity_a.metadata == entity_b.metadata {
+                shared += 1;
+            }
+        }
+    }
+
+    let total = a_count + b_count - shared;
+    if total == 0 {
+        return 0.0;
+    }
+
+    let different = total - shared;
+    different as f64 / total as f64
+}
+
+/// Assert that nodes have converged.
+///
+/// Note: `macro_rules!` macros in a module are automatically available
+/// to sibling modules without `#[macro_export]` when accessed via the parent.
+macro_rules! assert_converged {
+    ($($node:expr),+ $(,)?) => {{
+        let nodes: &mut [&mut $crate::sync_sim::node::SimNode] = &mut [$(&mut $node),+];
+        let digests: Vec<_> = nodes.iter_mut().map(|n| n.state_digest()).collect();
+
+        if !digests.windows(2).all(|w| w[0] == w[1]) {
+            panic!(
+                "Nodes not converged!\nDigests:\n{}",
+                nodes.iter()
+                    .zip(digests.iter())
+                    .map(|(n, d)| format!("  {}: {:?}", n.id(), d))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+    }};
+}
+
+/// Assert that nodes have NOT converged.
+macro_rules! assert_not_converged {
+    ($($node:expr),+ $(,)?) => {{
+        let nodes: &mut [&mut $crate::sync_sim::node::SimNode] = &mut [$(&mut $node),+];
+        let digests: Vec<_> = nodes.iter_mut().map(|n| n.state_digest()).collect();
+
+        if digests.windows(2).all(|w| w[0] == w[1]) {
+            panic!("Nodes unexpectedly converged with digest: {:?}", digests[0]);
+        }
+    }};
+}
+
+/// Assert that a node has specific entity count.
+macro_rules! assert_entity_count {
+    ($node:expr, $count:expr) => {{
+        let actual = $node.entity_count();
+        let expected = $count;
+        if actual != expected {
+            panic!(
+                "Node {} entity count mismatch: expected {}, got {}",
+                $node.id(),
+                expected,
+                actual
+            );
+        }
+    }};
+}
+
+/// Assert that a node has an entity.
+macro_rules! assert_has_entity {
+    ($node:expr, $id:expr) => {{
+        if !$node.has_entity(&$id) {
+            panic!("Node {} missing entity {:?}", $node.id(), $id);
+        }
+    }};
+}
+
+/// Assert that a node does not have an entity.
+macro_rules! assert_no_entity {
+    ($node:expr, $id:expr) => {{
+        if $node.has_entity(&$id) {
+            panic!("Node {} unexpectedly has entity {:?}", $node.id(), $id);
+        }
+    }};
+}
+
+/// Assert that a node is in idle sync state.
+macro_rules! assert_idle {
+    ($node:expr) => {{
+        if !$node.sync_state.is_idle() {
+            panic!(
+                "Node {} not idle, state: {:?}",
+                $node.id(),
+                $node.sync_state
+            );
+        }
+    }};
+}
+
+/// Assert that a node has empty delta buffer.
+macro_rules! assert_buffer_empty {
+    ($node:expr) => {{
+        if !$node.delta_buffer.is_empty() {
+            panic!(
+                "Node {} buffer not empty, size: {}",
+                $node.id(),
+                $node.buffer_size()
+            );
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync_sim::types::EntityId;
+    use calimero_primitives::crdt::CrdtType;
+
+    #[test]
+    fn test_nodes_converged() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Empty nodes are converged
+        assert!(nodes_converged(&mut a, &mut b));
+
+        // Add same entity to both
+        let id = EntityId::from_u64(1);
+        a.insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+        b.insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+
+        assert!(nodes_converged(&mut a, &mut b));
+
+        // Add different entity to one
+        a.insert_entity(EntityId::from_u64(2), vec![4, 5, 6], CrdtType::LwwRegister);
+
+        assert!(!nodes_converged(&mut a, &mut b));
+    }
+
+    #[test]
+    fn test_all_converged() {
+        let mut nodes = vec![SimNode::new("a"), SimNode::new("b"), SimNode::new("c")];
+
+        // Empty nodes are converged
+        assert!(all_converged(&mut nodes));
+
+        // Add same entity to all
+        let id = EntityId::from_u64(1);
+        for node in &mut nodes {
+            node.insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+        }
+
+        assert!(all_converged(&mut nodes));
+
+        // Modify one
+        nodes[1].insert_entity(EntityId::from_u64(2), vec![4], CrdtType::LwwRegister);
+
+        assert!(!all_converged(&mut nodes));
+    }
+
+    #[test]
+    fn test_divergence_percentage() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Empty nodes have 0% divergence
+        assert_eq!(divergence_percentage(&a, &b), 0.0);
+
+        // Same entities
+        let id = EntityId::from_u64(1);
+        a.insert_entity(id, vec![1], CrdtType::LwwRegister);
+        b.insert_entity(id, vec![1], CrdtType::LwwRegister);
+
+        assert_eq!(divergence_percentage(&a, &b), 0.0);
+
+        // Add unique entity to A
+        a.insert_entity(EntityId::from_u64(2), vec![2], CrdtType::LwwRegister);
+
+        // 1 shared, 1 unique = 2 total, 1 different = 50%
+        let div = divergence_percentage(&a, &b);
+        assert!((div - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_divergence_content_aware() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Same ID but different content should be considered divergent
+        let id = EntityId::from_u64(1);
+        a.insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+        b.insert_entity(id, vec![4, 5, 6], CrdtType::LwwRegister); // Different data!
+
+        // Both have 1 entity, but they conflict
+        // total = 1 + 1 - 0 (shared) = 2, different = 2
+        // divergence = 2/2 = 100%
+        let div = divergence_percentage(&a, &b);
+        assert!(
+            (div - 1.0).abs() < 0.001,
+            "Expected 100% divergence for conflicting content, got {}",
+            div
+        );
+    }
+
+    #[test]
+    fn test_assert_converged_macro() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Should pass
+        assert_converged!(a, b);
+
+        // Add same entity
+        let id = EntityId::from_u64(1);
+        a.insert_entity(id, vec![1], CrdtType::LwwRegister);
+        b.insert_entity(id, vec![1], CrdtType::LwwRegister);
+
+        assert_converged!(a, b);
+    }
+
+    #[test]
+    #[should_panic(expected = "Nodes not converged")]
+    fn test_assert_converged_macro_fails() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        a.insert_entity(EntityId::from_u64(1), vec![1], CrdtType::LwwRegister);
+
+        assert_converged!(a, b);
+    }
+
+    #[test]
+    fn test_assert_not_converged_macro() {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        a.insert_entity(EntityId::from_u64(1), vec![1], CrdtType::LwwRegister);
+
+        assert_not_converged!(a, b);
+    }
+
+    #[test]
+    fn test_assert_entity_count_macro() {
+        let mut a = SimNode::new("a");
+        assert_entity_count!(a, 0);
+
+        a.insert_entity(EntityId::from_u64(1), vec![1], CrdtType::LwwRegister);
+        assert_entity_count!(a, 1);
+    }
+
+    #[test]
+    fn test_assert_has_entity_macro() {
+        let mut a = SimNode::new("a");
+        let id = EntityId::from_u64(1);
+
+        a.insert_entity(id, vec![1], CrdtType::LwwRegister);
+        assert_has_entity!(a, id);
+    }
+
+    #[test]
+    fn test_assert_idle_macro() {
+        let a = SimNode::new("a");
+        assert_idle!(a);
+    }
+
+    #[test]
+    fn test_assert_buffer_empty_macro() {
+        let a = SimNode::new("a");
+        assert_buffer_empty!(a);
+    }
+}

--- a/crates/node/tests/sync_sim/convergence.rs
+++ b/crates/node/tests/sync_sim/convergence.rs
@@ -1,0 +1,433 @@
+//! Convergence checking for simulation.
+//!
+//! See spec §8 - Convergence Definition.
+
+use std::collections::HashMap;
+
+use super::types::{NodeId, StateDigest};
+
+/// Result of convergence check.
+#[derive(Debug, Clone)]
+pub enum ConvergenceResult {
+    /// System has converged - all properties satisfied.
+    Converged,
+    /// System is still converging - one or more properties not yet satisfied.
+    Pending(ConvergencePending),
+    /// System has diverged - state digests don't match.
+    Diverged(ConvergenceDiff),
+}
+
+impl ConvergenceResult {
+    /// Check if converged.
+    pub fn is_converged(&self) -> bool {
+        matches!(self, Self::Converged)
+    }
+
+    /// Check if pending.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending(_))
+    }
+
+    /// Check if diverged.
+    pub fn is_diverged(&self) -> bool {
+        matches!(self, Self::Diverged(_))
+    }
+}
+
+/// Reason why convergence is pending.
+#[derive(Debug, Clone)]
+pub struct ConvergencePending {
+    /// Which property is blocking.
+    pub blocking_property: ConvergenceProperty,
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+/// Convergence properties from spec §8.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConvergenceProperty {
+    /// C1: Network quiescent (no messages in flight).
+    NetworkQuiescent,
+    /// C2: All nodes idle (sync_state == Idle).
+    AllNodesIdle,
+    /// C3: No pending buffers (delta buffers empty).
+    NoPendingBuffers,
+    /// C4: No pending sync timers.
+    NoPendingSyncTimers,
+    /// C5: State digests equal.
+    StateDigestsEqual,
+}
+
+impl ConvergenceProperty {
+    /// Get property ID for display.
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::NetworkQuiescent => "C1",
+            Self::AllNodesIdle => "C2",
+            Self::NoPendingBuffers => "C3",
+            Self::NoPendingSyncTimers => "C4",
+            Self::StateDigestsEqual => "C5",
+        }
+    }
+}
+
+/// Difference details when diverged.
+#[derive(Debug, Clone)]
+pub struct ConvergenceDiff {
+    /// State digests by node.
+    pub digests: HashMap<NodeId, StateDigest>,
+    /// Nodes that differ from the majority.
+    pub differing_nodes: Vec<NodeId>,
+    /// The majority digest (most common).
+    pub majority_digest: Option<StateDigest>,
+}
+
+/// Input for convergence checking.
+#[derive(Debug, Clone)]
+pub struct ConvergenceInput {
+    /// Number of messages in flight.
+    pub in_flight_messages: usize,
+    /// Per-node state.
+    pub nodes: Vec<NodeConvergenceState>,
+}
+
+/// Per-node state for convergence checking.
+#[derive(Debug, Clone)]
+pub struct NodeConvergenceState {
+    /// Node ID.
+    pub id: NodeId,
+    /// Whether sync is active.
+    pub sync_active: bool,
+    /// Number of deltas in buffer.
+    pub buffer_size: usize,
+    /// Number of active sync timers.
+    pub sync_timer_count: usize,
+    /// State digest.
+    pub digest: StateDigest,
+}
+
+/// Check convergence according to spec §8.1.
+///
+/// Properties checked in order (fast-fail):
+/// 1. C1: Network quiescent
+/// 2. C2: All nodes idle
+/// 3. C3: No pending buffers
+/// 4. C4: No pending sync timers
+/// 5. C5: State digests equal
+pub fn check_convergence(input: &ConvergenceInput) -> ConvergenceResult {
+    // C1: Network quiescent
+    if input.in_flight_messages > 0 {
+        return ConvergenceResult::Pending(ConvergencePending {
+            blocking_property: ConvergenceProperty::NetworkQuiescent,
+            reason: format!("{} messages in flight", input.in_flight_messages),
+        });
+    }
+
+    // C2: All nodes idle
+    for node in &input.nodes {
+        if node.sync_active {
+            return ConvergenceResult::Pending(ConvergencePending {
+                blocking_property: ConvergenceProperty::AllNodesIdle,
+                reason: format!("node {} has sync active", node.id),
+            });
+        }
+    }
+
+    // C3: No pending buffers
+    for node in &input.nodes {
+        if node.buffer_size > 0 {
+            return ConvergenceResult::Pending(ConvergencePending {
+                blocking_property: ConvergenceProperty::NoPendingBuffers,
+                reason: format!("node {} has {} buffered deltas", node.id, node.buffer_size),
+            });
+        }
+    }
+
+    // C4: No pending sync timers
+    for node in &input.nodes {
+        if node.sync_timer_count > 0 {
+            return ConvergenceResult::Pending(ConvergencePending {
+                blocking_property: ConvergenceProperty::NoPendingSyncTimers,
+                reason: format!("node {} has {} sync timers", node.id, node.sync_timer_count),
+            });
+        }
+    }
+
+    // C5: State digests equal
+    if input.nodes.is_empty() {
+        return ConvergenceResult::Converged;
+    }
+
+    let first_digest = input.nodes[0].digest;
+    let all_equal = input.nodes.iter().all(|n| n.digest == first_digest);
+
+    if all_equal {
+        return ConvergenceResult::Converged;
+    }
+
+    // Compute diff
+    let mut digests = HashMap::new();
+    let mut digest_counts: HashMap<StateDigest, usize> = HashMap::new();
+
+    for node in &input.nodes {
+        digests.insert(node.id.clone(), node.digest);
+        *digest_counts.entry(node.digest).or_default() += 1;
+    }
+
+    // Find majority with deterministic tiebreaker (sort by digest value on ties)
+    let majority_digest = digest_counts
+        .iter()
+        .max_by(|(d1, c1), (d2, c2)| {
+            c1.cmp(c2).then_with(|| {
+                // On count tie, use lexicographic ordering of digest bytes for determinism
+                d1.0.cmp(&d2.0)
+            })
+        })
+        .map(|(digest, _)| *digest);
+
+    // Find differing nodes
+    let differing_nodes: Vec<_> = input
+        .nodes
+        .iter()
+        .filter(|n| Some(n.digest) != majority_digest)
+        .map(|n| n.id.clone())
+        .collect();
+
+    ConvergenceResult::Diverged(ConvergenceDiff {
+        digests,
+        differing_nodes,
+        majority_digest,
+    })
+}
+
+/// Deadlock detection according to spec §5.3.
+///
+/// System is in deadlock when ALL of:
+/// - Event queue is empty
+/// - System has NOT converged
+/// - At least one of:
+///   - Some node has sync_state != Idle
+///   - Some node has non-empty delta buffer
+///   - Some node has pending sync timers
+pub fn is_deadlocked(input: &ConvergenceInput, queue_empty: bool) -> bool {
+    if !queue_empty {
+        return false;
+    }
+
+    let result = check_convergence(input);
+    if result.is_converged() {
+        return false;
+    }
+
+    // Check if stuck
+    let has_active_sync = input.nodes.iter().any(|n| n.sync_active);
+    let has_buffered = input.nodes.iter().any(|n| n.buffer_size > 0);
+    let has_timers = input.nodes.iter().any(|n| n.sync_timer_count > 0);
+
+    has_active_sync || has_buffered || has_timers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_node(id: &str, digest: [u8; 32]) -> NodeConvergenceState {
+        NodeConvergenceState {
+            id: NodeId::new(id),
+            sync_active: false,
+            buffer_size: 0,
+            sync_timer_count: 0,
+            digest: StateDigest::from_bytes(digest),
+        }
+    }
+
+    #[test]
+    fn test_converged_empty() {
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![],
+        };
+
+        assert!(check_convergence(&input).is_converged());
+    }
+
+    #[test]
+    fn test_converged_single_node() {
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![make_node("a", [1; 32])],
+        };
+
+        assert!(check_convergence(&input).is_converged());
+    }
+
+    #[test]
+    fn test_converged_matching_digests() {
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![
+                make_node("a", [1; 32]),
+                make_node("b", [1; 32]),
+                make_node("c", [1; 32]),
+            ],
+        };
+
+        assert!(check_convergence(&input).is_converged());
+    }
+
+    #[test]
+    fn test_pending_messages_in_flight() {
+        let input = ConvergenceInput {
+            in_flight_messages: 5,
+            nodes: vec![make_node("a", [1; 32]), make_node("b", [1; 32])],
+        };
+
+        let result = check_convergence(&input);
+        assert!(result.is_pending());
+
+        if let ConvergenceResult::Pending(p) = result {
+            assert_eq!(p.blocking_property, ConvergenceProperty::NetworkQuiescent);
+        }
+    }
+
+    #[test]
+    fn test_pending_sync_active() {
+        let mut node = make_node("a", [1; 32]);
+        node.sync_active = true;
+
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![node, make_node("b", [1; 32])],
+        };
+
+        let result = check_convergence(&input);
+        assert!(result.is_pending());
+
+        if let ConvergenceResult::Pending(p) = result {
+            assert_eq!(p.blocking_property, ConvergenceProperty::AllNodesIdle);
+        }
+    }
+
+    #[test]
+    fn test_pending_buffer_not_empty() {
+        let mut node = make_node("a", [1; 32]);
+        node.buffer_size = 3;
+
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![node, make_node("b", [1; 32])],
+        };
+
+        let result = check_convergence(&input);
+        assert!(result.is_pending());
+
+        if let ConvergenceResult::Pending(p) = result {
+            assert_eq!(p.blocking_property, ConvergenceProperty::NoPendingBuffers);
+        }
+    }
+
+    #[test]
+    fn test_pending_sync_timers() {
+        let mut node = make_node("a", [1; 32]);
+        node.sync_timer_count = 1;
+
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![node, make_node("b", [1; 32])],
+        };
+
+        let result = check_convergence(&input);
+        assert!(result.is_pending());
+
+        if let ConvergenceResult::Pending(p) = result {
+            assert_eq!(
+                p.blocking_property,
+                ConvergenceProperty::NoPendingSyncTimers
+            );
+        }
+    }
+
+    #[test]
+    fn test_diverged() {
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![
+                make_node("a", [1; 32]),
+                make_node("b", [1; 32]),
+                make_node("c", [2; 32]), // Different!
+            ],
+        };
+
+        let result = check_convergence(&input);
+        assert!(result.is_diverged());
+
+        if let ConvergenceResult::Diverged(diff) = result {
+            assert_eq!(diff.differing_nodes.len(), 1);
+            assert!(diff.differing_nodes.contains(&NodeId::new("c")));
+            assert_eq!(diff.majority_digest, Some(StateDigest::from_bytes([1; 32])));
+        }
+    }
+
+    #[test]
+    fn test_deadlock_detection() {
+        // Not deadlocked: queue not empty
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![make_node("a", [1; 32]), make_node("b", [2; 32])],
+        };
+        assert!(!is_deadlocked(&input, false));
+
+        // Not deadlocked: converged
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![make_node("a", [1; 32]), make_node("b", [1; 32])],
+        };
+        assert!(!is_deadlocked(&input, true));
+
+        // Deadlocked: diverged, queue empty, sync active
+        let mut node = make_node("a", [1; 32]);
+        node.sync_active = true;
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![node, make_node("b", [2; 32])],
+        };
+        assert!(is_deadlocked(&input, true));
+    }
+
+    #[test]
+    fn test_majority_digest_tiebreaker() {
+        // With two digests having equal count, should deterministically pick
+        // the lexicographically greater digest (for consistent results)
+        let input = ConvergenceInput {
+            in_flight_messages: 0,
+            nodes: vec![
+                make_node("a", [1; 32]), // digest [1; 32]
+                make_node("b", [2; 32]), // digest [2; 32]
+            ],
+        };
+
+        let result = check_convergence(&input);
+        if let ConvergenceResult::Diverged(diff) = result {
+            // With tie, should pick the lexicographically greater digest [2; 32]
+            assert_eq!(
+                diff.majority_digest,
+                Some(StateDigest::from_bytes([2; 32])),
+                "Majority should be deterministic on tie"
+            );
+        } else {
+            panic!("Expected diverged result");
+        }
+
+        // Run multiple times to verify determinism
+        for _ in 0..10 {
+            let result = check_convergence(&input);
+            if let ConvergenceResult::Diverged(diff) = result {
+                assert_eq!(
+                    diff.majority_digest,
+                    Some(StateDigest::from_bytes([2; 32])),
+                    "Majority should be consistent across calls"
+                );
+            }
+        }
+    }
+}

--- a/crates/node/tests/sync_sim/digest.rs
+++ b/crates/node/tests/sync_sim/digest.rs
@@ -1,0 +1,302 @@
+//! State digest computation for convergence checking.
+//!
+//! See spec §7 - State Digest and Hashing.
+
+use sha2::{Digest, Sha256};
+
+use super::actions::EntityMetadata;
+use super::types::{EntityId, StateDigest};
+
+/// Compute canonical metadata digest.
+///
+/// Fields serialized in fixed order as per spec §7.2.
+pub fn hash_metadata(metadata: &EntityMetadata) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+
+    // CrdtType discriminant
+    // IMPORTANT: These discriminant values must remain stable for digest compatibility.
+    // Changing them will cause different digests for the same data across versions.
+    match &metadata.crdt_type {
+        calimero_primitives::crdt::CrdtType::LwwRegister => hasher.update([0u8]),
+        calimero_primitives::crdt::CrdtType::GCounter => hasher.update([1u8]),
+        calimero_primitives::crdt::CrdtType::PnCounter => hasher.update([2u8]),
+        calimero_primitives::crdt::CrdtType::Rga => hasher.update([3u8]),
+        calimero_primitives::crdt::CrdtType::UnorderedMap => hasher.update([4u8]),
+        calimero_primitives::crdt::CrdtType::UnorderedSet => hasher.update([5u8]),
+        calimero_primitives::crdt::CrdtType::Vector => hasher.update([6u8]),
+        calimero_primitives::crdt::CrdtType::UserStorage => hasher.update([7u8]),
+        calimero_primitives::crdt::CrdtType::FrozenStorage => hasher.update([8u8]),
+        calimero_primitives::crdt::CrdtType::Custom(s) => {
+            hasher.update([9u8]);
+            // Include the custom type identifier to differentiate different custom types
+            // Encode length first to prevent ambiguous serialization (e.g., "ab" + timestamp vs "a" + different timestamp)
+            hasher.update((s.len() as u64).to_le_bytes());
+            hasher.update(s.as_bytes());
+        }
+    };
+
+    hasher.update(metadata.hlc_timestamp.to_le_bytes());
+    hasher.update(metadata.version.to_le_bytes());
+    hasher.update(metadata.collection_id);
+
+    hasher.finalize().into()
+}
+
+/// Compute value digest.
+pub fn hash_value(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// Entity with data and metadata for digest computation.
+#[derive(Clone, Debug)]
+pub struct DigestEntity {
+    /// Entity ID.
+    pub id: EntityId,
+    /// Entity data.
+    pub data: Vec<u8>,
+    /// Entity metadata.
+    pub metadata: EntityMetadata,
+}
+
+/// Compute state digest from a collection of entities.
+///
+/// See spec §7.1 - Canonical State Digest.
+///
+/// Entities are sorted by EntityId for deterministic ordering.
+pub fn compute_state_digest(entities: &[DigestEntity]) -> StateDigest {
+    if entities.is_empty() {
+        return StateDigest::ZERO;
+    }
+
+    // Sort by entity ID for deterministic ordering
+    let mut sorted: Vec<_> = entities.iter().collect();
+    sorted.sort_by_key(|e| e.id);
+
+    let mut hasher = Sha256::new();
+
+    for entity in sorted {
+        // EntityId (32 bytes)
+        hasher.update(entity.id.as_bytes());
+
+        // ValueDigest = H(entity.data)
+        let value_digest = hash_value(&entity.data);
+        hasher.update(value_digest);
+
+        // MetadataDigest = H(canonical_serialize(entity.metadata))
+        let metadata_digest = hash_metadata(&entity.metadata);
+        hasher.update(metadata_digest);
+    }
+
+    StateDigest::from_bytes(hasher.finalize().into())
+}
+
+/// Builder for incremental digest computation with caching.
+///
+/// Uses HashMap internally for O(1) amortized upsert/remove operations.
+#[derive(Debug, Default)]
+pub struct DigestCache {
+    /// Cached digest (None if invalidated).
+    cached: Option<StateDigest>,
+    /// Entities by ID for O(1) lookup/upsert/remove.
+    entities: std::collections::HashMap<EntityId, DigestEntity>,
+}
+
+impl DigestCache {
+    /// Create a new empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add or update an entity. O(1) amortized.
+    pub fn upsert(&mut self, entity: DigestEntity) {
+        self.cached = None;
+        self.entities.insert(entity.id, entity);
+    }
+
+    /// Remove an entity. O(1) amortized.
+    pub fn remove(&mut self, id: &EntityId) {
+        if self.entities.remove(id).is_some() {
+            self.cached = None;
+        }
+    }
+
+    /// Get the state digest (computing if necessary).
+    pub fn digest(&mut self) -> StateDigest {
+        if let Some(digest) = self.cached {
+            return digest;
+        }
+
+        // Collect and sort for deterministic hashing
+        let entities: Vec<_> = self.entities.values().cloned().collect();
+        let digest = compute_state_digest(&entities);
+        self.cached = Some(digest);
+        digest
+    }
+
+    /// Clear the cache.
+    pub fn clear(&mut self) {
+        self.cached = None;
+        self.entities.clear();
+    }
+
+    /// Get entity count.
+    pub fn len(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// Check if empty.
+    pub fn is_empty(&self) -> bool {
+        self.entities.is_empty()
+    }
+
+    /// Get entity by ID. O(1).
+    pub fn get(&self, id: &EntityId) -> Option<&DigestEntity> {
+        self.entities.get(id)
+    }
+
+    /// Iterate over entities (unordered).
+    pub fn iter(&self) -> impl Iterator<Item = &DigestEntity> {
+        self.entities.values()
+    }
+
+    /// Get all entities sorted by ID.
+    pub fn entities_sorted(&self) -> Vec<DigestEntity> {
+        let mut entities: Vec<_> = self.entities.values().cloned().collect();
+        entities.sort_by_key(|e| e.id);
+        entities
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use calimero_primitives::crdt::CrdtType;
+
+    fn make_entity(id: u64, data: &[u8]) -> DigestEntity {
+        DigestEntity {
+            id: EntityId::from_u64(id),
+            data: data.to_vec(),
+            metadata: EntityMetadata::new(CrdtType::LwwRegister, id * 100),
+        }
+    }
+
+    #[test]
+    fn test_empty_digest() {
+        let digest = compute_state_digest(&[]);
+        assert_eq!(digest, StateDigest::ZERO);
+    }
+
+    #[test]
+    fn test_single_entity_digest() {
+        let entity = make_entity(1, b"hello");
+        let digest = compute_state_digest(&[entity]);
+        assert_ne!(digest, StateDigest::ZERO);
+    }
+
+    #[test]
+    fn test_digest_deterministic() {
+        let entities = vec![make_entity(1, b"hello"), make_entity(2, b"world")];
+
+        let digest1 = compute_state_digest(&entities);
+        let digest2 = compute_state_digest(&entities);
+
+        assert_eq!(digest1, digest2);
+    }
+
+    #[test]
+    fn test_digest_order_independent() {
+        let e1 = make_entity(1, b"hello");
+        let e2 = make_entity(2, b"world");
+
+        let digest1 = compute_state_digest(&[e1.clone(), e2.clone()]);
+        let digest2 = compute_state_digest(&[e2, e1]);
+
+        // Should be same because we sort by entity ID
+        assert_eq!(digest1, digest2);
+    }
+
+    #[test]
+    fn test_digest_different_data() {
+        let e1 = make_entity(1, b"hello");
+        let e2 = make_entity(1, b"world");
+
+        let digest1 = compute_state_digest(&[e1]);
+        let digest2 = compute_state_digest(&[e2]);
+
+        assert_ne!(digest1, digest2);
+    }
+
+    #[test]
+    fn test_digest_different_metadata() {
+        let mut e1 = make_entity(1, b"hello");
+        let mut e2 = make_entity(1, b"hello");
+
+        e1.metadata.hlc_timestamp = 100;
+        e2.metadata.hlc_timestamp = 200;
+
+        let digest1 = compute_state_digest(&[e1]);
+        let digest2 = compute_state_digest(&[e2]);
+
+        assert_ne!(digest1, digest2);
+    }
+
+    #[test]
+    fn test_digest_cache() {
+        let mut cache = DigestCache::new();
+
+        assert!(cache.is_empty());
+        assert_eq!(cache.digest(), StateDigest::ZERO);
+
+        cache.upsert(make_entity(1, b"hello"));
+        let d1 = cache.digest();
+        assert_ne!(d1, StateDigest::ZERO);
+
+        // Cached
+        let d2 = cache.digest();
+        assert_eq!(d1, d2);
+
+        // Update invalidates cache
+        cache.upsert(make_entity(2, b"world"));
+        let d3 = cache.digest();
+        assert_ne!(d3, d1);
+
+        // Remove
+        cache.remove(&EntityId::from_u64(2));
+        let d4 = cache.digest();
+        assert_eq!(d4, d1); // Back to single entity
+    }
+
+    #[test]
+    fn test_metadata_hash_different_crdt_types() {
+        let m1 = EntityMetadata::new(CrdtType::LwwRegister, 100);
+        let m2 = EntityMetadata::new(CrdtType::GCounter, 100);
+
+        let h1 = hash_metadata(&m1);
+        let h2 = hash_metadata(&m2);
+
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_metadata_hash_different_custom_types() {
+        // Different custom type identifiers should produce different hashes
+        let m1 = EntityMetadata::new(CrdtType::Custom("type_a".to_string()), 100);
+        let m2 = EntityMetadata::new(CrdtType::Custom("type_b".to_string()), 100);
+        let m3 = EntityMetadata::new(CrdtType::Custom("type_a".to_string()), 100);
+
+        let h1 = hash_metadata(&m1);
+        let h2 = hash_metadata(&m2);
+        let h3 = hash_metadata(&m3);
+
+        // Different custom types should have different hashes
+        assert_ne!(
+            h1, h2,
+            "Custom('type_a') and Custom('type_b') should differ"
+        );
+
+        // Same custom type should have same hash
+        assert_eq!(h1, h3, "Custom('type_a') should match itself");
+    }
+}

--- a/crates/node/tests/sync_sim/metrics.rs
+++ b/crates/node/tests/sync_sim/metrics.rs
@@ -1,0 +1,324 @@
+//! Simulation metrics collection.
+//!
+//! See spec §14 - Metrics.
+
+use super::runtime::SimTime;
+
+/// Combined metrics for simulation.
+#[derive(Debug, Default, Clone)]
+pub struct SimMetrics {
+    /// Protocol cost metrics.
+    pub protocol: ProtocolMetrics,
+    /// Simulation effect metrics.
+    pub effects: EffectMetrics,
+    /// Work done metrics.
+    pub work: WorkMetrics,
+    /// Convergence metrics.
+    pub convergence: ConvergenceMetrics,
+}
+
+impl SimMetrics {
+    /// Create new empty metrics.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reset all metrics.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Merge metrics from another instance.
+    pub fn merge(&mut self, other: &SimMetrics) {
+        self.protocol.merge(&other.protocol);
+        self.effects.merge(&other.effects);
+        self.work.merge(&other.work);
+        // Convergence metrics are not merged (they're per-run)
+    }
+}
+
+/// Protocol cost metrics (spec §14.1).
+#[derive(Debug, Default, Clone)]
+pub struct ProtocolMetrics {
+    /// Protocol messages emitted.
+    pub messages_sent: u64,
+    /// Application payload bytes.
+    pub payload_bytes: u64,
+    /// Request-response pairs.
+    pub round_trips: u64,
+    /// Hash comparisons.
+    pub entities_compared: u64,
+    /// Entities sent.
+    pub entities_transferred: u64,
+    /// CRDT merges.
+    pub merges_performed: u64,
+}
+
+impl ProtocolMetrics {
+    /// Record a message sent.
+    pub fn record_message(&mut self, payload_bytes: usize) {
+        self.messages_sent += 1;
+        self.payload_bytes += payload_bytes as u64;
+    }
+
+    /// Record a round trip.
+    pub fn record_round_trip(&mut self) {
+        self.round_trips += 1;
+    }
+
+    /// Record entity comparison.
+    pub fn record_comparison(&mut self) {
+        self.entities_compared += 1;
+    }
+
+    /// Record entity transfer.
+    pub fn record_transfer(&mut self) {
+        self.entities_transferred += 1;
+    }
+
+    /// Record CRDT merge.
+    pub fn record_merge(&mut self) {
+        self.merges_performed += 1;
+    }
+
+    /// Merge from another.
+    pub fn merge(&mut self, other: &ProtocolMetrics) {
+        self.messages_sent += other.messages_sent;
+        self.payload_bytes += other.payload_bytes;
+        self.round_trips += other.round_trips;
+        self.entities_compared += other.entities_compared;
+        self.entities_transferred += other.entities_transferred;
+        self.merges_performed += other.merges_performed;
+    }
+}
+
+/// Simulation effect metrics (spec §14.2).
+#[derive(Debug, Default, Clone)]
+pub struct EffectMetrics {
+    /// Lost to faults/partitions.
+    pub messages_dropped: u64,
+    /// Delivered out of order.
+    pub messages_reordered: u64,
+    /// Delivered multiple times.
+    pub messages_duplicated: u64,
+    /// Protocol timeouts fired.
+    pub timeouts_triggered: u64,
+    /// Protocol-level retransmissions.
+    pub retries_performed: u64,
+    /// Node crashes.
+    pub node_crashes: u64,
+    /// Node restarts.
+    pub node_restarts: u64,
+    /// Partition events.
+    pub partitions: u64,
+}
+
+impl EffectMetrics {
+    /// Record message drop.
+    pub fn record_drop(&mut self) {
+        self.messages_dropped += 1;
+    }
+
+    /// Record reorder.
+    pub fn record_reorder(&mut self) {
+        self.messages_reordered += 1;
+    }
+
+    /// Record duplicate.
+    pub fn record_duplicate(&mut self) {
+        self.messages_duplicated += 1;
+    }
+
+    /// Record timeout.
+    pub fn record_timeout(&mut self) {
+        self.timeouts_triggered += 1;
+    }
+
+    /// Record retry.
+    pub fn record_retry(&mut self) {
+        self.retries_performed += 1;
+    }
+
+    /// Record crash.
+    pub fn record_crash(&mut self) {
+        self.node_crashes += 1;
+    }
+
+    /// Record restart.
+    pub fn record_restart(&mut self) {
+        self.node_restarts += 1;
+    }
+
+    /// Record partition.
+    pub fn record_partition(&mut self) {
+        self.partitions += 1;
+    }
+
+    /// Merge from another.
+    pub fn merge(&mut self, other: &EffectMetrics) {
+        self.messages_dropped += other.messages_dropped;
+        self.messages_reordered += other.messages_reordered;
+        self.messages_duplicated += other.messages_duplicated;
+        self.timeouts_triggered += other.timeouts_triggered;
+        self.retries_performed += other.retries_performed;
+        self.node_crashes += other.node_crashes;
+        self.node_restarts += other.node_restarts;
+        self.partitions += other.partitions;
+    }
+}
+
+/// Work done metrics (spec §14.3).
+#[derive(Debug, Default, Clone)]
+pub struct WorkMetrics {
+    /// Digest/hash calculations.
+    pub hash_computations: u64,
+    /// DAG ancestry queries.
+    pub dag_lookups: u64,
+    /// Entity reads.
+    pub storage_reads: u64,
+    /// Entity writes.
+    pub storage_writes: u64,
+}
+
+impl WorkMetrics {
+    /// Record hash computation.
+    pub fn record_hash(&mut self) {
+        self.hash_computations += 1;
+    }
+
+    /// Record DAG lookup.
+    pub fn record_dag_lookup(&mut self) {
+        self.dag_lookups += 1;
+    }
+
+    /// Record storage read.
+    pub fn record_read(&mut self) {
+        self.storage_reads += 1;
+    }
+
+    /// Record storage write.
+    pub fn record_write(&mut self) {
+        self.storage_writes += 1;
+    }
+
+    /// Merge from another.
+    pub fn merge(&mut self, other: &WorkMetrics) {
+        self.hash_computations += other.hash_computations;
+        self.dag_lookups += other.dag_lookups;
+        self.storage_reads += other.storage_reads;
+        self.storage_writes += other.storage_writes;
+    }
+}
+
+/// Convergence metrics (spec §14.4).
+#[derive(Debug, Default, Clone)]
+pub struct ConvergenceMetrics {
+    /// From start to convergence.
+    pub time_to_converge: Option<SimTime>,
+    /// Total messages until converged.
+    pub messages_to_converge: u64,
+    /// Total events processed.
+    pub events_to_converge: u64,
+    /// Whether convergence was achieved.
+    pub converged: bool,
+    /// Reason if not converged.
+    pub failure_reason: Option<String>,
+}
+
+impl ConvergenceMetrics {
+    /// Mark as converged.
+    pub fn mark_converged(&mut self, time: SimTime, messages: u64, events: u64) {
+        self.converged = true;
+        self.time_to_converge = Some(time);
+        self.messages_to_converge = messages;
+        self.events_to_converge = events;
+        self.failure_reason = None;
+    }
+
+    /// Mark as failed.
+    pub fn mark_failed(&mut self, reason: String) {
+        self.converged = false;
+        self.failure_reason = Some(reason);
+        // Clear any prior success timestamps to avoid inconsistent state
+        self.time_to_converge = None;
+        self.messages_to_converge = 0;
+        self.events_to_converge = 0;
+    }
+}
+
+/// Per-node metrics.
+#[derive(Debug, Default, Clone)]
+pub struct NodeMetrics {
+    /// Messages sent by this node.
+    pub messages_sent: u64,
+    /// Messages received by this node.
+    pub messages_received: u64,
+    /// Bytes sent.
+    pub bytes_sent: u64,
+    /// Bytes received.
+    pub bytes_received: u64,
+    /// Storage operations.
+    pub storage_ops: u64,
+    /// Sync sessions initiated.
+    pub syncs_initiated: u64,
+    /// Sync sessions completed.
+    pub syncs_completed: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_protocol_metrics() {
+        let mut metrics = ProtocolMetrics::default();
+
+        metrics.record_message(100);
+        metrics.record_message(200);
+        metrics.record_round_trip();
+        metrics.record_comparison();
+        metrics.record_transfer();
+        metrics.record_merge();
+
+        assert_eq!(metrics.messages_sent, 2);
+        assert_eq!(metrics.payload_bytes, 300);
+        assert_eq!(metrics.round_trips, 1);
+        assert_eq!(metrics.entities_compared, 1);
+        assert_eq!(metrics.entities_transferred, 1);
+        assert_eq!(metrics.merges_performed, 1);
+    }
+
+    #[test]
+    fn test_metrics_merge() {
+        let mut m1 = SimMetrics::new();
+        m1.protocol.messages_sent = 10;
+        m1.effects.messages_dropped = 2;
+
+        let mut m2 = SimMetrics::new();
+        m2.protocol.messages_sent = 5;
+        m2.effects.messages_dropped = 1;
+
+        m1.merge(&m2);
+
+        assert_eq!(m1.protocol.messages_sent, 15);
+        assert_eq!(m1.effects.messages_dropped, 3);
+    }
+
+    #[test]
+    fn test_convergence_metrics() {
+        let mut metrics = ConvergenceMetrics::default();
+
+        assert!(!metrics.converged);
+
+        metrics.mark_converged(SimTime::from_millis(1000), 50, 100);
+
+        assert!(metrics.converged);
+        assert_eq!(metrics.time_to_converge, Some(SimTime::from_millis(1000)));
+        assert_eq!(metrics.messages_to_converge, 50);
+        assert_eq!(metrics.events_to_converge, 100);
+
+        metrics.mark_failed("timeout".to_string());
+        assert!(!metrics.converged);
+        assert_eq!(metrics.failure_reason, Some("timeout".to_string()));
+    }
+}

--- a/crates/node/tests/sync_sim/mod.rs
+++ b/crates/node/tests/sync_sim/mod.rs
@@ -1,0 +1,116 @@
+//! Sync Protocol Simulation Framework
+//!
+//! A deterministic, event-driven simulation framework for testing the Calimero
+//! sync protocol under realistic distributed system conditions.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                         Test Suite                               │
+//! └─────────────────────────────────────────────────────────────────┘
+//!                               │
+//!                               ▼
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                        SimRuntime                                │
+//! │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
+//! │  │  SimClock   │  │ EventQueue  │  │ ChaCha8Rng  │              │
+//! │  │  (logical)  │  │ (time,seq)  │  │  (seeded)   │              │
+//! │  └─────────────┘  └─────────────┘  └─────────────┘              │
+//! └─────────────────────────────────────────────────────────────────┘
+//!                               │
+//!                               ▼
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                        SimNetwork                                │
+//! │  - Message routing with delivery scheduling                     │
+//! │  - Fault injection (latency, loss, reorder, duplicate)          │
+//! │  - Partition modeling (connectivity cuts)                       │
+//! └─────────────────────────────────────────────────────────────────┘
+//!                               │
+//!               ┌───────────────┼───────────────┐
+//!               ▼               ▼               ▼
+//!        ┌──────────┐    ┌──────────┐    ┌──────────┐
+//!        │ SimNode  │    │ SimNode  │    │ SimNode  │
+//!        │ "alice"  │    │  "bob"   │    │"charlie" │
+//!        └──────────┘    └──────────┘    └──────────┘
+//! ```
+//!
+//! # Quick Start
+//!
+//! ```rust,ignore
+//! use sync_sim::prelude::*;
+//!
+//! // Create runtime with seed for reproducibility
+//! let mut rt = SimRuntime::new(42);
+//!
+//! // Add nodes
+//! let alice = rt.add_node("alice");
+//! let bob = rt.add_node("bob");
+//!
+//! // Set up initial state
+//! rt.node_mut(&alice).unwrap().insert_entity(
+//!     EntityId::from_u64(1),
+//!     vec![1, 2, 3],
+//!     CrdtType::LwwRegister,
+//! );
+//!
+//! // Run until convergence
+//! let converged = rt.run_until_converged();
+//! assert!(converged);
+//! ```
+//!
+//! # Features
+//!
+//! - **Deterministic execution**: Same seed = same results
+//! - **Event-driven**: Process events in (time, seq) order
+//! - **Fault injection**: Latency, loss, reorder, duplicates
+//! - **Partition modeling**: Network splits and heals
+//! - **Crash/restart**: Node failure and recovery
+//! - **Convergence checking**: Formal properties (C1-C5)
+//! - **Metrics collection**: Protocol cost, work done, effects
+
+pub mod actions;
+#[macro_use]
+pub mod assertions;
+pub mod convergence;
+pub mod digest;
+pub mod metrics;
+pub mod network;
+pub mod node;
+pub mod runtime;
+pub mod scenarios;
+pub mod sim_runtime;
+pub mod types;
+
+/// Prelude for convenient imports.
+pub mod prelude {
+    pub use super::actions::{
+        EntityMetadata, EntityTransfer, OutgoingMessage, SelectedProtocol, StorageOp, SyncActions,
+        SyncMessage, TimerOp,
+    };
+    pub use super::assertions::{
+        all_converged, divergence_percentage, majority_digest, nodes_converged,
+    };
+    pub use super::convergence::{
+        check_convergence, is_deadlocked, ConvergenceInput, ConvergencePending,
+        ConvergenceProperty, ConvergenceResult,
+    };
+    pub use super::digest::{compute_state_digest, DigestCache, DigestEntity};
+    pub use super::metrics::{
+        ConvergenceMetrics, EffectMetrics, NodeMetrics, ProtocolMetrics, SimMetrics, WorkMetrics,
+    };
+    pub use super::network::{
+        FaultConfig, NetworkRouter, PartitionManager, PartitionSpec, SimEvent,
+    };
+    pub use super::node::{SimNode, SyncState};
+    pub use super::runtime::{EventQueue, EventSeq, SimClock, SimDuration, SimRng, SimTime};
+    pub use super::scenarios::{RandomScenario, Scenario};
+    pub use super::sim_runtime::{SimConfig, SimRuntime, StopCondition};
+    pub use super::types::{DeltaId, EntityId, MessageId, NodeId, StateDigest, TimerId, TimerKind};
+
+    // Note: assertion macros (assert_converged!, assert_entity_count!, etc.) are available
+    // via `#[macro_use]` on the assertions module and don't need explicit re-export.
+}
+
+// Re-export for external use
+pub use prelude::*;

--- a/crates/node/tests/sync_sim/network/faults.rs
+++ b/crates/node/tests/sync_sim/network/faults.rs
@@ -1,0 +1,239 @@
+//! Fault injection configuration.
+//!
+//! See spec §13 - Fault Injection.
+
+use std::ops::Range;
+
+/// Network and node fault configuration.
+#[derive(Debug, Clone)]
+pub struct FaultConfig {
+    // =========================================================================
+    // Network Faults
+    // =========================================================================
+    /// Base network latency in milliseconds.
+    pub base_latency_ms: u64,
+
+    /// Latency jitter in milliseconds (±).
+    pub latency_jitter_ms: u64,
+
+    /// Message loss probability [0.0, 1.0].
+    pub message_loss_rate: f64,
+
+    /// Reorder window in milliseconds.
+    /// Messages within this window may be delivered out of order.
+    pub reorder_window_ms: u64,
+
+    /// Message duplication probability [0.0, 1.0].
+    pub duplicate_rate: f64,
+
+    // =========================================================================
+    // Partition Faults
+    // =========================================================================
+    /// Probability of spontaneous partition per tick.
+    pub partition_probability: f64,
+
+    /// Duration range for partitions in milliseconds.
+    pub partition_duration_ms: Range<u64>,
+
+    // =========================================================================
+    // Node Faults
+    // =========================================================================
+    /// Probability of node crash per tick.
+    pub crash_probability: f64,
+
+    /// Delay range before restart in milliseconds.
+    pub restart_delay_ms: Range<u64>,
+
+    /// Slow node processing delay multiplier.
+    pub slow_node_factor: f64,
+
+    // =========================================================================
+    // Concurrent Operations
+    // =========================================================================
+    /// Probability of write during sync.
+    pub write_during_sync_rate: f64,
+}
+
+impl Default for FaultConfig {
+    fn default() -> Self {
+        Self {
+            // Reasonable defaults for basic testing
+            base_latency_ms: 10,
+            latency_jitter_ms: 5,
+            message_loss_rate: 0.0,
+            reorder_window_ms: 0,
+            duplicate_rate: 0.0,
+            partition_probability: 0.0,
+            partition_duration_ms: 0..0,
+            crash_probability: 0.0,
+            restart_delay_ms: 0..0,
+            slow_node_factor: 1.0,
+            write_during_sync_rate: 0.0,
+        }
+    }
+}
+
+impl FaultConfig {
+    /// Create a config with no faults (instant delivery, no loss).
+    pub fn none() -> Self {
+        Self {
+            base_latency_ms: 0,
+            latency_jitter_ms: 0,
+            ..Default::default()
+        }
+    }
+
+    /// Create a config for light chaos testing.
+    pub fn light_chaos() -> Self {
+        Self {
+            base_latency_ms: 10,
+            latency_jitter_ms: 5,
+            message_loss_rate: 0.01,
+            reorder_window_ms: 20,
+            duplicate_rate: 0.01,
+            ..Default::default()
+        }
+    }
+
+    /// Create a config for heavy chaos testing.
+    pub fn heavy_chaos() -> Self {
+        Self {
+            base_latency_ms: 50,
+            latency_jitter_ms: 25,
+            message_loss_rate: 0.1,
+            reorder_window_ms: 100,
+            duplicate_rate: 0.05,
+            partition_probability: 0.01,
+            partition_duration_ms: 100..500,
+            crash_probability: 0.001,
+            restart_delay_ms: 100..1000,
+            ..Default::default()
+        }
+    }
+
+    /// Create a config focused on partition testing.
+    pub fn partition_heavy() -> Self {
+        Self {
+            base_latency_ms: 10,
+            latency_jitter_ms: 5,
+            partition_probability: 0.1,
+            partition_duration_ms: 200..1000,
+            ..Default::default()
+        }
+    }
+
+    /// Builder: set base latency.
+    pub fn with_latency(mut self, base_ms: u64, jitter_ms: u64) -> Self {
+        self.base_latency_ms = base_ms;
+        self.latency_jitter_ms = jitter_ms;
+        self
+    }
+
+    /// Builder: set message loss rate.
+    pub fn with_loss(mut self, rate: f64) -> Self {
+        self.message_loss_rate = rate.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Builder: set duplicate rate.
+    pub fn with_duplicates(mut self, rate: f64) -> Self {
+        self.duplicate_rate = rate.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Builder: set reorder window.
+    pub fn with_reorder(mut self, window_ms: u64) -> Self {
+        self.reorder_window_ms = window_ms;
+        self
+    }
+
+    /// Builder: set partition config.
+    pub fn with_partitions(mut self, probability: f64, duration_ms: Range<u64>) -> Self {
+        self.partition_probability = probability.clamp(0.0, 1.0);
+        self.partition_duration_ms = duration_ms;
+        self
+    }
+
+    /// Builder: set crash config.
+    pub fn with_crashes(mut self, probability: f64, restart_delay_ms: Range<u64>) -> Self {
+        self.crash_probability = probability.clamp(0.0, 1.0);
+        self.restart_delay_ms = restart_delay_ms;
+        self
+    }
+
+    /// Validate configuration.
+    pub fn validate(&self) -> Result<(), String> {
+        if !(0.0..=1.0).contains(&self.message_loss_rate) {
+            return Err("message_loss_rate must be in [0.0, 1.0]".to_string());
+        }
+        if !(0.0..=1.0).contains(&self.duplicate_rate) {
+            return Err("duplicate_rate must be in [0.0, 1.0]".to_string());
+        }
+        if !(0.0..=1.0).contains(&self.partition_probability) {
+            return Err("partition_probability must be in [0.0, 1.0]".to_string());
+        }
+        if !(0.0..=1.0).contains(&self.crash_probability) {
+            return Err("crash_probability must be in [0.0, 1.0]".to_string());
+        }
+        if self.slow_node_factor < 0.0 {
+            return Err("slow_node_factor must be non-negative".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = FaultConfig::default();
+        assert!(config.validate().is_ok());
+        assert_eq!(config.message_loss_rate, 0.0);
+    }
+
+    #[test]
+    fn test_none_config() {
+        let config = FaultConfig::none();
+        assert_eq!(config.base_latency_ms, 0);
+        assert_eq!(config.message_loss_rate, 0.0);
+    }
+
+    #[test]
+    fn test_chaos_configs() {
+        let light = FaultConfig::light_chaos();
+        assert!(light.validate().is_ok());
+        assert!(light.message_loss_rate > 0.0);
+
+        let heavy = FaultConfig::heavy_chaos();
+        assert!(heavy.validate().is_ok());
+        assert!(heavy.message_loss_rate > light.message_loss_rate);
+    }
+
+    #[test]
+    fn test_builder_pattern() {
+        let config = FaultConfig::none()
+            .with_latency(50, 10)
+            .with_loss(0.05)
+            .with_duplicates(0.02)
+            .with_reorder(100);
+
+        assert!(config.validate().is_ok());
+        assert_eq!(config.base_latency_ms, 50);
+        assert_eq!(config.latency_jitter_ms, 10);
+        assert_eq!(config.message_loss_rate, 0.05);
+        assert_eq!(config.duplicate_rate, 0.02);
+        assert_eq!(config.reorder_window_ms, 100);
+    }
+
+    #[test]
+    fn test_validation_clamps() {
+        // Builder should clamp invalid values
+        let config = FaultConfig::none().with_loss(2.0);
+        assert_eq!(config.message_loss_rate, 1.0);
+
+        let config = FaultConfig::none().with_loss(-0.5);
+        assert_eq!(config.message_loss_rate, 0.0);
+    }
+}

--- a/crates/node/tests/sync_sim/network/mod.rs
+++ b/crates/node/tests/sync_sim/network/mod.rs
@@ -1,0 +1,11 @@
+//! Network simulation components.
+//!
+//! Provides message routing, fault injection, and partition modeling.
+
+pub mod faults;
+pub mod partition;
+pub mod router;
+
+pub use faults::FaultConfig;
+pub use partition::{PartitionManager, PartitionSpec};
+pub use router::{InFlightMessage, NetworkMetrics, NetworkRouter, SimEvent};

--- a/crates/node/tests/sync_sim/network/partition.rs
+++ b/crates/node/tests/sync_sim/network/partition.rs
@@ -1,0 +1,306 @@
+//! Network partition modeling.
+//!
+//! See spec §12 - Partition Modeling.
+
+use std::collections::HashSet;
+
+use crate::sync_sim::runtime::SimTime;
+use crate::sync_sim::types::NodeId;
+
+/// Partition specification.
+#[derive(Debug, Clone)]
+pub enum PartitionSpec {
+    /// Symmetric: neither side can reach the other.
+    /// Groups are mutually isolated.
+    Bidirectional { groups: Vec<Vec<NodeId>> },
+
+    /// Asymmetric: specific directed links are blocked.
+    Directional { blocked: Vec<(NodeId, NodeId)> },
+}
+
+impl PartitionSpec {
+    /// Create a bidirectional partition splitting nodes into two groups.
+    pub fn split(group_a: Vec<NodeId>, group_b: Vec<NodeId>) -> Self {
+        Self::Bidirectional {
+            groups: vec![group_a, group_b],
+        }
+    }
+
+    /// Create a partition isolating a single node from all others.
+    pub fn isolate(node: NodeId, others: Vec<NodeId>) -> Self {
+        Self::Bidirectional {
+            groups: vec![vec![node], others],
+        }
+    }
+
+    /// Create a directional block (from cannot reach to).
+    pub fn block(from: NodeId, to: NodeId) -> Self {
+        Self::Directional {
+            blocked: vec![(from, to)],
+        }
+    }
+
+    /// Check if this partition blocks communication from `from` to `to`.
+    pub fn blocks(&self, from: &NodeId, to: &NodeId) -> bool {
+        match self {
+            Self::Bidirectional { groups } => {
+                // Find which groups contain from and to
+                let from_group = groups.iter().position(|g| g.contains(from));
+                let to_group = groups.iter().position(|g| g.contains(to));
+
+                match (from_group, to_group) {
+                    (Some(fg), Some(tg)) => fg != tg, // Different groups = blocked
+                    _ => false,                       // Unknown nodes = not blocked
+                }
+            }
+            Self::Directional { blocked } => blocked.iter().any(|(f, t)| f == from && t == to),
+        }
+    }
+}
+
+/// Active partition with timing.
+#[derive(Debug, Clone)]
+struct ActivePartition {
+    /// The partition specification.
+    spec: PartitionSpec,
+    /// When the partition started.
+    start_time: SimTime,
+    /// When the partition ends (None = permanent until explicitly removed).
+    end_time: Option<SimTime>,
+}
+
+impl ActivePartition {
+    /// Check if this partition is active at the given time.
+    fn is_active_at(&self, now: SimTime) -> bool {
+        let started = self.start_time <= now;
+        let not_ended = self.end_time.map_or(true, |end| end > now);
+        started && not_ended
+    }
+}
+
+/// Manages active network partitions.
+#[derive(Debug, Default)]
+pub struct PartitionManager {
+    /// Active partitions.
+    partitions: Vec<ActivePartition>,
+    /// Quick lookup: node pairs that are currently partitioned.
+    /// Key: (from, to) where from < to for bidirectional.
+    blocked_cache: HashSet<(String, String)>,
+    /// Cache validity time.
+    cache_time: Option<SimTime>,
+}
+
+impl PartitionManager {
+    /// Create a new partition manager.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a partition.
+    pub fn add_partition(&mut self, spec: PartitionSpec, start: SimTime, end: Option<SimTime>) {
+        self.partitions.push(ActivePartition {
+            spec,
+            start_time: start,
+            end_time: end,
+        });
+        self.invalidate_cache();
+    }
+
+    /// Remove partitions matching a predicate.
+    pub fn remove_partitions<F>(&mut self, predicate: F)
+    where
+        F: Fn(&PartitionSpec) -> bool,
+    {
+        self.partitions.retain(|p| !predicate(&p.spec));
+        self.invalidate_cache();
+    }
+
+    /// Clear all partitions.
+    pub fn clear(&mut self) {
+        self.partitions.clear();
+        self.invalidate_cache();
+    }
+
+    /// Check if communication from `from` to `to` is blocked at time `now`.
+    pub fn is_partitioned(&mut self, from: &NodeId, to: &NodeId, now: SimTime) -> bool {
+        // Remove fully expired partitions (end_time has passed)
+        self.partitions
+            .retain(|p| p.end_time.map_or(true, |end| end > now));
+
+        // Check each partition that is active at this time
+        for partition in &self.partitions {
+            if partition.is_active_at(now) && partition.spec.blocks(from, to) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Get number of active partitions at the given time.
+    pub fn partition_count_at(&self, now: SimTime) -> usize {
+        self.partitions
+            .iter()
+            .filter(|p| p.is_active_at(now))
+            .count()
+    }
+
+    /// Get number of stored partitions (may include not-yet-started or expired).
+    pub fn partition_count(&self) -> usize {
+        self.partitions.len()
+    }
+
+    /// Check if there are any active partitions at the given time.
+    pub fn has_partitions_at(&self, now: SimTime) -> bool {
+        self.partitions.iter().any(|p| p.is_active_at(now))
+    }
+
+    /// Check if there are any stored partitions.
+    pub fn has_partitions(&self) -> bool {
+        !self.partitions.is_empty()
+    }
+
+    /// Invalidate the cache.
+    fn invalidate_cache(&mut self) {
+        self.blocked_cache.clear();
+        self.cache_time = None;
+    }
+
+    /// Get all currently blocked node pairs (for debugging).
+    pub fn get_blocked_pairs(&self, nodes: &[NodeId], now: SimTime) -> Vec<(NodeId, NodeId)> {
+        let mut blocked = Vec::new();
+
+        for partition in &self.partitions {
+            if partition.is_active_at(now) {
+                for from in nodes {
+                    for to in nodes {
+                        if from != to && partition.spec.blocks(from, to) {
+                            blocked.push((from.clone(), to.clone()));
+                        }
+                    }
+                }
+            }
+        }
+
+        blocked
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bidirectional_partition() {
+        let spec = PartitionSpec::split(
+            vec![NodeId::new("a"), NodeId::new("b")],
+            vec![NodeId::new("c"), NodeId::new("d")],
+        );
+
+        // Within group: not blocked
+        assert!(!spec.blocks(&NodeId::new("a"), &NodeId::new("b")));
+        assert!(!spec.blocks(&NodeId::new("c"), &NodeId::new("d")));
+
+        // Across groups: blocked
+        assert!(spec.blocks(&NodeId::new("a"), &NodeId::new("c")));
+        assert!(spec.blocks(&NodeId::new("c"), &NodeId::new("a"))); // Symmetric
+        assert!(spec.blocks(&NodeId::new("b"), &NodeId::new("d")));
+    }
+
+    #[test]
+    fn test_directional_partition() {
+        let spec = PartitionSpec::block(NodeId::new("a"), NodeId::new("b"));
+
+        // a -> b is blocked
+        assert!(spec.blocks(&NodeId::new("a"), &NodeId::new("b")));
+
+        // b -> a is NOT blocked (directional)
+        assert!(!spec.blocks(&NodeId::new("b"), &NodeId::new("a")));
+
+        // Others not affected
+        assert!(!spec.blocks(&NodeId::new("a"), &NodeId::new("c")));
+    }
+
+    #[test]
+    fn test_isolate_partition() {
+        let spec = PartitionSpec::isolate(
+            NodeId::new("isolated"),
+            vec![NodeId::new("a"), NodeId::new("b"), NodeId::new("c")],
+        );
+
+        // Isolated node cannot reach anyone
+        assert!(spec.blocks(&NodeId::new("isolated"), &NodeId::new("a")));
+        assert!(spec.blocks(&NodeId::new("isolated"), &NodeId::new("b")));
+
+        // Others cannot reach isolated node
+        assert!(spec.blocks(&NodeId::new("a"), &NodeId::new("isolated")));
+
+        // Others can reach each other
+        assert!(!spec.blocks(&NodeId::new("a"), &NodeId::new("b")));
+    }
+
+    #[test]
+    fn test_partition_manager_timing() {
+        let mut manager = PartitionManager::new();
+
+        let now = SimTime::from_millis(100);
+        let end = SimTime::from_millis(200);
+
+        manager.add_partition(
+            PartitionSpec::split(vec![NodeId::new("a")], vec![NodeId::new("b")]),
+            now,
+            Some(end),
+        );
+
+        // During partition
+        assert!(manager.is_partitioned(&NodeId::new("a"), &NodeId::new("b"), now));
+        assert!(manager.is_partitioned(
+            &NodeId::new("a"),
+            &NodeId::new("b"),
+            SimTime::from_millis(150)
+        ));
+
+        // After partition expires
+        assert!(!manager.is_partitioned(
+            &NodeId::new("a"),
+            &NodeId::new("b"),
+            SimTime::from_millis(200)
+        ));
+    }
+
+    #[test]
+    fn test_partition_manager_permanent() {
+        let mut manager = PartitionManager::new();
+
+        manager.add_partition(
+            PartitionSpec::split(vec![NodeId::new("a")], vec![NodeId::new("b")]),
+            SimTime::ZERO,
+            None, // Permanent
+        );
+
+        // Always blocked
+        assert!(manager.is_partitioned(
+            &NodeId::new("a"),
+            &NodeId::new("b"),
+            SimTime::from_millis(1_000_000)
+        ));
+    }
+
+    #[test]
+    fn test_partition_manager_clear() {
+        let mut manager = PartitionManager::new();
+
+        manager.add_partition(
+            PartitionSpec::split(vec![NodeId::new("a")], vec![NodeId::new("b")]),
+            SimTime::ZERO,
+            None,
+        );
+
+        assert!(manager.has_partitions());
+
+        manager.clear();
+
+        assert!(!manager.has_partitions());
+        assert!(!manager.is_partitioned(&NodeId::new("a"), &NodeId::new("b"), SimTime::ZERO));
+    }
+}

--- a/crates/node/tests/sync_sim/network/router.rs
+++ b/crates/node/tests/sync_sim/network/router.rs
@@ -1,0 +1,439 @@
+//! Message routing and delivery scheduling.
+//!
+//! See spec §2 - SimNetwork and §12 - Partition Modeling.
+
+use super::faults::FaultConfig;
+use super::partition::PartitionManager;
+use crate::sync_sim::actions::{OutgoingMessage, SyncMessage};
+use crate::sync_sim::metrics::EffectMetrics;
+use crate::sync_sim::runtime::{EventQueue, SimDuration, SimRng, SimTime};
+use crate::sync_sim::types::{MessageId, NodeId};
+
+/// Event types for the simulation.
+#[derive(Debug, Clone)]
+pub enum SimEvent {
+    /// Deliver a message to a node.
+    DeliverMessage {
+        from: NodeId,
+        to: NodeId,
+        msg: SyncMessage,
+        msg_id: MessageId,
+    },
+    /// Fire a timer.
+    TimerFired { node: NodeId, timer_id: u64 },
+    /// Node crash event.
+    NodeCrash { node: NodeId },
+    /// Node restart event.
+    NodeRestart { node: NodeId },
+    /// Partition start.
+    PartitionStart { groups: Vec<Vec<NodeId>> },
+    /// Partition end.
+    PartitionEnd { groups: Vec<Vec<NodeId>> },
+}
+
+/// Message in flight with delivery metadata.
+#[derive(Debug)]
+pub struct InFlightMessage {
+    /// Source node.
+    pub from: NodeId,
+    /// Destination node.
+    pub to: NodeId,
+    /// The message.
+    pub msg: SyncMessage,
+    /// Message ID for deduplication.
+    pub msg_id: MessageId,
+    /// Scheduled delivery time.
+    pub delivery_time: SimTime,
+}
+
+/// Network router for message delivery.
+pub struct NetworkRouter {
+    /// Fault configuration.
+    fault_config: FaultConfig,
+    /// Partition manager.
+    partitions: PartitionManager,
+    /// RNG for fault injection.
+    rng: SimRng,
+    /// Messages currently in flight (for counting).
+    in_flight_count: usize,
+    /// Metrics.
+    pub metrics: NetworkMetrics,
+}
+
+/// Network metrics.
+#[derive(Debug, Default, Clone)]
+pub struct NetworkMetrics {
+    /// Total messages sent.
+    pub messages_sent: u64,
+    /// Messages dropped due to loss.
+    pub messages_dropped_loss: u64,
+    /// Messages dropped due to partition.
+    pub messages_dropped_partition: u64,
+    /// Messages reordered.
+    pub messages_reordered: u64,
+    /// Messages duplicated.
+    pub messages_duplicated: u64,
+    /// Total bytes sent.
+    pub bytes_sent: u64,
+}
+
+impl NetworkRouter {
+    /// Create a new router with default config.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            fault_config: FaultConfig::default(),
+            partitions: PartitionManager::new(),
+            rng: SimRng::new(seed),
+            in_flight_count: 0,
+            metrics: NetworkMetrics::default(),
+        }
+    }
+
+    /// Create with custom fault config.
+    pub fn with_faults(seed: u64, config: FaultConfig) -> Self {
+        Self {
+            fault_config: config,
+            partitions: PartitionManager::new(),
+            rng: SimRng::new(seed),
+            in_flight_count: 0,
+            metrics: NetworkMetrics::default(),
+        }
+    }
+
+    /// Set fault configuration.
+    pub fn set_fault_config(&mut self, config: FaultConfig) {
+        self.fault_config = config;
+    }
+
+    /// Get fault configuration.
+    pub fn fault_config(&self) -> &FaultConfig {
+        &self.fault_config
+    }
+
+    /// Get partition manager.
+    pub fn partitions(&self) -> &PartitionManager {
+        &self.partitions
+    }
+
+    /// Get mutable partition manager.
+    pub fn partitions_mut(&mut self) -> &mut PartitionManager {
+        &mut self.partitions
+    }
+
+    /// Get number of messages in flight.
+    pub fn in_flight_count(&self) -> usize {
+        self.in_flight_count
+    }
+
+    /// Increment in-flight count (for manually injected messages).
+    pub fn increment_in_flight(&mut self) {
+        self.in_flight_count += 1;
+    }
+
+    /// Route a message, potentially applying faults.
+    ///
+    /// The `msg_size` parameter should be the result of `msg.msg.estimated_size()`,
+    /// computed once by the caller to avoid redundant traversal.
+    ///
+    /// Also updates the provided `effect_metrics` to reflect any network faults applied.
+    pub fn route_message(
+        &mut self,
+        now: SimTime,
+        msg: OutgoingMessage,
+        msg_size: usize,
+        from: &NodeId,
+        queue: &mut EventQueue<SimEvent>,
+        effect_metrics: &mut EffectMetrics,
+    ) {
+        self.metrics.messages_sent += 1;
+        self.metrics.bytes_sent += msg_size as u64;
+
+        // Check for partition at send time
+        // Note: We also check at delivery time (spec §12.2)
+        // Checking here is optional but can short-circuit
+
+        // Check for message loss
+        if self
+            .rng
+            .bool_with_probability(self.fault_config.message_loss_rate)
+        {
+            self.metrics.messages_dropped_loss += 1;
+            effect_metrics.record_drop();
+            return;
+        }
+
+        // Calculate delivery time with latency and jitter
+        let base_latency = SimDuration::from_millis(self.fault_config.base_latency_ms);
+        let jitter = SimDuration::from_millis(self.fault_config.latency_jitter_ms);
+        let mut delivery_delay = self.rng.duration_with_jitter(base_latency, jitter);
+
+        // Apply reorder: add random delay within reorder window
+        // This causes messages to potentially arrive out of order
+        // Note: We don't increment reorder metrics here because adding a random delay
+        // doesn't guarantee actual reordering. True reordering depends on the relative
+        // delivery times of multiple messages, which we cannot determine at send time.
+        if self.fault_config.reorder_window_ms > 0 {
+            // Use saturating arithmetic to prevent overflow with large reorder_window_ms values
+            let reorder_window_micros =
+                (self.fault_config.reorder_window_ms as usize).saturating_mul(1000);
+            // Ensure we have at least 1 to avoid issues with gen_range_usize(0)
+            let reorder_delay_micros = if reorder_window_micros > 0 {
+                self.rng.gen_range_usize(reorder_window_micros)
+            } else {
+                0
+            };
+            delivery_delay = delivery_delay + SimDuration::from_micros(reorder_delay_micros as u64);
+        }
+
+        let delivery_time = now + delivery_delay;
+
+        // Create the delivery event
+        let event = SimEvent::DeliverMessage {
+            from: from.clone(),
+            to: msg.to.clone(),
+            msg: msg.msg.clone(),
+            msg_id: msg.msg_id.clone(),
+        };
+
+        // Schedule delivery
+        queue.schedule(delivery_time, event);
+        self.in_flight_count += 1;
+
+        // Check for duplication
+        if self
+            .rng
+            .bool_with_probability(self.fault_config.duplicate_rate)
+        {
+            self.metrics.messages_duplicated += 1;
+            effect_metrics.record_duplicate();
+
+            // Schedule duplicate with additional delay
+            let dup_delay = self.rng.duration_with_jitter(base_latency, jitter);
+            let dup_time = now + delivery_delay + dup_delay;
+
+            let dup_event = SimEvent::DeliverMessage {
+                from: from.clone(),
+                to: msg.to,
+                msg: msg.msg,
+                msg_id: msg.msg_id,
+            };
+
+            queue.schedule(dup_time, dup_event);
+            self.in_flight_count += 1;
+        }
+    }
+
+    /// Check if delivery should proceed (partition check at delivery time).
+    ///
+    /// Returns true if message should be delivered, false if dropped.
+    pub fn should_deliver(&mut self, from: &NodeId, to: &NodeId, now: SimTime) -> bool {
+        self.in_flight_count = self.in_flight_count.saturating_sub(1);
+
+        if self.partitions.is_partitioned(from, to, now) {
+            self.metrics.messages_dropped_partition += 1;
+            return false;
+        }
+
+        true
+    }
+
+    /// Reset metrics.
+    pub fn reset_metrics(&mut self) {
+        self.metrics = NetworkMetrics::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync_sim::actions::SyncMessage;
+
+    #[test]
+    fn test_router_basic_delivery() {
+        let mut router = NetworkRouter::new(42);
+        let mut queue = EventQueue::new();
+        let mut effects = EffectMetrics::default();
+        let now = SimTime::ZERO;
+
+        let msg = OutgoingMessage {
+            to: NodeId::new("bob"),
+            msg: SyncMessage::SyncComplete { success: true },
+            msg_id: MessageId::new("alice", 1, 1),
+        };
+
+        let msg_size = msg.msg.estimated_size();
+        router.route_message(
+            now,
+            msg,
+            msg_size,
+            &NodeId::new("alice"),
+            &mut queue,
+            &mut effects,
+        );
+
+        assert_eq!(router.metrics.messages_sent, 1);
+        assert!(!queue.is_empty());
+    }
+
+    #[test]
+    fn test_router_message_loss() {
+        let mut router = NetworkRouter::with_faults(
+            42,
+            FaultConfig {
+                message_loss_rate: 1.0, // 100% loss
+                ..Default::default()
+            },
+        );
+        let mut queue = EventQueue::new();
+        let mut effects = EffectMetrics::default();
+        let now = SimTime::ZERO;
+
+        let msg = OutgoingMessage {
+            to: NodeId::new("bob"),
+            msg: SyncMessage::SyncComplete { success: true },
+            msg_id: MessageId::new("alice", 1, 1),
+        };
+
+        let msg_size = msg.msg.estimated_size();
+        router.route_message(
+            now,
+            msg,
+            msg_size,
+            &NodeId::new("alice"),
+            &mut queue,
+            &mut effects,
+        );
+
+        assert_eq!(router.metrics.messages_sent, 1);
+        assert_eq!(router.metrics.messages_dropped_loss, 1);
+        assert_eq!(effects.messages_dropped, 1);
+        assert!(queue.is_empty()); // Message was lost
+    }
+
+    #[test]
+    fn test_router_duplication() {
+        let mut router = NetworkRouter::with_faults(
+            42,
+            FaultConfig {
+                duplicate_rate: 1.0, // 100% duplication
+                ..Default::default()
+            },
+        );
+        let mut queue = EventQueue::new();
+        let mut effects = EffectMetrics::default();
+        let now = SimTime::ZERO;
+
+        let msg = OutgoingMessage {
+            to: NodeId::new("bob"),
+            msg: SyncMessage::SyncComplete { success: true },
+            msg_id: MessageId::new("alice", 1, 1),
+        };
+
+        let msg_size = msg.msg.estimated_size();
+        router.route_message(
+            now,
+            msg,
+            msg_size,
+            &NodeId::new("alice"),
+            &mut queue,
+            &mut effects,
+        );
+
+        assert_eq!(router.metrics.messages_sent, 1);
+        assert_eq!(router.metrics.messages_duplicated, 1);
+        assert_eq!(effects.messages_duplicated, 1);
+        assert_eq!(queue.len(), 2); // Original + duplicate
+    }
+
+    #[test]
+    fn test_router_latency() {
+        let mut router = NetworkRouter::with_faults(
+            42,
+            FaultConfig {
+                base_latency_ms: 100,
+                latency_jitter_ms: 10,
+                ..Default::default()
+            },
+        );
+        let mut queue = EventQueue::new();
+        let mut effects = EffectMetrics::default();
+        let now = SimTime::from_millis(1000);
+
+        let msg = OutgoingMessage {
+            to: NodeId::new("bob"),
+            msg: SyncMessage::SyncComplete { success: true },
+            msg_id: MessageId::new("alice", 1, 1),
+        };
+
+        let msg_size = msg.msg.estimated_size();
+        router.route_message(
+            now,
+            msg,
+            msg_size,
+            &NodeId::new("alice"),
+            &mut queue,
+            &mut effects,
+        );
+
+        let (delivery_time, _, _) = queue.pop().unwrap();
+        let delay = delivery_time - now;
+
+        // Should be within base ± jitter
+        assert!(delay.as_millis() >= 90);
+        assert!(delay.as_millis() <= 110);
+    }
+
+    #[test]
+    fn test_router_reorder() {
+        let mut router = NetworkRouter::with_faults(
+            42,
+            FaultConfig {
+                base_latency_ms: 10,
+                latency_jitter_ms: 0,
+                reorder_window_ms: 50, // 50ms reorder window
+                ..Default::default()
+            },
+        );
+        let mut queue = EventQueue::new();
+        let mut effects = EffectMetrics::default();
+        let now = SimTime::ZERO;
+
+        // Send multiple messages
+        for seq in 0..10 {
+            let msg = OutgoingMessage {
+                to: NodeId::new("bob"),
+                msg: SyncMessage::SyncComplete { success: true },
+                msg_id: MessageId::new("alice", 1, seq),
+            };
+            let msg_size = msg.msg.estimated_size();
+            router.route_message(
+                now,
+                msg,
+                msg_size,
+                &NodeId::new("alice"),
+                &mut queue,
+                &mut effects,
+            );
+        }
+
+        // Reorder metrics are not incremented at send time because adding random delay
+        // doesn't guarantee actual reordering - that depends on relative delivery times.
+        // True reordering detection would require comparing delivery order vs send order.
+        assert_eq!(router.metrics.messages_reordered, 0);
+        assert_eq!(effects.messages_reordered, 0);
+
+        // Collect delivery times
+        let mut delivery_times = Vec::new();
+        while let Some((time, _, _)) = queue.pop() {
+            delivery_times.push(time);
+        }
+
+        // With reorder, delay should be base + random(0..reorder_window)
+        // So delays should be between 10ms and 60ms
+        for time in &delivery_times {
+            let delay_ms = time.as_millis();
+            assert!(delay_ms >= 10, "delay {} should be >= 10", delay_ms);
+            assert!(delay_ms <= 60, "delay {} should be <= 60", delay_ms);
+        }
+    }
+}

--- a/crates/node/tests/sync_sim/node/mod.rs
+++ b/crates/node/tests/sync_sim/node/mod.rs
@@ -1,0 +1,7 @@
+//! Simulated node implementation.
+//!
+//! See spec §2 - Architecture Overview and §3 - Side-Effect Model.
+
+pub mod state;
+
+pub use state::{SimNode, SyncState};

--- a/crates/node/tests/sync_sim/node/state.rs
+++ b/crates/node/tests/sync_sim/node/state.rs
@@ -1,0 +1,497 @@
+//! Simulated node state.
+//!
+//! Wraps storage, DAG, and sync state machine.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use calimero_node_primitives::sync::handshake::SyncHandshake;
+use calimero_primitives::crdt::CrdtType;
+
+use crate::sync_sim::actions::{EntityMetadata, StorageOp};
+use crate::sync_sim::digest::{DigestCache, DigestEntity};
+use crate::sync_sim::runtime::SimTime;
+use crate::sync_sim::types::{
+    DeltaId, EntityId, MessageId, NodeId, StateDigest, TimerId, TimerKind,
+};
+
+/// Sync state machine state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncState {
+    /// Not syncing.
+    Idle,
+    /// Initiating sync with a peer.
+    Initiating { peer: NodeId },
+    /// Responding to sync from a peer.
+    Responding { peer: NodeId },
+    /// Snapshot transfer in progress.
+    SnapshotTransfer { peer: NodeId, page: u32 },
+    /// Hash comparison in progress.
+    HashComparison { peer: NodeId, level: u32 },
+    /// Delta sync in progress.
+    DeltaSync { peer: NodeId },
+}
+
+impl SyncState {
+    /// Check if idle.
+    pub fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
+    /// Check if syncing.
+    pub fn is_active(&self) -> bool {
+        !self.is_idle()
+    }
+
+    /// Get peer if syncing.
+    pub fn peer(&self) -> Option<&NodeId> {
+        match self {
+            Self::Idle => None,
+            Self::Initiating { peer }
+            | Self::Responding { peer }
+            | Self::SnapshotTransfer { peer, .. }
+            | Self::HashComparison { peer, .. }
+            | Self::DeltaSync { peer } => Some(peer),
+        }
+    }
+}
+
+/// Timer entry.
+#[derive(Debug, Clone)]
+pub struct TimerEntry {
+    /// Timer ID.
+    pub id: TimerId,
+    /// Timer kind.
+    pub kind: TimerKind,
+    /// Scheduled fire time.
+    pub fire_time: SimTime,
+}
+
+/// Maximum number of processed messages to track before eviction.
+const MAX_PROCESSED_MESSAGES: usize = 10_000;
+
+/// Simulated node.
+#[derive(Debug)]
+pub struct SimNode {
+    /// Node ID.
+    pub id: NodeId,
+    /// Current session (increments on restart).
+    pub session: u64,
+    /// Outgoing message sequence counter.
+    pub out_seq: u64,
+    /// Storage with digest caching.
+    pub storage: DigestCache,
+    /// DAG heads.
+    pub dag_heads: Vec<DeltaId>,
+    /// Delta buffer (references to DAG entries).
+    pub delta_buffer: Vec<DeltaId>,
+    /// Sync state machine state.
+    pub sync_state: SyncState,
+    /// Active timers.
+    pub timers: Vec<TimerEntry>,
+    /// Next timer ID.
+    next_timer_id: u64,
+    /// Processed message IDs (for deduplication), bounded to MAX_PROCESSED_MESSAGES.
+    processed_messages: HashSet<MessageId>,
+    /// Ordered deque for O(1) LRU-like eviction of processed messages.
+    processed_order: VecDeque<MessageId>,
+    /// Highest session seen from each sender (for stale message detection).
+    sender_sessions: HashMap<String, u64>,
+    /// Whether node has been initialized (ever had state).
+    pub has_state: bool,
+    /// Whether node is currently crashed (offline).
+    pub is_crashed: bool,
+}
+
+impl SimNode {
+    /// Create a new node.
+    pub fn new(id: impl Into<NodeId>) -> Self {
+        Self {
+            id: id.into(),
+            session: 0,
+            out_seq: 0,
+            storage: DigestCache::new(),
+            dag_heads: vec![DeltaId::ZERO],
+            delta_buffer: Vec::new(),
+            sync_state: SyncState::Idle,
+            timers: Vec::new(),
+            next_timer_id: 0,
+            processed_messages: HashSet::new(),
+            processed_order: VecDeque::new(),
+            sender_sessions: HashMap::new(),
+            has_state: false,
+            is_crashed: false,
+        }
+    }
+
+    /// Get node ID.
+    pub fn id(&self) -> &NodeId {
+        &self.id
+    }
+
+    /// Generate next message ID.
+    pub fn next_message_id(&mut self) -> MessageId {
+        let id = MessageId::new(self.id.as_str(), self.session, self.out_seq);
+        self.out_seq += 1;
+        id
+    }
+
+    /// Generate next timer ID.
+    pub fn next_timer_id(&mut self) -> TimerId {
+        let id = TimerId::new(self.next_timer_id);
+        self.next_timer_id += 1;
+        id
+    }
+
+    /// Check if message was already processed.
+    ///
+    /// A message is considered duplicate if:
+    /// 1. We've seen a newer session from this sender (message is stale), OR
+    /// 2. We've already processed this exact message ID
+    pub fn is_duplicate(&self, msg_id: &MessageId) -> bool {
+        // Check if we've seen a newer session from this sender
+        if let Some(&last_session) = self.sender_sessions.get(&msg_id.sender) {
+            if msg_id.session < last_session {
+                // Stale session from this sender
+                return true;
+            }
+        }
+        self.processed_messages.contains(msg_id)
+    }
+
+    /// Mark message as processed.
+    ///
+    /// Uses bounded storage with LRU-like eviction when MAX_PROCESSED_MESSAGES is reached.
+    pub fn mark_processed(&mut self, msg_id: MessageId) {
+        // Update the highest session seen from this sender
+        let current = self
+            .sender_sessions
+            .entry(msg_id.sender.clone())
+            .or_insert(0);
+        if msg_id.session > *current {
+            *current = msg_id.session;
+        }
+
+        // Only add if not already present
+        if self.processed_messages.insert(msg_id.clone()) {
+            self.processed_order.push_back(msg_id);
+
+            // Evict oldest entries if over limit (O(1) with VecDeque::pop_front)
+            while self.processed_messages.len() > MAX_PROCESSED_MESSAGES {
+                if let Some(oldest) = self.processed_order.pop_front() {
+                    self.processed_messages.remove(&oldest);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Get state digest.
+    pub fn state_digest(&mut self) -> StateDigest {
+        self.storage.digest()
+    }
+
+    /// Get entity count.
+    pub fn entity_count(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// Get root hash (for handshake).
+    pub fn root_hash(&mut self) -> [u8; 32] {
+        self.storage.digest().0
+    }
+
+    /// Check if node has any state.
+    pub fn has_any_state(&self) -> bool {
+        self.has_state || !self.storage.is_empty()
+    }
+
+    /// Get DAG heads.
+    pub fn dag_heads(&self) -> &[DeltaId] {
+        &self.dag_heads
+    }
+
+    /// Get buffer size.
+    pub fn buffer_size(&self) -> usize {
+        self.delta_buffer.len()
+    }
+
+    /// Get sync timer count.
+    pub fn sync_timer_count(&self) -> usize {
+        self.timers
+            .iter()
+            .filter(|t| t.kind == TimerKind::Sync)
+            .count()
+    }
+
+    /// Apply storage operation.
+    pub fn apply_storage_op(&mut self, op: StorageOp) {
+        match op {
+            StorageOp::Insert { id, data, metadata } | StorageOp::Update { id, data, metadata } => {
+                self.storage.upsert(DigestEntity { id, data, metadata });
+                self.has_state = true;
+            }
+            StorageOp::Remove { id } => {
+                self.storage.remove(&id);
+            }
+        }
+    }
+
+    /// Set a timer.
+    pub fn set_timer(&mut self, id: TimerId, fire_time: SimTime, kind: TimerKind) {
+        // Remove any existing timer with same ID
+        self.timers.retain(|t| t.id != id);
+        self.timers.push(TimerEntry {
+            id,
+            kind,
+            fire_time,
+        });
+    }
+
+    /// Cancel a timer.
+    pub fn cancel_timer(&mut self, id: TimerId) {
+        self.timers.retain(|t| t.id != id);
+    }
+
+    /// Get timer by ID.
+    pub fn get_timer(&self, id: TimerId) -> Option<&TimerEntry> {
+        self.timers.iter().find(|t| t.id == id)
+    }
+
+    /// Buffer a delta (during sync).
+    pub fn buffer_delta(&mut self, delta_id: DeltaId) {
+        if !self.delta_buffer.contains(&delta_id) {
+            self.delta_buffer.push(delta_id);
+        }
+    }
+
+    /// Clear delta buffer.
+    pub fn clear_buffer(&mut self) {
+        self.delta_buffer.clear();
+    }
+
+    /// Crash the node (see spec §6).
+    pub fn crash(&mut self) {
+        // Preserve: storage, DAG (dag_heads)
+        // Lose: timers, sync state, buffer, processed messages, sender sessions, out_seq
+
+        self.timers.clear();
+        self.sync_state = SyncState::Idle;
+        self.delta_buffer.clear();
+        self.processed_messages.clear();
+        self.processed_order.clear();
+        self.sender_sessions.clear();
+        self.out_seq = 0;
+        self.is_crashed = true;
+    }
+
+    /// Restart the node after crash.
+    pub fn restart(&mut self) {
+        // Increment session
+        self.session += 1;
+        // out_seq already reset in crash()
+        // State machine already Idle from crash()
+        self.is_crashed = false;
+    }
+
+    /// Insert entity directly (for test setup).
+    pub fn insert_entity(&mut self, id: EntityId, data: Vec<u8>, crdt_type: CrdtType) {
+        let metadata = EntityMetadata::new(crdt_type, 0);
+        self.storage.upsert(DigestEntity { id, data, metadata });
+        self.has_state = true;
+    }
+
+    /// Insert entity with full metadata.
+    pub fn insert_entity_with_metadata(
+        &mut self,
+        id: EntityId,
+        data: Vec<u8>,
+        metadata: EntityMetadata,
+    ) {
+        self.storage.upsert(DigestEntity { id, data, metadata });
+        self.has_state = true;
+    }
+
+    /// Get entity.
+    pub fn get_entity(&self, id: &EntityId) -> Option<&DigestEntity> {
+        self.storage.get(id)
+    }
+
+    /// Check if entity exists.
+    pub fn has_entity(&self, id: &EntityId) -> bool {
+        self.storage.get(id).is_some()
+    }
+
+    /// Build a SyncHandshake for this node.
+    ///
+    /// Used for protocol negotiation testing.
+    pub fn build_handshake(&mut self) -> SyncHandshake {
+        let root_hash = self.root_hash();
+        let entity_count = self.entity_count() as u64;
+
+        // Estimate max_depth from entity count (log2-ish for balanced tree)
+        let max_depth = if entity_count == 0 {
+            0
+        } else {
+            (64 - entity_count.leading_zeros()).min(32)
+        };
+
+        let dag_heads: Vec<[u8; 32]> = self.dag_heads.iter().map(|d| d.0).collect();
+
+        SyncHandshake::new(root_hash, entity_count, max_depth, dag_heads)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_node_creation() {
+        let node = SimNode::new("alice");
+
+        assert_eq!(node.id().as_str(), "alice");
+        assert_eq!(node.session, 0);
+        assert!(node.sync_state.is_idle());
+        assert_eq!(node.entity_count(), 0);
+        assert!(!node.has_any_state());
+    }
+
+    #[test]
+    fn test_message_id_generation() {
+        let mut node = SimNode::new("alice");
+
+        let m1 = node.next_message_id();
+        let m2 = node.next_message_id();
+
+        assert_eq!(m1.sender, "alice");
+        assert_eq!(m1.session, 0);
+        assert_eq!(m1.seq, 0);
+
+        assert_eq!(m2.seq, 1);
+    }
+
+    #[test]
+    fn test_duplicate_detection() {
+        let mut node = SimNode::new("alice");
+
+        let msg_id = MessageId::new("bob", 0, 1);
+
+        assert!(!node.is_duplicate(&msg_id));
+        node.mark_processed(msg_id.clone());
+        assert!(node.is_duplicate(&msg_id));
+    }
+
+    #[test]
+    fn test_duplicate_detection_sender_session() {
+        let mut node = SimNode::new("alice");
+
+        // Process a message from bob's session 1
+        let msg_session1 = MessageId::new("bob", 1, 0);
+        assert!(!node.is_duplicate(&msg_session1));
+        node.mark_processed(msg_session1);
+
+        // A message from bob's older session 0 should be stale
+        let old_msg = MessageId::new("bob", 0, 5);
+        assert!(node.is_duplicate(&old_msg)); // Stale sender session
+
+        // A message from bob's current session 1 (different seq) should not be duplicate
+        let msg_session1_seq1 = MessageId::new("bob", 1, 1);
+        assert!(!node.is_duplicate(&msg_session1_seq1));
+
+        // A message from charlie should be independent
+        let charlie_msg = MessageId::new("charlie", 0, 0);
+        assert!(!node.is_duplicate(&charlie_msg));
+    }
+
+    #[test]
+    fn test_storage_operations() {
+        let mut node = SimNode::new("alice");
+
+        let id = EntityId::from_u64(1);
+        node.insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+
+        assert!(node.has_any_state());
+        assert_eq!(node.entity_count(), 1);
+        assert!(node.has_entity(&id));
+
+        let entity = node.get_entity(&id).unwrap();
+        assert_eq!(entity.data, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_crash_restart() {
+        let mut node = SimNode::new("alice");
+
+        // Set up some state
+        node.insert_entity(EntityId::from_u64(1), vec![1], CrdtType::LwwRegister);
+        node.sync_state = SyncState::Initiating {
+            peer: NodeId::new("bob"),
+        };
+        node.out_seq = 10;
+        node.set_timer(TimerId::new(1), SimTime::from_millis(100), TimerKind::Sync);
+
+        // Crash
+        node.crash();
+
+        // Preserved: storage
+        assert_eq!(node.entity_count(), 1);
+
+        // Lost
+        assert!(node.sync_state.is_idle());
+        assert!(node.timers.is_empty());
+        assert_eq!(node.out_seq, 0);
+
+        // Restart
+        node.restart();
+        assert_eq!(node.session, 1);
+    }
+
+    #[test]
+    fn test_timers() {
+        let mut node = SimNode::new("alice");
+
+        let t1 = node.next_timer_id();
+        let t2 = node.next_timer_id();
+
+        node.set_timer(t1, SimTime::from_millis(100), TimerKind::Sync);
+        node.set_timer(t2, SimTime::from_millis(200), TimerKind::Housekeeping);
+
+        assert_eq!(node.sync_timer_count(), 1);
+        assert!(node.get_timer(t1).is_some());
+
+        node.cancel_timer(t1);
+        assert!(node.get_timer(t1).is_none());
+        assert_eq!(node.sync_timer_count(), 0);
+    }
+
+    #[test]
+    fn test_delta_buffer() {
+        let mut node = SimNode::new("alice");
+
+        assert_eq!(node.buffer_size(), 0);
+
+        node.buffer_delta(DeltaId::from_bytes([1; 32]));
+        node.buffer_delta(DeltaId::from_bytes([2; 32]));
+        node.buffer_delta(DeltaId::from_bytes([1; 32])); // Duplicate
+
+        assert_eq!(node.buffer_size(), 2);
+
+        node.clear_buffer();
+        assert_eq!(node.buffer_size(), 0);
+    }
+
+    #[test]
+    fn test_state_digest() {
+        let mut node = SimNode::new("alice");
+
+        let d1 = node.state_digest();
+        assert_eq!(d1, StateDigest::ZERO);
+
+        node.insert_entity(EntityId::from_u64(1), vec![1], CrdtType::LwwRegister);
+
+        let d2 = node.state_digest();
+        assert_ne!(d2, StateDigest::ZERO);
+        assert_ne!(d2, d1);
+    }
+}

--- a/crates/node/tests/sync_sim/runtime/clock.rs
+++ b/crates/node/tests/sync_sim/runtime/clock.rs
@@ -1,0 +1,303 @@
+//! Simulated logical clock for deterministic time progression.
+//!
+//! See spec §5 - Deterministic Scheduling.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::ops::{Add, AddAssign, Sub};
+
+/// Simulated time in microseconds.
+///
+/// Using microseconds provides sufficient resolution for network simulation
+/// while avoiding floating-point imprecision.
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SimTime(u64);
+
+impl SimTime {
+    /// Zero time (simulation start).
+    pub const ZERO: SimTime = SimTime(0);
+
+    /// Maximum representable time.
+    pub const MAX: SimTime = SimTime(u64::MAX);
+
+    /// Create from microseconds.
+    #[must_use]
+    pub const fn from_micros(micros: u64) -> Self {
+        Self(micros)
+    }
+
+    /// Create from milliseconds.
+    #[must_use]
+    pub const fn from_millis(millis: u64) -> Self {
+        Self(millis.saturating_mul(1000))
+    }
+
+    /// Create from seconds.
+    #[must_use]
+    pub const fn from_secs(secs: u64) -> Self {
+        Self(secs.saturating_mul(1_000_000))
+    }
+
+    /// Get time in microseconds.
+    #[must_use]
+    pub const fn as_micros(&self) -> u64 {
+        self.0
+    }
+
+    /// Get time in milliseconds.
+    #[must_use]
+    pub const fn as_millis(&self) -> u64 {
+        self.0 / 1000
+    }
+
+    /// Get time in seconds (truncated).
+    #[must_use]
+    pub const fn as_secs(&self) -> u64 {
+        self.0 / 1_000_000
+    }
+
+    /// Saturating addition.
+    #[must_use]
+    pub const fn saturating_add(self, duration: SimDuration) -> Self {
+        Self(self.0.saturating_add(duration.0))
+    }
+
+    /// Saturating subtraction.
+    #[must_use]
+    pub const fn saturating_sub(self, other: Self) -> SimDuration {
+        SimDuration(self.0.saturating_sub(other.0))
+    }
+}
+
+impl Add<SimDuration> for SimTime {
+    type Output = SimTime;
+
+    fn add(self, rhs: SimDuration) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+impl AddAssign<SimDuration> for SimTime {
+    fn add_assign(&mut self, rhs: SimDuration) {
+        self.0 = self.0.saturating_add(rhs.0);
+    }
+}
+
+impl Sub for SimTime {
+    type Output = SimDuration;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        SimDuration(self.0.saturating_sub(rhs.0))
+    }
+}
+
+impl fmt::Debug for SimTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SimTime({}ms)", self.as_millis())
+    }
+}
+
+impl fmt::Display for SimTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let millis = self.as_millis();
+        if millis < 1000 {
+            write!(f, "{}ms", millis)
+        } else {
+            write!(f, "{:.2}s", millis as f64 / 1000.0)
+        }
+    }
+}
+
+/// Simulated duration in microseconds.
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SimDuration(u64);
+
+impl SimDuration {
+    /// Zero duration.
+    pub const ZERO: SimDuration = SimDuration(0);
+
+    /// Create from microseconds.
+    #[must_use]
+    pub const fn from_micros(micros: u64) -> Self {
+        Self(micros)
+    }
+
+    /// Create from milliseconds.
+    #[must_use]
+    pub const fn from_millis(millis: u64) -> Self {
+        Self(millis.saturating_mul(1000))
+    }
+
+    /// Create from seconds.
+    #[must_use]
+    pub const fn from_secs(secs: u64) -> Self {
+        Self(secs.saturating_mul(1_000_000))
+    }
+
+    /// Get duration in microseconds.
+    #[must_use]
+    pub const fn as_micros(&self) -> u64 {
+        self.0
+    }
+
+    /// Get duration in milliseconds.
+    #[must_use]
+    pub const fn as_millis(&self) -> u64 {
+        self.0 / 1000
+    }
+
+    /// Get duration in seconds (truncated).
+    #[must_use]
+    pub const fn as_secs(&self) -> u64 {
+        self.0 / 1_000_000
+    }
+
+    /// Check if zero.
+    #[must_use]
+    pub const fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl Add for SimDuration {
+    type Output = SimDuration;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+impl AddAssign for SimDuration {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 = self.0.saturating_add(rhs.0);
+    }
+}
+
+impl fmt::Debug for SimDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SimDuration({}ms)", self.as_millis())
+    }
+}
+
+impl fmt::Display for SimDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let millis = self.as_millis();
+        if millis < 1000 {
+            write!(f, "{}ms", millis)
+        } else {
+            write!(f, "{:.2}s", millis as f64 / 1000.0)
+        }
+    }
+}
+
+/// Logical clock for simulation.
+///
+/// Single-threaded, advances only when explicitly told to.
+#[derive(Debug, Clone)]
+pub struct SimClock {
+    /// Current simulation time.
+    now: SimTime,
+}
+
+impl SimClock {
+    /// Create a new clock at time zero.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { now: SimTime::ZERO }
+    }
+
+    /// Get current time.
+    #[must_use]
+    pub fn now(&self) -> SimTime {
+        self.now
+    }
+
+    /// Advance clock to a specific time.
+    ///
+    /// # Panics
+    /// Panics if `to` is before current time (time cannot go backwards).
+    pub fn advance_to(&mut self, to: SimTime) {
+        assert!(
+            to >= self.now,
+            "Cannot advance clock backwards: {} -> {}",
+            self.now,
+            to
+        );
+        self.now = to;
+    }
+
+    /// Advance clock by a duration.
+    pub fn advance_by(&mut self, duration: SimDuration) {
+        self.now += duration;
+    }
+}
+
+impl Default for SimClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sim_time_arithmetic() {
+        let t1 = SimTime::from_millis(100);
+        let t2 = SimTime::from_millis(250);
+        let d = SimDuration::from_millis(50);
+
+        assert_eq!(t1 + d, SimTime::from_millis(150));
+        assert_eq!(t2 - t1, SimDuration::from_millis(150));
+    }
+
+    #[test]
+    fn test_sim_time_ordering() {
+        let t1 = SimTime::from_millis(100);
+        let t2 = SimTime::from_millis(200);
+
+        assert!(t1 < t2);
+        assert!(t2 > t1);
+        assert_eq!(t1.cmp(&t1), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_sim_duration_conversions() {
+        let d = SimDuration::from_secs(2);
+        assert_eq!(d.as_secs(), 2);
+        assert_eq!(d.as_millis(), 2000);
+        assert_eq!(d.as_micros(), 2_000_000);
+    }
+
+    #[test]
+    fn test_clock_advance() {
+        let mut clock = SimClock::new();
+        assert_eq!(clock.now(), SimTime::ZERO);
+
+        clock.advance_by(SimDuration::from_millis(100));
+        assert_eq!(clock.now(), SimTime::from_millis(100));
+
+        clock.advance_to(SimTime::from_millis(500));
+        assert_eq!(clock.now(), SimTime::from_millis(500));
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot advance clock backwards")]
+    fn test_clock_cannot_go_backwards() {
+        let mut clock = SimClock::new();
+        clock.advance_to(SimTime::from_millis(100));
+        clock.advance_to(SimTime::from_millis(50)); // Panic!
+    }
+
+    #[test]
+    fn test_saturating_arithmetic() {
+        let t = SimTime::MAX;
+        let d = SimDuration::from_millis(1);
+        assert_eq!(t.saturating_add(d), SimTime::MAX);
+
+        let t = SimTime::ZERO;
+        let t2 = SimTime::from_millis(100);
+        assert_eq!(t.saturating_sub(t2), SimDuration::ZERO);
+    }
+}

--- a/crates/node/tests/sync_sim/runtime/mod.rs
+++ b/crates/node/tests/sync_sim/runtime/mod.rs
@@ -1,0 +1,14 @@
+//! Simulation runtime components.
+//!
+//! Provides the core infrastructure for deterministic event-driven simulation:
+//! - `SimClock` - Logical time progression
+//! - `EventQueue` - Priority queue with (time, seq) ordering
+//! - `SimRng` - Deterministic random number generation
+
+pub mod clock;
+pub mod queue;
+pub mod rng;
+
+pub use clock::{SimClock, SimDuration, SimTime};
+pub use queue::{EventQueue, EventSeq};
+pub use rng::SimRng;

--- a/crates/node/tests/sync_sim/runtime/queue.rs
+++ b/crates/node/tests/sync_sim/runtime/queue.rs
@@ -1,0 +1,359 @@
+//! Priority event queue with deterministic ordering.
+//!
+//! Events ordered by (time, seq) for deterministic processing.
+//! See spec §5.1 - Event Queue Ordering.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use super::clock::SimTime;
+
+/// Unique event sequence number for tie-breaking.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EventSeq(u64);
+
+impl EventSeq {
+    /// Create a new sequence number.
+    #[must_use]
+    pub const fn new(seq: u64) -> Self {
+        Self(seq)
+    }
+
+    /// Get the raw sequence number.
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl PartialOrd for EventSeq {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EventSeq {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+/// Wrapper for events in the queue with ordering metadata.
+#[derive(Debug)]
+struct QueuedEvent<E> {
+    /// Scheduled execution time.
+    time: SimTime,
+    /// Sequence number for tie-breaking (earlier enqueue = earlier process).
+    seq: EventSeq,
+    /// The actual event.
+    event: E,
+}
+
+impl<E> PartialEq for QueuedEvent<E> {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time && self.seq == other.seq
+    }
+}
+
+impl<E> Eq for QueuedEvent<E> {}
+
+impl<E> PartialOrd for QueuedEvent<E> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<E> Ord for QueuedEvent<E> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap is a max-heap, so we reverse the comparison
+        // to get min-heap behavior (earliest time first)
+        match other.time.cmp(&self.time) {
+            Ordering::Equal => other.seq.cmp(&self.seq),
+            ordering => ordering,
+        }
+    }
+}
+
+/// Priority queue for simulation events.
+///
+/// Events are processed in order of (time, seq) where:
+/// - `time`: Scheduled execution time
+/// - `seq`: Tie-breaker for events at the same time (FIFO within same time)
+#[derive(Debug)]
+pub struct EventQueue<E> {
+    /// Priority queue (min-heap by time, then by seq).
+    heap: BinaryHeap<QueuedEvent<E>>,
+    /// Counter for assigning sequence numbers.
+    next_seq: u64,
+}
+
+impl<E> EventQueue<E> {
+    /// Create a new empty event queue.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            next_seq: 0,
+        }
+    }
+
+    /// Check if the queue is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
+    /// Get the number of pending events.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    /// Schedule an event at a specific time.
+    ///
+    /// Returns the assigned sequence number.
+    pub fn schedule(&mut self, time: SimTime, event: E) -> EventSeq {
+        let seq = EventSeq::new(self.next_seq);
+        self.next_seq += 1;
+
+        self.heap.push(QueuedEvent { time, seq, event });
+        seq
+    }
+
+    /// Peek at the next event without removing it.
+    #[must_use]
+    pub fn peek(&self) -> Option<(SimTime, &E)> {
+        self.heap.peek().map(|qe| (qe.time, &qe.event))
+    }
+
+    /// Peek at the next event's time without removing it.
+    #[must_use]
+    pub fn peek_time(&self) -> Option<SimTime> {
+        self.heap.peek().map(|qe| qe.time)
+    }
+
+    /// Pop the next event (earliest time, lowest seq).
+    pub fn pop(&mut self) -> Option<(SimTime, EventSeq, E)> {
+        self.heap.pop().map(|qe| (qe.time, qe.seq, qe.event))
+    }
+
+    /// Pop the next event if its time is <= the given time.
+    pub fn pop_if_ready(&mut self, now: SimTime) -> Option<(SimTime, EventSeq, E)> {
+        if let Some(qe) = self.heap.peek() {
+            if qe.time <= now {
+                return self.pop();
+            }
+        }
+        None
+    }
+
+    /// Pop all events at or before the given time.
+    pub fn pop_all_ready(&mut self, now: SimTime) -> Vec<(SimTime, EventSeq, E)> {
+        let mut events = Vec::new();
+        while let Some(result) = self.pop_if_ready(now) {
+            events.push(result);
+        }
+        events
+    }
+
+    /// Cancel an event by predicate.
+    ///
+    /// Note: This is O(n) and rebuilds the heap. Use sparingly.
+    pub fn cancel_where<F>(&mut self, predicate: F) -> usize
+    where
+        F: Fn(&E) -> bool,
+    {
+        let original_len = self.heap.len();
+        let events: Vec<_> = self.heap.drain().collect();
+
+        for qe in events {
+            if !predicate(&qe.event) {
+                self.heap.push(qe);
+            }
+        }
+
+        original_len - self.heap.len()
+    }
+
+    /// Clear all events.
+    pub fn clear(&mut self) {
+        self.heap.clear();
+    }
+
+    /// Count events matching a predicate.
+    pub fn count_where<F>(&self, predicate: F) -> usize
+    where
+        F: Fn(&E) -> bool,
+    {
+        self.heap.iter().filter(|qe| predicate(&qe.event)).count()
+    }
+}
+
+impl<E> Default for EventQueue<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum TestEvent {
+        A(u32),
+        B(u32),
+    }
+
+    #[test]
+    fn test_queue_basic() {
+        let mut queue = EventQueue::new();
+
+        assert!(queue.is_empty());
+        assert_eq!(queue.len(), 0);
+
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(50), TestEvent::A(2));
+        queue.schedule(SimTime::from_millis(150), TestEvent::A(3));
+
+        assert!(!queue.is_empty());
+        assert_eq!(queue.len(), 3);
+    }
+
+    #[test]
+    fn test_queue_ordering_by_time() {
+        let mut queue = EventQueue::new();
+
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(50), TestEvent::A(2));
+        queue.schedule(SimTime::from_millis(150), TestEvent::A(3));
+
+        let (t1, _, e1) = queue.pop().unwrap();
+        let (t2, _, e2) = queue.pop().unwrap();
+        let (t3, _, e3) = queue.pop().unwrap();
+
+        assert_eq!(t1, SimTime::from_millis(50));
+        assert_eq!(t2, SimTime::from_millis(100));
+        assert_eq!(t3, SimTime::from_millis(150));
+
+        assert_eq!(e1, TestEvent::A(2));
+        assert_eq!(e2, TestEvent::A(1));
+        assert_eq!(e3, TestEvent::A(3));
+    }
+
+    #[test]
+    fn test_queue_ordering_by_seq_same_time() {
+        let mut queue = EventQueue::new();
+
+        // All at same time - should be FIFO
+        let t = SimTime::from_millis(100);
+        queue.schedule(t, TestEvent::A(1));
+        queue.schedule(t, TestEvent::A(2));
+        queue.schedule(t, TestEvent::A(3));
+
+        let (_, _, e1) = queue.pop().unwrap();
+        let (_, _, e2) = queue.pop().unwrap();
+        let (_, _, e3) = queue.pop().unwrap();
+
+        // FIFO order
+        assert_eq!(e1, TestEvent::A(1));
+        assert_eq!(e2, TestEvent::A(2));
+        assert_eq!(e3, TestEvent::A(3));
+    }
+
+    #[test]
+    fn test_peek() {
+        let mut queue = EventQueue::new();
+
+        assert!(queue.peek().is_none());
+        assert!(queue.peek_time().is_none());
+
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(50), TestEvent::A(2));
+
+        // Peek should show earliest
+        let (t, e) = queue.peek().unwrap();
+        assert_eq!(t, SimTime::from_millis(50));
+        assert_eq!(e, &TestEvent::A(2));
+
+        // Peek doesn't remove
+        assert_eq!(queue.len(), 2);
+    }
+
+    #[test]
+    fn test_pop_if_ready() {
+        let mut queue = EventQueue::new();
+
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(200), TestEvent::A(2));
+
+        // At time 50, nothing ready
+        assert!(queue.pop_if_ready(SimTime::from_millis(50)).is_none());
+
+        // At time 100, first event ready
+        let (t, _, e) = queue.pop_if_ready(SimTime::from_millis(100)).unwrap();
+        assert_eq!(t, SimTime::from_millis(100));
+        assert_eq!(e, TestEvent::A(1));
+
+        // At time 100, second event not ready yet
+        assert!(queue.pop_if_ready(SimTime::from_millis(100)).is_none());
+
+        // At time 200, second event ready
+        let (t, _, e) = queue.pop_if_ready(SimTime::from_millis(200)).unwrap();
+        assert_eq!(t, SimTime::from_millis(200));
+        assert_eq!(e, TestEvent::A(2));
+    }
+
+    #[test]
+    fn test_pop_all_ready() {
+        let mut queue = EventQueue::new();
+
+        queue.schedule(SimTime::from_millis(50), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(2));
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(3));
+        queue.schedule(SimTime::from_millis(200), TestEvent::A(4));
+
+        let ready = queue.pop_all_ready(SimTime::from_millis(100));
+        assert_eq!(ready.len(), 3);
+
+        // Should be in order
+        assert_eq!(ready[0].2, TestEvent::A(1));
+        assert_eq!(ready[1].2, TestEvent::A(2));
+        assert_eq!(ready[2].2, TestEvent::A(3));
+
+        // One event left
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn test_cancel_where() {
+        let mut queue = EventQueue::new();
+
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(100), TestEvent::B(2));
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(3));
+
+        // Cancel all A events
+        let cancelled = queue.cancel_where(|e| matches!(e, TestEvent::A(_)));
+        assert_eq!(cancelled, 2);
+        assert_eq!(queue.len(), 1);
+
+        let (_, _, e) = queue.pop().unwrap();
+        assert_eq!(e, TestEvent::B(2));
+    }
+
+    #[test]
+    fn test_count_where() {
+        let mut queue = EventQueue::new();
+
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(1));
+        queue.schedule(SimTime::from_millis(100), TestEvent::B(2));
+        queue.schedule(SimTime::from_millis(100), TestEvent::A(3));
+
+        let count_a = queue.count_where(|e| matches!(e, TestEvent::A(_)));
+        let count_b = queue.count_where(|e| matches!(e, TestEvent::B(_)));
+
+        assert_eq!(count_a, 2);
+        assert_eq!(count_b, 1);
+    }
+}

--- a/crates/node/tests/sync_sim/runtime/rng.rs
+++ b/crates/node/tests/sync_sim/runtime/rng.rs
@@ -1,0 +1,223 @@
+//! Deterministic random number generation for simulation.
+//!
+//! Uses ChaCha8Rng for reproducible randomness across platforms.
+//! See spec §17.2 - RNG Specification.
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use super::clock::SimDuration;
+
+/// Deterministic RNG wrapper for simulation.
+///
+/// Wraps `ChaCha8Rng` with convenient methods for simulation use cases.
+#[derive(Debug, Clone)]
+pub struct SimRng {
+    inner: ChaCha8Rng,
+}
+
+impl SimRng {
+    /// Create a new RNG from a seed.
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self {
+            inner: ChaCha8Rng::seed_from_u64(seed),
+        }
+    }
+
+    /// Fork a new independent RNG.
+    ///
+    /// Useful for giving each component its own RNG stream while maintaining
+    /// reproducibility (the order of forks must be deterministic).
+    #[must_use]
+    pub fn fork(&mut self) -> Self {
+        Self {
+            inner: ChaCha8Rng::seed_from_u64(self.inner.gen()),
+        }
+    }
+
+    /// Generate a random boolean with given probability of being true.
+    pub fn bool_with_probability(&mut self, probability: f64) -> bool {
+        debug_assert!(
+            (0.0..=1.0).contains(&probability),
+            "Probability must be in [0.0, 1.0]"
+        );
+        self.inner.gen::<f64>() < probability
+    }
+
+    /// Generate a random duration in range [min, max].
+    pub fn duration_range(&mut self, min: SimDuration, max: SimDuration) -> SimDuration {
+        let min_micros = min.as_micros();
+        let max_micros = max.as_micros();
+        if min_micros >= max_micros {
+            return min;
+        }
+        SimDuration::from_micros(self.inner.gen_range(min_micros..=max_micros))
+    }
+
+    /// Generate a random duration with base ± jitter.
+    ///
+    /// Returns a duration in range [base - jitter, base + jitter], clamped to >= 0.
+    /// Uses saturating arithmetic to avoid overflow with large duration values.
+    pub fn duration_with_jitter(&mut self, base: SimDuration, jitter: SimDuration) -> SimDuration {
+        let base_micros = base.as_micros();
+        let jitter_micros = jitter.as_micros();
+
+        // Use saturating operations to prevent underflow/overflow
+        let min = base_micros.saturating_sub(jitter_micros);
+        let max = base_micros.saturating_add(jitter_micros);
+
+        SimDuration::from_micros(self.inner.gen_range(min..=max))
+    }
+
+    /// Generate a random u64 in range [0, max).
+    pub fn gen_range_u64(&mut self, max: u64) -> u64 {
+        if max == 0 {
+            return 0;
+        }
+        self.inner.gen_range(0..max)
+    }
+
+    /// Generate a random usize in range [0, max).
+    pub fn gen_range_usize(&mut self, max: usize) -> usize {
+        if max == 0 {
+            return 0;
+        }
+        self.inner.gen_range(0..max)
+    }
+
+    /// Shuffle a slice in place.
+    pub fn shuffle<T>(&mut self, slice: &mut [T]) {
+        use rand::seq::SliceRandom;
+        slice.shuffle(&mut self.inner);
+    }
+
+    /// Pick a random element from a slice.
+    pub fn choose<'a, T>(&mut self, slice: &'a [T]) -> Option<&'a T> {
+        use rand::seq::SliceRandom;
+        slice.choose(&mut self.inner)
+    }
+
+    /// Generate random bytes.
+    pub fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.inner.fill(dest);
+    }
+
+    /// Generate a random u64.
+    pub fn gen_u64(&mut self) -> u64 {
+        self.inner.gen()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rng_deterministic() {
+        let mut rng1 = SimRng::new(42);
+        let mut rng2 = SimRng::new(42);
+
+        for _ in 0..100 {
+            assert_eq!(rng1.gen_u64(), rng2.gen_u64());
+        }
+    }
+
+    #[test]
+    fn test_rng_different_seeds() {
+        let mut rng1 = SimRng::new(42);
+        let mut rng2 = SimRng::new(43);
+
+        // Very unlikely to match with different seeds
+        let vals1: Vec<u64> = (0..10).map(|_| rng1.gen_u64()).collect();
+        let vals2: Vec<u64> = (0..10).map(|_| rng2.gen_u64()).collect();
+
+        assert_ne!(vals1, vals2);
+    }
+
+    #[test]
+    fn test_rng_fork() {
+        let mut rng1 = SimRng::new(42);
+        let mut rng2 = SimRng::new(42);
+
+        let fork1 = rng1.fork();
+        let fork2 = rng2.fork();
+
+        // Forked RNGs should be identical if forked in same order
+        let mut f1 = fork1;
+        let mut f2 = fork2;
+        for _ in 0..10 {
+            assert_eq!(f1.gen_u64(), f2.gen_u64());
+        }
+    }
+
+    #[test]
+    fn test_bool_with_probability() {
+        let mut rng = SimRng::new(42);
+
+        // 0% should always be false
+        for _ in 0..100 {
+            assert!(!rng.bool_with_probability(0.0));
+        }
+
+        // 100% should always be true
+        for _ in 0..100 {
+            assert!(rng.bool_with_probability(1.0));
+        }
+
+        // 50% should be roughly half (statistically)
+        let mut trues = 0;
+        for _ in 0..1000 {
+            if rng.bool_with_probability(0.5) {
+                trues += 1;
+            }
+        }
+        assert!(
+            trues > 400 && trues < 600,
+            "Expected ~500 trues, got {trues}"
+        );
+    }
+
+    #[test]
+    fn test_duration_range() {
+        let mut rng = SimRng::new(42);
+
+        let min = SimDuration::from_millis(10);
+        let max = SimDuration::from_millis(100);
+
+        for _ in 0..100 {
+            let d = rng.duration_range(min, max);
+            assert!(d >= min && d <= max);
+        }
+    }
+
+    #[test]
+    fn test_duration_with_jitter() {
+        let mut rng = SimRng::new(42);
+
+        let base = SimDuration::from_millis(50);
+        let jitter = SimDuration::from_millis(10);
+
+        for _ in 0..100 {
+            let d = rng.duration_with_jitter(base, jitter);
+            assert!(d.as_millis() >= 40 && d.as_millis() <= 60);
+        }
+    }
+
+    #[test]
+    fn test_shuffle() {
+        let mut rng = SimRng::new(42);
+
+        let original = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let mut shuffled = original.clone();
+        rng.shuffle(&mut shuffled);
+
+        // Should be different order (very unlikely to be same with 10 elements)
+        assert_ne!(shuffled, original);
+
+        // Should contain same elements
+        let mut sorted = shuffled.clone();
+        sorted.sort();
+        assert_eq!(sorted, original);
+    }
+}

--- a/crates/node/tests/sync_sim/scenarios/deterministic.rs
+++ b/crates/node/tests/sync_sim/scenarios/deterministic.rs
@@ -1,0 +1,424 @@
+//! Deterministic test scenarios.
+//!
+//! See spec §15 - Protocol Negotiation Tests.
+
+use calimero_primitives::crdt::CrdtType;
+
+use crate::sync_sim::actions::EntityMetadata;
+use crate::sync_sim::node::SimNode;
+use crate::sync_sim::types::{DeltaId, EntityId};
+
+/// Helper to generate entities.
+pub fn generate_entities(count: usize, seed: u64) -> Vec<(EntityId, Vec<u8>, EntityMetadata)> {
+    (0..count)
+        .map(|i| {
+            let id = EntityId::from_u64(seed * 10000 + i as u64);
+            let data = format!("entity-{}-{}", seed, i).into_bytes();
+            let metadata = EntityMetadata::new(CrdtType::LwwRegister, i as u64 * 100);
+            (id, data, metadata)
+        })
+        .collect()
+}
+
+/// Generate entities forming a deep tree structure.
+///
+/// Keys are structured to produce `max_depth` in Merkle tree.
+/// Depth is clamped to 24 (max usable key bytes before seed region).
+pub fn generate_deep_tree_entities(
+    count: usize,
+    depth: u32,
+    seed: u64,
+) -> Vec<(EntityId, Vec<u8>, EntityMetadata)> {
+    // Clamp depth: key[0..24] available, key[24..32] reserved for seed
+    let safe_depth = depth.min(24);
+
+    (0..count)
+        .map(|i| {
+            let mut key = [0u8; 32];
+            // Spread across tree levels
+            for d in 0..safe_depth {
+                // Use checked_shl to avoid overflow, default to 1 if overflow
+                let divisor = 1usize
+                    .checked_shl(d)
+                    .and_then(|shift| count.checked_div(shift))
+                    .unwrap_or(1)
+                    .max(1);
+                key[d as usize] = ((i / divisor) % 256) as u8;
+            }
+            key[24..32].copy_from_slice(&(seed + i as u64).to_le_bytes());
+
+            let id = EntityId::from_bytes(key);
+            let data = format!("deep-entity-{}-{}", seed, i).into_bytes();
+            let metadata = EntityMetadata::new(CrdtType::LwwRegister, i as u64 * 100);
+            (id, data, metadata)
+        })
+        .collect()
+}
+
+/// Generate entities forming a wide shallow tree.
+///
+/// For depth=1, only key[0] varies (256 unique prefix values).
+/// For depth=2, both key[0] and key[1] vary (65536 unique prefix values).
+pub fn generate_shallow_wide_tree(
+    count: usize,
+    depth: u32,
+    seed: u64,
+) -> Vec<(EntityId, Vec<u8>, EntityMetadata)> {
+    assert!(
+        depth >= 1 && depth <= 2,
+        "shallow tree depth must be 1 or 2"
+    );
+
+    (0..count)
+        .map(|i| {
+            let mut key = [0u8; 32];
+            // Vary key bytes based on depth
+            key[0] = (i % 256) as u8; // Level 1 fanout (always used)
+            if depth >= 2 {
+                key[1] = (i / 256) as u8; // Level 2 fanout (only for depth=2)
+            }
+            key[24..32].copy_from_slice(&(seed + i as u64).to_le_bytes());
+
+            let id = EntityId::from_bytes(key);
+            let data = format!("shallow-entity-{}-{}", seed, i).into_bytes();
+            let metadata = EntityMetadata::new(CrdtType::LwwRegister, i as u64 * 100);
+            (id, data, metadata)
+        })
+        .collect()
+}
+
+/// Scenario builders for protocol negotiation testing.
+///
+/// Each method sets up nodes in specific states to trigger deterministic
+/// protocol selection per CIP §2.3 rules.
+pub struct Scenario;
+
+impl Scenario {
+    /// Rule 1: Same root hash → None.
+    ///
+    /// Creates two nodes with identical state.
+    pub fn force_none() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Identical state
+        let entities = generate_entities(100, 1);
+        for (id, data, metadata) in &entities {
+            a.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+            b.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+        }
+
+        assert_eq!(a.root_hash(), b.root_hash(), "root hashes should match");
+        (a, b)
+    }
+
+    /// Rule 2: Fresh node → Snapshot.
+    ///
+    /// Creates a fresh node and an initialized source.
+    pub fn force_snapshot() -> (SimNode, SimNode) {
+        let fresh = SimNode::new("fresh"); // Empty, has_state = false
+        let mut source = SimNode::new("source");
+
+        for (id, data, metadata) in generate_entities(100, 2) {
+            source.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        assert!(!fresh.has_any_state(), "fresh node should have no state");
+        assert!(source.has_any_state(), "source should have state");
+        (fresh, source)
+    }
+
+    /// Rule 3: High divergence (>50%) → HashComparison.
+    ///
+    /// Creates two nodes with significant difference.
+    pub fn force_hash_high_divergence() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // A has 40 entities (seed 1)
+        for (id, data, metadata) in generate_entities(40, 1) {
+            a.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        // B has 100 entities (seed 2) → 60% divergence
+        for (id, data, metadata) in generate_entities(100, 2) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        assert!(a.has_any_state());
+        assert!(b.has_any_state());
+        // Divergence should be >50%
+        (a, b)
+    }
+
+    /// Rule 4: Deep tree + low divergence → SubtreePrefetch.
+    ///
+    /// Creates deep tree structures with small difference.
+    pub fn force_subtree_prefetch() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Shared base (80 entities)
+        let shared = generate_deep_tree_entities(80, 5, 1);
+        for (id, data, metadata) in &shared {
+            a.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+            b.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+        }
+
+        // A has 5 extra, B has 15 extra → 15% divergence
+        for (id, data, metadata) in generate_deep_tree_entities(5, 5, 2) {
+            a.insert_entity_with_metadata(id, data, metadata);
+        }
+        for (id, data, metadata) in generate_deep_tree_entities(15, 5, 3) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        (a, b)
+    }
+
+    /// Rule 5: Large tree + small diff → BloomFilter.
+    ///
+    /// Creates nodes with mostly shared state and small difference.
+    pub fn force_bloom_filter() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Shared base (95 entities)
+        let shared = generate_entities(95, 1);
+        for (id, data, metadata) in &shared {
+            a.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+            b.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+        }
+
+        // B has 5 extra → 5% divergence, >50 entities
+        for (id, data, metadata) in generate_entities(5, 2) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        assert!(b.entity_count() > 50);
+        (a, b)
+    }
+
+    /// Rule 6: Wide shallow tree → LevelWise.
+    ///
+    /// Creates shallow tree structures.
+    pub fn force_levelwise() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Shallow trees (depth ≤ 2) with many children per level
+        for (id, data, metadata) in generate_shallow_wide_tree(36, 2, 1) {
+            a.insert_entity_with_metadata(id, data, metadata);
+        }
+        for (id, data, metadata) in generate_shallow_wide_tree(40, 2, 2) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        (a, b)
+    }
+
+    /// DeltaSync: Small gap in DAG.
+    ///
+    /// Creates nodes with identical state but different DAG heads.
+    pub fn force_delta_sync() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Both start with same state
+        let base = generate_entities(100, 1);
+        for (id, data, metadata) in &base {
+            a.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+            b.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+        }
+
+        // Sync DAG heads
+        let base_head = DeltaId::from_bytes([1; 32]);
+        a.dag_heads = vec![base_head];
+        b.dag_heads = vec![base_head];
+
+        // B gets 2 new deltas (small gap)
+        for (id, data, metadata) in generate_entities(2, 2) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+        // Update B's DAG head
+        b.dag_heads = vec![DeltaId::from_bytes([2; 32])];
+
+        // DAG heads differ, but small divergence
+        assert_ne!(a.dag_heads(), b.dag_heads());
+        (a, b)
+    }
+
+    /// Both nodes initialized with partial overlap.
+    pub fn partial_overlap() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        // Shared entities
+        let shared = generate_entities(50, 1);
+        for (id, data, metadata) in &shared {
+            a.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+            b.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+        }
+
+        // A-only entities
+        for (id, data, metadata) in generate_entities(25, 2) {
+            a.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        // B-only entities
+        for (id, data, metadata) in generate_entities(25, 3) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        (a, b)
+    }
+
+    /// Both nodes initialized (for invariant I5 testing).
+    pub fn both_initialized() -> (SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+
+        for (id, data, metadata) in generate_entities(50, 1) {
+            a.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        for (id, data, metadata) in generate_entities(50, 2) {
+            b.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        assert!(a.has_any_state());
+        assert!(b.has_any_state());
+        (a, b)
+    }
+
+    /// Fresh node and initialized node (for snapshot testing).
+    pub fn fresh_and_initialized() -> (SimNode, SimNode) {
+        Self::force_snapshot()
+    }
+
+    /// Three nodes: A and B synced, C diverged.
+    pub fn three_nodes_one_diverged() -> (SimNode, SimNode, SimNode) {
+        let mut a = SimNode::new("a");
+        let mut b = SimNode::new("b");
+        let mut c = SimNode::new("c");
+
+        // A and B have same state
+        let shared = generate_entities(50, 1);
+        for (id, data, metadata) in &shared {
+            a.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+            b.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+        }
+
+        // C has different state
+        for (id, data, metadata) in generate_entities(50, 2) {
+            c.insert_entity_with_metadata(id, data, metadata);
+        }
+
+        assert_eq!(a.root_hash(), b.root_hash());
+        assert_ne!(a.root_hash(), c.root_hash());
+
+        (a, b, c)
+    }
+
+    /// Create N nodes, all with same state.
+    pub fn n_nodes_synced(n: usize) -> Vec<SimNode> {
+        let entities = generate_entities(50, 1);
+
+        (0..n)
+            .map(|i| {
+                let mut node = SimNode::new(format!("node-{}", i));
+                for (id, data, metadata) in &entities {
+                    node.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+                }
+                node
+            })
+            .collect()
+    }
+
+    /// Create N nodes, each with different state.
+    pub fn n_nodes_diverged(n: usize) -> Vec<SimNode> {
+        (0..n)
+            .map(|i| {
+                let mut node = SimNode::new(format!("node-{}", i));
+                for (id, data, metadata) in generate_entities(50, i as u64 + 1) {
+                    node.insert_entity_with_metadata(id, data, metadata);
+                }
+                node
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_force_none() {
+        let (mut a, mut b) = Scenario::force_none();
+        assert_eq!(a.root_hash(), b.root_hash());
+        assert!(a.has_any_state());
+        assert!(b.has_any_state());
+    }
+
+    #[test]
+    fn test_force_snapshot() {
+        let (fresh, source) = Scenario::force_snapshot();
+        assert!(!fresh.has_any_state());
+        assert!(source.has_any_state());
+    }
+
+    #[test]
+    fn test_force_hash_high_divergence() {
+        let (a, b) = Scenario::force_hash_high_divergence();
+        assert!(a.has_any_state());
+        assert!(b.has_any_state());
+        // Significant entity count difference
+        assert!(b.entity_count() > a.entity_count() * 2);
+    }
+
+    #[test]
+    fn test_partial_overlap() {
+        let (a, b) = Scenario::partial_overlap();
+        assert_eq!(a.entity_count(), 75); // 50 shared + 25 unique
+        assert_eq!(b.entity_count(), 75); // 50 shared + 25 unique
+    }
+
+    #[test]
+    fn test_n_nodes_synced() {
+        let mut nodes = Scenario::n_nodes_synced(5);
+        assert_eq!(nodes.len(), 5);
+
+        let hashes: Vec<_> = nodes.iter_mut().map(|n| n.storage.digest()).collect();
+        assert!(hashes.windows(2).all(|w| w[0] == w[1]));
+    }
+
+    #[test]
+    fn test_n_nodes_diverged() {
+        let mut nodes = Scenario::n_nodes_diverged(5);
+        assert_eq!(nodes.len(), 5);
+
+        let hashes: Vec<_> = nodes.iter_mut().map(|n| n.storage.digest()).collect();
+        // All different
+        for i in 0..hashes.len() {
+            for j in (i + 1)..hashes.len() {
+                assert_ne!(hashes[i], hashes[j]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_deep_tree_small_count_no_panic() {
+        // Regression test: ensure no division by zero when count < 2^depth
+        // Previously this would panic with "attempt to divide by zero"
+        let entities = generate_deep_tree_entities(3, 10, 1); // 3 entities, depth 10 (2^10 = 1024 > 3)
+        assert_eq!(entities.len(), 3);
+
+        // Also test edge cases
+        let entities = generate_deep_tree_entities(1, 5, 1);
+        assert_eq!(entities.len(), 1);
+
+        let entities = generate_deep_tree_entities(0, 5, 1);
+        assert_eq!(entities.len(), 0);
+    }
+}

--- a/crates/node/tests/sync_sim/scenarios/mod.rs
+++ b/crates/node/tests/sync_sim/scenarios/mod.rs
@@ -1,0 +1,9 @@
+//! Test scenario builders.
+//!
+//! See spec §15 - Protocol Negotiation Tests.
+
+pub mod deterministic;
+pub mod random;
+
+pub use deterministic::Scenario;
+pub use random::RandomScenario;

--- a/crates/node/tests/sync_sim/scenarios/random.rs
+++ b/crates/node/tests/sync_sim/scenarios/random.rs
@@ -1,0 +1,399 @@
+//! Random scenario generation for property-based testing.
+//!
+//! See spec §10 - Property-based tests over seeds.
+
+use std::collections::HashSet;
+
+use calimero_primitives::crdt::CrdtType;
+
+use crate::sync_sim::actions::EntityMetadata;
+use crate::sync_sim::node::SimNode;
+use crate::sync_sim::runtime::SimRng;
+use crate::sync_sim::types::EntityId;
+
+/// Configuration for random scenario generation.
+#[derive(Debug, Clone)]
+pub struct RandomScenarioConfig {
+    /// Number of nodes.
+    pub node_count: usize,
+    /// Entity count range per node.
+    pub entity_count_range: (usize, usize),
+    /// Probability that two nodes share an entity.
+    pub shared_entity_probability: f64,
+    /// Probability that a node is fresh (no state).
+    pub fresh_node_probability: f64,
+    /// Available CRDT types.
+    pub crdt_types: Vec<CrdtType>,
+}
+
+impl Default for RandomScenarioConfig {
+    fn default() -> Self {
+        Self {
+            node_count: 2,
+            entity_count_range: (10, 100),
+            shared_entity_probability: 0.5,
+            fresh_node_probability: 0.0,
+            crdt_types: vec![CrdtType::LwwRegister],
+        }
+    }
+}
+
+impl RandomScenarioConfig {
+    /// Builder: set node count.
+    pub fn with_nodes(mut self, count: usize) -> Self {
+        self.node_count = count;
+        self
+    }
+
+    /// Builder: set entity count range.
+    ///
+    /// If min > max, they will be swapped to ensure valid range.
+    pub fn with_entity_count(mut self, min: usize, max: usize) -> Self {
+        // Ensure min <= max to prevent underflow
+        self.entity_count_range = if min <= max { (min, max) } else { (max, min) };
+        self
+    }
+
+    /// Builder: set shared entity probability.
+    pub fn with_shared_probability(mut self, prob: f64) -> Self {
+        self.shared_entity_probability = prob.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Builder: allow fresh nodes.
+    pub fn with_fresh_probability(mut self, prob: f64) -> Self {
+        self.fresh_node_probability = prob.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Builder: set CRDT types.
+    pub fn with_crdt_types(mut self, types: Vec<CrdtType>) -> Self {
+        self.crdt_types = types;
+        self
+    }
+}
+
+/// Random scenario generator.
+pub struct RandomScenario {
+    rng: SimRng,
+    config: RandomScenarioConfig,
+}
+
+impl RandomScenario {
+    /// Create a new generator with seed and config.
+    pub fn new(seed: u64, config: RandomScenarioConfig) -> Self {
+        Self {
+            rng: SimRng::new(seed),
+            config,
+        }
+    }
+
+    /// Create with default config.
+    pub fn with_seed(seed: u64) -> Self {
+        Self::new(seed, RandomScenarioConfig::default())
+    }
+
+    /// Generate nodes according to config.
+    pub fn generate(&mut self) -> Vec<SimNode> {
+        let mut nodes = Vec::new();
+        let mut shared_pool = Vec::new();
+
+        // Generate shared entity pool
+        let max_entities = self.config.entity_count_range.1;
+        for _i in 0..max_entities {
+            let id = EntityId::from_u64(self.rng.gen_u64());
+            let data = self.random_data();
+            let crdt_type = self.random_crdt_type();
+            let timestamp = self.rng.gen_u64();
+            let metadata = EntityMetadata::new(crdt_type, timestamp);
+            shared_pool.push((id, data, metadata));
+        }
+
+        // Generate nodes
+        for i in 0..self.config.node_count {
+            let mut node = SimNode::new(format!("node-{}", i));
+
+            // Check if this node should be fresh
+            if self
+                .rng
+                .bool_with_probability(self.config.fresh_node_probability)
+            {
+                nodes.push(node);
+                continue;
+            }
+
+            // Determine entity count
+            let (min, max) = self.config.entity_count_range;
+            let range_size = max.saturating_sub(min);
+            let entity_count = if range_size == 0 {
+                min
+            } else {
+                self.rng.gen_range_usize(range_size + 1) + min
+            };
+
+            // Add entities, tracking inserted IDs to avoid duplicate overwrites
+            // that would reduce final entity count below the target
+            let mut inserted_ids: HashSet<EntityId> = HashSet::new();
+            // Use larger retry budget to handle coupon-collector behavior when sampling from shared pool.
+            // With high shared_entity_probability, we need O(n*ln(n)) attempts to collect n unique items.
+            // Using (entity_count + pool_size) * 5 provides sufficient margin.
+            let max_attempts = (entity_count + shared_pool.len()).saturating_mul(5);
+            let mut attempts = 0;
+
+            while inserted_ids.len() < entity_count && attempts < max_attempts {
+                attempts += 1;
+
+                if self
+                    .rng
+                    .bool_with_probability(self.config.shared_entity_probability)
+                    && !shared_pool.is_empty()
+                {
+                    // Use shared entity
+                    let idx = self.rng.gen_range_usize(shared_pool.len());
+                    let (id, data, metadata) = &shared_pool[idx];
+
+                    // Only insert if not already in this node
+                    if inserted_ids.insert(*id) {
+                        node.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
+                    }
+                    // If already inserted, loop will retry with another attempt
+                } else {
+                    // Create unique entity
+                    let id = EntityId::from_u64(self.rng.gen_u64());
+
+                    // Only insert if not already present (extremely unlikely collision)
+                    if inserted_ids.insert(id) {
+                        let data = self.random_data();
+                        let crdt_type = self.random_crdt_type();
+                        let timestamp = self.rng.gen_u64();
+                        let metadata = EntityMetadata::new(crdt_type, timestamp);
+                        node.insert_entity_with_metadata(id, data, metadata);
+                    }
+                }
+            }
+
+            nodes.push(node);
+        }
+
+        nodes
+    }
+
+    /// Generate random data.
+    fn random_data(&mut self) -> Vec<u8> {
+        let len = self.rng.gen_range_usize(100) + 10;
+        let mut data = vec![0u8; len];
+        self.rng.fill_bytes(&mut data);
+        data
+    }
+
+    /// Pick random CRDT type.
+    fn random_crdt_type(&mut self) -> CrdtType {
+        if self.config.crdt_types.is_empty() {
+            return CrdtType::LwwRegister;
+        }
+        let idx = self.rng.gen_range_usize(self.config.crdt_types.len());
+        self.config.crdt_types[idx].clone()
+    }
+}
+
+/// Common random scenarios.
+impl RandomScenario {
+    /// Two nodes with varying overlap.
+    pub fn two_nodes_random(seed: u64) -> Vec<SimNode> {
+        let config = RandomScenarioConfig::default()
+            .with_nodes(2)
+            .with_entity_count(50, 100)
+            .with_shared_probability(0.3);
+
+        Self::new(seed, config).generate()
+    }
+
+    /// Multiple nodes forming a mesh.
+    pub fn mesh_random(seed: u64, node_count: usize) -> Vec<SimNode> {
+        let config = RandomScenarioConfig::default()
+            .with_nodes(node_count)
+            .with_entity_count(20, 50)
+            .with_shared_probability(0.5);
+
+        Self::new(seed, config).generate()
+    }
+
+    /// Scenario with exactly one fresh node joining.
+    ///
+    /// Creates `existing_count` initialized nodes with shared state, plus one fresh
+    /// (empty) node. The fresh node is always the last node in the returned vector.
+    pub fn fresh_join_random(seed: u64, existing_count: usize) -> Vec<SimNode> {
+        // Generate initialized nodes with no fresh probability
+        let config = RandomScenarioConfig::default()
+            .with_nodes(existing_count)
+            .with_entity_count(50, 100)
+            .with_fresh_probability(0.0) // No fresh nodes in this batch
+            .with_shared_probability(0.8);
+
+        let mut nodes = Self::new(seed, config).generate();
+
+        // Add exactly one fresh node
+        let fresh = SimNode::new(format!("node-{}", existing_count));
+        nodes.push(fresh);
+
+        nodes
+    }
+
+    /// Heavy divergence scenario.
+    pub fn heavy_divergence(seed: u64, node_count: usize) -> Vec<SimNode> {
+        let config = RandomScenarioConfig::default()
+            .with_nodes(node_count)
+            .with_entity_count(50, 200)
+            .with_shared_probability(0.1); // Low overlap
+
+        Self::new(seed, config).generate()
+    }
+
+    /// Nearly synced scenario.
+    pub fn nearly_synced(seed: u64, node_count: usize) -> Vec<SimNode> {
+        let config = RandomScenarioConfig::default()
+            .with_nodes(node_count)
+            .with_entity_count(100, 150)
+            .with_shared_probability(0.95); // High overlap
+
+        Self::new(seed, config).generate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_random_scenario_deterministic() {
+        let mut nodes1 = RandomScenario::two_nodes_random(42);
+        let mut nodes2 = RandomScenario::two_nodes_random(42);
+
+        assert_eq!(nodes1.len(), nodes2.len());
+
+        for (n1, n2) in nodes1.iter_mut().zip(nodes2.iter_mut()) {
+            assert_eq!(n1.entity_count(), n2.entity_count());
+            assert_eq!(n1.storage.digest(), n2.storage.digest());
+        }
+    }
+
+    #[test]
+    fn test_random_scenario_different_seeds() {
+        let mut nodes1 = RandomScenario::two_nodes_random(42);
+        let mut nodes2 = RandomScenario::two_nodes_random(43);
+
+        // Very unlikely to have same digests
+        let digests1: Vec<_> = nodes1.iter_mut().map(|n| n.storage.digest()).collect();
+        let digests2: Vec<_> = nodes2.iter_mut().map(|n| n.storage.digest()).collect();
+
+        assert_ne!(digests1, digests2);
+    }
+
+    #[test]
+    fn test_mesh_random() {
+        let nodes = RandomScenario::mesh_random(42, 5);
+        assert_eq!(nodes.len(), 5);
+
+        // All nodes should have some state (at least some entities)
+        for node in &nodes {
+            // Each node should have at least the minimum from config (20)
+            // but shared probability means some might have fewer unique
+            assert!(
+                node.entity_count() >= 10,
+                "node {} has {} entities",
+                node.id(),
+                node.entity_count()
+            );
+        }
+    }
+
+    #[test]
+    fn test_fresh_join() {
+        let nodes = RandomScenario::fresh_join_random(42, 3);
+
+        // Should have exactly 4 nodes: 3 existing + 1 fresh
+        assert_eq!(nodes.len(), 4);
+
+        // First 3 nodes should have state
+        for node in &nodes[..3] {
+            assert!(
+                node.has_any_state(),
+                "existing node {} should have state",
+                node.id()
+            );
+        }
+
+        // Last node should be fresh (no state)
+        assert!(!nodes[3].has_any_state(), "fresh node should have no state");
+    }
+
+    #[test]
+    fn test_heavy_divergence() {
+        let nodes = RandomScenario::heavy_divergence(42, 3);
+
+        // With low shared probability, nodes should have mostly different entities
+        let all_ids: Vec<_> = nodes
+            .iter()
+            .flat_map(|n| n.storage.iter().map(|e| e.id))
+            .collect();
+
+        // Count unique IDs
+        let mut unique_ids = all_ids.clone();
+        unique_ids.sort();
+        unique_ids.dedup();
+
+        // Should have many unique IDs (high divergence)
+        assert!(unique_ids.len() as f64 > all_ids.len() as f64 * 0.5);
+    }
+
+    #[test]
+    fn test_nearly_synced() {
+        let nodes = RandomScenario::nearly_synced(42, 3);
+
+        // With high shared probability, nodes should have mostly same entities
+        // Digests might not be equal (due to unique entities), but entity counts should be similar
+        for node in &nodes {
+            // Entity counts depend on random selection from pool
+            assert!(
+                node.entity_count() >= 50,
+                "node {} has {} entities",
+                node.id(),
+                node.entity_count()
+            );
+        }
+    }
+
+    #[test]
+    fn test_entity_count_range_swap() {
+        // Test that min > max is handled gracefully
+        let config = RandomScenarioConfig::default().with_entity_count(100, 50);
+
+        // Should have swapped to (50, 100)
+        assert_eq!(config.entity_count_range, (50, 100));
+    }
+
+    #[test]
+    fn test_entity_count_range_equal() {
+        // Test that min == max works
+        let config = RandomScenarioConfig::default()
+            .with_nodes(2)
+            .with_entity_count(50, 50)
+            .with_shared_probability(0.0); // No shared to ensure exact count
+
+        let mut scenario = RandomScenario::new(42, config);
+        let nodes = scenario.generate();
+
+        // All nodes should have exactly 50 entities (or 0 if fresh)
+        for node in &nodes {
+            if node.has_any_state() {
+                assert_eq!(
+                    node.entity_count(),
+                    50,
+                    "node {} has {} entities",
+                    node.id(),
+                    node.entity_count()
+                );
+            }
+        }
+    }
+}

--- a/crates/node/tests/sync_sim/sim_runtime.rs
+++ b/crates/node/tests/sync_sim/sim_runtime.rs
@@ -1,0 +1,933 @@
+//! Main simulation runtime.
+//!
+//! See spec §2 - Architecture Overview.
+
+use std::collections::HashMap;
+
+use crate::sync_sim::actions::{SyncActions, SyncMessage, TimerOp};
+use crate::sync_sim::convergence::{
+    check_convergence, is_deadlocked, ConvergenceInput, ConvergenceResult, NodeConvergenceState,
+};
+use crate::sync_sim::metrics::SimMetrics;
+use crate::sync_sim::network::{FaultConfig, NetworkRouter, SimEvent};
+use crate::sync_sim::node::SimNode;
+use crate::sync_sim::runtime::{EventQueue, SimClock, SimDuration, SimRng, SimTime};
+use crate::sync_sim::types::NodeId;
+
+/// Simulation configuration.
+#[derive(Debug, Clone)]
+pub struct SimConfig {
+    /// Random seed.
+    pub seed: u64,
+    /// Maximum simulation time before stopping.
+    pub max_time: SimTime,
+    /// Maximum events before stopping.
+    pub max_events: u64,
+    /// Process all pending messages per node per tick (vs round-robin).
+    pub drain_inbox_per_tick: bool,
+    /// Fault configuration.
+    pub fault_config: FaultConfig,
+}
+
+impl Default for SimConfig {
+    fn default() -> Self {
+        Self {
+            seed: 0,
+            max_time: SimTime::from_secs(60),
+            max_events: 1_000_000,
+            drain_inbox_per_tick: false,
+            fault_config: FaultConfig::default(),
+        }
+    }
+}
+
+impl SimConfig {
+    /// Create with seed.
+    pub fn with_seed(seed: u64) -> Self {
+        Self {
+            seed,
+            ..Default::default()
+        }
+    }
+
+    /// Builder: set max time.
+    pub fn max_time(mut self, time: SimTime) -> Self {
+        self.max_time = time;
+        self
+    }
+
+    /// Builder: set max events.
+    pub fn max_events(mut self, events: u64) -> Self {
+        self.max_events = events;
+        self
+    }
+
+    /// Builder: enable drain inbox mode.
+    pub fn drain_inbox(mut self) -> Self {
+        self.drain_inbox_per_tick = true;
+        self
+    }
+
+    /// Builder: set fault config.
+    pub fn with_faults(mut self, config: FaultConfig) -> Self {
+        self.fault_config = config;
+        self
+    }
+}
+
+/// Stop condition for simulation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StopCondition {
+    /// Reached maximum time.
+    MaxTime,
+    /// Reached maximum events.
+    MaxEvents,
+    /// System converged.
+    Converged,
+    /// System deadlocked.
+    Deadlock,
+    /// System quiesced in a diverged state (not converged, not deadlocked, no pending events).
+    Diverged,
+    /// Manually stopped.
+    Manual,
+}
+
+/// Main simulation runtime.
+pub struct SimRuntime {
+    /// Configuration.
+    config: SimConfig,
+    /// Logical clock.
+    clock: SimClock,
+    /// Event queue.
+    queue: EventQueue<SimEvent>,
+    /// Network router.
+    network: NetworkRouter,
+    /// RNG.
+    rng: SimRng,
+    /// Nodes by ID.
+    nodes: HashMap<NodeId, SimNode>,
+    /// Node processing order (sorted by ID).
+    node_order: Vec<NodeId>,
+    /// Collected metrics.
+    metrics: SimMetrics,
+    /// Events processed count.
+    events_processed: u64,
+    /// Total messages sent.
+    messages_sent: u64,
+}
+
+impl SimRuntime {
+    /// Create a new runtime with seed.
+    pub fn new(seed: u64) -> Self {
+        let config = SimConfig::with_seed(seed);
+        Self::with_config(config)
+    }
+
+    /// Create with configuration.
+    pub fn with_config(config: SimConfig) -> Self {
+        // Note: drain_inbox_per_tick is not yet implemented.
+        // Assert to prevent unintended usage that would silently use different semantics.
+        assert!(
+            !config.drain_inbox_per_tick,
+            "drain_inbox_per_tick is not yet implemented; messages are processed one at a time"
+        );
+
+        let rng = SimRng::new(config.seed);
+        // Use wrapping_add to avoid overflow panic when seed is u64::MAX
+        let network =
+            NetworkRouter::with_faults(config.seed.wrapping_add(1), config.fault_config.clone());
+
+        Self {
+            config,
+            clock: SimClock::new(),
+            queue: EventQueue::new(),
+            network,
+            rng,
+            nodes: HashMap::new(),
+            node_order: Vec::new(),
+            metrics: SimMetrics::new(),
+            events_processed: 0,
+            messages_sent: 0,
+        }
+    }
+
+    // =========================================================================
+    // Node Management
+    // =========================================================================
+
+    /// Add a node to the simulation.
+    ///
+    /// If a node with the same ID already exists, it will be replaced
+    /// but not duplicated in node_order.
+    pub fn add_node(&mut self, id: impl Into<NodeId>) -> NodeId {
+        let id = id.into();
+        let is_new = !self.nodes.contains_key(&id);
+        let node = SimNode::new(id.clone());
+        self.nodes.insert(id.clone(), node);
+        if is_new {
+            self.node_order.push(id.clone());
+            self.node_order.sort();
+        }
+        id
+    }
+
+    /// Add multiple nodes.
+    pub fn add_nodes(&mut self, ids: impl IntoIterator<Item = impl Into<NodeId>>) -> Vec<NodeId> {
+        ids.into_iter().map(|id| self.add_node(id)).collect()
+    }
+
+    /// Get a node by ID.
+    pub fn node(&self, id: &NodeId) -> Option<&SimNode> {
+        self.nodes.get(id)
+    }
+
+    /// Get a mutable node by ID.
+    pub fn node_mut(&mut self, id: &NodeId) -> Option<&mut SimNode> {
+        self.nodes.get_mut(id)
+    }
+
+    /// Get all node IDs.
+    pub fn node_ids(&self) -> Vec<NodeId> {
+        self.node_order.clone()
+    }
+
+    /// Get number of nodes.
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Add a pre-configured node.
+    ///
+    /// If a node with the same ID already exists, it will be replaced
+    /// but not duplicated in node_order.
+    pub fn add_existing_node(&mut self, node: SimNode) -> NodeId {
+        let id = node.id().clone();
+        let is_new = !self.nodes.contains_key(&id);
+        self.nodes.insert(id.clone(), node);
+        if is_new {
+            self.node_order.push(id.clone());
+            self.node_order.sort();
+        }
+        id
+    }
+
+    // =========================================================================
+    // Simulation Control
+    // =========================================================================
+
+    /// Get current simulation time.
+    pub fn now(&self) -> SimTime {
+        self.clock.now()
+    }
+
+    /// Get metrics.
+    pub fn metrics(&self) -> &SimMetrics {
+        &self.metrics
+    }
+
+    /// Get mutable metrics.
+    pub fn metrics_mut(&mut self) -> &mut SimMetrics {
+        &mut self.metrics
+    }
+
+    /// Get events processed count.
+    pub fn events_processed(&self) -> u64 {
+        self.events_processed
+    }
+
+    /// Get network router.
+    pub fn network(&self) -> &NetworkRouter {
+        &self.network
+    }
+
+    /// Get mutable network router.
+    pub fn network_mut(&mut self) -> &mut NetworkRouter {
+        &mut self.network
+    }
+
+    /// Get RNG.
+    pub fn rng(&mut self) -> &mut SimRng {
+        &mut self.rng
+    }
+
+    /// Check convergence.
+    pub fn check_convergence(&mut self) -> ConvergenceResult {
+        let input = self.build_convergence_input();
+        check_convergence(&input)
+    }
+
+    /// Check if system is deadlocked.
+    pub fn is_deadlocked(&mut self) -> bool {
+        let input = self.build_convergence_input();
+        is_deadlocked(&input, self.queue.is_empty())
+    }
+
+    fn build_convergence_input(&mut self) -> ConvergenceInput {
+        let nodes: Vec<_> = self
+            .node_order
+            .iter()
+            .map(|id| {
+                let node = self.nodes.get_mut(id).unwrap();
+                NodeConvergenceState {
+                    id: id.clone(),
+                    sync_active: node.sync_state.is_active(),
+                    buffer_size: node.buffer_size(),
+                    sync_timer_count: node.sync_timer_count(),
+                    digest: node.state_digest(),
+                }
+            })
+            .collect();
+
+        ConvergenceInput {
+            in_flight_messages: self.network.in_flight_count(),
+            nodes,
+        }
+    }
+
+    // =========================================================================
+    // Event Scheduling
+    // =========================================================================
+
+    /// Schedule an event.
+    ///
+    /// # Panics
+    /// Panics if `time` is before the current simulation time, as this would
+    /// cause a clock advancement error when the event is processed.
+    pub fn schedule(&mut self, time: SimTime, event: SimEvent) {
+        assert!(
+            time >= self.clock.now(),
+            "Cannot schedule event in the past: event time {} < current time {}",
+            time,
+            self.clock.now()
+        );
+        self.queue.schedule(time, event);
+    }
+
+    /// Schedule event after delay.
+    pub fn schedule_after(&mut self, delay: SimDuration, event: SimEvent) {
+        let time = self.clock.now() + delay;
+        self.queue.schedule(time, event);
+    }
+
+    // =========================================================================
+    // Running
+    // =========================================================================
+
+    /// Run simulation until a stop condition is met.
+    pub fn run(&mut self) -> StopCondition {
+        loop {
+            // Check stop conditions
+            if self.clock.now() >= self.config.max_time {
+                return StopCondition::MaxTime;
+            }
+
+            if self.events_processed >= self.config.max_events {
+                return StopCondition::MaxEvents;
+            }
+
+            // If there are events pending, process them before checking convergence.
+            // This ensures scheduled events are executed before declaring convergence.
+            if !self.queue.is_empty() {
+                // Check if the next event would exceed max_time before processing it.
+                // This prevents executing events beyond the configured time bound.
+                if let Some(next_time) = self.queue.peek_time() {
+                    if next_time >= self.config.max_time {
+                        return StopCondition::MaxTime;
+                    }
+                }
+                self.step();
+                continue;
+            }
+
+            // Queue is empty - determine final state
+            return self.handle_empty_queue();
+        }
+    }
+
+    /// Handle empty queue state - determine if converged, deadlocked, or diverged.
+    fn handle_empty_queue(&mut self) -> StopCondition {
+        let convergence = self.check_convergence();
+
+        if convergence.is_converged() {
+            self.metrics.convergence.mark_converged(
+                self.clock.now(),
+                self.messages_sent,
+                self.events_processed,
+            );
+            return StopCondition::Converged;
+        }
+
+        if self.is_deadlocked() {
+            self.metrics.convergence.mark_failed("deadlock".to_string());
+            return StopCondition::Deadlock;
+        }
+
+        if convergence.is_diverged() {
+            self.metrics.convergence.mark_failed("diverged".to_string());
+            return StopCondition::Diverged;
+        }
+
+        // Queue empty but state is indeterminate (shouldn't normally happen)
+        StopCondition::Manual
+    }
+
+    /// Run until convergence or timeout.
+    pub fn run_until_converged(&mut self) -> bool {
+        let condition = self.run();
+        matches!(condition, StopCondition::Converged)
+    }
+
+    /// Run until a predicate is true.
+    pub fn run_until<F>(&mut self, mut predicate: F) -> StopCondition
+    where
+        F: FnMut(&Self) -> bool,
+    {
+        loop {
+            if predicate(self) {
+                return StopCondition::Manual;
+            }
+
+            if self.clock.now() >= self.config.max_time {
+                return StopCondition::MaxTime;
+            }
+
+            if self.events_processed >= self.config.max_events {
+                return StopCondition::MaxEvents;
+            }
+
+            if self.queue.is_empty() {
+                // Queue empty - determine final state
+                return self.handle_empty_queue();
+            }
+
+            // Check if the next event would exceed max_time before processing it.
+            if let Some(next_time) = self.queue.peek_time() {
+                if next_time >= self.config.max_time {
+                    return StopCondition::MaxTime;
+                }
+            }
+
+            self.step();
+        }
+    }
+
+    /// Process a single event.
+    pub fn step(&mut self) -> bool {
+        let Some((time, _seq, event)) = self.queue.pop() else {
+            return false;
+        };
+
+        // For timer events, check if timer is still valid BEFORE advancing clock.
+        // Cancelled or rescheduled timers should not advance simulation time, but they
+        // still count toward the event budget since they were dequeued and processed.
+        if let SimEvent::TimerFired { node, timer_id } = &event {
+            let timer_id_typed = crate::sync_sim::types::TimerId::new(*timer_id);
+            if let Some(sim_node) = self.nodes.get(node) {
+                // Skip if node is crashed
+                if sim_node.is_crashed {
+                    self.events_processed += 1;
+                    return true;
+                }
+                // Skip if timer was cancelled or rescheduled
+                match sim_node.get_timer(timer_id_typed) {
+                    None => {
+                        // Timer was cancelled
+                        self.events_processed += 1;
+                        return true;
+                    }
+                    Some(entry) if entry.fire_time != time => {
+                        // Stale event from reschedule
+                        self.events_processed += 1;
+                        return true;
+                    }
+                    Some(_) => {} // Valid timer, proceed
+                }
+            }
+        }
+
+        // Advance clock
+        self.clock.advance_to(time);
+        self.events_processed += 1;
+
+        // Process event
+        match event {
+            SimEvent::DeliverMessage {
+                from,
+                to,
+                msg,
+                msg_id,
+            } => {
+                // Check partition at delivery time
+                if !self.network.should_deliver(&from, &to, time) {
+                    // Record the partition drop in effect metrics
+                    self.metrics.effects.record_drop();
+                    return true;
+                }
+
+                // Get node and check duplicate
+                let Some(node) = self.nodes.get_mut(&to) else {
+                    return true;
+                };
+
+                // Crashed nodes cannot receive messages
+                if node.is_crashed {
+                    return true;
+                }
+
+                if node.is_duplicate(&msg_id) {
+                    return true;
+                }
+
+                node.mark_processed(msg_id);
+
+                // Process message and get actions
+                // Note: handle_message currently doesn't need &mut self, so we can pass the node
+                let actions = Self::handle_message_static(&from, msg);
+
+                // Apply actions
+                self.apply_actions(&to, actions);
+            }
+
+            SimEvent::TimerFired { node, timer_id } => {
+                let node_id = node.clone();
+                let timer_id_typed = crate::sync_sim::types::TimerId::new(timer_id);
+
+                let Some(sim_node) = self.nodes.get_mut(&node) else {
+                    return true;
+                };
+
+                // Crashed nodes cannot process timer events
+                if sim_node.is_crashed {
+                    return true;
+                }
+
+                // Check timer still exists and fire_time matches (handles rescheduled timers)
+                // If the timer was rescheduled, the stored fire_time won't match this event's time
+                let timer = sim_node.get_timer(timer_id_typed);
+                match timer {
+                    None => return true,                                   // Timer was cancelled
+                    Some(entry) if entry.fire_time != time => return true, // Stale event from before reschedule
+                    Some(_) => {}                                          // Valid timer fire
+                }
+
+                // Remove the fired timer from the node
+                sim_node.cancel_timer(timer_id_typed);
+
+                // Process timeout
+                let actions = Self::handle_timeout_static(timer_id);
+
+                // Apply actions
+                self.apply_actions(&node_id, actions);
+            }
+
+            SimEvent::NodeCrash { node } => {
+                if let Some(n) = self.nodes.get_mut(&node) {
+                    n.crash();
+                    self.metrics.effects.record_crash();
+                }
+            }
+
+            SimEvent::NodeRestart { node } => {
+                if let Some(n) = self.nodes.get_mut(&node) {
+                    // Only restart if node is actually crashed to avoid spurious session increments
+                    if n.is_crashed {
+                        n.restart();
+                        self.metrics.effects.record_restart();
+                    }
+                }
+            }
+
+            SimEvent::PartitionStart { groups } => {
+                use crate::sync_sim::network::PartitionSpec;
+                self.network.partitions_mut().add_partition(
+                    PartitionSpec::Bidirectional { groups },
+                    time,
+                    None,
+                );
+                self.metrics.effects.record_partition();
+            }
+
+            SimEvent::PartitionEnd { groups } => {
+                use crate::sync_sim::network::PartitionSpec;
+                // Normalize groups for comparison (sort each group and sort groups by first element)
+                // This ensures partition matching is independent of group/node ordering
+                let normalize = |groups: &Vec<Vec<NodeId>>| -> Vec<Vec<NodeId>> {
+                    let mut normalized: Vec<Vec<NodeId>> = groups
+                        .iter()
+                        .map(|g| {
+                            let mut sorted = g.clone();
+                            sorted.sort();
+                            sorted
+                        })
+                        .collect();
+                    normalized.sort_by(|a, b| a.first().cmp(&b.first()));
+                    normalized
+                };
+                let target = normalize(&groups);
+                self.network.partitions_mut().remove_partitions(|spec| {
+                    matches!(spec, PartitionSpec::Bidirectional { groups: g } if normalize(g) == target)
+                });
+            }
+        }
+
+        true
+    }
+
+    /// Handle incoming message (placeholder - protocol-specific).
+    fn handle_message_static(_from: &NodeId, _msg: SyncMessage) -> SyncActions {
+        // Protocol-specific handling will be implemented in later phases
+        // For now, return empty actions
+        SyncActions::new()
+    }
+
+    /// Handle timeout (placeholder - protocol-specific).
+    fn handle_timeout_static(_timer_id: u64) -> SyncActions {
+        // Protocol-specific handling will be implemented in later phases
+        SyncActions::new()
+    }
+
+    /// Apply actions from a node.
+    fn apply_actions(&mut self, node_id: &NodeId, actions: SyncActions) {
+        // Apply storage operations
+        if let Some(node) = self.nodes.get_mut(node_id) {
+            for op in actions.storage_ops {
+                node.apply_storage_op(op);
+                self.metrics.work.record_write();
+            }
+
+            // Apply timer operations
+            for timer_op in actions.timer_ops {
+                match timer_op {
+                    TimerOp::Set { id, delay, kind } => {
+                        let fire_time = self.clock.now() + delay;
+                        node.set_timer(id, fire_time, kind);
+
+                        // Schedule timer event
+                        self.queue.schedule(
+                            fire_time,
+                            SimEvent::TimerFired {
+                                node: node_id.clone(),
+                                timer_id: id.0,
+                            },
+                        );
+                    }
+                    TimerOp::Cancel { id } => {
+                        node.cancel_timer(id);
+                        // Note: We don't remove from queue; it will be ignored when fired
+                    }
+                }
+            }
+        }
+
+        // Route messages
+        for msg in actions.messages {
+            self.messages_sent += 1;
+            // Compute size once for both protocol and network metrics
+            let msg_size = msg.msg.estimated_size();
+            self.metrics.protocol.record_message(msg_size);
+
+            // Clone node_id before borrow
+            let from = node_id.clone();
+            let now = self.clock.now();
+            self.network.route_message(
+                now,
+                msg,
+                msg_size,
+                &from,
+                &mut self.queue,
+                &mut self.metrics.effects,
+            );
+        }
+    }
+
+    // =========================================================================
+    // Test Helpers
+    // =========================================================================
+
+    /// Inject a message directly into the queue.
+    ///
+    /// Note: This bypasses fault injection (loss, reorder, etc.) but properly
+    /// accounts for the message in convergence tracking.
+    ///
+    /// Returns None if the sender node doesn't exist.
+    pub fn inject_message(
+        &mut self,
+        from: NodeId,
+        to: NodeId,
+        msg: SyncMessage,
+        delay: SimDuration,
+    ) -> Option<()> {
+        let msg_id = {
+            let node = self.nodes.get_mut(&from)?;
+            node.next_message_id()
+        };
+
+        let delivery_time = self.clock.now() + delay;
+        self.queue.schedule(
+            delivery_time,
+            SimEvent::DeliverMessage {
+                from,
+                to,
+                msg,
+                msg_id,
+            },
+        );
+
+        // Track in-flight message for convergence checking
+        self.network.increment_in_flight();
+        Some(())
+    }
+
+    /// Send a message through the network router (with fault injection).
+    ///
+    /// Unlike `inject_message`, this method routes through the normal network path,
+    /// applying any configured faults (loss, latency, reorder, duplicate).
+    ///
+    /// Returns None if the sender node doesn't exist.
+    pub fn send_message(&mut self, from: NodeId, to: NodeId, msg: SyncMessage) -> Option<()> {
+        let msg_id = {
+            let node = self.nodes.get_mut(&from)?;
+            node.next_message_id()
+        };
+
+        let outgoing = crate::sync_sim::actions::OutgoingMessage { to, msg, msg_id };
+        let msg_size = outgoing.msg.estimated_size();
+        let now = self.clock.now();
+        self.network.route_message(
+            now,
+            outgoing,
+            msg_size,
+            &from,
+            &mut self.queue,
+            &mut self.metrics.effects,
+        );
+        Some(())
+    }
+
+    /// Crash a node after delay.
+    pub fn schedule_crash(&mut self, node: NodeId, delay: SimDuration) {
+        let time = self.clock.now() + delay;
+        self.queue.schedule(time, SimEvent::NodeCrash { node });
+    }
+
+    /// Restart a node after delay.
+    pub fn schedule_restart(&mut self, node: NodeId, delay: SimDuration) {
+        let time = self.clock.now() + delay;
+        self.queue.schedule(time, SimEvent::NodeRestart { node });
+    }
+
+    /// Create a partition.
+    pub fn schedule_partition(&mut self, groups: Vec<Vec<NodeId>>, delay: SimDuration) {
+        let time = self.clock.now() + delay;
+        self.queue
+            .schedule(time, SimEvent::PartitionStart { groups });
+    }
+
+    /// Heal a partition.
+    pub fn schedule_heal(&mut self, groups: Vec<Vec<NodeId>>, delay: SimDuration) {
+        let time = self.clock.now() + delay;
+        self.queue.schedule(time, SimEvent::PartitionEnd { groups });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync_sim::types::EntityId;
+    use calimero_primitives::crdt::CrdtType;
+
+    #[test]
+    fn test_runtime_creation() {
+        let rt = SimRuntime::new(42);
+        assert_eq!(rt.now(), SimTime::ZERO);
+        assert_eq!(rt.node_count(), 0);
+    }
+
+    #[test]
+    fn test_add_nodes() {
+        let mut rt = SimRuntime::new(42);
+
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        assert_eq!(rt.node_count(), 2);
+        assert!(rt.node(&a).is_some());
+        assert!(rt.node(&b).is_some());
+
+        // Node order should be sorted
+        assert_eq!(rt.node_ids(), vec![a, b]);
+    }
+
+    #[test]
+    fn test_convergence_empty() {
+        let mut rt = SimRuntime::new(42);
+
+        // Empty system is converged
+        assert!(rt.check_convergence().is_converged());
+    }
+
+    #[test]
+    fn test_convergence_same_state() {
+        let mut rt = SimRuntime::new(42);
+
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        // Same empty state
+        assert!(rt.check_convergence().is_converged());
+
+        // Add same entity to both
+        let id = EntityId::from_u64(1);
+        rt.node_mut(&a)
+            .unwrap()
+            .insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+        rt.node_mut(&b)
+            .unwrap()
+            .insert_entity(id, vec![1, 2, 3], CrdtType::LwwRegister);
+
+        assert!(rt.check_convergence().is_converged());
+    }
+
+    #[test]
+    fn test_convergence_different_state() {
+        let mut rt = SimRuntime::new(42);
+
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        // Different entities
+        rt.node_mut(&a).unwrap().insert_entity(
+            EntityId::from_u64(1),
+            vec![1],
+            CrdtType::LwwRegister,
+        );
+        rt.node_mut(&b).unwrap().insert_entity(
+            EntityId::from_u64(2),
+            vec![2],
+            CrdtType::LwwRegister,
+        );
+
+        assert!(rt.check_convergence().is_diverged());
+    }
+
+    #[test]
+    fn test_schedule_and_step() {
+        let mut rt = SimRuntime::new(42);
+        let _a = rt.add_node("alice");
+
+        // Schedule crash
+        rt.schedule_crash(NodeId::new("alice"), SimDuration::from_millis(100));
+
+        // Step should process it
+        assert!(rt.step());
+        assert_eq!(rt.now(), SimTime::from_millis(100));
+    }
+
+    #[test]
+    fn test_inject_message() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        rt.inject_message(
+            a.clone(),
+            b,
+            SyncMessage::SyncComplete { success: true },
+            SimDuration::from_millis(50),
+        )
+        .expect("sender node should exist");
+
+        // Message should be queued
+        assert!(!rt.queue.is_empty());
+
+        // Step should process it
+        assert!(rt.step());
+        assert_eq!(rt.now(), SimTime::from_millis(50));
+    }
+
+    #[test]
+    fn test_partition() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+        let b = rt.add_node("bob");
+
+        // Schedule partition
+        rt.schedule_partition(
+            vec![vec![a.clone()], vec![b.clone()]],
+            SimDuration::from_millis(0),
+        );
+
+        // Process partition event
+        rt.step();
+
+        // Network should be partitioned
+        assert!(rt.network().partitions().has_partitions());
+    }
+
+    #[test]
+    fn test_crash_restart() {
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+
+        // Add some state
+        rt.node_mut(&a).unwrap().insert_entity(
+            EntityId::from_u64(1),
+            vec![1],
+            CrdtType::LwwRegister,
+        );
+
+        // Schedule crash and restart
+        rt.schedule_crash(a.clone(), SimDuration::from_millis(100));
+        rt.schedule_restart(a.clone(), SimDuration::from_millis(200));
+
+        // Process crash
+        rt.step();
+        let node = rt.node(&a).unwrap();
+        assert!(node.sync_state.is_idle());
+        assert_eq!(node.session, 0); // Not incremented until restart
+
+        // Process restart
+        rt.step();
+        let node = rt.node(&a).unwrap();
+        assert_eq!(node.session, 1);
+
+        // Storage should be preserved
+        assert_eq!(node.entity_count(), 1);
+    }
+
+    #[test]
+    fn test_fired_timer_is_removed() {
+        use crate::sync_sim::types::TimerKind;
+
+        let mut rt = SimRuntime::new(42);
+        let a = rt.add_node("alice");
+
+        // Set a timer on the node
+        let timer_id = {
+            let node = rt.node_mut(&a).unwrap();
+            let tid = node.next_timer_id();
+            node.set_timer(tid, SimTime::from_millis(100), TimerKind::Sync);
+            tid
+        };
+
+        // Schedule the timer event
+        rt.schedule(
+            SimTime::from_millis(100),
+            SimEvent::TimerFired {
+                node: a.clone(),
+                timer_id: timer_id.0,
+            },
+        );
+
+        // Before firing, timer should exist
+        assert!(rt.node(&a).unwrap().get_timer(timer_id).is_some());
+        assert_eq!(rt.node(&a).unwrap().sync_timer_count(), 1);
+
+        // Process the timer event
+        rt.step();
+
+        // After firing, timer should be removed
+        assert!(rt.node(&a).unwrap().get_timer(timer_id).is_none());
+        assert_eq!(rt.node(&a).unwrap().sync_timer_count(), 0);
+    }
+}

--- a/crates/node/tests/sync_sim/types.rs
+++ b/crates/node/tests/sync_sim/types.rs
@@ -1,0 +1,250 @@
+//! Core types for the simulation framework.
+
+use std::fmt;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+/// Node identifier in the simulation.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(pub String);
+
+impl NodeId {
+    /// Create a new node ID.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Get the ID as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for NodeId {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for NodeId {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+/// Unique message identifier for deduplication.
+///
+/// See spec §4.1 - Message Identity.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
+pub struct MessageId {
+    /// Sender node.
+    pub sender: String,
+    /// Sender's session (increments on restart).
+    pub session: u64,
+    /// Monotonic sequence within session.
+    pub seq: u64,
+}
+
+impl MessageId {
+    /// Create a new message ID.
+    pub fn new(sender: impl Into<String>, session: u64, seq: u64) -> Self {
+        Self {
+            sender: sender.into(),
+            session,
+            seq,
+        }
+    }
+}
+
+impl fmt::Display for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}:{}", self.sender, self.session, self.seq)
+    }
+}
+
+/// Timer identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TimerId(pub u64);
+
+impl TimerId {
+    /// Create a new timer ID.
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+/// Timer kind for convergence checking.
+///
+/// See spec §8.1 - C4: sync timers only block convergence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TimerKind {
+    /// Sync protocol timer (affects convergence check).
+    Sync,
+    /// Background/housekeeping timer (does not affect convergence).
+    Housekeeping,
+}
+
+/// Entity identifier (32 bytes).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize)]
+pub struct EntityId(pub [u8; 32]);
+
+impl EntityId {
+    /// Create from bytes.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Create from a u64 (for testing).
+    pub fn from_u64(n: u64) -> Self {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&n.to_le_bytes());
+        Self(bytes)
+    }
+
+    /// Get as bytes.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for EntityId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "EntityId({:02x}{:02x}..)", self.0[0], self.0[1])
+    }
+}
+
+impl fmt::Display for EntityId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:02x}{:02x}..{:02x}{:02x}",
+            self.0[0], self.0[1], self.0[30], self.0[31]
+        )
+    }
+}
+
+impl From<[u8; 32]> for EntityId {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<u64> for EntityId {
+    fn from(n: u64) -> Self {
+        Self::from_u64(n)
+    }
+}
+
+/// Delta identifier (32 bytes, typically a hash).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize)]
+pub struct DeltaId(pub [u8; 32]);
+
+impl DeltaId {
+    /// Create from bytes.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Get as bytes.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Zero/genesis delta ID.
+    pub const ZERO: DeltaId = DeltaId([0; 32]);
+}
+
+impl fmt::Debug for DeltaId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DeltaId({:02x}{:02x}..)", self.0[0], self.0[1])
+    }
+}
+
+impl From<[u8; 32]> for DeltaId {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// State digest for convergence checking.
+///
+/// See spec §7 - State Digest and Hashing.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StateDigest(pub [u8; 32]);
+
+impl StateDigest {
+    /// Create from bytes.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Get as bytes.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Zero digest (empty state).
+    pub const ZERO: StateDigest = StateDigest([0; 32]);
+}
+
+impl fmt::Debug for StateDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StateDigest({:02x}{:02x}..)", self.0[0], self.0[1])
+    }
+}
+
+impl From<[u8; 32]> for StateDigest {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_node_id() {
+        let id = NodeId::new("alice");
+        assert_eq!(id.as_str(), "alice");
+        assert_eq!(format!("{id}"), "alice");
+    }
+
+    #[test]
+    fn test_message_id() {
+        let mid = MessageId::new("alice", 1, 42);
+        assert_eq!(mid.sender, "alice");
+        assert_eq!(mid.session, 1);
+        assert_eq!(mid.seq, 42);
+        assert_eq!(format!("{mid}"), "alice:1:42");
+    }
+
+    #[test]
+    fn test_entity_id_from_u64() {
+        let id = EntityId::from_u64(12345);
+        let bytes = id.as_bytes();
+
+        // First 8 bytes are the u64 in little endian
+        let n = u64::from_le_bytes(bytes[..8].try_into().unwrap());
+        assert_eq!(n, 12345);
+
+        // Rest are zeros
+        assert!(bytes[8..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_entity_id_ordering() {
+        let id1 = EntityId::from_u64(1);
+        let id2 = EntityId::from_u64(2);
+        let id3 = EntityId::from_u64(1);
+
+        assert!(id1 < id2);
+        assert_eq!(id1, id3);
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for sync protocol using the existing simulation framework:

- **12 tests** for Snapshot Merge Protection (Invariant I5)
- **16 tests** for CIP §2.3 Protocol Negotiation Compliance
- Adds `build_handshake()` helper to `SimNode` for protocol negotiation testing

## What's Tested

### 1. Snapshot Merge Protection (`snapshot_merge_protection.rs`)
Tests for **Invariant I5: No Silent Data Loss** - verifies:
- Initialized nodes **never** receive Snapshot protocol
- Protection holds across various entity counts and scenarios
- Fresh nodes **can** still bootstrap via Snapshot

### 2. Protocol Negotiation Compliance (`negotiation.rs`)
Tests for **CIP §2.3** protocol selection decision table:
- All 7 rules (None, Snapshot, HashComparison, SubtreePrefetch, BloomFilter, LevelWise, default)
- Rule priority ordering (R1 > R2 > R3 > ...)
- Deterministic protocol selection (1000 iterations)
- Symmetry and edge cases

## Test Plan

- [x] `cargo test --package calimero-node --test sync_sim sync_scenarios::` (12 tests pass)
- [x] `cargo test --package calimero-node --test sync_sim sync_compliance::` (16 tests pass)
- [x] `cargo fmt` - no formatting issues
- [x] Pre-commit hooks pass

## Related Issues

Relates to #1783 (Snapshot Merge Protection)
Relates to #1785 (Compliance Test Suite)