### PR TITLE
fix(context): unfreeze namespace DAG on KeyDelivery side-effect failure; event-driven join_context

### DIFF
--- a/crates/context/src/group_store/group_keys.rs
+++ b/crates/context/src/group_store/group_keys.rs
@@ -123,7 +123,21 @@ impl<'a> GroupKeyring<'a> {
         let plaintext = shared_key
             .decrypt(encrypted.ciphertext.clone(), encrypted.nonce)
             .ok_or_else(|| eyre::eyre!("failed to decrypt group op (bad sender_key or corrupt)"))?;
-        borsh::from_slice(&plaintext).map_err(|e| eyre::eyre!("borsh decode inner GroupOp: {e}"))
+        borsh::from_slice(&plaintext).map_err(|e| {
+            // "Unexpected length of input" on this path means the decrypted
+            // plaintext length does not match the current `GroupOp` borsh
+            // schema — almost always a cross-version schema drift where an
+            // older node wrote an op shape the current node can't decode.
+            // Log the plaintext length + prefix so the failing op type can
+            // be identified and either forward-migrated or skipped.
+            tracing::warn!(
+                plaintext_len = plaintext.len(),
+                plaintext_prefix = %hex::encode(&plaintext[..plaintext.len().min(32)]),
+                error = %e,
+                "borsh decode inner GroupOp failed (codec/schema mismatch)"
+            );
+            eyre::eyre!("borsh decode inner GroupOp: {e}")
+        })
     }
 
     pub fn wrap_for_member(

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -899,6 +899,10 @@ fn apply_group_op_mutations(
             if let Some(name) = service_name {
                 set_context_service_name(store, context_id, name)?;
             }
+            // Signal any waiters (e.g. `join_context` racing against gossipsub
+            // propagation) that the context→group mapping has just been
+            // persisted. See `crate::registration_notify` for rationale.
+            crate::registration_notify::notify(*context_id);
         }
         GroupOp::ContextDetached { context_id } => {
             context_registration.detach(&permissions, signer, context_id)?;

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -107,29 +107,59 @@ impl<'a> NamespaceGovernance<'a> {
                         ref envelope,
                     } => {
                         let ns_id = ContextGroupId::from(op.namespace_id);
-                        if let Some(identity) = get_namespace_identity_record(self.store, &ns_id)? {
-                            let recipient_sk = PrivateKey::from(identity.private_key);
-                            if envelope.recipient == recipient_sk.public_key() {
-                                match unwrap_group_key(&recipient_sk, envelope) {
-                                    Ok(group_key) => {
-                                        let gid = ContextGroupId::from(*group_id);
-                                        let key_id = store_group_key(self.store, &gid, &group_key)?;
-                                        tracing::info!(
-                                            group_id = %hex::encode(group_id),
-                                            key_id = %hex::encode(key_id),
-                                            "received group key via KeyDelivery"
-                                        );
-                                        self.retry_encrypted_ops_for_group(*group_id)?;
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!(?e, "failed to unwrap KeyDelivery envelope");
-                                        result.key_unwrap_failures.push(KeyUnwrapFailure {
-                                            group_id: *group_id,
-                                            reason: format!("KeyDelivery unwrap failed: {e}"),
-                                        });
+                        // Any error inside the KeyDelivery side-effect path below
+                        // is captured and logged, but NOT propagated. KeyDelivery
+                        // is an idempotent best-effort op — its side-effect (storing
+                        // a group key locally) is not part of governance consensus.
+                        // Failing to apply the side-effect must not block the DAG,
+                        // because every subsequent governance op for this namespace
+                        // would then be orphaned as an unreconcilable pending delta.
+                        // This was the root cause of the "Unexpected length of input"
+                        // stuck-sync observed when a KeyDelivery op's retry-apply
+                        // path hit a pre-existing stored op that failed to decode.
+                        let mut apply_kd = || -> EyreResult<()> {
+                            if let Some(identity) =
+                                get_namespace_identity_record(self.store, &ns_id)?
+                            {
+                                let recipient_sk = PrivateKey::from(identity.private_key);
+                                if envelope.recipient == recipient_sk.public_key() {
+                                    match unwrap_group_key(&recipient_sk, envelope) {
+                                        Ok(group_key) => {
+                                            let gid = ContextGroupId::from(*group_id);
+                                            let key_id =
+                                                store_group_key(self.store, &gid, &group_key)?;
+                                            tracing::info!(
+                                                group_id = %hex::encode(group_id),
+                                                key_id = %hex::encode(key_id),
+                                                "received group key via KeyDelivery"
+                                            );
+                                            self.retry_encrypted_ops_for_group(*group_id)?;
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                ?e,
+                                                "failed to unwrap KeyDelivery envelope"
+                                            );
+                                            result.key_unwrap_failures.push(KeyUnwrapFailure {
+                                                group_id: *group_id,
+                                                reason: format!("KeyDelivery unwrap failed: {e}"),
+                                            });
+                                        }
                                     }
                                 }
                             }
+                            Ok(())
+                        };
+                        if let Err(e) = apply_kd() {
+                            tracing::warn!(
+                                group_id = %hex::encode(group_id),
+                                error = %e,
+                                "KeyDelivery side-effect failed; DAG apply continues"
+                            );
+                            result.key_unwrap_failures.push(KeyUnwrapFailure {
+                                group_id: *group_id,
+                                reason: format!("KeyDelivery side-effect failed: {e}"),
+                            });
                         }
                     }
                     RootOp::MemberJoined {

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -5,30 +5,22 @@ use calimero_context_client::group::{JoinContextRequest, JoinContextResponse};
 use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::ContextConfigParams;
 use eyre::bail;
+use tokio::sync::broadcast::error::RecvError;
 use tracing::{info, warn};
 
-use crate::{group_store, ContextManager};
+use crate::{group_store, registration_notify, ContextManager};
 
-/// Per-attempt sleep schedule for resolving the context->group mapping.
-///
-/// The mapping is delivered by the `ContextRegistered` governance op, which
-/// propagates asynchronously over gossipsub from the creating node.
-///
-/// Exponential-ish backoff is used so we:
-/// 1. Wake fast for the common case where the op arrives within a few hundred
-///    ms of `join_context` being called (CI evidence: ops observed arriving
-///    ~40ms after the previous flat 1.8s budget expired).
-/// 2. Still cover the slow-propagation tail (~10s total budget) without
-///    waiting the full budget on every successful join.
-///
-/// Total worst-case wait ≈ 150ms + 400ms + 1s + 2.5s + 6s = ~10s.
-const GROUP_LOOKUP_BACKOFF: &[Duration] = &[
-    Duration::from_millis(150),
-    Duration::from_millis(400),
-    Duration::from_secs(1),
-    Duration::from_millis(2500),
-    Duration::from_secs(6),
-];
+/// Overall budget for the context→group mapping to land locally after a
+/// `sync_known_namespaces` kick. Dominated by peer-discovery in the cold
+/// case (`Mesh low` / no peers); the normal case wakes within a few ms as
+/// soon as `registration_notify::notify` fires from the apply path.
+const GROUP_LOOKUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Fallback poll interval in case the notifier channel lags (burst of
+/// registrations overflowing the broadcast capacity). Lag is handled by
+/// re-reading the datastore; this bounds how long a lagged receiver
+/// waits before that recheck.
+const FALLBACK_POLL: Duration = Duration::from_millis(200);
 
 impl Handler<JoinContextRequest> for ContextManager {
     type Result = ActorResponse<Self, <JoinContextRequest as Message>::Result>;
@@ -45,24 +37,82 @@ impl Handler<JoinContextRequest> for ContextManager {
             async move {
                 let mut group_id = group_store::get_group_for_context(&datastore, &context_id)?;
                 if group_id.is_none() {
+                    // Subscribe BEFORE kicking sync so we cannot miss a signal
+                    // that fires between the sync returning and us starting to
+                    // wait. All messages sent after this point are delivered.
+                    let mut rx = registration_notify::subscribe();
+
                     warn!(
                         %context_id,
                         "context->group mapping missing locally; syncing known namespaces"
                     );
                     sync_known_namespaces(&datastore, &node_client).await;
 
-                    for (attempt, delay) in GROUP_LOOKUP_BACKOFF.iter().enumerate() {
-                        tokio::time::sleep(*delay).await;
-                        group_id = group_store::get_group_for_context(&datastore, &context_id)?;
-                        if group_id.is_some() {
-                            info!(
-                                %context_id,
-                                attempt = attempt + 1,
-                                "resolved context->group mapping after namespace sync"
-                            );
-                            break;
+                    // Mapping may have landed synchronously during sync (creator's
+                    // own apply, or a sync that completed and applied inline).
+                    group_id = group_store::get_group_for_context(&datastore, &context_id)?;
+
+                    if group_id.is_none() {
+                        let deadline = tokio::time::Instant::now() + GROUP_LOOKUP_TIMEOUT;
+                        let started = tokio::time::Instant::now();
+                        loop {
+                            // Race the notifier against a short poll interval: if
+                            // the channel lagged (bursty traffic), we still catch
+                            // the mapping via the periodic datastore recheck.
+                            let recv = tokio::time::timeout(FALLBACK_POLL, rx.recv()).await;
+                            match recv {
+                                Ok(Ok(cid)) if cid == context_id => {
+                                    group_id = group_store::get_group_for_context(
+                                        &datastore, &context_id,
+                                    )?;
+                                    if group_id.is_some() {
+                                        info!(
+                                            %context_id,
+                                            elapsed_ms = started.elapsed().as_millis() as u64,
+                                            "resolved context->group mapping via registration signal"
+                                        );
+                                        break;
+                                    }
+                                }
+                                Ok(Ok(_)) => {
+                                    // Signal for a different context — keep waiting.
+                                }
+                                Ok(Err(RecvError::Lagged(skipped))) => {
+                                    warn!(
+                                        %context_id,
+                                        skipped,
+                                        "registration_notify lagged; falling back to datastore poll"
+                                    );
+                                    group_id = group_store::get_group_for_context(
+                                        &datastore, &context_id,
+                                    )?;
+                                    if group_id.is_some() {
+                                        break;
+                                    }
+                                }
+                                Ok(Err(RecvError::Closed)) => {
+                                    // Channel sender dropped; final datastore check then bail.
+                                    group_id = group_store::get_group_for_context(
+                                        &datastore, &context_id,
+                                    )?;
+                                    break;
+                                }
+                                Err(_elapsed) => {
+                                    // Poll tick — recheck the datastore and kick another
+                                    // namespace sync to cover the "peer arrived late" case.
+                                    group_id = group_store::get_group_for_context(
+                                        &datastore, &context_id,
+                                    )?;
+                                    if group_id.is_some() {
+                                        break;
+                                    }
+                                    sync_known_namespaces(&datastore, &node_client).await;
+                                }
+                            }
+                            if tokio::time::Instant::now() >= deadline {
+                                break;
+                            }
                         }
-                        sync_known_namespaces(&datastore, &node_client).await;
                     }
                 }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -27,6 +27,7 @@ pub mod group_store;
 pub mod handlers;
 mod lifecycle;
 mod metrics;
+pub mod registration_notify;
 
 /// A metadata container for a single, in-memory context.
 ///

--- a/crates/context/src/registration_notify.rs
+++ b/crates/context/src/registration_notify.rs
@@ -1,0 +1,48 @@
+//! Process-wide signal for `ContextRegistered` governance-op application.
+//!
+//! When a peer's `join_context` runs before the context→group mapping has
+//! propagated via gossipsub, it must wait for the mapping to land locally.
+//! Polling `get_group_for_context` after `sync_namespace().await` is racy:
+//! `sync_namespace` returns once the sync RPC completes, but the received
+//! ops are applied on a separate network-handler task — observed to lag by
+//! ~1–2 ms on real networks (merobox CI) and deterministically miss the
+//! polling window.
+//!
+//! This module exposes a broadcast channel that is signalled from the op
+//! apply path (`apply_group_op_mutations` → `GroupOp::ContextRegistered`)
+//! once the mapping is written. `join_context` subscribes before kicking
+//! the sync, then awaits the signal for its target context.
+//!
+//! Using a module-level `OnceLock` avoids threading the channel handle
+//! through `NamespaceGovernance`, `ContextRegistrationService`, and every
+//! call site of `apply_group_op_mutations`.
+
+use std::sync::OnceLock;
+
+use calimero_primitives::context::ContextId;
+use tokio::sync::broadcast;
+
+/// Broadcast capacity. The channel only carries `ContextId` values and
+/// slow subscribers fall back to rechecking the datastore on `Lagged`, so
+/// this bound is about bursting multiple near-simultaneous registrations
+/// without forcing a lag event in the common case.
+const CHANNEL_CAPACITY: usize = 256;
+
+static NOTIFIER: OnceLock<broadcast::Sender<ContextId>> = OnceLock::new();
+
+fn sender() -> &'static broadcast::Sender<ContextId> {
+    NOTIFIER.get_or_init(|| broadcast::channel(CHANNEL_CAPACITY).0)
+}
+
+/// Signal that a context→group mapping has been written locally. A
+/// best-effort broadcast: if there are no subscribers the send is a noop.
+pub fn notify(context_id: ContextId) {
+    let _ = sender().send(context_id);
+}
+
+/// Subscribe to future `ContextRegistered` signals. Subscribe *before*
+/// kicking the sync that may deliver the op — otherwise the signal can
+/// fire in the gap between sync-apply and subscribe.
+pub fn subscribe() -> broadcast::Receiver<ContextId> {
+    sender().subscribe()
+}

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2714,7 +2714,7 @@ impl SyncManager {
                     ops = deltas.len(),
                     "received namespace governance ops from peer"
                 );
-                for (_delta_id, op_bytes) in deltas {
+                for (delta_id, op_bytes) in deltas {
                     match borsh::from_slice::<
                         calimero_context_client::local_governance::SignedNamespaceOp,
                     >(&op_bytes)
@@ -2725,8 +2725,27 @@ impl SyncManager {
                                 .apply_signed_namespace_op(op.clone())
                                 .await
                             {
+                                // Capture enough context to diagnose codec/schema
+                                // mismatches (observed as "Unexpected length of
+                                // input" from the inner GroupOp decode when a
+                                // variant's binary layout has drifted). The
+                                // op-type tag + byte-length give us a fingerprint
+                                // without logging potentially sensitive payload.
+                                let op_kind = match &op.op {
+                                    calimero_context_client::local_governance::NamespaceOp::Root(r) => {
+                                        format!("Root::{r:?}").split('{').next().unwrap_or("Root").trim().to_owned()
+                                    }
+                                    calimero_context_client::local_governance::NamespaceOp::Group { .. } => {
+                                        "Group".to_owned()
+                                    }
+                                };
                                 warn!(
                                     namespace_id = %hex::encode(namespace_id),
+                                    delta_id = %hex::encode(delta_id),
+                                    op_kind = %op_kind,
+                                    signer = %op.signer,
+                                    nonce = op.nonce,
+                                    op_bytes_len = op_bytes.len(),
                                     ?err,
                                     "failed to apply namespace governance op from backfill"
                                 );
@@ -2742,6 +2761,9 @@ impl SyncManager {
                         Err(err) => {
                             warn!(
                                 namespace_id = %hex::encode(namespace_id),
+                                delta_id = %hex::encode(delta_id),
+                                op_bytes_len = op_bytes.len(),
+                                op_bytes_prefix = %hex::encode(&op_bytes[..op_bytes.len().min(64)]),
                                 %err,
                                 "failed to decode namespace governance op from backfill"
                             );


### PR DESCRIPTION
## Summary

Two independent correctness fixes for the subgroup-join path that landed in #2127, plus diagnostic visibility improvements.

- Stops a single failed `KeyDelivery` side-effect from permanently freezing the namespace governance DAG for every subsequent op.
- Replaces the polling backoff in `join_context` (from #2142) with an event-driven notifier fired from the op-apply path.
- Adds structured diagnostics at the two codec failure sites that caught the underlying bug in live testing.

## The core issue

With per-match subgroups (#2127), joiners receive subgroup-scoped encrypted `GroupOp`s before they have the subgroup's key. Those ops are stored as skeletons. When `Root::KeyDelivery` arrives, `retry_encrypted_ops_for_group` scans the queued candidates and tries to decrypt + borsh-decode each one. A decode failure in that retry (observed in practice as \`\"Unexpected length of input\"\` — a \`GroupOp\` schema drift across versions) propagates out of \`apply_signed_op\` as an eyre error.

\`calimero_dag::DagStore::add_delta\` stores the delta in \`self.deltas\` **before** calling the applier, but only marks it in \`self.applied\` on success:

\`\`\`rust
self.deltas.insert(delta_id, delta.clone());
if self.can_apply(&delta) {
    self.apply_delta(delta, applier).await?;   // ← on Err, delta stays in self.deltas, not in self.applied
    Ok(true)
} else { ... }
\`\`\`

\`can_apply\` requires both:
\`\`\`rust
delta.parents.iter().all(|p| self.applied.contains(p) && self.deltas.contains_key(p))
\`\`\`

So one failed \`KeyDelivery\` leaves itself in a \"known but not applied\" state and orphans every descendant forever. The creator keeps re-broadcasting via gossipsub, the joiner keeps receiving, and nothing after that KeyDelivery ever takes effect. For a freshly created match-subgroup this means \`GroupCreated\`, \`MemberAdded\`, \`ContextRegistered\` are all permanently pending on the joiner's side. The context→group mapping is never written, and \`join_context\` times out with \`\"context does not belong to any group\"\`.

**Why KeyDelivery specifically is safe to isolate:** the signed op's presence in the DAG is governance-critical, but its side-effect (cache a group key locally, retry queued encrypted ops) is local best-effort and **not** part of governance consensus. Other ops that perform consensus-relevant mutations do not have this property and continue to propagate their errors.

## Secondary issue — polling race in \`join_context\`

\`join_context\` awaits \`sync_namespace()\` then polls the datastore for the context→group mapping. But \`sync_namespace\` returns once the sync RPC completes — the actual **apply** (which writes the mapping) happens on a separate network-handler task. On native-binary networks the apply lands 1–2 ms *after* the polling check.

merobox binary-mode CI evidence: ops arrive **1.4 ms after** the 500 fires. Docker-loopback masks the gap; real TCP doesn't. Extending the backoff (#2142) buys marginal reliability because the primitive is wrong — by construction the poll can always miss by an unbounded margin.

## Fix

### 1. Unfreeze the DAG (\`namespace_governance.rs\`)

Wrap \`KeyDelivery\` side-effects in a closure whose errors are logged + surfaced via \`key_unwrap_failures\` but not propagated. DAG advance now succeeds regardless; children apply; an encrypted op that couldn't decode stays queued for later instead of freezing the entire namespace DAG.

### 2. Notifier replaces polling (\`registration_notify.rs\` + \`join_context.rs\`)

\`registration_notify::notify(context_id)\` is called from \`ContextRegistrationService::register()\` (inside \`apply_group_op_mutations\`) the instant the mapping is written. \`join_context\` subscribes **before** kicking \`sync_known_namespaces\`, then awaits the signal with a 30 s outer timeout and a 200 ms fallback poll for \`Lagged\`/\`Closed\` safety.

Typical subgroup-join latency drops from missed-by-1.4 ms (500) to **< 100 ms**.

A module-static \`OnceLock<broadcast::Sender<ContextId>>\` avoids threading the channel through \`NamespaceGovernance\`, \`ContextRegistrationService\`, and every call site of \`apply_group_op_mutations\`.

### 3. Diagnostics

Structured logging added at:
- \`sync/manager/mod.rs\` backfill apply — \`delta_id\`, \`op_kind\`, \`signer\`, \`nonce\`, \`op_bytes_len\` on failure, plus a hex prefix for outer borsh decode failures.
- \`group_keys.rs::decrypt_op\` — plaintext length + 32-byte hex prefix when the inner \`GroupOp\` borsh decode fails.

These fired in live testing and identified the exact failing variant (\`Root::KeyDelivery\` nonce 4).

## Files touched

| File | Change |
|------|--------|
| \`crates/context/src/registration_notify.rs\` (new) | Module-static \`broadcast::Sender<ContextId>\`, \`notify\` / \`subscribe\`. |
| \`crates/context/src/lib.rs\` | Expose module. |
| \`crates/context/src/group_store/mod.rs\` | Signal notifier from \`GroupOp::ContextRegistered\` arm. |
| \`crates/context/src/group_store/namespace_governance.rs\` | Isolate KeyDelivery side-effects. |
| \`crates/context/src/group_store/group_keys.rs\` | Plaintext-fingerprint logging on inner \`GroupOp\` decode failure. |
| \`crates/context/src/handlers/join_context.rs\` | subscribe → sync → await-signal replaces polling. |
| \`crates/node/src/sync/manager/mod.rs\` | Richer per-op apply-failure warning. |

## Test plan

- [x] \`cargo test -p calimero-context\` — 75 lib + 22 integration tests pass.
- [x] \`cargo check --workspace\` — clean.
- [x] \`cargo fmt --check\` — clean.
- [x] Reproduced original bug (merobox subgroup workflow + live two-node battleships) → confirmed \`context does not belong to any group\` 500s with the previous binary.
- [x] Applied this PR, rebuilt \`merod\`, re-ran the same flow → subgroup context joins succeed, \`WARN KeyDelivery side-effect failed; DAG apply continues\` appears when the codec issue fires, but the DAG advances and \`ContextRegistered\` for the subgroup applies.

## Out of scope

- The underlying \`GroupOp\` borsh schema drift causing \"Unexpected length of input\". This PR's diagnostics surface it but don't fix it. Follow-up once the specific drift is identified from logs.
- #2139 (event handlers not executed when deltas arrive via sync instead of broadcast) — pre-existing, independent bug that still affects gameplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace governance apply semantics and the `join_context` join flow; mistakes could mask real apply errors or cause joins to wait/timeout incorrectly under load or notifier lag.
> 
> **Overview**
> Fixes a stuck-sync failure mode by making `RootOp::KeyDelivery` side-effects best-effort: errors while unwrapping/storing a group key or retrying queued encrypted ops are now logged and recorded but **do not abort** namespace DAG application.
> 
> Replaces `join_context`’s backoff polling with an event-driven wait: a new `registration_notify` broadcast channel is signaled when `GroupOp::ContextRegistered` persists the context→group mapping, and `join_context` subscribes before syncing namespaces then waits (with timeout + fallback polling) for the signal.
> 
> Improves diagnostics for codec/schema mismatches by logging decrypted plaintext fingerprints on inner `GroupOp` decode failures and by adding richer metadata (e.g., `delta_id`, op kind, lengths/prefixes) when namespace backfill ops fail to decode or apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f9703a9efbe62abfcfacfd419e5c84717ae1db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->