### PR TITLE
fix: add governance propagation waits to prevent join_context race

### DIFF
--- a/apps/e2e-kv-store/workflows/group-membership.yml
+++ b/apps/e2e-kv-store/workflows/group-membership.yml
@@ -129,6 +129,10 @@ steps:
     statements:
       - "is_set({{sub_ctx_id}})"
 
+  - name: Wait for membership and context governance propagation
+    type: wait
+    seconds: 5
+
   - name: Node-2 joins subgroup context
     type: join_context
     node: e2e-node-2

--- a/apps/e2e-kv-store/workflows/group-subgroup.yml
+++ b/apps/e2e-kv-store/workflows/group-subgroup.yml
@@ -170,6 +170,10 @@ steps:
     statements:
       - "is_set({{sub_ctx_id}})"
 
+  - name: Wait for membership and context governance propagation
+    type: wait
+    seconds: 5
+
   - name: Node-2 joins subgroup context
     type: join_context
     node: e2e-node-2


### PR DESCRIPTION
## Summary

Adds 5s propagation waits before `join_context` on subgroup contexts in both `group-subgroup` and `group-membership` workflows.

## Root cause analysis

The `join_context` failures we saw were **not** a code bug:

1. **"Unexpected length of input"** — borsh schema mismatch in `KeyDelivery` side-effect retry path. This is intentionally non-fatal (DAG apply continues). It happens when ops from different code versions are replayed during governance DAG processing.

2. **"identity is not a member"** — timing race. `add_group_members` publishes a governance op that needs to propagate to node-2 via gossipsub before `join_context` can succeed. Without a wait, the join can happen before the membership op arrives.

3. **The old `calimero-client-py` deserialization errors** — caused by the stale `Cargo.lock` pointing to a core version before the `ListGroupMembersApiResponse` field rename. Already fixed by calimero-client-py#30 and core#2155.

The `group-subgroup` workflow currently passes on master, but the race is latent. This PR makes it robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only timing change that adds a fixed delay to reduce e2e flakiness; main impact is slightly longer test runtime and potential for still-flaky behavior if 5s is insufficient.
> 
> **Overview**
> Adds a **5s `wait` step** before `join_context` for newly created subgroup contexts in the `group-membership` and `group-subgroup` e2e workflows to avoid race conditions where membership/governance updates haven’t propagated to the joining node yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987e0dd0afa31fdf48fa3c7abe5176f9d95808e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->