### PR TITLE
chore: version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.0-rc.42"
+version = "0.10.0-rc.43"
 exclude = [
     "./apps/abi_conformance",
     "./apps/access-control",


### PR DESCRIPTION
# Calimero Core Version Bump

## Description

Bumps the core workspace version from `0.10.0-rc.42` to `0.10.0-rc.43`.

This change follows the new versioning model established in commit `01bb295f` (`fix(crates): publish calimero version`), where the canonical version is managed solely in the root `Cargo.toml` under `[workspace.metadata.workspaces].version`. It mirrors the previous version bump in `3656d96e` (`chore: bump core version rc42`).

## Test plan

To verify the change, the following command was executed:
- `cargo metadata --format-version=1 --no-deps`

This command succeeded, confirming the `Cargo.toml` file is valid after the version update.
No user interface changes are involved.

## Documentation update

No specific documentation updates are anticipated for this minor release candidate version bump, beyond standard release notes if applicable.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1ae6041f-f0e9-4541-8dd2-468fd63eb4ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ae6041f-f0e9-4541-8dd2-468fd63eb4ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version metadata change only; no runtime logic, dependencies, or APIs are modified.
> 
> **Overview**
> Bumps the canonical workspace release-candidate version in root `Cargo.toml` from `0.10.0-rc.42` to `0.10.0-rc.43` under `[workspace.metadata.workspaces].version`, affecting versioning for all public crates in the workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fded0e3ab0bf5f11fce946a4ce4701705aab833d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->