### PR TITLE
ci(fuzzy-load-test): run after Release rebuilds the profiling image

### DIFF
--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -4,10 +4,28 @@ permissions:
   contents: read
 
 on:
+  # Fire after Release completes on master — whenever Release republishes
+  # `merod:edge-profiling` (which covers Cargo.toml/Lock, crates/**,
+  # release.yml itself, deps/**, actions/**, and scripts/profiling/**),
+  # we want fuzzy-load-test to run against the fresh image.
+  # Without this, changes to the profiling image (e.g. #2218, which only
+  # touched release.yml) rebuild the image but never exercise it in a
+  # fuzzy run.
+  # Gated on Release success via a job-level `if` below.
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [master]
+  # Direct push trigger for paths that don't need a Release rebuild:
+  # - apps/** : app WASMs are compiled freshly in the Build Apps job,
+  #   not baked into the image, so no image rebuild is required.
+  # - workflows/fuzzy-tests/** and this workflow file: config-only.
+  # `crates/**` is intentionally omitted — Release already fires on it
+  # and rebuilds the image, and workflow_run below triggers fuzzy
+  # against the fresh image.
   push:
     branches: [master]
     paths:
-      - "crates/**"
       - "apps/**"
       - "workflows/fuzzy-tests/**"
       - ".github/workflows/fuzzy-load-test.yml"
@@ -56,6 +74,12 @@ jobs:
   build:
     name: Build Apps
     runs-on: ubuntu-24.04-8cpu
+    # When triggered via `workflow_run` (after Release completes), only
+    # proceed if Release succeeded — a failed Release means the
+    # edge-profiling image wasn't republished, and running fuzzy against
+    # a stale image is worse than not running at all. Other triggers
+    # (push to fuzzy-tests/** or workflow_dispatch) always run.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -83,6 +83,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Under workflow_run, github.sha is the default-branch HEAD —
+          # not the commit Release actually built from. Pin to the
+          # upstream commit so the fuzzy run's source tree matches the
+          # image. Falls back to github.sha for push / workflow_dispatch.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -139,6 +145,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Under workflow_run, github.sha is the default-branch HEAD —
+          # not the commit Release actually built from. Pin to the
+          # upstream commit so the fuzzy run's source tree matches the
+          # image. Falls back to github.sha for push / workflow_dispatch.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -349,6 +361,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Under workflow_run, github.sha is the default-branch HEAD —
+          # not the commit Release actually built from. Pin to the
+          # upstream commit so the fuzzy run's source tree matches the
+          # image. Falls back to github.sha for push / workflow_dispatch.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

Commit [5a4ac18a](https://github.com/calimero-network/core/commit/5a4ac18a63bc541fe508bb1db8b32a1100000ae0) (#2218) only touched `.github/workflows/release.yml` to add `scripts/profiling/**` to Release's path filter. Release fired on that merge and rebuilt `merod:edge-profiling` with the entrypoint fix from #2217 — but **fuzzy-load-test never ran**, because its path filter didn't match `release.yml`.

Net result: the image was fixed, but we had no end-to-end signal that #2217's host-mount harvest actually produced real `perf.data` under the runtime container. That's exactly the scenario this workflow exists to cover.

Broader gap: any future change that republishes `edge-profiling` without also touching `crates/**`, `apps/**`, `workflows/fuzzy-tests/**`, or this workflow itself will have the same hole — the image ships, but fuzzy doesn't exercise it.

## Fix

Gate fuzzy-load-test on Release completion via `workflow_run`:

```yaml
workflow_run:
  workflows: ["Release"]
  types: [completed]
  branches: [master]
```

Job-level `if` ensures fuzzy only proceeds when Release actually succeeded — a failed rebuild shouldn't trigger a 45-min soak against a stale image:

```yaml
if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
```

Removed `crates/**` from the push filter: Release already fires on `crates/**` (via `Cargo.toml`/`Cargo.lock`/`crates/**`), and covering it via `workflow_run` avoids a duplicate run on the same commit.

Kept `apps/**` on push: app WASMs are compiled fresh in the `Build Apps` job, not baked into the image, so app changes don't need a Release rebuild.

Kept `workflows/fuzzy-tests/**` and the workflow file itself on push: config-only changes.

## Trigger matrix after this PR

| Change                             | Release fires? | Fuzzy fires?                  | Image used       |
|------------------------------------|----------------|-------------------------------|------------------|
| `crates/**`, `Cargo.toml`, `Cargo.lock` | Yes | After Release succeeds        | Fresh            |
| `scripts/profiling/**`             | Yes            | After Release succeeds        | Fresh            |
| `.github/workflows/release.yml`    | Yes            | After Release succeeds        | Fresh            |
| `.github/workflows/deps/**`        | Yes            | After Release succeeds        | Fresh            |
| `.github/actions/**`               | Yes            | After Release succeeds        | Fresh            |
| `apps/**`                          | No             | Immediately on push           | Existing (fine) |
| `workflows/fuzzy-tests/**`         | No             | Immediately on push           | Existing (fine) |
| `.github/workflows/fuzzy-load-test.yml` | No | Immediately on push (this file) | Existing (fine) |

## Related

- #2217 — host-mount profiling harvest (merged, image baked in)
- #2218 — release-path fix that revealed this gap (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/what commit the long-running fuzzy workflow runs against; misconfiguration could cause missed runs, duplicate runs, or running tests against the wrong image/commit (costly, but limited to CI).
> 
> **Overview**
> Runs `fuzzy-load-test` automatically **after the `Release` workflow completes on `master`** (via `workflow_run`) so performance soaks exercise freshly republished `merod:edge-profiling` images.
> 
> Removes `crates/**` from the push path filter to avoid duplicate runs, gates execution on *Release success* when triggered via `workflow_run`, and pins `actions/checkout` to `github.event.workflow_run.head_sha` so the workflow tests the same commit the image was built from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a387740b7ac293b99a2c36a08c3b7c930f97fba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->