### PR TITLE
fix(node/delta): preserve events in DB until handler execution confirmed

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -789,7 +789,13 @@ impl DeltaStore {
 
         drop(dag); // Release lock before calling context_client
 
-        // Update persistence if delta applied (was pre-persisted with events=Some, now needs events=None)
+        // Update persistence if delta applied. Preserve events until
+        // the caller confirms handler execution via
+        // `mark_events_executed(&delta_id)` — same crash-safety contract
+        // as the cascade path (#2185, #2194 review). If we crash between
+        // this write and the caller's `execute_event_handlers_parsed`
+        // success, the next init's `load_persisted_deltas` surfaces the
+        // record via `pending_handler_events` and replays the handler.
         if result && events.is_some() {
             let mut handle = self.applier.context_client.datastore_handle();
             let serialized_actions = borsh::to_vec(&actions_for_db)
@@ -805,7 +811,7 @@ impl DeltaStore {
                         hlc,
                         applied: true,
                         expected_root_hash,
-                        events: None, // Clear events after immediate application
+                        events: events.clone(),
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to update applied delta: {}", e))?;

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -36,6 +36,19 @@ pub struct AddDeltaResult {
     pub cascaded_events: Vec<([u8; 32], Vec<u8>)>,
 }
 
+/// Result of `load_persisted_deltas`.
+#[derive(Debug, Default)]
+pub struct LoadPersistedResult {
+    /// Number of deltas restored into the DAG.
+    pub loaded_count: usize,
+    /// Deltas that still have `events: Some(..)` on disk with
+    /// `applied: true` — handlers for these were interrupted before
+    /// `execute_cascaded_events` could clear them (#2185). Caller is
+    /// expected to feed these through `execute_cascaded_events` which
+    /// will clear them on success.
+    pub pending_handler_events: Vec<([u8; 32], Vec<u8>)>,
+}
+
 /// Result of checking for missing parents with cascaded event information
 #[derive(Debug)]
 pub struct MissingParentsResult {
@@ -496,7 +509,7 @@ impl DeltaStore {
     ///
     /// Deltas are loaded in topological order (parents before children) to properly
     /// reconstruct the DAG topology.
-    pub async fn load_persisted_deltas(&self) -> Result<usize> {
+    pub async fn load_persisted_deltas(&self) -> Result<LoadPersistedResult> {
         use std::collections::HashMap;
 
         let handle = self.applier.context_client.datastore_handle();
@@ -504,6 +517,12 @@ impl DeltaStore {
         // Step 1: Collect ALL deltas for this context from DB
         let mut iter = handle.iter::<calimero_store::key::ContextDagDelta>()?;
         let mut all_deltas: HashMap<[u8; 32], CausalDelta<Vec<Action>>> = HashMap::new();
+        // Collected in the same pass: records with `applied: true,
+        // events: Some(..)` are crash-leftovers whose handlers never
+        // completed. Surfaced via the return struct so the caller can
+        // replay through `execute_cascaded_events` without re-scanning
+        // the DB (#2185 / #2194 review).
+        let mut pending_handler_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
 
         for entry in iter.entries() {
             let (key_result, value_result) = entry;
@@ -513,6 +532,14 @@ impl DeltaStore {
             // Filter by context_id
             if key.context_id() != self.applier.context_id {
                 continue;
+            }
+
+            // Harvest pending handler events before taking ownership of
+            // `events` fields we may clone elsewhere.
+            if stored_delta.applied {
+                if let Some(ref events_data) = stored_delta.events {
+                    pending_handler_events.push((stored_delta.delta_id, events_data.clone()));
+                }
             }
 
             // Deserialize actions
@@ -567,7 +594,10 @@ impl DeltaStore {
         }
 
         if all_deltas.is_empty() {
-            return Ok(0);
+            return Ok(LoadPersistedResult {
+                loaded_count: 0,
+                pending_handler_events,
+            });
         }
 
         debug!(
@@ -660,7 +690,10 @@ impl DeltaStore {
             }
         }
 
-        Ok(loaded_count)
+        Ok(LoadPersistedResult {
+            loaded_count,
+            pending_handler_events,
+        })
     }
 
     /// Add a delta with optional event data to the store
@@ -1413,37 +1446,6 @@ impl DeltaStore {
                 "Failed to clear events after handler execution; next restart will replay"
             );
         }
-    }
-
-    /// Scan the DB for deltas that have `applied: true, events: Some(..)`
-    /// — records whose handlers were interrupted between the DB write in
-    /// `persist_cascaded_deltas_and_update_heads` and the
-    /// `execute_cascaded_events` call that would have cleared the column.
-    /// Returns `(delta_id, events_blob)` pairs for the caller to replay
-    /// through `execute_cascaded_events` (#2185 restart recovery).
-    pub fn collect_pending_handler_events(&self) -> Result<Vec<([u8; 32], Vec<u8>)>> {
-        let handle = self.applier.context_client.datastore_handle();
-        let mut iter = handle.iter::<calimero_store::key::ContextDagDelta>()?;
-        let mut pending: Vec<([u8; 32], Vec<u8>)> = Vec::new();
-
-        for entry in iter.entries() {
-            let (key_result, value_result) = entry;
-            let key = key_result?;
-            if key.context_id() != self.applier.context_id {
-                continue;
-            }
-
-            let stored = value_result?;
-            if !stored.applied {
-                continue;
-            }
-            let Some(events_data) = stored.events else {
-                continue;
-            };
-            pending.push((stored.delta_id, events_data));
-        }
-
-        Ok(pending)
     }
 
     /// Check if a delta has been applied to the DAG

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1214,13 +1214,15 @@ impl DeltaStore {
     /// parent just applied via `get_missing_parents`'s Add path):
     /// - The in-memory DAG body (in `applied_bodies`) is the authoritative
     ///   source; the DB may or may not already contain a record.
-    /// - Any existing DB record's `events` column is read and forwarded in
-    ///   the return value (so the caller can run handlers) before the
-    ///   record is rewritten with `applied: true, events: None`.
-    ///   Events-less deltas are never pre-persisted, so a missing DB
-    ///   record is normal for the cascade path — the helper rebuilds the
-    ///   full record from the in-memory body. Add-path parents always
-    ///   have a DB record present (phase 1 loaded it).
+    /// - Any existing DB record's `events` column is read, forwarded in
+    ///   the return value (so the caller can run handlers), AND kept in
+    ///   the rewritten DB record as `events: Some(..)`. Events are only
+    ///   cleared (via `mark_events_executed`) after the caller confirms
+    ///   handler execution succeeded — this is the crash-safety contract
+    ///   from #2185. Events-less deltas are never pre-persisted, so a
+    ///   missing DB record is normal for the cascade path — the helper
+    ///   rebuilds the full record from the in-memory body. Add-path
+    ///   parents always have a DB record present (phase 1 loaded it).
     ///
     /// After the loop, `update_dag_heads` is called unconditionally with
     /// the supplied `heads`. Pass an empty slice when you only need the
@@ -1299,6 +1301,13 @@ impl DeltaStore {
                     forwarded_events.push((*cid, events_data.clone()));
                 }
 
+                // Preserve `events` in the DB until handler execution is
+                // confirmed by the caller (#2185). If we crash between
+                // this write and `execute_cascaded_events` succeeding,
+                // the next `load_persisted_deltas` / cascade scan will
+                // find `applied: true, events: Some(..)` and replay the
+                // handlers. `mark_events_executed` clears the column
+                // once handlers have run.
                 let record = calimero_store::types::ContextDagDelta {
                     delta_id: *cid,
                     parents: applied_delta.parents.clone(),
@@ -1306,7 +1315,7 @@ impl DeltaStore {
                     hlc: applied_delta.hlc,
                     applied: true,
                     expected_root_hash: applied_delta.expected_root_hash,
-                    events: None, // Cleared — caller will run handlers.
+                    events: stored_events.clone(),
                 };
                 if let Err(e) = handle.put(&db_key, &record) {
                     warn!(
@@ -1329,18 +1338,13 @@ impl DeltaStore {
         // `broadcast_heartbeat` see the post-cascade state. Failing to
         // do this was the original bug behind #2178.
         //
-        // The failure is logged rather than propagated: the applied
-        // deltas above have already been rewritten in the DB with
-        // `events: None`, so their event payloads now survive only in
-        // our return value. If we bailed out with `Err` here, the caller
-        // would drop the Vec and those events would be permanently lost
-        // — handlers would never run for deltas that *were* successfully
-        // persisted. Stale `dag_heads` in the database is recoverable
-        // (the next sync session overwrites them); silently dropped
-        // events are not. This mirrors the original `get_missing_parents`
-        // behaviour (warn-and-continue) and fixes an equivalent latent
-        // bug that was present in the old inline `add_delta_internal`
-        // code (which `?`-propagated and lost the same events).
+        // The failure is logged rather than propagated to match
+        // `get_missing_parents`'s warn-and-continue behaviour. Stale
+        // `dag_heads` is recoverable (the next sync session overwrites
+        // them). Since #2185, events are preserved in the DB record
+        // until the caller confirms handler execution, so a failure
+        // here no longer risks losing the event payloads — they still
+        // live in both the in-memory Vec we return *and* in the DB.
         match self
             .applier
             .context_client
@@ -1359,6 +1363,87 @@ impl DeltaStore {
         }
 
         forwarded_events
+    }
+
+    /// Mark a delta's events as executed by clearing its `events` column
+    /// in the DB. Called by `execute_cascaded_events` after the handler
+    /// for this delta runs successfully (#2185).
+    ///
+    /// Failures are logged, not propagated: if the clear fails, the
+    /// worst case is a duplicate handler run on the next restart (the
+    /// record still shows `applied: true, events: Some(..)` and the
+    /// replay path will pick it up). That's strictly less bad than
+    /// losing events, which is the bug #2185 fixes.
+    pub fn mark_events_executed(&self, delta_id: &[u8; 32]) {
+        let mut handle = self.applier.context_client.datastore_handle();
+        let db_key = calimero_store::key::ContextDagDelta::new(self.applier.context_id, *delta_id);
+
+        let stored = match handle.get(&db_key) {
+            Ok(Some(record)) => record,
+            Ok(None) => {
+                // Events-less deltas aren't pre-persisted, so the helper
+                // would have rebuilt the record before this point. Absent
+                // here means another code path raced us; nothing to do.
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    ?e,
+                    context_id = %self.applier.context_id,
+                    delta_id = ?delta_id,
+                    "Failed to read DB for events clear; next restart will replay"
+                );
+                return;
+            }
+        };
+
+        if stored.events.is_none() {
+            return;
+        }
+
+        let record = calimero_store::types::ContextDagDelta {
+            events: None,
+            ..stored
+        };
+        if let Err(e) = handle.put(&db_key, &record) {
+            warn!(
+                ?e,
+                context_id = %self.applier.context_id,
+                delta_id = ?delta_id,
+                "Failed to clear events after handler execution; next restart will replay"
+            );
+        }
+    }
+
+    /// Scan the DB for deltas that have `applied: true, events: Some(..)`
+    /// — records whose handlers were interrupted between the DB write in
+    /// `persist_cascaded_deltas_and_update_heads` and the
+    /// `execute_cascaded_events` call that would have cleared the column.
+    /// Returns `(delta_id, events_blob)` pairs for the caller to replay
+    /// through `execute_cascaded_events` (#2185 restart recovery).
+    pub fn collect_pending_handler_events(&self) -> Result<Vec<([u8; 32], Vec<u8>)>> {
+        let handle = self.applier.context_client.datastore_handle();
+        let mut iter = handle.iter::<calimero_store::key::ContextDagDelta>()?;
+        let mut pending: Vec<([u8; 32], Vec<u8>)> = Vec::new();
+
+        for entry in iter.entries() {
+            let (key_result, value_result) = entry;
+            let key = key_result?;
+            if key.context_id() != self.applier.context_id {
+                continue;
+            }
+
+            let stored = value_result?;
+            if !stored.applied {
+                continue;
+            }
+            let Some(events_data) = stored.events else {
+                continue;
+            };
+            pending.push((stored.delta_id, events_data));
+        }
+
+        Ok(pending)
     }
 
     /// Check if a delta has been applied to the DAG

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -819,7 +819,7 @@ impl DeltaStore {
             debug!(
                 context_id = %self.applier.context_id,
                 delta_id = ?delta_id,
-                "Updated pre-persisted delta as applied (cleared events)"
+                "Updated pre-persisted delta as applied (events preserved until handler success)"
             );
         } else if result {
             // Delta applied and had no events - just persist normally
@@ -1437,6 +1437,24 @@ impl DeltaStore {
         };
 
         if stored.events.is_none() {
+            return;
+        }
+
+        // Safety guard against a stale read (#2194 review): if `applied`
+        // is false in the snapshot we just read, something else is
+        // mid-write on this record — our `..stored` spread would clobber
+        // any concurrent `applied: true` write. Bail out; the stored
+        // `events: Some(..)` stays in the DB and the next restart
+        // replays via `load_persisted_deltas`. The race is narrow (same
+        // delta id being cascaded + handler-executed twice in parallel),
+        // but silently downgrading `applied: true → false` would be a
+        // correctness bug, not just a lost clear.
+        if !stored.applied {
+            debug!(
+                context_id = %self.applier.context_id,
+                delta_id = ?delta_id,
+                "mark_events_executed observed applied=false; skipping clear to avoid clobbering concurrent write"
+            );
             return;
         }
 

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -571,13 +571,32 @@ async fn init_delta_store(
 
     if is_new_store {
         let init_result = async {
-            if let Err(e) = delta_store_ref.load_persisted_deltas().await {
-                warn!(
-                    ?e,
-                    %context_id,
-                    "Failed to load persisted deltas, starting with empty DAG"
-                );
-            }
+            // `load_persisted_deltas` surfaces any records with
+            // `applied: true, events: Some(..)` — crash-leftovers
+            // whose handlers never completed. Merged with the normal
+            // cascade events below so a single handler pass covers both
+            // (#2185). Share the DB scan with the DAG restore to avoid
+            // a second full-table iteration (#2194 review).
+            let pending_handler_events = match delta_store_ref.load_persisted_deltas().await {
+                Ok(result) => {
+                    if !result.pending_handler_events.is_empty() {
+                        info!(
+                            %context_id,
+                            pending_count = result.pending_handler_events.len(),
+                            "Replaying handlers interrupted by crash before events were cleared"
+                        );
+                    }
+                    result.pending_handler_events
+                }
+                Err(e) => {
+                    warn!(
+                        ?e,
+                        %context_id,
+                        "Failed to load persisted deltas, starting with empty DAG"
+                    );
+                    Vec::new()
+                }
+            };
 
             let missing_result = delta_store_ref.get_missing_parents().await;
             if !missing_result.missing_ids.is_empty() {
@@ -588,29 +607,12 @@ async fn init_delta_store(
                 );
             }
 
-            // Replay any events whose handlers were interrupted by a
-            // crash between `persist_cascaded_deltas_and_update_heads`
-            // and the `execute_cascaded_events` that would have cleared
-            // them (#2185). Merge with the normal cascade events so a
-            // single pass through the handler covers both.
             let mut events_to_run = missing_result.cascaded_events;
-            match delta_store_ref.collect_pending_handler_events() {
-                Ok(pending) if !pending.is_empty() => {
-                    info!(
-                        %context_id,
-                        pending_count = pending.len(),
-                        "Replaying handlers interrupted by crash before events were cleared"
-                    );
-                    // Dedup: the cascade path may surface the same id.
-                    events_to_run.retain(|(id, _)| !pending.iter().any(|(pid, _)| pid == id));
-                    events_to_run.extend(pending);
-                }
-                Ok(_) => {}
-                Err(e) => warn!(
-                    ?e,
-                    %context_id,
-                    "Failed to scan for pending handler events; replay skipped"
-                ),
+            if !pending_handler_events.is_empty() {
+                // Dedup: the cascade path may surface the same id.
+                events_to_run
+                    .retain(|(id, _)| !pending_handler_events.iter().any(|(pid, _)| pid == id));
+                events_to_run.extend(pending_handler_events);
             }
 
             execute_cascaded_events(
@@ -734,8 +736,15 @@ async fn execute_cascaded_events(
                     delta_id = ?cascaded_id,
                     error = %e,
                     phase = phase,
-                    "Failed to deserialize cascaded events"
+                    "Failed to deserialize cascaded events — clearing blob to prevent permanent replay loop"
                 );
+                // `serde_json::from_slice` failures on this blob are
+                // structural, not transient: a blob that fails to
+                // deserialize now will fail every restart. Without the
+                // clear, `collect_pending_handler_events` would surface
+                // this record on every init and we'd burn through the
+                // same warn-and-skip cycle forever (#2194 review).
+                delta_store.mark_events_executed(cascaded_id);
             }
         }
     }

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -755,7 +755,16 @@ async fn execute_cascaded_events(
                 }
 
                 if current_delta == Some(cascaded_id) {
-                    outcome.handlers_executed_for_current = all_succeeded;
+                    // Handlers for the current delta were *attempted* —
+                    // set this to `true` regardless of `all_succeeded`
+                    // so `handle_state_delta`'s outer flow doesn't
+                    // re-run them in the same request (which would
+                    // duplicate the succeeded handlers). On partial
+                    // failure, `mark_events_executed` above is skipped,
+                    // so `events: Some(..)` stays in the DB and a
+                    // restart replays — that is the retry path, not
+                    // in-request re-execution.
+                    outcome.handlers_executed_for_current = true;
                 }
             }
             Err(e) => {

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -318,6 +318,7 @@ pub async fn handle_state_delta(
             sync_timeout,
             "missing parent check",
             Some(&delta_id),
+            &delta_store_ref,
         )
         .await?;
         applied |= cascade_outcome.applied_current;
@@ -384,6 +385,7 @@ pub async fn handle_state_delta(
                             sync_timeout,
                             "peer-fetch cascade",
                             Some(&delta_id),
+                            &delta_store_ref,
                         )
                         .await?;
                         applied |= cascade_outcome.applied_current;
@@ -473,6 +475,7 @@ pub async fn handle_state_delta(
         sync_timeout,
         "dag cascade",
         None,
+        &delta_store_ref,
     )
     .await?;
 
@@ -585,14 +588,40 @@ async fn init_delta_store(
                 );
             }
 
+            // Replay any events whose handlers were interrupted by a
+            // crash between `persist_cascaded_deltas_and_update_heads`
+            // and the `execute_cascaded_events` that would have cleared
+            // them (#2185). Merge with the normal cascade events so a
+            // single pass through the handler covers both.
+            let mut events_to_run = missing_result.cascaded_events;
+            match delta_store_ref.collect_pending_handler_events() {
+                Ok(pending) if !pending.is_empty() => {
+                    info!(
+                        %context_id,
+                        pending_count = pending.len(),
+                        "Replaying handlers interrupted by crash before events were cleared"
+                    );
+                    // Dedup: the cascade path may surface the same id.
+                    events_to_run.retain(|(id, _)| !pending.iter().any(|(pid, _)| pid == id));
+                    events_to_run.extend(pending);
+                }
+                Ok(_) => {}
+                Err(e) => warn!(
+                    ?e,
+                    %context_id,
+                    "Failed to scan for pending handler events; replay skipped"
+                ),
+            }
+
             execute_cascaded_events(
-                &missing_result.cascaded_events,
+                &events_to_run,
                 node_clients,
                 &context_id,
                 &our_identity,
                 sync_timeout,
                 "initial load",
                 None,
+                &delta_store_ref,
             )
             .await
         }
@@ -624,6 +653,7 @@ async fn execute_cascaded_events(
     sync_timeout: std::time::Duration,
     phase: &str,
     current_delta: Option<&[u8; 32]>,
+    delta_store: &DeltaStore,
 ) -> Result<CascadeOutcome> {
     if cascaded_events.is_empty() {
         return Ok(CascadeOutcome::default());
@@ -687,6 +717,12 @@ async fn execute_cascaded_events(
                     &cascaded_payload,
                 )
                 .await?;
+
+                // Handlers ran successfully — clear events from the DB
+                // record (#2185). If a later iteration's handler fails
+                // with `?`, the remaining deltas keep `events: Some(..)`
+                // and the next restart replays only those.
+                delta_store.mark_events_executed(cascaded_id);
 
                 if current_delta == Some(cascaded_id) {
                     outcome.handlers_executed_for_current = true;
@@ -1384,6 +1420,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
         sync_timeout,
         "buffered delta replay",
         None,
+        &delta_store,
     )
     .await?;
 

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -440,13 +440,29 @@ pub async fn handle_state_delta(
             if !is_author {
                 // Application availability was already verified at the start of this function,
                 // so we can safely execute handlers without re-checking.
-                execute_event_handlers_parsed(
+                let all_succeeded = execute_event_handlers_parsed(
                     &node_clients.context,
                     &context_id,
                     &our_identity,
                     payload,
                 )
                 .await?;
+
+                // Clear the DB's `events` blob once every handler ran
+                // successfully (#2185, #2194 review). Partial failure
+                // leaves the blob for restart replay. `add_delta_internal`
+                // preserves `events: Some(..)` when a delta is directly
+                // applied, so this clear is the normal termination
+                // point for the direct-apply path.
+                if all_succeeded {
+                    delta_store_ref.mark_events_executed(&delta_id);
+                } else {
+                    warn!(
+                        %context_id,
+                        delta_id = ?delta_id,
+                        "One or more handlers failed on direct-apply path; keeping events in DB for restart replay"
+                    );
+                }
             } else {
                 info!(
                     %context_id,
@@ -698,7 +714,7 @@ async fn execute_cascaded_events(
             %context_id,
             cascaded_count = cascaded_events.len(),
             phase = phase,
-            "Application not available - skipping cascaded handler execution"
+            "Application not available - skipping cascaded handler execution. Events are preserved in DB (applied: true, events: Some(..)) and will replay on next init once the application becomes available."
         );
         return Ok(outcome);
     }
@@ -713,7 +729,7 @@ async fn execute_cascaded_events(
                     phase = phase,
                     "Executing handlers for cascaded delta"
                 );
-                execute_event_handlers_parsed(
+                let all_succeeded = execute_event_handlers_parsed(
                     &node_clients.context,
                     context_id,
                     our_identity,
@@ -721,14 +737,25 @@ async fn execute_cascaded_events(
                 )
                 .await?;
 
-                // Handlers ran successfully — clear events from the DB
-                // record (#2185). If a later iteration's handler fails
-                // with `?`, the remaining deltas keep `events: Some(..)`
-                // and the next restart replays only those.
-                delta_store.mark_events_executed(cascaded_id);
+                // Clear the DB's `events` blob only when every handler
+                // in the payload succeeded (#2185, #2194 review). On a
+                // partial failure, leave `events: Some(..)` so the next
+                // restart replays via `load_persisted_deltas`. Each
+                // retry is at-least-once — handler idempotency concern
+                // is tracked separately.
+                if all_succeeded {
+                    delta_store.mark_events_executed(cascaded_id);
+                } else {
+                    warn!(
+                        %context_id,
+                        delta_id = ?cascaded_id,
+                        phase = phase,
+                        "One or more handlers failed; keeping events in DB for restart replay"
+                    );
+                }
 
                 if current_delta == Some(cascaded_id) {
-                    outcome.handlers_executed_for_current = true;
+                    outcome.handlers_executed_for_current = all_succeeded;
                 }
             }
             Err(e) => {
@@ -879,12 +906,19 @@ mod tests {
 /// 1. Document why parallelization is unsafe
 /// 2. Consider refactoring to use CRDTs
 /// 3. Or disable parallelization if absolutely necessary
+/// Returns `Ok(true)` if every handler in the payload ran successfully,
+/// `Ok(false)` if at least one handler errored (individual errors are
+/// logged but swallowed so later handlers in the list still run). Callers
+/// use the bool to decide whether it's safe to clear the persisted events
+/// blob via `mark_events_executed` — clearing after a partial failure
+/// would prevent restart-replay of the failed handlers (#2194 review).
 async fn execute_event_handlers_parsed(
     context_client: &ContextClient,
     context_id: &ContextId,
     our_identity: &PublicKey,
     events_payload: &[ExecutionEvent],
-) -> Result<()> {
+) -> Result<bool> {
+    let mut all_succeeded = true;
     for event in events_payload {
         if let Some(handler_name) = &event.handler {
             debug!(
@@ -917,12 +951,13 @@ async fn execute_event_handlers_parsed(
                         error = %err,
                         "Handler execution failed"
                     );
+                    all_succeeded = false;
                 }
             }
         }
     }
 
-    Ok(())
+    Ok(all_succeeded)
 }
 
 /// Emit state mutation event to WebSocket clients (frontends)
@@ -1319,8 +1354,53 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
         })
         .clone();
 
-    // Load any persisted deltas first
-    let _ = delta_store.load_persisted_deltas().await;
+    // Load any persisted deltas first. If this is the first time this
+    // context's DeltaStore has been created in the process (post-crash
+    // restart, buffered-replay hits before a live delta), the load
+    // also surfaces any handler events whose execution was interrupted
+    // before they were cleared (#2185, #2194 review). Replay them
+    // *before* processing the buffered delta so causal order is
+    // preserved.
+    let pending_from_load = match delta_store.load_persisted_deltas().await {
+        Ok(result) => result.pending_handler_events,
+        Err(e) => {
+            warn!(
+                ?e,
+                %context_id,
+                "Failed to load persisted deltas during buffered-delta replay"
+            );
+            Vec::new()
+        }
+    };
+    if !pending_from_load.is_empty() {
+        let node_clients = crate::NodeClients {
+            context: context_client.clone(),
+            node: node_client.clone(),
+        };
+        info!(
+            %context_id,
+            pending_count = pending_from_load.len(),
+            "Replaying crash-interrupted handlers before buffered delta"
+        );
+        if let Err(e) = execute_cascaded_events(
+            &pending_from_load,
+            &node_clients,
+            &context_id,
+            &our_identity,
+            sync_timeout,
+            "buffered-replay crash recovery",
+            None,
+            &delta_store,
+        )
+        .await
+        {
+            warn!(
+                ?e,
+                %context_id,
+                "Crash-recovery replay failed during buffered-delta replay; events stay in DB for next init"
+            );
+        }
+    }
 
     // If this delta is covered by checkpoint (ancestor of checkpoint) but is NOT the checkpoint
     // itself, skip adding it to the DAG. Its state is already present via snapshot, and adding
@@ -1389,13 +1469,26 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                         "Executing handlers for replayed buffered delta"
                     );
 
-                    execute_event_handlers_parsed(
+                    let all_succeeded = execute_event_handlers_parsed(
                         &context_client,
                         &context_id,
                         &our_identity,
                         &events,
                     )
                     .await?;
+
+                    // Same clear-on-success contract as the other two
+                    // caller sites: keep `events: Some(..)` if any
+                    // handler failed so the next restart replays.
+                    if all_succeeded {
+                        delta_store.mark_events_executed(&delta_id);
+                    } else {
+                        warn!(
+                            %context_id,
+                            delta_id = ?delta_id,
+                            "One or more handlers failed on buffered-replay path; keeping events in DB for restart replay"
+                        );
+                    }
                 }
 
                 // Emit to WebSocket clients

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -469,6 +469,13 @@ pub async fn handle_state_delta(
                     %author_id,
                     "Skipping event handler execution (we are the author node)"
                 );
+                // Author already ran handlers locally at authoring time,
+                // so there is nothing to replay. Clear the preserved
+                // `events: Some(..)` blob so `load_persisted_deltas` on
+                // restart doesn't surface it as "pending handler events"
+                // and mistakenly re-run handlers the author deliberately
+                // skipped (#2194 review, High).
+                delta_store_ref.mark_events_executed(&delta_id);
             }
         }
     } else if !applied && events_payload.is_some() {
@@ -1498,6 +1505,12 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                             "One or more handlers failed on buffered-replay path; keeping events in DB for restart replay"
                         );
                     }
+                } else {
+                    // Author path: handlers already ran locally at
+                    // authoring time; clear the preserved blob so
+                    // restart replay doesn't mistakenly run them
+                    // again (#2194 review, High).
+                    delta_store.mark_events_executed(&delta_id);
                 }
 
                 // Emit to WebSocket clients

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -607,13 +607,14 @@ async fn init_delta_store(
                 );
             }
 
+            // The two sources are disjoint by construction:
+            // `pending_handler_events` are records that were `applied:
+            // true` on disk before this init ran, so they're restored
+            // into the DAG as already-applied by `load_persisted_deltas`
+            // and can't show up in `get_missing_parents`'s
+            // pending→applied diff. Concat directly.
             let mut events_to_run = missing_result.cascaded_events;
-            if !pending_handler_events.is_empty() {
-                // Dedup: the cascade path may surface the same id.
-                events_to_run
-                    .retain(|(id, _)| !pending_handler_events.iter().any(|(pid, _)| pid == id));
-                events_to_run.extend(pending_handler_events);
-            }
+            events_to_run.extend(pending_handler_events);
 
             execute_cascaded_events(
                 &events_to_run,


### PR DESCRIPTION
## Summary

Closes #2185.

**Bug**: `persist_cascaded_deltas_and_update_heads` rewrites each cascaded/applied delta's DB record with `events: None` *before* `execute_cascaded_events` has had a chance to run handlers. If the process dies (or handler call errors) in that window, events are lost — DB says `events: None`, the ephemeral Vec evaporates.

**Fix** — delayed-clear pattern (option 1 from issue):
1. Helper preserves `events: stored_events.clone()` in the rewritten record.
2. `execute_cascaded_events` clears per-delta via a new `DeltaStore::mark_events_executed(id)` immediately after the handler call succeeds. Per-delta granularity: a mid-loop `?` failure leaves the remaining deltas' events intact for restart replay.
3. `DeltaStore::collect_pending_handler_events` scans the DB for `applied: true, events: Some(..)` (crash-leftover records). The primary `is_new_store` init flow merges them with any fresh cascade events before calling `execute_cascaded_events`, so one pass covers both.

## Tradeoffs

- **Write amplification**: one extra DB write per cascaded delta on the happy path (the clear).
- **At-most-once → at-least-once**: a crash-free run is effectively unchanged. A crash between helper-write and handler-run now triggers a replay on next startup instead of silently dropping events. Handler idempotency concern is tracked separately (option (2) of the issue).

## Scope note

Only the primary `is_new_store` init flow triggers the crash-recovery scan. Secondary `load_persisted_deltas` callers (sync manager, buffered-delta replay) don't — any crash-leftover events for a given context clean up when that context's next live delta hits the primary init path, which creates a fresh store and runs replay. Contexts that receive no further deltas keep their pending events stuck in the DB — still strictly better than today's silent loss.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p calimero-node --lib` — 46 pass
- [ ] CI on the PR: e2e-rust-apps, fuzzy-load-test
- [ ] Manual crash test: kill node between delta apply and handler run → restart → verify handler runs exactly once and DB clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crash-recovery semantics for event handler execution and DB persistence, which can cause duplicate handler runs or missed clears if edge cases are wrong; impact is limited to delta event replay/persistence paths.
> 
> **Overview**
> Fixes a crash window where delta `events` could be cleared from the DB before handlers ran by **preserving `events: Some(..)` on applied records** until handler execution is confirmed.
> 
> `DeltaStore::load_persisted_deltas` now returns `LoadPersistedResult` including `pending_handler_events` (records with `applied: true` and `events` still present) so startup/buffered-replay can re-run interrupted handlers. Handler execution paths (`execute_cascaded_events` and direct/buffered delta handling) now clear events via new `DeltaStore::mark_events_executed` only after all handlers succeed (and also clears on author-skip / bad-json to avoid infinite replay), enabling at-least-once replay after crashes or partial failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7975b6b28d725e899510b1eaeb345730ddea3920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->