### PR TITLE
ci: capture merobox runtime logs + instrument state-delta latency

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -210,16 +210,24 @@ jobs:
                   --image merod:local \
                   --e2e-mode; then
                   success=true
-                  break
               else
-                  echo "Collecting Docker logs for ${{ matrix.workflow }} attempt $attempt"
-                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
-                      if [ -n "$container" ]; then
-                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/${{ matrix.workflow }}-attempt${attempt}-${container}.log" 2>&1 || true
-                      fi
-                  done
-                  attempt=$((attempt + 1))
+                  attempt_failed=1
               fi
+
+              # debug branch: always capture runtime docker logs so we can see
+              # SYNC_LATENCY events emitted by the merod containers, not just
+              # the init output. Happens on both success and failure.
+              echo "Collecting Docker logs for ${{ matrix.workflow }} attempt $attempt"
+              for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
+                  if [ -n "$container" ]; then
+                      docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/${{ matrix.workflow }}-attempt${attempt}-${container}.log" 2>&1 || true
+                  fi
+              done
+
+              if [ "$success" = true ]; then
+                  break
+              fi
+              attempt=$((attempt + 1))
           done
 
           merobox stop --all || true

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -198,6 +198,32 @@ jobs:
           attempt=1
           success=false
 
+          # debug branch: start a background log watcher that streams
+          # `docker logs -f` to a file for any running node container as
+          # soon as it appears. Must be done before `merobox bootstrap run`
+          # because merobox tears down the runtime containers (`e2e-node-*`
+          # etc.) when the workflow completes, and our previous one-shot
+          # `docker logs` after the bootstrap only ever caught the already-
+          # removed init containers' leftover names.
+          LOGDIR="$GITHUB_WORKSPACE/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+              while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+                  # Match any container whose name ends with `-node-<digit>`
+                  # (e2e-node-1, kvh-node-1, etc.), excluding `-init` suffix.
+                  for c in $(docker ps --format "{{.Names}}" 2>/dev/null | grep -E '\-node-[0-9]+$' || true); do
+                      mark="$WATCHER_STATE_DIR/$c"
+                      if [ ! -f "$mark" ]; then
+                          touch "$mark"
+                          echo "[watcher] following logs for $c"
+                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-${c}.log" 2>&1 &
+                      fi
+                  done
+                  sleep 1
+              done
+          ) &
+          WATCHER_PID=$!
+
           while [ $attempt -le $max_attempts ]; do
               if [ $attempt -gt 1 ]; then
                   merobox stop --all || true
@@ -210,25 +236,17 @@ jobs:
                   --image merod:local \
                   --e2e-mode; then
                   success=true
-              else
-                  attempt_failed=1
-              fi
-
-              # debug branch: always capture runtime docker logs so we can see
-              # SYNC_LATENCY events emitted by the merod containers, not just
-              # the init output. Happens on both success and failure.
-              echo "Collecting Docker logs for ${{ matrix.workflow }} attempt $attempt"
-              for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
-                  if [ -n "$container" ]; then
-                      docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/${{ matrix.workflow }}-attempt${attempt}-${container}.log" 2>&1 || true
-                  fi
-              done
-
-              if [ "$success" = true ]; then
                   break
               fi
               attempt=$((attempt + 1))
           done
+
+          # Stop the watcher and give tail followers a moment to flush.
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
 
           merobox stop --all || true
           merobox nuke --force || true

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -629,21 +629,23 @@ impl Handler<ExecuteRequest> for ContextManager {
                             let governance_epoch: Vec<[u8; 32]> = vec![];
 
                             // sync_latency: publish timestamp (wall clock for
-                            // cross-node correlation via delta_id).
+                            // cross-node correlation via delta_id). Default
+                            // filter `calimero_=info` picks these up because
+                            // this module is in `calimero_context::`. Grep
+                            // logs for `SYNC_LATENCY` to isolate the trace.
                             let publish_at_ms = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map(|d| d.as_millis())
                                 .unwrap_or(0);
                             info!(
-                                target: "sync_latency",
-                                event = "publish",
+                                sync_event = "publish",
                                 delta_id = %hex::encode(the_delta.id),
                                 %context_id,
                                 publish_at_ms,
                                 parents = the_delta.parents.len(),
                                 has_events = events_data.is_some(),
                                 artifact_bytes = outcome.artifact.len(),
-                                "publishing state delta"
+                                "SYNC_LATENCY publish"
                             );
 
                             node_client

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -628,6 +628,24 @@ impl Handler<ExecuteRequest> for ContextManager {
                             // Skip the store lookup to avoid unnecessary I/O.
                             let governance_epoch: Vec<[u8; 32]> = vec![];
 
+                            // sync_latency: publish timestamp (wall clock for
+                            // cross-node correlation via delta_id).
+                            let publish_at_ms = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_millis())
+                                .unwrap_or(0);
+                            info!(
+                                target: "sync_latency",
+                                event = "publish",
+                                delta_id = %hex::encode(the_delta.id),
+                                %context_id,
+                                publish_at_ms,
+                                parents = the_delta.parents.len(),
+                                has_events = events_data.is_some(),
+                                artifact_bytes = outcome.artifact.len(),
+                                "publishing state delta"
+                            );
+
                             node_client
                                 .broadcast(
                                     &context,

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -963,7 +963,19 @@ impl DeltaStore {
         // Filter out parents that exist in the database
         let handle = self.applier.context_client.datastore_handle();
         let mut actually_missing = Vec::new();
-        let all_cascaded_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
+        let mut all_cascaded_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
+        // Tracks whether we mutated the DAG so we know to run a cascade at the
+        // end. Without this, pending children whose parent was just restored
+        // from DB stay stuck until the next periodic sync fires — see the
+        // "Delta pending - parents exist but not yet applied" WARN path and
+        // the fix comment further down.
+        let mut any_parent_added = false;
+        // Snapshot pending deltas before we mutate the DAG so we can diff
+        // against the post-cascade set and collect events for cascaded deltas.
+        let pending_before: std::collections::HashSet<[u8; 32]> = {
+            let dag = self.dag.read().await;
+            dag.get_pending_delta_ids().into_iter().collect()
+        };
 
         for parent_id in &potentially_missing {
             let db_key =
@@ -1019,7 +1031,9 @@ impl DeltaStore {
 
                         // Re-acquire lock as write lock to mutate DAG
                         let mut dag = self.dag.write().await;
-                        if !dag.restore_applied_delta(dag_delta) {
+                        if dag.restore_applied_delta(dag_delta) {
+                            any_parent_added = true;
+                        } else {
                             tracing::debug!(
                                 context_id = %self.applier.context_id,
                                 parent_id = ?parent_id,
@@ -1029,13 +1043,18 @@ impl DeltaStore {
                     } else {
                         // Re-acquire lock as write lock to mutate DAG
                         let mut dag = self.dag.write().await;
-                        if let Err(e) = dag.add_delta(dag_delta, &*self.applier).await {
-                            tracing::warn!(
-                                ?e,
-                                context_id = %self.applier.context_id,
-                                parent_id = ?parent_id,
-                                "Failed to load persisted parent delta into DAG"
-                            );
+                        match dag.add_delta(dag_delta, &*self.applier).await {
+                            Ok(_) => {
+                                any_parent_added = true;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    ?e,
+                                    context_id = %self.applier.context_id,
+                                    parent_id = ?parent_id,
+                                    "Failed to load persisted parent delta into DAG"
+                                );
+                            }
                         }
                     }
                 }
@@ -1051,6 +1070,105 @@ impl DeltaStore {
                         "Error checking database for parent delta, treating as missing"
                     );
                     actually_missing.push(*parent_id);
+                }
+            }
+        }
+
+        // Cascade any pending deltas whose parents we just restored from DB.
+        //
+        // Background: `DAG::restore_applied_delta` — used when a parent is
+        // already marked applied in the database (typically because *this*
+        // node authored it) — updates topology but does NOT call
+        // `apply_pending`. `DAG::add_delta` does. So a child delta that
+        // arrived via gossipsub while its parent was only in DB (not in the
+        // in-memory DAG) gets parked in `pending`, the parent is restored
+        // here without running `apply_pending`, and the child stays stuck
+        // until the 10-second periodic sync fires and re-processes it.
+        //
+        // Observed in instrumented e2e runs: `SYNC_LATENCY apply applied=false`
+        // on a received delta followed by a ~5.5s gap until the next
+        // `Starting sync session` unblocks it. This explicit
+        // `try_process_pending` turns that gap into the normal apply
+        // (~10ms) and lets us emit the cascaded deltas' events for handler
+        // execution, matching `add_delta_with_events`'s cascade path.
+        if any_parent_added {
+            let mut dag = self.dag.write().await;
+            match dag.try_process_pending(&*self.applier).await {
+                Ok(0) => {}
+                Ok(n) => {
+                    tracing::info!(
+                        context_id = %self.applier.context_id,
+                        cascaded_count = n,
+                        "Cascaded pending deltas after restoring parent from database"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        ?e,
+                        context_id = %self.applier.context_id,
+                        "try_process_pending failed after parent restore"
+                    );
+                }
+            }
+
+            let pending_after: std::collections::HashSet<[u8; 32]> =
+                dag.get_pending_delta_ids().into_iter().collect();
+            let cascaded: Vec<[u8; 32]> = pending_before
+                .difference(&pending_after)
+                .copied()
+                .collect();
+            drop(dag);
+
+            // Persist each cascaded delta as applied (clearing any stored
+            // events) and forward its events for handler execution. Mirrors
+            // the cascade-handling block in `add_delta_with_events` so that
+            // these two entry points produce identical on-disk + event state.
+            if !cascaded.is_empty() {
+                let mut handle = self.applier.context_client.datastore_handle();
+                for cid in &cascaded {
+                    let db_key = calimero_store::key::ContextDagDelta::new(
+                        self.applier.context_id,
+                        *cid,
+                    );
+                    match handle.get(&db_key) {
+                        Ok(Some(stored)) => {
+                            if let Some(ref events_data) = stored.events {
+                                all_cascaded_events.push((*cid, events_data.clone()));
+                            }
+                            let updated = calimero_store::types::ContextDagDelta {
+                                delta_id: stored.delta_id,
+                                parents: stored.parents,
+                                actions: stored.actions,
+                                hlc: stored.hlc,
+                                applied: true,
+                                expected_root_hash: stored.expected_root_hash,
+                                events: None,
+                            };
+                            if let Err(e) = handle.put(&db_key, &updated) {
+                                tracing::warn!(
+                                    ?e,
+                                    context_id = %self.applier.context_id,
+                                    cascaded_id = ?cid,
+                                    "Failed to persist cascaded delta after parent restore"
+                                );
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::debug!(
+                                context_id = %self.applier.context_id,
+                                cascaded_id = ?cid,
+                                "Cascaded delta not found in DB during parent-restore cascade"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                ?e,
+                                context_id = %self.applier.context_id,
+                                cascaded_id = ?cid,
+                                "Failed to load cascaded delta for persistence"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -89,16 +89,15 @@ pub async fn handle_state_delta(
         key_id,
     } = message;
 
-    // sync_latency: receive timestamp. Pair with `publish` event on another
-    // node by matching delta_id to compute wire-time.
+    // sync_latency: receive timestamp. Pair with SYNC_LATENCY publish on
+    // the author node by matching delta_id to compute wire-time.
     let receive_at_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
     let handle_start = std::time::Instant::now();
     info!(
-        target: "sync_latency",
-        event = "receive",
+        sync_event = "receive",
         delta_id = %hex::encode(delta_id),
         %context_id,
         %source,
@@ -106,7 +105,7 @@ pub async fn handle_state_delta(
         parent_count = parent_ids.len(),
         has_events = events.is_some(),
         artifact_bytes = artifact.len(),
-        "received state delta"
+        "SYNC_LATENCY receive"
     );
 
     let Some(context) = node_clients.context.get_context(&context_id)? else {
@@ -328,14 +327,13 @@ pub async fn handle_state_delta(
         .await?;
     let apply_ms = apply_start.elapsed().as_millis();
     info!(
-        target: "sync_latency",
-        event = "apply",
+        sync_event = "apply",
         delta_id = %hex::encode(delta_id),
         %context_id,
         applied = add_result.applied,
         apply_ms,
         handle_elapsed_ms = handle_start.elapsed().as_millis(),
-        "add_delta_with_events returned"
+        "SYNC_LATENCY apply"
     );
     let mut applied = add_result.applied;
     let mut handlers_already_executed = false;
@@ -344,12 +342,11 @@ pub async fn handle_state_delta(
         let missing_result = delta_store_ref.get_missing_parents().await;
         if !missing_result.missing_ids.is_empty() {
             info!(
-                target: "sync_latency",
-                event = "missing_parents",
+                sync_event = "missing_parents",
                 delta_id = %hex::encode(delta_id),
                 %context_id,
                 missing_count = missing_result.missing_ids.len(),
-                "delta pending, will trigger serial parent backfill"
+                "SYNC_LATENCY missing_parents"
             );
         }
 
@@ -444,14 +441,13 @@ pub async fn handle_state_delta(
                 )
                 .await?;
                 info!(
-                    target: "sync_latency",
-                    event = "handlers",
+                    sync_event = "handlers",
                     delta_id = %hex::encode(delta_id),
                     %context_id,
                     event_count,
                     handler_count,
                     handlers_ms = handlers_start.elapsed().as_millis() as u64,
-                    "event handlers finished"
+                    "SYNC_LATENCY handlers"
                 );
             } else {
                 info!(

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -89,6 +89,26 @@ pub async fn handle_state_delta(
         key_id,
     } = message;
 
+    // sync_latency: receive timestamp. Pair with `publish` event on another
+    // node by matching delta_id to compute wire-time.
+    let receive_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let handle_start = std::time::Instant::now();
+    info!(
+        target: "sync_latency",
+        event = "receive",
+        delta_id = %hex::encode(delta_id),
+        %context_id,
+        %source,
+        receive_at_ms,
+        parent_count = parent_ids.len(),
+        has_events = events.is_some(),
+        artifact_bytes = artifact.len(),
+        "received state delta"
+    );
+
     let Some(context) = node_clients.context.get_context(&context_id)? else {
         bail!("context '{}' not found", context_id);
     };
@@ -301,14 +321,37 @@ pub async fn handle_state_delta(
     )
     .await?;
 
+    // sync_latency: apply duration (inclusive of WASM __calimero_sync_next).
+    let apply_start = std::time::Instant::now();
     let add_result = delta_store_ref
         .add_delta_with_events(delta, events.clone())
         .await?;
+    let apply_ms = apply_start.elapsed().as_millis();
+    info!(
+        target: "sync_latency",
+        event = "apply",
+        delta_id = %hex::encode(delta_id),
+        %context_id,
+        applied = add_result.applied,
+        apply_ms,
+        handle_elapsed_ms = handle_start.elapsed().as_millis(),
+        "add_delta_with_events returned"
+    );
     let mut applied = add_result.applied;
     let mut handlers_already_executed = false;
 
     if !applied {
         let missing_result = delta_store_ref.get_missing_parents().await;
+        if !missing_result.missing_ids.is_empty() {
+            info!(
+                target: "sync_latency",
+                event = "missing_parents",
+                delta_id = %hex::encode(delta_id),
+                %context_id,
+                missing_count = missing_result.missing_ids.len(),
+                "delta pending, will trigger serial parent backfill"
+            );
+        }
 
         let cascade_outcome = execute_cascaded_events(
             &missing_result.cascaded_events,
@@ -388,6 +431,11 @@ pub async fn handle_state_delta(
             if !is_author {
                 // Application availability was already verified at the start of this function,
                 // so we can safely execute handlers without re-checking.
+                // sync_latency: handler duration (can cascade into more mutations).
+                let handlers_start = std::time::Instant::now();
+                let event_count = payload.len();
+                let handler_count =
+                    payload.iter().filter(|e| e.handler.is_some()).count();
                 execute_event_handlers_parsed(
                     &node_clients.context,
                     &context_id,
@@ -395,6 +443,16 @@ pub async fn handle_state_delta(
                     payload,
                 )
                 .await?;
+                info!(
+                    target: "sync_latency",
+                    event = "handlers",
+                    delta_id = %hex::encode(delta_id),
+                    %context_id,
+                    event_count,
+                    handler_count,
+                    handlers_ms = handlers_start.elapsed().as_millis() as u64,
+                    "event handlers finished"
+                );
             } else {
                 info!(
                     %context_id,


### PR DESCRIPTION
… path

Throwaway branch for measuring actual state-delta latency in merobox workflows. Do not merge — this exists purely to collect numbers so we can attribute the "sometimes slow pubsub even when mesh is formed" symptom to a specific stage.

Adds five `info!` events on the `sync_latency` target, correlatable across nodes by `delta_id`:

- `event=publish` on the author node just before `node_client.broadcast`. Emits `publish_at_ms` (Unix epoch) for cross-node wire-time math, plus parent count / event flag / artifact size.
- `event=receive` at entry to `handle_state_delta` on receivers. Emits `receive_at_ms` — diff with `publish_at_ms` for wire latency.
- `event=apply` around `add_delta_with_events` — `apply_ms` includes WASM `__calimero_sync_next`.
- `event=missing_parents` when the post-apply `get_missing_parents` returns a non-empty set — logs `missing_count` so we can attribute lag to the serial backfill loop.
- `event=handlers` around `execute_event_handlers_parsed` — emits `event_count`, `handler_count`, `handlers_ms`.

Usage:
  RUST_LOG="sync_latency=info,warn" merod --node nodeX run ...

Grep logs by `delta_id=...` to reconstruct full per-delta timeline across all three nodes. Expected clean split: wire time (publish→receive), apply time, handler cascade time, missing-parent backfill time.

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
