### PR TITLE
docs: update architecture for SRP split and governance refactoring

### DIFF
--- a/architecture/crates/context.html
+++ b/architecture/crates/context.html
@@ -266,6 +266,32 @@
      5. GROUPSTORE DEEP-DIVE
      ════════════════════════════════════════════════════════ -->
 <div class="card gb">
+<h2>Governance Preflight &amp; Signing Key Resolution</h2>
+<p style="margin-bottom:18px;">Every governance mutation handler calls <span class="code">governance_preflight()</span> before signing and publishing. The common pattern is encapsulated in <span class="code">sign_and_publish_group_op()</span> which handles the boilerplate.</p>
+
+<h3>governance_preflight Flow</h3>
+<div class="step"><div class="n">1</div><div class="sd"><strong>Resolve requester identity</strong> &mdash; from explicit parameter, or fall back to <span class="code">node_namespace_identity()</span> which walks the parent chain to the namespace root</div></div>
+<div class="step"><div class="n">2</div><div class="sd"><strong>Verify group exists</strong> &mdash; <span class="code">load_group_meta()</span> must return <span class="code">Some</span></div></div>
+<div class="step"><div class="n">3</div><div class="sd"><strong>Admin check</strong> (optional) &mdash; <span class="code">require_group_admin()</span> if <span class="code">require_admin=true</span></div></div>
+<div class="step"><div class="n">4</div><div class="sd"><strong>Resolve signing key via ancestor walk</strong> &mdash; <span class="code">resolve_group_signing_key()</span> checks self, then walks parent chain up to <span class="code">MAX_NAMESPACE_DEPTH</span> (16) levels. Returns the first signing key found for the requester identity.</div></div>
+
+<h3 style="margin-top:24px;">Signing Key Hierarchy</h3>
+<p style="margin-bottom:12px;">When a child group is created via <span class="code">create_group_in_namespace</span>, the signing key is stored only at the namespace root. Child groups resolve signing authority by walking up the parent chain:</p>
+<div class="typedef">
+<span class="comment">// resolve_group_signing_key (signing_keys.rs)</span><br>
+<span class="kw">for</span> _ <span class="kw">in</span> 0..<span class="ty">MAX_NAMESPACE_DEPTH</span> {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="kw">if let</span> <span class="ty">Some</span>(sk) = get_group_signing_key(store, &amp;current, public_key)? {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="kw">return</span> <span class="ty">Ok</span>(<span class="ty">Some</span>(sk));<br>
+&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+&nbsp;&nbsp;&nbsp;&nbsp;current = get_parent_group(store, &amp;current)?; <span class="comment">// walk up</span><br>
+}<br>
+get_group_signing_key(store, &amp;current, public_key) <span class="comment">// final check at root</span>
+</div>
+<p style="margin-top:12px;">Key revocation at the namespace level automatically propagates &mdash; child groups lose access because the ancestor walk finds nothing. No stale copies to clean up.</p>
+
+<h3 style="margin-top:24px;">sign_and_publish_group_op Helper</h3>
+<p style="margin-bottom:12px;">Encapsulates the governance handler boilerplate: preflight &rarr; clone datastore/node_client &rarr; build signer &rarr; sign, apply, publish via async actor response. Used by 7 handlers (set_group_alias, set_default_capabilities, set_default_visibility, update_group_settings, set_member_alias, set_member_capabilities, update_member_role).</p>
+
 <h2>GroupStore Deep-Dive</h2>
 <p style="margin-bottom:18px;">The authoritative persistence layer for all group and governance state. Handles signature verification, state-hash optimistic locking, nonce-based idempotency, DAG maintenance, and cascading side effects.</p>
 

--- a/architecture/crates/node.html
+++ b/architecture/crates/node.html
@@ -66,7 +66,10 @@
 
 <h3 style="margin-top:24px;">calimero-node-primitives</h3>
 <div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client.rs" target="_blank" rel="noopener">primitives/src/client.rs</a></div><div class="fd">NodeClient façade — subscribe, broadcast, heartbeat, group ops, sync trigger</div></div>
-<div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/application.rs" target="_blank" rel="noopener">client/application.rs</a></div><div class="fd">Application install / uninstall / list / bundle operations</div></div>
+<div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/application.rs" target="_blank" rel="noopener">client/application.rs</a></div><div class="fd">Application module root &mdash; get/has app, module declarations</div></div>
+<div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/application/install.rs" target="_blank" rel="noopener">client/application/install.rs</a></div><div class="fd">All installation paths (path, URL, blob, bundle), uninstall, artifact extraction</div></div>
+<div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/application/bundle.rs" target="_blank" rel="noopener">client/application/bundle.rs</a></div><div class="fd">Bundle manifest verification, signature validation, path safety checks</div></div>
+<div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/application/query.rs" target="_blank" rel="noopener">client/application/query.rs</a></div><div class="fd">List applications, packages, versions; update compiled app</div></div>
 <div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/blob.rs" target="_blank" rel="noopener">client/blob.rs</a></div><div class="fd">Blob add / get / delete / list / auth operations</div></div>
 <div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/client/alias.rs" target="_blank" rel="noopener">client/alias.rs</a></div><div class="fd">Generic alias create / delete / lookup / resolve / list</div></div>
 <div class="fr"><div class="fp"><a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/node/primitives/src/messages.rs" target="_blank" rel="noopener">primitives/src/messages.rs</a></div><div class="fd">NodeMessage enum — GetBlobBytes, RegisterPendingSpecializedNodeInvite, etc.</div></div>
@@ -204,7 +207,13 @@
 </div>
 
 <h3>Application &amp; Blob Management</h3>
-<p style="margin-bottom:12px;">NodeClient also exposes application lifecycle and blob storage through sub-modules:</p>
+<p style="margin-bottom:12px;">NodeClient exposes application lifecycle through four focused sub-modules (<span class="code">application/</span>):</p>
+<div class="fr" style="margin-bottom:12px;">
+<div class="fp" style="font-size:0.85em;color:#6b6b80;">
+<strong>application.rs</strong> (module root) &rarr; <strong>install.rs</strong> (all install paths + uninstall) &rarr; <strong>bundle.rs</strong> (manifest verification + path safety) &rarr; <strong>query.rs</strong> (list/search)
+</div>
+</div>
+<p style="margin-bottom:12px;">Bundle signature verification: <span class="code">verify_and_extract_manifest</span> (strict, production) vs <span class="code">extract_manifest_allow_unsigned</span> (dev installs &mdash; verifies if present, allows unsigned).</p>
 <div class="g3">
   <div class="cb">
     <h4 style="color:#3b82f6;">Applications</h4>

--- a/architecture/local-governance.html
+++ b/architecture/local-governance.html
@@ -441,6 +441,19 @@
   </div>
 </div>
 
+<h3 style="margin-top:24px;">Signing Key Hierarchy (Ancestor Walk)</h3>
+<p style="font-size:.88rem;margin-bottom:12px;">Signing keys are stored at the <strong>namespace root</strong> when a namespace is created. Child groups (created via <span class="code">create_group_in_namespace</span>) do not get their own copy. Instead, <span class="code">governance_preflight</span> resolves signing authority by walking the parent chain:</p>
+<div class="step" style="padding:10px 14px;">
+  <p style="font-size:.82rem;"><strong>1.</strong> Check current group for a signing key matching the requester identity</p>
+  <p style="font-size:.82rem;"><strong>2.</strong> If not found, walk to parent via <span class="code">get_parent_group()</span></p>
+  <p style="font-size:.82rem;"><strong>3.</strong> Repeat up to <span class="code">MAX_NAMESPACE_DEPTH</span> (16) levels + final check at root</p>
+  <p style="font-size:.82rem;"><strong>4.</strong> Return the first key found, or error if none exists</p>
+</div>
+<p style="font-size:.88rem;margin-top:12px;"><strong>Revocation:</strong> Revoking a signing key at the namespace root automatically prevents all descendant groups from signing &mdash; no stale copies to clean up. <strong>Unnesting:</strong> breaks the parent link, so the child can no longer walk to the ancestor&rsquo;s key.</p>
+
+<h3 style="margin-top:24px;">Recursive Member Removal</h3>
+<p style="font-size:.88rem;">When a member is removed from a group, <span class="code">recursive_remove_member()</span> cascades the removal to all descendant groups and their contexts. Removal from a child group does <strong>not</strong> affect the parent (upward isolation).</p>
+
 <h3>Namespace Governance Epoch</h3>
 <p style="font-size:.88rem;">Context state deltas carry a <span class="code">governance_epoch</span> field. This is now computed from the <strong>namespace DAG heads</strong> (not per-group heads), ensuring a consistent governance state reference across all groups in a namespace. Computed via <span class="code">compute_namespace_governance_epoch(store, context_id)</span>.</p>
 </div>


### PR DESCRIPTION
Updates architecture docs to reflect recent changes:

**node.html:**
- Application module now split into 4 files (install.rs, bundle.rs, query.rs, tests.rs)
- Bundle signature verification: strict vs dev-mode

**context.html:**
- governance_preflight 4-step flow
- Signing key hierarchy resolution (ancestor walk)
- sign_and_publish_group_op helper (used by 7 handlers)

**local-governance.html:**
- Signing key ancestor walk mechanism
- Revocation propagation and unnesting behavior
- Recursive member removal cascade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates with no runtime code changes; primary risk is minor mismatch if docs drift from implementation.
> 
> **Overview**
> Updates the architecture docs to reflect recent governance and SRP refactors.
> 
> `context.html` now documents the `governance_preflight()` sequence, the ancestor-walk signing key resolution (`resolve_group_signing_key`), and the shared `sign_and_publish_group_op()` helper used across multiple governance mutation handlers.
> 
> `node.html` updates the NodeClient application docs to match the split into `application.rs` + `install.rs` + `bundle.rs` + `query.rs`, and clarifies strict vs dev-mode bundle manifest/signature verification.
> 
> `local-governance.html` adds explanations for signing key hierarchy (revocation + unnesting effects) and the recursive member removal cascade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd8e1979079c2254ad6cb5f4561cd84591536a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->