### PR TITLE
chore: bump core version rc42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-version"
-version = "0.10.0-rc.41"
+version = "0.10.0-rc.42"
 dependencies = [
  "eyre",
  "rustc_version 0.2.3",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-version"
-version = "0.10.0-rc.41"
+version = "0.10.0-rc.42"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-number bump only; no functional or behavioral code changes.
> 
> **Overview**
> Bumps the `calimero-version` crate version from `0.10.0-rc.41` to `0.10.0-rc.42` and updates the corresponding entry in `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d50639ca9c7d8d8b545646eafe9238e470b5212d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->