### PR TITLE
chore(release): bump core version to rc50

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.0-rc.49"
+version = "0.10.0-rc.50"
 exclude = [
     "./apps/abi_conformance",
     "./apps/access-control",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single metadata/version change with no functional or runtime logic impact.
> 
> **Overview**
> Bumps the workspace shared crate version in `Cargo.toml` from `0.10.0-rc.49` to `0.10.0-rc.50` to cut the next release candidate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5338fee0f174e8445572bbead1be4f304c5cb0cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->