### PR TITLE
perf(runtime): per-host-function callback breakdown per WASM run (#2215)

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -248,6 +248,12 @@ impl Module {
 
         let mut store = Store::new(self.engine.clone());
 
+        // #2215 — snapshot per-fn callback counts at entry so we can
+        // compute the delta contributed by *this* invocation. Counts
+        // are thread-local and accumulate across runs; the delta
+        // isolates our run.
+        let fn_counts_before = logic::imports::hotpath_fn_counts_snapshot();
+
         let imports = logic.imports(&mut store);
 
         // Wrap WASM execution in catch_unwind to prevent panics from crashing the node.
@@ -304,6 +310,40 @@ impl Module {
             for (i, log) in outcome.logs.iter().enumerate() {
                 info!(%context_id, method, log_index = i, log_content = %log, "WASM_LOG");
             }
+        }
+
+        // #2215 — emit per-host-function callback breakdown for this
+        // run. Compute the delta between start-of-run and end-of-run
+        // snapshots, sort by count descending, join top-N into a
+        // compact string. We emit only when total callbacks are
+        // non-trivial (>= 100) to avoid spamming for short runs like
+        // app init.
+        let fn_counts_after = logic::imports::hotpath_fn_counts_snapshot();
+        let mut deltas: Vec<(&'static str, u64)> = Vec::new();
+        let mut total: u64 = 0;
+        for (name, &count_after) in &fn_counts_after {
+            let before = fn_counts_before.get(name).copied().unwrap_or(0);
+            let delta = count_after.saturating_sub(before);
+            if delta > 0 {
+                deltas.push((name, delta));
+                total += delta;
+            }
+        }
+        if total >= 100 {
+            deltas.sort_by(|a, b| b.1.cmp(&a.1));
+            let breakdown = deltas
+                .iter()
+                .take(10)
+                .map(|(name, count)| format!("{}={}", name, count))
+                .collect::<Vec<_>>()
+                .join(" ");
+            info!(
+                %context_id,
+                method,
+                total,
+                breakdown = %breakdown,
+                "WASM host-fn callback breakdown (#2215)"
+            );
         }
 
         Ok(outcome)

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -43,7 +43,7 @@ use crate::Constraint;
 
 mod errors;
 mod host_functions;
-mod imports;
+pub(crate) mod imports;
 mod registers;
 
 pub use errors::VMLogicError;

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -1,5 +1,6 @@
 use core::cell::RefCell;
 use core::sync::atomic::{AtomicBool, Ordering};
+use std::collections::HashMap;
 use std::sync::Once;
 
 use wasmer::{Imports, Store};
@@ -11,6 +12,30 @@ thread_local! {
     static HOOKER: Once = const { Once::new() };
     static PAYLOAD: RefCell<Option<(String, Location)>> = const { RefCell::new(None) };
     static HOST_CTX: AtomicBool = const { AtomicBool::new(false) };
+
+    /// Per-host-function call counts, accumulated across every WASM→host
+    /// dispatch on the current thread. Used by `Module::run` to emit a
+    /// per-run breakdown of which imports the guest invoked — helps narrow
+    /// where the ~864ms of WASM-side work in a 908ms merge-apply outlier
+    /// is actually spent (issue #2215). Keys are the `stringify!`-generated
+    /// host-function names from the `imports!` macro (so interning is
+    /// free — they're `&'static str`).
+    ///
+    /// Cheap: per callback, one HashMap::entry lookup + `+= 1`. At ~50ns
+    /// per callback × 10k callbacks per outlier = ~0.5ms of overhead.
+    /// Negligible against the 908ms we're measuring.
+    pub(crate) static HOTPATH_FN_COUNTS: RefCell<HashMap<&'static str, u64>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Snapshot of the per-function call counts at the current moment.
+/// Used by `Module::run` to compute the delta contributed by one WASM
+/// invocation (subtracts a start-of-run snapshot from an end-of-run
+/// snapshot so counts from earlier runs on the same thread don't bleed
+/// in).
+#[must_use]
+pub fn hotpath_fn_counts_snapshot() -> HashMap<&'static str, u64> {
+    HOTPATH_FN_COUNTS.with(|m| m.borrow().clone())
 }
 
 impl VMLogic<'_> {
@@ -179,6 +204,15 @@ macro_rules! _imports {
                     };
 
                     HOST_CTX.with(|ctx| ctx.store(true, Ordering::Relaxed));
+                    // #2215 — per-host-function callback counts, used
+                    // by Module::run to emit a per-invocation
+                    // breakdown. `stringify!($func)` is the host-fn
+                    // name as a `&'static str`, so the HashMap key is
+                    // interned at compile time (no allocation per
+                    // callback).
+                    HOTPATH_FN_COUNTS.with(|m| {
+                        *m.borrow_mut().entry(stringify!($func)).or_insert(0) += 1;
+                    });
                     let res = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
                         let (data, store) = env.data_and_store_mut();
                         let data = unsafe { &mut *(*data.get_mut()).cast::<VMLogic<'_>>() };


### PR DESCRIPTION
## Summary

Measurement PR. No behaviour change. Adds thread-local per-host-function call counters in `logic/imports.rs` and emits a top-10 breakdown at the end of every `Module::run` via `info!`. Helps narrow the three #2215 fix candidates by telling us which host functions dominate on outlier runs.

## Why

PR #2214's data showed that host-side per-callback cost is only ~44ms on a 908ms worst-case merge-apply (~3.8µs × 11k callbacks). The remaining ~864ms is pure WASM-side compute between callbacks. Before pursuing cross-crate WASM-side instrumentation (host-function bridge + `env` wrapper + `Root::sync` instrumentation — ~150 lines), this PR cheaply tells us WHICH host functions the guest is invoking, which correlates with which algorithm in `crates/storage` is doing the calling.

Expected signal shapes:

| Pattern | Likely cause |
|---------|--------------|
| Heavy `storage_read` (+matching register protocol calls) on outliers | `UnorderedMap::merge` iterating entries, O(N) |
| Heavy `get_ancestors_of`-related patterns | `Compare` action tree walk (`generate_comparison_data`) |
| High `storage_read` count per-action with ancestor hierarchy | `recalculate_ancestor_hashes_for` |
| Something else surprising | New hypothesis |

## What gets logged

Per WASM run when total callbacks ≥ 100:

```
INFO WASM host-fn callback breakdown (#2215)
  context_id=... method=__calimero_sync_next
  total=10523
  breakdown="storage_read=2167 register_len=2894 read_register=2167
             storage_write=727 ..."
```

Top 10 host functions by call count, sorted descending. `stringify!($func)` in the `imports!` macro produces a `&'static str` interned at compile time, so the HashMap key is free.

## Cost

Per callback: one thread-local HashMap lookup + `+= 1`. ~50ns. Across 11k callbacks = ~0.5ms total overhead on the worst outlier. Negligible against the 908ms we're measuring.

## Test plan

- [x] `cargo check -p calimero-runtime` — clean
- [x] `cargo test -p calimero-runtime --lib` — 86/86 pass
- [ ] CI e2e run: verify log lines appear with expected shape in artifacts
- [ ] Pull artifacts, distribute callback-type ratios, post analysis comment

## Related

- #2199 — umbrella merge-apply cost
- #2215 — WASM-side CRDT algorithm cost (this PR's measurement feeds decisions here)
- #2208 — closed, superseded by #2215
- PR #2214 — ouroboros timer (ruled out ouroboros rebuild as the target)
- PR #2207 — debug log removal (70% per-callback cost reduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds thread-local counting on the WASM→host hot path and emits new `info!` logs per run, which could slightly impact performance and increase log volume in high-callback workloads.
> 
> **Overview**
> Adds thread-local per-host-function callback counters inside the `imports!` dispatch path and exposes `hotpath_fn_counts_snapshot()` to snapshot counts.
> 
> `Module::run` now snapshots counts before/after execution, computes per-run deltas, and conditionally logs a top-10 callback breakdown (only when total callbacks ≥ 100) via `info!` for performance investigation (#2215).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e6c4a54c2f0c76ce39a979d62e5b374a5cab88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->