### PR TITLE
feat(meroctl): add 'tee fleet-join' subcommand + bump to rc.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.26"
+version = "0.10.1-rc.27"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/crates/client/src/client/system.rs
+++ b/crates/client/src/client/system.rs
@@ -1,8 +1,8 @@
 //! System-level operations for the Calimero client.
 
 use calimero_server_primitives::admin::{
-    GenerateContextIdentityResponse, GetPeersCountResponse, InviteSpecializedNodeRequest,
-    InviteSpecializedNodeResponse,
+    FleetJoinRequest, FleetJoinResponse, GenerateContextIdentityResponse, GetPeersCountResponse,
+    InviteSpecializedNodeRequest, InviteSpecializedNodeResponse,
 };
 use eyre::Result;
 
@@ -38,6 +38,21 @@ where
         let response = self
             .connection
             .post("admin-api/contexts/invite-specialized-node", request)
+            .await?;
+        Ok(response)
+    }
+
+    /// Announce this node as a TEE fleet member for the given group.
+    ///
+    /// Calls POST /admin-api/tee/fleet-join. The local node generates a TDX
+    /// attestation, broadcasts `TeeAttestationAnnounce` on the namespace
+    /// topic, waits for admission (up to 30s), and auto-joins all contexts
+    /// in the group. Used by the mero-tee fleet sidecar after the manager
+    /// assigns it to a group via /api/fleet/should-join.
+    pub async fn fleet_join(&self, group_id: String) -> Result<FleetJoinResponse> {
+        let response = self
+            .connection
+            .post("admin-api/tee/fleet-join", FleetJoinRequest { group_id })
             .await?;
         Ok(response)
     }

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -26,6 +26,7 @@ mod group;
 mod namespace;
 mod node;
 mod peers;
+mod tee;
 mod upgrade_policy;
 pub mod validation;
 
@@ -38,6 +39,7 @@ use group::GroupCommand;
 use namespace::NamespaceCommand;
 use node::NodeCommand;
 use peers::PeersCommand;
+use tee::TeeCommand;
 
 use crate::auth::{authenticate_with_session_cache, check_authentication};
 
@@ -93,6 +95,7 @@ pub enum SubCommands {
     Namespace(NamespaceCommand),
     Call(CallCommand),
     Peers(PeersCommand),
+    Tee(TeeCommand),
     #[command(subcommand)]
     Node(NodeCommand),
 }
@@ -167,6 +170,7 @@ impl RootCommand {
             SubCommands::Namespace(ns) => ns.run(&mut environment).await,
             SubCommands::Call(call) => call.run(&mut environment).await,
             SubCommands::Peers(peers) => peers.run(&mut environment).await,
+            SubCommands::Tee(tee) => tee.run(&mut environment).await,
             SubCommands::Node(node) => {
                 node.run(&environment, self.args.node.as_deref(), &self.args.home)
                     .await

--- a/crates/meroctl/src/cli/tee.rs
+++ b/crates/meroctl/src/cli/tee.rs
@@ -1,0 +1,38 @@
+use clap::{Parser, Subcommand};
+use const_format::concatcp;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+pub mod fleet_join;
+
+pub const EXAMPLES: &str = r"
+  # Announce this node as a TEE fleet member and auto-join all contexts
+  # in the group once admission succeeds.
+  $ meroctl --node node1 tee fleet-join <GROUP_ID>
+";
+
+#[derive(Debug, Parser)]
+#[command(about = "TEE fleet-node commands")]
+#[command(after_help = concatcp!(
+    "Examples:",
+    EXAMPLES
+))]
+pub struct TeeCommand {
+    #[command(subcommand)]
+    pub subcommand: TeeSubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TeeSubCommands {
+    #[command(name = "fleet-join", alias = "fleet_join")]
+    FleetJoin(fleet_join::FleetJoinCommand),
+}
+
+impl TeeCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        match self.subcommand {
+            TeeSubCommands::FleetJoin(cmd) => cmd.run(environment).await,
+        }
+    }
+}

--- a/crates/meroctl/src/cli/tee/fleet_join.rs
+++ b/crates/meroctl/src/cli/tee/fleet_join.rs
@@ -1,0 +1,21 @@
+use clap::Parser;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+#[derive(Clone, Debug, Parser)]
+#[command(about = "Announce this node as a TEE fleet member for a group")]
+pub struct FleetJoinCommand {
+    /// Hex-encoded group ID (64 hex chars / 32 bytes).
+    #[clap(name = "GROUP_ID")]
+    pub group_id: String,
+}
+
+impl FleetJoinCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?;
+        let response = client.fleet_join(self.group_id).await?;
+        environment.output.write(&response);
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/output.rs
+++ b/crates/meroctl/src/output.rs
@@ -5,6 +5,7 @@ pub mod blobs;
 pub mod common;
 pub mod contexts;
 pub mod groups;
+pub mod tee;
 
 // Re-export common types
 pub use blobs::{BlobDownloadResponse, BlobUploadResponse};

--- a/crates/meroctl/src/output/tee.rs
+++ b/crates/meroctl/src/output/tee.rs
@@ -1,0 +1,27 @@
+use calimero_server_primitives::admin::FleetJoinResponse;
+use comfy_table::{Cell, Color, Table};
+
+use super::Report;
+
+impl Report for FleetJoinResponse {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.set_header(vec![
+            Cell::new("Fleet Join").fg(Color::Green),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = table.add_row(vec!["Status", &self.status]);
+        let _ = table.add_row(vec!["Admitted", &self.admitted.to_string()]);
+        let _ = table.add_row(vec!["Group ID", &self.group_id]);
+        let _ = table.add_row(vec!["Namespace ID", &self.namespace_id]);
+        let _ = table.add_row(vec!["Public Key", &self.public_key]);
+        let _ = table.add_row(vec![
+            "Contexts Joined",
+            &self.contexts_joined.len().to_string(),
+        ]);
+        println!("{table}");
+        for (idx, ctx) in self.contexts_joined.iter().enumerate() {
+            println!("  [{idx}] {ctx}");
+        }
+    }
+}

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1153,6 +1153,16 @@ impl Validate for FleetJoinRequest {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FleetJoinResponse {
+    pub status: String,
+    pub group_id: String,
+    pub namespace_id: String,
+    pub public_key: String,
+    pub admitted: bool,
+    pub contexts_joined: Vec<String>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeeInfoResponseData {


### PR DESCRIPTION
## Summary
- Add \`meroctl tee fleet-join <GROUP_ID>\` as a thin wrapper around POST /admin-api/tee/fleet-join, so the mero-tee fleet sidecar can stop curling the admin API by hand.
- Add \`FleetJoinResponse\` to server primitives + \`Client::fleet_join\` so the response type is shared between the handler and the client.
- Bump workspace version 0.10.1-rc.26 → rc.27.

## Context
The fleet sidecar (\`mero-tee/.../fleet-sidecar.sh.j2:73\`) currently calls \`meroctl tee fleet-join\` and logs \"fleet-join not available yet (core upgrade needed)\" because the subcommand didn't exist. With this PR it does.

## Test plan
- [ ] \`cargo check -p meroctl\` (done locally)
- [ ] \`meroctl tee fleet-join <group>\` against a running node with real TDX hardware — expect \"admitted\":true and contexts_joined populated
- [ ] \`meroctl tee fleet-join <group> --output-format json\` returns typed response
- [ ] On a non-TDX machine, expect 501 \"TDX attestation required\" (handler already gates on \`is_mock\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI subcommand and corresponding client/primitives types without changing core consensus/auth flows; primary risk is compatibility/serialization of the new `FleetJoinResponse` shape across server/client.
> 
> **Overview**
> Adds TEE fleet onboarding support to the Rust client and `meroctl` by introducing `Client::fleet_join` (POST `admin-api/tee/fleet-join`) and a new `meroctl tee fleet-join <GROUP_ID>` subcommand with human/JSON output formatting.
> 
> Introduces a shared `FleetJoinResponse` type in `calimero-server-primitives` for typed responses, and bumps the workspace version from `0.10.1-rc.26` to `0.10.1-rc.27`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f088437a534fea3aeca4bff92c7d9b56def8750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->