### PR TITLE
ci(release): rebuild image when profiling scripts change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/deps/**"
       - ".github/actions/**"
+      # prebuilt.profiling.Dockerfile COPYs these scripts into the
+      # edge-profiling image, so changes here need to rebuild.
+      - "scripts/profiling/**"
   pull_request:
     paths:
       - Cargo.toml
@@ -19,6 +22,7 @@ on:
       - ".github/workflows/release.yml"
       - ".github/workflows/deps/**"
       - ".github/actions/**"
+      - "scripts/profiling/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
prebuilt.profiling.Dockerfile COPYs scripts/profiling/*.sh into the edge-profiling image (line 124). Without scripts/profiling/** in the release.yml path filter, changes to those scripts land on master but never rebuild the image — so the edge-profiling tag silently lags the source tree.

Came up after #2217: the entrypoint fix merged but didn't trigger release.yml, so the next fuzzy-load-test ran against the old image and produced the same init-only artifacts the PR was meant to fix.

This PR itself touches release.yml (which IS already on its own trigger path), so merging it will trigger one rebuild under the new rules — the edge-profiling image will catch up to master on the same merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions path filters to ensure releases rebuild when `scripts/profiling/**` changes; no production code or release logic is modified.
> 
> **Overview**
> Ensures the `Release` GitHub Actions workflow runs when `scripts/profiling/**` changes (in both `push` and `pull_request` path filters), so updates to the profiling entrypoint scripts copied into `prebuilt.profiling.Dockerfile` trigger a rebuild of the profiling image instead of silently lagging behind `master`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd5149c4d3ae6f31f22f5a714868b8fc80f456a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->