### PR TITLE
fix(node/delta): persist parent as applied=true after ParentPlan::Add

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -994,15 +994,29 @@ impl DeltaStore {
             restored_head_hashes,
             cascaded_ids,
             cascaded_bodies,
+            added_parent_bodies,
             heads_after_cascade,
         ) = if plans.is_empty() {
-            (false, Vec::new(), Vec::new(), Vec::new(), Vec::new())
+            (
+                false,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            )
         } else {
             let mut dag = self.dag.write().await;
             let pending_before: HashSet<[u8; 32]> =
                 dag.get_pending_delta_ids().into_iter().collect();
             let mut any_parent_added = false;
             let mut restored_head_hashes: Vec<([u8; 32], [u8; 32])> = Vec::new();
+            // Parents we just transitioned from `applied: false` → applied
+            // in the DAG via `add_delta`. Their DB records still say
+            // `applied: false`; phase 3 persists the update alongside any
+            // cascaded children. Without this, `load_persisted_deltas_into_dag`
+            // re-runs WASM for these parents on every restart (#2187).
+            let mut added_parent_bodies: Vec<([u8; 32], CausalDelta<Vec<Action>>)> = Vec::new();
 
             for plan in plans {
                 match plan {
@@ -1025,19 +1039,28 @@ impl DeltaStore {
                     ParentPlan::Add {
                         parent_id,
                         dag_delta,
-                    } => match dag.add_delta(dag_delta, &*self.applier).await {
-                        Ok(_) => {
-                            any_parent_added = true;
+                    } => {
+                        // Clone before `add_delta` consumes — on success
+                        // we hand the body to phase 3 to rewrite the DB
+                        // record as `applied: true` and forward any
+                        // pre-stored events (same treatment as cascaded
+                        // children).
+                        let body_for_persist = dag_delta.clone();
+                        match dag.add_delta(dag_delta, &*self.applier).await {
+                            Ok(_) => {
+                                any_parent_added = true;
+                                added_parent_bodies.push((parent_id, body_for_persist));
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    ?e,
+                                    context_id = %self.applier.context_id,
+                                    parent_id = ?parent_id,
+                                    "Failed to load persisted parent delta into DAG"
+                                );
+                            }
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                ?e,
-                                context_id = %self.applier.context_id,
-                                parent_id = ?parent_id,
-                                "Failed to load persisted parent delta into DAG"
-                            );
-                        }
-                    },
+                    }
                 }
             }
 
@@ -1082,6 +1105,7 @@ impl DeltaStore {
                 restored_head_hashes,
                 cascaded_ids,
                 cascaded_bodies,
+                added_parent_bodies,
                 dag.get_heads(),
             )
         };
@@ -1096,14 +1120,27 @@ impl DeltaStore {
         }
 
         if any_parent_added {
-            // Persist cascaded deltas and push updated `dag_heads` via the
-            // shared helper — same code path `add_delta_with_events` uses
-            // after an in-line cascade. Helper logs-and-continues on
-            // `dag_heads` write failure, so events are preserved even if
-            // the heads write fails (next sync will correct the heads).
+            // Persist cascaded deltas, newly-applied parents (Add path),
+            // and push updated `dag_heads` via the shared helper. Helper
+            // logs-and-continues on `dag_heads` write failure, so events
+            // are preserved even if the heads write fails (next sync will
+            // correct the heads).
+            //
+            // Parents and cascaded children get the same per-entry
+            // treatment: read any pre-stored `events` and forward them in
+            // the return value, then rewrite the DB record as
+            // `applied: true, events: None`. For a `ParentPlan::Add` that
+            // had events pre-persisted on this node, this means its
+            // handlers run on the next `execute_cascaded_events` call.
+            // For one without events, it simply flips `applied: false →
+            // true` so restart's `load_persisted_deltas_into_dag` stops
+            // re-running its WASM (#2187).
+            let mut bodies_to_persist = added_parent_bodies;
+            bodies_to_persist.extend(cascaded_bodies);
+
             all_cascaded_events.extend(
                 self.persist_cascaded_deltas_and_update_heads(
-                    &cascaded_bodies,
+                    &bodies_to_persist,
                     heads_after_cascade,
                 )
                 .await,
@@ -1128,9 +1165,10 @@ impl DeltaStore {
         }
     }
 
-    /// Persist cascaded deltas to the database and push the updated DAG
-    /// heads — the two writes that must always land together after any
-    /// code path that cascades pending deltas.
+    /// Persist newly-applied deltas to the database and push the updated
+    /// DAG heads — the two writes that must always land together after
+    /// any code path that flips deltas from "not applied on this node"
+    /// to applied.
     ///
     /// Used by both `add_delta_internal` and `get_missing_parents`. Before
     /// this helper existed, each site inlined its own copy of the persist
@@ -1141,19 +1179,21 @@ impl DeltaStore {
     ///
     /// # Semantics
     ///
-    /// For each cascaded delta passed in:
-    /// - The in-memory DAG body (in `cascaded_bodies`) is the authoritative
+    /// For each delta body passed in (cascaded-from-pending child *or*
+    /// parent just applied via `get_missing_parents`'s Add path):
+    /// - The in-memory DAG body (in `applied_bodies`) is the authoritative
     ///   source; the DB may or may not already contain a record.
     /// - Any existing DB record's `events` column is read and forwarded in
     ///   the return value (so the caller can run handlers) before the
-    ///   record is rewritten with `events: None`. Events-less deltas are
-    ///   never pre-persisted, so a missing DB record is normal for that
-    ///   path — the helper rebuilds the full record from the in-memory body.
+    ///   record is rewritten with `applied: true, events: None`.
+    ///   Events-less deltas are never pre-persisted, so a missing DB
+    ///   record is normal for the cascade path — the helper rebuilds the
+    ///   full record from the in-memory body. Add-path parents always
+    ///   have a DB record present (phase 1 loaded it).
     ///
     /// After the loop, `update_dag_heads` is called unconditionally with
-    /// the supplied `heads`. Pass an empty `cascaded_bodies` slice when
-    /// you only need the heads write (e.g. a plain `add_delta` with no
-    /// cascades).
+    /// the supplied `heads`. Pass an empty slice when you only need the
+    /// heads write (e.g. a plain `add_delta` with no cascades).
     ///
     /// # Locking
     ///
@@ -1162,20 +1202,20 @@ impl DeltaStore {
     /// chose. This keeps DB I/O out of the DAG critical section.
     async fn persist_cascaded_deltas_and_update_heads(
         &self,
-        cascaded_bodies: &[([u8; 32], CausalDelta<Vec<Action>>)],
+        applied_bodies: &[([u8; 32], CausalDelta<Vec<Action>>)],
         heads: Vec<[u8; 32]>,
     ) -> Vec<([u8; 32], Vec<u8>)> {
         let mut forwarded_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
 
-        if !cascaded_bodies.is_empty() {
+        if !applied_bodies.is_empty() {
             info!(
                 context_id = %self.applier.context_id,
-                cascaded_count = cascaded_bodies.len(),
-                "Persisting cascaded deltas that were applied from pending queue"
+                applied_count = applied_bodies.len(),
+                "Persisting newly-applied deltas (cascades and/or Add-path parents)"
             );
 
             let mut handle = self.applier.context_client.datastore_handle();
-            for (cid, cascaded_delta) in cascaded_bodies {
+            for (cid, cascaded_delta) in applied_bodies {
                 let db_key =
                     calimero_store::key::ContextDagDelta::new(self.applier.context_id, *cid);
 
@@ -1258,18 +1298,18 @@ impl DeltaStore {
         // `broadcast_heartbeat` see the post-cascade state. Failing to
         // do this was the original bug behind #2178.
         //
-        // The failure is logged rather than propagated: cascaded deltas
-        // have already been rewritten in the DB with `events: None`, so
-        // their event payloads now survive only in our return value. If
-        // we bailed out with `Err` here, the caller would drop the Vec
-        // and those events would be permanently lost — handlers would
-        // never run for deltas that *were* successfully persisted.
-        // Stale `dag_heads` in the database is recoverable (the next
-        // sync session overwrites them); silently dropped events are
-        // not. This mirrors the original `get_missing_parents` behaviour
-        // (warn-and-continue) and fixes an equivalent latent bug that
-        // was present in the old inline `add_delta_internal` code (which
-        // `?`-propagated and lost the same events).
+        // The failure is logged rather than propagated: the applied
+        // deltas above have already been rewritten in the DB with
+        // `events: None`, so their event payloads now survive only in
+        // our return value. If we bailed out with `Err` here, the caller
+        // would drop the Vec and those events would be permanently lost
+        // — handlers would never run for deltas that *were* successfully
+        // persisted. Stale `dag_heads` in the database is recoverable
+        // (the next sync session overwrites them); silently dropped
+        // events are not. This mirrors the original `get_missing_parents`
+        // behaviour (warn-and-continue) and fixes an equivalent latent
+        // bug that was present in the old inline `add_delta_internal`
+        // code (which `?`-propagated and lost the same events).
         match self
             .applier
             .context_client

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1040,16 +1040,34 @@ impl DeltaStore {
                         parent_id,
                         dag_delta,
                     } => {
-                        // Clone before `add_delta` consumes — on success
-                        // we hand the body to phase 3 to rewrite the DB
-                        // record as `applied: true` and forward any
-                        // pre-stored events (same treatment as cascaded
-                        // children).
+                        // Clone before `add_delta` consumes — on
+                        // actually-applied (`Ok(true)`) we hand the body
+                        // to phase 3 to rewrite the DB record as
+                        // `applied: true` and forward any pre-stored
+                        // events (same treatment as cascaded children).
+                        //
+                        // `Ok(false)` means either a duplicate (already
+                        // in the DAG; nothing changed) OR the delta went
+                        // pending because its own ancestors are missing
+                        // from the DAG. Persisting `applied: true` in
+                        // the latter case would be catastrophic:
+                        // `load_persisted_deltas_into_dag` on restart
+                        // takes the `restore_applied_delta` path for
+                        // `applied=true` records, which skips WASM —
+                        // the delta's actions would never run on this
+                        // node, causing state divergence.
                         let body_for_persist = dag_delta.clone();
                         match dag.add_delta(dag_delta, &*self.applier).await {
-                            Ok(_) => {
+                            Ok(true) => {
                                 any_parent_added = true;
                                 added_parent_bodies.push((parent_id, body_for_persist));
+                            }
+                            Ok(false) => {
+                                tracing::debug!(
+                                    context_id = %self.applier.context_id,
+                                    parent_id = ?parent_id,
+                                    "ParentPlan::Add did not apply (duplicate or went pending); DB record stays applied=false"
+                                );
                             }
                             Err(e) => {
                                 tracing::warn!(

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -41,9 +41,12 @@ pub struct AddDeltaResult {
 pub struct MissingParentsResult {
     /// IDs of deltas that are truly missing (need to be requested from network)
     pub missing_ids: Vec<[u8; 32]>,
-    /// IDs of ALL deltas cascaded during the check, regardless of whether
-    /// they carry events. Callers can use this to detect whether the current
-    /// delta was applied via cascade without re-acquiring the DAG lock.
+    /// IDs of ALL deltas newly applied during the check, regardless of
+    /// whether they carry events. Includes both cascade-from-pending
+    /// applications and parents loaded from the DB and applied via
+    /// `ParentPlan::Add`. Callers can use this to detect whether the
+    /// current delta was applied as a side effect of the call without
+    /// re-acquiring the DAG lock.
     pub cascaded_ids: Vec<[u8; 32]>,
     /// Subset of `cascaded_ids` that have events to forward to handlers,
     /// as (delta_id, events_data) pairs.
@@ -1014,7 +1017,7 @@ impl DeltaStore {
             // Parents we just transitioned from `applied: false` → applied
             // in the DAG via `add_delta`. Their DB records still say
             // `applied: false`; phase 3 persists the update alongside any
-            // cascaded children. Without this, `load_persisted_deltas_into_dag`
+            // cascaded children. Without this, `load_persisted_deltas`
             // re-runs WASM for these parents on every restart (#2187).
             let mut added_parent_bodies: Vec<([u8; 32], CausalDelta<Vec<Action>>)> = Vec::new();
 
@@ -1040,27 +1043,31 @@ impl DeltaStore {
                         parent_id,
                         dag_delta,
                     } => {
-                        // Clone before `add_delta` consumes — on
-                        // actually-applied (`Ok(true)`) we hand the body
-                        // to phase 3 to rewrite the DB record as
-                        // `applied: true` and forward any pre-stored
-                        // events (same treatment as cascaded children).
+                        // `add_delta` consumes `dag_delta`, so we can't
+                        // reuse the value after the call. Instead of
+                        // pre-cloning (which pays the payload-sized clone
+                        // on every iteration even for Ok(false) / Err
+                        // where we don't need the body), we re-fetch
+                        // from the DAG after `Ok(true)` — `add_delta`
+                        // stores a clone at insert time, so the body is
+                        // already there and the lock is still ours.
                         //
                         // `Ok(false)` means either a duplicate (already
                         // in the DAG; nothing changed) OR the delta went
                         // pending because its own ancestors are missing
                         // from the DAG. Persisting `applied: true` in
                         // the latter case would be catastrophic:
-                        // `load_persisted_deltas_into_dag` on restart
-                        // takes the `restore_applied_delta` path for
-                        // `applied=true` records, which skips WASM —
-                        // the delta's actions would never run on this
-                        // node, causing state divergence.
-                        let body_for_persist = dag_delta.clone();
+                        // `load_persisted_deltas` on restart takes the
+                        // `restore_applied_delta` path for `applied=true`
+                        // records, which skips WASM — the delta's actions
+                        // would never run on this node, causing state
+                        // divergence.
                         match dag.add_delta(dag_delta, &*self.applier).await {
                             Ok(true) => {
                                 any_parent_added = true;
-                                added_parent_bodies.push((parent_id, body_for_persist));
+                                if let Some(body) = dag.get_delta(&parent_id) {
+                                    added_parent_bodies.push((parent_id, body.clone()));
+                                }
                             }
                             Ok(false) => {
                                 tracing::debug!(
@@ -1109,7 +1116,7 @@ impl DeltaStore {
 
             let pending_after: HashSet<[u8; 32]> =
                 dag.get_pending_delta_ids().into_iter().collect();
-            let cascaded_ids: Vec<[u8; 32]> =
+            let mut cascaded_ids: Vec<[u8; 32]> =
                 pending_before.difference(&pending_after).copied().collect();
 
             // Clone bodies now so DB I/O in phase 3 runs without the lock.
@@ -1117,6 +1124,12 @@ impl DeltaStore {
                 .iter()
                 .filter_map(|cid| dag.get_delta(cid).map(|d| (*cid, d.clone())))
                 .collect();
+
+            // Add-path parents are also newly-applied deltas; include
+            // their IDs so `cascaded_events` stays a subset of
+            // `cascaded_ids` (documented invariant of
+            // `MissingParentsResult`).
+            cascaded_ids.extend(added_parent_bodies.iter().map(|(id, _)| *id));
 
             (
                 any_parent_added,
@@ -1151,7 +1164,7 @@ impl DeltaStore {
             // had events pre-persisted on this node, this means its
             // handlers run on the next `execute_cascaded_events` call.
             // For one without events, it simply flips `applied: false →
-            // true` so restart's `load_persisted_deltas_into_dag` stops
+            // true` so restart's `load_persisted_deltas` stops
             // re-running its WASM (#2187).
             let mut bodies_to_persist = added_parent_bodies;
             bodies_to_persist.extend(cascaded_bodies);
@@ -1233,7 +1246,7 @@ impl DeltaStore {
             );
 
             let mut handle = self.applier.context_client.datastore_handle();
-            for (cid, cascaded_delta) in applied_bodies {
+            for (cid, applied_delta) in applied_bodies {
                 let db_key =
                     calimero_store::key::ContextDagDelta::new(self.applier.context_id, *cid);
 
@@ -1246,7 +1259,7 @@ impl DeltaStore {
                             context_id = %self.applier.context_id,
                             delta_id = ?cid,
                             has_events = stored.events.is_some(),
-                            "Retrieved stored delta for cascaded delta"
+                            "Retrieved stored delta for applied delta"
                         );
                         stored.events
                     }
@@ -1254,7 +1267,7 @@ impl DeltaStore {
                         debug!(
                             context_id = %self.applier.context_id,
                             delta_id = ?cid,
-                            "Cascaded delta not found in database (was never persisted)"
+                            "Applied delta not found in database (was never persisted)"
                         );
                         None
                     }
@@ -1263,20 +1276,20 @@ impl DeltaStore {
                             ?e,
                             context_id = %self.applier.context_id,
                             delta_id = ?cid,
-                            "Failed to query database for cascaded delta"
+                            "Failed to query database for applied delta"
                         );
                         None
                     }
                 };
 
-                let serialized_actions = match borsh::to_vec(&cascaded_delta.payload) {
+                let serialized_actions = match borsh::to_vec(&applied_delta.payload) {
                     Ok(s) => s,
                     Err(e) => {
                         warn!(
                             ?e,
                             context_id = %self.applier.context_id,
                             delta_id = ?cid,
-                            "Failed to serialize cascaded delta actions, skipping persistence"
+                            "Failed to serialize applied delta actions, skipping persistence"
                         );
                         continue;
                     }
@@ -1288,11 +1301,11 @@ impl DeltaStore {
 
                 let record = calimero_store::types::ContextDagDelta {
                     delta_id: *cid,
-                    parents: cascaded_delta.parents.clone(),
+                    parents: applied_delta.parents.clone(),
                     actions: serialized_actions,
-                    hlc: cascaded_delta.hlc,
+                    hlc: applied_delta.hlc,
                     applied: true,
-                    expected_root_hash: cascaded_delta.expected_root_hash,
+                    expected_root_hash: applied_delta.expected_root_hash,
                     events: None, // Cleared — caller will run handlers.
                 };
                 if let Err(e) = handle.put(&db_key, &record) {
@@ -1300,13 +1313,13 @@ impl DeltaStore {
                         ?e,
                         context_id = %self.applier.context_id,
                         delta_id = ?cid,
-                        "Failed to persist cascaded delta to database"
+                        "Failed to persist applied delta to database"
                     );
                 } else if stored_events.is_some() {
                     info!(
                         context_id = %self.applier.context_id,
                         delta_id = ?cid,
-                        "Persisted cascaded delta - has events for handler execution"
+                        "Persisted applied delta - has events for handler execution"
                     );
                 }
             }


### PR DESCRIPTION
## Summary

Closes #2187.

When `get_missing_parents` loads a parent from the DB with `applied: false`, it runs the parent through `dag.add_delta` (executing WASM) and marks it applied in the in-memory DAG — but the parent's own DB record stayed `applied: false`. Only the cascaded children it unblocked got persisted.

On restart, `load_persisted_deltas_into_dag` re-reads that parent as unapplied and the next `get_missing_parents` call classifies it as `ParentPlan::Add` again → re-executes its WASM. CRDT semantics (idempotent action replay) mean this doesn't corrupt state, so it's not a correctness bug — but it wastes WASM cost, re-computes root hashes, and any observable side effects (metrics, logs) fire twice.

## Change

Track newly-applied parents alongside cascaded children in the write-lock scope, then hand both to the shared `persist_cascaded_deltas_and_update_heads` helper in phase 3.

The helper's per-entry semantics already do exactly what we need:
- Read any pre-stored `events` → forward to caller's return value
- Rewrite the DB record as `applied: true, events: None`

So parents get the same atomicity and failure characteristics as cascaded children. For a parent that had events pre-persisted (pending+events state), its handlers now run on the next `execute_cascaded_events` call. For one without events, it simply flips `applied: false → true`.

Widens the helper's param name (`cascaded_bodies` → `applied_bodies`) and docstring to reflect the broader use.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p calimero-node --lib` — 46 pass
- [ ] CI on the PR: e2e-rust-apps, fuzzy-load-test (smoke)
- [ ] Manual: restart a node after a `ParentPlan::Add` — parent's DB record now reads `applied: true`, no repeat WASM execution on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delta application/persistence and `dag_heads` updates; an incorrect `applied` transition could cause missed action replay or extra replays on restart, though the change is narrowly scoped and guarded against `Ok(false)` pending cases.
> 
> **Overview**
> Fixes `get_missing_parents` so parents loaded from the DB with `applied: false` and successfully applied via `ParentPlan::Add` are also persisted back as `applied: true` (and any stored `events` are forwarded/cleared), preventing repeated WASM re-execution after node restarts.
> 
> Expands the “cascade persistence” path to treat *all newly-applied deltas* the same (Add-path parents plus cascaded-from-pending children): collects applied parent bodies under the DAG write lock, merges them with cascaded bodies, and persists them together via the shared helper (including updated `dag_heads`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f2a1798b97c65b208d68a7ca0ce1800e4e5695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->