### PR TITLE
fix(ci): install calimero-client-py from git, not PyPI

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -29,7 +29,10 @@ runs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install uv
+        # Install calimero-client-py from git first so it takes priority
+        # over the stale PyPI version when merobox resolves dependencies.
         uv pip install --system \
+          "calimero-client-py @ git+https://github.com/calimero-network/calimero-client-py.git@master" \
           "merobox @ git+https://github.com/calimero-network/merobox.git@master"
 
     - name: Verify merobox installation


### PR DESCRIPTION
## Summary

`group-membership` e2e test has been failing on master because `calimero-client-py` from PyPI (v0.5.2) has a stale `Cargo.lock` pinned to a core commit before the `ListGroupMembersApiResponse` field rename (`data` → `members`).

The fix: install `calimero-client-py` from git alongside merobox in the setup-merobox action, so it builds from the latest `Cargo.lock` which points to current core master.

## Root cause chain

1. Core #2152 renamed `ListGroupMembersApiResponse.data` → `.members`
2. `calimero-client-py` on PyPI (0.5.2) has `Cargo.lock` pinned to old core
3. merobox's `pyproject.toml` declares `calimero-client-py>=0.5.2` → resolves from PyPI
4. `uv pip install merobox@git+...` pulls the PyPI version of calimero-client-py
5. The old client tries to deserialize `members` as `data` → fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adjusts dependency resolution for merobox installs; main risk is transient breakage if the referenced git `master` branch changes unexpectedly.
> 
> **Overview**
> Ensures CI installs a *current* `calimero-client-py` by explicitly installing it from the upstream git `master` **before** installing `merobox`, so dependency resolution doesn’t pull the stale PyPI release.
> 
> This updates the `.github/actions/setup-merobox` composite action’s install step to pin both packages to git sources and rely on install order to prioritize the git-built client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff1fb8dd31a0de7d7ed101cfb737a71d6196037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->