### PR TITLE
perf(node/delta): instrument DAG write-lock hold time (#2186)

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -773,8 +773,14 @@ impl DeltaStore {
         // callers on the same DeltaStore. Emit the hold time so we
         // can decide from real data whether throttling (issue #2186
         // options 1/2) is needed. Threshold-gated warn for the tail.
-        let lock_start = std::time::Instant::now();
+        //
+        // `lock_start` is captured AFTER `.write().await` so we measure
+        // hold time only, not acquire-wait. Under contention the two
+        // are distinct signals; conflating them would inflate hold
+        // numbers purely because other callers are slow, defeating the
+        // measurement (#2196 review).
         let mut dag = self.dag.write().await;
+        let lock_start = std::time::Instant::now();
 
         // Track which deltas are currently pending BEFORE we add the new delta
         // This lets us detect which pending deltas got applied during the cascade
@@ -796,12 +802,9 @@ impl DeltaStore {
             Vec::new()
         };
 
+        let hold = lock_start.elapsed();
         drop(dag); // Release lock before calling context_client
-        self.record_dag_write_lock_hold(
-            "add_delta_internal",
-            lock_start.elapsed(),
-            cascaded_deltas.len(),
-        );
+        self.record_dag_write_lock_hold("add_delta_internal", hold, None, cascaded_deltas.len());
 
         // Update persistence if delta applied. Preserve events until
         // the caller confirms handler execution via
@@ -1054,8 +1057,13 @@ impl DeltaStore {
         // many pending children. Emit hold time + plans/cascade
         // counts so we can decide from real data whether throttling
         // (issue #2186 options 1/2) is warranted.
+        //
+        // `hold` is captured inside the `else` branch only (where the
+        // lock is actually acquired) and after `.write().await` resolves
+        // — so we measure hold time only, not acquire-wait nor the
+        // lock-never-taken case (#2196 review).
         let plans_count = plans.len();
-        let lock_start = std::time::Instant::now();
+        let mut hold: Option<Duration> = None;
         let (
             any_parent_added,
             restored_head_hashes,
@@ -1074,6 +1082,7 @@ impl DeltaStore {
             )
         } else {
             let mut dag = self.dag.write().await;
+            let lock_start = std::time::Instant::now();
             let pending_before: HashSet<[u8; 32]> =
                 dag.get_pending_delta_ids().into_iter().collect();
             let mut any_parent_added = false;
@@ -1195,21 +1204,25 @@ impl DeltaStore {
             // `MissingParentsResult`).
             cascaded_ids.extend(added_parent_bodies.iter().map(|(id, _)| *id));
 
+            let heads = dag.get_heads();
+            hold = Some(lock_start.elapsed());
             (
                 any_parent_added,
                 restored_head_hashes,
                 cascaded_ids,
                 cascaded_bodies,
                 added_parent_bodies,
-                dag.get_heads(),
+                heads,
             )
         };
-        self.record_dag_write_lock_hold_with_plans(
-            "get_missing_parents",
-            lock_start.elapsed(),
-            plans_count,
-            cascaded_ids.len(),
-        );
+        if let Some(hold) = hold {
+            self.record_dag_write_lock_hold(
+                "get_missing_parents",
+                hold,
+                Some(plans_count),
+                cascaded_ids.len(),
+            );
+        }
 
         // Phase 3: post-DAG work — head-root-hash tracking + cascaded delta
         // persistence + dag_heads write. Runs with no DAG lock held.
@@ -1509,23 +1522,33 @@ impl DeltaStore {
     /// "long-tail WASM-under-write-lock" concern without committing to
     /// the larger throttling refactor.
     ///
-    /// Always emits at `debug!` so aggregators/dashboards can scrape;
-    /// bumps to `warn!` above 500ms so long tails are visible in
-    /// production logs without dashboard plumbing. The threshold is
-    /// intentionally generous — WASM execution is often 50-200ms on
-    /// its own, so anything under 500ms is within-budget.
+    /// Emits at `debug!` so aggregators/dashboards can scrape; bumps
+    /// to `warn!` above 500ms so long tails are visible in production
+    /// logs without dashboard plumbing. The threshold is intentionally
+    /// generous — WASM execution is often 50-200ms on its own, so
+    /// anything under 500ms is within-budget.
+    ///
+    /// `plans_count` is `Some(n)` for `get_missing_parents` (each plan
+    /// runs WASM for the `Add` variant) and `None` for
+    /// `add_delta_internal` where the notion doesn't apply. The pair
+    /// `(plans, cascaded)` is what a future throttling fix would need
+    /// to bound, so surfacing both matters for the Add-path call site.
     fn record_dag_write_lock_hold(
         &self,
         site: &'static str,
         hold: Duration,
+        plans_count: Option<usize>,
         cascaded_count: usize,
     ) {
         let hold_ms = hold.as_secs_f64() * 1000.0;
+        let hold_ms_s = format!("{:.2}", hold_ms);
+        let plans = plans_count.unwrap_or(0);
         if hold.as_millis() >= 500 {
             warn!(
                 context_id = %self.applier.context_id,
                 site = site,
-                hold_ms = format!("{:.2}", hold_ms),
+                hold_ms = %hold_ms_s,
+                plans_count = plans,
                 cascaded_count,
                 "DAG write lock held for long tail (#2186)"
             );
@@ -1533,40 +1556,8 @@ impl DeltaStore {
             debug!(
                 context_id = %self.applier.context_id,
                 site = site,
-                hold_ms = format!("{:.2}", hold_ms),
-                cascaded_count,
-                "DAG write lock hold time"
-            );
-        }
-    }
-
-    /// Same as `record_dag_write_lock_hold` but also surfaces the plan
-    /// count for `get_missing_parents` (each plan runs WASM for the
-    /// `Add` variant). The pair `(plans, cascaded)` is what a future
-    /// throttling fix would need to bound.
-    fn record_dag_write_lock_hold_with_plans(
-        &self,
-        site: &'static str,
-        hold: Duration,
-        plans_count: usize,
-        cascaded_count: usize,
-    ) {
-        let hold_ms = hold.as_secs_f64() * 1000.0;
-        if hold.as_millis() >= 500 {
-            warn!(
-                context_id = %self.applier.context_id,
-                site = site,
-                hold_ms = format!("{:.2}", hold_ms),
-                plans_count,
-                cascaded_count,
-                "DAG write lock held for long tail (#2186)"
-            );
-        } else {
-            debug!(
-                context_id = %self.applier.context_id,
-                site = site,
-                hold_ms = format!("{:.2}", hold_ms),
-                plans_count,
+                hold_ms = %hold_ms_s,
+                plans_count = plans,
                 cascaded_count,
                 "DAG write lock hold time"
             );

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -765,6 +765,15 @@ impl DeltaStore {
             );
         }
 
+        // Instrument the DAG write-lock scope (#2186). The `add_delta`
+        // call below runs WASM `__calimero_sync_next` via the applier,
+        // and its internal `apply_pending` may cascade additional
+        // pending children — each also running WASM. All of that
+        // happens under this single write lock, serializing concurrent
+        // callers on the same DeltaStore. Emit the hold time so we
+        // can decide from real data whether throttling (issue #2186
+        // options 1/2) is needed. Threshold-gated warn for the tail.
+        let lock_start = std::time::Instant::now();
         let mut dag = self.dag.write().await;
 
         // Track which deltas are currently pending BEFORE we add the new delta
@@ -788,6 +797,11 @@ impl DeltaStore {
         };
 
         drop(dag); // Release lock before calling context_client
+        self.record_dag_write_lock_hold(
+            "add_delta_internal",
+            lock_start.elapsed(),
+            cascaded_deltas.len(),
+        );
 
         // Update persistence if delta applied. Preserve events until
         // the caller confirms handler execution via
@@ -1031,6 +1045,17 @@ impl DeltaStore {
         // DB I/O is deliberately hoisted out of this scope (phase 1 above,
         // phase 3 below) to keep the lock window short and deterministic.
         let mut all_cascaded_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
+        // Instrument the phase-2 write-lock scope (#2186). Under this
+        // single critical section we run `add_delta` (→ WASM) for each
+        // `ParentPlan::Add`, `restore_applied_delta` for Restore plans,
+        // then a final `try_process_pending` that may cascade a long
+        // chain of pending children — each also running WASM. The
+        // total work can be unbounded if a restored parent unblocks
+        // many pending children. Emit hold time + plans/cascade
+        // counts so we can decide from real data whether throttling
+        // (issue #2186 options 1/2) is warranted.
+        let plans_count = plans.len();
+        let lock_start = std::time::Instant::now();
         let (
             any_parent_added,
             restored_head_hashes,
@@ -1179,6 +1204,12 @@ impl DeltaStore {
                 dag.get_heads(),
             )
         };
+        self.record_dag_write_lock_hold_with_plans(
+            "get_missing_parents",
+            lock_start.elapsed(),
+            plans_count,
+            cascaded_ids.len(),
+        );
 
         // Phase 3: post-DAG work — head-root-hash tracking + cascaded delta
         // persistence + dag_heads write. Runs with no DAG lock held.
@@ -1468,6 +1499,76 @@ impl DeltaStore {
                 context_id = %self.applier.context_id,
                 delta_id = ?delta_id,
                 "Failed to clear events after handler execution; next restart will replay"
+            );
+        }
+    }
+
+    /// Emit a structured log for the DAG write-lock hold time at a
+    /// given call site (#2186). Used by `add_delta_internal` and
+    /// `get_missing_parents` to surface observability data for the
+    /// "long-tail WASM-under-write-lock" concern without committing to
+    /// the larger throttling refactor.
+    ///
+    /// Always emits at `debug!` so aggregators/dashboards can scrape;
+    /// bumps to `warn!` above 500ms so long tails are visible in
+    /// production logs without dashboard plumbing. The threshold is
+    /// intentionally generous — WASM execution is often 50-200ms on
+    /// its own, so anything under 500ms is within-budget.
+    fn record_dag_write_lock_hold(
+        &self,
+        site: &'static str,
+        hold: Duration,
+        cascaded_count: usize,
+    ) {
+        let hold_ms = hold.as_secs_f64() * 1000.0;
+        if hold.as_millis() >= 500 {
+            warn!(
+                context_id = %self.applier.context_id,
+                site = site,
+                hold_ms = format!("{:.2}", hold_ms),
+                cascaded_count,
+                "DAG write lock held for long tail (#2186)"
+            );
+        } else {
+            debug!(
+                context_id = %self.applier.context_id,
+                site = site,
+                hold_ms = format!("{:.2}", hold_ms),
+                cascaded_count,
+                "DAG write lock hold time"
+            );
+        }
+    }
+
+    /// Same as `record_dag_write_lock_hold` but also surfaces the plan
+    /// count for `get_missing_parents` (each plan runs WASM for the
+    /// `Add` variant). The pair `(plans, cascaded)` is what a future
+    /// throttling fix would need to bound.
+    fn record_dag_write_lock_hold_with_plans(
+        &self,
+        site: &'static str,
+        hold: Duration,
+        plans_count: usize,
+        cascaded_count: usize,
+    ) {
+        let hold_ms = hold.as_secs_f64() * 1000.0;
+        if hold.as_millis() >= 500 {
+            warn!(
+                context_id = %self.applier.context_id,
+                site = site,
+                hold_ms = format!("{:.2}", hold_ms),
+                plans_count,
+                cascaded_count,
+                "DAG write lock held for long tail (#2186)"
+            );
+        } else {
+            debug!(
+                context_id = %self.applier.context_id,
+                site = site,
+                hold_ms = format!("{:.2}", hold_ms),
+                plans_count,
+                cascaded_count,
+                "DAG write lock hold time"
             );
         }
     }


### PR DESCRIPTION
## Summary

Closes (measurement phase of) #2186.

Issue #2186 flagged that the DAG write-lock scope in `get_missing_parents` holds across all `ParentPlan::Add` WASM executions plus any cascaded children promoted by the final `try_process_pending`. Same concern applies to `add_delta_internal` where `add_delta`'s internal `apply_pending` can chain arbitrarily long cascades under one lock. Per-context, so concurrent `add_delta_with_events` / `get_missing_parents` on the same `DeltaStore` serialize behind us.

The issue's own recommendation was **option (3): measurement-first** — observability first, decide from data whether throttling (options 1/2) is needed. This PR does exactly that.

## What's emitted

- `debug!` per call with `site`, `hold_ms`, `plans_count` (for `get_missing_parents`), `cascaded_count`.
- `warn!` at the same fields when `hold_ms >= 500` so long tails surface in production logs without needing a dashboard. 500ms is generous — a single WASM `__calimero_sync_next` apply is routinely 50-200ms; past that is worth attention.

## Instrumented sites

1. `add_delta_internal` — brackets the `dag.write().await` scope.
2. `get_missing_parents` — brackets phase 2 (plans loop + `try_process_pending` + body cloning), which is where the lock is held longest.

## Non-goals

- No Prometheus histogram — intentional. The log-based approach is zero-setup and immediately usable for grep/aggregation; a Prometheus scrape can be added later if the data warrants plumbing it through `SyncMetricsCollector` or a new collector.
- No behaviour change. Just observability.

## Acceptance

Satisfies issue #2186's first acceptance checkbox ("metric or tracing span capturing time spent holding the DAG write lock"). The second checkbox ("decision backed by data on whether throttling is needed") stays open — this PR produces the data; reading it is the follow-up.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p calimero-node --lib` — 46 pass
- [ ] CI on the PR
- [ ] Manual: run a fuzzy-load test, grep for `DAG write lock held for long tail (#2186)` warnings to see real-world distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds timing and logging around existing write-lock scopes with no functional behavior changes; main risk is minor performance/log-volume impact on hot paths.
> 
> **Overview**
> Adds **observability for DAG write-lock hold time** in `DeltaStore` to quantify how long `WASM` execution and cascaded pending applications run while holding the DAG write lock.
> 
> `add_delta_internal` and `get_missing_parents` now time the write-lock *hold* (measured after `.write().await` completes) and emit structured `debug!` logs, escalating to `warn!` when holds exceed 500ms; logs include call `site`, `hold_ms`, `plans_count` (for `get_missing_parents`), and `cascaded_count`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49947a4d926c178856b7bd684edb4fec2e2aeb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->