### PR TITLE
chore(release): update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.0-rc.52"
+version = "0.10.0"
 exclude = [
     "./apps/abi_conformance",
     "./apps/access-control",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure metadata/version change with no runtime logic impact; main risk is unintended release/versioning mismatch if downstream expects the RC string.
> 
> **Overview**
> Bumps the workspace release metadata in `Cargo.toml` from `0.10.0-rc.52` to the final `0.10.0`, so builds that read `[workspace.metadata.workspaces].version` use the stable release version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cfbde5be86daebbbef8187575819694e7dedee9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->