### PR TITLE
chore: bump node version to rc25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.24"
+version = "0.10.1-rc.25"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
## chore: bump node version to rc25

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that affects crate versioning/release outputs but not runtime behavior.
> 
> **Overview**
> Updates the workspace metadata version in `Cargo.toml`, bumping the shared crate version from `0.10.1-rc.24` to `0.10.1-rc.25` for the next release candidate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9508abe7f461b7d9a596819bfbb5a50eea78fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->