### PR TITLE
fix(profiling): fall back to linux-tools-generic when version match fails

### DIFF
--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -20,22 +20,44 @@ mkdir -p "${PROFILING_REPORTS_DIR:-/profiling/reports}"
 install_kernel_tools() {
     local kernel_version=$(uname -r)
     echo "[Profiling] Detected kernel: $kernel_version"
-    
+
     if perf record -o /dev/null -- true 2>/dev/null; then
         echo "[Profiling] perf is compatible with current kernel"
         return 0
     fi
-    
+
     echo "[Profiling] Installing kernel tools..."
     apt-get update -qq 2>/dev/null || true
-    
+
     if apt-get install -y -qq "linux-tools-${kernel_version}" 2>/dev/null; then
         if perf record -o /dev/null -- true 2>/dev/null; then
-            echo "[Profiling] perf is now working"
+            echo "[Profiling] perf is now working (linux-tools-${kernel_version})"
             return 0
         fi
     fi
-    
+
+    # Fallback: linux-tools-generic. Ships a version-agnostic perf binary
+    # that works for userspace sampling on most kernels. Needed on Azure
+    # runners like 6.17.0-1010-azure where linux-tools-<uname-r> isn't in
+    # the Ubuntu package index.
+    #
+    # The Ubuntu /usr/bin/perf wrapper looks up /usr/lib/linux-tools/$(uname -r)/perf
+    # and errors if it's missing, so we symlink the generic binary into place.
+    echo "[Profiling] Exact-version tools unavailable, trying linux-tools-generic..."
+    if apt-get install -y -qq linux-tools-generic 2>/dev/null; then
+        local generic_perf
+        generic_perf=$(ls /usr/lib/linux-tools/*/perf 2>/dev/null | grep -v "/${kernel_version}/" | head -1)
+        if [ -n "$generic_perf" ]; then
+            local target_dir="/usr/lib/linux-tools/${kernel_version}"
+            mkdir -p "$target_dir" 2>/dev/null || true
+            ln -sf "$generic_perf" "$target_dir/perf" 2>/dev/null || true
+            if perf record -o /dev/null -- true 2>/dev/null; then
+                echo "[Profiling] perf is now working (linux-tools-generic via $generic_perf)"
+                return 0
+            fi
+        fi
+    fi
+
     echo "[Profiling] WARNING: Could not install compatible kernel tools"
     echo "[Profiling] CPU profiling (flamegraphs) will not be available"
     return 1

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -45,16 +45,31 @@ install_kernel_tools() {
     # and errors if it's missing, so we symlink the generic binary into place.
     echo "[Profiling] Exact-version tools unavailable, trying linux-tools-generic..."
     if apt-get install -y -qq linux-tools-generic 2>/dev/null; then
-        local generic_perf
-        generic_perf=$(ls /usr/lib/linux-tools/*/perf 2>/dev/null | grep -v "/${kernel_version}/" | head -1)
+        # Glob-based lookup — avoids parsing ls output and avoids regex
+        # pitfalls (dots in kernel_version are regex metacharacters).
+        local generic_perf=""
+        for candidate in /usr/lib/linux-tools/*/perf; do
+            [ -f "$candidate" ] || continue
+            # Skip the version-matched path (it's what the Ubuntu wrapper
+            # already tried and failed on).
+            if [ "$(basename "$(dirname "$candidate")")" = "$kernel_version" ]; then
+                continue
+            fi
+            generic_perf="$candidate"
+            break
+        done
         if [ -n "$generic_perf" ]; then
             local target_dir="/usr/lib/linux-tools/${kernel_version}"
-            mkdir -p "$target_dir" 2>/dev/null || true
-            ln -sf "$generic_perf" "$target_dir/perf" 2>/dev/null || true
-            if perf record -o /dev/null -- true 2>/dev/null; then
+            if ! mkdir -p "$target_dir" 2>/dev/null; then
+                echo "[Profiling] WARNING: could not create $target_dir"
+            elif ! ln -sf "$generic_perf" "$target_dir/perf" 2>/dev/null; then
+                echo "[Profiling] WARNING: could not symlink $target_dir/perf -> $generic_perf"
+            elif perf record -o /dev/null -- true 2>/dev/null; then
                 echo "[Profiling] perf is now working (linux-tools-generic via $generic_perf)"
                 return 0
             fi
+        else
+            echo "[Profiling] linux-tools-generic installed but no perf binary found under /usr/lib/linux-tools/*/"
         fi
     fi
 


### PR DESCRIPTION
## Context

Last fuzzy run ([24801298877](https://github.com/calimero-network/core/actions/runs/24801298877)) confirmed #2217's host-mount harvest is working — runtime `fuzzy-kv-node-N/` directories now show up in the artifact with real runtime jemalloc heaps + Wasmer JIT maps. **But `perf-*.data` is still absent**, because `install_kernel_tools` fails before `perf record` even gets a chance:

```
[Profiling] Detected kernel: 6.17.0-1010-azure
[Profiling] Installing kernel tools...
[Profiling] WARNING: Could not install compatible kernel tools
```

`apt-get install linux-tools-6.17.0-1010-azure` returns "no such package" on stock Ubuntu repos — this kernel just hasn't gotten matching tools published yet.

## Fix

When the exact-version package fails, fall back to `linux-tools-generic`. That ships a version-agnostic `perf` binary that works for userspace sampling on most kernels.

The Ubuntu `/usr/bin/perf` wrapper looks up `/usr/lib/linux-tools/$(uname -r)/perf` before running and errors if missing, so after installing generic we symlink the installed binary into that path so the wrapper resolves to it:

```bash
ln -sf "$generic_perf" "/usr/lib/linux-tools/${kernel_version}/perf"
```

The second perf-compatibility gate re-runs after the fallback, so if it still doesn't work we fall through to the existing WARNING and CI continues without CPU profiling (same behaviour as today, just a better chance of actually getting data).

## Scope

- Kernel frames not recordable via `linux-tools-generic` perf on some Azure kernels — fine, the entire #2199/#2215 investigation is WASM-side anyway.
- If this fallback also fails on future runners, the next escalation is `samply` (pure-userspace ptrace-based profiler) or a self-hosted runner with a stable kernel.

## Test plan

- [ ] Merge. Release rebuilds `edge-profiling` with the new entrypoint.
- [ ] `workflow_run` (from #2220) fires fuzzy-load-test against the fresh image.
- [ ] Download artifact, confirm `fuzzy-kv-node-N/perf-fuzzy-kv-node-N.data` and `perf-fuzzy-kv-node-N.log` both present.
- [ ] Generate flamegraph locally via `scripts/profiling/generate-flamegraph.sh` — looking for WASM-side hotspots for #2215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change limited to CI/container profiling; main impact is altering package installation and symlink behavior when kernel-specific `linux-tools-<uname -r>` packages are missing.
> 
> **Overview**
> Improves profiling startup robustness by adding a fallback path when `linux-tools-$(uname -r)` is unavailable: installs `linux-tools-generic`, locates an available `perf` binary, and symlinks it into `/usr/lib/linux-tools/$(uname -r)/perf` so the Ubuntu `perf` wrapper works.
> 
> Updates logging to indicate which toolchain enabled `perf`, and keeps the existing behavior of continuing without CPU profiling if `perf record` still fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5455019d74f9cc87b9d22bf14d21d4d6f72720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->