### PR TITLE
perf(network): tune gossipsub mesh for small (2-20) peer clusters

### DIFF
--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -108,7 +108,22 @@ impl Behaviour {
                     },
                     gossipsub: gossipsub::Behaviour::new(
                         gossipsub::MessageAuthenticity::Signed(key.clone()),
-                        gossipsub::Config::default(),
+                        // Tuned for Calimero's typical 2-20 peer meshes.
+                        // libp2p's defaults assume larger swarms: mesh_n_low=4
+                        // and mesh_outbound_min=2 are never satisfied in a 2-3
+                        // node cluster, which keeps gossipsub out of stable
+                        // mesh-push mode and falls back on slower fanout /
+                        // lazy IHAVE-IWANT delivery. Lowering the water marks
+                        // lets small clusters form a stable mesh while still
+                        // scaling fine for larger deployments (mesh_n=4 is
+                        // below the mesh_n_high of 8, so growth is bounded).
+                        gossipsub::ConfigBuilder::default()
+                            .mesh_n_low(2)
+                            .mesh_n(4)
+                            .mesh_n_high(8)
+                            .mesh_outbound_min(1)
+                            .build()
+                            .map_err(|e| eyre::eyre!("invalid gossipsub config: {e}"))?,
                     )?,
                     ping: ping::Behaviour::default(),
                     rendezvous: rendezvous::client::Behaviour::new(key.clone()),


### PR DESCRIPTION
## Summary

Overrides libp2p's default gossipsub config in `crates/network/src/behaviour.rs` with water marks sized for Calimero's typical 2–20 peer meshes. This is the hypothesised root cause of the state-delta propagation lag observed in the 3-node merobox workflows, where nodes converge via the 10 s periodic-sync fallback rather than gossipsub push.

**New values:**

| Parameter            | libp2p default | This PR |
| -------------------- | -------------- | ------- |
| `mesh_n_low`         | 4              | **2**   |
| `mesh_n`             | 6              | **4**   |
| `mesh_n_high`        | 12             | **8**   |
| `mesh_outbound_min`  | 2              | **1**   |

`mesh_outbound_min = mesh_n_low / 2` is the libp2p-enforced invariant, so `1 / 2` is at the allowed ceiling for `mesh_n_low = 2`.

## Why

Default `mesh_n_low = 4` means a node with fewer than 4 same-topic peers is **permanently below the low water mark**. In that state, gossipsub:

1. Never enters stable mesh-push mode for that topic.
2. Falls back on fanout (time-limited, less reliable) and lazy IHAVE/IWANT pulls that only run on the 1 s heartbeat.
3. Publishes delivered to late joiners or flapping peers via fanout are not redelivered once fanout expires.

In a 3-node cluster each peer has only 2 same-topic peers, so the low water mark is never met. When `node-1` publishes a `StateDelta`:

- Best case: both peers get the eager push and apply the delta within ~100 ms.
- Worse case (observed in merobox): one peer is still in fanout mode because the mesh never stabilised, the eager push misses it, and the delta only arrives via IWANT on a later heartbeat — or not at all, in which case the receiving node has to wait for the next periodic sync cycle (up to 10 s) to discover the new DAG heads.

Lowering `mesh_n_low` to 2 lets a 3-peer cluster stabilise at `mesh = 2`, above the low water mark, so gossipsub operates in proper mesh-push mode and delta propagation latency drops to the network RTT + a handful of ms.

## Impact on larger deployments

`mesh_n = 4` and `mesh_n_high = 8` keep a large swarm's mesh size modest and bounded. This is a mild reduction from the default `mesh_n = 6` — the cost is slightly less redundancy per node (4 eager-push targets instead of 6), the benefit is the same behaviour across deployment sizes without needing config scaling. `mesh_n_high = 8` still provides headroom before mesh shedding kicks in.

## What this PR does NOT do

- Does not change the sync manager, periodic sync interval (10 s), or delta/snapshot protocols.
- Does not change gossipsub's `heartbeat_interval` (kept at 1 s default). A shorter heartbeat would speed mesh maintenance further but doubles background chatter; can revisit if data justifies it.
- Does not expose these as runtime config. They're hardcoded defaults here; a future PR can lift them into `NetworkConfig` if operators need to tune per-deployment.

## Relationship to #2172

Complementary and independent. #2172 parallelises the uninitialized-bootstrap peer probe — improves tail latency when some peers are slow/dead. This PR addresses the small-cluster gossipsub delivery problem directly. Either can land first; both together is the expected "fixes the merobox flake" combination.

## Test plan

- [x] `cargo check -p calimero-network` passes
- [ ] CI green
- [ ] Run merobox workflows (`kv-store-with-handlers`, `three-node-sync`, etc.) and compare convergence times vs. master. Expected: substantial drop on 3-node scenarios, negligible change on single-node local-first runs.
- [ ] Soak larger (8-16 node) test network for a few minutes to confirm no regressions in mesh churn / bandwidth

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts core libp2p gossipsub mesh sizing, which can materially change message propagation, redundancy, and bandwidth characteristics across deployments. Mis-tuning could cause reduced delivery reliability or increased churn in larger swarms.
> 
> **Overview**
> Replaces libp2p’s default gossipsub configuration with a custom `ConfigBuilder` tuned for small (2–20 peer) clusters, lowering mesh watermarks (`mesh_n_low`, `mesh_n`, `mesh_n_high`, `mesh_outbound_min`) to allow stable meshes in 2–3 node deployments.
> 
> Adds explicit validation/error mapping for the new gossipsub config and documents the rationale inline to explain expected improvements in push-based propagation vs fanout/IHAVE-IWANT fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217fdf1501854e35c51208d065e2f48e7c80e9f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->