### PR TITLE
chore(release): auth zstd fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ quote = "1.0.37"
 rand = "0.8.5"
 reqwest = { version = "0.12.2", default-features = false, features = ["rustls-tls"] }
 ring = "0.17.8"
-rocksdb = "0.22.0"
+rocksdb = { version = "0.22.0", default-features = false }
 rust-embed = "8.5.0"
 rustc_version = "0.4"
 semver = "1.0.22"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -35,7 +35,7 @@ near-primitives.workspace = true
 parking_lot.workspace = true
 rand.workspace = true
 regex = "1.10.2"
-rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "lz4", "zlib", "bzip2"] }
+rocksdb.workspace = true
 rust-embed = { workspace = true, features = ["mime-guess", "interpolate-folder-path"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency feature changes to `rocksdb` can alter build/link behavior and runtime storage capabilities (e.g., compression support) across the workspace.
> 
> **Overview**
> Bumps the shared workspace crate version from `0.10.0-rc.45` to `0.10.0-rc.46`.
> 
> Updates the workspace `rocksdb` dependency to disable `default-features`, which changes the enabled compression/feature set for all crates using the workspace `rocksdb` spec.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01e1afce3f2f0c6ecd48d12bda29a35e9374f985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->