### PR TITLE
chore: bump 0.10.1 rc.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.28"
+version = "0.10.1-rc.29"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
## Summary
Bumps `workspace.metadata.workspaces.version` to `0.10.1-rc.29` to ship the namespace-scope TEE admission policy change and the recent node/delta refactor + fix.

## What's in this release (vs rc.28)
- **feat(context): namespace-scope TEE admission policies (#2188).** Reader resolves subgroup lookups to the namespace root; write handler and governance-apply path both refuse `TeeAdmissionPolicySet` on a subgroup. Aligns the code with how auto-follow actually behaves and lets the Phase 6 cleanup cascade merge.
- **refactor(node/delta): shared `persist_cascaded_deltas` helper (#2191).**
- **fix(node/delta): persist parent `applied=true` after `ParentPlan::Add` (#2192).**

## Why now
#2188 is a behavior change that isn't in any published binary yet. Operationally everything downstream waits on rc.29:
- mero-tee sidecar image rebuild (hygiene — picks up the new `meroctl` / `merod`).
- calimero-network/tauri-app#59 — drops per-subgroup `setTeeAdmissionPolicy`; becomes required against an rc.29 merod.
- calimero-network/mdma#46 — collapses HaRequest to one row per namespace; the sidecar wastage only fully disappears once rc.29 is running on the fleet *and* mdma is emitting one assignment per namespace.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check` clean
- [ ] CI runs pass (build matrix, clippy, tests)
- [ ] Release workflow publishes tag + container/binary artifacts on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the workspace release/version metadata and does not change runtime code paths.
> 
> **Overview**
> Bumps `workspace.metadata.workspaces.version` in `Cargo.toml` from `0.10.1-rc.28` to `0.10.1-rc.29` to advance the workspace release identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3853fca5d66fc55551d88e3cd2a29e48158f886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->