### PR TITLE
fix: backwards-compatible deserialization for ApplicationMeta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.21"
+version = "0.10.1-rc.22"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::entry::Borsh;
@@ -12,7 +14,7 @@ pub struct ServiceMeta {
     pub compiled: key::BlobMeta,
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
+#[derive(BorshSerialize, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ApplicationMeta {
     pub bytecode: key::BlobMeta,
@@ -26,6 +28,47 @@ pub struct ApplicationMeta {
     /// Named services within this application. Empty for single-service apps.
     /// When non-empty, `bytecode`/`compiled` above point to the first (default) service.
     pub services: Vec<ServiceMeta>,
+}
+
+// Custom deserialization: handle backwards compatibility for old data
+// that doesn't have the `services` field (added in rc.19).
+impl BorshDeserialize for ApplicationMeta {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+        let bytecode = key::BlobMeta::deserialize_reader(reader)?;
+        let size = u64::deserialize_reader(reader)?;
+        let source = Box::<str>::deserialize_reader(reader)?;
+        let metadata = Box::<[u8]>::deserialize_reader(reader)?;
+        let compiled = key::BlobMeta::deserialize_reader(reader)?;
+        let package = Box::<str>::deserialize_reader(reader)?;
+        let version = Box::<str>::deserialize_reader(reader)?;
+        let signer_id = Box::<str>::deserialize_reader(reader)?;
+
+        // `services` was added after the initial schema. Old records end after `signer_id`.
+        // Try to read it; if there's no more data, default to an empty Vec.
+        let services = match Vec::<ServiceMeta>::deserialize_reader(reader) {
+            Ok(v) => v,
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Vec::new(),
+            Err(e)
+                if e.kind() == std::io::ErrorKind::InvalidData
+                    && e.to_string().contains("Unexpected length") =>
+            {
+                Vec::new()
+            }
+            Err(e) => return Err(e),
+        };
+
+        Ok(Self {
+            bytecode,
+            size,
+            source,
+            metadata,
+            compiled,
+            package,
+            version,
+            signer_id,
+            services,
+        })
+    }
 }
 
 impl ApplicationMeta {


### PR DESCRIPTION
## Summary
- Fix HTTP 500 `"Unexpected length of input"` on `GET /admin-api/applications` for nodes upgraded from rc.17 or earlier
- The `services: Vec<ServiceMeta>` field was added to `ApplicationMeta` in e76a2e4a but old on-disk records lack this field
- Borsh strict parsing rejects the missing trailing bytes, crashing the endpoint

## Fix
Replace `derive(BorshDeserialize)` on `ApplicationMeta` with a manual implementation that defaults `services` to an empty `Vec` when the field is absent (EOF or unexpected length), matching the pattern used in `Counter` deserialization.

## Test plan
- [ ] Start a node with data from rc.17 (without `services` field in stored applications)
- [ ] Verify `GET /admin-api/applications` returns 200 with the application list
- [ ] Verify installing new applications (with `services`) still serializes/deserializes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted-data deserialization for `ApplicationMeta`; while it should prevent upgrade breakages, it could also mask genuinely corrupted records by defaulting `services` to empty on certain decode errors.
> 
> **Overview**
> Prevents failures when reading older `ApplicationMeta` records by replacing the derived `BorshDeserialize` with a custom implementation that treats missing trailing `services` data (EOF / "Unexpected length") as an empty `Vec`.
> 
> Also bumps the workspace release-candidate version from `0.10.1-rc.21` to `0.10.1-rc.22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0745f0b701e4edd8a8a0a69cc39a5239358e2dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->