### PR TITLE
feat: add ReadOnlyTee member role for TEE fleet nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.25"
+version = "0.10.1-rc.26"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -12,6 +12,7 @@ use calimero_server_primitives::admin::DetachContextFromGroupApiRequest;
 use calimero_server_primitives::admin::DetachContextFromGroupApiResponse;
 use calimero_server_primitives::admin::GetGroupUpgradeStatusApiResponse;
 use calimero_server_primitives::admin::GetMemberCapabilitiesApiResponse;
+use calimero_server_primitives::admin::GetTeeAdmissionPolicyApiResponse;
 use calimero_server_primitives::admin::GroupInfoApiResponse;
 use calimero_server_primitives::admin::JoinContextApiResponse;
 use calimero_server_primitives::admin::ListGroupContextsApiResponse;
@@ -26,6 +27,8 @@ use calimero_server_primitives::admin::RemoveGroupMembersApiResponse;
 use calimero_server_primitives::admin::RetryGroupUpgradeApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiResponse;
+use calimero_server_primitives::admin::SetTeeAdmissionPolicyApiRequest;
+use calimero_server_primitives::admin::SetTeeAdmissionPolicyApiResponse;
 use calimero_server_primitives::admin::SetDefaultVisibilityApiRequest;
 use calimero_server_primitives::admin::SetDefaultVisibilityApiResponse;
 use calimero_server_primitives::admin::SetMemberCapabilitiesApiRequest;
@@ -331,6 +334,36 @@ where
             .connection
             .put_json(
                 &format!("admin-api/groups/{group_id}/settings/default-visibility"),
+                request,
+            )
+            .await?;
+        Ok(response)
+    }
+
+    pub async fn get_tee_admission_policy(
+        &self,
+        group_id: &str,
+    ) -> Result<GetTeeAdmissionPolicyApiResponse> {
+        let response = self
+            .connection
+            .get(&format!(
+                "admin-api/groups/{group_id}/settings/tee-admission-policy"
+            ))
+            .await?;
+        Ok(response)
+    }
+
+    pub async fn set_tee_admission_policy(
+        &self,
+        group_id: &str,
+        request: SetTeeAdmissionPolicyApiRequest,
+    ) -> Result<SetTeeAdmissionPolicyApiResponse> {
+        let response = self
+            .connection
+            .put_json(
+                &format!(
+                    "admin-api/groups/{group_id}/settings/tee-admission-policy"
+                ),
                 request,
             )
             .await?;

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -27,12 +27,12 @@ use calimero_server_primitives::admin::RemoveGroupMembersApiResponse;
 use calimero_server_primitives::admin::RetryGroupUpgradeApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiResponse;
-use calimero_server_primitives::admin::SetTeeAdmissionPolicyApiRequest;
-use calimero_server_primitives::admin::SetTeeAdmissionPolicyApiResponse;
 use calimero_server_primitives::admin::SetDefaultVisibilityApiRequest;
 use calimero_server_primitives::admin::SetDefaultVisibilityApiResponse;
 use calimero_server_primitives::admin::SetMemberCapabilitiesApiRequest;
 use calimero_server_primitives::admin::SetMemberCapabilitiesApiResponse;
+use calimero_server_primitives::admin::SetTeeAdmissionPolicyApiRequest;
+use calimero_server_primitives::admin::SetTeeAdmissionPolicyApiResponse;
 use calimero_server_primitives::admin::SyncGroupApiRequest;
 use calimero_server_primitives::admin::SyncGroupApiResponse;
 use calimero_server_primitives::admin::UnnestGroupApiRequest;
@@ -361,9 +361,7 @@ where
         let response = self
             .connection
             .put_json(
-                &format!(
-                    "admin-api/groups/{group_id}/settings/tee-admission-policy"
-                ),
+                &format!("admin-api/groups/{group_id}/settings/tee-admission-policy"),
                 request,
             )
             .await?;

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -854,6 +854,9 @@ fn apply_group_op_mutations(
     match op {
         GroupOp::Noop => {}
         GroupOp::MemberAdded { member, role } => {
+            if *role == GroupMemberRole::ReadOnlyTee {
+                bail!("ReadOnlyTee can only be assigned via MemberJoinedViaTeeAttestation");
+            }
             permissions.require_manage_members(signer, "add member")?;
             permissions.require_admin_to_add_admin(signer, role)?;
             add_group_member(store, group_id, member, role.clone())?;
@@ -866,6 +869,9 @@ fn apply_group_op_mutations(
             remove_group_member(store, group_id, member)?;
         }
         GroupOp::MemberRoleSet { member, role } => {
+            if *role == GroupMemberRole::ReadOnlyTee {
+                bail!("ReadOnlyTee can only be assigned via MemberJoinedViaTeeAttestation");
+            }
             permissions.require_admin(signer)?;
             membership_policy.ensure_not_last_admin_demotion(member, role)?;
             add_group_member(store, group_id, member, role.clone())?;

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -983,6 +983,9 @@ fn apply_group_op_mutations(
             tcb_status,
             role,
         } => {
+            if *role != GroupMemberRole::ReadOnlyTee {
+                bail!("MemberJoinedViaTeeAttestation must use ReadOnlyTee role");
+            }
             membership_policy.require_tee_attestation_verifier_membership(signer)?;
             let policy = membership_policy.read_required_tee_admission_policy()?;
             membership_policy.validate_tee_attestation_allowlists(

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -57,7 +57,8 @@ pub fn compute_namespace_governance_epoch(
     }
 }
 
-/// Returns `true` if the member has a `ReadOnly` role in the group that owns this context.
+/// Returns `true` if the member has a read-only role (`ReadOnly` or `ReadOnlyTee`)
+/// in the group that owns this context.
 /// Returns `false` if the context has no group, the member is not found, or the member
 /// has `Admin` or `Member` role.
 pub fn is_read_only_for_context(
@@ -69,7 +70,10 @@ pub fn is_read_only_for_context(
         return Ok(false);
     };
     match get_group_member_role(store, &group_id, identity)? {
-        Some(calimero_primitives::context::GroupMemberRole::ReadOnly) => Ok(true),
+        Some(
+            calimero_primitives::context::GroupMemberRole::ReadOnly
+            | calimero_primitives::context::GroupMemberRole::ReadOnlyTee,
+        ) => Ok(true),
         _ => Ok(false),
     }
 }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -1003,6 +1003,77 @@ fn apply_local_signed_group_op_nonce_and_admin() {
 }
 
 #[test]
+fn reject_read_only_tee_via_member_added() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    let tee_pk = PrivateKey::random(&mut rng).public_key();
+    let op = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes,
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::MemberAdded {
+            member: tee_pk,
+            role: GroupMemberRole::ReadOnlyTee,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("ReadOnlyTee"),
+        "expected ReadOnlyTee rejection, got: {err}"
+    );
+}
+
+#[test]
+fn reject_read_only_tee_via_member_role_set() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+    add_group_member(&store, &gid, &member_pk, GroupMemberRole::Member).unwrap();
+
+    let op = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes,
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::MemberRoleSet {
+            member: member_pk,
+            role: GroupMemberRole::ReadOnlyTee,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("ReadOnlyTee"),
+        "expected ReadOnlyTee rejection, got: {err}"
+    );
+}
+
+#[test]
 fn apply_local_member_alias_member_signer_or_admin() {
     use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
     use calimero_primitives::identity::PrivateKey;

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -132,7 +132,7 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
                         rtmr2,
                         rtmr3,
                         tcb_status,
-                        role: GroupMemberRole::Member,
+                        role: GroupMemberRole::ReadOnlyTee,
                     },
                 )
                 .await?;

--- a/crates/context/src/handlers/update_member_role.rs
+++ b/crates/context/src/handlers/update_member_role.rs
@@ -18,18 +18,18 @@ impl Handler<UpdateMemberRoleRequest> for ContextManager {
         }: UpdateMemberRoleRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
+        // Admin check first — prevents non-admins from probing role status.
+        let preflight = match self.governance_preflight(&group_id, requester, true) {
+            Ok(p) => p,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+
         // ReadOnlyTee is only assigned via TEE attestation, not manually.
         if new_role == GroupMemberRole::ReadOnlyTee {
             return ActorResponse::reply(Err(eyre::eyre!(
                 "ReadOnlyTee role can only be assigned via TEE attestation admission"
             )));
         }
-
-        // Admin check first — prevents non-admins from probing role status.
-        let preflight = match self.governance_preflight(&group_id, requester, true) {
-            Ok(p) => p,
-            Err(err) => return ActorResponse::reply(Err(err)),
-        };
 
         // Single DB read for current role.
         let current_role =

--- a/crates/context/src/handlers/update_member_role.rs
+++ b/crates/context/src/handlers/update_member_role.rs
@@ -18,6 +18,13 @@ impl Handler<UpdateMemberRoleRequest> for ContextManager {
         }: UpdateMemberRoleRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
+        // ReadOnlyTee is only assigned via TEE attestation, not manually.
+        if new_role == GroupMemberRole::ReadOnlyTee {
+            return ActorResponse::reply(Err(eyre::eyre!(
+                "ReadOnlyTee role can only be assigned via TEE attestation admission"
+            )));
+        }
+
         // Admin check first — prevents non-admins from probing role status.
         let preflight = match self.governance_preflight(&group_id, requester, true) {
             Ok(p) => p,

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -265,6 +265,8 @@ pub enum GroupMemberRole {
     Admin,
     Member,
     ReadOnly,
+    /// Read-only TEE fleet node admitted via hardware attestation.
+    ReadOnlyTee,
 }
 
 /// A serialized and encoded payload for inviting a user to join a Context Group.

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2334,6 +2334,21 @@ pub struct GetTeeAdmissionPolicyApiResponse {
     pub accept_mock: bool,
 }
 
+impl GetTeeAdmissionPolicyApiResponse {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            allowed_mrtd: vec![],
+            allowed_rtmr0: vec![],
+            allowed_rtmr1: vec![],
+            allowed_rtmr2: vec![],
+            allowed_rtmr3: vec![],
+            allowed_tcb_statuses: vec![],
+            accept_mock: false,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetDefaultVisibilityApiRequest {

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2308,6 +2308,19 @@ pub struct SetTeeAdmissionPolicyApiResponse {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct GetTeeAdmissionPolicyApiResponse {
+    pub enabled: bool,
+    pub allowed_mrtd: Vec<String>,
+    pub allowed_rtmr0: Vec<String>,
+    pub allowed_rtmr1: Vec<String>,
+    pub allowed_rtmr2: Vec<String>,
+    pub allowed_rtmr3: Vec<String>,
+    pub allowed_tcb_statuses: Vec<String>,
+    pub accept_mock: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SetDefaultVisibilityApiRequest {
     pub default_visibility: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1653,6 +1653,14 @@ impl Validate for AddGroupMembersApiRequest {
         if self.members.is_empty() {
             errors.push(ValidationError::EmptyField { field: "members" });
         }
+        for member in &self.members {
+            if member.role == GroupMemberRole::ReadOnlyTee {
+                errors.push(ValidationError::InvalidFormat {
+                    field: "members[].role",
+                    reason: "ReadOnlyTee role can only be assigned via TEE attestation".to_owned(),
+                });
+            }
+        }
         errors
     }
 }
@@ -2049,7 +2057,14 @@ pub struct UpdateMemberRoleApiRequest {
 
 impl Validate for UpdateMemberRoleApiRequest {
     fn validate(&self) -> Vec<ValidationError> {
-        Vec::new()
+        let mut errors = Vec::new();
+        if self.role == GroupMemberRole::ReadOnlyTee {
+            errors.push(ValidationError::InvalidFormat {
+                field: "role",
+                reason: "ReadOnlyTee role can only be assigned via TEE attestation".to_owned(),
+            });
+        }
+        errors
     }
 }
 

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -6,6 +6,7 @@ pub mod detach_context_from_group;
 pub mod get_group_info;
 pub mod get_group_upgrade_status;
 pub mod get_member_capabilities;
+pub mod get_tee_admission_policy;
 pub mod join_group;
 pub mod list_all_groups;
 pub mod list_group_contexts;

--- a/crates/server/src/admin/handlers/groups/get_tee_admission_policy.rs
+++ b/crates/server/src/admin/handlers/groups/get_tee_admission_policy.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_server_primitives::admin::GetTeeAdmissionPolicyApiResponse;
+use tracing::info;
+
+use super::parse_group_id;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(group_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let group_id = match parse_group_id(&group_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(group_id=%group_id_str, "Getting TEE admission policy");
+
+    match calimero_context::group_store::read_tee_admission_policy(&state.store, &group_id) {
+        Ok(Some(policy)) => ApiResponse {
+            payload: GetTeeAdmissionPolicyApiResponse {
+                enabled: true,
+                allowed_mrtd: policy.allowed_mrtd,
+                allowed_rtmr0: policy.allowed_rtmr0,
+                allowed_rtmr1: policy.allowed_rtmr1,
+                allowed_rtmr2: policy.allowed_rtmr2,
+                allowed_rtmr3: policy.allowed_rtmr3,
+                allowed_tcb_statuses: policy.allowed_tcb_statuses,
+                accept_mock: policy.accept_mock,
+            },
+        }
+        .into_response(),
+        Ok(None) => ApiResponse {
+            payload: GetTeeAdmissionPolicyApiResponse {
+                enabled: false,
+                allowed_mrtd: vec![],
+                allowed_rtmr0: vec![],
+                allowed_rtmr1: vec![],
+                allowed_rtmr2: vec![],
+                allowed_rtmr3: vec![],
+                allowed_tcb_statuses: vec![],
+                accept_mock: false,
+            },
+        }
+        .into_response(),
+        Err(err) => parse_api_error(err).into_response(),
+    }
+}

--- a/crates/server/src/admin/handlers/groups/get_tee_admission_policy.rs
+++ b/crates/server/src/admin/handlers/groups/get_tee_admission_policy.rs
@@ -36,16 +36,7 @@ pub async fn handler(
         }
         .into_response(),
         Ok(None) => ApiResponse {
-            payload: GetTeeAdmissionPolicyApiResponse {
-                enabled: false,
-                allowed_mrtd: vec![],
-                allowed_rtmr0: vec![],
-                allowed_rtmr1: vec![],
-                allowed_rtmr2: vec![],
-                allowed_rtmr3: vec![],
-                allowed_tcb_statuses: vec![],
-                accept_mock: false,
-            },
+            payload: GetTeeAdmissionPolicyApiResponse::disabled(),
         }
         .into_response(),
         Err(err) => parse_api_error(err).into_response(),

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -237,7 +237,8 @@ pub(crate) fn setup(
         )
         .route(
             "/groups/:group_id/settings/tee-admission-policy",
-            put(groups::set_tee_admission_policy::handler),
+            get(groups::get_tee_admission_policy::handler)
+                .put(groups::set_tee_admission_policy::handler),
         )
         .route(
             "/groups/:group_id/settings/default-visibility",


### PR DESCRIPTION
TEE nodes admitted via attestation now get `ReadOnlyTee` role instead of `Member`. This makes them identifiable in `list_group_members` directly — clients can filter by role to show HA status and TEE node counts without scanning the governance log.

The role is only assigned by `admit_tee_node` — cannot be set via admin API or CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes membership/governance logic for TEE-admitted nodes and adds a new admin API read endpoint; mistakes could incorrectly grant/deny access or break TEE fleet admission/visibility.
> 
> **Overview**
> Introduces a new group member role `ReadOnlyTee` for TEE fleet nodes and switches TEE admission (`MemberJoinedViaTeeAttestation` / `admit_tee_node`) to assign this role instead of `Member`.
> 
> Hardens governance/admin flows so `ReadOnlyTee` **cannot be set manually** (rejected in group op application, `update_member_role` handler, and server primitive request validation), and treats `ReadOnlyTee` as read-only in context authorization checks.
> 
> Adds `GET /admin-api/groups/:group_id/settings/tee-admission-policy` (server handler + client method) returning the current policy or a disabled default, and bumps workspace version to `0.10.1-rc.26`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93fff73088d0eb4e35d65bb876d0d740d31b05f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->