### PR TITLE
perf(runtime): sub-timers on Module::run for #2199

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -3,7 +3,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use wasmer::{DeserializeError, Instance, SerializeError, Store};
 
 // Profiling feature: Only compile these imports when profiling feature is enabled
@@ -242,17 +242,33 @@ impl Module {
         info!(%context_id, method, "Running WASM method");
         debug!(%context_id, method, input_len = input.len(), "WASM execution input");
 
+        // #2199 sub-timers. The outer timer in
+        // `crates/node/src/delta_store.rs` (`wasm_ms`) measures this
+        // whole call. Wasmer `Store` and `Instance` are created fresh
+        // per invocation — no caching — so setup cost is per-call.
+        // These sub-timers break the total into: store-create,
+        // import-setup, instance-new+register-merge, function-call.
+        // If `function_call_ms` dominates, the app's WASM work is the
+        // bottleneck; if setup does, caching Store/Instance becomes
+        // the fix direction.
+        let run_start = std::time::Instant::now();
+
         let context = VMContext::new(input.into(), *context_id, *executor);
 
         let mut logic = VMLogic::new(storage, private_storage, context, &self.limits, node_client);
 
+        let store_start = std::time::Instant::now();
         let mut store = Store::new(self.engine.clone());
+        let store_create_ms = store_start.elapsed().as_secs_f64() * 1000.0;
 
+        let imports_start = std::time::Instant::now();
         let imports = logic.imports(&mut store);
+        let imports_setup_ms = imports_start.elapsed().as_secs_f64() * 1000.0;
 
         // Wrap WASM execution in catch_unwind to prevent panics from crashing the node.
         // This catches any unhandled panics during instance creation, memory access,
         // or function execution and converts them to proper error responses.
+        let execute_start = std::time::Instant::now();
         let execution_result = catch_unwind(AssertUnwindSafe(|| {
             Self::execute_wasm(
                 &mut store,
@@ -264,6 +280,7 @@ impl Module {
                 self.limits.max_method_name_length,
             )
         }));
+        let execute_wasm_ms = execute_start.elapsed().as_secs_f64() * 1000.0;
 
         // Determine the error to pass to finish() based on execution result
         let err = match execution_result {
@@ -306,6 +323,34 @@ impl Module {
             }
         }
 
+        // #2199 — emit the sub-timer breakdown. `debug!` for routine
+        // calls so dashboards/aggregators can scrape; `warn!` when
+        // total is ≥100ms so long tails surface in production logs.
+        // The 918ms apply-outlier from PR #2196's e2e data sat here,
+        // so the warn gate picks up anything in its neighbourhood.
+        let run_total_ms = run_start.elapsed().as_secs_f64() * 1000.0;
+        if run_total_ms >= 100.0 {
+            warn!(
+                %context_id,
+                method,
+                run_total_ms = format!("{:.2}", run_total_ms),
+                store_create_ms = format!("{:.2}", store_create_ms),
+                imports_setup_ms = format!("{:.2}", imports_setup_ms),
+                execute_wasm_ms = format!("{:.2}", execute_wasm_ms),
+                "WASM run hit long tail (#2199)"
+            );
+        } else {
+            debug!(
+                %context_id,
+                method,
+                run_total_ms = format!("{:.2}", run_total_ms),
+                store_create_ms = format!("{:.2}", store_create_ms),
+                imports_setup_ms = format!("{:.2}", imports_setup_ms),
+                execute_wasm_ms = format!("{:.2}", execute_wasm_ms),
+                "WASM run timing"
+            );
+        }
+
         Ok(outcome)
     }
 
@@ -327,6 +372,11 @@ impl Module {
             error!(%context_id, method, error=?err, "Invalid method name");
             return Ok(Some(err));
         }
+        // #2199 sub-timer: Instance::new is one of the two main setup
+        // costs. Wasmer builds a fresh instance every call (no
+        // caching); if this dominates the 918ms outlier, caching the
+        // Instance-per-context becomes the fix direction.
+        let instance_new_start = std::time::Instant::now();
         let instance = match Instance::new(store, module, imports) {
             Ok(instance) => instance,
             Err(err) => {
@@ -334,6 +384,7 @@ impl Module {
                 return Ok(Some(err.into()));
             }
         };
+        let instance_new_ms = instance_new_start.elapsed().as_secs_f64() * 1000.0;
 
         // Get memory from the WASM instance and attach it to VMLogic.
         // Note: memory.clone() is cheap - it just increments an Arc reference count,
@@ -392,7 +443,28 @@ impl Module {
             )));
         }
 
-        if let Err(err) = function.call(store, &[]) {
+        // #2199 sub-timer: function.call is the actual app-level WASM
+        // work plus all host callbacks made during it. If this
+        // dominates, the investigation moves into the WASM module
+        // itself (or into reducing host callback count / cost).
+        let function_call_start = std::time::Instant::now();
+        let function_call_result = function.call(store, &[]);
+        let function_call_ms = function_call_start.elapsed().as_secs_f64() * 1000.0;
+
+        // Emit sub-timer breakdown at debug! for `execute_wasm`'s slice
+        // of the total. The outer `run` timer already emits a
+        // run_total + warn at 100ms threshold; this one fires always
+        // at debug! so filter-enabled logs show the instance-vs-call
+        // split.
+        debug!(
+            %context_id,
+            method,
+            instance_new_ms = format!("{:.2}", instance_new_ms),
+            function_call_ms = format!("{:.2}", function_call_ms),
+            "execute_wasm sub-timings"
+        );
+
+        if let Err(err) = function_call_result {
             let traces = err
                 .trace()
                 .iter()


### PR DESCRIPTION
## Summary

Follow-up from the #2203 bench series. PR #2203 ruled out all three originally-identified structural suspects for #2199 (merkle rehash, `merge_root_state` framework, RocksDB read) at realistic sizes. The 918ms apply-latency outlier in PR #2196's e2e data must therefore come from somewhere within `context_client.execute(...)` that the synthetic benches don't reach — most likely either wasmer setup cost (`Store` + `Instance` created fresh every call, no caching) or inside the WASM function call itself (all host callbacks included).

This PR breaks the existing `wasm_ms` timer (in `crates/node/src/delta_store.rs`) into sub-components via tracing logs emitted from `Module::run`:

- `store_create_ms`: wasmer `Store::new`
- `imports_setup_ms`: `logic.imports(&mut store)` setup
- `instance_new_ms`: wasmer `Instance::new` — one of the two main setup costs
- `function_call_ms`: the actual app-level WASM work + all host callbacks made during it

`debug!` on the common path; `warn!` when `run_total_ms >= 100` so 918ms-class outliers surface in production logs without dashboard plumbing. Threshold is deliberately generous — a single apply routinely runs 10-50ms, past 100ms is worth a look.

## What the data will tell us

- **If `function_call_ms` dominates**, remaining suspicion moves into the WASM module and its host callbacks. Next step: aggregate host-callback counts + total time per `storage_read`/`storage_write` in `crates/runtime/src/logic/host_functions/*.rs`.
- **If `instance_new_ms` or `store_create_ms` dominates**, the fix becomes caching the wasmer `Instance` per context instead of rebuilding per-call. Wasmer instances are reusable across calls with the same module + imports.
- **If `imports_setup_ms` dominates**, the import table itself is the cost centre.

## Non-goals

- No behaviour change. Pure instrumentation.
- Not caching anything — that's the fix direction once data points at a specific sub-timer. This PR produces that data.
- Not instrumenting individual host functions yet (`storage_read`, `storage_write`, etc.). If `function_call_ms` turns out to dominate, that's the follow-up PR.

## Test plan

- [x] `cargo check -p calimero-runtime` clean
- [ ] CI: verify no test regressions from added timing overhead (`Instant::now()` is ~20ns on stable x86_64, immaterial at this call frequency)
- [ ] Manual: run e2e-rust-apps or fuzzy-load-test, grep for `WASM run hit long tail (#2199)` warnings, inspect the breakdown

## Related

- #2199 — the root question
- PR #2196 — original 918ms observation
- PR #2203 — criterion benches that narrowed #2199 to "not one of the structural suspects"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot-path WASM execution loop by adding timing and additional tracing, which could add minor overhead and increase log volume. No functional behavior changes are intended beyond new `debug!`/`warn!` emissions.
> 
> **Overview**
> Adds **sub-timer instrumentation** around WASM execution in `crates/runtime/src/lib.rs`, measuring `Store::new`, import setup, `Instance::new`, and the exported function call, and emitting the breakdown via tracing.
> 
> Introduces a **long-tail log gate**: routine calls log at `debug!`, while runs with total time ≥100ms emit a `warn!` with the same timing fields to make outliers visible in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d03f094b823af295580b5b799b8ca5e04de4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->