### PR TITLE
test(sync): add delta buffering simulation tests for Invariant I6

### DIFF
--- a/crates/node/primitives/src/delta_buffer.rs
+++ b/crates/node/primitives/src/delta_buffer.rs
@@ -1,19 +1,33 @@
-//! Delta buffering for sync scenarios.
+//! Delta buffering for sync scenarios (Invariant I6).
 //!
 //! When a snapshot sync is in progress, incoming deltas are buffered so they
 //! can be replayed after the snapshot completes. This ensures that:
-//! 1. Deltas arriving during sync aren't lost
+//! 1. Deltas arriving during sync aren't lost (Invariant I6 - Liveness Guarantee)
 //! 2. Event handlers can execute for buffered deltas after context is initialized
+//!
+//! ## Delivery Contract
+//!
+//! - **Buffer size**: Configurable, default 10,000 deltas per context
+//! - **Drop policy**: Oldest-first when buffer full (with metric increment)
+//! - **Backpressure**: None (fire-and-forget from network layer)
+//! - **Metrics**: `drops` counter MUST be observable
 
 use calimero_crypto::Nonce;
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
+
+/// Default buffer capacity (10,000 deltas per context).
+pub const DEFAULT_BUFFER_CAPACITY: usize = 10_000;
 
 /// A single buffered delta.
 ///
 /// Contains ALL fields needed for replay after snapshot sync completes.
 /// Previously missing fields (nonce, author_id, root_hash, events) caused
 /// data loss because deltas couldn't be decrypted or processed.
+///
+/// **POC Bug 7**: This struct MUST include all fields for replay - not just
+/// `id`, `parents`, `hlc`, `payload`, but also `nonce`, `author_id`, `root_hash`,
+/// `events`, and `source_peer`.
 #[derive(Debug, Clone)]
 pub struct BufferedDelta {
     /// Delta ID.
@@ -37,63 +51,63 @@ pub struct BufferedDelta {
 }
 
 /// Buffer for storing deltas during snapshot sync.
+///
+/// Implements Invariant I6: Deltas received during state-based sync MUST be
+/// preserved and applied after sync completes.
+///
+/// When the buffer is full, the oldest delta is evicted (FIFO eviction policy)
+/// and the `drops` counter is incremented. Drops MUST be observable via metrics.
 #[derive(Debug)]
 pub struct DeltaBuffer {
-    /// Buffered deltas.
-    deltas: Vec<BufferedDelta>,
+    /// Buffered deltas (FIFO queue - oldest at front).
+    deltas: std::collections::VecDeque<BufferedDelta>,
     /// HLC timestamp when buffering started.
     sync_start_hlc: u64,
-    /// Maximum buffer size before overflow.
-    max_size: usize,
+    /// Maximum buffer size before eviction.
+    capacity: usize,
+    /// Number of deltas dropped due to buffer overflow (observable metric).
+    drops: u64,
 }
-
-/// Error when delta buffer is full.
-#[derive(Debug, Clone)]
-pub struct DeltaBufferFull {
-    /// Number of deltas already buffered.
-    pub buffered_count: usize,
-}
-
-impl std::fmt::Display for DeltaBufferFull {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Delta buffer full ({} deltas buffered)",
-            self.buffered_count
-        )
-    }
-}
-
-impl std::error::Error for DeltaBufferFull {}
 
 impl DeltaBuffer {
     /// Create a new delta buffer with specified capacity.
     #[must_use]
-    pub fn new(max_size: usize, sync_start_hlc: u64) -> Self {
+    pub fn new(capacity: usize, sync_start_hlc: u64) -> Self {
         Self {
-            deltas: Vec::with_capacity(max_size.min(1000)),
+            deltas: std::collections::VecDeque::with_capacity(capacity.min(1000)),
             sync_start_hlc,
-            max_size,
+            capacity,
+            drops: 0,
         }
     }
 
     /// Add a delta to the buffer.
     ///
-    /// Returns `Err(DeltaBufferFull)` if buffer is at capacity.
-    pub fn push(&mut self, delta: BufferedDelta) -> Result<(), DeltaBufferFull> {
-        if self.deltas.len() >= self.max_size {
-            return Err(DeltaBufferFull {
-                buffered_count: self.deltas.len(),
-            });
+    /// If the buffer is full, the oldest delta is evicted (oldest-first policy)
+    /// and the `drops` counter is incremented. This ensures we never reject
+    /// incoming deltas but may lose old ones under extreme load.
+    ///
+    /// Returns `true` if the delta was added without eviction, `false` if
+    /// an older delta was evicted to make room.
+    pub fn push(&mut self, delta: BufferedDelta) -> bool {
+        if self.deltas.len() >= self.capacity {
+            // Evict oldest delta (front of queue)
+            let _evicted = self.deltas.pop_front();
+            self.drops += 1;
+            self.deltas.push_back(delta);
+            false
+        } else {
+            self.deltas.push_back(delta);
+            true
         }
-        self.deltas.push(delta);
-        Ok(())
     }
 
     /// Get all buffered deltas for replay, clearing the buffer.
+    ///
+    /// Returns deltas in FIFO order (oldest first), preserving causality.
     #[must_use]
     pub fn drain(&mut self) -> Vec<BufferedDelta> {
-        std::mem::take(&mut self.deltas)
+        self.deltas.drain(..).collect()
     }
 
     /// Number of buffered deltas.
@@ -112,6 +126,20 @@ impl DeltaBuffer {
     #[must_use]
     pub fn sync_start_hlc(&self) -> u64 {
         self.sync_start_hlc
+    }
+
+    /// Get the number of deltas dropped due to buffer overflow.
+    ///
+    /// This metric MUST be observable per Invariant I6 delivery contract.
+    #[must_use]
+    pub fn drops(&self) -> u64 {
+        self.drops
+    }
+
+    /// Get the buffer capacity.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
     }
 }
 
@@ -138,8 +166,11 @@ mod tests {
         let mut buffer = DeltaBuffer::new(100, 12345);
         assert!(buffer.is_empty());
         assert_eq!(buffer.sync_start_hlc(), 12345);
+        assert_eq!(buffer.capacity(), 100);
+        assert_eq!(buffer.drops(), 0);
 
-        buffer.push(make_test_delta(1)).unwrap();
+        let added_without_eviction = buffer.push(make_test_delta(1));
+        assert!(added_without_eviction);
         assert_eq!(buffer.len(), 1);
 
         let drained = buffer.drain();
@@ -148,12 +179,95 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_overflow() {
-        let mut buffer = DeltaBuffer::new(2, 0);
-        buffer.push(make_test_delta(1)).unwrap();
-        buffer.push(make_test_delta(2)).unwrap();
+    fn test_buffer_only_during_sync() {
+        // Buffer should only accept deltas - caller decides when to buffer
+        let mut buffer = DeltaBuffer::new(10, 12345);
+        assert!(buffer.is_empty());
 
-        let result = buffer.push(make_test_delta(3));
-        assert!(result.is_err());
+        // Push deltas
+        buffer.push(make_test_delta(1));
+        buffer.push(make_test_delta(2));
+        assert_eq!(buffer.len(), 2);
+
+        // Drain returns all in FIFO order
+        let drained = buffer.drain();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].id[0], 1);
+        assert_eq!(drained[1].id[0], 2);
+    }
+
+    #[test]
+    fn test_buffer_overflow_drops_oldest() {
+        let mut buffer = DeltaBuffer::new(2, 0);
+
+        // Fill buffer
+        assert!(buffer.push(make_test_delta(1))); // No eviction
+        assert!(buffer.push(make_test_delta(2))); // No eviction
+        assert_eq!(buffer.drops(), 0);
+
+        // Third delta causes eviction of oldest
+        assert!(!buffer.push(make_test_delta(3))); // Evicts delta 1
+        assert_eq!(buffer.drops(), 1);
+        assert_eq!(buffer.len(), 2);
+
+        // Fourth delta causes another eviction
+        assert!(!buffer.push(make_test_delta(4))); // Evicts delta 2
+        assert_eq!(buffer.drops(), 2);
+        assert_eq!(buffer.len(), 2);
+
+        // Verify remaining deltas are 3 and 4 (FIFO order)
+        let drained = buffer.drain();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].id[0], 3);
+        assert_eq!(drained[1].id[0], 4);
+    }
+
+    #[test]
+    fn test_finish_sync_returns_fifo() {
+        let mut buffer = DeltaBuffer::new(100, 0);
+
+        // Add deltas in order
+        buffer.push(make_test_delta(1));
+        buffer.push(make_test_delta(2));
+        buffer.push(make_test_delta(3));
+
+        // Drain should return in FIFO order
+        let drained = buffer.drain();
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].id[0], 1);
+        assert_eq!(drained[1].id[0], 2);
+        assert_eq!(drained[2].id[0], 3);
+    }
+
+    #[test]
+    fn test_cancel_sync_clears_buffer() {
+        let mut buffer = DeltaBuffer::new(100, 0);
+        buffer.push(make_test_delta(1));
+        buffer.push(make_test_delta(2));
+        assert_eq!(buffer.len(), 2);
+
+        // Simulate cancel by draining and discarding
+        let _ = buffer.drain();
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.len(), 0);
+    }
+
+    #[test]
+    fn test_drops_counter_observable() {
+        let mut buffer = DeltaBuffer::new(1, 0);
+        assert_eq!(buffer.drops(), 0);
+
+        buffer.push(make_test_delta(1));
+        assert_eq!(buffer.drops(), 0);
+
+        // Each overflow increments drops
+        buffer.push(make_test_delta(2));
+        assert_eq!(buffer.drops(), 1);
+
+        buffer.push(make_test_delta(3));
+        assert_eq!(buffer.drops(), 2);
+
+        buffer.push(make_test_delta(4));
+        assert_eq!(buffer.drops(), 3);
     }
 }

--- a/crates/node/tests/sync_sim/network/router.rs
+++ b/crates/node/tests/sync_sim/network/router.rs
@@ -29,6 +29,18 @@ pub enum SimEvent {
     PartitionStart { groups: Vec<Vec<NodeId>> },
     /// Partition end.
     PartitionEnd { groups: Vec<Vec<NodeId>> },
+    /// Gossip delta arrives (simulates BroadcastMessage::StateDelta).
+    /// This tests Invariant I6 - deltas arriving during sync must be buffered.
+    GossipDelta {
+        to: NodeId,
+        delta_id: crate::sync_sim::types::DeltaId,
+        /// Storage operations in the delta.
+        operations: Vec<crate::sync_sim::actions::StorageOp>,
+    },
+    /// Sync session starts on a node (for explicit state control in tests).
+    SyncStart { node: NodeId },
+    /// Sync session completes (triggers buffer replay).
+    SyncComplete { node: NodeId },
 }
 
 /// Message in flight with delivery metadata.

--- a/crates/node/tests/sync_sim/scenarios/buffering.rs
+++ b/crates/node/tests/sync_sim/scenarios/buffering.rs
@@ -1,0 +1,436 @@
+//! Delta buffering scenarios for Invariant I6 testing.
+//!
+//! These scenarios test the behavior of delta buffering during state-based sync.
+//! Per CIP Invariant I6: "Deltas received during state-based sync MUST be preserved
+//! and applied after sync completes. Implementations MUST NOT drop buffered deltas."
+//!
+//! # Test Coverage
+//!
+//! 1. `test_deltas_buffered_during_sync` - Deltas arriving during sync are buffered
+//! 2. `test_buffered_deltas_replayed_on_completion` - Buffered deltas applied after sync
+//! 3. `test_deltas_applied_immediately_when_idle` - Deltas applied immediately when not syncing
+//! 4. `test_buffered_deltas_cleared_on_crash` - Buffer cleared on node crash
+//! 5. `test_multiple_deltas_preserved_fifo` - Multiple deltas replayed in FIFO order
+
+use crate::sync_sim::actions::{EntityMetadata, StorageOp};
+use crate::sync_sim::node::SimNode;
+use crate::sync_sim::runtime::SimDuration;
+use crate::sync_sim::sim_runtime::SimRuntime;
+use crate::sync_sim::types::{DeltaId, EntityId};
+use calimero_primitives::crdt::CrdtType;
+
+/// Create a DeltaId from a u64 for testing convenience.
+fn delta_id_from_u64(n: u64) -> DeltaId {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&n.to_le_bytes());
+    DeltaId::from_bytes(bytes)
+}
+
+/// Create a simple insert operation for testing.
+fn make_insert_op(entity_id: u64, value: &str) -> StorageOp {
+    StorageOp::Insert {
+        id: EntityId::from_u64(entity_id),
+        data: value.as_bytes().to_vec(),
+        metadata: EntityMetadata::new(CrdtType::LwwRegister, entity_id * 100),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test: Deltas arriving during active sync are buffered, not applied.
+    ///
+    /// Verifies Invariant I6: deltas MUST be preserved during sync.
+    #[test]
+    fn test_deltas_buffered_during_sync() {
+        let mut rt = SimRuntime::new(42);
+
+        // Create a fresh node
+        let node_id = rt.add_node("syncing_node");
+
+        // Start sync on the node
+        rt.schedule_sync_start(node_id.clone(), SimDuration::ZERO);
+        rt.step(); // Process SyncStart
+
+        // Verify node is now syncing
+        assert!(
+            rt.node(&node_id).unwrap().sync_state.is_active(),
+            "Node should be in active sync state"
+        );
+
+        // Schedule a gossip delta to arrive during sync
+        let delta_id = delta_id_from_u64(1);
+        let operations = vec![make_insert_op(100, "buffered_value")];
+        rt.schedule_gossip_delta(
+            node_id.clone(),
+            delta_id,
+            operations,
+            SimDuration::from_millis(10),
+        );
+        rt.step(); // Process GossipDelta
+
+        // Verify: delta was buffered, NOT applied to storage
+        let node = rt.node(&node_id).unwrap();
+        assert_eq!(
+            node.buffer_size(),
+            1,
+            "Delta should be buffered during sync"
+        );
+        assert_eq!(
+            node.entity_count(),
+            0,
+            "Delta should NOT be applied to storage during sync"
+        );
+        assert_eq!(
+            node.buffered_operations_count(),
+            1,
+            "Operations should be buffered for replay"
+        );
+    }
+
+    /// Test: Buffered deltas are replayed when sync completes.
+    ///
+    /// Verifies Invariant I6: deltas MUST be applied after sync completes.
+    #[test]
+    fn test_buffered_deltas_replayed_on_completion() {
+        let mut rt = SimRuntime::new(42);
+
+        let node_id = rt.add_node("syncing_node");
+
+        // Start sync
+        rt.schedule_sync_start(node_id.clone(), SimDuration::ZERO);
+        rt.step();
+
+        // Send delta during sync
+        let delta_id = delta_id_from_u64(1);
+        let operations = vec![make_insert_op(100, "replayed_value")];
+        rt.schedule_gossip_delta(
+            node_id.clone(),
+            delta_id,
+            operations,
+            SimDuration::from_millis(10),
+        );
+        rt.step();
+
+        // Verify buffered
+        assert_eq!(rt.node(&node_id).unwrap().buffer_size(), 1);
+        assert_eq!(rt.node(&node_id).unwrap().entity_count(), 0);
+
+        // Complete sync - should replay buffered deltas
+        rt.schedule_sync_complete(node_id.clone(), SimDuration::from_millis(20));
+        rt.step();
+
+        // Verify: delta was applied, buffer cleared
+        let node = rt.node(&node_id).unwrap();
+        assert_eq!(node.buffer_size(), 0, "Buffer should be cleared after sync");
+        assert_eq!(
+            node.entity_count(),
+            1,
+            "Buffered delta should be applied after sync"
+        );
+        assert!(
+            !node.sync_state.is_active(),
+            "Node should be idle after sync completes"
+        );
+    }
+
+    /// Test: Deltas are applied immediately when node is not syncing.
+    #[test]
+    fn test_deltas_applied_immediately_when_idle() {
+        let mut rt = SimRuntime::new(42);
+
+        let node_id = rt.add_node("idle_node");
+
+        // Node is idle (not syncing)
+        assert!(!rt.node(&node_id).unwrap().sync_state.is_active());
+
+        // Send delta
+        let delta_id = delta_id_from_u64(1);
+        let operations = vec![make_insert_op(100, "immediate_value")];
+        rt.schedule_gossip_delta(
+            node_id.clone(),
+            delta_id,
+            operations,
+            SimDuration::from_millis(10),
+        );
+        rt.step();
+
+        // Verify: delta applied immediately, nothing buffered
+        let node = rt.node(&node_id).unwrap();
+        assert_eq!(
+            node.buffer_size(),
+            0,
+            "No buffering when node is not syncing"
+        );
+        assert_eq!(
+            node.entity_count(),
+            1,
+            "Delta should be applied immediately when idle"
+        );
+    }
+
+    /// Test: Buffered deltas are lost on node crash (not persisted).
+    ///
+    /// This is expected behavior - crash recovery restarts sync from scratch.
+    #[test]
+    fn test_buffered_deltas_cleared_on_crash() {
+        let mut rt = SimRuntime::new(42);
+
+        let node_id = rt.add_node("crashing_node");
+
+        // Start sync and buffer a delta
+        rt.schedule_sync_start(node_id.clone(), SimDuration::ZERO);
+        rt.step();
+
+        let delta_id = delta_id_from_u64(1);
+        let operations = vec![make_insert_op(100, "will_be_lost")];
+        rt.schedule_gossip_delta(
+            node_id.clone(),
+            delta_id,
+            operations,
+            SimDuration::from_millis(10),
+        );
+        rt.step();
+
+        assert_eq!(rt.node(&node_id).unwrap().buffer_size(), 1);
+
+        // Crash the node
+        rt.schedule_crash(node_id.clone(), SimDuration::from_millis(20));
+        rt.step();
+
+        // Verify: buffer cleared, sync state reset
+        let node = rt.node(&node_id).unwrap();
+        assert!(node.is_crashed, "Node should be crashed");
+        assert_eq!(node.buffer_size(), 0, "Buffer should be cleared on crash");
+        assert_eq!(
+            node.buffered_operations_count(),
+            0,
+            "Buffered operations should be cleared"
+        );
+        assert!(
+            !node.sync_state.is_active(),
+            "Sync state should be reset on crash"
+        );
+    }
+
+    /// Test: Multiple deltas are preserved and replayed in FIFO order.
+    ///
+    /// Verifies that the buffering mechanism maintains insertion order.
+    #[test]
+    fn test_multiple_deltas_preserved_fifo() {
+        let mut rt = SimRuntime::new(42);
+
+        let node_id = rt.add_node("multi_delta_node");
+
+        // Start sync
+        rt.schedule_sync_start(node_id.clone(), SimDuration::ZERO);
+        rt.step();
+
+        // Send multiple deltas with different timestamps
+        for i in 1..=5 {
+            let delta_id = delta_id_from_u64(i);
+            let operations = vec![make_insert_op(100 + i, &format!("delta_{}", i))];
+            rt.schedule_gossip_delta(
+                node_id.clone(),
+                delta_id,
+                operations,
+                SimDuration::from_millis(10 * i),
+            );
+        }
+
+        // Process all deltas
+        for _ in 0..5 {
+            rt.step();
+        }
+
+        // Verify all buffered
+        assert_eq!(
+            rt.node(&node_id).unwrap().buffer_size(),
+            5,
+            "All 5 deltas should be buffered"
+        );
+        assert_eq!(
+            rt.node(&node_id).unwrap().entity_count(),
+            0,
+            "No deltas applied yet"
+        );
+
+        // Complete sync
+        rt.schedule_sync_complete(node_id.clone(), SimDuration::from_millis(100));
+        rt.step();
+
+        // Verify all deltas applied
+        let node = rt.node(&node_id).unwrap();
+        assert_eq!(node.buffer_size(), 0, "Buffer should be empty");
+        assert_eq!(
+            node.entity_count(),
+            5,
+            "All 5 deltas should be applied after sync"
+        );
+    }
+
+    /// Test: Convergence is blocked while deltas are buffered.
+    ///
+    /// The simulation's convergence check (C3) requires all buffers to be empty.
+    #[test]
+    fn test_convergence_blocked_with_buffered_deltas() {
+        let mut rt = SimRuntime::new(42);
+
+        // Create two nodes - one syncing, one idle
+        let syncing = rt.add_node("syncing");
+        let idle = rt.add_node("idle");
+
+        // Give idle node some state with specific data
+        let shared_data = b"shared_data".to_vec();
+        let metadata = EntityMetadata::new(CrdtType::LwwRegister, 100);
+        rt.node_mut(&idle).unwrap().insert_entity_with_metadata(
+            EntityId::from_u64(1),
+            shared_data.clone(),
+            metadata.clone(),
+        );
+
+        // Start sync on syncing node
+        rt.schedule_sync_start(syncing.clone(), SimDuration::ZERO);
+        rt.step();
+
+        // Buffer a delta on syncing node with SAME data as idle node
+        let delta_id = delta_id_from_u64(1);
+        let operations = vec![StorageOp::Insert {
+            id: EntityId::from_u64(1),
+            data: shared_data,
+            metadata,
+        }];
+        rt.schedule_gossip_delta(
+            syncing.clone(),
+            delta_id,
+            operations,
+            SimDuration::from_millis(10),
+        );
+        rt.step();
+
+        // Convergence should be blocked (C3: all buffers must be empty)
+        let convergence = rt.check_convergence();
+        assert!(
+            !convergence.is_converged(),
+            "Should NOT converge while deltas are buffered"
+        );
+
+        // Complete sync
+        rt.schedule_sync_complete(syncing.clone(), SimDuration::from_millis(20));
+        rt.step();
+
+        // Now should converge (both have same entity with same data)
+        let convergence = rt.check_convergence();
+        assert!(
+            convergence.is_converged(),
+            "Should converge after sync completes and deltas replayed"
+        );
+    }
+
+    /// Test: Complex scenario - snapshot sync with concurrent writes.
+    ///
+    /// Simulates a real-world scenario where:
+    /// 1. Fresh node joins network
+    /// 2. Snapshot sync starts
+    /// 3. Source node produces new writes during sync
+    /// 4. New writes are gossiped to fresh node
+    /// 5. Fresh node buffers them
+    /// 6. Snapshot completes
+    /// 7. Buffered writes are replayed
+    /// 8. Both nodes converge
+    #[test]
+    fn test_snapshot_sync_with_concurrent_writes() {
+        let mut rt = SimRuntime::new(42);
+
+        // Source node with existing data
+        let mut source = SimNode::new("source");
+        for i in 0..10 {
+            source.insert_entity(
+                EntityId::from_u64(i),
+                format!("initial_{}", i).into_bytes(),
+                CrdtType::LwwRegister,
+            );
+        }
+        let source_id = rt.add_existing_node(source);
+
+        // Fresh node (needs snapshot sync)
+        let fresh_id = rt.add_node("fresh");
+
+        // Fresh node starts snapshot sync
+        rt.schedule_sync_start(fresh_id.clone(), SimDuration::ZERO);
+        rt.step();
+
+        // Simulate snapshot transfer (copy source's entities to fresh)
+        // In real implementation, this happens via SnapshotPage messages
+        let source_entities: Vec<_> = {
+            let s = rt.node(&source_id).unwrap();
+            s.storage
+                .entities_sorted()
+                .into_iter()
+                .map(|e| (e.id, e.data.clone(), e.metadata.clone()))
+                .collect()
+        };
+        for (id, data, metadata) in source_entities {
+            rt.node_mut(&fresh_id)
+                .unwrap()
+                .insert_entity_with_metadata(id, data, metadata);
+        }
+
+        // MEANWHILE: Source produces new writes that get gossiped to fresh
+        // (These arrive during sync and must be buffered)
+        for i in 10..15 {
+            let delta_id = delta_id_from_u64(i);
+            let data = format!("concurrent_{}", i).into_bytes();
+            // Use consistent metadata for both source and fresh
+            let metadata = EntityMetadata::new(CrdtType::LwwRegister, i * 100);
+            let operations = vec![StorageOp::Insert {
+                id: EntityId::from_u64(i),
+                data: data.clone(),
+                metadata: metadata.clone(),
+            }];
+
+            // Also apply to source immediately with same metadata
+            rt.node_mut(&source_id)
+                .unwrap()
+                .insert_entity_with_metadata(EntityId::from_u64(i), data, metadata);
+
+            // Gossip to fresh (will be buffered)
+            rt.schedule_gossip_delta(
+                fresh_id.clone(),
+                delta_id,
+                operations,
+                SimDuration::from_millis(10 + i),
+            );
+        }
+
+        // Process all gossip deltas
+        for _ in 0..5 {
+            rt.step();
+        }
+
+        // Verify: fresh has initial 10, source has all 15
+        // fresh should have 5 buffered
+        assert_eq!(rt.node(&fresh_id).unwrap().entity_count(), 10);
+        assert_eq!(rt.node(&fresh_id).unwrap().buffer_size(), 5);
+        assert_eq!(rt.node(&source_id).unwrap().entity_count(), 15);
+
+        // System should NOT be converged yet
+        assert!(!rt.check_convergence().is_converged());
+
+        // Complete sync on fresh - replays buffered deltas
+        rt.schedule_sync_complete(fresh_id.clone(), SimDuration::from_millis(100));
+        rt.step();
+
+        // Both nodes should now have 15 entities
+        assert_eq!(rt.node(&fresh_id).unwrap().entity_count(), 15);
+        assert_eq!(rt.node(&source_id).unwrap().entity_count(), 15);
+        assert_eq!(rt.node(&fresh_id).unwrap().buffer_size(), 0);
+
+        // System should converge
+        assert!(
+            rt.check_convergence().is_converged(),
+            "Nodes should converge after buffered deltas are replayed"
+        );
+    }
+}

--- a/crates/node/tests/sync_sim/scenarios/mod.rs
+++ b/crates/node/tests/sync_sim/scenarios/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! See spec §15 - Protocol Negotiation Tests.
 
+pub mod buffering;
 pub mod deterministic;
 pub mod random;
 


### PR DESCRIPTION
## Summary

Add comprehensive simulation tests verifying delta buffering behavior during state-based sync (Invariant I6: deltas arriving during sync MUST be preserved and applied after sync completes).

**Changes:**
- Enhanced `DeltaBuffer` with FIFO eviction (oldest-first drop policy)
- Added drops counter and configurable capacity
- Integrated `cancel_sync_session` for proper error handling
- Added 7 simulation test scenarios covering:
  - Deltas buffered during active sync
  - Buffered deltas replayed on completion
  - Immediate application when idle
  - Buffer cleared on crash
  - Multiple deltas preserved in FIFO order
  - Convergence blocked while buffer non-empty
  - Complex snapshot sync with concurrent writes

## Test Plan

- [x] All 176 sync_sim tests pass
- [x] Delta buffering scenarios verify I6 invariant
- [x] FIFO eviction tested with capacity limits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snapshot-sync buffering semantics from fail-on-full to evict-on-full and adds new session lifecycle paths (`cancel_sync_session`), which can affect sync correctness and data loss behavior under load.
> 
> **Overview**
> Implements and tests *Invariant I6* delta buffering during snapshot sync. `DeltaBuffer` is reworked to be a bounded FIFO (`VecDeque`) with configurable capacity (default `10_000`), oldest-first eviction instead of erroring, and an observable `drops` counter.
> 
> Node sync session handling is updated to use the new buffer semantics: rate-limited warnings on eviction, explicit `cancel_sync_session()` on snapshot-sync failure, and end-of-sync logging/metrics. The sync simulation gains new events (`GossipDelta`, `SyncStart`, `SyncComplete`) plus a new `buffering` scenario suite that validates buffering, FIFO replay, crash clearing, and convergence behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d3e04a215edb0479e0e0079cfb5124286c7cd15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->