### PR TITLE
fix(context): allow governance ops on orphaned groups (#2174)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -157,6 +157,9 @@ jobs:
           - workflow: group-nesting
             file: workflows/group-nesting.yml
             app: e2e-kv-store
+          - workflow: group-orphan-delete
+            file: workflows/group-orphan-delete.yml
+            app: e2e-kv-store
           - workflow: group-multi-service
             file: workflows/group-multi-service.yml
             app: e2e-kv-store

--- a/apps/e2e-kv-store/workflows/group-orphan-delete.yml
+++ b/apps/e2e-kv-store/workflows/group-orphan-delete.yml
@@ -1,0 +1,91 @@
+name: E2E KV Store - Orphaned Group Deletion
+description: >
+  Regression test for issue #2174 — delete_group must work on orphaned
+  (unparented) groups. Before the fix, the handler's implicit-requester
+  resolution walked the parent chain up to a namespace root; a group whose
+  parent edge had been removed (unnest_group with no subsequent nest_group)
+  was effectively undeletable because no namespace identity could be resolved.
+
+  The scenario reproduces the exact sequence from the issue:
+    1. create_namespace
+    2. create_group_in_namespace  (group is nested under namespace)
+    3. unnest_group               (group is now orphaned — no parent edge)
+    4. delete_group               (must succeed via admin_identity fallback)
+  Without the fix, step 4 fails with:
+    "requester not provided and node has no configured group identity"
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 1
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  - name: Create child group in namespace
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: orphan-target
+    outputs:
+      child_id: groupId
+
+  - name: Assert child group created
+    type: assert
+    statements:
+      - "is_set({{child_id}})"
+
+  - name: Unnest child from namespace (orphan the group)
+    type: unnest_group
+    node: e2e-node-1
+    parent_group_id: '{{namespace_id}}'
+    child_group_id: '{{child_id}}'
+
+  - name: Assert child is no longer listed as a subgroup
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      subs_after_unnest: subgroups
+
+  - name: Confirm namespace has no subgroups
+    type: json_assert
+    statements:
+      - 'json_equal({{subs_after_unnest}}, [])'
+
+  # The critical step: before fix #2174 this fails with
+  # "requester not provided and node has no configured group identity".
+  # After the fix, the admin_identity fallback resolves the node's
+  # local signing key for the group's admin and delete succeeds.
+  - name: Delete orphaned group (regression test for #2174)
+    type: delete_group
+    node: e2e-node-1
+    group_id: '{{child_id}}'
+
+stop_all_nodes: false

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -87,11 +87,11 @@ pub use self::migrations::{
 };
 pub use self::namespace::{
     collect_descendant_groups, compute_namespace_governance_epoch, create_recursive_invitations,
-    get_namespace_identity, get_namespace_identity_record, get_or_create_namespace_identity,
-    get_or_create_namespace_identity_bundle, get_parent_group, is_read_only_for_context,
-    list_child_groups, nest_group, recursive_remove_member, resolve_namespace,
-    resolve_namespace_identity, resolve_namespace_identity_record, store_namespace_identity,
-    unnest_group, NamespaceIdentityRecord, ResolvedNamespaceIdentity,
+    find_namespace_identity_by_public_key, get_namespace_identity, get_namespace_identity_record,
+    get_or_create_namespace_identity, get_or_create_namespace_identity_bundle, get_parent_group,
+    is_read_only_for_context, list_child_groups, nest_group, recursive_remove_member,
+    resolve_namespace, resolve_namespace_identity, resolve_namespace_identity_record,
+    store_namespace_identity, unnest_group, NamespaceIdentityRecord, ResolvedNamespaceIdentity,
 };
 pub use self::namespace_dag::{NamespaceDagService, NamespaceHead};
 pub use self::namespace_governance::{

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -3,7 +3,7 @@ use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::key::{
     GroupChildIndex, GroupParentRef, NamespaceIdentity, NamespaceIdentityValue,
-    GROUP_CHILD_INDEX_PREFIX,
+    GROUP_CHILD_INDEX_PREFIX, NAMESPACE_IDENTITY_PREFIX,
 };
 use calimero_store::Store;
 use eyre::{bail, Result as EyreResult};
@@ -279,6 +279,45 @@ pub fn resolve_namespace(store: &Store, group_id: &ContextGroupId) -> EyreResult
     eyre::bail!(
         "namespace resolution exceeded max depth ({MAX_NAMESPACE_DEPTH}), possible circular reference"
     )
+}
+
+/// Scan this node's stored namespace identities and return the first one
+/// whose public key matches `target`. Used as a fallback identity resolver
+/// for orphaned groups (parent chain severed) where the node still holds
+/// the original namespace's signing key but `resolve_namespace` cannot
+/// reach it via the group tree. See issue #2174.
+///
+/// O(N) in the number of namespaces the node has identities for. N is
+/// typically small (<100); deferring to this function only happens on the
+/// orphan fallback path, not in the common case.
+pub fn find_namespace_identity_by_public_key(
+    store: &Store,
+    target: &PublicKey,
+) -> EyreResult<Option<(ContextGroupId, NamespaceIdentityRecord)>> {
+    let keys = collect_keys_with_prefix(
+        store,
+        NamespaceIdentity::new([0u8; 32]),
+        NAMESPACE_IDENTITY_PREFIX,
+        |_| true,
+    )?;
+    let handle = store.handle();
+    for key in keys {
+        let Some(val) = handle.get(&key)? else {
+            continue;
+        };
+        let pk = PublicKey::from(val.public_key);
+        if pk == *target {
+            return Ok(Some((
+                ContextGroupId::from(key.namespace_id()),
+                NamespaceIdentityRecord {
+                    public_key: pk,
+                    private_key: val.private_key,
+                    sender_key: val.sender_key,
+                },
+            )));
+        }
+    }
+    Ok(None)
 }
 
 /// Read this node's identity for a namespace from the store.

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -2554,6 +2554,69 @@ fn orphan_admin_identity_returns_none_for_nonexistent_group() {
     assert!(load_group_meta(&store, &gid).unwrap().is_none());
 }
 
+#[test]
+fn orphan_admin_identity_resolves_via_namespace_identity_scan() {
+    // Groups created via create_group_in_namespace do NOT get a group-level
+    // GroupSigningKey record — the signing key only lives in the namespace
+    // identity record. After unnest, the parent edge is gone, so the key
+    // must be recovered by scanning namespace-identity records for one whose
+    // public_key matches meta.admin_identity.
+    let store = test_store();
+    let ns_id = ContextGroupId::from([0xF0; 32]);
+    let child_id = ContextGroupId::from([0xF1; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let ns_sk = [0xAA; 32];
+    let ns_sender = [0xBB; 32];
+
+    // Simulate a namespace that was created with (admin, ns_sk).
+    store_namespace_identity(&store, &ns_id, &admin, &ns_sk, &ns_sender).unwrap();
+
+    // Simulate a child group created under that namespace. meta.admin_identity
+    // is set to the namespace admin (matching execute_group_created). No
+    // GroupSigningKey is stored at the child level.
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    save_group_meta(&store, &child_id, &meta).unwrap();
+    add_group_member(&store, &child_id, &admin, GroupMemberRole::Admin).unwrap();
+
+    // Simulate the orphan condition: child was previously nested under ns_id,
+    // but unnest_group removed the parent edge. There is no parent link now.
+    assert!(get_parent_group(&store, &child_id).unwrap().is_none());
+    // And there is no direct group-level signing key for the admin.
+    assert!(get_group_signing_key(&store, &child_id, &admin)
+        .unwrap()
+        .is_none());
+
+    // The scanner finds the namespace identity by public key and returns its
+    // (namespace_id, record). The record's private_key is what the orphan
+    // handler will use as the signing key.
+    let hit = find_namespace_identity_by_public_key(&store, &admin)
+        .unwrap()
+        .expect("namespace identity for admin must be discoverable by pk scan");
+    assert_eq!(hit.0, ns_id);
+    assert_eq!(hit.1.public_key, admin);
+    assert_eq!(hit.1.private_key, ns_sk);
+}
+
+#[test]
+fn namespace_identity_scan_returns_none_when_no_match() {
+    // Scanner must not fabricate a match: if no stored namespace identity has
+    // the target public_key, it returns None even if the store is non-empty.
+    let store = test_store();
+    let ns_id = ContextGroupId::from([0xF0; 32]);
+    let other_pk = PublicKey::from([0x99; 32]);
+    let ns_sk = [0xAA; 32];
+    let ns_sender = [0xBB; 32];
+    let target = PublicKey::from([0x01; 32]);
+
+    store_namespace_identity(&store, &ns_id, &other_pk, &ns_sk, &ns_sender).unwrap();
+
+    // Target pk differs from the one stored → no match.
+    assert!(find_namespace_identity_by_public_key(&store, &target)
+        .unwrap()
+        .is_none());
+}
+
 // -----------------------------------------------------------------------
 // recursive_remove_member — cascade removal through group hierarchy
 // -----------------------------------------------------------------------

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -2454,6 +2454,107 @@ fn preflight_fails_for_nonexistent_group() {
 }
 
 // -----------------------------------------------------------------------
+// Orphan fallback — identity resolution for groups whose parent chain has
+// been severed (unnest_group with no subsequent nest_group). Without this
+// fallback, delete_group and sibling handlers bail with "requester not
+// provided and node has no configured group identity" even though the
+// group's admin IS locally known and holds a signing key. See issue #2174.
+// -----------------------------------------------------------------------
+
+#[test]
+fn orphan_admin_identity_resolves_when_signing_key_held_locally() {
+    // Orphaned group: meta exists with admin_identity set, no parent edge,
+    // and this node holds the admin's signing key at the group level.
+    // Governance handlers must be able to resolve (admin_pk, sk) directly
+    // from group meta when the namespace walk terminates at the group.
+    let store = test_store();
+    let gid = ContextGroupId::from([0xF0; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let sk = [0xAA; 32];
+
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    store_group_signing_key(&store, &gid, &admin, &sk).unwrap();
+
+    // No parent edge — this is the orphan condition.
+    assert!(get_parent_group(&store, &gid).unwrap().is_none());
+
+    // Simulate node_group_admin_identity: read meta.admin_identity, look up
+    // its group-level signing key.
+    let loaded = load_group_meta(&store, &gid).unwrap().unwrap();
+    let resolved_sk = get_group_signing_key(&store, &gid, &loaded.admin_identity)
+        .unwrap()
+        .expect("admin signing key must be retrievable for orphan fallback");
+    assert_eq!(loaded.admin_identity, admin);
+    assert_eq!(resolved_sk, sk);
+
+    // Downstream: require_group_admin must accept the admin.
+    assert!(require_group_admin(&store, &gid, &admin).is_ok());
+}
+
+#[test]
+fn orphan_admin_identity_returns_none_when_no_local_signing_key() {
+    // Orphan with admin_identity set but no local signing key for the admin:
+    // the fallback must NOT succeed (security: we never "pick" an identity
+    // for which we can't prove local possession of the signing key).
+    let store = test_store();
+    let gid = ContextGroupId::from([0xF0; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    // Intentionally no store_group_signing_key call.
+
+    let loaded = load_group_meta(&store, &gid).unwrap().unwrap();
+    let resolved_sk = get_group_signing_key(&store, &gid, &loaded.admin_identity).unwrap();
+    assert!(
+        resolved_sk.is_none(),
+        "orphan fallback must fail when no local signing key for admin_identity"
+    );
+}
+
+#[test]
+fn orphan_admin_identity_ignores_keys_for_non_admin_identities() {
+    // Node holds a group-level signing key for some identity that is NOT
+    // meta.admin_identity. The fallback must match ONLY on admin_identity
+    // and must not elevate the non-admin identity.
+    let store = test_store();
+    let gid = ContextGroupId::from([0xF0; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let other = PublicKey::from([0x02; 32]);
+    let other_sk = [0xBB; 32];
+
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &other, GroupMemberRole::Member).unwrap();
+    // Node holds a signing key for `other`, not for `admin`.
+    store_group_signing_key(&store, &gid, &other, &other_sk).unwrap();
+
+    let loaded = load_group_meta(&store, &gid).unwrap().unwrap();
+    // Fallback queries admin_identity — must return None (no key for admin).
+    assert!(get_group_signing_key(&store, &gid, &loaded.admin_identity)
+        .unwrap()
+        .is_none());
+    // require_group_admin must still reject `other` regardless.
+    assert!(require_group_admin(&store, &gid, &other).is_err());
+}
+
+#[test]
+fn orphan_admin_identity_returns_none_for_nonexistent_group() {
+    // Nonexistent group → load_group_meta returns None, fallback returns None.
+    let store = test_store();
+    let gid = ContextGroupId::from([0xF0; 32]);
+
+    assert!(load_group_meta(&store, &gid).unwrap().is_none());
+}
+
+// -----------------------------------------------------------------------
 // recursive_remove_member — cascade removal through group hierarchy
 // -----------------------------------------------------------------------
 

--- a/crates/context/src/handlers/create_group_invitation.rs
+++ b/crates/context/src/handlers/create_group_invitation.rs
@@ -22,7 +22,12 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
         }: CreateGroupInvitationRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        let node_identity = self.node_namespace_identity(&group_id);
+        // Resolve implicit node identity: prefer the namespace identity, then
+        // fall back to the group's admin identity for orphaned groups
+        // (see issue #2174).
+        let node_identity = self
+            .node_namespace_identity(&group_id)
+            .or_else(|| self.node_group_admin_identity(&group_id));
 
         let requester = match requester {
             Some(pk) => pk,
@@ -30,7 +35,9 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
                 Some((pk, _)) => pk,
                 None => {
                     return ActorResponse::reply(Err(eyre::eyre!(
-                        "requester not provided and node has no configured group identity"
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
                     )))
                 }
             },

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -19,7 +19,12 @@ impl Handler<DeleteGroupRequest> for ContextManager {
         }: DeleteGroupRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        let node_identity = self.node_namespace_identity(&group_id);
+        // Resolve implicit node identity: prefer the namespace identity, then
+        // fall back to the group's admin identity if the parent chain has been
+        // severed (see issue #2174 — orphaned groups).
+        let node_identity = self
+            .node_namespace_identity(&group_id)
+            .or_else(|| self.node_group_admin_identity(&group_id));
 
         // Resolve requester: use provided value or fall back to node group identity
         let requester = match requester {
@@ -28,7 +33,9 @@ impl Handler<DeleteGroupRequest> for ContextManager {
                 Some((pk, _)) => pk,
                 None => {
                     return ActorResponse::reply(Err(eyre::eyre!(
-                        "requester not provided and node has no configured group identity"
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
                     )))
                 }
             },

--- a/crates/context/src/handlers/retry_group_upgrade.rs
+++ b/crates/context/src/handlers/retry_group_upgrade.rs
@@ -18,14 +18,20 @@ impl Handler<RetryGroupUpgradeRequest> for ContextManager {
         }: RetryGroupUpgradeRequest,
         ctx: &mut Self::Context,
     ) -> Self::Result {
-        // Resolve requester: use provided value or fall back to node group identity
+        // Resolve requester: prefer provided, else the namespace identity, else
+        // the group's admin identity for orphaned groups (see issue #2174).
         let requester = match requester {
             Some(pk) => pk,
-            None => match self.node_namespace_identity(&group_id) {
+            None => match self
+                .node_namespace_identity(&group_id)
+                .or_else(|| self.node_group_admin_identity(&group_id))
+            {
                 Some((pk, _)) => pk,
                 None => {
                     return ActorResponse::reply(Err(eyre::eyre!(
-                        "requester not provided and node has no namespace identity"
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
                     )))
                 }
             },

--- a/crates/context/src/handlers/set_member_alias.rs
+++ b/crates/context/src/handlers/set_member_alias.rs
@@ -17,14 +17,23 @@ impl Handler<SetMemberAliasRequest> for ContextManager {
         }: SetMemberAliasRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        // Resolve the requester identity to check alias ownership.
+        // Resolve the requester identity to check alias ownership. Prefer the
+        // namespace identity, then fall back to the group's admin identity
+        // for orphaned groups (see issue #2174). The subsequent ownership
+        // check (`resolved_requester != member`) still enforces that a member
+        // can only set their own alias.
         let resolved_requester = match requester {
             Some(pk) => pk,
-            None => match self.node_namespace_identity(&group_id) {
+            None => match self
+                .node_namespace_identity(&group_id)
+                .or_else(|| self.node_group_admin_identity(&group_id))
+            {
                 Some((pk, _)) => pk,
                 None => {
                     return ActorResponse::reply(Err(eyre::eyre!(
-                        "requester not provided and node has no configured group identity"
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
                     )));
                 }
             },

--- a/crates/context/src/handlers/set_tee_admission_policy.rs
+++ b/crates/context/src/handlers/set_tee_admission_policy.rs
@@ -26,7 +26,12 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
         }: SetTeeAdmissionPolicyRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        let node_identity = self.node_namespace_identity(&group_id);
+        // Resolve implicit node identity: prefer the namespace identity, then
+        // fall back to the group's admin identity for orphaned groups
+        // (see issue #2174).
+        let node_identity = self
+            .node_namespace_identity(&group_id)
+            .or_else(|| self.node_group_admin_identity(&group_id));
 
         let requester = match requester {
             Some(pk) => pk,
@@ -34,7 +39,9 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
                 Some((pk, _)) => pk,
                 None => {
                     return ActorResponse::reply(Err(eyre::eyre!(
-                        "requester not provided and node has no configured group identity"
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
                     )))
                 }
             },

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -27,7 +27,12 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
         }: UpgradeGroupRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        let node_identity = self.node_namespace_identity(&group_id);
+        // Resolve implicit node identity: prefer the namespace identity, then
+        // fall back to the group's admin identity for orphaned groups
+        // (see issue #2174).
+        let node_identity = self
+            .node_namespace_identity(&group_id)
+            .or_else(|| self.node_group_admin_identity(&group_id));
 
         // Resolve requester: use provided value or fall back to node group identity
         let requester = match requester {
@@ -36,7 +41,9 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                 Some((pk, _)) => pk,
                 None => {
                     return ActorResponse::reply(Err(eyre::eyre!(
-                        "requester not provided and node has no configured group identity"
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
                     )))
                 }
             },

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -135,25 +135,75 @@ impl ContextManager {
 
     /// Fallback identity resolver for groups whose parent chain has been severed
     /// (orphans — `unnest_group` with no subsequent `nest_group`). Returns the
-    /// group's `meta.admin_identity` together with its locally-stored signing
-    /// key iff the node legitimately holds that key at the group level.
+    /// group's `meta.admin_identity` together with a locally-held signing key.
+    ///
+    /// Lookup order:
+    /// 1. `GroupSigningKey(group_id, admin_identity)` — the direct group-level
+    ///    record (present if the node created the group via `create_group`,
+    ///    joined it, or previously ran a governance op that auto-stored the key).
+    /// 2. If that is absent, scan this node's stored namespace-identity records
+    ///    for one whose public key equals `admin_identity`. This covers groups
+    ///    created via `create_group_in_namespace`, where the signing key is
+    ///    stored only at the namespace level. Once found, the namespace's
+    ///    private key is the signing key for the child's admin (they are the
+    ///    same identity — the namespace admin).
     ///
     /// Security: returning `Some(..)` requires both (a) the public record that
     /// this identity is the group's canonical admin, and (b) local possession
-    /// of the corresponding private key. Both conditions mirror what
-    /// `node_namespace_identity` demands for non-orphaned groups.
+    /// of the corresponding private key (via either lookup path). Both
+    /// conditions mirror what `node_namespace_identity` demands for
+    /// non-orphaned groups.
     pub fn node_group_admin_identity(
         &self,
         group_id: &ContextGroupId,
     ) -> Option<(calimero_primitives::identity::PublicKey, [u8; 32])> {
-        let meta = group_store::load_group_meta(&self.datastore, group_id)
-            .ok()
-            .flatten()?;
-        let sk =
-            group_store::get_group_signing_key(&self.datastore, group_id, &meta.admin_identity)
-                .ok()
-                .flatten()?;
-        Some((meta.admin_identity, sk))
+        let meta = match group_store::load_group_meta(&self.datastore, group_id) {
+            Ok(Some(meta)) => meta,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::warn!(
+                    ?group_id,
+                    error=?e,
+                    "failed to load group meta for admin identity fallback"
+                );
+                return None;
+            }
+        };
+
+        // 1. Direct lookup at the group level.
+        match group_store::get_group_signing_key(&self.datastore, group_id, &meta.admin_identity) {
+            Ok(Some(sk)) => return Some((meta.admin_identity, sk)),
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    ?group_id,
+                    error=?e,
+                    "failed to load group signing key for admin identity fallback"
+                );
+                // Fall through to namespace-identity scan rather than giving
+                // up — a transient read error on one record shouldn't mask
+                // a valid namespace-identity match.
+            }
+        }
+
+        // 2. Namespace-identity scan: the signing key for the child's admin
+        //    may only be stored at the original namespace (the case for
+        //    groups created via `create_group_in_namespace`).
+        match group_store::find_namespace_identity_by_public_key(
+            &self.datastore,
+            &meta.admin_identity,
+        ) {
+            Ok(Some((_ns_id, record))) => Some((record.public_key, record.private_key)),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(
+                    ?group_id,
+                    error=?e,
+                    "failed to scan namespace identities for admin identity fallback"
+                );
+                None
+            }
+        }
     }
 
     /// Get or create this node's identity for the namespace containing `group_id`.

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -133,6 +133,29 @@ impl ContextManager {
         }
     }
 
+    /// Fallback identity resolver for groups whose parent chain has been severed
+    /// (orphans — `unnest_group` with no subsequent `nest_group`). Returns the
+    /// group's `meta.admin_identity` together with its locally-stored signing
+    /// key iff the node legitimately holds that key at the group level.
+    ///
+    /// Security: returning `Some(..)` requires both (a) the public record that
+    /// this identity is the group's canonical admin, and (b) local possession
+    /// of the corresponding private key. Both conditions mirror what
+    /// `node_namespace_identity` demands for non-orphaned groups.
+    pub fn node_group_admin_identity(
+        &self,
+        group_id: &ContextGroupId,
+    ) -> Option<(calimero_primitives::identity::PublicKey, [u8; 32])> {
+        let meta = group_store::load_group_meta(&self.datastore, group_id)
+            .ok()
+            .flatten()?;
+        let sk =
+            group_store::get_group_signing_key(&self.datastore, group_id, &meta.admin_identity)
+                .ok()
+                .flatten()?;
+        Some((meta.admin_identity, sk))
+    }
+
     /// Get or create this node's identity for the namespace containing `group_id`.
     /// Generates a new keypair if none exists. Returns (namespace_id, public_key, private_key, sender_key).
     pub fn get_or_create_namespace_identity(
@@ -187,9 +210,14 @@ impl ContextManager {
             Some(pk) => pk,
             None => self
                 .node_namespace_identity(group_id)
+                .or_else(|| self.node_group_admin_identity(group_id))
                 .map(|(pk, _)| pk)
                 .ok_or_else(|| {
-                    eyre::eyre!("requester not provided and node has no configured group identity")
+                    eyre::eyre!(
+                        "cannot resolve node identity for group {group_id:?}: no requester \
+                         provided, no namespace identity reachable (group may be orphaned — \
+                         try nest_group first), and node holds no admin signing key for this group"
+                    )
                 })?,
         };
 


### PR DESCRIPTION
## Summary

- Adds a `node_group_admin_identity` fallback on `ContextManager` so implicit-requester resolution works on orphaned groups (groups whose parent chain was severed by `unnest_group` with no re-nest). Fallback returns `meta.admin_identity` together with its group-level signing key iff both are locally present — same security invariants as `node_namespace_identity`.
- Applies the fallback in `governance_preflight` (transitively covering 10 handlers) plus the 6 inline handlers that bypass preflight: `delete_group`, `upgrade_group`, `retry_group_upgrade`, `create_group_invitation`, `set_tee_admission_policy`, `set_member_alias`. Improves the error message to name orphaning as a likely cause.
- Adds 4 store-level unit tests (incl. a security assertion that non-admin signing keys are ignored) and a new `group-orphan-delete` merobox E2E workflow that reproduces the exact `create_namespace → create_group_in_namespace → unnest_group → delete_group` sequence from the issue. Wired into the PR-gating CI matrix.

Fixes #2174

## Root cause (copied from the issue)

`delete_group` calls `node_namespace_identity(&group_id)` → `resolve_namespace_identity` → `resolve_namespace`, which walks parent edges up to a namespace root. For an orphaned group the walk terminates at the group itself and returns `None`, so the handler bails with *\"requester not provided and node has no configured group identity\"* — even though `meta.admin_identity` is populated and `require_group_admin` (the actual auth check further down) would have passed. The check at `require_group_admin` was simply unreachable for orphans via the implicit path.

## Why this approach (vs. forbidding orphans in `unnest_group`)

Keeps `unnest_group → delete_group` composable, which is a legitimate pattern (soft-delete, transient reparenting). The fix is purely in identity resolution — authorization still runs through `require_group_admin` unchanged.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p calimero-context -- -A warnings` passes
- [x] `cargo test -p calimero-context --lib` — 113 tests pass (109 pre-existing + 4 new)
- [ ] `group-orphan-delete` E2E workflow passes in CI (reproduces #2174)
- [ ] All existing `group-*` E2E workflows still pass (non-orphan governance flows unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identity/requester resolution paths used by governance handlers; incorrect fallback behavior could allow unintended signing key selection or break admin-only operations, though the implementation gates on locally-held keys and existing admin checks.
> 
> **Overview**
> Fixes governance operations on *orphaned groups* (groups whose parent edge was removed via `unnest_group`) by adding a `ContextManager::node_group_admin_identity` fallback when implicit requester/identity resolution via namespace traversal fails.
> 
> The fallback resolves `meta.admin_identity` **only if** the node locally holds the corresponding signing key, including a new store scan helper `find_namespace_identity_by_public_key` to recover keys that exist only as stored namespace identities (e.g., groups created via `create_group_in_namespace`). This fallback is wired into `governance_preflight` and several handlers that bypass it (`delete_group`, `upgrade_group`, `retry_group_upgrade`, `create_group_invitation`, `set_tee_admission_policy`, `set_member_alias`), and updates the error message to explicitly call out likely orphaning.
> 
> Adds regression coverage via new unit tests around orphan identity resolution and a new merobox E2E workflow (`group-orphan-delete`) that is included in the CI matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c40af4f56bcf86b5350128f7e25256d9e47df57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->