### PR TITLE
fix(ci): pin release E2E checkout to triggering commit SHA

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -81,6 +83,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Follows up on #2149. Under `workflow_run`, `actions/checkout` defaults to HEAD of the default branch, not the commit that triggered the Release workflow. If another push lands on master while Release is running, E2E checks out newer code but pulls a Docker image built from the older commit — reintroducing the code/image mismatch.

Pins both checkout steps to `${{ github.event.workflow_run.head_sha }}` (falls back to `github.sha` for manual `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that just pins `actions/checkout` to a specific SHA; low blast radius but could affect which commit the E2E workflow executes.
> 
> **Overview**
> Ensures `.github/workflows/e2e-rust-apps-release.yml` checks out the *same commit* that triggered the `Release` workflow when running under `workflow_run`.
> 
> Both the `build-apps` and `test` jobs now pass `ref: ${{ github.event.workflow_run.head_sha || github.sha }}` to `actions/checkout`, preventing races where E2E tests run newer code against an older released Docker image (with a fallback for manual `workflow_dispatch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc729dce400b1f48fee59ea68d71a371becc6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->