### PR TITLE
fix: require non-empty allowed_mrtd in TEE admission policy

### DIFF
--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -56,7 +56,12 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
             )));
         }
 
-        if !policy.allowed_mrtd.is_empty() && !policy.allowed_mrtd.iter().any(|a| a == &mrtd) {
+        if policy.allowed_mrtd.is_empty() {
+            return ActorResponse::reply(Err(eyre::eyre!(
+                "TEE admission policy has empty allowed_mrtd — at least one MRTD must be specified"
+            )));
+        }
+        if !policy.allowed_mrtd.iter().any(|a| a == &mrtd) {
             return ActorResponse::reply(Err(eyre::eyre!("MRTD not in policy allowlist")));
         }
         if !policy.allowed_tcb_statuses.is_empty()

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2292,7 +2292,14 @@ pub struct SetTeeAdmissionPolicyApiRequest {
 
 impl Validate for SetTeeAdmissionPolicyApiRequest {
     fn validate(&self) -> Vec<ValidationError> {
-        Vec::new()
+        let mut errors = Vec::new();
+        if self.allowed_mrtd.is_empty() && !self.accept_mock {
+            errors.push(ValidationError::InvalidFormat {
+                field: "allowed_mrtd",
+                reason: "at least one MRTD must be specified when accept_mock is false".to_owned(),
+            });
+        }
+        errors
     }
 }
 


### PR DESCRIPTION
Empty `allowed_mrtd` previously meant 'accept any MRTD' — a dangerous default if someone sets a TEE policy but forgets to populate the allowlist.

**Two changes:**

1. **`admit_tee_node`**: reject if `allowed_mrtd` is empty. Empty = no TEE node can join (safe default).

2. **`SetTeeAdmissionPolicyApiRequest` validation**: reject setting a policy with empty `allowed_mrtd` unless `accept_mock` is true (for testing). Catches misconfiguration at the API layer.

The default behavior (no policy set = reject all) is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes TEE node admission and admin API validation behavior in a security-sensitive path; misconfigured policies will now hard-fail and may prevent legitimate nodes from joining until fixed.
> 
> **Overview**
> Tightens TEE admission policy semantics so an empty `allowed_mrtd` is no longer treated as “allow any”. `admit_tee_node` now rejects policies with an empty MRTD allowlist, and `SetTeeAdmissionPolicyApiRequest` validation prevents setting an empty `allowed_mrtd` unless `accept_mock` is enabled (to catch misconfiguration earlier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9364aed7abba6da10aad2e04d23a09a304237bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->