### PR TITLE
feat: add e2e tests for ns - groups

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -48,6 +48,11 @@ jobs:
           cd apps/e2e-kv-store
           ./build.sh
 
+      - name: Build e2e-kv-store multi-service bundle
+        run: |
+          cd apps/e2e-kv-store
+          ./build-multi-service-bundle.sh
+
       - name: Build xcall-example app
         run: |
           cd apps/xcall-example
@@ -304,6 +309,129 @@ jobs:
               echo "failed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Run group-subgroup Workflow
+        id: run_group_subgroup
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-subgroup.yml" \
+                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-subgroup-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run group-multi-service Workflow
+        id: run_group_multi_service
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-multi-service.yml" \
+                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-multi-service-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run handler-test Workflow
+        id: run_handler_test
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/handler-test.yml" \
+                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/handler-test-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run xcall-example Workflow
         id: run_xcall
         run: |
@@ -378,6 +506,9 @@ jobs:
           steps.run_group_3node.outputs.failed == 'true' ||
           steps.run_group_context_isolation.outputs.failed == 'true' ||
           steps.run_group_late_joiner.outputs.failed == 'true' ||
+          steps.run_group_subgroup.outputs.failed == 'true' ||
+          steps.run_group_multi_service.outputs.failed == 'true' ||
+          steps.run_handler_test.outputs.failed == 'true' ||
           steps.run_xcall.outputs.failed == 'true'
         run: |
           echo "Workflow failures detected:"
@@ -395,6 +526,15 @@ jobs:
           fi
           if [ "${{ steps.run_group_late_joiner.outputs.failed }}" == "true" ]; then
             echo "  - group-late-joiner workflow failed"
+          fi
+          if [ "${{ steps.run_group_subgroup.outputs.failed }}" == "true" ]; then
+            echo "  - group-subgroup workflow failed"
+          fi
+          if [ "${{ steps.run_group_multi_service.outputs.failed }}" == "true" ]; then
+            echo "  - group-multi-service workflow failed"
+          fi
+          if [ "${{ steps.run_handler_test.outputs.failed }}" == "true" ]; then
+            echo "  - handler-test workflow failed"
           fi
           if [ "${{ steps.run_xcall.outputs.failed }}" == "true" ]; then
             echo "  - xcall-example workflow failed"

--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -181,6 +181,129 @@ jobs:
               echo "failed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Run group-3node Workflow
+        id: run_group_3node
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-3node.yml" \
+                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-3node-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run group-context-isolation Workflow
+        id: run_group_context_isolation
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-context-isolation.yml" \
+                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-context-isolation-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run group-late-joiner Workflow
+        id: run_group_late_joiner
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-late-joiner.yml" \
+                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-late-joiner-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run xcall-example Workflow
         id: run_xcall
         run: |
@@ -249,7 +372,13 @@ jobs:
           if-no-files-found: warn
 
       - name: Check workflow results
-        if: steps.run_e2e_kv_store.outputs.failed == 'true' || steps.run_groups.outputs.failed == 'true' || steps.run_xcall.outputs.failed == 'true'
+        if: |
+          steps.run_e2e_kv_store.outputs.failed == 'true' ||
+          steps.run_groups.outputs.failed == 'true' ||
+          steps.run_group_3node.outputs.failed == 'true' ||
+          steps.run_group_context_isolation.outputs.failed == 'true' ||
+          steps.run_group_late_joiner.outputs.failed == 'true' ||
+          steps.run_xcall.outputs.failed == 'true'
         run: |
           echo "Workflow failures detected:"
           if [ "${{ steps.run_e2e_kv_store.outputs.failed }}" == "true" ]; then
@@ -257,6 +386,15 @@ jobs:
           fi
           if [ "${{ steps.run_groups.outputs.failed }}" == "true" ]; then
             echo "  - groups workflow failed"
+          fi
+          if [ "${{ steps.run_group_3node.outputs.failed }}" == "true" ]; then
+            echo "  - group-3node workflow failed"
+          fi
+          if [ "${{ steps.run_group_context_isolation.outputs.failed }}" == "true" ]; then
+            echo "  - group-context-isolation workflow failed"
+          fi
+          if [ "${{ steps.run_group_late_joiner.outputs.failed }}" == "true" ]; then
+            echo "  - group-late-joiner workflow failed"
           fi
           if [ "${{ steps.run_xcall.outputs.failed }}" == "true" ]; then
             echo "  - xcall-example workflow failed"

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -178,6 +178,159 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      # Run group-3node workflow
+      - name: Run group-3node Workflow
+        id: run_group_3node
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-3node.yml" \
+                  --image merod:local \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  echo "Collecting Docker logs for group-3node attempt $attempt"
+                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                      if [ -n "$container" ]; then
+                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-3node-attempt${attempt}-${container}.log" 2>&1 || true
+                      fi
+                  done
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload group-3node logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-group-3node-${{ github.sha }}
+          path: docker-logs/group-3node*
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Run group-context-isolation workflow
+      - name: Run group-context-isolation Workflow
+        id: run_group_context_isolation
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-context-isolation.yml" \
+                  --image merod:local \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  echo "Collecting Docker logs for group-context-isolation attempt $attempt"
+                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                      if [ -n "$container" ]; then
+                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-context-isolation-attempt${attempt}-${container}.log" 2>&1 || true
+                      fi
+                  done
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload group-context-isolation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-group-context-isolation-${{ github.sha }}
+          path: docker-logs/group-context-isolation*
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Run group-late-joiner workflow
+      - name: Run group-late-joiner Workflow
+        id: run_group_late_joiner
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-late-joiner.yml" \
+                  --image merod:local \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  echo "Collecting Docker logs for group-late-joiner attempt $attempt"
+                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                      if [ -n "$container" ]; then
+                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-late-joiner-attempt${attempt}-${container}.log" 2>&1 || true
+                      fi
+                  done
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload group-late-joiner logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-group-late-joiner-${{ github.sha }}
+          path: docker-logs/group-late-joiner*
+          retention-days: 7
+          if-no-files-found: ignore
+
       # Run xcall-example workflow
       - name: Run xcall-example Workflow
         id: run_xcall
@@ -255,7 +408,13 @@ jobs:
           if-no-files-found: warn
 
       - name: Check workflow results
-        if: steps.run_e2e_kv_store.outputs.failed == 'true' || steps.run_groups.outputs.failed == 'true' || steps.run_xcall.outputs.failed == 'true'
+        if: |
+          steps.run_e2e_kv_store.outputs.failed == 'true' ||
+          steps.run_groups.outputs.failed == 'true' ||
+          steps.run_group_3node.outputs.failed == 'true' ||
+          steps.run_group_context_isolation.outputs.failed == 'true' ||
+          steps.run_group_late_joiner.outputs.failed == 'true' ||
+          steps.run_xcall.outputs.failed == 'true'
         run: |
           echo "Workflow failures detected:"
           if [ "${{ steps.run_e2e_kv_store.outputs.failed }}" == "true" ]; then
@@ -263,6 +422,15 @@ jobs:
           fi
           if [ "${{ steps.run_groups.outputs.failed }}" == "true" ]; then
             echo "  - groups workflow failed"
+          fi
+          if [ "${{ steps.run_group_3node.outputs.failed }}" == "true" ]; then
+            echo "  - group-3node workflow failed"
+          fi
+          if [ "${{ steps.run_group_context_isolation.outputs.failed }}" == "true" ]; then
+            echo "  - group-context-isolation workflow failed"
+          fi
+          if [ "${{ steps.run_group_late_joiner.outputs.failed }}" == "true" ]; then
+            echo "  - group-late-joiner workflow failed"
           fi
           if [ "${{ steps.run_xcall.outputs.failed }}" == "true" ]; then
             echo "  - xcall-example workflow failed"

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -66,6 +66,11 @@ jobs:
           cd apps/e2e-kv-store
           ./build.sh
 
+      - name: Build e2e-kv-store multi-service bundle
+        run: |
+          cd apps/e2e-kv-store
+          ./build-multi-service-bundle.sh
+
       - name: Build xcall-example app
         run: |
           cd apps/xcall-example
@@ -331,6 +336,159 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      # Run group-subgroup workflow
+      - name: Run group-subgroup Workflow
+        id: run_group_subgroup
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-subgroup.yml" \
+                  --image merod:local \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  echo "Collecting Docker logs for group-subgroup attempt $attempt"
+                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                      if [ -n "$container" ]; then
+                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-subgroup-attempt${attempt}-${container}.log" 2>&1 || true
+                      fi
+                  done
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload group-subgroup logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-group-subgroup-${{ github.sha }}
+          path: docker-logs/group-subgroup*
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Run group-multi-service workflow
+      - name: Run group-multi-service Workflow
+        id: run_group_multi_service
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/group-multi-service.yml" \
+                  --image merod:local \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  echo "Collecting Docker logs for group-multi-service attempt $attempt"
+                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                      if [ -n "$container" ]; then
+                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/group-multi-service-attempt${attempt}-${container}.log" 2>&1 || true
+                      fi
+                  done
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload group-multi-service logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-group-multi-service-${{ github.sha }}
+          path: docker-logs/group-multi-service*
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Run handler-test workflow
+      - name: Run handler-test Workflow
+        id: run_handler_test
+        run: |
+          cd apps/e2e-kv-store
+          max_attempts=2
+          attempt=1
+          success=false
+
+          while [ $attempt -le $max_attempts ]; do
+              if [ $attempt -gt 1 ]; then
+                  merobox stop --all || true
+                  merobox nuke --force || true
+                  sleep 2
+              fi
+
+              if merobox bootstrap run \
+                  "workflows/handler-test.yml" \
+                  --image merod:local \
+                  --e2e-mode; then
+                  success=true
+                  break
+              else
+                  echo "Collecting Docker logs for handler-test attempt $attempt"
+                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                      if [ -n "$container" ]; then
+                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/handler-test-attempt${attempt}-${container}.log" 2>&1 || true
+                      fi
+                  done
+                  attempt=$((attempt + 1))
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          if [ "$success" = false ]; then
+              echo "failed=true" >> $GITHUB_OUTPUT
+          else
+              echo "failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload handler-test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-handler-test-${{ github.sha }}
+          path: docker-logs/handler-test*
+          retention-days: 7
+          if-no-files-found: ignore
+
       # Run xcall-example workflow
       - name: Run xcall-example Workflow
         id: run_xcall
@@ -414,6 +572,9 @@ jobs:
           steps.run_group_3node.outputs.failed == 'true' ||
           steps.run_group_context_isolation.outputs.failed == 'true' ||
           steps.run_group_late_joiner.outputs.failed == 'true' ||
+          steps.run_group_subgroup.outputs.failed == 'true' ||
+          steps.run_group_multi_service.outputs.failed == 'true' ||
+          steps.run_handler_test.outputs.failed == 'true' ||
           steps.run_xcall.outputs.failed == 'true'
         run: |
           echo "Workflow failures detected:"
@@ -431,6 +592,15 @@ jobs:
           fi
           if [ "${{ steps.run_group_late_joiner.outputs.failed }}" == "true" ]; then
             echo "  - group-late-joiner workflow failed"
+          fi
+          if [ "${{ steps.run_group_subgroup.outputs.failed }}" == "true" ]; then
+            echo "  - group-subgroup workflow failed"
+          fi
+          if [ "${{ steps.run_group_multi_service.outputs.failed }}" == "true" ]; then
+            echo "  - group-multi-service workflow failed"
+          fi
+          if [ "${{ steps.run_handler_test.outputs.failed }}" == "true" ]; then
+            echo "  - handler-test workflow failed"
           fi
           if [ "${{ steps.run_xcall.outputs.failed }}" == "true" ]; then
             echo "  - xcall-example workflow failed"

--- a/apps/e2e-kv-store/build-multi-service-bundle.sh
+++ b/apps/e2e-kv-store/build-multi-service-bundle.sh
@@ -32,6 +32,7 @@ cat > res/multi-bundle-temp/manifest.json <<EOF
   "version": "1.0",
   "package": "com.calimero.e2e-kv-store-multi",
   "appVersion": "0.1.0",
+  "minRuntimeVersion": "0.0.0",
   "services": [
     {
       "name": "store-a",

--- a/apps/e2e-kv-store/build-multi-service-bundle.sh
+++ b/apps/e2e-kv-store/build-multi-service-bundle.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname $0)"
+
+# Build the WASM first
+# Note: wasm-opt validation errors are non-fatal
+./build.sh 2>&1 | grep -v "wasm-validator error" || true
+
+mkdir -p res/multi-bundle-temp
+
+# Both services use the same WASM — this is what we want to test:
+# the multi-service bundle install + service_name selection path in merod.
+cp res/e2e_kv_store.wasm res/multi-bundle-temp/store-a.wasm
+cp res/e2e_kv_store.wasm res/multi-bundle-temp/store-b.wasm
+
+ABI_ARGS=""
+if [ -f res/abi.json ]; then
+    cp res/abi.json res/multi-bundle-temp/store-a-abi.json
+    cp res/abi.json res/multi-bundle-temp/store-b-abi.json
+    ABI_ARGS="store-a-abi.json store-b-abi.json"
+fi
+
+WASM_SIZE=$(stat -f%z res/e2e_kv_store.wasm 2>/dev/null || stat -c%s res/e2e_kv_store.wasm 2>/dev/null || echo 0)
+ABI_SIZE=0
+if [ -f res/abi.json ]; then
+    ABI_SIZE=$(stat -f%z res/abi.json 2>/dev/null || stat -c%s res/abi.json 2>/dev/null || echo 0)
+fi
+
+cat > res/multi-bundle-temp/manifest.json <<EOF
+{
+  "version": "1.0",
+  "package": "com.calimero.e2e-kv-store-multi",
+  "appVersion": "0.1.0",
+  "services": [
+    {
+      "name": "store-a",
+      "wasm": {
+        "path": "store-a.wasm",
+        "size": ${WASM_SIZE},
+        "hash": null
+      },
+      "abi": {
+        "path": "store-a-abi.json",
+        "size": ${ABI_SIZE},
+        "hash": null
+      }
+    },
+    {
+      "name": "store-b",
+      "wasm": {
+        "path": "store-b.wasm",
+        "size": ${WASM_SIZE},
+        "hash": null
+      },
+      "abi": {
+        "path": "store-b-abi.json",
+        "size": ${ABI_SIZE},
+        "hash": null
+      }
+    }
+  ],
+  "migrations": []
+}
+EOF
+
+cd res/multi-bundle-temp
+tar -czf ../e2e-kv-store-multi-0.1.0.mpk manifest.json store-a.wasm store-b.wasm ${ABI_ARGS} 2>/dev/null || \
+tar -czf ../e2e-kv-store-multi-0.1.0.mpk manifest.json store-a.wasm store-b.wasm 2>/dev/null
+
+cd ..
+rm -rf multi-bundle-temp
+
+echo "Multi-service bundle created: res/e2e-kv-store-multi-0.1.0.mpk"

--- a/apps/e2e-kv-store/workflows/group-3node.yml
+++ b/apps/e2e-kv-store/workflows/group-3node.yml
@@ -1,0 +1,284 @@
+name: E2E KV Store - Group 3-Node Convergence
+description: >
+  Tests that three nodes can all join the same namespace and converge on shared
+  state. Each node writes a distinct key and all three verify they see every
+  write — covering the multi-party sync path that the 2-node test misses.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  - name: Create context in namespace on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Assert context created
+    type: assert
+    statements:
+      - "is_set({{ctx_id}})"
+
+  # --- Node-2 joins ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+
+  - name: Node-2 joins context via group membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+
+  # --- Node-3 joins ---
+
+  - name: Create namespace invitation for node-3
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+
+  - name: Node-3 joins context via group membership
+    type: join_context
+    node: e2e-node-3
+    context_id: '{{ctx_id}}'
+
+  # --- SCENARIO 1: node-1 writes, all three converge ---
+
+  - name: Node-1 writes key-A
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "key_a"
+      value: "from_node1"
+
+  - name: Wait for sync after node-1 write
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads key-A
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "key_a"
+    outputs:
+      key_a_node2: result
+
+  - name: Assert key-A on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{key_a_node2}}, {"output": "from_node1"})'
+
+  - name: Node-3 reads key-A
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "key_a"
+    outputs:
+      key_a_node3: result
+
+  - name: Assert key-A on node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{key_a_node3}}, {"output": "from_node1"})'
+
+  # --- SCENARIO 2: node-2 writes, node-1 and node-3 converge ---
+
+  - name: Node-2 writes key-B
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "key_b"
+      value: "from_node2"
+
+  - name: Wait for sync after node-2 write
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads key-B
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "key_b"
+    outputs:
+      key_b_node1: result
+
+  - name: Assert key-B on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{key_b_node1}}, {"output": "from_node2"})'
+
+  - name: Node-3 reads key-B
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "key_b"
+    outputs:
+      key_b_node3: result
+
+  - name: Assert key-B on node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{key_b_node3}}, {"output": "from_node2"})'
+
+  # --- SCENARIO 3: node-3 writes, node-1 and node-2 converge ---
+
+  - name: Node-3 writes key-C
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "key_c"
+      value: "from_node3"
+
+  - name: Wait for sync after node-3 write
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads key-C
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "key_c"
+    outputs:
+      key_c_node1: result
+
+  - name: Assert key-C on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{key_c_node1}}, {"output": "from_node3"})'
+
+  - name: Node-2 reads key-C
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "key_c"
+    outputs:
+      key_c_node2: result
+
+  - name: Assert key-C on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{key_c_node2}}, {"output": "from_node3"})'
+
+  # --- SCENARIO 4: verify full state visibility on all nodes ---
+
+  - name: Node-1 reads all entries
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: entries
+    outputs:
+      entries_node1: result
+
+  - name: Node-2 reads all entries
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: entries
+    outputs:
+      entries_node2: result
+
+  - name: Node-3 reads all entries
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx_id}}'
+    method: entries
+    outputs:
+      entries_node3: result
+
+  - name: Assert all nodes see same entry count
+    type: json_assert
+    statements:
+      - 'json_equal({{entries_node1}}, {{entries_node2}})'
+      - 'json_equal({{entries_node2}}, {{entries_node3}})'
+
+stop_all_nodes: false

--- a/apps/e2e-kv-store/workflows/group-context-isolation.yml
+++ b/apps/e2e-kv-store/workflows/group-context-isolation.yml
@@ -1,0 +1,273 @@
+name: E2E KV Store - Group Context Isolation
+description: >
+  Tests that two contexts within the same namespace are fully isolated from each
+  other. Writes to context-A must not be visible in context-B and vice versa.
+  Also verifies that a node which is a member of both contexts sees the correct
+  state in each independently.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create context-A in namespace
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_a_id: contextId
+
+  - name: Create context-B in namespace
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_b_id: contextId
+
+  - name: Assert both contexts created
+    type: assert
+    statements:
+      - "is_set({{ctx_a_id}})"
+      - "is_set({{ctx_b_id}})"
+
+  # --- Node-2 joins namespace and both contexts ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+
+  - name: Node-2 joins context-A via group membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+
+  - name: Node-2 joins context-B via group membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+
+  # --- SCENARIO 1: write to context-A, assert not visible in context-B ---
+
+  - name: Node-1 writes to context-A
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_a_id}}'
+    method: set
+    args:
+      key: "shared_key"
+      value: "context_a_value"
+
+  - name: Wait for context-A sync
+    type: wait_for_sync
+    context_id: '{{ctx_a_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads shared_key from context-A
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+    method: get
+    args:
+      key: "shared_key"
+    outputs:
+      key_in_ctx_a: result
+
+  - name: Assert context-A value correct on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{key_in_ctx_a}}, {"output": "context_a_value"})'
+
+  - name: Node-1 reads shared_key from context-B (should be absent)
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "shared_key"
+    outputs:
+      key_in_ctx_b_node1: result
+
+  - name: Assert shared_key absent in context-B on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{key_in_ctx_b_node1}}, {"output": null})'
+
+  - name: Node-2 reads shared_key from context-B (should be absent)
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "shared_key"
+    outputs:
+      key_in_ctx_b_node2: result
+
+  - name: Assert shared_key absent in context-B on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{key_in_ctx_b_node2}}, {"output": null})'
+
+  # --- SCENARIO 2: write to context-B, assert not visible in context-A ---
+
+  - name: Node-2 writes to context-B
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+    method: set
+    args:
+      key: "shared_key"
+      value: "context_b_value"
+
+  - name: Wait for context-B sync
+    type: wait_for_sync
+    context_id: '{{ctx_b_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads shared_key from context-B
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "shared_key"
+    outputs:
+      ctx_b_key_node1: result
+
+  - name: Assert context-B value correct on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{ctx_b_key_node1}}, {"output": "context_b_value"})'
+
+  - name: Node-1 re-reads shared_key from context-A (must still be context-A value)
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_a_id}}'
+    method: get
+    args:
+      key: "shared_key"
+    outputs:
+      ctx_a_key_after_b_write: result
+
+  - name: Assert context-A value unchanged after context-B write
+    type: json_assert
+    statements:
+      - 'json_equal({{ctx_a_key_after_b_write}}, {"output": "context_a_value"})'
+
+  # --- SCENARIO 3: distinct keys per context, verify no bleed ---
+
+  - name: Node-1 writes ctx-A-only key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_a_id}}'
+    method: set
+    args:
+      key: "ctx_a_only"
+      value: "only_in_a"
+
+  - name: Node-1 writes ctx-B-only key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_b_id}}'
+    method: set
+    args:
+      key: "ctx_b_only"
+      value: "only_in_b"
+
+  - name: Wait for both contexts to sync
+    type: wait_for_sync
+    context_id: '{{ctx_a_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Wait for context-B to sync
+    type: wait_for_sync
+    context_id: '{{ctx_b_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads ctx-A-only key from context-B (should be absent)
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "ctx_a_only"
+    outputs:
+      ctx_a_key_in_b: result
+
+  - name: Assert ctx-A-only key absent in context-B
+    type: json_assert
+    statements:
+      - 'json_equal({{ctx_a_key_in_b}}, {"output": null})'
+
+  - name: Node-2 reads ctx-B-only key from context-A (should be absent)
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+    method: get
+    args:
+      key: "ctx_b_only"
+    outputs:
+      ctx_b_key_in_a: result
+
+  - name: Assert ctx-B-only key absent in context-A
+    type: json_assert
+    statements:
+      - 'json_equal({{ctx_b_key_in_a}}, {"output": null})'
+
+stop_all_nodes: false

--- a/apps/e2e-kv-store/workflows/group-late-joiner.yml
+++ b/apps/e2e-kv-store/workflows/group-late-joiner.yml
@@ -1,0 +1,246 @@
+name: E2E KV Store - Group Late Joiner State Catch-Up
+description: >
+  Tests that a node joining a namespace after data already exists in a context
+  correctly catches up to the pre-existing state. Node-1 writes several keys
+  before node-2 joins, then node-2 joins and must see all pre-existing data as
+  well as new writes after joining.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: node-1 alone creates namespace and context ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create context in namespace on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+
+  # --- SCENARIO 1: node-1 writes data before anyone else joins ---
+
+  - name: Node-1 writes pre-join key-1
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_join_1"
+      value: "written_before_join"
+
+  - name: Node-1 writes pre-join key-2
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_join_2"
+      value: "also_before_join"
+
+  - name: Node-1 writes pre-join key-3
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_join_3"
+      value: "third_before_join"
+
+  # --- Node-2 joins after data exists ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+
+  - name: Node-2 joins context via group membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+
+  - name: Wait for node-2 to catch up to existing state
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 90
+    check_interval: 3
+    trigger_sync: true
+
+  # --- Verify node-2 sees all pre-existing state ---
+
+  - name: Node-2 reads pre-join key-1
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_join_1"
+    outputs:
+      pre1_node2: result
+
+  - name: Assert pre-join key-1 on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{pre1_node2}}, {"output": "written_before_join"})'
+
+  - name: Node-2 reads pre-join key-2
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_join_2"
+    outputs:
+      pre2_node2: result
+
+  - name: Assert pre-join key-2 on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{pre2_node2}}, {"output": "also_before_join"})'
+
+  - name: Node-2 reads pre-join key-3
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_join_3"
+    outputs:
+      pre3_node2: result
+
+  - name: Assert pre-join key-3 on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{pre3_node2}}, {"output": "third_before_join"})'
+
+  # --- SCENARIO 2: writes after join sync normally ---
+
+  - name: Node-1 writes post-join key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_join"
+      value: "written_after_join"
+
+  - name: Wait for post-join sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads post-join key
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_join"
+    outputs:
+      post_join_node2: result
+
+  - name: Assert post-join key on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{post_join_node2}}, {"output": "written_after_join"})'
+
+  - name: Node-2 writes after joining
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "node2_post_join"
+      value: "node2_wrote_this"
+
+  - name: Wait for node-2 post-join write to sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads node-2 post-join key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "node2_post_join"
+    outputs:
+      node2_post_join_node1: result
+
+  - name: Assert node-2 post-join write visible on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_post_join_node1}}, {"output": "node2_wrote_this"})'
+
+  # --- SCENARIO 3: verify full entry count matches across both nodes ---
+
+  - name: Node-1 reads entry count
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: len
+    outputs:
+      len_node1: result
+
+  - name: Node-2 reads entry count
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: len
+    outputs:
+      len_node2: result
+
+  - name: Assert both nodes see same entry count
+    type: json_assert
+    statements:
+      - 'json_equal({{len_node1}}, {{len_node2}})'
+
+stop_all_nodes: false

--- a/apps/e2e-kv-store/workflows/group-multi-service.yml
+++ b/apps/e2e-kv-store/workflows/group-multi-service.yml
@@ -1,0 +1,271 @@
+name: E2E KV Store - Multi-Service Bundle
+description: >
+  Tests the multi-service bundle install and service_name context selection.
+  Both services (store-a, store-b) are backed by the same e2e_kv_store WASM
+  but are treated as independent services by merod. The test verifies:
+    1. A multi-service .mpk bundle can be installed.
+    2. Contexts can be pinned to a named service via service_name.
+    3. Contexts on different services are fully isolated — writes in store-a
+       are NOT visible in store-b and vice versa.
+    4. CRDT sync works correctly within each service's context.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: install multi-service bundle ---
+
+  - name: Install multi-service bundle on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e-kv-store-multi-0.1.0.mpk
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert bundle installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  # --- Create two contexts, one per service ---
+
+  - name: Create context for service store-a on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    service_name: store-a
+    outputs:
+      ctx_a_id: contextId
+      ctx_a_key_node1: memberPublicKey
+
+  - name: Create context for service store-b on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    service_name: store-b
+    outputs:
+      ctx_b_id: contextId
+      ctx_b_key_node1: memberPublicKey
+
+  - name: Assert both contexts created
+    type: assert
+    statements:
+      - "is_set({{ctx_a_id}})"
+      - "is_set({{ctx_b_id}})"
+
+  # --- Node-2 joins namespace and both contexts ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+
+  - name: Node-2 joins context-A via namespace membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+    outputs:
+      ctx_a_key_node2: memberPublicKey
+
+  - name: Node-2 joins context-B via namespace membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+    outputs:
+      ctx_b_key_node2: memberPublicKey
+
+  # --- SCENARIO 1: Write to store-a, verify isolation from store-b ---
+
+  - name: Node-1 writes to store-a context
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_a_id}}'
+    method: set
+    args:
+      key: "service_key"
+      value: "in_store_a"
+
+  - name: Wait for store-a sync
+    type: wait_for_sync
+    context_id: '{{ctx_a_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads service_key from store-a (must be set)
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+    method: get
+    args:
+      key: "service_key"
+    outputs:
+      key_in_a: result
+
+  - name: Assert store-a value visible on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{key_in_a}}, {"output": "in_store_a"})'
+
+  - name: Node-1 reads service_key from store-b (must be absent)
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "service_key"
+    outputs:
+      key_in_b_node1: result
+
+  - name: Assert store-a write did NOT bleed into store-b on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{key_in_b_node1}}, {"output": null})'
+
+  - name: Node-2 reads service_key from store-b (must also be absent)
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "service_key"
+    outputs:
+      key_in_b_node2: result
+
+  - name: Assert store-a write did NOT bleed into store-b on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{key_in_b_node2}}, {"output": null})'
+
+  # --- SCENARIO 2: Write to store-b, verify isolation from store-a ---
+
+  - name: Node-2 writes to store-b context
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_b_id}}'
+    method: set
+    args:
+      key: "service_key"
+      value: "in_store_b"
+
+  - name: Wait for store-b sync
+    type: wait_for_sync
+    context_id: '{{ctx_b_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads service_key from store-b (must be set)
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_b_id}}'
+    method: get
+    args:
+      key: "service_key"
+    outputs:
+      b_key_on_node1: result
+
+  - name: Assert store-b value visible on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{b_key_on_node1}}, {"output": "in_store_b"})'
+
+  - name: Node-1 re-reads service_key from store-a (must still be store-a value)
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_a_id}}'
+    method: get
+    args:
+      key: "service_key"
+    outputs:
+      a_key_after_b_write: result
+
+  - name: Assert store-b write did NOT overwrite store-a value
+    type: json_assert
+    statements:
+      - 'json_equal({{a_key_after_b_write}}, {"output": "in_store_a"})'
+
+  # --- SCENARIO 3: Event handler dispatch within a service context ---
+
+  - name: Node-1 calls set_with_handler in store-a context
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_a_id}}'
+    method: set_with_handler
+    args:
+      key: "handler_key"
+      value: "handler_value"
+
+  - name: Wait for handler sync in store-a
+    type: wait_for_sync
+    context_id: '{{ctx_a_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 verifies handler_key synced in store-a
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+    method: get
+    args:
+      key: "handler_key"
+    outputs:
+      handler_read: result
+
+  - name: Assert handler dispatch synced the value in store-a
+    type: json_assert
+    statements:
+      - 'json_equal({{handler_read}}, {"output": "handler_value"})'
+
+  - name: Node-2 checks handler execution count in store-a
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_a_id}}'
+    method: get_handler_execution_count
+    outputs:
+      handler_count: result
+
+  - name: Assert handler was executed at least once
+    type: assert
+    statements:
+      - "is_set({{handler_count}})"
+
+stop_all_nodes: false

--- a/apps/e2e-kv-store/workflows/group-subgroup.yml
+++ b/apps/e2e-kv-store/workflows/group-subgroup.yml
@@ -1,0 +1,182 @@
+name: E2E KV Store - Subgroup Lifecycle
+description: >
+  Tests the create_group_in_namespace API path alongside normal namespace
+  operations. A subgroup is created inside the namespace, then the subgroup
+  is verified via list_subgroups. Context operations on the namespace root
+  run in parallel to prove the two tiers co-exist correctly.
+
+  NOTE: Full per-subgroup permission isolation (namespace member cannot join
+  a context scoped to a subgroup they are not in) requires add_group_members
+  merobox support — tracked separately.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  # --- Create context in namespace root ---
+
+  - name: Create context in namespace root on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+      ctx_key_node1: memberPublicKey
+
+  - name: Assert context created
+    type: assert
+    statements:
+      - "is_set({{ctx_id}})"
+
+  # --- Node-2 joins namespace and context ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+    outputs:
+      member_identity_node2: memberIdentity
+
+  - name: Node-2 joins context via namespace membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      ctx_key_node2: memberPublicKey
+
+  # --- SCENARIO 1: Verify namespace-root context sync works ---
+
+  - name: Node-1 writes to namespace-root context
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "ns_root_key"
+      value: "from_node1"
+
+  - name: Wait for sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads namespace-root context value
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "ns_root_key"
+    outputs:
+      ns_root_read: result
+
+  - name: Assert namespace-root context synced
+    type: json_assert
+    statements:
+      - 'json_equal({{ns_root_read}}, {"output": "from_node1"})'
+
+  # --- SCENARIO 2: Create subgroup inside the namespace ---
+
+  - name: Create subgroup inside namespace on node-1
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: match-subgroup
+
+  # Verify the subgroup appears in the namespace's subgroup list.
+  # list_subgroups takes the PARENT group id (the namespace root here).
+  - name: List subgroups of namespace on node-1
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      subgroups_node1: subgroups
+
+  - name: Assert subgroup is present in listing
+    type: assert
+    statements:
+      - "is_set({{subgroups_node1}})"
+
+  # --- SCENARIO 3: Namespace-root context is unaffected by subgroup creation ---
+
+  - name: Node-2 writes to namespace-root context after subgroup created
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_subgroup_key"
+      value: "still_works"
+
+  - name: Wait for sync after subgroup creation
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads post-subgroup key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_subgroup_key"
+    outputs:
+      post_subgroup_read: result
+
+  - name: Assert namespace-root context unaffected
+    type: json_assert
+    statements:
+      - 'json_equal({{post_subgroup_read}}, {"output": "still_works"})'
+
+stop_all_nodes: false

--- a/apps/e2e-kv-store/workflows/handler-test.yml
+++ b/apps/e2e-kv-store/workflows/handler-test.yml
@@ -1,10 +1,16 @@
-name: Handler Sync Test
-description: Test set_with_handler sync
+name: E2E KV Store - Event Handler Dispatch
+description: >
+  Tests the app::emit! / insert_handler path in the namespace model.
+  set_with_handler emits an event that merod dispatches back to all
+  context members as an execute call. The test verifies:
+    1. set_with_handler writes the value and fires the event.
+    2. The handler-inserted value syncs to both nodes via CRDT.
+    3. get_handler_execution_count reflects handler invocations.
 
 force_pull_image: false
+near_devnet: false
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
@@ -18,34 +24,170 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create mesh with node-2
-    type: create_mesh
-    context_node: e2e-node-1
-    application_id: "{{app_id}}"
-    path: res/e2e_kv_store.wasm
-    nodes:
-      - e2e-node-2
-    capability: member
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  - name: Create context in namespace on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
     outputs:
       context_id: contextId
-      node1_key: memberPublicKey
+      ctx_key_node1: memberPublicKey
 
-  # set_with_handler emits event that triggers insert_handler on receivers
-  - name: Set with handler on node-1
+  - name: Assert context created
+    type: assert
+    statements:
+      - "is_set({{context_id}})"
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+
+  - name: Node-2 joins context via namespace membership
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{context_id}}'
+    outputs:
+      ctx_key_node2: memberPublicKey
+
+  # --- SCENARIO 1: set_with_handler fires event; value syncs ---
+
+  - name: Node-1 calls set_with_handler
     type: call
     node: e2e-node-1
-    context_id: "{{context_id}}"
+    context_id: '{{context_id}}'
     method: set_with_handler
     args:
       key: "test_key"
       value: "test_value"
 
-  - name: Wait for sync
+  - name: Wait for handler sync
     type: wait_for_sync
-    context_id: "{{context_id}}"
+    context_id: '{{context_id}}'
     nodes:
       - e2e-node-1
       - e2e-node-2
     timeout: 60
     check_interval: 2
     trigger_sync: true
+
+  - name: Node-2 reads the handler-written value
+    type: call
+    node: e2e-node-2
+    context_id: '{{context_id}}'
+    method: get
+    args:
+      key: "test_key"
+    outputs:
+      read_result: result
+
+  - name: Assert handler value synced to node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{read_result}}, {"output": "test_value"})'
+
+  - name: Node-1 reads back handler-written value
+    type: call
+    node: e2e-node-1
+    context_id: '{{context_id}}'
+    method: get
+    args:
+      key: "test_key"
+    outputs:
+      read_result_node1: result
+
+  - name: Assert handler value present on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{read_result_node1}}, {"output": "test_value"})'
+
+  # --- SCENARIO 2: Handler execution count is tracked ---
+
+  - name: Node-1 gets handler execution count
+    type: call
+    node: e2e-node-1
+    context_id: '{{context_id}}'
+    method: get_handler_execution_count
+    outputs:
+      handler_count_node1: result
+
+  - name: Assert handler was executed at least once on node-1
+    type: assert
+    statements:
+      - "is_set({{handler_count_node1}})"
+
+  - name: Node-2 gets handler execution count
+    type: call
+    node: e2e-node-2
+    context_id: '{{context_id}}'
+    method: get_handler_execution_count
+    outputs:
+      handler_count_node2: result
+
+  - name: Assert handler was executed at least once on node-2
+    type: assert
+    statements:
+      - "is_set({{handler_count_node2}})"
+
+  # --- SCENARIO 3: Second call accumulates handler invocations ---
+
+  - name: Node-2 calls set_with_handler a second time
+    type: call
+    node: e2e-node-2
+    context_id: '{{context_id}}'
+    method: set_with_handler
+    args:
+      key: "test_key2"
+      value: "second_value"
+
+  - name: Wait for second handler sync
+    type: wait_for_sync
+    context_id: '{{context_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-1 reads second handler-written value
+    type: call
+    node: e2e-node-1
+    context_id: '{{context_id}}'
+    method: get
+    args:
+      key: "test_key2"
+    outputs:
+      second_read: result
+
+  - name: Assert second handler value synced to node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{second_read}}, {"output": "second_value"})'
+
+stop_all_nodes: false

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -387,7 +387,9 @@ async fn list_subgroups() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path(format!("/admin-api/groups/{GID}/subgroups")))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"subgroups": []})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"subgroups": []})),
+        )
         .expect(1)
         .mount(&server)
         .await;

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -387,14 +387,14 @@ async fn list_subgroups() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path(format!("/admin-api/groups/{GID}/subgroups")))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"subgroups": []})))
         .expect(1)
         .mount(&server)
         .await;
 
     let client = make_client(&Url::parse(&server.uri()).unwrap());
     let resp = client.list_subgroups(GID).await.unwrap();
-    assert!(resp.data.is_empty());
+    assert!(resp.subgroups.is_empty());
 }
 
 // ---- Namespaces ----

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -164,7 +164,7 @@ impl Report for ListNamespaceGroupsApiResponse {
 
 impl Report for ListSubgroupsApiResponse {
     fn report(&self) {
-        if self.data.is_empty() {
+        if self.subgroups.is_empty() {
             println!("No subgroups found");
             return;
         }
@@ -174,7 +174,7 @@ impl Report for ListSubgroupsApiResponse {
             Cell::new("Group ID").fg(Color::Blue),
             Cell::new("Alias").fg(Color::Blue),
         ]);
-        for group in &self.data {
+        for group in &self.subgroups {
             let _ = table.add_row(vec![
                 group.group_id.clone(),
                 group.alias.clone().unwrap_or_else(|| "-".to_owned()),

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -418,6 +418,83 @@ impl NodeClient {
         )
     }
 
+    /// Install a bundle from a local dev path, skipping signature verification.
+    async fn install_dev_bundle(
+        &self,
+        bundle_data: Arc<Vec<u8>>,
+        blob_id: &BlobId,
+        stored_size: u64,
+        source: &ApplicationSource,
+    ) -> eyre::Result<ApplicationId> {
+        let bundle_data_clone = Arc::clone(&bundle_data);
+        let (_manifest_json, manifest) =
+            tokio::task::spawn_blocking(move || Self::extract_bundle_manifest(&bundle_data_clone))
+                .await??;
+
+        let signer_id = "dev:unsigned";
+        let package = &manifest.package;
+        let version = &manifest.app_version;
+
+        let blobstore_root = self.blob_manager.root_path();
+        let node_root = blobstore_root
+            .parent()
+            .ok_or_else(|| eyre::eyre!("blobstore root has no parent"))?
+            .to_path_buf();
+        let extract_dir = node_root
+            .join("applications")
+            .join(package)
+            .join(version)
+            .join("extracted");
+
+        let bundle_data_clone = Arc::clone(&bundle_data);
+        let manifest_clone = manifest.clone();
+        let extract_dir_clone = extract_dir.clone();
+        let node_root_clone = node_root.clone();
+        let package_clone = package.to_string();
+        let version_clone = version.to_string();
+        tokio::task::spawn_blocking(move || {
+            Self::extract_bundle_artifacts(
+                &bundle_data_clone,
+                &manifest_clone,
+                &extract_dir_clone,
+                &node_root_clone,
+                &package_clone,
+                &version_clone,
+            )
+        })
+        .await??;
+
+        let mut services = Vec::new();
+        for artifact in manifest.wasm_artifacts() {
+            if let Some(name) = artifact.name {
+                let wasm_path = extract_dir.join(&artifact.wasm.path);
+                let wasm_bytes = tokio::fs::read(&wasm_path).await?;
+                let cursor = Cursor::new(wasm_bytes.as_slice());
+                let (svc_blob_id, _svc_size) = self
+                    .add_blob(cursor, Some(wasm_bytes.len() as u64), None)
+                    .await?;
+                services.push(types::ServiceMeta {
+                    name: name.to_owned().into_boxed_str(),
+                    bytecode: key::BlobMeta::new(svc_blob_id),
+                    compiled: key::BlobMeta::new(BlobId::from([0; 32])),
+                });
+            }
+        }
+
+        let bundle_metadata = manifest.to_metadata_json()?;
+
+        self.install_bundle_application(
+            blob_id,
+            stored_size,
+            source,
+            bundle_metadata,
+            package,
+            version,
+            signer_id,
+            services,
+        )
+    }
+
     /// Check if a path points to a bundle archive (.mpk - Mero Package Kit)
     fn is_bundle_archive(path: &Utf8Path) -> bool {
         path.extension().map(|ext| ext == "mpk").unwrap_or(false)
@@ -593,7 +670,9 @@ impl NodeClient {
             bail!("non-absolute path")
         };
 
-        self.install_verified_bundle(
+        // Dev installs from local path skip signature verification — the
+        // bundle may be unsigned during development/testing.
+        self.install_dev_bundle(
             bundle_data,
             &bundle_blob_id,
             stored_size,

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -101,12 +101,12 @@ impl NodeClient {
         };
 
         if is_bundle {
-            // This is a bundle, extract WASM from extracted directory or bundle
-            // Extract manifest and verify signature (blocking I/O wrapped in spawn_blocking)
-            // Signature verification ensures blob integrity even when re-extracting
+            // This is a bundle, extract WASM from extracted directory or bundle.
+            // The bundle was already admitted (possibly unsigned in dev mode),
+            // so use the unsigned-tolerant extractor here.
             let blob_bytes_clone = Arc::clone(&blob_bytes);
             let (_, manifest) = tokio::task::spawn_blocking(move || {
-                Self::verify_and_extract_manifest(&blob_bytes_clone)
+                Self::extract_manifest_allow_unsigned(&blob_bytes_clone)
             })
             .await??;
             let package = &manifest.package;
@@ -420,10 +420,12 @@ impl NodeClient {
 
     /// Install a bundle from a local dev path.
     ///
-    /// If the manifest contains a signature, it is verified (and invalid
-    /// signatures are rejected). If no signature field is present, the
-    /// bundle is treated as an unsigned dev build and installed with a
-    /// placeholder signer id.
+    /// Uses `extract_manifest_allow_unsigned`: if the manifest contains a
+    /// signature it is verified (invalid signatures are rejected); if no
+    /// signature field is present the bundle is treated as unsigned dev build.
+    ///
+    /// Production installs from registries go through `install_verified_bundle`
+    /// which always requires a valid signature.
     async fn install_dev_bundle(
         &self,
         bundle_data: Arc<Vec<u8>>,
@@ -432,23 +434,12 @@ impl NodeClient {
         source: &ApplicationSource,
     ) -> eyre::Result<ApplicationId> {
         let bundle_data_clone = Arc::clone(&bundle_data);
-        let (manifest_json, manifest) =
-            tokio::task::spawn_blocking(move || Self::extract_bundle_manifest(&bundle_data_clone))
-                .await??;
+        let (verification, manifest) = tokio::task::spawn_blocking(move || {
+            Self::extract_manifest_allow_unsigned(&bundle_data_clone)
+        })
+        .await??;
 
-        let signer_id = if manifest_json.get("signature").is_some() {
-            let verification = verify_manifest_signature(&manifest_json)?;
-            debug!(
-                signer_id = %verification.signer_id,
-                bundle_hash = %hex::encode(verification.bundle_hash),
-                "dev bundle manifest signature verified"
-            );
-            verification.signer_id
-        } else {
-            debug!("dev bundle has no signature field, installing as unsigned");
-            "dev:unsigned".to_owned()
-        };
-
+        let signer_id = verification.signer_id;
         let package = &manifest.package;
         let version = &manifest.app_version;
 
@@ -765,6 +756,36 @@ impl NodeClient {
             bundle_hash = %hex::encode(verification.bundle_hash),
             "bundle manifest signature verified"
         );
+        Ok((verification, manifest))
+    }
+
+    /// Extracts bundle manifest, verifying signature only if present.
+    ///
+    /// Used for dev installs and WASM loading of already-installed bundles,
+    /// where the bundle may have been admitted unsigned. If a signature IS
+    /// present it is still verified — invalid signatures are always rejected.
+    ///
+    /// Production installs MUST use `verify_and_extract_manifest` instead,
+    /// which requires a valid signature.
+    fn extract_manifest_allow_unsigned(
+        bundle_data: &[u8],
+    ) -> eyre::Result<(ManifestVerification, BundleManifest)> {
+        let (manifest_json, manifest) = Self::extract_bundle_manifest(bundle_data)?;
+        let verification = if manifest_json.get("signature").is_some() {
+            let v = verify_manifest_signature(&manifest_json)?;
+            debug!(
+                signer_id = %v.signer_id,
+                bundle_hash = %hex::encode(v.bundle_hash),
+                "bundle manifest signature verified"
+            );
+            v
+        } else {
+            debug!("bundle has no signature field, treating as unsigned dev bundle");
+            ManifestVerification {
+                signer_id: "dev:unsigned".to_owned(),
+                bundle_hash: [0u8; 32],
+            }
+        };
         Ok((verification, manifest))
     }
 

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -341,19 +341,16 @@ impl NodeClient {
         Ok(application_id)
     }
 
-    async fn install_verified_bundle(
+    /// Install a bundle given an already-resolved manifest and verification.
+    async fn install_bundle_with_manifest(
         &self,
         bundle_data: Arc<Vec<u8>>,
         blob_id: &BlobId,
         stored_size: u64,
         source: &ApplicationSource,
+        verification: ManifestVerification,
+        manifest: BundleManifest,
     ) -> eyre::Result<ApplicationId> {
-        let bundle_data_clone = Arc::clone(&bundle_data);
-        let (verification, manifest) = tokio::task::spawn_blocking(move || {
-            Self::verify_and_extract_manifest(&bundle_data_clone)
-        })
-        .await??;
-
         let signer_id = verification.signer_id;
         let package = &manifest.package;
         let version = &manifest.app_version;
@@ -418,12 +415,34 @@ impl NodeClient {
         )
     }
 
+    /// Install a bundle from a registry. Signature is mandatory.
+    async fn install_verified_bundle(
+        &self,
+        bundle_data: Arc<Vec<u8>>,
+        blob_id: &BlobId,
+        stored_size: u64,
+        source: &ApplicationSource,
+    ) -> eyre::Result<ApplicationId> {
+        let bundle_data_clone = Arc::clone(&bundle_data);
+        let (verification, manifest) = tokio::task::spawn_blocking(move || {
+            Self::verify_and_extract_manifest(&bundle_data_clone)
+        })
+        .await??;
+
+        self.install_bundle_with_manifest(
+            bundle_data,
+            blob_id,
+            stored_size,
+            source,
+            verification,
+            manifest,
+        )
+        .await
+    }
+
     /// Install a bundle from a local dev path.
     ///
-    /// Uses `extract_manifest_allow_unsigned`: if the manifest contains a
-    /// signature it is verified (invalid signatures are rejected); if no
-    /// signature field is present the bundle is treated as unsigned dev build.
-    ///
+    /// Signature is optional: verified if present, unsigned allowed otherwise.
     /// Production installs from registries go through `install_verified_bundle`
     /// which always requires a valid signature.
     async fn install_dev_bundle(
@@ -439,68 +458,15 @@ impl NodeClient {
         })
         .await??;
 
-        let signer_id = verification.signer_id;
-        let package = &manifest.package;
-        let version = &manifest.app_version;
-
-        let blobstore_root = self.blob_manager.root_path();
-        let node_root = blobstore_root
-            .parent()
-            .ok_or_else(|| eyre::eyre!("blobstore root has no parent"))?
-            .to_path_buf();
-        let extract_dir = node_root
-            .join("applications")
-            .join(package)
-            .join(version)
-            .join("extracted");
-
-        let bundle_data_clone = Arc::clone(&bundle_data);
-        let manifest_clone = manifest.clone();
-        let extract_dir_clone = extract_dir.clone();
-        let node_root_clone = node_root.clone();
-        let package_clone = package.to_string();
-        let version_clone = version.to_string();
-        tokio::task::spawn_blocking(move || {
-            Self::extract_bundle_artifacts(
-                &bundle_data_clone,
-                &manifest_clone,
-                &extract_dir_clone,
-                &node_root_clone,
-                &package_clone,
-                &version_clone,
-            )
-        })
-        .await??;
-
-        let mut services = Vec::new();
-        for artifact in manifest.wasm_artifacts() {
-            if let Some(name) = artifact.name {
-                let wasm_path = extract_dir.join(&artifact.wasm.path);
-                let wasm_bytes = tokio::fs::read(&wasm_path).await?;
-                let cursor = Cursor::new(wasm_bytes.as_slice());
-                let (svc_blob_id, _svc_size) = self
-                    .add_blob(cursor, Some(wasm_bytes.len() as u64), None)
-                    .await?;
-                services.push(types::ServiceMeta {
-                    name: name.to_owned().into_boxed_str(),
-                    bytecode: key::BlobMeta::new(svc_blob_id),
-                    compiled: key::BlobMeta::new(BlobId::from([0; 32])),
-                });
-            }
-        }
-
-        let bundle_metadata = manifest.to_metadata_json()?;
-
-        self.install_bundle_application(
+        self.install_bundle_with_manifest(
+            bundle_data,
             blob_id,
             stored_size,
             source,
-            bundle_metadata,
-            package,
-            version,
-            &signer_id,
-            services,
+            verification,
+            manifest,
         )
+        .await
     }
 
     /// Check if a path points to a bundle archive (.mpk - Mero Package Kit)

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -418,7 +418,12 @@ impl NodeClient {
         )
     }
 
-    /// Install a bundle from a local dev path, skipping signature verification.
+    /// Install a bundle from a local dev path.
+    ///
+    /// If the manifest contains a signature, it is verified (and invalid
+    /// signatures are rejected). If no signature field is present, the
+    /// bundle is treated as an unsigned dev build and installed with a
+    /// placeholder signer id.
     async fn install_dev_bundle(
         &self,
         bundle_data: Arc<Vec<u8>>,
@@ -427,11 +432,23 @@ impl NodeClient {
         source: &ApplicationSource,
     ) -> eyre::Result<ApplicationId> {
         let bundle_data_clone = Arc::clone(&bundle_data);
-        let (_manifest_json, manifest) =
+        let (manifest_json, manifest) =
             tokio::task::spawn_blocking(move || Self::extract_bundle_manifest(&bundle_data_clone))
                 .await??;
 
-        let signer_id = "dev:unsigned";
+        let signer_id = if manifest_json.get("signature").is_some() {
+            let verification = verify_manifest_signature(&manifest_json)?;
+            debug!(
+                signer_id = %verification.signer_id,
+                bundle_hash = %hex::encode(verification.bundle_hash),
+                "dev bundle manifest signature verified"
+            );
+            verification.signer_id
+        } else {
+            debug!("dev bundle has no signature field, installing as unsigned");
+            "dev:unsigned".to_owned()
+        };
+
         let package = &manifest.package;
         let version = &manifest.app_version;
 
@@ -490,7 +507,7 @@ impl NodeClient {
             bundle_metadata,
             package,
             version,
-            signer_id,
+            &signer_id,
             services,
         )
     }

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -1705,10 +1705,11 @@ fn create_test_bundle_with_key(
     bundle_path.try_into().unwrap()
 }
 
-/// Test: Installation should fail when bundle manifest has no signature field.
+/// Test: Dev installation of an unsigned bundle should succeed.
 ///
-/// All bundles must be signed. A bundle with a valid manifest
-/// but no signature field MUST be rejected during installation.
+/// Bundles installed from local paths (dev mode) are allowed to omit the
+/// signature field. Signature verification is only mandatory for production
+/// installs from registries.
 #[tokio::test]
 async fn test_bundle_installation_fails_without_signature() {
     let temp_dir = TempDir::new().unwrap();
@@ -1718,21 +1719,15 @@ async fn test_bundle_installation_fails_without_signature() {
     let bundle_path =
         create_unsigned_bundle(&temp_dir, "com.example.unsigned", "1.0.0", b"wasm content");
 
-    // Installation should fail
+    // Dev installs allow unsigned bundles
     let result = node_client
         .install_application_from_path(bundle_path, vec![], None, None)
         .await;
 
     assert!(
-        result.is_err(),
-        "Bundle installation should fail without signature"
-    );
-
-    let error_msg = result.unwrap_err().to_string();
-    assert!(
-        error_msg.contains("signature") || error_msg.contains("missing"),
-        "Error should mention missing signature, got: {}",
-        error_msg
+        result.is_ok(),
+        "Dev bundle installation should succeed without signature, got: {}",
+        result.unwrap_err()
     );
 }
 

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -1711,7 +1711,7 @@ fn create_test_bundle_with_key(
 /// signature field. Signature verification is only mandatory for production
 /// installs from registries.
 #[tokio::test]
-async fn test_bundle_installation_fails_without_signature() {
+async fn test_dev_bundle_installation_succeeds_without_signature() {
     let temp_dir = TempDir::new().unwrap();
     let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
 

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1906,7 +1906,7 @@ pub struct SubgroupEntryApiResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListSubgroupsApiResponse {
-    pub data: Vec<SubgroupEntryApiResponse>,
+    pub subgroups: Vec<SubgroupEntryApiResponse>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -26,20 +26,20 @@ pub async fn handler(
         Err(err) => return parse_api_error(err).into_response(),
     };
 
-    let mut data = Vec::with_capacity(children.len());
+    let mut subgroups = Vec::with_capacity(children.len());
     for child in children {
         let alias = match calimero_context::group_store::get_group_alias(&state.store, &child) {
             Ok(alias) => alias,
             Err(err) => return parse_api_error(err).into_response(),
         };
-        data.push(SubgroupEntryApiResponse {
+        subgroups.push(SubgroupEntryApiResponse {
             group_id: hex::encode(child.to_bytes()),
             alias,
         });
     }
 
     ApiResponse {
-        payload: ListSubgroupsApiResponse { data },
+        payload: ListSubgroupsApiResponse { subgroups },
     }
     .into_response()
 }


### PR DESCRIPTION
# feat: add e2e tests for ns - groups

## Description
TBD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and e2e changes are low-impact, but the PR also changes bundle signature enforcement for local-path installs and alters the `list_subgroups` API response shape, which could break consumers or weaken expectations if used outside dev paths.
> 
> **Overview**
> Adds a larger suite of `merobox` E2E workflows for namespace/group behavior in `apps/e2e-kv-store` (3-node convergence, context isolation, late joiner catch-up, subgroup lifecycle, and improved handler dispatch coverage), and updates both `e2e-rust-apps.yml` and `e2e-rust-apps-release.yml` to build the new multi-service `.mpk` bundle and execute these workflows with retry + log collection.
> 
> Introduces `build-multi-service-bundle.sh` to generate a multi-service package (two services backed by the same WASM) and a new `group-multi-service.yml` workflow to validate service-level isolation and sync.
> 
> Aligns the subgroup listing API to return `subgroups` instead of `data` across server handler/primitives, client tests, and `meroctl` output, and relaxes bundle signature requirements for **dev installs from local paths** by adding an unsigned-tolerant manifest extractor while keeping registry installs signature-mandatory (tests updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb27324261007bba1bc6c899beb288ec600a1a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->