### PR TITLE
fix(ci): trigger release-image E2E after Release workflow completes

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -3,18 +3,19 @@ name: E2E - Rust Apps (Released Image)
 # Tests e2e-kv-store and xcall-example apps using the released Docker image from GHCR.
 # Validates that released images work correctly on master merges.
 # For fast PR testing with locally-built images, see e2e-rust-apps.yml
+#
+# Triggered after the Release workflow completes (not on push) to avoid a race
+# where this workflow pulls a stale `edge` image before Release publishes the
+# new one.
 
 permissions:
   contents: read
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
     branches: [master]
-    paths:
-      - "crates/**"
-      - "apps/e2e-kv-store/**"
-      - "apps/xcall-example/**"
-      - ".github/workflows/e2e-rust-apps-release.yml"
 
   workflow_dispatch:
 
@@ -31,6 +32,9 @@ env:
 jobs:
   build-apps:
     name: Build Apps
+    # Only run if Release succeeded (workflow_run fires on both success and failure)
+    # Always run for manual workflow_dispatch triggers
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04-8cpu
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- The `E2E - Rust Apps (Released Image)` workflow was racing with the `Release` workflow — both triggered on `push` to master, but E2E pulled the stale `edge` Docker image before Release published the new one
- Changed trigger from `push` to `workflow_run` on the Release workflow, so E2E only starts after the new image is available
- Added guard to skip if Release failed

## The race

```
push to master
  ├── Release workflow (builds + publishes merod:edge)  ~10min
  └── E2E Release workflow (pulls merod:edge)           ~2min to start
                                                        ↑ stale image!
```

## After fix

```
push to master
  └── Release workflow (builds + publishes merod:edge)  ~10min
        └── E2E Release workflow (pulls merod:edge)     ← fresh image
```

The local-build E2E (`E2E - Rust Apps`) is unaffected — it builds `merod:local` from source and continues to run on `push`.

## Test plan

- [x] `E2E - Rust Apps` (local build) already passes on master
- [ ] After merge, next Release completion should trigger `E2E - Rust Apps (Released Image)` with the correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only trigger/condition change; main risk is reduced test coverage if the `workflow_run` filter or conclusion check is misconfigured.
> 
> **Overview**
> Ensures `E2E - Rust Apps (Released Image)` no longer runs on `push` to `master`, and instead triggers via `workflow_run` after the `Release` workflow completes to avoid pulling a stale `edge` Docker image.
> 
> Adds a job-level guard so `build-apps` only runs when the triggering `Release` run succeeded (while still allowing manual `workflow_dispatch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc5f3c8396c57f3677b7f07a6ce82a938ff65c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->