### PR TITLE
fix(node/delta): forward cascaded events from peer-fetched parents

### DIFF
--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -357,7 +357,7 @@ pub async fn handle_state_delta(
                 "Delta pending due to missing parents - requesting them from peer"
             );
 
-            if let Err(e) = request_missing_deltas(
+            match request_missing_deltas(
                 network_client,
                 sync_timeout,
                 context_id,
@@ -368,20 +368,39 @@ pub async fn handle_state_delta(
             )
             .await
             {
-                warn!(?e, %context_id, ?source, "Failed to request missing deltas");
+                Ok(peer_fetch_cascaded_events) => {
+                    // Peer-fetched parents can cascade pending children via
+                    // `apply_pending` inside `add_delta_with_events`. Those
+                    // cascaded children's events were discarded before this
+                    // fix — now they ride back on `peer_fetch_cascaded_events`
+                    // and go through `execute_cascaded_events` exactly like
+                    // the cascade path inside `get_missing_parents`.
+                    if !peer_fetch_cascaded_events.is_empty() {
+                        let cascade_outcome = execute_cascaded_events(
+                            &peer_fetch_cascaded_events,
+                            &node_clients,
+                            &context_id,
+                            &our_identity,
+                            sync_timeout,
+                            "peer-fetch cascade",
+                            Some(&delta_id),
+                        )
+                        .await?;
+                        applied |= cascade_outcome.applied_current;
+                        handlers_already_executed |= cascade_outcome.handlers_executed_for_current;
+                    }
+                }
+                Err(e) => {
+                    warn!(?e, %context_id, ?source, "Failed to request missing deltas");
+                }
             }
 
-            // `request_missing_deltas` fetches parents from peers and calls
-            // `DeltaStore::add_delta` internally. Those `add_delta` calls
-            // can cascade the current delta via `apply_pending`, but
-            // `add_delta`'s `AddDeltaResult.cascaded_events` is discarded
-            // inside the fetch loop — there's no way for us to see which
-            // deltas it cascaded without checking the DAG. `cascaded_ids`
-            // from the earlier `get_missing_parents` doesn't cover this
-            // path (cascades happened *after* that call returned), so
-            // consult the DAG directly here to avoid the misleading
-            // "child did not apply" downstream warn + permanent handler
-            // skip on peer-fetched parents.
+            // Some peer-fetched cascades may still apply the current delta
+            // without having its events in the DB (events-less deltas are
+            // never pre-persisted, so they won't show up in
+            // `peer_fetch_cascaded_events`). The DAG state reflects the
+            // apply regardless; check it before falling through to the
+            // "still pending" path so we don't warn misleadingly.
             if !applied && delta_store_ref.dag_has_delta_applied(&delta_id).await {
                 info!(
                     %context_id,
@@ -896,6 +915,14 @@ fn emit_state_mutation_event_parsed(
 ///
 /// Opens a stream to the peer and requests each missing delta sequentially.
 /// Adds successfully retrieved deltas back to the DAG for processing.
+/// Fetch missing ancestor deltas from a peer and add them to the DAG in
+/// topological order.
+///
+/// Returns the aggregated `cascaded_events` from every `add_delta_with_events`
+/// call. Each peer-fetched parent that resolves a pending child carries that
+/// child's stored events along in its `AddDeltaResult`; callers *must* run
+/// `execute_cascaded_events` on the returned list, otherwise handler execution
+/// for cascaded children silently never happens.
 async fn request_missing_deltas(
     network_client: calimero_network_primitives::client::NetworkClient,
     sync_timeout: std::time::Duration,
@@ -904,7 +931,7 @@ async fn request_missing_deltas(
     source: PeerId,
     our_identity: PublicKey,
     delta_store: DeltaStore,
-) -> Result<()> {
+) -> Result<Vec<([u8; 32], Vec<u8>)>> {
     use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
     // Open stream to peer
@@ -914,6 +941,10 @@ async fn request_missing_deltas(
     let mut to_fetch = missing_ids;
     let mut fetched_deltas: Vec<(calimero_dag::CausalDelta<Vec<Action>>, [u8; 32])> = Vec::new();
     let mut fetch_count = 0;
+    // Accumulated (delta_id, events_data) pairs from any cascades that
+    // happen while adding peer-fetched parents below. Passed back to the
+    // caller so handlers can run.
+    let mut cascaded_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
 
     // Phase 1: Fetch ALL missing deltas recursively
     // No artificial limit - DAG is acyclic so this will naturally terminate at genesis
@@ -1019,8 +1050,28 @@ async fn request_missing_deltas(
         fetched_deltas.reverse();
 
         for (dag_delta, delta_id) in fetched_deltas {
-            if let Err(e) = delta_store.add_delta(dag_delta).await {
-                warn!(?e, %context_id, delta_id = ?delta_id, "Failed to add fetched delta to DAG");
+            // Use the events-aware entry point so we can forward any events
+            // attached to *cascaded children* to the caller. The peer-fetched
+            // parent itself has no events (the wire protocol doesn't carry
+            // them on `DeltaResponse`) — hence `None` for the second arg —
+            // but `add_delta_internal`'s internal `apply_pending` can cascade
+            // children that were pre-persisted with events, and those need
+            // to reach `execute_cascaded_events` at the caller.
+            match delta_store.add_delta_with_events(dag_delta, None).await {
+                Ok(result) => {
+                    if !result.cascaded_events.is_empty() {
+                        info!(
+                            %context_id,
+                            parent_delta_id = ?delta_id,
+                            cascaded_count = result.cascaded_events.len(),
+                            "Peer-fetched parent cascaded pending children with events"
+                        );
+                        cascaded_events.extend(result.cascaded_events);
+                    }
+                }
+                Err(e) => {
+                    warn!(?e, %context_id, delta_id = ?delta_id, "Failed to add fetched delta to DAG");
+                }
             }
         }
 
@@ -1034,7 +1085,7 @@ async fn request_missing_deltas(
         }
     }
 
-    Ok(())
+    Ok(cascaded_events)
 }
 
 /// Ensures the application blob is available for a context before handler execution.


### PR DESCRIPTION
Closes #2182.

## Summary

When a child delta arrives via gossipsub before its parents are in the DAG or DB, `handle_state_delta` fetches the missing parents from a peer via `request_missing_deltas`. Each peer-fetched parent is then fed back through `DeltaStore::add_delta`, whose internal `apply_pending` can cascade any pending children — carrying along events that were pre-persisted when those deltas went pending.

Before this change, `request_missing_deltas` called `add_delta`, which discards `AddDeltaResult.cascaded_events`. Cascaded children got applied in DAG + DB, but their events never reached `execute_cascaded_events`, so their handlers **never ran**. State still converged across nodes (CRDT), but handler-driven side effects silently diverged — metrics, counters, outbound notifications, whatever the handler does.

## Fix

- `request_missing_deltas` switched to `add_delta_with_events(delta, None)` so each call's `cascaded_events` is visible. Accumulates them into a `Vec<([u8; 32], Vec<u8>)>` and returns that. Signature changed from `Result<()>` to `Result<Vec<([u8; 32], Vec<u8>)>>`.
- The caller in `handle_state_delta` runs `execute_cascaded_events` on the returned list — same path already used for cascades inside `get_missing_parents` — and updates `applied` and `handlers_already_executed` from the outcome.
- Kept the existing `dag_has_delta_applied` check after `request_missing_deltas`: events-less deltas aren't in `cascaded_events`, but the DAG state still reflects the apply, so we mustn't warn "child did not apply" in that case.

The peer-fetched parent itself has no events on the wire (the `DeltaResponse` message doesn't carry them), so `None` is passed as the events arg. Only cascaded children contribute to the returned list.

## Scope

One file, one function signature change, one call site updated. No protocol changes, no storage changes, no new config.

Only one caller of this `request_missing_deltas` in the codebase (in `state_delta/mod.rs` itself). The sync manager has a differently-typed method of the same name (`crates/node/src/sync/delta_request.rs`) that this PR doesn't touch.

## Observable behaviour change

Scenario: receiver gets child delta X with events; X's parent P isn't yet on the receiver.

| Before | After |
|---|---|
| `X` pending, `P` fetched from peer, `add_delta(P)` cascades X in DAG + DB | Same up to here |
| `X`'s events stored in DB, never read back, no handler ever runs | `X`'s events returned up the call chain, handler runs via `execute_cascaded_events` |

State convergence is unchanged (already happened). Handler-execution correctness is restored.

## Test plan

- [x] `cargo check -p calimero-node` passes
- [x] `cargo fmt --check` clean
- [ ] CI green
- [ ] Ideally: integration test that delivers a child delta before its parent, with events on the child, and asserts the child's handler runs exactly once. (Not adding in this PR; targeted fix first, test coverage as follow-up.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes state-delta sync/handler execution flow so newly surfaced cascades run application handlers; mistakes could lead to missed or duplicated handler side effects during peer catch-up.
> 
> **Overview**
> Fixes a gap in `handle_state_delta` where fetching missing parent deltas from a peer could *apply* pending children but silently drop their persisted `events`, causing handlers to never run.
> 
> `request_missing_deltas` now uses `DeltaStore::add_delta_with_events(..., None)` and returns aggregated `cascaded_events`; the caller runs `execute_cascaded_events` on that list and updates `applied`/`handlers_already_executed`, with an additional DAG applied check to avoid misleading "still pending" warnings for events-less cascades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e0a28aaeae834ecc80e54d93e0b6f3d554264d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->