### PR TITLE
fix(release): include mero-auth in workspace publish set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.0-rc.44"
+version = "0.10.0-rc.45"
 exclude = [
     "./apps/abi_conformance",
     "./apps/access-control",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only `Cargo.toml` changes affecting release/publishing configuration; no runtime code paths are modified.
> 
> **Overview**
> Updates workspace release metadata by bumping the shared workspace version to `0.10.0-rc.45` and **removing `./crates/auth` from the `workspace.metadata.workspaces.exclude` list**, ensuring `mero-auth` is included in the set of publishable workspace crates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b1c5f7aca0aa738d0d0fa848bc464a09c6a0eb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->