### PR TITLE
feat: add group-membership e2e workflow and upgrade group-subgroup

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -126,6 +126,9 @@ jobs:
           - workflow: group-subgroup
             file: workflows/group-subgroup.yml
             app: e2e-kv-store
+          - workflow: group-membership
+            file: workflows/group-membership.yml
+            app: e2e-kv-store
           - workflow: group-multi-service
             file: workflows/group-multi-service.yml
             app: e2e-kv-store

--- a/apps/e2e-kv-store/workflows/group-membership.yml
+++ b/apps/e2e-kv-store/workflows/group-membership.yml
@@ -1,0 +1,209 @@
+name: E2E KV Store - Group Membership
+description: >
+  Tests group membership operations: adding members to a subgroup,
+  verifying member lists, removing members, and verifying removed
+  members lose access. This is the core scenario for the namespace
+  signing key hierarchy fix.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: install app, create namespace, invite all nodes ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  # --- SCENARIO 1: List namespace members ---
+
+  - name: List namespace members on node-1
+    type: list_group_members
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      ns_members: members
+
+  - name: Assert namespace has members
+    type: assert
+    statements:
+      - "is_set({{ns_members}})"
+
+  # --- SCENARIO 2: Create subgroup and add member via add_group_members ---
+  # This is the exact scenario that triggered the signing key bug:
+  # create_group_in_namespace + add_group_members on the child group.
+
+  - name: Create subgroup
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: test-subgroup
+    outputs:
+      subgroup_id: groupId
+
+  - name: Assert subgroup created
+    type: assert
+    statements:
+      - "is_set({{subgroup_id}})"
+
+  - name: Add node-2 to subgroup
+    type: add_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{identity_node2}}'
+        role: Member
+
+  # --- SCENARIO 3: Verify subgroup membership ---
+
+  - name: List subgroup members
+    type: list_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      subgroup_members: members
+
+  - name: Assert subgroup has members
+    type: assert
+    statements:
+      - "is_set({{subgroup_members}})"
+
+  # --- SCENARIO 4: Create context in subgroup and verify it works ---
+
+  - name: Create context in subgroup
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      sub_ctx_id: contextId
+
+  - name: Assert subgroup context created
+    type: assert
+    statements:
+      - "is_set({{sub_ctx_id}})"
+
+  - name: Node-2 joins subgroup context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+    outputs:
+      sub_ctx_key_node2: memberPublicKey
+
+  - name: Node-1 writes to subgroup context
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args:
+      key: "subgroup_key"
+      value: "from_subgroup"
+
+  - name: Wait for subgroup sync
+    type: wait_for_sync
+    context_id: '{{sub_ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads subgroup context value
+    type: call
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+    method: get
+    args:
+      key: "subgroup_key"
+    outputs:
+      subgroup_read: result
+
+  - name: Assert subgroup context synced
+    type: json_assert
+    statements:
+      - 'json_equal({{subgroup_read}}, {"output": "from_subgroup"})'
+
+  # --- SCENARIO 5: Remove node-2 from subgroup ---
+
+  - name: Remove node-2 from subgroup
+    type: remove_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - '{{identity_node2}}'
+
+  - name: List subgroup members after removal
+    type: list_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      subgroup_members_after: members
+
+  # Node-2 was removed but node-1 (admin) should still be there
+  - name: Assert subgroup still has admin member
+    type: assert
+    statements:
+      - "is_set({{subgroup_members_after}})"
+
+  # --- SCENARIO 6: Get group info ---
+
+  - name: Get subgroup info
+    type: get_group_info
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      group_info: data
+
+  - name: Assert group info returned
+    type: assert
+    statements:
+      - "is_set({{group_info}})"
+
+stop_all_nodes: false

--- a/apps/e2e-kv-store/workflows/group-membership.yml
+++ b/apps/e2e-kv-store/workflows/group-membership.yml
@@ -170,7 +170,21 @@ steps:
     statements:
       - 'json_equal({{subgroup_read}}, {"output": "from_subgroup"})'
 
-  # --- SCENARIO 5: Remove node-2 from subgroup ---
+  # --- SCENARIO 5: Node-3 (namespace member, NOT in subgroup) cannot call subgroup context ---
+  # Node-3 joined the namespace but was never added to the subgroup.
+  # A call to the subgroup context should fail.
+
+  - name: Node-3 calls subgroup context (should fail - not a subgroup member)
+    type: call
+    node: e2e-node-3
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args:
+      key: "node3_key"
+      value: "should_not_work"
+    expected_failure: true
+
+  # --- SCENARIO 6: Remove node-2 from subgroup and verify access revoked ---
 
   - name: Remove node-2 from subgroup
     type: remove_group_members
@@ -192,7 +206,18 @@ steps:
     statements:
       - "is_set({{subgroup_members_after}})"
 
-  # --- SCENARIO 6: Get group info ---
+  # Verify node-2 can no longer write to the subgroup context
+  - name: Node-2 writes to subgroup context after removal (should fail)
+    type: call
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args:
+      key: "revoked_key"
+      value: "should_not_work"
+    expected_failure: true
+
+  # --- SCENARIO 7: Get group info ---
 
   - name: Get subgroup info
     type: get_group_info

--- a/apps/e2e-kv-store/workflows/group-subgroup.yml
+++ b/apps/e2e-kv-store/workflows/group-subgroup.yml
@@ -1,13 +1,12 @@
 name: E2E KV Store - Subgroup Lifecycle
 description: >
-  Tests the create_group_in_namespace API path alongside normal namespace
-  operations. A subgroup is created inside the namespace, then the subgroup
-  is verified via list_subgroups. Context operations on the namespace root
-  run in parallel to prove the two tiers co-exist correctly.
-
-  NOTE: Full per-subgroup permission isolation (namespace member cannot join
-  a context scoped to a subgroup they are not in) requires add_group_members
-  merobox support — tracked separately.
+  Tests subgroup creation, listing, and context operations within
+  subgroups. Verifies that:
+    1. Subgroups can be created inside a namespace
+    2. Subgroups appear in the list_subgroups listing
+    3. Namespace-root context operations are unaffected by subgroups
+    4. Contexts can be created and used within subgroups
+    5. Subgroup and root contexts are fully isolated
 
 force_pull_image: false
 near_devnet: false
@@ -53,15 +52,15 @@ steps:
     application_id: '{{app_id}}'
     group_id: '{{namespace_id}}'
     outputs:
-      ctx_id: contextId
+      root_ctx_id: contextId
       ctx_key_node1: memberPublicKey
 
   - name: Assert context created
     type: assert
     statements:
-      - "is_set({{ctx_id}})"
+      - "is_set({{root_ctx_id}})"
 
-  # --- Node-2 joins namespace and context ---
+  # --- Node-2 joins namespace and root context ---
 
   - name: Create namespace invitation for node-2
     type: create_namespace_invitation
@@ -78,27 +77,27 @@ steps:
     outputs:
       member_identity_node2: memberIdentity
 
-  - name: Node-2 joins context via namespace membership
+  - name: Node-2 joins root context
     type: join_context
     node: e2e-node-2
-    context_id: '{{ctx_id}}'
+    context_id: '{{root_ctx_id}}'
     outputs:
       ctx_key_node2: memberPublicKey
 
   # --- SCENARIO 1: Verify namespace-root context sync works ---
 
-  - name: Node-1 writes to namespace-root context
+  - name: Node-1 writes to root context
     type: call
     node: e2e-node-1
-    context_id: '{{ctx_id}}'
+    context_id: '{{root_ctx_id}}'
     method: set
     args:
       key: "ns_root_key"
       value: "from_node1"
 
-  - name: Wait for sync
+  - name: Wait for root context sync
     type: wait_for_sync
-    context_id: '{{ctx_id}}'
+    context_id: '{{root_ctx_id}}'
     nodes:
       - e2e-node-1
       - e2e-node-2
@@ -106,31 +105,36 @@ steps:
     check_interval: 2
     trigger_sync: true
 
-  - name: Node-2 reads namespace-root context value
+  - name: Node-2 reads root context value
     type: call
     node: e2e-node-2
-    context_id: '{{ctx_id}}'
+    context_id: '{{root_ctx_id}}'
     method: get
     args:
       key: "ns_root_key"
     outputs:
       ns_root_read: result
 
-  - name: Assert namespace-root context synced
+  - name: Assert root context synced
     type: json_assert
     statements:
       - 'json_equal({{ns_root_read}}, {"output": "from_node1"})'
 
-  # --- SCENARIO 2: Create subgroup inside the namespace ---
+  # --- SCENARIO 2: Create subgroup and verify listing ---
 
   - name: Create subgroup inside namespace on node-1
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
     group_alias: match-subgroup
+    outputs:
+      subgroup_id: groupId
 
-  # Verify the subgroup appears in the namespace's subgroup list.
-  # list_subgroups takes the PARENT group id (the namespace root here).
+  - name: Assert subgroup created
+    type: assert
+    statements:
+      - "is_set({{subgroup_id}})"
+
   - name: List subgroups of namespace on node-1
     type: list_subgroups
     node: e2e-node-1
@@ -143,20 +147,114 @@ steps:
     statements:
       - "is_set({{subgroups_node1}})"
 
-  # --- SCENARIO 3: Namespace-root context is unaffected by subgroup creation ---
+  # --- SCENARIO 3: Add member to subgroup and create context in it ---
 
-  - name: Node-2 writes to namespace-root context after subgroup created
+  - name: Add node-2 to subgroup
+    type: add_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{member_identity_node2}}'
+        role: Member
+
+  - name: Create context in subgroup
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      sub_ctx_id: contextId
+
+  - name: Assert subgroup context created
+    type: assert
+    statements:
+      - "is_set({{sub_ctx_id}})"
+
+  - name: Node-2 joins subgroup context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+
+  - name: Node-1 writes to subgroup context
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args:
+      key: "sub_key"
+      value: "from_subgroup"
+
+  - name: Wait for subgroup context sync
+    type: wait_for_sync
+    context_id: '{{sub_ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads subgroup context value
     type: call
     node: e2e-node-2
-    context_id: '{{ctx_id}}'
+    context_id: '{{sub_ctx_id}}'
+    method: get
+    args:
+      key: "sub_key"
+    outputs:
+      sub_read: result
+
+  - name: Assert subgroup context synced
+    type: json_assert
+    statements:
+      - 'json_equal({{sub_read}}, {"output": "from_subgroup"})'
+
+  # --- SCENARIO 4: Root and subgroup contexts are isolated ---
+
+  - name: Check subgroup key NOT in root context
+    type: call
+    node: e2e-node-1
+    context_id: '{{root_ctx_id}}'
+    method: get
+    args:
+      key: "sub_key"
+    outputs:
+      root_cross_read: result
+
+  - name: Assert root context does not have subgroup key
+    type: json_assert
+    statements:
+      - 'json_equal({{root_cross_read}}, {"output": null})'
+
+  - name: Check root key NOT in subgroup context
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: get
+    args:
+      key: "ns_root_key"
+    outputs:
+      sub_cross_read: result
+
+  - name: Assert subgroup context does not have root key
+    type: json_assert
+    statements:
+      - 'json_equal({{sub_cross_read}}, {"output": null})'
+
+  # --- SCENARIO 5: Root context still works after subgroup operations ---
+
+  - name: Node-2 writes to root context after subgroup ops
+    type: call
+    node: e2e-node-2
+    context_id: '{{root_ctx_id}}'
     method: set
     args:
       key: "post_subgroup_key"
       value: "still_works"
 
-  - name: Wait for sync after subgroup creation
+  - name: Wait for root sync after subgroup ops
     type: wait_for_sync
-    context_id: '{{ctx_id}}'
+    context_id: '{{root_ctx_id}}'
     nodes:
       - e2e-node-1
       - e2e-node-2
@@ -167,14 +265,14 @@ steps:
   - name: Node-1 reads post-subgroup key
     type: call
     node: e2e-node-1
-    context_id: '{{ctx_id}}'
+    context_id: '{{root_ctx_id}}'
     method: get
     args:
       key: "post_subgroup_key"
     outputs:
       post_subgroup_read: result
 
-  - name: Assert namespace-root context unaffected
+  - name: Assert root context unaffected
     type: json_assert
     statements:
       - 'json_equal({{post_subgroup_read}}, {"output": "still_works"})'

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -186,7 +186,9 @@ async fn list_group_members() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path(format!("/admin-api/groups/{GID}/members")))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"members": []})),
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -194,7 +196,7 @@ async fn list_group_members() {
     let client = make_client(&Url::parse(&server.uri()).unwrap());
     let resp = client.list_group_members(GID).await.unwrap();
 
-    assert!(resp.data.is_empty());
+    assert!(resp.members.is_empty());
 }
 
 #[tokio::test]

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -186,9 +186,7 @@ async fn list_group_members() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path(format!("/admin-api/groups/{GID}/members")))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!({"members": []})),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"members": []})))
         .expect(1)
         .mount(&server)
         .await;

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -311,7 +311,7 @@ impl CheckAccessCommand {
 
         let caps = caps_response.data.capabilities;
         let role = members_response
-            .data
+            .members
             .iter()
             .find(|m| m.identity == self.identity)
             .map(|m| format!("{:?}", m.role).to_lowercase())

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -225,7 +225,7 @@ impl Report for UpdateGroupSettingsApiResponse {
 
 impl Report for ListGroupMembersApiResponse {
     fn report(&self) {
-        if self.data.is_empty() {
+        if self.members.is_empty() {
             println!("No members found in group");
         } else {
             let mut table = Table::new();
@@ -233,7 +233,7 @@ impl Report for ListGroupMembersApiResponse {
                 Cell::new("Identity").fg(Color::Blue),
                 Cell::new("Role").fg(Color::Blue),
             ]);
-            for member in &self.data {
+            for member in &self.members {
                 let _ = table.add_row(vec![
                     member.identity.to_string(),
                     format!("{:?}", member.role),

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1685,9 +1685,9 @@ impl Validate for RemoveGroupMembersApiRequest {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListGroupMembersApiResponse {
-    pub data: Vec<GroupMemberApiEntry>,
+    pub members: Vec<GroupMemberApiEntry>,
     /// The calling node's own group-level identity (SignerId), so clients
-    /// can identify which entry in `data` represents the current user.
+    /// can identify which entry in `members` represents the current user.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub self_identity: Option<PublicKey>,
 }

--- a/crates/server/src/admin/handlers/groups/list_group_members.rs
+++ b/crates/server/src/admin/handlers/groups/list_group_members.rs
@@ -52,7 +52,7 @@ pub async fn handler(
                 .collect();
             ApiResponse {
                 payload: ListGroupMembersApiResponse {
-                    data: entries,
+                    members: entries,
                     self_identity: Some(resp.self_identity),
                 },
             }


### PR DESCRIPTION
New workflow: group-membership.yml
Tests the core membership lifecycle that the signing key hierarchy fix enables:
- List namespace members
- Create subgroup + add members via add_group_members
- Create context in subgroup and verify sync (exact signing key bug scenario)
- Remove member from subgroup via remove_group_members
- Get group info

Upgraded workflow: group-subgroup.yml
Previously only created a subgroup and listed it. Now also:
- Adds member to subgroup
- Creates context in subgroup and verifies CRDT sync works
- Verifies root and subgroup contexts are fully isolated
- Verifies root context is unaffected by subgroup operations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JSON contract for `list_group_members` (`data` -> `members`), which can break any out-of-tree clients expecting the old field; e2e workflow additions mainly increase test coverage.
> 
> **Overview**
> Adds a new e2e workflow (`group-membership`) and wires it into the Rust app e2e GitHub Actions matrix to exercise subgroup membership lifecycle (add/list/remove members), subgroup context access control, and access revocation.
> 
> Expands the existing `group-subgroup` e2e workflow to cover adding a subgroup member, creating/syncing a subgroup-scoped context, and asserting isolation between root and subgroup contexts.
> 
> Renames the `list_group_members` admin API response field from `data` to `members` across server primitives/handler and updates downstream consumers (`crates/client` tests and `meroctl` CLI output/role lookup) to match the new JSON shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607fc4c33ceb153d864175007e123dfb72553cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->