### PR TITLE
test(sync): I5 protection and CIP §2.3 negotiation compliance tests

### DIFF
--- a/crates/node/tests/sync_compliance/mod.rs
+++ b/crates/node/tests/sync_compliance/mod.rs
@@ -5,15 +5,15 @@
 //!
 //! ## Categories (from issue #1785)
 //!
-//! - Negotiation compliance
-//! - Buffering compliance  
-//! - CRDT merge compliance
-//! - Convergence compliance
-//! - Security compliance
+//! - `negotiation.rs` - CIP §2.3 Protocol negotiation compliance
+//! - Buffering compliance (TODO)
+//! - CRDT merge compliance (TODO)
+//! - Convergence compliance (TODO)
+//! - Security compliance (TODO)
 //!
 //! ## Adding Tests
 //!
 //! See `../sync_sim/AGENT_GUIDE.md` for framework usage.
 //! Each test should reference the specific CIP section it validates.
 
-// Compliance tests will be added when implementing issue #1785
+pub mod negotiation;

--- a/crates/node/tests/sync_compliance/negotiation.rs
+++ b/crates/node/tests/sync_compliance/negotiation.rs
@@ -1,0 +1,519 @@
+//! Protocol Negotiation Compliance Tests (CIP §2.3)
+//!
+//! These tests verify that protocol selection conforms to CIP §2.3 decision table.
+//! Each test forces specific conditions to trigger a deterministic protocol selection.
+//!
+//! # Decision Table (CIP §2.3)
+//!
+//! | # | Condition | Selected Protocol |
+//! |---|-----------|-------------------|
+//! | 1 | `root_hash` match | `None` |
+//! | 2 | `!has_state` (fresh node) | `Snapshot` |
+//! | 3 | `has_state` AND divergence >50% | `HashComparison` |
+//! | 4 | `max_depth` >3 AND divergence <20% | `SubtreePrefetch` |
+//! | 5 | `entity_count` >50 AND divergence <10% | `BloomFilter` |
+//! | 6 | `max_depth` 1-2 AND avg children/level >10 | `LevelWise` |
+//! | 7 | (default) | `HashComparison` |
+
+use calimero_node_primitives::sync::handshake::SyncHandshake;
+use calimero_node_primitives::sync::protocol::{select_protocol, SyncProtocol};
+
+use crate::sync_sim::prelude::*;
+
+// =============================================================================
+// Rule 1: Same root hash → None
+// =============================================================================
+
+/// CIP-2.3-R1: Same root hash results in protocol None.
+#[test]
+fn test_cip23_rule1_same_root_hash() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Precondition: same root hash
+    assert_eq!(
+        hs_a.root_hash, hs_b.root_hash,
+        "Precondition: same root hash"
+    );
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "CIP §2.3 R1 VIOLATION: Same root hash should select None, got {:?}",
+        selection.protocol
+    );
+}
+
+/// CIP-2.3-R1: Verify symmetry - both directions give None.
+#[test]
+fn test_cip23_rule1_symmetric() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    let sel_ab = select_protocol(&hs_a, &hs_b);
+    let sel_ba = select_protocol(&hs_b, &hs_a);
+
+    assert!(matches!(sel_ab.protocol, SyncProtocol::None));
+    assert!(matches!(sel_ba.protocol, SyncProtocol::None));
+}
+
+// =============================================================================
+// Rule 2: Fresh node → Snapshot
+// =============================================================================
+
+/// CIP-2.3-R2: Fresh node bootstrap uses Snapshot.
+#[test]
+fn test_cip23_rule2_fresh_node_snapshot() {
+    let (mut fresh, mut source) = Scenario::force_snapshot();
+
+    let hs_fresh = fresh.build_handshake();
+    let hs_source = source.build_handshake();
+
+    // Preconditions
+    assert!(!hs_fresh.has_state, "Precondition: fresh node has no state");
+    assert!(hs_source.has_state, "Precondition: source has state");
+
+    let selection = select_protocol(&hs_fresh, &hs_source);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "CIP §2.3 R2 VIOLATION: Fresh node should use Snapshot, got {:?}",
+        selection.protocol
+    );
+}
+
+/// CIP-2.3-R2: Fresh node with empty source still returns None (both empty).
+#[test]
+fn test_cip23_rule2_both_fresh_nodes() {
+    let fresh_a = SimNode::new("fresh_a");
+    let fresh_b = SimNode::new("fresh_b");
+
+    let mut a = fresh_a;
+    let mut b = fresh_b;
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Both empty - same root hash (zeros)
+    assert_eq!(hs_a.root_hash, hs_b.root_hash);
+    assert_eq!(hs_a.root_hash, [0; 32]);
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    // Same hash = None (Rule 1 takes precedence)
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "Both empty nodes should match and select None, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 3: High divergence (>50%) → HashComparison
+// =============================================================================
+
+/// CIP-2.3-R3: High divergence triggers HashComparison.
+#[test]
+fn test_cip23_rule3_high_divergence_hash_comparison() {
+    let (mut a, mut b) = Scenario::force_hash_high_divergence();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Preconditions
+    assert!(hs_a.has_state);
+    assert!(hs_b.has_state);
+    // Calculate divergence
+    let max_count = hs_a.entity_count.max(hs_b.entity_count) as f64;
+    let min_count = hs_a.entity_count.min(hs_b.entity_count) as f64;
+    let divergence = if max_count > 0.0 {
+        1.0 - (min_count / max_count)
+    } else {
+        0.0
+    };
+    assert!(
+        divergence > 0.5,
+        "Precondition: divergence > 50%, got {:.2}%",
+        divergence * 100.0
+    );
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "CIP §2.3 R3 VIOLATION: High divergence should use HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+/// CIP-2.3-R3: Verify 51% divergence triggers HashComparison.
+#[test]
+fn test_cip23_rule3_boundary_51_percent() {
+    // Create scenario with exactly ~51% divergence
+    // Local: 49 entities, Remote: 100 entities → 51% divergence
+    let hs_local = SyncHandshake::new([1; 32], 49, 3, vec![]);
+    let hs_remote = SyncHandshake::new([2; 32], 100, 3, vec![]);
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "51% divergence should use HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 4: Deep tree + low divergence → SubtreePrefetch
+// =============================================================================
+
+/// CIP-2.3-R4: Deep tree with localized changes uses SubtreePrefetch.
+#[test]
+fn test_cip23_rule4_deep_tree_subtree_prefetch() {
+    let (mut a, mut b) = Scenario::force_subtree_prefetch();
+
+    let hs_a = a.build_handshake();
+    let hs_b = b.build_handshake();
+
+    // Preconditions
+    assert!(hs_a.has_state);
+    assert!(hs_b.has_state);
+    // max_depth > 3
+    assert!(
+        hs_b.max_depth > 3,
+        "Precondition: max_depth > 3, got {}",
+        hs_b.max_depth
+    );
+    // divergence < 20%
+    let max_count = hs_a.entity_count.max(hs_b.entity_count) as f64;
+    let min_count = hs_a.entity_count.min(hs_b.entity_count) as f64;
+    let divergence = if max_count > 0.0 {
+        1.0 - (min_count / max_count)
+    } else {
+        0.0
+    };
+    assert!(
+        divergence < 0.2,
+        "Precondition: divergence < 20%, got {:.2}%",
+        divergence * 100.0
+    );
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::SubtreePrefetch { .. }),
+        "CIP §2.3 R4 VIOLATION: Deep tree + low divergence should use SubtreePrefetch, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 5: Large tree + small diff → BloomFilter
+// =============================================================================
+
+/// CIP-2.3-R5: Large tree with tiny diff uses BloomFilter.
+///
+/// Requirements: entity_count > 50 AND divergence < 10% AND NOT (max_depth > 3)
+/// (R4 SubtreePrefetch takes precedence when depth > 3)
+#[test]
+fn test_cip23_rule5_large_tree_bloom_filter() {
+    // Construct handshakes that precisely meet R5 conditions:
+    // - entity_count > 50: yes (100)
+    // - divergence < 10%: yes (~5%)
+    // - max_depth <= 3: yes (3) - to avoid R4 SubtreePrefetch
+    let hs_local = SyncHandshake::new([1; 32], 95, 3, vec![]); // 95 entities, depth 3
+    let hs_remote = SyncHandshake::new([2; 32], 100, 3, vec![]); // 100 entities, depth 3
+
+    // Verify preconditions
+    assert!(
+        hs_remote.entity_count > 50,
+        "Precondition: entity_count > 50"
+    );
+    let divergence = 1.0 - (95.0 / 100.0);
+    assert!(divergence < 0.1, "Precondition: divergence < 10%");
+    assert!(
+        hs_remote.max_depth <= 3,
+        "Precondition: max_depth <= 3 to avoid R4"
+    );
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::BloomFilter { .. }),
+        "CIP §2.3 R5 VIOLATION: Large tree + tiny diff should use BloomFilter, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 6: Wide shallow tree → LevelWise
+// =============================================================================
+
+/// CIP-2.3-R6: Wide shallow tree uses LevelWise.
+///
+/// Requirements: max_depth 1-2 AND avg_children/level > 10 AND divergence <= 50%
+#[test]
+fn test_cip23_rule6_wide_shallow_levelwise() {
+    // Construct handshakes that precisely meet R6 conditions:
+    // - max_depth 1-2: yes (2)
+    // - avg_children/level > 10: yes (50 entities / 2 depth = 25 avg)
+    // - divergence <= 50%: yes (~20%)
+    let hs_local = SyncHandshake::new([1; 32], 40, 2, vec![]); // 40 entities, depth 2
+    let hs_remote = SyncHandshake::new([2; 32], 50, 2, vec![]); // 50 entities, depth 2
+
+    // Verify preconditions
+    assert!(hs_remote.has_state);
+    assert!(
+        hs_remote.max_depth >= 1 && hs_remote.max_depth <= 2,
+        "Precondition: max_depth 1-2, got {}",
+        hs_remote.max_depth
+    );
+    let avg_children = hs_remote.entity_count / u64::from(hs_remote.max_depth);
+    assert!(
+        avg_children > 10,
+        "Precondition: avg_children > 10, got {}",
+        avg_children
+    );
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::LevelWise { .. }),
+        "CIP §2.3 R6 VIOLATION: Wide shallow tree should use LevelWise, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Rule 7: Default → HashComparison
+// =============================================================================
+
+/// CIP-2.3-R7: Default fallback is HashComparison.
+#[test]
+fn test_cip23_rule7_default_hash_comparison() {
+    // Create a scenario that doesn't match any specific rule
+    // Medium divergence, medium depth, medium entity count
+    let hs_local = SyncHandshake::new([1; 32], 30, 3, vec![]); // 30 entities, depth 3
+    let hs_remote = SyncHandshake::new([2; 32], 40, 3, vec![]); // 40 entities, depth 3
+
+    // Divergence: ~25% (doesn't match R3 >50%, R4 <20%, R5 <10%)
+    // Depth: 3 (doesn't match R6 depth 1-2)
+    // Entity count: 40 (doesn't match R5 >50)
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "CIP §2.3 R7: Default should use HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Version Compatibility Tests
+// =============================================================================
+
+/// CIP-2.3: Version mismatch falls back to HashComparison.
+#[test]
+fn test_cip23_version_mismatch_fallback() {
+    let mut hs_local = SyncHandshake::new([1; 32], 50, 3, vec![]);
+    let mut hs_remote = SyncHandshake::new([2; 32], 50, 3, vec![]);
+
+    // Force version mismatch
+    hs_local.version = 1;
+    hs_remote.version = 999;
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "Version mismatch should fall back to HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Edge Cases and Priority Tests
+// =============================================================================
+
+/// Rule priority: R1 (same hash) takes precedence over everything.
+#[test]
+fn test_cip23_rule1_priority() {
+    // Even if other conditions would trigger different protocols,
+    // same hash = None
+    let hs = SyncHandshake::new([42; 32], 1000, 10, vec![]);
+
+    let selection = select_protocol(&hs, &hs);
+
+    assert!(matches!(selection.protocol, SyncProtocol::None));
+}
+
+/// Rule priority: R2 (fresh node) takes precedence over R3-R7.
+#[test]
+fn test_cip23_rule2_priority_over_divergence() {
+    // Fresh node with 100% divergence should still use Snapshot
+    let hs_fresh = SyncHandshake::new([0; 32], 0, 0, vec![]);
+    let hs_full = SyncHandshake::new([1; 32], 10000, 20, vec![]);
+
+    // This would be 100% divergence, but fresh node takes precedence
+    let selection = select_protocol(&hs_fresh, &hs_full);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "Fresh node should use Snapshot regardless of divergence, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Rule priority: R3 (high divergence) takes precedence over R4-R6.
+#[test]
+fn test_cip23_rule3_priority_over_optimization() {
+    // High divergence with deep tree should use HashComparison, not SubtreePrefetch
+    let hs_local = SyncHandshake::new([1; 32], 20, 10, vec![]); // 20 entities, depth 10
+    let hs_remote = SyncHandshake::new([2; 32], 100, 10, vec![]); // 100 entities, depth 10
+                                                                  // Divergence: 80%
+
+    let selection = select_protocol(&hs_local, &hs_remote);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "High divergence should use HashComparison even with deep tree, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Sweep Tests
+// =============================================================================
+
+/// Sweep test: verify all rules are reachable.
+#[test]
+fn test_cip23_all_rules_reachable() {
+    let mut rules_hit = [false; 7]; // R1-R7
+
+    // R1: Same hash
+    {
+        let (mut a, mut b) = Scenario::force_none();
+        let hs_a = a.build_handshake();
+        let hs_b = b.build_handshake();
+        if matches!(select_protocol(&hs_a, &hs_b).protocol, SyncProtocol::None) {
+            rules_hit[0] = true;
+        }
+    }
+
+    // R2: Fresh node
+    {
+        let (mut fresh, mut source) = Scenario::force_snapshot();
+        let hs_f = fresh.build_handshake();
+        let hs_s = source.build_handshake();
+        if matches!(
+            select_protocol(&hs_f, &hs_s).protocol,
+            SyncProtocol::Snapshot { .. }
+        ) {
+            rules_hit[1] = true;
+        }
+    }
+
+    // R3: High divergence
+    {
+        let (mut a, mut b) = Scenario::force_hash_high_divergence();
+        let hs_a = a.build_handshake();
+        let hs_b = b.build_handshake();
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::HashComparison { .. }
+        ) {
+            // Only count as R3 if divergence > 50%
+            let max = hs_a.entity_count.max(hs_b.entity_count) as f64;
+            let min = hs_a.entity_count.min(hs_b.entity_count) as f64;
+            let div = 1.0 - (min / max);
+            if div > 0.5 {
+                rules_hit[2] = true;
+            }
+        }
+    }
+
+    // R4: SubtreePrefetch
+    {
+        let (mut a, mut b) = Scenario::force_subtree_prefetch();
+        let hs_a = a.build_handshake();
+        let hs_b = b.build_handshake();
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::SubtreePrefetch { .. }
+        ) {
+            rules_hit[3] = true;
+        }
+    }
+
+    // R5: BloomFilter - use direct handshake construction for precise control
+    // Requires: entity_count > 50, divergence < 10%, max_depth <= 3 (to avoid R4)
+    {
+        let hs_a = SyncHandshake::new([1; 32], 95, 3, vec![]);
+        let hs_b = SyncHandshake::new([2; 32], 100, 3, vec![]);
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::BloomFilter { .. }
+        ) {
+            rules_hit[4] = true;
+        }
+    }
+
+    // R6: LevelWise - use direct handshake construction for precise control
+    // Requires: max_depth 1-2, avg_children/level > 10
+    {
+        let hs_a = SyncHandshake::new([1; 32], 40, 2, vec![]);
+        let hs_b = SyncHandshake::new([2; 32], 50, 2, vec![]);
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::LevelWise { .. }
+        ) {
+            rules_hit[5] = true;
+        }
+    }
+
+    // R7: Default HashComparison
+    {
+        let hs_a = SyncHandshake::new([1; 32], 30, 3, vec![]);
+        let hs_b = SyncHandshake::new([2; 32], 40, 3, vec![]);
+        if matches!(
+            select_protocol(&hs_a, &hs_b).protocol,
+            SyncProtocol::HashComparison { .. }
+        ) {
+            rules_hit[6] = true;
+        }
+    }
+
+    // Verify all rules were hit
+    for (i, hit) in rules_hit.iter().enumerate() {
+        assert!(
+            *hit,
+            "CIP §2.3 Rule {} was never triggered by any scenario!",
+            i + 1
+        );
+    }
+}
+
+/// Determinism test: same inputs = same outputs across 1000 runs.
+#[test]
+fn test_cip23_deterministic_selection() {
+    let hs_a = SyncHandshake::new([1; 32], 100, 5, vec![[1; 32]]);
+    let hs_b = SyncHandshake::new([2; 32], 80, 5, vec![[2; 32]]);
+
+    let baseline = select_protocol(&hs_a, &hs_b);
+
+    for i in 0..1000 {
+        let result = select_protocol(&hs_a, &hs_b);
+        assert_eq!(
+            std::mem::discriminant(&result.protocol),
+            std::mem::discriminant(&baseline.protocol),
+            "Protocol selection changed on iteration {}!",
+            i
+        );
+    }
+}

--- a/crates/node/tests/sync_scenarios/mod.rs
+++ b/crates/node/tests/sync_scenarios/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! ## Test Categories
 //!
+//! - `snapshot_merge_protection.rs` - Invariant I5 protection tests
 //! - `negotiation.rs` - Protocol negotiation tests
 //! - `snapshot.rs` - Snapshot sync path tests
 //! - `hash_compare.rs` - Hash comparison sync tests
@@ -16,4 +17,4 @@
 //! - `partitions.rs` - Network partition tests
 //! - `failures.rs` - Fault tolerance tests
 
-// Tests will be added as sync protocol issues are implemented
+pub mod snapshot_merge_protection;

--- a/crates/node/tests/sync_scenarios/snapshot_merge_protection.rs
+++ b/crates/node/tests/sync_scenarios/snapshot_merge_protection.rs
@@ -1,0 +1,400 @@
+//! Snapshot Merge Protection Tests
+//!
+//! # Invariant I5: No Silent Data Loss
+//!
+//! > "State-based sync on initialized nodes MUST use CRDT merge.
+//! >  LWW overwrite is ONLY permitted when local value is absent (fresh node bootstrap)."
+//!
+//! This is one of the most critical safety invariants in the Calimero Sync Protocol.
+//!
+//! # Why This Matters
+//!
+//! When syncing, **Snapshot** means "copy all state, replacing local state entirely".
+//! If a node already has data and receives a Snapshot, all its local data would be
+//! **silently deleted** and replaced. This violates CRDT semantics where concurrent
+//! changes should be merged, not overwritten.
+//!
+//! ```text
+//! Example of what I5 prevents:
+//!
+//!   Node A: has entities [1, 2, 3]
+//!   Node B: has entities [4, 5, 6]
+//!
+//!   WITHOUT I5 protection:
+//!     B syncs from A using Snapshot
+//!     B now has: [1, 2, 3]  ← entities 4, 5, 6 LOST FOREVER!
+//!
+//!   WITH I5 protection:
+//!     Protocol selector sees B.has_state = true
+//!     Forces HashComparison instead of Snapshot
+//!     B now has: [1, 2, 3, 4, 5, 6]  ← All data preserved via CRDT merge
+//! ```
+//!
+//! **Rule**: Snapshot is ONLY allowed for fresh (empty) nodes. Initialized nodes
+//! MUST use CRDT-merge protocols (HashComparison, BloomFilter, SubtreePrefetch, etc.).
+//!
+//! # CIP Reference
+//! - CIP §6.3 - Snapshot Usage Constraints
+//! - CIP §2.3 - Protocol Selection Rules (Rule 2 is the ONLY case for Snapshot)
+//!
+//! # Test Categories
+//! - Protocol selection layer (automatic protection)
+//! - Simulation-based tests (runtime verification)
+//! - Edge cases (single entity, version mismatch, etc.)
+
+use calimero_node_primitives::sync::handshake::SyncHandshake;
+use calimero_node_primitives::sync::protocol::{select_protocol, SyncProtocol};
+
+use crate::sync_sim::prelude::*;
+use crate::sync_sim::scenarios::deterministic::Scenario;
+
+// =============================================================================
+// Protocol Selection Layer Tests (CIP §2.3)
+// =============================================================================
+
+/// Protocol selection NEVER returns Snapshot when local node has state.
+///
+/// This is the primary protection layer. The `select_protocol` function
+/// must return a state-based protocol (HashComparison, etc.) when `has_state = true`.
+#[test]
+fn test_initialized_node_never_gets_snapshot() {
+    // Test with both_initialized scenario
+    let (mut a, mut b) = Scenario::both_initialized();
+
+    let local_hs = build_handshake(&mut a);
+    let remote_hs = build_handshake(&mut b);
+
+    // Verify preconditions
+    assert!(local_hs.has_state, "Local must have state for this test");
+    assert!(remote_hs.has_state, "Remote must have state for this test");
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Snapshot selected for initialized node!\n\
+         Local has_state: {}\n\
+         Remote has_state: {}\n\
+         Selected: {:?}\n\
+         Reason: {}",
+        local_hs.has_state,
+        remote_hs.has_state,
+        selection.protocol,
+        selection.reason
+    );
+}
+
+/// Even with extreme divergence (60%+), Snapshot must NOT be selected
+/// for initialized nodes - uses HashComparison instead.
+#[test]
+fn test_high_divergence_uses_hash_comparison_not_snapshot() {
+    let (mut a, mut b) = Scenario::force_hash_high_divergence();
+
+    let local_hs = build_handshake(&mut a);
+    let remote_hs = build_handshake(&mut b);
+
+    // This scenario has ~60% divergence
+    assert!(local_hs.has_state);
+    assert!(remote_hs.has_state);
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Snapshot selected despite high divergence!\n\
+         Expected: HashComparison (or similar state-based protocol)\n\
+         Got: {:?}",
+        selection.protocol
+    );
+
+    // Should use HashComparison for high divergence
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "Expected HashComparison for high divergence, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Verify Snapshot IS selected for fresh (empty) nodes - the valid case.
+///
+/// This confirms that Snapshot works correctly when it SHOULD be used.
+#[test]
+fn test_fresh_node_allowed_to_use_snapshot() {
+    let (mut fresh, mut source) = Scenario::force_snapshot();
+
+    let local_hs = build_handshake(&mut fresh);
+    let remote_hs = build_handshake(&mut source);
+
+    // Verify preconditions
+    assert!(!local_hs.has_state, "Fresh node must have has_state=false");
+    assert!(remote_hs.has_state, "Source must have state");
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "Snapshot should be selected for fresh node, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Property test - protection holds regardless of entity counts or divergence levels.
+#[test]
+fn test_protection_holds_across_entity_count_combinations() {
+    // Test various entity count combinations where both have state
+    let test_cases = [
+        (1, 1),       // Minimal
+        (1, 100),     // Asymmetric
+        (100, 1),     // Asymmetric reversed
+        (50, 50),     // Balanced
+        (1000, 1000), // Large
+        (1, 10000),   // Extreme asymmetric
+    ];
+
+    for (local_count, remote_count) in test_cases {
+        let local_hs = SyncHandshake::new(
+            [1; 32], // Non-zero hash (has state)
+            local_count,
+            3,
+            vec![],
+        );
+
+        let remote_hs = SyncHandshake::new(
+            [2; 32], // Different hash
+            remote_count,
+            3,
+            vec![],
+        );
+
+        assert!(local_hs.has_state);
+        assert!(remote_hs.has_state);
+
+        let selection = select_protocol(&local_hs, &remote_hs);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION at counts ({}, {}): {:?}",
+            local_count,
+            remote_count,
+            selection.protocol
+        );
+    }
+}
+
+/// All deterministic scenarios with initialized nodes must not use Snapshot.
+#[test]
+fn test_all_initialized_scenarios_avoid_snapshot() {
+    let scenarios: Vec<(&str, (SimNode, SimNode))> = vec![
+        ("both_initialized", Scenario::both_initialized()),
+        ("partial_overlap", Scenario::partial_overlap()),
+        (
+            "force_hash_high_div",
+            Scenario::force_hash_high_divergence(),
+        ),
+        ("force_subtree_prefetch", Scenario::force_subtree_prefetch()),
+        ("force_bloom_filter", Scenario::force_bloom_filter()),
+        ("force_levelwise", Scenario::force_levelwise()),
+        ("force_delta_sync", Scenario::force_delta_sync()),
+    ];
+
+    for (name, (mut a, mut b)) in scenarios {
+        let local_hs = build_handshake(&mut a);
+        let remote_hs = build_handshake(&mut b);
+
+        // Skip if local doesn't have state (e.g., force_snapshot)
+        if !local_hs.has_state {
+            continue;
+        }
+
+        let selection = select_protocol(&local_hs, &remote_hs);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION in scenario '{}': Snapshot selected!\n\
+             Local entities: {}, Remote entities: {}\n\
+             Protocol: {:?}",
+            name,
+            local_hs.entity_count,
+            remote_hs.entity_count,
+            selection.protocol
+        );
+    }
+}
+
+// =============================================================================
+// Simulation-Based Tests
+// =============================================================================
+
+/// Verify protocol negotiation in simulation runtime.
+#[test]
+fn test_simulation_runtime_negotiation() {
+    let mut rt = SimRuntime::new(42);
+
+    // Add two initialized nodes
+    let (node_a, node_b) = Scenario::both_initialized();
+    let a = rt.add_existing_node(node_a);
+    let b = rt.add_existing_node(node_b);
+
+    // Build handshakes
+    let hs_a = rt.node_mut(&a).unwrap().build_handshake();
+    let hs_b = rt.node_mut(&b).unwrap().build_handshake();
+
+    // Negotiate
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION in simulation: {:?}",
+        selection.protocol
+    );
+}
+
+/// Protection holds across 100 random seeds.
+#[test]
+fn test_protection_holds_across_random_seeds() {
+    for seed in 0..100 {
+        let mut rt = SimRuntime::new(seed);
+
+        // Create two diverged nodes (both have state)
+        let nodes = Scenario::n_nodes_diverged(2);
+        let a = rt.add_existing_node(nodes.into_iter().next().unwrap());
+        let b_node = Scenario::n_nodes_diverged(2).into_iter().nth(1).unwrap();
+        let b = rt.add_existing_node(b_node);
+
+        let hs_a = rt.node_mut(&a).unwrap().build_handshake();
+        let hs_b = rt.node_mut(&b).unwrap().build_handshake();
+
+        // Both should have state
+        if !hs_a.has_state || !hs_b.has_state {
+            continue;
+        }
+
+        let selection = select_protocol(&hs_a, &hs_b);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION at seed {}: {:?}",
+            seed,
+            selection.protocol
+        );
+    }
+}
+
+/// Three-node topology - all pairwise negotiations avoid Snapshot.
+#[test]
+fn test_three_node_pairwise_negotiations() {
+    let (mut a, mut b, mut c) = Scenario::three_nodes_one_diverged();
+
+    let hs_a = build_handshake(&mut a);
+    let hs_b = build_handshake(&mut b);
+    let hs_c = build_handshake(&mut c);
+
+    // All nodes have state
+    assert!(hs_a.has_state);
+    assert!(hs_b.has_state);
+    assert!(hs_c.has_state);
+
+    // Test all pairs
+    let pairs = [
+        ("a→b", &hs_a, &hs_b),
+        ("a→c", &hs_a, &hs_c),
+        ("b→a", &hs_b, &hs_a),
+        ("b→c", &hs_b, &hs_c),
+        ("c→a", &hs_c, &hs_a),
+        ("c→b", &hs_c, &hs_b),
+    ];
+
+    for (label, local, remote) in pairs {
+        let selection = select_protocol(local, remote);
+
+        assert!(
+            !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+            "VIOLATION in pair {}: {:?}",
+            label,
+            selection.protocol
+        );
+    }
+}
+
+// =============================================================================
+// Edge Case Tests
+// =============================================================================
+
+/// Even a single entity should prevent Snapshot (no data loss tolerance).
+#[test]
+fn test_single_entity_still_prevents_snapshot() {
+    // Local has just 1 entity, remote has 1000
+    let local_hs = SyncHandshake::new([1; 32], 1, 1, vec![]);
+    let remote_hs = SyncHandshake::new([2; 32], 1000, 10, vec![]);
+
+    assert!(local_hs.has_state);
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Even 1 entity should prevent Snapshot!\n\
+         Got: {:?}",
+        selection.protocol
+    );
+}
+
+/// Version mismatch falls back to HashComparison, not Snapshot.
+#[test]
+fn test_version_mismatch_uses_safe_fallback() {
+    let mut local_hs = SyncHandshake::new([1; 32], 50, 3, vec![]);
+    let mut remote_hs = SyncHandshake::new([2; 32], 50, 3, vec![]);
+
+    // Force version mismatch
+    local_hs.version = 1;
+    remote_hs.version = 2;
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    // Should fall back to HashComparison
+    assert!(
+        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
+        "Version mismatch should fall back to HashComparison, got {:?}",
+        selection.protocol
+    );
+}
+
+/// Same root hash means no sync needed - nodes already in sync.
+#[test]
+fn test_same_hash_means_no_sync_needed() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let hs_a = build_handshake(&mut a);
+    let hs_b = build_handshake(&mut b);
+
+    assert_eq!(hs_a.root_hash, hs_b.root_hash);
+
+    let selection = select_protocol(&hs_a, &hs_b);
+
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "Same root hash should select None, got {:?}",
+        selection.protocol
+    );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Build a SyncHandshake from a SimNode.
+fn build_handshake(node: &mut SimNode) -> SyncHandshake {
+    node.build_handshake()
+}
+
+#[cfg(test)]
+mod compile_check {
+    //! Ensure all tests compile and types are correct.
+    use super::*;
+
+    #[test]
+    fn types_compile() {
+        let _ = Scenario::both_initialized();
+        let _ = Scenario::force_snapshot();
+    }
+}

--- a/crates/node/tests/sync_sim.rs
+++ b/crates/node/tests/sync_sim.rs
@@ -31,6 +31,12 @@
 #[path = "sync_sim/mod.rs"]
 pub mod sync_sim;
 
+#[path = "sync_scenarios/mod.rs"]
+pub mod sync_scenarios;
+
+#[path = "sync_compliance/mod.rs"]
+pub mod sync_compliance;
+
 // Re-export prelude for convenience
 pub use sync_sim::prelude::*;
 


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for sync protocol using the existing simulation framework:

- **12 tests** for Snapshot Merge Protection (Invariant I5)
- **16 tests** for CIP §2.3 Protocol Negotiation Compliance
- Adds `build_handshake()` helper to `SimNode` for protocol negotiation testing

## What's Tested

### 1. Snapshot Merge Protection (`snapshot_merge_protection.rs`)
Tests for **Invariant I5: No Silent Data Loss** - verifies:
- Initialized nodes **never** receive Snapshot protocol
- Protection holds across various entity counts and scenarios
- Fresh nodes **can** still bootstrap via Snapshot

### 2. Protocol Negotiation Compliance (`negotiation.rs`)
Tests for **CIP §2.3** protocol selection decision table:
- All 7 rules (None, Snapshot, HashComparison, SubtreePrefetch, BloomFilter, LevelWise, default)
- Rule priority ordering (R1 > R2 > R3 > ...)
- Deterministic protocol selection (1000 iterations)
- Symmetry and edge cases

## Test Plan

- [x] `cargo test --package calimero-node --test sync_sim sync_scenarios::` (12 tests pass)
- [x] `cargo test --package calimero-node --test sync_sim sync_compliance::` (16 tests pass)
- [x] `cargo fmt` - no formatting issues
- [x] Pre-commit hooks pass

## Related Issues

Relates to #1783 (Snapshot Merge Protection)
Relates to #1785 (Compliance Test Suite)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a small simulation helper; main risk is increased test runtime/flakiness from seed sweeps and large iteration determinism checks.
> 
> **Overview**
> Adds a new `sync_compliance` test module with CIP §2.3 protocol negotiation compliance coverage, asserting the decision-table outcomes (including rule priority, symmetry, version-mismatch fallback, and determinism).
> 
> Introduces `sync_scenarios/snapshot_merge_protection.rs` to enforce *Invariant I5 (no silent data loss)* by asserting `select_protocol` never returns `Snapshot` for initialized nodes across deterministic scenarios, constructed edge cases, and simulation runs.
> 
> Extends the sync simulation harness by exporting the new test modules and adding `SimNode::build_handshake()` to generate `SyncHandshake` inputs for negotiation tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905d084cfe8a3a8fc32fb0982b776a958121d8f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->