### PR TITLE
test: add workflow-example.yml to kv-store workflows

### DIFF
--- a/apps/kv-store/workflows/workflow-example.yml
+++ b/apps/kv-store/workflows/workflow-example.yml
@@ -1,0 +1,243 @@
+description: A sample workflow that demonstrates the bootstrap functionality with dynamic value capture
+name: Sample Calimero Workflow
+
+# Force pull Docker images even if they exist locally
+force_pull_image: true
+
+nodes:
+  chain_id: testnet-1
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: calimero-node
+
+steps:
+  # Step 1: Install the application on the first node
+  # This captures the application ID for use in subsequent steps
+  # Path is relative to where merobox runs (apps/kv-store/)
+  - name: Install Application on Node 1
+    type: install_application
+    node: calimero-node-1
+    path: res/kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId          # Export 'applicationId' field as 'app_id'
+
+  # Step 2: Create a context using the installed application
+  # Uses the captured application ID from step 1
+  - name: Create Context on Node 1
+    type: create_context
+    node: calimero-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      context_id: contextId          # Export 'contextId' field as 'context_id'
+      member_public_key: memberPublicKey  # Export 'memberPublicKey' as 'member_public_key'
+
+  # Step 3: Generate an identity on the second node
+  # This captures the public key for use in invitation and joining
+  - name: Create Identity on Node 2
+    type: create_identity
+    node: calimero-node-2
+    outputs:
+      public_key_node2: publicKey         # Export 'publicKey' as 'public_key_node2'
+
+  # Step 4: Generate an identity on the third node
+  # This captures the public key for use in invitation and joining
+  - name: Create Identity on Node 3
+    type: create_identity
+    node: calimero-node-3
+    outputs:
+      public_key_node3: publicKey         # Export 'publicKey' as 'public_key_node3'
+
+  # Step 5: Wait for identity creation to complete
+  - name: Wait for Identity Creation
+    type: wait
+    seconds: 5
+
+  # Step 6: Invite the second node to join the context
+  # Uses captured values: context ID, member public key, and identity public key
+  - name: Invite Node 2 from Node 1
+    type: invite_identity
+    node: calimero-node-1
+    context_id: '{{context_id}}'
+    grantee_id: '{{public_key_node2}}'
+    granter_id: '{{member_public_key}}'
+    capability: member
+    outputs:
+      invitation_node2: invitation         # Export 'invitation' as 'invitation_node2'
+
+  # Step 7: Join the context from the second node
+  # Uses captured values: context ID, invitee identity, and invitation data
+  - name: Join Context from Node 2
+    type: join_context
+    node: calimero-node-2
+    context_id: '{{context_id}}'
+    invitee_id: '{{public_key_node2}}'
+    invitation: '{{invitation_node2}}'
+
+  # Step 8: Invite the third node to join the context
+  # Uses captured values: context ID, member public key, and identity public key
+  - name: Invite Node 3 from Node 1
+    type: invite_identity
+    node: calimero-node-1
+    context_id: '{{context_id}}'
+    grantee_id: '{{public_key_node3}}'
+    granter_id: '{{member_public_key}}'
+    capability: member
+    outputs:
+      invitation_node3: invitation         # Export 'invitation' as 'invitation_node3'
+
+  # Step 9: Join the context from the third node
+  # Uses captured values: context ID, invitee identity, and invitation data
+  - name: Join Context from Node 3
+    type: join_context
+    node: calimero-node-3
+    context_id: '{{context_id}}'
+    invitee_id: '{{public_key_node3}}'
+    invitation: '{{invitation_node3}}'
+
+  # Step 10: Execute a contract call to set a key-value pair
+  # Uses the member public key from the context as the executor
+  - name: Execute Contract Call - Set Key-Value
+    type: call
+    node: calimero-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: set
+    args:
+      key: hello
+      value: world
+    outputs:
+      set_result: result            # Export 'result' as 'set_result'
+
+  # Step 11: Wait for the set operation to complete and propagate
+  - name: Wait for Set Operation
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  # Step 12: Execute a view call to retrieve the stored value from node 2
+  # Demonstrates cross-node execution using the joined context
+  - name: Execute View Call - Get Value from Node 2
+    type: call
+    node: calimero-node-2
+    context_id: '{{context_id}}'
+    executor_public_key: '{{public_key_node2}}'
+    method: get
+    args:
+      key: hello
+    outputs:
+      get_result_node2: result            # Export 'result' as 'get_result_node2'
+
+  # Step 13: Execute a view call to retrieve the stored value from node 3
+  # Demonstrates that all nodes can access the same context data
+  - name: Execute View Call - Get Value from Node 3
+    type: call
+    node: calimero-node-3
+    context_id: '{{context_id}}'
+    executor_public_key: '{{public_key_node3}}'
+    method: get
+    args:
+      key: hello
+    outputs:
+      get_result_node3: result            # Export 'result' as 'get_result_node3'
+
+  # Step 14: Set a value from node 3 to demonstrate write operations from any node
+  - name: Execute Contract Call - Set from Node 3
+    type: call
+    node: calimero-node-3
+    context_id: '{{context_id}}'
+    executor_public_key: '{{public_key_node3}}'
+    method: set
+    args:
+      key: node3_key
+      value: node3_value
+    outputs:
+      set_result_node3: result            # Export 'result' as 'set_result_node3'
+
+  # Step 15: Wait for propagation
+  - name: Wait for Node 3 Set Operation
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  # Step 16: Verify the node 3 value can be read from other nodes
+  - name: Verify Node 3 Value from Node 1
+    type: call
+    node: calimero-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: get
+    args:
+      key: node3_key
+    outputs:
+      verify_result: result            # Export 'result' as 'verify_result'
+
+  # Step 17: Repeat a set of operations multiple times across all three nodes
+  # Demonstrates the new repeat step functionality with three-node rotation
+  - name: Repeat Operations Multiple Times
+    type: repeat
+    count: 3
+    outputs:
+      current_iteration: iteration   # Export 'iteration' as 'current_iteration'
+    steps:
+      - name: Set Key-Value Pair from Node 1
+        type: call
+        node: calimero-node-1
+        context_id: '{{context_id}}'
+        executor_public_key: '{{member_public_key}}'
+        method: set
+        args:
+          key: "iteration_{{current_iteration}}"
+          value: "value_{{current_iteration}}_from_node1"
+        outputs:
+          iteration_set_result: result  # Export 'result' as 'iteration_set_result'
+
+      - name: Wait for Set Operation
+        type: wait_for_sync
+        context_id: "{{context_id}}"
+        nodes:
+          - calimero-node-1
+          - calimero-node-2
+          - calimero-node-3
+        timeout: 60
+        check_interval: 2
+        trigger_sync: true
+
+      - name: Get Key-Value Pair from Node 2
+        type: call
+        node: calimero-node-2
+        context_id: '{{context_id}}'
+        executor_public_key: '{{public_key_node2}}'
+        method: get
+        args:
+          key: "iteration_{{current_iteration}}"
+        outputs:
+          iteration_get_result_node2: result  # Export 'result' as 'iteration_get_result_node2'
+
+      - name: Get Key-Value Pair from Node 3
+        type: call
+        node: calimero-node-3
+        context_id: '{{context_id}}'
+        executor_public_key: '{{public_key_node3}}'
+        method: get
+        args:
+          key: "iteration_{{current_iteration}}"
+        outputs:
+          iteration_get_result_node3: result  # Export 'result' as 'iteration_get_result_node3'
+
+# Configuration options
+stop_all_nodes: false   # Stop all nodes at the end of workflow
+restart: false          # Don't restart nodes at the beginning of workflow
+wait_timeout: 60


### PR DESCRIPTION
Copy of merobox workflow-example.yml (sample Calimero workflow with install, context, invite/join, set/get, wait_for_sync, and repeat). Path adapted for core: res/kv_store.wasm (relative to apps/kv-store).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone example YAML workflow only; no production code paths are modified.
> 
> **Overview**
> Adds a new `apps/kv-store/workflows/workflow-example.yml` sample merobox workflow that bootstraps a 3-node local network, installs the `kv_store.wasm` app, creates a context, invites/joins additional nodes, then runs `set`/`get` calls with `wait_for_sync` and a `repeat` loop using captured step outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5740f0d0623b145d2d30b188d977df36d6a917ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->