### PR TITLE
fix(storage): make merge registry thread-local under #[cfg(test)]

### DIFF
--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -54,10 +54,27 @@ static MERGE_REGISTRY: LazyLock<RwLock<HashMap<TypeId, MergeFn>>> =
 // against each other — unrelated non-serial tests still ran in
 // parallel with them. Thread-local storage makes each test's
 // registry state private to its own thread, so the race can't occur.
+//
+// Trade-off: unit tests can no longer observe cross-thread visibility
+// of registrations (a property the production RwLock does provide).
+// We consider this acceptable — the cross-thread-share story is
+// delegated to `std::sync::RwLock`, which we trust, and in practice
+// apps register their types once at startup before any async workers
+// are spawned. If cross-thread dispatch ever becomes part of the
+// behaviour-under-test (not just implementation detail), that belongs
+// in an integration test compiled without `#[cfg(test)]` rather than
+// here.
 #[cfg(test)]
 thread_local! {
     static MERGE_REGISTRY: RefCell<HashMap<TypeId, MergeFn>> = RefCell::new(HashMap::new());
 }
+
+// Both backends assume merge functions don't call back into the registry
+// while one is being dispatched. A reentrant call would deadlock under
+// RwLock (write-during-read) or panic under RefCell (already borrowed) —
+// either way a bug. The merge closure built in `register_crdt_merge` only
+// calls borsh and the type's own `Mergeable::merge`; adding registry
+// access to it would break this invariant.
 
 /// Run `f` with mutable access to the registry.
 #[cfg(not(test))]
@@ -72,9 +89,21 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R
     f(&mut registry)
 }
 
+/// Test-only variant: uses thread-local RefCell instead of global RwLock.
+/// try_borrow_mut to surface re-entrant access as a clear panic message
+/// rather than the less-useful default `BorrowMutError` debug print.
 #[cfg(test)]
 fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
-    MERGE_REGISTRY.with(|r| f(&mut r.borrow_mut()))
+    MERGE_REGISTRY.with(|r| {
+        let mut borrowed = r.try_borrow_mut().unwrap_or_else(|e| {
+            panic!(
+                "MERGE_REGISTRY RefCell already borrowed ({e}). Merge \
+                 functions must not call try_merge_registered / \
+                 register_crdt_merge / clear_merge_registry (see module docs)."
+            )
+        });
+        f(&mut borrowed)
+    })
 }
 
 /// Run `f` with read-only access to the registry.
@@ -90,9 +119,19 @@ fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     f(&registry)
 }
 
+/// Test-only variant: uses thread-local RefCell instead of global RwLock.
 #[cfg(test)]
 fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
-    MERGE_REGISTRY.with(|r| f(&r.borrow()))
+    MERGE_REGISTRY.with(|r| {
+        let borrowed = r.try_borrow().unwrap_or_else(|e| {
+            panic!(
+                "MERGE_REGISTRY RefCell already mutably borrowed ({e}). \
+                 Merge functions must not call try_merge_registered / \
+                 register_crdt_merge / clear_merge_registry (see module docs)."
+            )
+        });
+        f(&borrowed)
+    })
 }
 
 /// Register a CRDT merge function for a type

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -75,6 +75,13 @@ thread_local! {
 // either way a bug. The merge closure built in `register_crdt_merge` only
 // calls borsh and the type's own `Mergeable::merge`; adding registry
 // access to it would break this invariant.
+//
+// Production-path coverage: because unit tests only exercise the
+// `#[cfg(test)]` thread-local backend, register+dispatch against the
+// real `RwLock` path is covered by the integration test at
+// `tests/merge_registry_integration.rs`. If you touch the
+// `#[cfg(not(test))]` helpers below, that integration test is the thing
+// to run.
 
 /// Run `f` with mutable access to the registry.
 #[cfg(not(test))]

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -18,17 +18,82 @@
 //!
 //! // Now sync automatically calls MyAppState::merge()
 //! ```
+//!
+//! # Storage
+//!
+//! Production uses a process-global `RwLock<HashMap<...>>`; apps register
+//! their state types once at startup and every async worker dispatches
+//! against the same table.
+//!
+//! Under `#[cfg(test)]` the backing store is a `thread_local!` so that
+//! parallel-running tests can't stomp on each other's registrations.
+//! See the comment on the `#[cfg(test)]` declaration below.
 
 use std::any::TypeId;
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(not(test))]
 use std::sync::{LazyLock, RwLock};
 
 /// Function signature for merging serialized state
 pub type MergeFn = fn(&[u8], &[u8], u64, u64) -> Result<Vec<u8>, Box<dyn std::error::Error>>;
 
-/// Global registry of merge functions by type
+/// Production registry — process-global, shared across async workers.
+#[cfg(not(test))]
 static MERGE_REGISTRY: LazyLock<RwLock<HashMap<TypeId, MergeFn>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
+
+// Test registry — per-thread. cargo test runs tests in parallel on
+// different threads; with a global registry, a test calling
+// `clear_merge_registry()` (e.g. to assert "no merge functions
+// registered" behaviour) could wipe entries that another thread's
+// test had just populated via `register_test_merge_functions()`, and
+// the subsequent `apply_action` on that other thread would then fail
+// dispatch mid-flight. `#[serial]` only serialises the clearers
+// against each other — unrelated non-serial tests still ran in
+// parallel with them. Thread-local storage makes each test's
+// registry state private to its own thread, so the race can't occur.
+#[cfg(test)]
+thread_local! {
+    static MERGE_REGISTRY: RefCell<HashMap<TypeId, MergeFn>> = RefCell::new(HashMap::new());
+}
+
+/// Run `f` with mutable access to the registry.
+#[cfg(not(test))]
+fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
+    let mut registry = MERGE_REGISTRY.write().unwrap_or_else(|_| {
+        tracing::error!(
+            target: "calimero_storage::merge",
+            "MERGE_REGISTRY lock poisoned during write, aborting. This indicates a panic in merge code."
+        );
+        std::process::abort()
+    });
+    f(&mut registry)
+}
+
+#[cfg(test)]
+fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
+    MERGE_REGISTRY.with(|r| f(&mut r.borrow_mut()))
+}
+
+/// Run `f` with read-only access to the registry.
+#[cfg(not(test))]
+fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
+    let registry = MERGE_REGISTRY.read().unwrap_or_else(|_| {
+        tracing::error!(
+            target: "calimero_storage::merge",
+            "MERGE_REGISTRY lock poisoned, aborting. This indicates a panic in merge code."
+        );
+        std::process::abort()
+    });
+    f(&registry)
+}
+
+#[cfg(test)]
+fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
+    MERGE_REGISTRY.with(|r| f(&r.borrow()))
+}
 
 /// Register a CRDT merge function for a type
 ///
@@ -80,29 +145,15 @@ where
         borsh::to_vec(&existing_state).map_err(|e| format!("Serialization failed: {}", e).into())
     };
 
-    let mut registry = MERGE_REGISTRY.write().unwrap_or_else(|_| {
-        // Lock poisoning indicates a panic occurred while holding the lock.
-        // This is a serious error - abort to prevent undefined behavior.
-        tracing::error!(
-            target: "calimero_storage::merge",
-            "MERGE_REGISTRY lock poisoned during write, aborting. This indicates a panic in merge code."
-        );
-        std::process::abort()
+    with_registry_mut(|registry| {
+        let _ = registry.insert(type_id, merge_fn);
     });
-    let _ = registry.insert(type_id, merge_fn);
 }
 
 /// Clear the merge registry (for testing only)
 #[cfg(test)]
 pub fn clear_merge_registry() {
-    let mut registry = MERGE_REGISTRY.write().unwrap_or_else(|_| {
-        tracing::error!(
-            target: "calimero_storage::merge",
-            "MERGE_REGISTRY lock poisoned during clear, aborting. This indicates a panic in merge code."
-        );
-        std::process::abort()
-    });
-    registry.clear();
+    with_registry_mut(|registry| registry.clear());
 }
 
 /// Result of attempting to merge using registered merge functions
@@ -133,28 +184,19 @@ pub fn try_merge_registered(
     // TODO: Store type hints with root entity for O(1) dispatch (see issue #1993)
 
     // Try each registered merge function until one succeeds (O(n) where n = registered types)
-    let registry = MERGE_REGISTRY.read().unwrap_or_else(|_poisoned| {
-        // Lock poisoning indicates a panic occurred while holding the lock.
-        // This is a serious error - abort to prevent undefined behavior.
-        // This is consistent with the write side behavior in register_crdt_merge().
-        tracing::error!(
-            target: "calimero_storage::merge",
-            "MERGE_REGISTRY lock poisoned, aborting. This indicates a panic in merge code."
-        );
-        std::process::abort();
-    });
-
-    if registry.is_empty() {
-        return MergeRegistryResult::NoFunctionsRegistered;
-    }
-
-    for (_type_id, merge_fn) in registry.iter() {
-        if let Ok(merged) = merge_fn(existing, incoming, existing_ts, incoming_ts) {
-            return MergeRegistryResult::Success(merged);
+    with_registry(|registry| {
+        if registry.is_empty() {
+            return MergeRegistryResult::NoFunctionsRegistered;
         }
-    }
 
-    MergeRegistryResult::AllFunctionsFailed
+        for (_type_id, merge_fn) in registry.iter() {
+            if let Ok(merged) = merge_fn(existing, incoming, existing_ts, incoming_ts) {
+                return MergeRegistryResult::Success(merged);
+            }
+        }
+
+        MergeRegistryResult::AllFunctionsFailed
+    })
 }
 
 #[cfg(test)]

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -83,7 +83,17 @@ thread_local! {
 // `#[cfg(not(test))]` helpers below, that integration test is the thing
 // to run.
 
-/// Run `f` with mutable access to the registry.
+// The `with_registry_mut` / `with_registry` helpers come in paired
+// cfg-gated implementations (prod: RwLock, test: thread-local RefCell).
+// The signatures must stay identical so call sites compile under both
+// configurations; if you change one pair, change the other. Divergence
+// would go undetected — unit tests only build the test variants, the
+// integration test only builds the prod variants.
+
+/// Runs `f` with mutable access to the registry. Aborts the process
+/// if the lock is poisoned (a poisoned lock means a prior writer
+/// panicked, which we treat as unrecoverable for a process-global
+/// singleton).
 #[cfg(not(test))]
 fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
     let mut registry = MERGE_REGISTRY.write().unwrap_or_else(|_| {
@@ -96,9 +106,11 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R
     f(&mut registry)
 }
 
-/// Test-only variant: uses thread-local RefCell instead of global RwLock.
-/// try_borrow_mut to surface re-entrant access as a clear panic message
-/// rather than the less-useful default `BorrowMutError` debug print.
+/// Test-only variant: uses thread-local RefCell instead of global
+/// RwLock. `try_borrow_mut` surfaces re-entrant access as a clear
+/// panic message rather than the less-useful default `BorrowMutError`
+/// debug print. Keep the signature in sync with the `cfg(not(test))`
+/// variant above.
 #[cfg(test)]
 fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
     MERGE_REGISTRY.with(|r| {
@@ -113,7 +125,8 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R
     })
 }
 
-/// Run `f` with read-only access to the registry.
+/// Runs `f` with read-only access to the registry. Aborts the process
+/// if the lock is poisoned (same reasoning as `with_registry_mut`).
 #[cfg(not(test))]
 fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     let registry = MERGE_REGISTRY.read().unwrap_or_else(|_| {
@@ -126,7 +139,9 @@ fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     f(&registry)
 }
 
-/// Test-only variant: uses thread-local RefCell instead of global RwLock.
+/// Test-only variant: uses thread-local RefCell instead of global
+/// RwLock. Keep the signature in sync with the `cfg(not(test))`
+/// variant above.
 #[cfg(test)]
 fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     MERGE_REGISTRY.with(|r| {
@@ -141,7 +156,19 @@ fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     })
 }
 
-/// Register a CRDT merge function for a type
+/// Register a CRDT merge function for a type.
+///
+/// # Testing note
+///
+/// Under `#[cfg(test)]` the registry is **thread-local**, not global.
+/// Registrations made in one test thread are not visible from a
+/// `std::thread::spawn` / `tokio::spawn` worker on another thread. If
+/// a test relies on cross-thread dispatch, move it to an integration
+/// test under `tests/` (which links the library without `cfg(test)`
+/// and therefore hits the real `RwLock`-backed registry).
+///
+/// Production callers (non-test builds) see the global `RwLock`
+/// registry as expected.
 ///
 /// # Example
 ///

--- a/crates/storage/tests/merge_registry_concurrent.rs
+++ b/crates/storage/tests/merge_registry_concurrent.rs
@@ -1,0 +1,127 @@
+//! Concurrent coverage for the production merge-registry backend.
+//!
+//! Same rationale as `merge_registry_integration.rs`: this test binary
+//! links the library without `#[cfg(test)]`, so it exercises the real
+//! `LazyLock<RwLock<HashMap<TypeId, MergeFn>>>` path — the one unit
+//! tests can't reach.
+//!
+//! This file specifically stresses *concurrent* register + dispatch to
+//! prove the `RwLock` backend is contention-safe (no deadlock, no lost
+//! registrations) under the kind of parallel load the production
+//! runtime can generate when several async workers process sync traffic
+//! simultaneously. Single-threaded happy-path coverage lives in
+//! `merge_registry_integration.rs`.
+//!
+//! Same one-test-per-file convention applies: the production registry
+//! has no cleanup hook here, so adding a second `#[test]` in this file
+//! would leak state into it.
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::Mergeable;
+use calimero_storage::merge::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
+
+#[derive(BorshSerialize, BorshDeserialize)]
+struct ConcurrentState {
+    values: Vec<u32>,
+}
+
+impl Mergeable for ConcurrentState {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.values.extend_from_slice(&other.values);
+        self.values.sort_unstable();
+        self.values.dedup();
+        Ok(())
+    }
+}
+
+#[test]
+fn concurrent_register_and_dispatch_against_production_registry() {
+    const THREADS: usize = 16;
+    const ITERATIONS_PER_THREAD: usize = 50;
+
+    // Barrier forces all threads to reach the race window at the same
+    // time rather than serialising one-after-another — that's what
+    // actually stresses the RwLock.
+    let barrier = Arc::new(Barrier::new(THREADS));
+
+    let handles: Vec<_> = (0..THREADS)
+        .map(|t| {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+
+                for i in 0..ITERATIONS_PER_THREAD {
+                    // Odd threads mostly write (register), even threads
+                    // mostly read (dispatch). Both code paths hit the
+                    // lock so readers and writers interleave.
+                    if t % 2 == 1 {
+                        register_crdt_merge::<ConcurrentState>();
+                    }
+
+                    let a = ConcurrentState {
+                        values: vec![t as u32, i as u32],
+                    };
+                    let b = ConcurrentState {
+                        values: vec![(t * 100 + i) as u32],
+                    };
+                    let bytes_a = borsh::to_vec(&a).unwrap();
+                    let bytes_b = borsh::to_vec(&b).unwrap();
+
+                    match try_merge_registered(&bytes_a, &bytes_b, 1, 2) {
+                        MergeRegistryResult::Success(merged_bytes) => {
+                            let merged: ConcurrentState = borsh::from_slice(&merged_bytes).unwrap();
+                            // Merge must be sorted + deduped, containing
+                            // every input value exactly once.
+                            for v in &a.values {
+                                assert!(merged.values.contains(v));
+                            }
+                            for v in &b.values {
+                                assert!(merged.values.contains(v));
+                            }
+                            assert!(merged.values.windows(2).all(|w| w[0] < w[1]));
+                        }
+                        MergeRegistryResult::NoFunctionsRegistered => {
+                            // Acceptable early in the run — before any
+                            // writer has landed its first register call.
+                            // Writers are always running, so we'll
+                            // catch up.
+                        }
+                        MergeRegistryResult::AllFunctionsFailed => {
+                            panic!(
+                                "thread {t} iter {i}: dispatch failed despite \
+                                 registration being in flight"
+                            );
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("no worker thread should panic");
+    }
+
+    // Final check: after all threads have finished registering, a
+    // single-threaded dispatch must still succeed. Proves the last
+    // writer didn't leave the map in a weird state.
+    let a = ConcurrentState {
+        values: vec![100, 200],
+    };
+    let b = ConcurrentState {
+        values: vec![150, 250],
+    };
+    let bytes_a = borsh::to_vec(&a).unwrap();
+    let bytes_b = borsh::to_vec(&b).unwrap();
+    match try_merge_registered(&bytes_a, &bytes_b, 1, 2) {
+        MergeRegistryResult::Success(merged_bytes) => {
+            let merged: ConcurrentState = borsh::from_slice(&merged_bytes).unwrap();
+            assert_eq!(merged.values, vec![100, 150, 200, 250]);
+        }
+        other => panic!("post-contention dispatch failed: {other:?}"),
+    }
+}

--- a/crates/storage/tests/merge_registry_integration.rs
+++ b/crates/storage/tests/merge_registry_integration.rs
@@ -6,16 +6,35 @@
 //! production uses.
 //!
 //! This file lives under `tests/` and is compiled as a separate integration
-//! test binary WITHOUT `#[cfg(test)]`, so it links against the real
-//! `LazyLock<RwLock<HashMap<TypeId, MergeFn>>>` backend. Its job is to
-//! prove that register + dispatch plumb through correctly against the
-//! production code path.
+//! test binary. The binary itself IS built with `#[cfg(test)]` (so `#[test]`
+//! attributes work), but the `calimero-storage` *library* it links against
+//! is compiled WITHOUT `#[cfg(test)]` — which is what matters here. The
+//! library side is where the registry backend selection happens, so this
+//! test exercises the real `LazyLock<RwLock<HashMap<TypeId, MergeFn>>>`
+//! path. Its job is to prove that register + dispatch plumb through
+//! correctly against the production code.
 //!
 //! Intentionally not tested here: the abort-on-poison branch. Exercising
 //! it requires panicking inside the lock's critical section, and the
 //! response is `std::process::abort()` — which would tear down the test
 //! runner along with the lock. That branch is small enough to verify by
 //! review.
+//!
+//! # Only one test per file
+//!
+//! The production registry is a process-global `RwLock`; there is no
+//! `clear_merge_registry` available here because it's gated behind
+//! `#[cfg(test)]` on the library side. Every `#[test]` in this binary
+//! runs against the same registry and cannot clean up after itself. If
+//! two tests register different types with overlapping borsh layouts,
+//! `try_merge_registered`'s HashMap-order iteration could dispatch to
+//! the wrong one — a flake we just eliminated in the unit tests.
+//!
+//! Convention for this crate: **one registering test per `tests/*.rs`
+//! file**. Each file gets its own test binary (Cargo default), so
+//! process-global state doesn't leak between them. If you need another
+//! integration scenario, add a new `tests/merge_registry_<scenario>.rs`
+//! file rather than another `#[test]` here.
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::MergeError;

--- a/crates/storage/tests/merge_registry_integration.rs
+++ b/crates/storage/tests/merge_registry_integration.rs
@@ -1,0 +1,61 @@
+//! Integration coverage for the production merge-registry backend.
+//!
+//! Unit tests inside `src/merge/registry.rs` compile under `#[cfg(test)]`
+//! and therefore exercise the thread-local `RefCell` backend. That backend
+//! exists only to give parallel test runners isolation — it is NOT what
+//! production uses.
+//!
+//! This file lives under `tests/` and is compiled as a separate integration
+//! test binary WITHOUT `#[cfg(test)]`, so it links against the real
+//! `LazyLock<RwLock<HashMap<TypeId, MergeFn>>>` backend. Its job is to
+//! prove that register + dispatch plumb through correctly against the
+//! production code path.
+//!
+//! Intentionally not tested here: the abort-on-poison branch. Exercising
+//! it requires panicking inside the lock's critical section, and the
+//! response is `std::process::abort()` — which would tear down the test
+//! runner along with the lock. That branch is small enough to verify by
+//! review.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::Mergeable;
+use calimero_storage::merge::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
+
+#[derive(BorshSerialize, BorshDeserialize)]
+struct IntegrationState {
+    values: Vec<u32>,
+}
+
+impl Mergeable for IntegrationState {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.values.extend_from_slice(&other.values);
+        self.values.sort_unstable();
+        self.values.dedup();
+        Ok(())
+    }
+}
+
+#[test]
+fn register_and_dispatch_against_production_registry() {
+    // Registering against the real RwLock-backed global registry.
+    register_crdt_merge::<IntegrationState>();
+
+    let a = IntegrationState {
+        values: vec![1, 3, 5],
+    };
+    let b = IntegrationState {
+        values: vec![2, 3, 4],
+    };
+
+    let bytes_a = borsh::to_vec(&a).unwrap();
+    let bytes_b = borsh::to_vec(&b).unwrap();
+
+    let merged_bytes = match try_merge_registered(&bytes_a, &bytes_b, 100, 200) {
+        MergeRegistryResult::Success(bytes) => bytes,
+        other => panic!("expected Success from production registry, got {:?}", other),
+    };
+
+    let merged: IntegrationState = borsh::from_slice(&merged_bytes).unwrap();
+    assert_eq!(merged.values, vec![1, 2, 3, 4, 5]);
+}


### PR DESCRIPTION
## Problem

Intermittent CI failures in `calimero-storage`'s test suite. Symptom: three tests panic on assertions that should always pass:

- `interface::tests::user_storage_signature_verification::user_update_with_valid_signature_succeeds`
- `interface::tests::user_storage_replay_protection::sequential_updates_with_increasing_nonces_succeed`
- `interface::tests::storage_type_edge_cases::user_delete_replay_protection`

Observed in runs [24799493814](https://github.com/calimero-network/core/actions/runs/24799493814/job/72578008668) and [24799790060](https://github.com/calimero-network/core/actions/runs/24799790060/job/72579053356). Not reproducible locally.

## Root cause

`MERGE_REGISTRY` is a process-global `RwLock<HashMap<TypeId, MergeFn>>`. Three tests in `merge::registry::tests` and `tests::merge_integration` call `clear_merge_registry()` to set up clean-slate assertions, and carry `#[serial]`. The attribute from `serial_test` serialises those three against *each other* — it does **not** prevent unrelated non-serial tests from running concurrently with them.

The racy interleaving:

```
t=0  non-serial test:  register_test_merge_functions()   // registry populated
t=1  serial test:      clear_merge_registry()            // registry empty
t=2  non-serial test:  apply_action(...)                 // lookup -> None
                         └─ assertion fails
t=3  serial test:      register_crdt_merge::<TestState>() // too late
```

Everything observed — failure signature, intermittence, no reproduction under low load — matches.

## Fix

Production keeps the global `RwLock`. Under `#[cfg(test)]` the backing swaps to `thread_local!`, so each test-runner worker thread gets its own private registry. One thread clearing can't affect dispatch on another — the race is eliminated by construction.

All call sites stay unchanged; access is routed through small `with_registry` / `with_registry_mut` helpers that are cfg-gated to pick the right backend.

## Why not tag more tests `#[serial]`

Would require finding and annotating every test that touches the registry directly or transitively (~20+, growing). Easy to forget. Thread-local makes the isolation structural.

## Test plan

- [x] `cargo test -p calimero-storage --lib` — 387/387 pass, five runs in a row
- [x] `cargo check --workspace` clean
- [ ] CI green across a few merges (to confirm the flake is gone, not just quieter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core merge-registry dispatch/registration paths (now routed through new helpers) and changes test-vs-prod storage semantics, which could impact merge behavior if the cfg-gated implementations diverge. Added integration/concurrency tests reduce risk by exercising the production `RwLock` backend.
> 
> **Overview**
> Fixes flaky `calimero-storage` tests by making the merge-function registry **thread-local under `#[cfg(test)]`**, preventing parallel test threads from clearing or overwriting each other’s registrations.
> 
> Refactors registry access behind `with_registry`/`with_registry_mut` (prod: global `RwLock`, tests: thread-local `RefCell` with clearer re-entrancy failures), and adds new integration tests (`merge_registry_integration.rs` and a concurrent stress test) to cover the production `RwLock` register+dispatch path that unit tests can’t reach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc1dfd0808d27b552ec7a07e9d240b29421cc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->