### PR TITLE
fix(ci): capture runtime merobox logs on success

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -207,18 +207,27 @@ jobs:
           # behind by the time the shell regains control. The watcher
           # captures logs *while* containers are live, so post-run cleanup
           # can't remove what we've already written to disk.
+          #
+          # Workaround tracked in calimero-network/merobox#207; once merobox
+          # persists logs natively we'll remove this block (calimero/core#2179).
           LOGDIR="$GITHUB_WORKSPACE/docker-logs"
           WATCHER_STATE_DIR="$(mktemp -d)"
+          # The watcher reads the current attempt from this file each poll so
+          # that (a) retry containers, which are nuked and recreated with the
+          # same names as attempt 1's, get picked up as new followers, and
+          # (b) attempt 1's logs aren't clobbered by attempt 2's output.
+          echo "1" > "$WATCHER_STATE_DIR/attempt"
           (
               while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+                  cur_attempt=$(cat "$WATCHER_STATE_DIR/attempt" 2>/dev/null || echo 1)
                   # Follow containers labeled by merobox, excluding the
                   # short-lived init containers (`*-init`).
                   for c in $(docker ps --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null | grep -v -- '-init$' || true); do
-                      mark="$WATCHER_STATE_DIR/$c"
+                      mark="$WATCHER_STATE_DIR/attempt${cur_attempt}-${c}"
                       if [ ! -f "$mark" ]; then
                           touch "$mark"
-                          echo "[log-watcher] following $c"
-                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-${c}.log" 2>&1 &
+                          echo "[log-watcher] following $c (attempt $cur_attempt)"
+                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-attempt${cur_attempt}-${c}.log" 2>&1 &
                       fi
                   done
                   sleep 1
@@ -232,6 +241,10 @@ jobs:
                   merobox nuke --force || true
                   sleep 2
               fi
+              # Tell the watcher which attempt we're on; it namespaces its
+              # mark files + log filenames by this so each retry captures
+              # cleanly without clobbering prior-attempt logs.
+              echo "$attempt" > "$WATCHER_STATE_DIR/attempt"
 
               if merobox bootstrap run \
                   "${{ matrix.file }}" \

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -198,6 +198,34 @@ jobs:
           attempt=1
           success=false
 
+          # Start a background watcher that streams `docker logs -f` from
+          # each node container to an artifact file as soon as it appears.
+          # A post-run `docker logs` loop does not work reliably on current
+          # merobox because the runtime containers are torn down as part of
+          # `merobox bootstrap run`'s exit path (regardless of
+          # `stop_all_nodes: false`), leaving only the init-container names
+          # behind by the time the shell regains control. The watcher
+          # captures logs *while* containers are live, so post-run cleanup
+          # can't remove what we've already written to disk.
+          LOGDIR="$GITHUB_WORKSPACE/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+              while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+                  # Follow containers labeled by merobox, excluding the
+                  # short-lived init containers (`*-init`).
+                  for c in $(docker ps --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null | grep -v -- '-init$' || true); do
+                      mark="$WATCHER_STATE_DIR/$c"
+                      if [ ! -f "$mark" ]; then
+                          touch "$mark"
+                          echo "[log-watcher] following $c"
+                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-${c}.log" 2>&1 &
+                      fi
+                  done
+                  sleep 1
+              done
+          ) &
+          WATCHER_PID=$!
+
           while [ $attempt -le $max_attempts ]; do
               if [ $attempt -gt 1 ]; then
                   merobox stop --all || true
@@ -211,16 +239,17 @@ jobs:
                   --e2e-mode; then
                   success=true
                   break
-              else
-                  echo "Collecting Docker logs for ${{ matrix.workflow }} attempt $attempt"
-                  for container in $(docker ps -a --format "{{.Names}}" 2>/dev/null || true); do
-                      if [ -n "$container" ]; then
-                          docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/${{ matrix.workflow }}-attempt${attempt}-${container}.log" 2>&1 || true
-                      fi
-                  done
-                  attempt=$((attempt + 1))
               fi
+              attempt=$((attempt + 1))
           done
+
+          # Signal the watcher to stop and give `docker logs -f` followers
+          # a moment to flush their final output.
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
 
           merobox stop --all || true
           merobox nuke --force || true


### PR DESCRIPTION
## Summary

Restores E2E runtime-log capture for green runs, regressed in #2096 (`52145275`, 2026-04-06). Since that commit, every successful `e2e-rust-apps` job has uploaded zero node logs; artifacts contained only the short-lived init-container stubs on retry paths. This made post-mortem of intermittent issues impossible because there was nothing to look at unless a test outright failed.

## Root cause

In commit `52145275`, the `docker logs` loop in `.github/workflows/e2e-rust-apps.yml` was moved from **after** the retry `while` loop (where it ran once per workflow on both success and failure) into the **`else` branch** of the `if merobox bootstrap run ... ; then` check (where it only runs on a failed attempt, and exits via `break` on success without capturing anything).

Before (`a0ab5d2e` through `47d93216`):

```yaml
while ... ; do
    if merobox bootstrap run ...; then
        success=true; break
    else
        attempt=$((attempt + 1))
    fi
done

# Collect logs — after the loop, runs on success too
for container in $(docker ps -a --filter "label=calimero.node=true" ...); do
    docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/..."
done
```

After (`52145275` onward):

```yaml
while ... ; do
    if merobox bootstrap run ...; then
        success=true; break        # ← skips log collection entirely
    else
        for container in $(docker ps -a ...); do
            docker logs "$container" > "...-attempt${attempt}-..."
        done
        attempt=$((attempt + 1))
    fi
done
```

The matrix-parallelization PR (`32357a56`) inherited the broken pattern and reshaped it into per-matrix entries without fixing it.

## Why a plain revert doesn't work

I tried the obvious "move the `docker logs` loop back outside the `if`" fix on the debug branch first. Result: artifacts still only contained the init containers — the runtime `e2e-node-*` containers were no longer in `docker ps -a` by the time control returned to the shell, despite `stop_all_nodes: false` in the workflow config. Current merobox tears down runtime containers as part of `bootstrap run`'s exit path, so a post-run `docker logs` loop races the teardown and loses.

## Fix

Start a background watcher **before** `merobox bootstrap run` that polls `docker ps --filter label=calimero.node=true` once per second and spawns `docker logs -f <container>` the moment each node appears, writing straight to the artifact file. Logs are captured *while* containers are live, so post-run cleanup can't remove what's already on disk. Init containers are excluded via `grep -v -- '-init$'` to keep artifacts focused on the running-node output operators actually need.

## Verified

On `debug/sync-latency-instrumentation` commit `18d98b17` (same watcher), all 13 matrix jobs in run [24720343999](https://github.com/calimero-network/core/actions/runs/24720343999) produced runtime logs:

| Workflow | Log artifact size |
|---|---|
| e2e-kv-store | 2.5 MB |
| group-multi-service | 678 KB |
| group-3node | 621 KB |
| groups | 413 KB |
| group-context-isolation | 409 KB |
| handler-test | 384 KB |
| group-late-joiner | 378 KB |
| group-membership | 366 KB |
| group-subgroup, group-subgroup-cold-sync, group-nesting | 357 KB each |
| group-capabilities | 333 KB |

vs. the same jobs against master shipping ~0 KB artifacts.

## Test plan

- [x] Cherry-picked the watcher from `debug/sync-latency-instrumentation`; proved it captures runtime logs on green e2e runs there (333 KB–2.5 MB per matrix entry).
- [ ] CI green on this PR
- [ ] After merge, verify the next master E2E run's `logs-*` artifacts contain real `merod::` stdout/stderr, not just init stubs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; main risk is flakiness from the new background `docker logs -f` processes and cleanup timing, not production behavior.
> 
> **Overview**
> Restores log artifacts for green `e2e-rust-apps` matrix jobs by replacing the post-failure `docker logs` collection with a background watcher that follows `docker logs -f` for merobox node containers as soon as they appear.
> 
> The watcher namespaces output by retry attempt, filters out short-lived `*-init` containers, and is explicitly stopped/cleaned up after the retry loop to ensure logs are flushed before merobox teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8adefa6d1096047075919cd21b8fe433a8c8bbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->