### PR TITLE
chore: bump workspace version to 0.10.0-rc.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.0-rc.51"
+version = "0.10.0-rc.52"
 exclude = [
     "./apps/abi_conformance",
     "./apps/access-control",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no functional code changes.
> 
> **Overview**
> Bumps the workspace shared crate version in `Cargo.toml` from `0.10.0-rc.51` to `0.10.0-rc.52` for the next release candidate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac750961d8ce0e37dbc5ce8ca188301b5a772157. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->