### PR TITLE
fix(context): exponential backoff for context->group lookup in join_context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.23"
+version = "0.10.1-rc.24"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::{JoinContextRequest, JoinContextResponse};
 use calimero_context_config::types::ContextGroupId;
@@ -6,6 +8,27 @@ use eyre::bail;
 use tracing::{info, warn};
 
 use crate::{group_store, ContextManager};
+
+/// Per-attempt sleep schedule for resolving the context->group mapping.
+///
+/// The mapping is delivered by the `ContextRegistered` governance op, which
+/// propagates asynchronously over gossipsub from the creating node.
+///
+/// Exponential-ish backoff is used so we:
+/// 1. Wake fast for the common case where the op arrives within a few hundred
+///    ms of `join_context` being called (CI evidence: ops observed arriving
+///    ~40ms after the previous flat 1.8s budget expired).
+/// 2. Still cover the slow-propagation tail (~10s total budget) without
+///    waiting the full budget on every successful join.
+///
+/// Total worst-case wait ≈ 150ms + 400ms + 1s + 2.5s + 6s = ~10s.
+const GROUP_LOOKUP_BACKOFF: &[Duration] = &[
+    Duration::from_millis(150),
+    Duration::from_millis(400),
+    Duration::from_secs(1),
+    Duration::from_millis(2500),
+    Duration::from_secs(6),
+];
 
 impl Handler<JoinContextRequest> for ContextManager {
     type Result = ActorResponse<Self, <JoinContextRequest as Message>::Result>;
@@ -28,8 +51,8 @@ impl Handler<JoinContextRequest> for ContextManager {
                     );
                     sync_known_namespaces(&datastore, &node_client).await;
 
-                    for attempt in 0..3 {
-                        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+                    for (attempt, delay) in GROUP_LOOKUP_BACKOFF.iter().enumerate() {
+                        tokio::time::sleep(*delay).await;
                         group_id = group_store::get_group_for_context(&datastore, &context_id)?;
                         if group_id.is_some() {
                             info!(


### PR DESCRIPTION
## Summary

Fixes #2141.

`join_context` could fail with `"context does not belong to any group"` when called shortly after a peer created the context, because the handler's flat retry budget (3 × 600ms = 1.8s) was too short for the `ContextRegistered` governance op to propagate over gossipsub.

CI logs from [merobox PR #192](https://github.com/calimero-network/merobox/pull/192) show the race clearly — the op consistently arrives ~40ms *after* the previous budget expires:

```
07:47:29.747  join_context called
07:47:31.555  join_context fails (1.8s = 3 × 600ms retries exhausted)
07:47:31.594  "received namespace governance ops from peer" ← 40ms too late
```

## Fix

Replace the flat retry schedule with an exponential-ish backoff:

```
150ms, 400ms, 1s, 2.5s, 6s  (~10s total)
```

- **Fast common case:** first sleep of 150ms catches ops that are already in flight, instead of always paying 600ms.
- **Slow tail coverage:** later sleeps extend the total budget to ~10s, comfortably covering the observed propagation times on 2-node CI runners without forcing every successful join to wait that long.

## Alternatives considered

- **Flat 5 × 2s = 10s** (as suggested in the issue): simplest, but makes the common case slower than today.
- **Event-driven wait** on a governance-op-applied broadcast channel: architecturally correct but requires threading a broadcaster through `ApplyNamespaceOpResult` → `apply_group_op_mutations` → `NamespaceGovernanceApplier` → `ContextManager` → `ContextClient`, plus changes in both gossipsub and backfill apply paths. High regression risk on a governance path that's seen several recent fixes; worth considering as a follow-up.

## Test plan

- [x] `cargo check -p calimero-context`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p calimero-context --lib` — 75 passed
- [x] `cargo test -p calimero-context --tests` — 22 passed
- [x] `cargo clippy -p calimero-context --lib` — no new warnings
- [ ] Re-run merobox workflow-subgroups-example.yml in binary mode (previously failed 100%, expected to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts `join_context` retry timing and extends the worst-case wait to ~10s, which can change join latency and masking/handling of propagation delays. Scope is small but touches a key join flow that can affect connectivity and CI stability.
> 
> **Overview**
> Improves `join_context` resilience to delayed gossipsub propagation by replacing the previous fixed retry loop (3 × 600ms) with a documented exponential-ish backoff schedule (`GROUP_LOOKUP_BACKOFF`) totaling ~10s, re-checking the context→group mapping between sync attempts.
> 
> Bumps workspace release-candidate version from `0.10.1-rc.23` to `0.10.1-rc.24`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8f6b95caf694dd7ba540cb7cd59a8a957ffe9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->