### PR TITLE
feat: re-add group-nesting e2e workflow

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -151,6 +151,9 @@ jobs:
           - workflow: group-capabilities
             file: workflows/group-capabilities.yml
             app: e2e-kv-store
+          - workflow: group-nesting
+            file: workflows/group-nesting.yml
+            app: e2e-kv-store
           - workflow: group-multi-service
             file: workflows/group-multi-service.yml
             app: e2e-kv-store

--- a/apps/e2e-kv-store/workflows/group-nesting.yml
+++ b/apps/e2e-kv-store/workflows/group-nesting.yml
@@ -1,0 +1,200 @@
+name: E2E KV Store - Group Nesting
+description: >
+  Tests subgroup nesting operations:
+    1. Create subgroup via create_group_in_namespace, verify in listing
+    2. Unnest the group, verify it disappears from subgroup list
+    3. Re-nest via explicit nest_group, verify it reappears
+    4. Verify namespace root context is unaffected through all transitions
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace (parent group)
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      parent_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{parent_id}})"
+
+  - name: Invite node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{parent_id}}'
+    outputs:
+      invite: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{parent_id}}'
+    invitation: '{{invite}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  # Create a root context to verify it survives nest/unnest
+  - name: Create root context
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{parent_id}}'
+    outputs:
+      root_ctx_id: contextId
+
+  - name: Node-2 joins root context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{root_ctx_id}}'
+
+  - name: Write baseline to root context
+    type: call
+    node: e2e-node-1
+    context_id: '{{root_ctx_id}}'
+    method: set
+    args:
+      key: "baseline"
+      value: "before_nesting"
+
+  - name: Wait for baseline sync
+    type: wait_for_sync
+    context_id: '{{root_ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  # --- SCENARIO 1: Create child group, verify in listing ---
+
+  - name: Create child group via namespace
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{parent_id}}'
+    group_alias: nestable-child
+    outputs:
+      child_id: groupId
+
+  - name: Assert child group created
+    type: assert
+    statements:
+      - "is_set({{child_id}})"
+
+  - name: List subgroups after creation
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{parent_id}}'
+    outputs:
+      subs_after_create: subgroups
+
+  - name: Assert child is listed as subgroup
+    type: assert
+    statements:
+      - "is_set({{subs_after_create}})"
+
+  # --- SCENARIO 2: Unnest the child group, verify removal ---
+
+  - name: Unnest child from parent
+    type: unnest_group
+    node: e2e-node-1
+    parent_group_id: '{{parent_id}}'
+    child_group_id: '{{child_id}}'
+
+  - name: List subgroups after unnest
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{parent_id}}'
+    outputs:
+      subs_after_unnest: subgroups
+
+  - name: Assert subgroup list is empty after unnest
+    type: json_assert
+    statements:
+      - 'json_equal({{subs_after_unnest}}, [])'
+
+  # --- SCENARIO 3: Re-nest via explicit nest_group, verify it reappears ---
+
+  - name: Wait for unnest propagation
+    type: wait
+    seconds: 3
+
+  - name: Re-nest child under parent via nest_group
+    type: nest_group
+    node: e2e-node-1
+    parent_group_id: '{{parent_id}}'
+    child_group_id: '{{child_id}}'
+
+  - name: List subgroups after re-nest
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{parent_id}}'
+    outputs:
+      subs_after_renest: subgroups
+
+  - name: Assert child reappears in subgroup list
+    type: assert
+    statements:
+      - "is_set({{subs_after_renest}})"
+
+  # --- SCENARIO 4: Root context unaffected by nest/unnest ---
+
+  - name: Write after nest/unnest cycle
+    type: call
+    node: e2e-node-1
+    context_id: '{{root_ctx_id}}'
+    method: set
+    args:
+      key: "after_nesting"
+      value: "still_works"
+
+  - name: Wait for sync after nesting ops
+    type: wait_for_sync
+    context_id: '{{root_ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads after nesting cycle
+    type: call
+    node: e2e-node-2
+    context_id: '{{root_ctx_id}}'
+    method: get
+    args:
+      key: "after_nesting"
+    outputs:
+      after_nest_read: result
+
+  - name: Assert root context works after nest/unnest
+    type: json_assert
+    statements:
+      - 'json_equal({{after_nest_read}}, {"output": "still_works"})'
+
+stop_all_nodes: false


### PR DESCRIPTION
Re-adds the nest/unnest/re-nest e2e workflow that was removed due to the unnest_group API failure. Root cause: calimero-client-py was using wrong endpoints (fixed in calimero-client-py#32). Depends on calimero-client-py#33 (Cargo.lock update) being merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI coverage by adding a new E2E workflow to the Rust apps matrix, which can introduce new pipeline failures/flakiness but does not affect production code paths.
> 
> **Overview**
> Re-adds the `group-nesting` E2E run to `.github/workflows/e2e-rust-apps.yml` so it executes in the Rust apps workflow matrix.
> 
> Adds a new `apps/e2e-kv-store/workflows/group-nesting.yml` test that creates a namespace and subgroup, performs `unnest_group` then `nest_group`, asserts subgroup listing changes accordingly, and verifies an existing root context continues to replicate data across nodes throughout the nesting transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e3fd1fb5846af96e07942c3ebc21f4904b6626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->