### PR TITLE
feat(sync): integrate CIP §2.3 protocol selection into SyncManager

### DIFF
--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -40,6 +40,7 @@ pub mod hash_comparison;
 pub mod levelwise;
 pub mod protocol;
 pub mod snapshot;
+pub mod state_machine;
 pub mod subtree;
 
 // =============================================================================
@@ -95,4 +96,10 @@ pub use subtree::{
 pub use levelwise::{
     compare_level_nodes, should_use_levelwise, LevelCompareResult, LevelNode, LevelWiseRequest,
     LevelWiseResponse, MAX_LEVELWISE_DEPTH, MAX_NODES_PER_LEVEL, MAX_PARENTS_PER_REQUEST,
+};
+
+// State machine types (shared between SyncManager and SimNode)
+pub use state_machine::{
+    build_handshake, build_handshake_from_raw, estimate_entity_count, estimate_max_depth,
+    LocalSyncState,
 };

--- a/crates/node/primitives/src/sync/state_machine.rs
+++ b/crates/node/primitives/src/sync/state_machine.rs
@@ -1,0 +1,266 @@
+//! Shared sync state abstractions for protocol negotiation.
+//!
+//! Provides types and functions shared between production code (`SyncManager`)
+//! and simulation (`SimNode`) for building handshakes and protocol selection.
+//!
+//! # Design
+//!
+//! - `LocalSyncState` trait abstracts access to node state
+//! - `build_handshake()` creates handshakes from any implementor
+//! - Estimation functions provide consistent heuristics for both environments
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! // Any type can provide its local state
+//! impl LocalSyncState for MyNode {
+//!     fn root_hash(&self) -> [u8; 32] { ... }
+//!     fn entity_count(&self) -> u64 { ... }
+//!     fn max_depth(&self) -> u32 { ... }
+//!     fn dag_heads(&self) -> Vec<[u8; 32]> { ... }
+//! }
+//!
+//! // Build handshake using shared logic
+//! let handshake = build_handshake(&my_node);
+//!
+//! // Use select_protocol() for negotiation
+//! let selection = select_protocol(&local_hs, &remote_hs);
+//! ```
+
+use super::handshake::SyncHandshake;
+
+// =============================================================================
+// Local State Trait
+// =============================================================================
+
+/// Trait for accessing local sync state.
+///
+/// Implement this trait to enable building handshakes and protocol selection.
+/// Both `SyncManager` (production) and `SimNode` (simulation) implement this,
+/// ensuring consistent behavior across both environments.
+pub trait LocalSyncState {
+    /// Current Merkle root hash.
+    ///
+    /// Returns `[0; 32]` for fresh nodes with no state.
+    fn root_hash(&self) -> [u8; 32];
+
+    /// Number of entities in local storage.
+    ///
+    /// Used for divergence calculation in protocol selection.
+    fn entity_count(&self) -> u64;
+
+    /// Maximum depth of the Merkle tree.
+    ///
+    /// Used to select optimal sync protocol:
+    /// - Depth > 3 with low divergence → SubtreePrefetch
+    /// - Depth 1-2 with many children → LevelWise
+    fn max_depth(&self) -> u32;
+
+    /// Current DAG heads (latest delta IDs).
+    ///
+    /// Used for delta sync compatibility checking.
+    fn dag_heads(&self) -> Vec<[u8; 32]>;
+
+    /// Whether this node has any state.
+    ///
+    /// Default implementation: `root_hash != [0; 32]`
+    fn has_state(&self) -> bool {
+        self.root_hash() != [0; 32]
+    }
+}
+
+// =============================================================================
+// Handshake Builder
+// =============================================================================
+
+/// Build a `SyncHandshake` from any type implementing `LocalSyncState`.
+///
+/// This is the canonical way to create handshakes, ensuring consistent
+/// behavior between production and simulation code.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let handshake = build_handshake(&my_node);
+/// ```
+#[must_use]
+pub fn build_handshake<T: LocalSyncState>(state: &T) -> SyncHandshake {
+    SyncHandshake::new(
+        state.root_hash(),
+        state.entity_count(),
+        state.max_depth(),
+        state.dag_heads(),
+    )
+}
+
+/// Build a `SyncHandshake` from raw state values.
+///
+/// Useful when you have the values but don't have a `LocalSyncState` implementor.
+#[must_use]
+pub fn build_handshake_from_raw(
+    root_hash: [u8; 32],
+    entity_count: u64,
+    max_depth: u32,
+    dag_heads: Vec<[u8; 32]>,
+) -> SyncHandshake {
+    SyncHandshake::new(root_hash, entity_count, max_depth, dag_heads)
+}
+
+// =============================================================================
+// Estimation Helpers
+// =============================================================================
+
+/// Estimate entity count from available data.
+///
+/// This provides a consistent heuristic used when exact entity count is unknown.
+/// The estimation is based on:
+/// - Zero if root hash is zero (fresh node)
+/// - dag_heads.len() if available, minimum 1 if has state
+///
+/// # Arguments
+///
+/// * `root_hash` - The Merkle root hash
+/// * `dag_heads_len` - Number of DAG heads
+#[must_use]
+pub fn estimate_entity_count(root_hash: [u8; 32], dag_heads_len: usize) -> u64 {
+    if root_hash == [0; 32] {
+        0
+    } else if dag_heads_len == 0 {
+        1 // Has state but no heads - assume at least 1 entity
+    } else {
+        dag_heads_len as u64
+    }
+}
+
+/// Estimate max depth from entity count.
+///
+/// Uses log2 approximation for balanced tree estimation:
+/// `max_depth ≈ ceil(log2(entity_count))`
+///
+/// This is bounded to a reasonable maximum to prevent overflow.
+///
+/// # Arguments
+///
+/// * `entity_count` - Number of entities in the tree
+#[must_use]
+pub fn estimate_max_depth(entity_count: u64) -> u32 {
+    if entity_count == 0 {
+        0
+    } else {
+        // log2(n) ≈ 64 - leading_zeros(n)
+        // For a balanced tree, depth is roughly log2(entity_count)
+        let log2_approx = 64u32.saturating_sub(entity_count.leading_zeros());
+        log2_approx.max(1).min(32)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test implementation of LocalSyncState
+    struct TestNode {
+        root_hash: [u8; 32],
+        entity_count: u64,
+        max_depth: u32,
+        dag_heads: Vec<[u8; 32]>,
+    }
+
+    impl LocalSyncState for TestNode {
+        fn root_hash(&self) -> [u8; 32] {
+            self.root_hash
+        }
+
+        fn entity_count(&self) -> u64 {
+            self.entity_count
+        }
+
+        fn max_depth(&self) -> u32 {
+            self.max_depth
+        }
+
+        fn dag_heads(&self) -> Vec<[u8; 32]> {
+            self.dag_heads.clone()
+        }
+    }
+
+    #[test]
+    fn test_build_handshake_fresh_node() {
+        let node = TestNode {
+            root_hash: [0; 32],
+            entity_count: 0,
+            max_depth: 0,
+            dag_heads: vec![],
+        };
+
+        let hs = build_handshake(&node);
+
+        assert_eq!(hs.root_hash, [0; 32]);
+        assert_eq!(hs.entity_count, 0);
+        assert_eq!(hs.max_depth, 0);
+        assert!(hs.dag_heads.is_empty());
+        assert!(!hs.has_state);
+    }
+
+    #[test]
+    fn test_build_handshake_initialized_node() {
+        let node = TestNode {
+            root_hash: [42; 32],
+            entity_count: 100,
+            max_depth: 5,
+            dag_heads: vec![[1; 32], [2; 32]],
+        };
+
+        let hs = build_handshake(&node);
+
+        assert_eq!(hs.root_hash, [42; 32]);
+        assert_eq!(hs.entity_count, 100);
+        assert_eq!(hs.max_depth, 5);
+        assert_eq!(hs.dag_heads.len(), 2);
+        assert!(hs.has_state);
+    }
+
+    #[test]
+    fn test_estimate_entity_count() {
+        // Fresh node
+        assert_eq!(estimate_entity_count([0; 32], 0), 0);
+
+        // Has state, no heads
+        assert_eq!(estimate_entity_count([1; 32], 0), 1);
+
+        // Has state with heads
+        assert_eq!(estimate_entity_count([1; 32], 5), 5);
+    }
+
+    #[test]
+    fn test_estimate_max_depth() {
+        assert_eq!(estimate_max_depth(0), 0);
+        assert_eq!(estimate_max_depth(1), 1);
+        assert_eq!(estimate_max_depth(2), 2);
+        assert_eq!(estimate_max_depth(16), 5); // log2(16) = 4, +1 = 5
+        assert_eq!(estimate_max_depth(256), 9); // log2(256) = 8, +1 = 9
+    }
+
+    #[test]
+    fn test_has_state_default_implementation() {
+        let fresh = TestNode {
+            root_hash: [0; 32],
+            entity_count: 0,
+            max_depth: 0,
+            dag_heads: vec![],
+        };
+        assert!(!fresh.has_state());
+
+        let initialized = TestNode {
+            root_hash: [1; 32],
+            entity_count: 1,
+            max_depth: 1,
+            dag_heads: vec![],
+        };
+        assert!(initialized.has_state());
+    }
+}

--- a/crates/node/tests/sync_scenarios/mod.rs
+++ b/crates/node/tests/sync_scenarios/mod.rs
@@ -10,6 +10,7 @@
 //! ## Test Categories
 //!
 //! - `snapshot_merge_protection.rs` - Invariant I5 protection tests
+//! - `protocol_dispatch.rs` - Protocol dispatch integration tests
 //! - `negotiation.rs` - Protocol negotiation tests
 //! - `snapshot.rs` - Snapshot sync path tests
 //! - `hash_compare.rs` - Hash comparison sync tests
@@ -17,4 +18,5 @@
 //! - `partitions.rs` - Network partition tests
 //! - `failures.rs` - Fault tolerance tests
 
+pub mod protocol_dispatch;
 pub mod snapshot_merge_protection;

--- a/crates/node/tests/sync_scenarios/protocol_dispatch.rs
+++ b/crates/node/tests/sync_scenarios/protocol_dispatch.rs
@@ -1,0 +1,405 @@
+//! Protocol Dispatch Integration Tests
+//!
+//! These tests verify that both `SyncManager` (production) and `SimNode` (simulation):
+//! 1. Use the shared `LocalSyncState` trait for handshake building
+//! 2. Use the same `select_protocol()` function for negotiation
+//! 3. Maintain critical invariants (I5, etc.) across both environments
+//!
+//! # Architecture
+//!
+//! Per the Simulation Framework Spec (§3 - Effects-Only Model):
+//! > "Same code in simulation and production"
+//!
+//! Both `SimNode` and `SyncManager` now use:
+//! - `LocalSyncState` trait for accessing local state
+//! - `build_handshake()` from `calimero_node_primitives::sync::state_machine`
+//! - `select_protocol()` from `calimero_node_primitives::sync::protocol`
+//!
+//! # Key Differences
+//!
+//! While using the same trait, implementations differ in:
+//! - `SimNode`: Has exact `entity_count()` from storage
+//! - `SyncManager`: Estimates `entity_count` from `dag_heads.len()`
+//!
+//! This is acceptable as the critical invariants (I5, None selection) still hold.
+
+use calimero_node_primitives::sync::handshake::SyncHandshake;
+use calimero_node_primitives::sync::protocol::{select_protocol, SyncProtocol};
+use calimero_node_primitives::sync::state_machine::{
+    build_handshake, build_handshake_from_raw, estimate_entity_count, estimate_max_depth,
+    LocalSyncState,
+};
+
+use crate::sync_sim::prelude::*;
+use crate::sync_sim::scenarios::deterministic::Scenario;
+
+// =============================================================================
+// LocalSyncState Trait Implementation Tests
+// =============================================================================
+
+/// Verify that `SimNode` implements `LocalSyncState` trait correctly.
+///
+/// This is the key integration test - it proves that `SimNode` uses the shared
+/// trait infrastructure from `calimero_node_primitives::sync::state_machine`.
+#[test]
+fn test_simnode_implements_local_sync_state() {
+    let sim_node = SimNode::new("test");
+
+    // Verify we can use the trait methods
+    let root_hash = LocalSyncState::root_hash(&sim_node);
+    let entity_count = LocalSyncState::entity_count(&sim_node);
+    let max_depth = LocalSyncState::max_depth(&sim_node);
+    let dag_heads = LocalSyncState::dag_heads(&sim_node);
+    let has_state = LocalSyncState::has_state(&sim_node);
+
+    // Fresh node should have specific values
+    // Note: SimNode initializes dag_heads with [DeltaId::ZERO] for simulation purposes,
+    // but has_state is still false until entities are added.
+    assert_eq!(root_hash, [0; 32], "Fresh node should have zero root hash");
+    assert_eq!(entity_count, 0, "Fresh node should have zero entities");
+    assert_eq!(max_depth, 0, "Fresh node should have zero depth");
+    assert!(!has_state, "Fresh node should have has_state=false");
+    // SimNode always has at least one DAG head (ZERO) - this is simulation behavior
+    assert!(
+        !dag_heads.is_empty(),
+        "SimNode initializes with at least one DAG head"
+    );
+
+    // Verify build_handshake uses the trait
+    let handshake = build_handshake(&sim_node);
+    assert_eq!(handshake.root_hash, root_hash);
+    assert_eq!(handshake.entity_count, entity_count);
+    assert_eq!(handshake.max_depth, max_depth);
+    assert!(!handshake.has_state);
+}
+
+/// Verify that `SimNode.build_handshake()` uses the shared `build_handshake()` function.
+#[test]
+fn test_simnode_build_handshake_uses_trait() {
+    let mut sim_node = SimNode::new("test");
+
+    // Both should produce identical results
+    let via_method = sim_node.build_handshake();
+    let via_trait = build_handshake(&sim_node);
+
+    assert_eq!(via_method.root_hash, via_trait.root_hash);
+    assert_eq!(via_method.entity_count, via_trait.entity_count);
+    assert_eq!(via_method.max_depth, via_trait.max_depth);
+    assert_eq!(via_method.dag_heads, via_trait.dag_heads);
+    assert_eq!(via_method.has_state, via_trait.has_state);
+}
+
+// =============================================================================
+// Handshake Building Consistency Tests
+// =============================================================================
+
+/// Verify handshake building algorithm produces same results as SimNode.
+///
+/// This tests that `SyncManager.build_local_handshake()` uses the same algorithm
+/// as `SimNode.build_handshake()` for:
+/// - entity_count estimation
+/// - max_depth calculation
+/// - has_state determination
+#[test]
+fn test_handshake_algorithm_consistency_fresh_node() {
+    // Fresh node in simulation
+    let sim_node = SimNode::new("fresh");
+
+    // Use trait to build handshake
+    let sim_hs = build_handshake(&sim_node);
+
+    // Equivalent state using shared estimation functions (what SyncManager uses)
+    let root_hash = [0u8; 32];
+    let dag_heads: Vec<[u8; 32]> = vec![];
+    let entity_count = estimate_entity_count(root_hash, dag_heads.len());
+    let max_depth = estimate_max_depth(entity_count);
+    let manager_hs = build_handshake_from_raw(root_hash, entity_count, max_depth, dag_heads);
+
+    // Both should agree on fresh node state
+    assert_eq!(
+        sim_hs.has_state, manager_hs.has_state,
+        "has_state mismatch for fresh node"
+    );
+    assert_eq!(
+        sim_hs.entity_count, manager_hs.entity_count,
+        "entity_count mismatch for fresh node"
+    );
+    assert_eq!(
+        sim_hs.max_depth, manager_hs.max_depth,
+        "max_depth mismatch for fresh node"
+    );
+}
+
+/// Verify handshake algorithm for initialized nodes with entities.
+#[test]
+fn test_handshake_algorithm_consistency_initialized() {
+    // Initialized node in simulation
+    let (mut a, _) = Scenario::both_initialized();
+    let sim_hs = a.build_handshake();
+
+    // Verify SimNode has state
+    assert!(sim_hs.has_state, "SimNode should have state");
+
+    // Build using manager's algorithm with equivalent data
+    let root_hash = sim_hs.root_hash;
+    let dag_heads = sim_hs.dag_heads.clone();
+    let manager_hs = build_manager_style_handshake(root_hash, &dag_heads);
+
+    // Both should agree on initialized state
+    assert_eq!(
+        sim_hs.has_state, manager_hs.has_state,
+        "has_state mismatch for initialized node"
+    );
+    assert_eq!(sim_hs.root_hash, manager_hs.root_hash, "root_hash mismatch");
+    assert_eq!(sim_hs.dag_heads, manager_hs.dag_heads, "dag_heads mismatch");
+
+    // Note: entity_count and max_depth may differ because SimNode counts actual
+    // entities while manager estimates from dag_heads.len(). This is acceptable
+    // as long as protocol selection still works correctly.
+}
+
+/// Verify protocol selection maintains critical invariants with manager-style handshakes.
+///
+/// Note: SimNode uses `log2` for max_depth, while SyncManager uses `log2/4` (log16).
+/// This means the SPECIFIC protocol may differ (HashComparison vs SubtreePrefetch),
+/// but the CRITICAL invariants must still hold:
+/// - has_state consistency
+/// - None selected when root hashes match
+/// - Snapshot only for fresh nodes (I5)
+#[test]
+fn test_protocol_selection_critical_invariants_with_manager_handshakes() {
+    // Test all major scenarios
+    let scenarios: Vec<(&str, (SimNode, SimNode))> = vec![
+        ("force_none", Scenario::force_none()),
+        ("force_snapshot", Scenario::force_snapshot()),
+        ("both_initialized", Scenario::both_initialized()),
+        ("partial_overlap", Scenario::partial_overlap()),
+    ];
+
+    for (name, (mut a, mut b)) in scenarios {
+        // Build handshakes using SimNode (existing test approach)
+        let sim_hs_a = a.build_handshake();
+        let sim_hs_b = b.build_handshake();
+
+        // Build handshakes using manager-style algorithm
+        let mgr_hs_a = build_manager_style_handshake(sim_hs_a.root_hash, &sim_hs_a.dag_heads);
+        let mgr_hs_b = build_manager_style_handshake(sim_hs_b.root_hash, &sim_hs_b.dag_heads);
+
+        // CRITICAL: has_state must match
+        assert_eq!(
+            sim_hs_a.has_state, mgr_hs_a.has_state,
+            "has_state mismatch for {} (local)",
+            name
+        );
+        assert_eq!(
+            sim_hs_b.has_state, mgr_hs_b.has_state,
+            "has_state mismatch for {} (remote)",
+            name
+        );
+
+        let sim_selection = select_protocol(&sim_hs_a, &sim_hs_b);
+        let mgr_selection = select_protocol(&mgr_hs_a, &mgr_hs_b);
+
+        // CRITICAL: None must agree (same root hash case)
+        if matches!(sim_selection.protocol, SyncProtocol::None) {
+            assert!(
+                matches!(mgr_selection.protocol, SyncProtocol::None),
+                "None mismatch in scenario '{}': SimNode=None, Manager={:?}",
+                name,
+                mgr_selection.protocol
+            );
+        }
+
+        // CRITICAL: Snapshot only when local has no state (Invariant I5)
+        if mgr_hs_a.has_state {
+            assert!(
+                !matches!(mgr_selection.protocol, SyncProtocol::Snapshot { .. }),
+                "I5 VIOLATION: Snapshot selected for initialized node in '{}'",
+                name
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Protocol Dispatch Tests
+// =============================================================================
+
+/// Verify that fresh node syncing from initialized gets Snapshot dispatch.
+#[test]
+fn test_dispatch_fresh_to_initialized_selects_snapshot() {
+    let (mut fresh, mut source) = Scenario::force_snapshot();
+
+    let local_hs = fresh.build_handshake();
+    let remote_hs = source.build_handshake();
+
+    assert!(!local_hs.has_state, "Precondition: fresh has no state");
+    assert!(remote_hs.has_state, "Precondition: source has state");
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    // This would dispatch to fallback_to_snapshot_sync() in handle_dag_sync()
+    assert!(
+        matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "Expected Snapshot dispatch, got {:?}",
+        selection.protocol
+    );
+    assert!(
+        selection.reason.contains("fresh"),
+        "Reason should mention fresh node: {}",
+        selection.reason
+    );
+}
+
+/// Verify that same root hash gets None dispatch (no sync needed).
+#[test]
+fn test_dispatch_same_hash_selects_none() {
+    let (mut a, mut b) = Scenario::force_none();
+
+    let local_hs = a.build_handshake();
+    let remote_hs = b.build_handshake();
+
+    assert_eq!(
+        local_hs.root_hash, remote_hs.root_hash,
+        "Precondition: same root hash"
+    );
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    // This would return Ok(None) in handle_dag_sync()
+    assert!(
+        matches!(selection.protocol, SyncProtocol::None),
+        "Expected None dispatch (already synced), got {:?}",
+        selection.protocol
+    );
+    assert!(
+        selection.reason.contains("already in sync") || selection.reason.contains("match"),
+        "Reason should mention already synced: {}",
+        selection.reason
+    );
+}
+
+/// Verify that diverged initialized nodes get state-based protocol (not Snapshot).
+#[test]
+fn test_dispatch_diverged_initialized_avoids_snapshot() {
+    let (mut a, mut b) = Scenario::both_initialized();
+
+    let local_hs = a.build_handshake();
+    let remote_hs = b.build_handshake();
+
+    assert!(local_hs.has_state);
+    assert!(remote_hs.has_state);
+    assert_ne!(local_hs.root_hash, remote_hs.root_hash);
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    // Should NOT be Snapshot (Invariant I5)
+    assert!(
+        !matches!(selection.protocol, SyncProtocol::Snapshot { .. }),
+        "VIOLATION: Snapshot selected for initialized nodes!\n\
+         Should use HashComparison/DeltaSync/etc., got {:?}",
+        selection.protocol
+    );
+}
+
+/// Verify unimplemented protocols are identified for fallback.
+#[test]
+fn test_dispatch_identifies_unimplemented_protocols() {
+    // Force deep tree scenario (would select SubtreePrefetch)
+    let (mut a, mut b) = Scenario::force_subtree_prefetch();
+
+    let local_hs = a.build_handshake();
+    let remote_hs = b.build_handshake();
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    // SubtreePrefetch is not yet implemented, so SyncManager would log warning
+    // and fall back to snapshot
+    if matches!(selection.protocol, SyncProtocol::SubtreePrefetch { .. }) {
+        // This is expected - handle_dag_sync() would warn and fallback
+        assert!(
+            selection.reason.contains("subtree") || selection.reason.contains("deep"),
+            "Reason should explain subtree selection: {}",
+            selection.reason
+        );
+    }
+
+    // Force wide shallow scenario (would select LevelWise)
+    let (mut c, mut d) = Scenario::force_levelwise();
+    let local_hs = c.build_handshake();
+    let remote_hs = d.build_handshake();
+
+    let selection = select_protocol(&local_hs, &remote_hs);
+
+    if matches!(selection.protocol, SyncProtocol::LevelWise { .. }) {
+        assert!(
+            selection.reason.contains("level") || selection.reason.contains("wide"),
+            "Reason should explain levelwise selection: {}",
+            selection.reason
+        );
+    }
+}
+
+// =============================================================================
+// Reason Logging Tests
+// =============================================================================
+
+/// Verify all protocol selections have meaningful reasons.
+#[test]
+fn test_all_selections_have_reasons() {
+    let test_cases: Vec<(&str, SyncHandshake, SyncHandshake)> = vec![
+        (
+            "same_hash",
+            SyncHandshake::new([42; 32], 100, 5, vec![]),
+            SyncHandshake::new([42; 32], 100, 5, vec![]),
+        ),
+        (
+            "fresh_to_init",
+            SyncHandshake::new([0; 32], 0, 0, vec![]),
+            SyncHandshake::new([42; 32], 100, 5, vec![]),
+        ),
+        (
+            "high_divergence",
+            SyncHandshake::new([1; 32], 10, 2, vec![]),
+            SyncHandshake::new([2; 32], 100, 5, vec![]),
+        ),
+        (
+            "low_divergence_deep",
+            SyncHandshake::new([1; 32], 90, 5, vec![]),
+            SyncHandshake::new([2; 32], 100, 5, vec![]),
+        ),
+    ];
+
+    for (name, local, remote) in test_cases {
+        let selection = select_protocol(&local, &remote);
+
+        assert!(
+            !selection.reason.is_empty(),
+            "Selection for '{}' has empty reason",
+            name
+        );
+        assert!(
+            selection.reason.len() > 5,
+            "Selection reason for '{}' is too short: '{}'",
+            name,
+            selection.reason
+        );
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Build a SyncHandshake using the shared functions from `calimero_node_primitives::sync`.
+///
+/// This uses the same `estimate_entity_count()` and `estimate_max_depth()` functions
+/// that `SyncManager.build_local_handshake()` uses, ensuring consistency.
+///
+/// **Note**: This matches `SyncManager`'s estimation-based approach.
+/// `SimNode` may have different values because it uses actual storage counts.
+fn build_manager_style_handshake(root_hash: [u8; 32], dag_heads: &[[u8; 32]]) -> SyncHandshake {
+    let entity_count = estimate_entity_count(root_hash, dag_heads.len());
+    let max_depth = estimate_max_depth(entity_count);
+    build_handshake_from_raw(root_hash, entity_count, max_depth, dag_heads.to_vec())
+}


### PR DESCRIPTION
## Summary

Integrates CIP §2.3 protocol selection into SyncManager, enabling optimal sync strategy negotiation between nodes.

## Changes

- Wire `select_protocol()` from primitives into `SyncManager::handle_dag_sync`
- Add `LocalSyncState` trait for shared handshake building logic
- Implement `LocalSyncState` for `SimNode` (simulation framework)
- Add protocol mapping (7-variant → 3-variant) for metrics tracking
- Add shared estimation functions (`estimate_entity_count`, `estimate_max_depth`)
- Remove unused `ProtocolDispatch` enum (dead code cleanup)
- Add comprehensive tests for protocol dispatch and trait impl

## CIP Sections

- §2.3 Protocol Selection Decision Table

## Testing

- ✅ 169 unit/integration tests pass (`cargo test -p calimero-node`)
- ✅ 169 simulation tests pass (`cargo test --test sync_sim`)
- ✅ E2E merobox workflow passes (kv-store sync verified)
- ✅ `cargo fmt --check` passes
- ✅ `cargo clippy -p calimero-node` passes

## Key Files

| File | Purpose |
|------|---------|
| `crates/node/primitives/src/sync/state_machine.rs` | LocalSyncState trait + shared helpers |
| `crates/node/src/sync/manager.rs` | Protocol selection integration |
| `crates/node/src/sync/tracking.rs` | Protocol mapping for metrics |
| `crates/node/tests/sync_sim/node/state.rs` | SimNode trait impl |
| `crates/node/tests/sync_scenarios/protocol_dispatch.rs` | Protocol dispatch tests |

## Invariants

- None affected (protocol selection doesn't change data flow, only optimizes sync strategy)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sync decision logic and protocol/result reporting paths, which can alter when nodes choose snapshot vs delta catchup and how failures fall back. While new tests cover key invariants, behavior changes could impact real-world sync convergence and retry patterns.
> 
> **Overview**
> Sync protocol negotiation in `SyncManager::handle_dag_sync` is refactored to build local/remote `SyncHandshake`s and use primitives’ `select_protocol()` (CIP §2.3) to decide between `None`, `DeltaSync`, or `Snapshot`, with explicit fallbacks for currently-unimplemented protocols (HashComparison/BloomFilter/SubtreePrefetch/LevelWise).
> 
> A new shared `sync::state_machine` module adds the `LocalSyncState` trait plus handshake builders and estimation helpers, which are re-exported from `sync` and adopted by simulation (`SimNode`) to keep production/sim protocol selection consistent. Internal sync tracking is updated to map the 7-variant primitives `SyncProtocol` into the existing 3-variant metrics enum, and comprehensive unit/simulation tests are added to validate handshake building, protocol dispatch, and key invariants (e.g., snapshot only for fresh nodes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d986408e9f521fdd4ef7f4cb11f51cbe38267b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->