### PR TITLE
fix(ci): harvest profiling data from host bind mount

### DIFF
--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -251,36 +251,10 @@ jobs:
       - name: Collect profiling data from host-side bind mounts
         if: always() && steps.image.outputs.profiling == 'true'
         run: |
-          # Runtime containers (fuzzy-kv-node-N) are removed during merobox's
-          # graceful shutdown before the Docker-based collector runs above —
-          # so their /profiling/data vanishes with them. entrypoint-profiling.sh
-          # mirrors that data into /app/data/profiling-dump (a host bind mount)
-          # on shutdown; harvest it here regardless of container state.
-          SRC_ROOT="workflows/fuzzy-tests/kv-store/data"
-          DEST_ROOT="profiling-data/kv-store"
-          if [ ! -d "$SRC_ROOT" ]; then
-            echo "No data dir at $SRC_ROOT — nothing to harvest"
-            exit 0
-          fi
-          found=0
-          for node_dir in "$SRC_ROOT"/*/; do
-            [ -d "$node_dir" ] || continue
-            node_name=$(basename "$node_dir")
-            dump="$node_dir/profiling-dump"
-            if [ -d "$dump" ]; then
-              dest="$DEST_ROOT/$node_name"
-              mkdir -p "$dest"
-              cp -r "$dump/." "$dest/" 2>/dev/null || true
-              size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
-              perf_count=$(find "$dest" -maxdepth 2 -name 'perf-*.data' 2>/dev/null | wc -l | tr -d ' ')
-              heap_count=$(find "$dest" -maxdepth 2 -name 'jemalloc.*.heap' 2>/dev/null | wc -l | tr -d ' ')
-              echo "  $node_name: ${size:-?} (perf.data=$perf_count, heap=$heap_count)"
-              found=$((found + 1))
-            else
-              echo "  $node_name: no profiling-dump (runtime container may not have used profiling entrypoint)"
-            fi
-          done
-          echo "Harvested profiling dumps from $found nodes"
+          chmod +x scripts/profiling/harvest-host-profiling.sh
+          ./scripts/profiling/harvest-host-profiling.sh \
+            "workflows/fuzzy-tests/kv-store/data" \
+            "profiling-data/kv-store"
 
       - name: Set test result
         id: set-result
@@ -487,33 +461,10 @@ jobs:
       - name: Collect profiling data from host-side bind mounts
         if: always() && steps.image.outputs.profiling == 'true'
         run: |
-          # See kv-store job for rationale — runtime containers are removed
-          # during merobox graceful shutdown; harvest from host bind mount.
-          SRC_ROOT="workflows/fuzzy-tests/kv-store-with-handlers/data"
-          DEST_ROOT="profiling-data/kv-store-with-handlers"
-          if [ ! -d "$SRC_ROOT" ]; then
-            echo "No data dir at $SRC_ROOT — nothing to harvest"
-            exit 0
-          fi
-          found=0
-          for node_dir in "$SRC_ROOT"/*/; do
-            [ -d "$node_dir" ] || continue
-            node_name=$(basename "$node_dir")
-            dump="$node_dir/profiling-dump"
-            if [ -d "$dump" ]; then
-              dest="$DEST_ROOT/$node_name"
-              mkdir -p "$dest"
-              cp -r "$dump/." "$dest/" 2>/dev/null || true
-              size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
-              perf_count=$(find "$dest" -maxdepth 2 -name 'perf-*.data' 2>/dev/null | wc -l | tr -d ' ')
-              heap_count=$(find "$dest" -maxdepth 2 -name 'jemalloc.*.heap' 2>/dev/null | wc -l | tr -d ' ')
-              echo "  $node_name: ${size:-?} (perf.data=$perf_count, heap=$heap_count)"
-              found=$((found + 1))
-            else
-              echo "  $node_name: no profiling-dump (runtime container may not have used profiling entrypoint)"
-            fi
-          done
-          echo "Harvested profiling dumps from $found nodes"
+          chmod +x scripts/profiling/harvest-host-profiling.sh
+          ./scripts/profiling/harvest-host-profiling.sh \
+            "workflows/fuzzy-tests/kv-store-with-handlers/data" \
+            "profiling-data/kv-store-with-handlers"
 
       - name: Set test result
         id: set-result-handlers

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -248,6 +248,40 @@ jobs:
             "profiling-data/kv-store" \
             "profiling-reports/kv-store"
 
+      - name: Collect profiling data from host-side bind mounts
+        if: always() && steps.image.outputs.profiling == 'true'
+        run: |
+          # Runtime containers (fuzzy-kv-node-N) are removed during merobox's
+          # graceful shutdown before the Docker-based collector runs above —
+          # so their /profiling/data vanishes with them. entrypoint-profiling.sh
+          # mirrors that data into /app/data/profiling-dump (a host bind mount)
+          # on shutdown; harvest it here regardless of container state.
+          SRC_ROOT="workflows/fuzzy-tests/kv-store/data"
+          DEST_ROOT="profiling-data/kv-store"
+          if [ ! -d "$SRC_ROOT" ]; then
+            echo "No data dir at $SRC_ROOT — nothing to harvest"
+            exit 0
+          fi
+          found=0
+          for node_dir in "$SRC_ROOT"/*/; do
+            [ -d "$node_dir" ] || continue
+            node_name=$(basename "$node_dir")
+            dump="$node_dir/profiling-dump"
+            if [ -d "$dump" ]; then
+              dest="$DEST_ROOT/$node_name"
+              mkdir -p "$dest"
+              cp -r "$dump/." "$dest/" 2>/dev/null || true
+              size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
+              perf_count=$(find "$dest" -maxdepth 2 -name 'perf-*.data' 2>/dev/null | wc -l | tr -d ' ')
+              heap_count=$(find "$dest" -maxdepth 2 -name 'jemalloc.*.heap' 2>/dev/null | wc -l | tr -d ' ')
+              echo "  $node_name: ${size:-?} (perf.data=$perf_count, heap=$heap_count)"
+              found=$((found + 1))
+            else
+              echo "  $node_name: no profiling-dump (runtime container may not have used profiling entrypoint)"
+            fi
+          done
+          echo "Harvested profiling dumps from $found nodes"
+
       - name: Set test result
         id: set-result
         if: always()
@@ -449,6 +483,37 @@ jobs:
             "fuzzy-test-logs/kv-store-with-handlers" \
             "profiling-data/kv-store-with-handlers" \
             "profiling-reports/kv-store-with-handlers"
+
+      - name: Collect profiling data from host-side bind mounts
+        if: always() && steps.image.outputs.profiling == 'true'
+        run: |
+          # See kv-store job for rationale — runtime containers are removed
+          # during merobox graceful shutdown; harvest from host bind mount.
+          SRC_ROOT="workflows/fuzzy-tests/kv-store-with-handlers/data"
+          DEST_ROOT="profiling-data/kv-store-with-handlers"
+          if [ ! -d "$SRC_ROOT" ]; then
+            echo "No data dir at $SRC_ROOT — nothing to harvest"
+            exit 0
+          fi
+          found=0
+          for node_dir in "$SRC_ROOT"/*/; do
+            [ -d "$node_dir" ] || continue
+            node_name=$(basename "$node_dir")
+            dump="$node_dir/profiling-dump"
+            if [ -d "$dump" ]; then
+              dest="$DEST_ROOT/$node_name"
+              mkdir -p "$dest"
+              cp -r "$dump/." "$dest/" 2>/dev/null || true
+              size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
+              perf_count=$(find "$dest" -maxdepth 2 -name 'perf-*.data' 2>/dev/null | wc -l | tr -d ' ')
+              heap_count=$(find "$dest" -maxdepth 2 -name 'jemalloc.*.heap' 2>/dev/null | wc -l | tr -d ' ')
+              echo "  $node_name: ${size:-?} (perf.data=$perf_count, heap=$heap_count)"
+              found=$((found + 1))
+            else
+              echo "  $node_name: no profiling-dump (runtime container may not have used profiling entrypoint)"
+            fi
+          done
+          echo "Harvested profiling dumps from $found nodes"
 
       - name: Set test result
         id: set-result-handlers

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -211,27 +211,39 @@ preserve_to_host_mount() {
     # merobox manager.py), and graceful shutdown removes the runtime
     # container before the GHA collector runs — so anything left only in
     # /profiling/{data,reports} is lost.
+    #
+    # Must not fail under `set -e` even if the copy partially fails —
+    # this runs right before `exit $EXIT_CODE` in the mainline path, and
+    # a non-zero return here would replace merod's real exit code with
+    # the copy error.
     local host_mount="${CALIMERO_HOME:-/app/data}"
     if [ ! -d "$host_mount" ]; then
         echo "[Profiling] Host mount $host_mount not present, skipping preserve step"
-        return
+        return 0
     fi
     local dest="$host_mount/profiling-dump"
-    mkdir -p "$dest" 2>/dev/null || {
-        echo "[Profiling] WARNING: could not create $dest"
-        return
-    }
+    if ! mkdir -p "$dest" 2>/tmp/preserve.err; then
+        echo "[Profiling] WARNING: could not create $dest: $(head -1 /tmp/preserve.err 2>/dev/null)"
+        return 0
+    fi
     if [ -d "$PROFILING_OUTPUT_DIR" ]; then
-        cp -r "$PROFILING_OUTPUT_DIR/." "$dest/" 2>/dev/null || true
+        if ! cp -r "$PROFILING_OUTPUT_DIR/." "$dest/" 2>/tmp/preserve.err; then
+            echo "[Profiling] WARNING: cp from $PROFILING_OUTPUT_DIR may be incomplete: $(head -3 /tmp/preserve.err 2>/dev/null | tr '\n' ' ')"
+        fi
     fi
     local reports_dir="${PROFILING_REPORTS_DIR:-/profiling/reports}"
     if [ -d "$reports_dir" ]; then
-        mkdir -p "$dest/reports" 2>/dev/null
-        cp -r "$reports_dir/." "$dest/reports/" 2>/dev/null || true
+        if ! mkdir -p "$dest/reports" 2>/tmp/preserve.err; then
+            echo "[Profiling] WARNING: could not create $dest/reports: $(head -1 /tmp/preserve.err 2>/dev/null)"
+        elif ! cp -r "$reports_dir/." "$dest/reports/" 2>/tmp/preserve.err; then
+            echo "[Profiling] WARNING: cp from $reports_dir may be incomplete: $(head -3 /tmp/preserve.err 2>/dev/null | tr '\n' ' ')"
+        fi
     fi
+    rm -f /tmp/preserve.err
     local size
     size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
     echo "[Profiling] ✓ Preserved profiling data to $dest (${size:-unknown size})"
+    return 0
 }
 
 cleanup() {

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -205,27 +205,58 @@ stop_profiling() {
     fi
 }
 
+preserve_to_host_mount() {
+    # Copy profiling data onto the CALIMERO_HOME bind mount so it survives
+    # container removal. Merobox mounts a host dir at /app/data (see
+    # merobox manager.py), and graceful shutdown removes the runtime
+    # container before the GHA collector runs — so anything left only in
+    # /profiling/{data,reports} is lost.
+    local host_mount="${CALIMERO_HOME:-/app/data}"
+    if [ ! -d "$host_mount" ]; then
+        echo "[Profiling] Host mount $host_mount not present, skipping preserve step"
+        return
+    fi
+    local dest="$host_mount/profiling-dump"
+    mkdir -p "$dest" 2>/dev/null || {
+        echo "[Profiling] WARNING: could not create $dest"
+        return
+    }
+    if [ -d "$PROFILING_OUTPUT_DIR" ]; then
+        cp -r "$PROFILING_OUTPUT_DIR/." "$dest/" 2>/dev/null || true
+    fi
+    local reports_dir="${PROFILING_REPORTS_DIR:-/profiling/reports}"
+    if [ -d "$reports_dir" ]; then
+        mkdir -p "$dest/reports" 2>/dev/null
+        cp -r "$reports_dir/." "$dest/reports/" 2>/dev/null || true
+    fi
+    local size
+    size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
+    echo "[Profiling] ✓ Preserved profiling data to $dest (${size:-unknown size})"
+}
+
 cleanup() {
     local signal_exit_code=$?
     echo "[Profiling] Received signal, cleaning up..."
-    
+
     stop_profiling
-    
+
     if [ -n "$MAIN_PID" ] && kill -0 "$MAIN_PID" 2>/dev/null; then
         echo "[Profiling] Stopping main process (PID: $MAIN_PID)..."
         kill -TERM "$MAIN_PID" 2>/dev/null || true
-        
+
         local wait_count=0
         while kill -0 "$MAIN_PID" 2>/dev/null && [ $wait_count -lt 10 ]; do
             sleep 1
             wait_count=$((wait_count + 1))
         done
-        
+
         if kill -0 "$MAIN_PID" 2>/dev/null; then
             kill -KILL "$MAIN_PID" 2>/dev/null || true
         fi
     fi
-    
+
+    preserve_to_host_mount
+
     if [ "$EXIT_CODE" -ne 0 ]; then
         exit $EXIT_CODE
     elif [ "$signal_exit_code" -ne 0 ]; then
@@ -312,8 +343,9 @@ if [ "$ENABLE_PROFILING" = "true" ] && [ "$ENABLE_PERF" = "true" ] && [ "$SHOULD
     
     wait $MAIN_PID
     EXIT_CODE=$?
-    
+
     stop_profiling
+    preserve_to_host_mount
     exit $EXIT_CODE
 else
     exec "$@"

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -146,8 +146,11 @@ stop_profiling() {
         if kill -0 "$perf_pid" 2>/dev/null; then
             kill -INT "$perf_pid" 2>/dev/null || true
             
+            # 15s, not 5s: a 45-minute perf.data can be hundreds of MB and
+            # the final flush on SIGINT may take longer than expected. Capping
+            # too low truncates the output file.
             local wait_count=0
-            while kill -0 "$perf_pid" 2>/dev/null && [ $wait_count -lt 5 ]; do
+            while kill -0 "$perf_pid" 2>/dev/null && [ $wait_count -lt 15 ]; do
                 sleep 1
                 wait_count=$((wait_count + 1))
             done
@@ -221,25 +224,32 @@ preserve_to_host_mount() {
         echo "[Profiling] Host mount $host_mount not present, skipping preserve step"
         return 0
     fi
+    # mktemp instead of a fixed /tmp path — avoids a symlink race where a
+    # pre-existing /tmp/preserve.err symlink would redirect our 2> into an
+    # arbitrary file (CWE-377). Low risk inside a single-root container, but
+    # free to fix and keeps the function consistent with harvest-host-profiling.sh.
+    local err_file
+    err_file=$(mktemp -t preserve.err.XXXXXX 2>/dev/null) || err_file=/dev/null
     local dest="$host_mount/profiling-dump"
-    if ! mkdir -p "$dest" 2>/tmp/preserve.err; then
-        echo "[Profiling] WARNING: could not create $dest: $(head -1 /tmp/preserve.err 2>/dev/null)"
+    if ! mkdir -p "$dest" 2>"$err_file"; then
+        echo "[Profiling] WARNING: could not create $dest: $(head -1 "$err_file" 2>/dev/null)"
+        [ "$err_file" != /dev/null ] && rm -f "$err_file"
         return 0
     fi
     if [ -d "$PROFILING_OUTPUT_DIR" ]; then
-        if ! cp -r "$PROFILING_OUTPUT_DIR/." "$dest/" 2>/tmp/preserve.err; then
-            echo "[Profiling] WARNING: cp from $PROFILING_OUTPUT_DIR may be incomplete: $(head -3 /tmp/preserve.err 2>/dev/null | tr '\n' ' ')"
+        if ! cp -r "$PROFILING_OUTPUT_DIR/." "$dest/" 2>"$err_file"; then
+            echo "[Profiling] WARNING: cp from $PROFILING_OUTPUT_DIR may be incomplete: $(head -3 "$err_file" 2>/dev/null | tr '\n' ' ')"
         fi
     fi
     local reports_dir="${PROFILING_REPORTS_DIR:-/profiling/reports}"
     if [ -d "$reports_dir" ]; then
-        if ! mkdir -p "$dest/reports" 2>/tmp/preserve.err; then
-            echo "[Profiling] WARNING: could not create $dest/reports: $(head -1 /tmp/preserve.err 2>/dev/null)"
-        elif ! cp -r "$reports_dir/." "$dest/reports/" 2>/tmp/preserve.err; then
-            echo "[Profiling] WARNING: cp from $reports_dir may be incomplete: $(head -3 /tmp/preserve.err 2>/dev/null | tr '\n' ' ')"
+        if ! mkdir -p "$dest/reports" 2>"$err_file"; then
+            echo "[Profiling] WARNING: could not create $dest/reports: $(head -1 "$err_file" 2>/dev/null)"
+        elif ! cp -r "$reports_dir/." "$dest/reports/" 2>"$err_file"; then
+            echo "[Profiling] WARNING: cp from $reports_dir may be incomplete: $(head -3 "$err_file" 2>/dev/null | tr '\n' ' ')"
         fi
     fi
-    rm -f /tmp/preserve.err
+    [ "$err_file" != /dev/null ] && rm -f "$err_file"
     local size
     size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
     echo "[Profiling] ✓ Preserved profiling data to $dest (${size:-unknown size})"

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -209,19 +209,33 @@ stop_profiling() {
 }
 
 preserve_to_host_mount() {
-    # Copy profiling data onto the CALIMERO_HOME bind mount so it survives
-    # container removal. Merobox mounts a host dir at /app/data (see
-    # merobox manager.py), and graceful shutdown removes the runtime
-    # container before the GHA collector runs — so anything left only in
-    # /profiling/{data,reports} is lost.
+    # Copy profiling data under $CALIMERO_HOME so it survives container
+    # removal. /profiling/{data,reports} lives on the container rootfs and
+    # is lost when the container is removed — which happens during merobox
+    # graceful shutdown, before the GHA collector reaches the container.
+    #
+    # $CALIMERO_HOME resolves to a persistent path in both deployments:
+    #   - Merobox (CI): passes CALIMERO_HOME=/app/data and bind-mounts the
+    #     host dir workflows/fuzzy-tests/<test>/data/<node>/ to /app/data
+    #     (see merobox manager.py).
+    #   - Standalone docker run: prebuilt.profiling.Dockerfile sets
+    #     ENV CALIMERO_HOME=/data and VOLUME /data, so the path lives on a
+    #     Docker-managed volume even without explicit -v.
+    # We intentionally don't supply a fallback — if CALIMERO_HOME is unset,
+    # we'd only be guessing, and silent writes to the wrong path would
+    # defeat the point of this function.
     #
     # Must not fail under `set -e` even if the copy partially fails —
     # this runs right before `exit $EXIT_CODE` in the mainline path, and
     # a non-zero return here would replace merod's real exit code with
     # the copy error.
-    local host_mount="${CALIMERO_HOME:-/app/data}"
+    local host_mount="${CALIMERO_HOME:-}"
+    if [ -z "$host_mount" ]; then
+        echo "[Profiling] CALIMERO_HOME is unset — cannot locate persistent dir, skipping preserve step"
+        return 0
+    fi
     if [ ! -d "$host_mount" ]; then
-        echo "[Profiling] Host mount $host_mount not present, skipping preserve step"
+        echo "[Profiling] CALIMERO_HOME=$host_mount is not a directory, skipping preserve step"
         return 0
     fi
     # mktemp instead of a fixed /tmp path — avoids a symlink race where a

--- a/scripts/profiling/harvest-host-profiling.sh
+++ b/scripts/profiling/harvest-host-profiling.sh
@@ -37,7 +37,11 @@ for node_dir in "$SRC_ROOT"/*/; do
         continue
     fi
     dest="$DEST_ROOT/$node_name"
-    mkdir -p "$dest"
+    if ! mkdir -p "$dest" 2>"$ERR_LOG"; then
+        err=$(head -3 "$ERR_LOG" 2>/dev/null | tr '\n' ' ')
+        echo "  $node_name: ERROR — could not create $dest: ${err:-(no stderr captured)}"
+        continue
+    fi
     if ! cp -r "$dump/." "$dest/" 2>"$ERR_LOG"; then
         err=$(head -3 "$ERR_LOG" 2>/dev/null | tr '\n' ' ')
         echo "  $node_name: WARNING — cp may be incomplete: ${err:-(no stderr captured)}"

--- a/scripts/profiling/harvest-host-profiling.sh
+++ b/scripts/profiling/harvest-host-profiling.sh
@@ -4,11 +4,12 @@
 # Runtime containers (fuzzy-*-node-N) are removed during merobox's
 # graceful shutdown before any Docker-based collector can reach them,
 # so /profiling/data inside the container vanishes with it.
-# entrypoint-profiling.sh mirrors that data into /app/data/profiling-dump
-# on shutdown — and merobox bind-mounts /app/data to the host (see
-# merobox manager.py: `{host_path: {bind: /app/data}}`). This script
-# harvests those dumps from the host filesystem, regardless of whether
-# the runtime container still exists.
+# entrypoint-profiling.sh mirrors that data to $CALIMERO_HOME/profiling-dump
+# on shutdown — and merobox passes CALIMERO_HOME=/app/data plus a bind
+# mount from the host (manager.py: `{host_path: {bind: /app/data}}`),
+# so the dump lands under workflows/fuzzy-tests/<test>/data/<node>/
+# on the GHA runner. This script harvests those dumps from that host
+# tree regardless of whether the runtime container still exists.
 #
 # Usage: harvest-host-profiling.sh <src-root> <dest-root>
 #   <src-root>  e.g. workflows/fuzzy-tests/kv-store/data

--- a/scripts/profiling/harvest-host-profiling.sh
+++ b/scripts/profiling/harvest-host-profiling.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Harvest profiling dumps from host-side bind mounts.
+#
+# Runtime containers (fuzzy-*-node-N) are removed during merobox's
+# graceful shutdown before any Docker-based collector can reach them,
+# so /profiling/data inside the container vanishes with it.
+# entrypoint-profiling.sh mirrors that data into /app/data/profiling-dump
+# on shutdown — and merobox bind-mounts /app/data to the host (see
+# merobox manager.py: `{host_path: {bind: /app/data}}`). This script
+# harvests those dumps from the host filesystem, regardless of whether
+# the runtime container still exists.
+#
+# Usage: harvest-host-profiling.sh <src-root> <dest-root>
+#   <src-root>  e.g. workflows/fuzzy-tests/kv-store/data
+#   <dest-root> e.g. profiling-data/kv-store
+
+set -u
+
+SRC_ROOT="${1:?Error: src-root is required}"
+DEST_ROOT="${2:?Error: dest-root is required}"
+
+if [ ! -d "$SRC_ROOT" ]; then
+    echo "No data dir at $SRC_ROOT — nothing to harvest"
+    exit 0
+fi
+
+ERR_LOG=$(mktemp -t harvest-host-profiling.XXXXXX.err)
+trap 'rm -f "$ERR_LOG"' EXIT
+
+found=0
+for node_dir in "$SRC_ROOT"/*/; do
+    [ -d "$node_dir" ] || continue
+    node_name=$(basename "$node_dir")
+    dump="$node_dir/profiling-dump"
+    if [ ! -d "$dump" ]; then
+        echo "  $node_name: no profiling-dump (runtime container may not have used profiling entrypoint)"
+        continue
+    fi
+    dest="$DEST_ROOT/$node_name"
+    mkdir -p "$dest"
+    if ! cp -r "$dump/." "$dest/" 2>"$ERR_LOG"; then
+        err=$(head -3 "$ERR_LOG" 2>/dev/null | tr '\n' ' ')
+        echo "  $node_name: WARNING — cp may be incomplete: ${err:-(no stderr captured)}"
+    fi
+    size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')
+    perf_count=$(find "$dest" -maxdepth 2 -name 'perf-*.data' 2>/dev/null | wc -l | tr -d ' ')
+    heap_count=$(find "$dest" -maxdepth 2 -name 'jemalloc.*.heap' 2>/dev/null | wc -l | tr -d ' ')
+    echo "  $node_name: ${size:-?} (perf.data=$perf_count, heap=$heap_count)"
+    found=$((found + 1))
+done
+echo "Harvested profiling dumps from $found nodes"


### PR DESCRIPTION
## Problem

The profiling-data artifacts uploaded by the fuzzy-load-test workflow contain **only jemalloc heap dumps from `merod init`** — 1073 tiny (5–12 KB) files per run, all from the init phase. No CPU perf.data, no runtime heap, no perf.map, no data from the 45-minute `merod run` phase that we actually care about for #2199 / #2215.

Concretely, in run [24787476234](https://github.com/calimero-network/core/actions/runs/24787476234), the collection step logs:

```
Collecting from container: fuzzy-kv-node-4-init
  Could not stop perf (container may have stopped)
  WARNING: Container not running - collecting existing data only
... (same for nodes 3, 2, 1)
```

All four containers listed are `-init`.

## Root cause

Merobox creates each node as two containers (manager.py:327):
- `fuzzy-*-node-N-init` — runs `merod init`, exits, fails to auto-remove (so it lingers in Exited state)
- `fuzzy-*-node-N` — runs `merod run`, and is explicitly **removed during merobox's graceful shutdown** before our `collect-from-containers.sh` step executes

By the time `docker ps -a --filter "label=calimero.node=true"` runs, only the dead init containers are still present. Their /profiling/data rootfs is intact, so `docker cp` succeeds — but it contains only init-phase data.

## Fix

`entrypoint-profiling.sh` now mirrors `/profiling/data` (and reports) into `$CALIMERO_HOME/profiling-dump` in the shutdown path. Merobox bind-mounts `/app/data` to `workflows/fuzzy-tests/<test>/data/<node>/` on the host (manager.py:474), so the dump **survives container removal**.

A new workflow step after the existing collector harvests those dumps into the `profiling-data-*` artifact tree.

Both preserve paths fire:
- `cleanup()` trap on SIGTERM/SIGINT (merobox graceful shutdown)
- Mainline `wait $MAIN_PID; stop_profiling; preserve_to_host_mount` on normal exit

Init containers are untouched: they hit the `exec "$@"` branch (because `SHOULD_PROFILE_WITH_PERF=false`), which replaces the shell and drops the trap.

## What the artifact will look like after this merges

Today: `profiling-data-kv-store-*/fuzzy-kv-node-N-init/jemalloc.1.*.heap` × 1073 files.

After: `profiling-data-kv-store-*/fuzzy-kv-node-N/` containing `perf-fuzzy-kv-node-N.data` (100–500 MB each, 45min × 99Hz), `perf-fuzzy-kv-node-N-<pid>.map` (WASM symbolization), `jemalloc.*.heap` (runtime heap, not init), and `memory-stats-*.log`.

Artifact size will grow from ~1.7MB to probably 1–2GB per run. Still well under GitHub's per-artifact limit.

## Test plan

- [ ] Merge → next `release.yml` rebuilds `ghcr.io/calimero-network/merod:edge-profiling` with the new entrypoint
- [ ] Manually trigger `fuzzy-load-test` workflow (or wait for next master push)
- [ ] Download the new `profiling-data-kv-store-*` artifact, verify it contains `perf-fuzzy-kv-node-*.data` files with real sample counts (`perf report -i file.data --stdio | head`)
- [ ] Run `generate-flamegraph.sh` locally against one of the perf.data files, confirm a real CPU flamegraph with WASM frames visible (needs the matching perf.map)

## Related

- #2199 — umbrella merge-apply cost. Blocked on getting real CPU profiles.
- #2215 — successor to #2208 with corrected framing: WASM-side CRDT algorithm cost. Needs this data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI profiling collection logic changes and introduces large new artifacts; failures could hide profiling output or increase workflow time/storage usage.
> 
> **Overview**
> Fixes missing runtime profiling artifacts in `fuzzy-load-test` by **mirroring `/profiling/{data,reports}` into `$CALIMERO_HOME/profiling-dump` on shutdown** (`entrypoint-profiling.sh`) and then **harvesting those dumps from the host bind-mount tree** into `profiling-data/*` via the new `harvest-host-profiling.sh` step.
> 
> Also increases the `perf` graceful-stop wait from 5s to 15s to reduce truncation risk for long-running `perf.data` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01eb90d4829db0481722902b426a45d9cc78604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->