### PR TITLE
feat(context): namespace-scope TEE admission policies

### DIFF
--- a/architecture/auto-follow.html
+++ b/architecture/auto-follow.html
@@ -128,6 +128,19 @@ A TEE fleet node calls <code>POST /admin-api/tee/fleet-join</code>. The handler 
 From this point, every new context in the group is auto-joined by the core handler. The
 <code>mero-tee</code> sidecar's per-group polling loop becomes redundant.
 </p>
+<p>
+<b>Policy scope — namespace, not per-group.</b> Because auto-follow propagates fleet-node
+membership down into subgroups without a second admission check, any TEE admission policy set on
+a subgroup would be inert. As of 2026-04-21 this is made explicit: the canonical
+<code>TeeAdmissionPolicy</code> lives on the namespace root only.
+<code>read_tee_admission_policy</code> in <code>group_store::tee</code> resolves its argument to
+the namespace root before reading, and both the write handler
+(<code>handlers::set_tee_admission_policy</code>) and the apply path in
+<code>group_store::apply_group_op_mutations</code> refuse a <code>TeeAdmissionPolicySet</code>
+targeting a subgroup. Subgroup policy bytes in any legacy op logs are ignored. A deferred
+follow-up adds a drift guard that validates the root policy against Calimero's canonical fleet
+measurements.
+</p>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -984,6 +984,16 @@ fn apply_group_op_mutations(
         }
         GroupOp::TeeAdmissionPolicySet { .. } => {
             permissions.require_admin(signer)?;
+            // TEE policies are namespace-scoped — refuse to apply an op
+            // targeting a subgroup even if it arrives via replication.
+            // Reader resolves to root anyway, so a stored subgroup op would
+            // be dead data; rejecting at apply time keeps state clean.
+            if self::namespace::get_parent_group(store, group_id)?.is_some() {
+                bail!(
+                    "TeeAdmissionPolicySet rejected on subgroup {group_id:?}: policy is \
+                     namespace-scoped, set it on the namespace root"
+                );
+            }
         }
         GroupOp::MemberJoinedViaTeeAttestation {
             member,

--- a/crates/context/src/group_store/tee.rs
+++ b/crates/context/src/group_store/tee.rs
@@ -3,7 +3,7 @@ use calimero_context_config::types::ContextGroupId;
 use calimero_store::Store;
 use eyre::Result as EyreResult;
 
-use super::read_op_log_after;
+use super::{read_op_log_after, resolve_namespace};
 
 /// Reconstructed TEE admission policy from the governance DAG.
 #[derive(Debug)]
@@ -17,12 +17,20 @@ pub struct TeeAdmissionPolicy {
     pub accept_mock: bool,
 }
 
-/// Read the most recent `TeeAdmissionPolicySet` from the group's governance op log.
+/// Read the TEE admission policy that applies to `group_id`.
+///
+/// Policies are namespace-scoped: the canonical policy lives on the namespace
+/// root's governance op log. Subgroups resolve to their root before reading,
+/// so any policy bytes that may exist on a subgroup's own log are intentionally
+/// ignored. See `project_subgroup_policy_decision.md` for the design rationale;
+/// auto-follow already propagates membership across subgroups without a second
+/// admission check, so per-subgroup policies were inert.
 pub fn read_tee_admission_policy(
     store: &Store,
     group_id: &ContextGroupId,
 ) -> EyreResult<Option<TeeAdmissionPolicy>> {
-    let entries = read_op_log_after(store, group_id, 0, usize::MAX)?;
+    let root = resolve_namespace(store, group_id)?;
+    let entries = read_op_log_after(store, &root, 0, usize::MAX)?;
     let mut latest: Option<TeeAdmissionPolicy> = None;
 
     for (_seq, bytes) in &entries {

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -2170,6 +2170,130 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
     assert!(!is_quote_hash_used(&store, &gid, &quote_b).unwrap());
 }
 
+fn append_tee_policy_op(store: &Store, group: &ContextGroupId, seq: u64, mrtd: &str) {
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let signer_sk = PrivateKey::random(&mut rng);
+    let op = SignedGroupOp::sign(
+        &signer_sk,
+        group.to_bytes(),
+        vec![],
+        [0u8; 32],
+        seq,
+        GroupOp::TeeAdmissionPolicySet {
+            allowed_mrtd: vec![mrtd.to_owned()],
+            allowed_rtmr0: vec![],
+            allowed_rtmr1: vec![],
+            allowed_rtmr2: vec![],
+            allowed_rtmr3: vec![],
+            allowed_tcb_statuses: vec!["ok".to_owned()],
+            accept_mock: false,
+        },
+    )
+    .unwrap();
+    append_op_log_entry(store, group, seq, &borsh::to_vec(&op).unwrap()).unwrap();
+}
+
+#[test]
+fn tee_policy_lookup_from_subgroup_returns_root() {
+    // Policy set on the root — a lookup via a nested subgroup resolves up
+    // the parent chain and returns the root's policy. Core of the
+    // namespace-scoped policy decision (see
+    // project_subgroup_policy_decision.md).
+    let store = test_store();
+    let root = ContextGroupId::from([0xE0; 32]);
+    let child = ContextGroupId::from([0xE1; 32]);
+    let grandchild = ContextGroupId::from([0xE2; 32]);
+
+    nest_group(&store, &root, &child).unwrap();
+    nest_group(&store, &child, &grandchild).unwrap();
+    append_tee_policy_op(&store, &root, 1, "mrtd-root");
+
+    for gid in [root, child, grandchild] {
+        let p = read_tee_admission_policy(&store, &gid)
+            .unwrap()
+            .expect("policy resolved via root");
+        assert_eq!(p.allowed_mrtd, vec!["mrtd-root".to_owned()]);
+    }
+}
+
+#[test]
+fn tee_policy_lookup_from_subgroup_ignores_subgroup_own_bytes() {
+    // A subgroup carrying a stale policy op in its own log (e.g. legacy
+    // data written before we started rejecting subgroup-scoped policies)
+    // must NOT be returned. The reader walks to the root; the root has
+    // no policy, so the result is None.
+    let store = test_store();
+    let root = ContextGroupId::from([0xF0; 32]);
+    let child = ContextGroupId::from([0xF1; 32]);
+
+    nest_group(&store, &root, &child).unwrap();
+    append_tee_policy_op(&store, &child, 1, "mrtd-subgroup-ignored");
+
+    assert!(
+        read_tee_admission_policy(&store, &child).unwrap().is_none(),
+        "subgroup's own policy bytes must be ignored"
+    );
+    assert!(read_tee_admission_policy(&store, &root).unwrap().is_none());
+}
+
+#[test]
+fn tee_policy_lookup_on_root_without_policy_is_none() {
+    let store = test_store();
+    let root = ContextGroupId::from([0xC0; 32]);
+    assert!(read_tee_admission_policy(&store, &root).unwrap().is_none());
+}
+
+#[test]
+fn apply_tee_policy_op_on_subgroup_rejected() {
+    // Even a signed, otherwise-valid TeeAdmissionPolicySet op targeting a
+    // subgroup must be refused at apply time. Reader resolves to root, so
+    // accepting the op would create dead data; rejecting it keeps state
+    // aligned with the decision that policies are namespace-scoped.
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let store = test_store();
+    let mut rng = OsRng;
+    let root = ContextGroupId::from([0xB0; 32]);
+    let child = ContextGroupId::from([0xB1; 32]);
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+
+    save_group_meta(&store, &root, &test_meta()).unwrap();
+    save_group_meta(&store, &child, &test_meta()).unwrap();
+    add_group_member(&store, &root, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &child, &admin_pk, GroupMemberRole::Admin).unwrap();
+    nest_group(&store, &root, &child).unwrap();
+
+    let op = SignedGroupOp::sign(
+        &admin_sk,
+        child.to_bytes(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::TeeAdmissionPolicySet {
+            allowed_mrtd: vec!["m".to_owned()],
+            allowed_rtmr0: vec![],
+            allowed_rtmr1: vec![],
+            allowed_rtmr2: vec![],
+            allowed_rtmr3: vec![],
+            allowed_tcb_statuses: vec!["ok".to_owned()],
+            accept_mock: false,
+        },
+    )
+    .unwrap();
+
+    let err = apply_local_signed_group_op(&store, &op).expect_err("apply on subgroup must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("namespace-scoped") || msg.contains("root"),
+        "error should mention namespace scoping, got: {msg}"
+    );
+}
+
 // -----------------------------------------------------------------------
 // resolve_group_signing_key — ancestor hierarchy walk tests
 // -----------------------------------------------------------------------

--- a/crates/context/src/handlers/set_tee_admission_policy.rs
+++ b/crates/context/src/handlers/set_tee_admission_policy.rs
@@ -48,6 +48,18 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
                 bail!("group '{group_id:?}' not found");
             }
 
+            // TEE admission policies are namespace-scoped. Reject attempts to
+            // set one on a subgroup — callers must target the namespace root.
+            // The policy a subgroup "inherits" is whatever is set on the root;
+            // see project_subgroup_policy_decision.md.
+            if let Some(parent) = group_store::get_parent_group(&self.datastore, &group_id)? {
+                let root = group_store::resolve_namespace(&self.datastore, &group_id)?;
+                bail!(
+                    "TEE admission policy is namespace-scoped; set it on the namespace root \
+                     '{root:?}' instead of subgroup '{group_id:?}' (parent: '{parent:?}')"
+                );
+            }
+
             group_store::require_group_admin(&self.datastore, &group_id, &requester)?;
 
             if signing_key.is_none() {


### PR DESCRIPTION
## Summary
TEE admission policies are namespace-scoped, not per-group. Reader resolves to root; writer and governance-apply path refuse `TeeAdmissionPolicySet` on subgroups.

## Why
Auto-follow (shipped in #2169) propagates fleet-node membership into subgroups without a second admission check, so per-subgroup TEE policies were inert — the reader was checking the subgroup's own op log but nothing in the fleet-join path ever consulted it during the propagation step. This PR makes the scope explicit.

## Changes
- `group_store::tee::read_tee_admission_policy` — resolves `group_id` → namespace root before reading the op log. Subgroup policy bytes (legacy writes) are ignored.
- `handlers::set_tee_admission_policy` — HTTP `PUT` on a subgroup bails with an error pointing to the namespace root.
- `group_store::apply_group_op_mutations` — a `TeeAdmissionPolicySet` op targeting a subgroup is refused at apply time. Catches replicated ops that would otherwise leave dead data in the subgroup's log.
- `architecture/auto-follow.html` — "Policy scope" note added under TEE Fleet Integration.

## Knock-on / follow-ups
- **tauri-app:** `enableHaForNamespace` currently calls `setTeeAdmissionPolicy` per subgroup — that now errors. Tauri must drop that loop and call only on the namespace root. Tracked separately (Phase 6 continuation).
- **mdma:** the sidecar-wastage fix (one fleet-join per namespace instead of per group) rides on top of this decision. Tracked separately.
- **MRTD drift guard:** deferred follow-up in core — validate root policy against Calimero's canonical fleet measurements at set time.

## Test plan
- [x] `cargo test -p calimero-context --lib` — 113/113 pass (4 new)
  - `tee_policy_lookup_from_subgroup_returns_root`
  - `tee_policy_lookup_from_subgroup_ignores_subgroup_own_bytes`
  - `tee_policy_lookup_on_root_without_policy_is_none`
  - `apply_tee_policy_op_on_subgroup_rejected`
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check` clean
- [ ] Coordinate merge with tauri-app PR (hard-break — once this lands, subgroup `PUT` errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TEE admission policy evaluation and enforcement (security-adjacent) and introduces hard rejections for subgroup-scoped writes/replicated ops, which can break existing clients or migrations that relied on per-subgroup policies.
> 
> **Overview**
> Makes **TEE admission policies namespace-scoped** rather than per-group/subgroup.
> 
> `read_tee_admission_policy` now resolves any `group_id` to the namespace root before scanning the op log, intentionally ignoring any legacy policy ops stored on subgroups. Both the `set_tee_admission_policy` handler and `apply_group_op_mutations` now **reject** `TeeAdmissionPolicySet` operations targeting subgroups (including via replication), and new tests cover root resolution, legacy-ignore behavior, and subgroup apply rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d22c70c41202df0e1d4590b6dfb963979a2d8ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->