### PR TITLE
perf(node/sync): parallelize peer probing and random-peer sync fallback

### DIFF
--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -60,14 +60,10 @@ pub const DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED: u64 = 1_000;
 /// Max concurrent peer probes when looking for a peer with state.
 /// Typical meshes are 2-20 peers; a pool of 4 is enough parallelism
 /// that the tail is bounded by the fastest responder, without racing
-/// the whole mesh simultaneously on larger deployments.
+/// the whole mesh simultaneously on larger deployments. The probe
+/// itself is read-only (a single `DagHeadsRequest`), so parallelising
+/// it does not risk racing on per-context sync state.
 pub const DEFAULT_PEER_STATE_PROBE_CONCURRENCY: usize = 4;
-
-/// Max concurrent full sync attempts in the random-peer fallback.
-/// Each attempt is heavy (full sync protocol), so we keep this low:
-/// the goal is to avoid a single slow/dead peer stalling the whole
-/// retry chain, not to run parallel syncs against multiple peers.
-pub const DEFAULT_PEER_SYNC_CONCURRENCY: usize = 2;
 
 /// Synchronization configuration.
 ///

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -87,6 +87,9 @@ pub struct SyncConfig {
 
     /// Maximum delta gap before falling back to full resync
     pub delta_sync_threshold: usize,
+
+    /// Max concurrent peer probes in `find_peer_with_state`.
+    pub peer_state_probe_concurrency: usize,
 }
 
 impl Default for SyncConfig {
@@ -98,6 +101,7 @@ impl Default for SyncConfig {
             max_concurrent: DEFAULT_MAX_CONCURRENT_SYNCS,
             snapshot_chunk_size: DEFAULT_SNAPSHOT_CHUNK_SIZE,
             delta_sync_threshold: DEFAULT_DELTA_SYNC_THRESHOLD,
+            peer_state_probe_concurrency: DEFAULT_PEER_STATE_PROBE_CONCURRENCY,
         }
     }
 }

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -58,15 +58,16 @@ pub const DEFAULT_MESH_RETRIES_UNINITIALIZED: u32 = 10;
 pub const DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED: u64 = 1_000;
 
 /// Max concurrent peer probes when looking for a peer with state.
-/// Each probe is one small round-trip, so we can race many in parallel;
-/// the cap only matters when a context has a large mesh.
-pub const DEFAULT_PEER_STATE_PROBE_CONCURRENCY: usize = 16;
+/// Typical meshes are 2-20 peers; a pool of 4 is enough parallelism
+/// that the tail is bounded by the fastest responder, without racing
+/// the whole mesh simultaneously on larger deployments.
+pub const DEFAULT_PEER_STATE_PROBE_CONCURRENCY: usize = 4;
 
 /// Max concurrent full sync attempts in the random-peer fallback.
-/// Kept small because each attempt is a heavy sync; the goal is to
-/// avoid a single slow/dead peer stalling the whole retry chain,
-/// not to hammer every peer at once.
-pub const DEFAULT_PEER_SYNC_CONCURRENCY: usize = 3;
+/// Each attempt is heavy (full sync protocol), so we keep this low:
+/// the goal is to avoid a single slow/dead peer stalling the whole
+/// retry chain, not to run parallel syncs against multiple peers.
+pub const DEFAULT_PEER_SYNC_CONCURRENCY: usize = 2;
 
 /// Synchronization configuration.
 ///

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -57,6 +57,17 @@ pub const DEFAULT_MESH_RETRIES_UNINITIALIZED: u32 = 10;
 /// Default mesh discovery retry delay for uninitialized nodes (milliseconds).
 pub const DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED: u64 = 1_000;
 
+/// Max concurrent peer probes when looking for a peer with state.
+/// Each probe is one small round-trip, so we can race many in parallel;
+/// the cap only matters when a context has a large mesh.
+pub const DEFAULT_PEER_STATE_PROBE_CONCURRENCY: usize = 16;
+
+/// Max concurrent full sync attempts in the random-peer fallback.
+/// Kept small because each attempt is a heavy sync; the goal is to
+/// avoid a single slow/dead peer stalling the whole retry chain,
+/// not to hammer every peer at once.
+pub const DEFAULT_PEER_SYNC_CONCURRENCY: usize = 3;
+
 /// Synchronization configuration.
 ///
 /// Controls timing, concurrency, and protocol behavior for node synchronization.

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -632,7 +632,9 @@ impl SyncManager {
         };
 
         let timeout_budget = self.sync_config.timeout / 6;
-        let concurrency = super::config::DEFAULT_PEER_STATE_PROBE_CONCURRENCY
+        let concurrency = self
+            .sync_config
+            .peer_state_probe_concurrency
             .min(peers.len())
             .max(1);
 
@@ -643,6 +645,15 @@ impl SyncManager {
             "Probing peers for state in parallel"
         );
 
+        // Each probe opens a P2P stream, sends one `DagHeadsRequest`, and
+        // reads the response. When we find a peer with state and return, the
+        // remaining in-flight probes are dropped without sending a close
+        // frame; libp2p's idle-timeout handles the cleanup, and the peer may
+        // log a write-error if it was mid-response. This is an accepted
+        // trade-off — the probe is read-only on the local node, so there is
+        // no partial state to unwind, and adding an explicit graceful-close
+        // path would require async work in `Drop`, which Rust does not
+        // support cleanly.
         let mut probes = stream::iter(peers.iter().copied())
             .map(|peer_id| async move {
                 let outcome = async {
@@ -675,15 +686,16 @@ impl SyncManager {
                         // Peer has state if root_hash is not zeros (dag_heads may
                         // be empty for migrated/legacy contexts).
                         let has_state = *root_hash != [0; 32];
+                        let heads_count = dag_heads.len();
                         debug!(
                             %context_id,
                             %peer_id,
-                            heads_count = dag_heads.len(),
+                            heads_count,
                             %root_hash,
                             has_state,
                             "Received DAG heads from peer"
                         );
-                        Ok(Some(has_state))
+                        Ok(Some((has_state, heads_count, root_hash)))
                     } else {
                         Ok(None)
                     }
@@ -696,15 +708,17 @@ impl SyncManager {
 
         while let Some((peer_id, outcome)) = probes.next().await {
             match outcome {
-                Ok(Some(true)) => {
+                Ok(Some((true, heads_count, root_hash))) => {
                     info!(
                         %context_id,
                         %peer_id,
+                        heads_count,
+                        %root_hash,
                         "Found peer with state for bootstrapping"
                     );
                     return Ok(peer_id);
                 }
-                Ok(Some(false)) => {
+                Ok(Some((false, _, _))) => {
                     debug!(%context_id, %peer_id, "peer reported no state");
                 }
                 Ok(None) => {

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -584,31 +584,19 @@ impl SyncManager {
             }
         }
 
-        // Normal sync: race a small pool of peers so that a single slow or
-        // dead peer no longer serializes the entire retry chain. The first
-        // successful attempt wins; remaining in-flight attempts are cancelled
-        // when the stream is dropped.
-        let concurrency = super::config::DEFAULT_PEER_SYNC_CONCURRENCY
-            .min(peers.len())
-            .max(1);
-
-        debug!(
-            %context_id,
-            peer_count = peers.len(),
-            concurrency,
-            "Using parallel peer selection for sync"
-        );
-
-        let mut shuffled = peers.clone();
-        shuffled.shuffle(&mut rand::thread_rng());
-
-        let mut attempts = stream::iter(shuffled.into_iter())
-            .map(|peer_id| self.initiate_sync(context_id, peer_id))
-            .buffer_unordered(concurrency);
-
-        while let Some(result) = attempts.next().await {
-            if let Ok(success) = result {
-                return Ok(success);
+        // Normal sync: try peers serially. Parallelising `initiate_sync` for
+        // the same context is unsafe — the sync protocol mutates per-context
+        // state (sync-in-progress marker at snapshot.rs:581, sync sessions at
+        // state.rs:235, snapshot-page cleanup in `request_and_apply_snapshot_pages`
+        // which documents "assumes no concurrent writes") and futures cancelled
+        // mid-flight can leak a sync session into the DashMap, causing
+        // `should_buffer_delta` to return true permanently. Tail-latency
+        // benefit is still obtained from the parallel probe above, which
+        // narrows this loop to "try a known-good peer first".
+        debug!(%context_id, "Using random peer selection for sync");
+        for peer_id in peers.choose_multiple(&mut rand::thread_rng(), peers.len()) {
+            if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
+                return Ok(result);
             }
         }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -584,12 +584,31 @@ impl SyncManager {
             }
         }
 
-        // Normal sync: try all peers until we find one that works
-        // (for initialized nodes or fallback when we can't find a peer with state)
-        debug!(%context_id, "Using random peer selection for sync");
-        for peer_id in peers.choose_multiple(&mut rand::thread_rng(), peers.len()) {
-            if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
-                return Ok(result);
+        // Normal sync: race a small pool of peers so that a single slow or
+        // dead peer no longer serializes the entire retry chain. The first
+        // successful attempt wins; remaining in-flight attempts are cancelled
+        // when the stream is dropped.
+        let concurrency = super::config::DEFAULT_PEER_SYNC_CONCURRENCY
+            .min(peers.len())
+            .max(1);
+
+        debug!(
+            %context_id,
+            peer_count = peers.len(),
+            concurrency,
+            "Using parallel peer selection for sync"
+        );
+
+        let mut shuffled = peers.clone();
+        shuffled.shuffle(&mut rand::thread_rng());
+
+        let mut attempts = stream::iter(shuffled.into_iter())
+            .map(|peer_id| self.initiate_sync(context_id, peer_id))
+            .buffer_unordered(concurrency);
+
+        while let Some(result) = attempts.next().await {
+            if let Ok(success) = result {
+                return Ok(success);
             }
         }
 
@@ -601,6 +620,10 @@ impl SyncManager {
     /// This is critical for bootstrapping newly joined nodes. Without this,
     /// uninitialized nodes may query other uninitialized nodes, resulting in
     /// all nodes remaining uninitialized.
+    ///
+    /// Peers are probed concurrently so a single slow/unreachable peer no
+    /// longer stalls the entire discovery. The first peer to report state
+    /// wins and remaining probes are cancelled when this function returns.
     async fn find_peer_with_state(
         &self,
         context_id: ContextId,
@@ -620,82 +643,87 @@ impl SyncManager {
             bail!("no owned identities found for context: {}", context_id);
         };
 
-        // Query peers to find one with state
-        for peer_id in peers {
-            debug!(%context_id, %peer_id, "Querying peer for state");
+        let timeout_budget = self.sync_config.timeout / 6;
+        let concurrency = super::config::DEFAULT_PEER_STATE_PROBE_CONCURRENCY
+            .min(peers.len())
+            .max(1);
 
-            // Try to open stream and request DAG heads
-            let stream_result = self.network_client.open_stream(*peer_id).await;
-            let mut stream = match stream_result {
-                Ok(s) => s,
-                Err(e) => {
-                    debug!(%context_id, %peer_id, error = %e, "Failed to open stream to peer");
-                    continue;
+        debug!(
+            %context_id,
+            peer_count = peers.len(),
+            concurrency,
+            "Probing peers for state in parallel"
+        );
+
+        let mut probes = stream::iter(peers.iter().copied())
+            .map(|peer_id| async move {
+                let outcome = async {
+                    let mut stream = self.network_client.open_stream(peer_id).await?;
+
+                    let request_msg = StreamMessage::Init {
+                        context_id,
+                        party_id: our_identity,
+                        payload: InitPayload::DagHeadsRequest { context_id },
+                        next_nonce: rand::thread_rng().gen(),
+                    };
+
+                    self.send(&mut stream, &request_msg, None).await?;
+
+                    let Some(response) =
+                        super::stream::recv(&mut stream, None, timeout_budget).await?
+                    else {
+                        return Ok::<_, eyre::Error>(None);
+                    };
+
+                    if let StreamMessage::Message {
+                        payload:
+                            MessagePayload::DagHeadsResponse {
+                                dag_heads,
+                                root_hash,
+                            },
+                        ..
+                    } = response
+                    {
+                        // Peer has state if root_hash is not zeros (dag_heads may
+                        // be empty for migrated/legacy contexts).
+                        let has_state = *root_hash != [0; 32];
+                        debug!(
+                            %context_id,
+                            %peer_id,
+                            heads_count = dag_heads.len(),
+                            %root_hash,
+                            has_state,
+                            "Received DAG heads from peer"
+                        );
+                        Ok(Some(has_state))
+                    } else {
+                        Ok(None)
+                    }
                 }
-            };
+                .await;
 
-            // Send DAG heads request
-            let request_msg = StreamMessage::Init {
-                context_id,
-                party_id: our_identity,
-                payload: InitPayload::DagHeadsRequest { context_id },
-                next_nonce: {
-                    use rand::Rng;
-                    rand::thread_rng().gen()
-                },
-            };
+                (peer_id, outcome)
+            })
+            .buffer_unordered(concurrency);
 
-            if let Err(e) = self.send(&mut stream, &request_msg, None).await {
-                debug!(%context_id, %peer_id, error = %e, "Failed to send DAG heads request");
-                continue;
-            }
-
-            // Receive response with short timeout
-            let timeout_budget = self.sync_config.timeout / 6;
-            let response = match super::stream::recv(&mut stream, None, timeout_budget).await {
-                Ok(Some(resp)) => resp,
-                Ok(None) => {
-                    debug!(%context_id, %peer_id, "No response from peer");
-                    continue;
-                }
-                Err(e) => {
-                    debug!(%context_id, %peer_id, error = %e, "Failed to receive response");
-                    continue;
-                }
-            };
-
-            // Check if peer has state
-            if let StreamMessage::Message {
-                payload:
-                    MessagePayload::DagHeadsResponse {
-                        dag_heads,
-                        root_hash,
-                    },
-                ..
-            } = response
-            {
-                // Peer has state if root_hash is not zeros
-                // (even if dag_heads is empty due to migration/legacy contexts)
-                let has_state = *root_hash != [0; 32];
-
-                debug!(
-                    %context_id,
-                    %peer_id,
-                    heads_count = dag_heads.len(),
-                    %root_hash,
-                    has_state,
-                    "Received DAG heads from peer"
-                );
-
-                if has_state {
+        while let Some((peer_id, outcome)) = probes.next().await {
+            match outcome {
+                Ok(Some(true)) => {
                     info!(
                         %context_id,
                         %peer_id,
-                        heads_count = dag_heads.len(),
-                        %root_hash,
                         "Found peer with state for bootstrapping"
                     );
-                    return Ok(*peer_id);
+                    return Ok(peer_id);
+                }
+                Ok(Some(false)) => {
+                    debug!(%context_id, %peer_id, "peer reported no state");
+                }
+                Ok(None) => {
+                    debug!(%context_id, %peer_id, "peer did not return DAG heads");
+                }
+                Err(e) => {
+                    debug!(%context_id, %peer_id, error = %e, "peer probe failed");
                 }
             }
         }


### PR DESCRIPTION
## Summary

Parallelizes only the **read-only peer probe** in the sync manager. The random-peer sync fallback remains serial after PR review flagged concurrency hazards in `initiate_sync_inner`.

- **`find_peer_with_state`** (uninitialized-bootstrap path): probes race concurrently via `buffer_unordered(DEFAULT_PEER_STATE_PROBE_CONCURRENCY = 4)`. Each probe is a single `DagHeadsRequest` — read-only, no per-context state writes — so racing probes and cancelling the losers is safe.
- **Random-peer sync fallback**: unchanged from master (serial loop). Earlier commits on this branch had parallelised it; reverted in `0be293a4` after review.

## Motivation

Before this change, `find_peer_with_state` iterated peers serially with a `sync_config.timeout / 6` budget per peer (~5 s at defaults). A single slow or unreachable peer could add ~5 s of wall-clock before the next peer was even probed. Now tail latency is bounded by the fastest responder.

## Why the full-sync fallback stayed serial

`initiate_sync_inner` is not concurrency-safe for the same context:

- `snapshot.rs:581` writes a per-context `sync-in-progress` marker to RocksDB without synchronisation; concurrent snapshot syncs would race on it and on the snapshot-page cleanup logic (which documents "assumes no concurrent writes occur to the context's state during snapshot sync").
- `start_sync_session` (state.rs:235) inserts into a DashMap with no Drop guard. A future cancelled between `start_sync_session` and cleanup leaves the session pinned, so `should_buffer_delta` returns true forever and subsequent deltas buffer indefinitely.

Making the full-sync path concurrency-safe would require a per-context lock or Drop-guard refactor and is out of scope for this PR.

## Scope

- Does not change the probe/sync wire protocol, timeouts, or gossipsub config.
- A follow-up PR will likely tune gossipsub mesh parameters (`Config::default()` at `crates/network/src/behaviour.rs:111`) — the more probable root cause of the small-cluster sync lag in merobox workflows.
- Expected impact of this PR alone: tail-latency win on partition / dead-peer scenarios during uninitialized bootstrap. Modest impact on the 3-node merobox flake.

## Test plan

- [x] `cargo check -p calimero-node` passes
- [ ] CI green
- [ ] Run merobox workflows (e.g. `kv-store-with-handlers`, `three-node-sync`) and compare convergence times vs. master
- [ ] Manual: trigger a sync with one peer deliberately slow/unreachable during uninitialized bootstrap and confirm the probe no longer blocks on that peer's timeout

## Review feedback resolution

- Concurrent `initiate_sync` race on sync-in-progress marker / sync session leak / snapshot-page cleanup — **fixed by reverting** `buffer_unordered` in the fallback (kept in probe path, which is read-only).
- PR description mismatch with constants — **fixed** (now reflects the single remaining constant = 4).
- `peers.clone()` in fallback — **N/A after revert** (original loop uses `choose_multiple` which doesn't clone).
- `SyncConfig` field vs module-level const — **deferred**; the one remaining const is narrowly scoped and changing the config surface is out of scope here.
- Probe-path stream cleanup on cancellation — libp2p streams have their own idle timeouts; an explicit Drop guard could be added later if it proves needed in practice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync bootstrap behavior by introducing concurrent peer probing and new config, which can affect network load and timing; core `initiate_sync` path remains serial to avoid per-context state races.
> 
> **Overview**
> Improves uninitialized-node bootstrap by probing multiple peers *concurrently* in `find_peer_with_state` (via `buffer_unordered`) so slow/unreachable peers don’t add per-peer timeout latency before a stateful peer is found.
> 
> Adds a new `SyncConfig.peer_state_probe_concurrency` (default `4`) to cap parallel probes, and clarifies in-code that the subsequent random-peer sync fallback remains **serial** due to per-context sync state concurrency hazards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e36c9dccc450ac62dbe7147bd65883f217331f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->