### PR TITLE
perf(runtime): per-callback sub-timers for ouroboros rebuild measurement (#2208)

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -248,6 +248,12 @@ impl Module {
 
         let mut store = Store::new(self.engine.clone());
 
+        // #2208 investigation: snapshot per-thread hot-path counters
+        // at entry so we can compute the delta contributed by *this*
+        // invocation. Same pattern as CPU perf counters. See
+        // `logic/imports.rs` HOTPATH_* thread-locals.
+        let (prev_cb, prev_build, prev_body) = logic::imports::hotpath_snapshot();
+
         let imports = logic.imports(&mut store);
 
         // Wrap WASM execution in catch_unwind to prevent panics from crashing the node.
@@ -304,6 +310,30 @@ impl Module {
             for (i, log) in outcome.logs.iter().enumerate() {
                 info!(%context_id, method, log_index = i, log_content = %log, "WASM_LOG");
             }
+        }
+
+        // #2208 — emit per-run hot-path breakdown. Deltas from the
+        // snapshot taken at entry isolate this invocation's
+        // contribution from any earlier runs on the same thread.
+        let (now_cb, now_build, now_body) = logic::imports::hotpath_snapshot();
+        let callbacks = now_cb.saturating_sub(prev_cb);
+        let build_ns = now_build.saturating_sub(prev_build);
+        let body_ns = now_body.saturating_sub(prev_body);
+        if callbacks > 0 {
+            let build_ms = build_ns as f64 / 1_000_000.0;
+            let body_ms = body_ns as f64 / 1_000_000.0;
+            let avg_build_us = (build_ns as f64 / callbacks as f64) / 1_000.0;
+            let avg_body_us = (body_ns as f64 / callbacks as f64) / 1_000.0;
+            info!(
+                %context_id,
+                method,
+                callbacks,
+                build_ms = format!("{:.2}", build_ms),
+                body_ms = format!("{:.2}", body_ms),
+                avg_build_us = format!("{:.3}", avg_build_us),
+                avg_body_us = format!("{:.3}", avg_body_us),
+                "WASM hot-path breakdown (#2208)"
+            );
         }
 
         Ok(outcome)

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -43,7 +43,7 @@ use crate::Constraint;
 
 mod errors;
 mod host_functions;
-mod imports;
+pub(crate) mod imports;
 mod registers;
 
 pub use errors::VMLogicError;

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -1,4 +1,4 @@
-use core::cell::RefCell;
+use core::cell::{Cell, RefCell};
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
@@ -11,6 +11,32 @@ thread_local! {
     static HOOKER: Once = const { Once::new() };
     static PAYLOAD: RefCell<Option<(String, Location)>> = const { RefCell::new(None) };
     static HOST_CTX: AtomicBool = const { AtomicBool::new(false) };
+
+    /// Per-thread callback accounting for #2199/#2208 investigation.
+    /// Incremented on every WASM→host dispatch inside the `imports!`
+    /// macro. `Module::run` snapshots these at the beginning of a run
+    /// and reads them at the end to emit a per-run breakdown of:
+    ///   - total host callbacks made
+    ///   - cumulative time building `VMHostFunctions` (the ouroboros
+    ///     self-ref rebuild — hypothesised hot spot)
+    ///   - cumulative time inside the host function body itself
+    /// Cells are cheaper than Atomics for thread-local counters since
+    /// each WASM run is single-threaded through wasmer's dispatcher.
+    pub(crate) static HOTPATH_CALLBACK_COUNT: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static HOTPATH_BUILD_NS: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static HOTPATH_BODY_NS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Snapshot of the hot-path thread-local counters. Used by
+/// `Module::run` to measure the delta contributed by one WASM
+/// invocation. See `HOTPATH_*` thread-locals above.
+#[must_use]
+pub fn hotpath_snapshot() -> (u64, u64, u64) {
+    (
+        HOTPATH_CALLBACK_COUNT.with(Cell::get),
+        HOTPATH_BUILD_NS.with(Cell::get),
+        HOTPATH_BODY_NS.with(Cell::get),
+    )
 }
 
 impl VMLogic<'_> {
@@ -183,7 +209,26 @@ macro_rules! _imports {
                         let (data, store) = env.data_and_store_mut();
                         let data = unsafe { &mut *(*data.get_mut()).cast::<VMLogic<'_>>() };
 
-                        data.host_functions(store).$func($($arg),*)
+                        // #2208 investigation: split per-callback cost
+                        // into (a) ouroboros VMHostFunctions rebuild
+                        // and (b) host function body. Results
+                        // aggregated in thread-local counters and
+                        // surfaced from Module::run. The two
+                        // `Instant::now()` calls add ~40ns of overhead
+                        // per callback — negligible against the 13µs
+                        // per-callback cost we're measuring.
+                        let build_start = std::time::Instant::now();
+                        let mut hf = data.host_functions(store);
+                        let build_ns = build_start.elapsed().as_nanos() as u64;
+                        let body_start = std::time::Instant::now();
+                        let out = hf.$func($($arg),*);
+                        let body_ns = body_start.elapsed().as_nanos() as u64;
+
+                        HOTPATH_CALLBACK_COUNT.with(|c| c.set(c.get() + 1));
+                        HOTPATH_BUILD_NS.with(|c| c.set(c.get() + build_ns));
+                        HOTPATH_BODY_NS.with(|c| c.set(c.get() + body_ns));
+
+                        out
                     })).unwrap_or_else(|_| {
                         let (message, location) = PAYLOAD.with(|payload| {
                             payload.borrow_mut().take().unwrap_or_else(|| ("<no message>".to_owned(), Location::Unknown))


### PR DESCRIPTION
## Summary

**Result of measurement: ouroboros rebuild is not the bottleneck — 86 ns per callback.** Ruling out one hypothesis, the timer stays as permanent observability.

Emits per-WASM-run stats splitting per-callback cost into "ouroboros `VMHostFunctions` rebuild" vs "host function body." Drop-in along the existing `imports!` macro dispatch path.

## Findings from e2e artifacts (n=367 runs, issue #2215)

| Metric | Value |
|--------|-------|
| avg_build_us (ouroboros) | **0.086 µs** (p50=0.085, p99=0.177, max=0.255) |
| avg_body_us (host fn body) | 3.7 µs (p50=3.2, p99=16.3, max=17.7) |
| total per-callback | ~3.8 µs |
| callbacks on worst outlier | 11,524 |
| total host-side cost on worst outlier | ~44 ms |
| `wasm_ms` on worst outlier | **908 ms** |
| remaining (pure WASM-side) | **~864 ms** |

**Interpretation**: ~95% of #2199's tail latency is in WASM-side algorithmic work, not the host boundary. Real fixes live in `crates/storage` CRDT algorithms, tracked under #2215.

## What stays in the codebase

Thread-local counters in `logic/imports.rs` + `hotpath_snapshot()` helper + a per-run info-level log in `Module::run`:

```
INFO WASM hot-path breakdown (#2208)
  context_id=... method=__calimero_sync_next
  callbacks=10523 build_ms=... body_ms=...
  avg_build_us=0.086 avg_body_us=3.7
```

Keeps future investigators from guessing the same way I did. If per-callback cost ever regresses (e.g. someone adds another per-callback `debug!` or the VMHostFunctions construction gets more expensive), this metric catches it.

Two `Instant::now()` calls per callback add ~40ns of overhead — negligible against the 3.8µs per-callback cost.

## Test plan

- [x] `cargo check -p calimero-runtime` clean
- [x] `cargo test -p calimero-runtime --lib` — 86/86 pass
- [x] e2e artifacts parsed, data above

## Related

- #2199 — umbrella merge-apply cost (status updated: substantially improved via PR #2207)
- #2208 — closed (callback-count hypothesis ruled out by this PR's data)
- #2215 — successor issue with corrected framing: WASM-side CRDT algorithm cost
- PR #2196 — sub-timers that pointed at `function.call`
- PR #2207 — debug-log removal (the single biggest win, 70% per-callback cost reduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
