### PR TITLE
fix(context): resolve signing keys via ancestor traversal instead of …

### DIFF
--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -105,7 +105,7 @@ pub use self::namespace_retry::NamespaceRetryService;
 pub use self::permission_checker::PermissionChecker;
 pub use self::signing_keys::{
     delete_all_group_signing_keys, delete_group_signing_key, get_group_signing_key,
-    require_group_signing_key, store_group_signing_key,
+    require_group_signing_key, resolve_group_signing_key, store_group_signing_key,
 };
 pub use self::tee::{is_quote_hash_used, read_tee_admission_policy, TeeAdmissionPolicy};
 pub use self::upgrades::{

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -16,7 +16,7 @@ use super::{
     get_group_for_context, get_group_member_role, get_op_head, remove_group_member,
 };
 
-const MAX_NAMESPACE_DEPTH: usize = 16;
+pub(crate) const MAX_NAMESPACE_DEPTH: usize = 16;
 
 #[derive(Debug, Clone, Copy)]
 pub struct NamespaceIdentityRecord {

--- a/crates/context/src/group_store/signing_keys.rs
+++ b/crates/context/src/group_store/signing_keys.rs
@@ -6,6 +6,8 @@ use eyre::{bail, Result as EyreResult};
 
 use super::{collect_keys_with_prefix, GroupStoreError};
 
+const MAX_ANCESTOR_DEPTH: usize = 16;
+
 pub fn store_group_signing_key(
     store: &Store,
     group_id: &ContextGroupId,
@@ -58,6 +60,27 @@ pub fn require_group_signing_key(
         });
     }
     Ok(())
+}
+
+/// Walk the ancestor chain from `group_id` upward looking for a signing key
+/// for `public_key`. Returns the first match found (closest ancestor), or
+/// `None` if no ancestor holds a key for this identity.
+pub fn resolve_group_signing_key(
+    store: &Store,
+    group_id: &ContextGroupId,
+    public_key: &PublicKey,
+) -> EyreResult<Option<[u8; 32]>> {
+    let mut current = *group_id;
+    for _ in 0..MAX_ANCESTOR_DEPTH {
+        if let Some(sk) = get_group_signing_key(store, &current, public_key)? {
+            return Ok(Some(sk));
+        }
+        match super::get_parent_group(store, &current)? {
+            Some(parent) => current = parent,
+            None => return Ok(None),
+        }
+    }
+    Ok(None)
 }
 
 /// Delete all signing keys for a group (used during group deletion).

--- a/crates/context/src/group_store/signing_keys.rs
+++ b/crates/context/src/group_store/signing_keys.rs
@@ -4,9 +4,7 @@ use calimero_store::key::{GroupSigningKey, GroupSigningKeyValue, GROUP_SIGNING_K
 use calimero_store::Store;
 use eyre::{bail, Result as EyreResult};
 
-use super::{collect_keys_with_prefix, GroupStoreError};
-
-const MAX_ANCESTOR_DEPTH: usize = 16;
+use super::{collect_keys_with_prefix, namespace::MAX_NAMESPACE_DEPTH, GroupStoreError};
 
 pub fn store_group_signing_key(
     store: &Store,
@@ -71,7 +69,7 @@ pub fn resolve_group_signing_key(
     public_key: &PublicKey,
 ) -> EyreResult<Option<[u8; 32]>> {
     let mut current = *group_id;
-    for _ in 0..MAX_ANCESTOR_DEPTH {
+    for _ in 0..MAX_NAMESPACE_DEPTH {
         if let Some(sk) = get_group_signing_key(store, &current, public_key)? {
             return Ok(Some(sk));
         }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -196,14 +196,11 @@ impl ContextManager {
             group_store::require_group_admin(&self.datastore, group_id, &requester)?;
         }
 
-        let signing_key = group_store::resolve_group_signing_key(
-            &self.datastore,
-            group_id,
-            &requester,
-        )?
-        .ok_or_else(|| {
-            eyre::eyre!("local group governance requires a signing key for the requester")
-        })?;
+        let signing_key =
+            group_store::resolve_group_signing_key(&self.datastore, group_id, &requester)?
+                .ok_or_else(|| {
+                    eyre::eyre!("local group governance requires a signing key for the requester")
+                })?;
 
         Ok(GovernancePreflight {
             requester,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -179,20 +179,15 @@ impl ContextManager {
         requester: Option<calimero_primitives::identity::PublicKey>,
         require_admin: bool,
     ) -> eyre::Result<GovernancePreflight> {
-        let node_identity = self.node_namespace_identity(group_id);
-
         let requester = match requester {
             Some(pk) => pk,
-            None => match node_identity {
-                Some((pk, _)) => pk,
-                None => {
-                    eyre::bail!("requester not provided and node has no configured group identity")
-                }
-            },
+            None => self
+                .node_namespace_identity(group_id)
+                .map(|(pk, _)| pk)
+                .ok_or_else(|| {
+                    eyre::eyre!("requester not provided and node has no configured group identity")
+                })?,
         };
-
-        let node_sk = node_identity.map(|(_, sk)| sk);
-        let signing_key = node_sk;
 
         if group_store::load_group_meta(&self.datastore, group_id)?.is_none() {
             eyre::bail!("group '{group_id:?}' not found");
@@ -200,27 +195,19 @@ impl ContextManager {
         if require_admin {
             group_store::require_group_admin(&self.datastore, group_id, &requester)?;
         }
-        if signing_key.is_none() {
-            group_store::require_group_signing_key(&self.datastore, group_id, &requester)?;
-        }
 
-        if let Some(ref sk) = signing_key {
-            let _ = group_store::store_group_signing_key(&self.datastore, group_id, &requester, sk);
-        }
-
-        let effective_signing_key = signing_key.or_else(|| {
-            group_store::get_group_signing_key(&self.datastore, group_id, &requester)
-                .ok()
-                .flatten()
-        });
-
-        let sk_bytes = effective_signing_key.ok_or_else(|| {
+        let signing_key = group_store::resolve_group_signing_key(
+            &self.datastore,
+            group_id,
+            &requester,
+        )?
+        .ok_or_else(|| {
             eyre::eyre!("local group governance requires a signing key for the requester")
         })?;
 
         Ok(GovernancePreflight {
             requester,
-            signing_key: sk_bytes,
+            signing_key,
             datastore: self.datastore.clone(),
             node_client: self.node_client.clone(),
         })


### PR DESCRIPTION
…per-group copies

governance_preflight previously required each child group to have its own copy of the signing key, which create_group_in_namespace never stored. This caused add_group_members (and other governance ops) to fail on namespace-created child groups.

Replace the direct key lookup with resolve_group_signing_key, which walks the parent chain upward until it finds a signing key for the requester. This means revoking a key at the namespace level automatically prevents all descendant groups from using it — no stale copies to clean up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signing-key resolution for governance operations, which can affect authorization/signing behavior across nested groups; traversal is bounded but may surface new edge cases with incorrect parent links or missing keys.
> 
> **Overview**
> Fixes local governance preflight to **resolve a requester’s signing key by walking up the group’s parent (namespace) chain**, rather than requiring each child group to store its own copy.
> 
> Adds `resolve_group_signing_key` (bounded by `MAX_NAMESPACE_DEPTH`) and exposes it via `group_store`, and makes `MAX_NAMESPACE_DEPTH` visible to sibling modules to share traversal limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b161365a82c8dc845fff25bc4ce1891af96d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->