### PR TITLE
chore: fix nested workflow

### DIFF
--- a/apps/e2e-kv-store/workflows/group-nesting.yml
+++ b/apps/e2e-kv-store/workflows/group-nesting.yml
@@ -54,8 +54,6 @@ steps:
     node: e2e-node-2
     namespace_id: '{{parent_id}}'
     invitation: '{{invite}}'
-    outputs:
-      identity_node2: memberIdentity
 
   # Create a root context to verify it survives nest/unnest
   - name: Create root context
@@ -89,6 +87,21 @@ steps:
     timeout: 60
     check_interval: 2
     trigger_sync: true
+
+  - name: Node-2 reads baseline
+    type: call
+    node: e2e-node-2
+    context_id: '{{root_ctx_id}}'
+    method: get
+    args:
+      key: "baseline"
+    outputs:
+      baseline_read: result
+
+  - name: Assert baseline synced
+    type: json_assert
+    statements:
+      - 'json_equal({{baseline_read}}, {"output": "before_nesting"})'
 
   # --- SCENARIO 1: Create child group, verify in listing ---
 
@@ -138,10 +151,6 @@ steps:
       - 'json_equal({{subs_after_unnest}}, [])'
 
   # --- SCENARIO 3: Re-nest via explicit nest_group, verify it reappears ---
-
-  - name: Wait for unnest propagation
-    type: wait
-    seconds: 3
 
   - name: Re-nest child under parent via nest_group
     type: nest_group


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because it only adjusts E2E test workflow steps and assertions; main impact is potentially changing test timing/flake behavior.
> 
> **Overview**
> Improves the `apps/e2e-kv-store/workflows/group-nesting.yml` E2E workflow by adding an explicit read+`json_assert` on node-2 after the initial `wait_for_sync`, ensuring the baseline value actually replicated before subgroup operations begin.
> 
> Cleans up the workflow by removing an unused `join_namespace` output and dropping a fixed `wait` before re-nesting, relying on explicit assertions/sync checks instead of sleeps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0725dfe85aed6248f72c613d81d7cd807cd10a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->