### PR TITLE
fix(node/sync): cold-start join_context full fix — data + governance parent pull (#2198)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -148,6 +148,9 @@ jobs:
           - workflow: group-subgroup-cold-sync
             file: workflows/group-subgroup-cold-sync.yml
             app: e2e-kv-store
+          - workflow: group-subgroup-queued-deltas
+            file: workflows/group-subgroup-queued-deltas.yml
+            app: e2e-kv-store
           - workflow: group-membership
             file: workflows/group-membership.yml
             app: e2e-kv-store

--- a/apps/e2e-kv-store/workflows/group-subgroup-queued-deltas.yml
+++ b/apps/e2e-kv-store/workflows/group-subgroup-queued-deltas.yml
@@ -1,0 +1,388 @@
+name: E2E KV Store - Subgroup Queued-Deltas Cold-Start
+description: >
+  Regression test for issue #2198: `join_context` deterministic first-attempt
+  failure when a subgroup-owned context has queued gossip deltas.
+
+  Reproduces the mero-drive e2e failure shape:
+
+    1. Node-1 (Alice) creates a subgroup and adds node-2 (Bob) to it.
+    2. Node-1 creates a subgroup-owned context.
+    3. Node-1 generates many writes on that context. Each write broadcasts
+       a delta over the context's gossipsub topic.
+    4. Because node-2 is a subgroup member, it receives those gossip deltas
+       into its `delta_store`. Parents are not in node-2's local DB yet
+       (node-2 has never synced the context), so the deltas accumulate as
+       pending.
+    5. Node-2 calls `join_context(subgroup_ctx)`. The fix under test makes
+       this succeed on the FIRST attempt.
+
+  Pre-fix behaviour (root cause, see docs/superpowers/specs/2026-04-22-join-
+  context-cold-start-design.md):
+    - `delta_store: Some deltas could not be loaded — remaining_count=N
+       loaded_count=0`
+    - `sync::manager: Failed to handle stream message err=context not found:
+       <subgroup-internal-ctx-id>` (an unrelated context leaking onto the
+      sync channel tears down the legitimate sync)
+    - `join_context` returns error ~30ms after the call.
+
+  Post-fix behaviour:
+    - Inbound streams for unknown contexts close cleanly without killing
+      the active sync (Fix C).
+    - The sync session pulls missing parents from additional mesh peers
+      within a bounded budget before reporting success, and reports a
+      typed error if it genuinely cannot (Fix B).
+    - Result: `join_context` succeeds deterministically on attempt 1 with
+      a fully-applied DAG; the post-join read sees the last value node-1
+      wrote before join.
+
+  Why this catches the bug that `group-subgroup-cold-sync.yml` misses:
+  that test has node-2 join the context IMMEDIATELY after creation, so
+  node-2's `delta_store` is empty at join time and the queued-deltas race
+  never fires. This workflow specifically delays the join so gossip deltas
+  can accumulate first.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # ── Setup: install app on both nodes ──────────────────────────────
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: e2e-node-2
+    path: res/e2e_kv_store.wasm
+    dev: true
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+    outputs:
+      member_identity_node2: memberIdentity
+
+  # Gossipsub mesh warmup: after joining the namespace, node-2 subscribes
+  # to `ns/{namespace_id}` but the mesh on that topic doesn't GRAFT between
+  # both nodes instantly. GRAFT typically takes a handful of heartbeat
+  # cycles (~1-3s). If we broadcast governance ops before GRAFT completes,
+  # node-2 misses them entirely and has to wait for the next periodic
+  # heartbeat (~30s) to catch up — which exceeds the probe's window.
+  #
+  # The proactive backfill path (#2198) only fires once node-2 actually
+  # receives a gossip op; it cannot recover from a mesh that hasn't formed
+  # yet. This small wait ensures gossip delivery works by the time we
+  # start touching the subgroup.
+  - name: Warm up namespace gossipsub mesh
+    type: wait
+    seconds: 3
+    message: allow gossipsub GRAFT on ns/<id> before broadcasting governance ops
+
+  # ── Subgroup: node-2 is a member BEFORE the context exists ────────
+  #
+  # Membership must precede context creation so that gossip deltas on
+  # the subgroup-owned context reach node-2 via auto-follow (#2169)
+  # and populate its delta_store.
+
+  - name: Create subgroup inside namespace
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: queued-deltas-subgroup
+    outputs:
+      subgroup_id: groupId
+
+  - name: Add node-2 to subgroup
+    type: add_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{member_identity_node2}}'
+        role: Member
+
+  # Wait + probe: we must verify node-2 has APPLIED the subgroup-membership
+  # governance op before we start burst-generating deltas on the subgroup
+  # context. If we skip this and rely on a fixed sleep alone, gossip
+  # delivery of the delta burst on the subgroup-context topic can
+  # interleave with governance op application on node-2's gossipsub /
+  # actor pipeline and push membership recognition past the join_context
+  # check, surfacing as ApiError 500 "identity is not a member of the
+  # group". That is a separate bug from #2198; we defend against it here
+  # by asserting node-2's local view of subgroup membership BEFORE the
+  # delta burst begins, so the two bugs can't conflate in this workflow.
+
+  # With the proactive-backfill code path (#2198) in place, governance ops
+  # that arrive on node-2 with missing parents trigger an immediate
+  # cross-peer backfill instead of waiting for the 30s heartbeat cycle.
+  # A short wall-clock window here covers gossip propagation latency; the
+  # probe below is the real gate.
+  - name: Short window for subgroup governance propagation
+    type: wait
+    seconds: 5
+    message: cover gossip hop + proactive backfill; probe is the real gate
+
+  - name: Node-2 lists subgroup members (local view)
+    type: list_group_members
+    node: e2e-node-2
+    group_id: '{{subgroup_id}}'
+    outputs:
+      node2_view_of_subgroup_members: members
+
+  - name: Assert node-2's local group_store knows about the subgroup
+    type: assert
+    statements:
+      - "is_set({{node2_view_of_subgroup_members}})"
+
+  - name: Node-1 lists subgroup members (authoritative view)
+    type: list_group_members
+    node: e2e-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      node1_view_of_subgroup_members: members
+
+  - name: Assert node-1 also knows about the subgroup
+    type: assert
+    statements:
+      - "is_set({{node1_view_of_subgroup_members}})"
+
+  # ── Create subgroup-owned context; node-2 does NOT join yet ───────
+
+  - name: Create context inside subgroup (node-1 only)
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      sub_ctx_id: contextId
+
+  # ── Generate many deltas on node-1 while node-2 has NOT joined ────
+  #
+  # Each call produces a delta that is broadcast on the context's
+  # gossipsub topic. Because node-2 is a subgroup member it is
+  # auto-subscribed to contexts owned by the subgroup and will
+  # accumulate these deltas in its delta_store as pending (parents
+  # absent from node-2's local DB).
+  #
+  # 20 deltas chosen to match mero-drive's "remaining_count=19" signal
+  # with a safety margin. Too few deltas may not reliably trigger the
+  # race; too many wastes CI time.
+
+  - name: Alice delta 01
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k01", value: "v01" }
+
+  - name: Alice delta 02
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k02", value: "v02" }
+
+  - name: Alice delta 03
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k03", value: "v03" }
+
+  - name: Alice delta 04
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k04", value: "v04" }
+
+  - name: Alice delta 05
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k05", value: "v05" }
+
+  - name: Alice delta 06
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k06", value: "v06" }
+
+  - name: Alice delta 07
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k07", value: "v07" }
+
+  - name: Alice delta 08
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k08", value: "v08" }
+
+  - name: Alice delta 09
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k09", value: "v09" }
+
+  - name: Alice delta 10
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k10", value: "v10" }
+
+  - name: Alice delta 11
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k11", value: "v11" }
+
+  - name: Alice delta 12
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k12", value: "v12" }
+
+  - name: Alice delta 13
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k13", value: "v13" }
+
+  - name: Alice delta 14
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k14", value: "v14" }
+
+  - name: Alice delta 15
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k15", value: "v15" }
+
+  - name: Alice delta 16
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k16", value: "v16" }
+
+  - name: Alice delta 17
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k17", value: "v17" }
+
+  - name: Alice delta 18
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k18", value: "v18" }
+
+  - name: Alice delta 19
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "k19", value: "v19" }
+
+  - name: Alice delta 20 (the sentinel the join_context read will check)
+    type: call
+    node: e2e-node-1
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args: { key: "sentinel", value: "queued_delta_20" }
+
+  # ── Let gossip catch up: node-2's delta_store should now be loaded
+  # ──  with ~20 pending children whose parents are not in local DB.
+  #
+  # This window mirrors mero-drive's "Wait 10s for docs-context gossip"
+  # step, which is the precondition for the original failure.
+
+  - name: Wait for gossip deltas to accumulate in node-2's delta_store
+    type: wait
+    seconds: 10
+    message: queued gossip deltas must be present before join_context
+
+  # ── The test: node-2 joins the context. Must succeed first attempt.
+  #
+  # Pre-fix: bails within ~30ms due to
+  #   - "context not found" (unrelated stream tears down sync), and/or
+  #   - pending parents never get pulled before sync "success".
+  # Post-fix: succeeds; DAG is fully applied by the time this returns.
+
+  - name: Node-2 joins subgroup context (regression point for #2198)
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+
+  # ── Post-join sanity: the sentinel (last delta written by node-1)
+  # ──  must be readable on node-2. This proves the DAG is fully
+  # ──  applied, not just that join_context returned Ok on a partial
+  # ──  DAG (which is the specific foot-gun the typed
+  # ──  PendingParentsUnresolved error in Fix B closes).
+
+  - name: Allow sync to finalise
+    type: wait_for_sync
+    context_id: '{{sub_ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 30
+    trigger_sync: true
+
+  - name: Node-2 reads the sentinel key
+    type: call
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+    method: get
+    args: { key: "sentinel" }
+    outputs:
+      sentinel_read: result
+
+  - name: Assert node-2 sees the final pre-join write
+    type: json_assert
+    statements:
+      - 'json_equal({{sentinel_read}}, {"output": "queued_delta_20"})'
+
+stop_all_nodes: false

--- a/architecture/error-flows.html
+++ b/architecture/error-flows.html
@@ -499,7 +499,8 @@
   </div>
   <div class="flow-step">
     <h4 style="color:var(--blue);">Fetch Missing</h4>
-    <p><span class="code">NodeManager</span> sends a <span class="code">DeltaRequest</span> stream to peers who likely have the missing parent. Peers respond with the missing delta payload.</p>
+    <p><span class="code">NodeManager</span> sends a <span class="code">DeltaRequest</span> stream to peers who likely have the missing parent. Peers respond with the missing delta payload. If the initial peer does not resolve every missing parent, <span class="code">SyncManager</span> iterates additional mesh peers for the context up to <span class="code">parent_pull_additional_peers</span>, bounded by <span class="code">parent_pull_budget</span>; unresolved pending parents after the budget surface as a sync-session error so callers (e.g. <span class="code">join_context</span>) fail loud rather than reporting success on a partial DAG.</p>
+    <p>The same pattern applies to <strong>governance DAG</strong> ops. When a <span class="code">NamespaceGovernanceDelta</span> arrives via gossip with missing parents, the node immediately opens a <span class="code">NamespaceBackfillRequest</span> stream to the gossip source (rather than waiting for the periodic <span class="code">NamespaceStateHeartbeat</span> cycle) and falls through to the same cross-peer iteration if the first peer cannot drain the pending chain.</p>
   </div>
   <div class="flow-step">
     <h4 style="color:var(--green);">Resolution</h4>
@@ -513,6 +514,8 @@
     <li><span class="kn">pending_deltas_count</span> — gauge for deltas awaiting parents</li>
     <li><span class="kn">delta_request_sent</span> — counter for DeltaRequest messages emitted</li>
     <li><span class="kn">stale_pending_cleanup_interval</span> — periodic cleanup timer</li>
+    <li><span class="kn">parent_pull_additional_peers</span> — max additional mesh peers tried after the initial sync peer (default 3, applies to data-delta and namespace governance parent pulls)</li>
+    <li><span class="kn">parent_pull_budget</span> — wall-clock budget for the cross-peer parent-pull loop (default 10s)</li>
   </ul>
 </div>
 </div>

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -40,7 +40,8 @@ use crate::group::{
 use crate::messages::{
     ApplySignedGroupOpRequest, ApplySignedNamespaceOpRequest, ContextMessage, CreateContextRequest,
     CreateContextResponse, DeleteContextRequest, DeleteContextResponse, ExecuteError,
-    ExecuteRequest, ExecuteResponse, MigrationParams, UpdateApplicationRequest,
+    ExecuteRequest, ExecuteResponse, MigrationParams, NamespaceApplyOutcome,
+    UpdateApplicationRequest,
 };
 use crate::ContextAtomic;
 
@@ -1301,15 +1302,13 @@ impl ContextClient {
 
     /// Apply a signed namespace governance op to this node's local state.
     ///
-    /// Returns `Ok(true)` if the op was applied immediately, `Ok(false)` if it
-    /// was deferred as pending (missing parents) or is a duplicate. Callers
-    /// that observe `Ok(false)` may proactively trigger a backfill against the
-    /// gossip source so the pending chain resolves without waiting for the
-    /// periodic namespace heartbeat.
+    /// Returns a [`NamespaceApplyOutcome`] distinguishing the three success
+    /// states: `Applied`, `Pending` (parents missing — caller should trigger
+    /// backfill), and `Duplicate` (already present — no action required).
     pub async fn apply_signed_namespace_op(
         &self,
         op: crate::local_governance::SignedNamespaceOp,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<NamespaceApplyOutcome> {
         let (sender, receiver) = oneshot::channel();
 
         self.context_manager

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -1292,15 +1292,41 @@ impl ContextClient {
         receiver.await.expect("Mailbox not to be dropped")
     }
 
+    /// Apply a signed namespace governance op to this node's local state.
+    ///
+    /// Returns `Ok(true)` if the op was applied immediately, `Ok(false)` if it
+    /// was deferred as pending (missing parents) or is a duplicate. Callers
+    /// that observe `Ok(false)` may proactively trigger a backfill against the
+    /// gossip source so the pending chain resolves without waiting for the
+    /// periodic namespace heartbeat.
     pub async fn apply_signed_namespace_op(
         &self,
         op: crate::local_governance::SignedNamespaceOp,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<bool> {
         let (sender, receiver) = oneshot::channel();
 
         self.context_manager
             .send(ContextMessage::ApplySignedNamespaceOp {
                 request: ApplySignedNamespaceOpRequest { op },
+                outcome: sender,
+            })
+            .await
+            .expect("Mailbox not to be dropped");
+
+        receiver.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Returns the number of ops in this namespace's governance DAG whose
+    /// parents have not yet been applied locally (the "pending" queue size).
+    ///
+    /// Used by the cross-peer parent-pull loop (#2198) to decide whether
+    /// another backfill round against another mesh peer is needed.
+    pub async fn namespace_pending_op_count(&self, namespace_id: [u8; 32]) -> eyre::Result<usize> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.context_manager
+            .send(ContextMessage::NamespacePendingOpCount {
+                request: crate::messages::NamespacePendingOpCountRequest { namespace_id },
                 outcome: sender,
             })
             .await

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -143,7 +143,22 @@ pub struct ApplySignedNamespaceOpRequest {
 }
 
 impl Message for ApplySignedNamespaceOpRequest {
-    type Result = eyre::Result<()>;
+    /// `Ok(true)`  — op was applied immediately.
+    /// `Ok(false)` — op is pending (missing parents) or a duplicate; caller may
+    ///               proactively trigger backfill to resolve the pending chain.
+    type Result = eyre::Result<bool>;
+}
+
+/// Query the number of pending (not-yet-applied) ops in a namespace's
+/// governance DAG. Used by the cross-peer parent-pull loop (#2198) to
+/// decide whether another backfill round is needed.
+#[derive(Debug, Clone)]
+pub struct NamespacePendingOpCountRequest {
+    pub namespace_id: [u8; 32],
+}
+
+impl Message for NamespacePendingOpCountRequest {
+    type Result = eyre::Result<usize>;
 }
 
 /// Parameters for executing a state migration during application update.
@@ -213,6 +228,10 @@ pub enum ContextMessage {
     ApplySignedNamespaceOp {
         request: ApplySignedNamespaceOpRequest,
         outcome: oneshot::Sender<<ApplySignedNamespaceOpRequest as Message>::Result>,
+    },
+    NamespacePendingOpCount {
+        request: NamespacePendingOpCountRequest,
+        outcome: oneshot::Sender<<NamespacePendingOpCountRequest as Message>::Result>,
     },
     RemoveGroupMembers {
         request: RemoveGroupMembersRequest,

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -137,16 +137,37 @@ impl Message for ApplySignedGroupOpRequest {
     type Result = eyre::Result<bool>;
 }
 
+/// Outcome of applying a signed namespace governance op.
+///
+/// Needed by callers that must distinguish "pending, please trigger backfill"
+/// from "duplicate, do nothing" — the underlying DAG used to collapse both
+/// into `Ok(false)`, causing every duplicate gossip op to open a redundant
+/// backfill stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamespaceApplyOutcome {
+    /// Op was applied immediately.
+    Applied,
+    /// Op was accepted but is waiting for missing parents; caller should
+    /// proactively trigger a namespace backfill.
+    Pending,
+    /// Op was already present in the governance DAG; no action required.
+    Duplicate,
+}
+
+impl NamespaceApplyOutcome {
+    /// `true` if the op is pending and a backfill should be triggered.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ApplySignedNamespaceOpRequest {
     pub op: crate::local_governance::SignedNamespaceOp,
 }
 
 impl Message for ApplySignedNamespaceOpRequest {
-    /// `Ok(true)`  — op was applied immediately.
-    /// `Ok(false)` — op is pending (missing parents) or a duplicate; caller may
-    ///               proactively trigger backfill to resolve the pending chain.
-    type Result = eyre::Result<bool>;
+    type Result = eyre::Result<NamespaceApplyOutcome>;
 }
 
 /// Query the number of pending (not-yet-applied) ops in a namespace's

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -29,6 +29,7 @@ pub mod list_group_contexts;
 pub mod list_group_members;
 pub mod list_namespaces;
 pub mod list_namespaces_for_application;
+pub mod namespace_pending_op_count;
 pub mod remove_group_members;
 pub mod retry_group_upgrade;
 pub mod set_default_capabilities;
@@ -85,6 +86,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::ApplySignedNamespaceOp { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::NamespacePendingOpCount { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::RemoveGroupMembers { request, outcome } => {

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -1,5 +1,6 @@
 use actix::{ActorResponse, Handler, Message, WrapFuture};
-use calimero_context_client::messages::ApplySignedNamespaceOpRequest;
+use calimero_context_client::messages::{ApplySignedNamespaceOpRequest, NamespaceApplyOutcome};
+use calimero_dag::AddDeltaOutcome;
 
 use crate::governance_dag::{signed_namespace_op_to_delta, NamespaceGovernanceApplier};
 use crate::ContextManager;
@@ -26,8 +27,10 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
         ActorResponse::r#async(
             async move {
                 let mut dag = dag.lock().await;
-                match dag.add_delta(delta, &applier).await {
-                    Ok(applied) => Ok(applied),
+                match dag.add_delta_with_outcome(delta, &applier).await {
+                    Ok(AddDeltaOutcome::Applied) => Ok(NamespaceApplyOutcome::Applied),
+                    Ok(AddDeltaOutcome::Pending) => Ok(NamespaceApplyOutcome::Pending),
+                    Ok(AddDeltaOutcome::Duplicate) => Ok(NamespaceApplyOutcome::Duplicate),
                     Err(e) => Err(eyre::eyre!("namespace DAG apply error: {e}")),
                 }
             }

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -27,7 +27,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
             async move {
                 let mut dag = dag.lock().await;
                 match dag.add_delta(delta, &applier).await {
-                    Ok(_applied) => Ok(()),
+                    Ok(applied) => Ok(applied),
                     Err(e) => Err(eyre::eyre!("namespace DAG apply error: {e}")),
                 }
             }

--- a/crates/context/src/handlers/namespace_pending_op_count.rs
+++ b/crates/context/src/handlers/namespace_pending_op_count.rs
@@ -1,0 +1,24 @@
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::messages::NamespacePendingOpCountRequest;
+
+use crate::ContextManager;
+
+impl Handler<NamespacePendingOpCountRequest> for ContextManager {
+    type Result = ActorResponse<Self, <NamespacePendingOpCountRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        NamespacePendingOpCountRequest { namespace_id }: NamespacePendingOpCountRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let dag = self.get_or_create_namespace_dag(&namespace_id);
+
+        ActorResponse::r#async(
+            async move {
+                let dag = dag.lock().await;
+                Ok(dag.stats().pending_deltas)
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -190,6 +190,41 @@ pub struct PendingStats {
     pub total_missing_parents: usize,
 }
 
+/// Detailed outcome of [`DagStore::add_delta_with_outcome`].
+///
+/// The bool-returning [`DagStore::add_delta`] collapses `Pending` and
+/// `Duplicate` into `Ok(false)`. Callers that need to distinguish the two —
+/// e.g. to avoid triggering a network backfill on a duplicate gossip op —
+/// should use the `_with_outcome` variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddDeltaOutcome {
+    /// The delta was applied immediately (all parents present).
+    Applied,
+    /// The delta was stored as pending (at least one parent missing).
+    Pending,
+    /// The delta was already present in the DAG; no work performed.
+    Duplicate,
+}
+
+impl AddDeltaOutcome {
+    /// `true` when the outcome is [`AddDeltaOutcome::Applied`].
+    pub fn is_applied(&self) -> bool {
+        matches!(self, Self::Applied)
+    }
+
+    /// `true` when the outcome is [`AddDeltaOutcome::Pending`] — i.e. the
+    /// delta was accepted but is waiting for missing parents. This is the
+    /// only outcome that warrants proactive backfill.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// `true` when the outcome is [`AddDeltaOutcome::Duplicate`].
+    pub fn is_duplicate(&self) -> bool {
+        matches!(self, Self::Duplicate)
+    }
+}
+
 /// DAG-based delta store
 ///
 /// Manages causal deltas in a DAG structure, applying them in topological order.
@@ -320,17 +355,39 @@ impl<T: Clone> DagStore<T> {
         Ok(applied_count)
     }
 
-    /// Add a delta to the DAG
+    /// Add a delta to the DAG.
     ///
+    /// Bool-returning compatibility wrapper over [`Self::add_delta_with_outcome`].
     /// Returns:
     /// - `Ok(true)` if applied immediately
-    /// - `Ok(false)` if pending (waiting for parents)
-    /// - `Err(DagError)` if delta already exists or application fails
+    /// - `Ok(false)` if pending *or* a duplicate
+    ///
+    /// Callers that need to distinguish pending from duplicate (e.g. to avoid
+    /// triggering a network backfill on a duplicate gossip op) should use
+    /// [`Self::add_delta_with_outcome`] instead.
     pub async fn add_delta(
         &mut self,
         delta: CausalDelta<T>,
         applier: &impl DeltaApplier<T>,
     ) -> Result<bool, DagError> {
+        Ok(matches!(
+            self.add_delta_with_outcome(delta, applier).await?,
+            AddDeltaOutcome::Applied
+        ))
+    }
+
+    /// Add a delta to the DAG and return the detailed outcome.
+    ///
+    /// Differentiates the three success states that `add_delta` collapses into
+    /// a bool:
+    /// - `AddDeltaOutcome::Applied`   — applied immediately
+    /// - `AddDeltaOutcome::Pending`   — stored pending, waiting for parents
+    /// - `AddDeltaOutcome::Duplicate` — already present in the DAG
+    pub async fn add_delta_with_outcome(
+        &mut self,
+        delta: CausalDelta<T>,
+        applier: &impl DeltaApplier<T>,
+    ) -> Result<AddDeltaOutcome, DagError> {
         let delta_id = delta.id;
 
         // Check if delta already exists
@@ -344,8 +401,7 @@ impl<T: Clone> DagStore<T> {
                     "Received real delta for existing checkpoint - skipping (state already present via snapshot)"
                 );
             }
-            // Skip duplicate
-            return Ok(false);
+            return Ok(AddDeltaOutcome::Duplicate);
         }
 
         // Store delta in memory
@@ -354,11 +410,11 @@ impl<T: Clone> DagStore<T> {
         // Check if we can apply immediately
         if self.can_apply(&delta) {
             self.apply_delta(delta, applier).await?;
-            Ok(true)
+            Ok(AddDeltaOutcome::Applied)
         } else {
             // Missing parents - store as pending
             self.pending.insert(delta_id, PendingDelta::new(delta));
-            Ok(false)
+            Ok(AddDeltaOutcome::Pending)
         }
     }
 

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -134,6 +134,57 @@ async fn test_dag_duplicate_delta() {
     assert_eq!(applied[0], [1; 32]);
 }
 
+/// Regression: `add_delta_with_outcome` must distinguish Pending from
+/// Duplicate. The bool-returning `add_delta` collapses both into `Ok(false)`,
+/// which caused the namespace governance handler to trigger a wasteful
+/// network backfill on every duplicate gossip op.
+#[tokio::test]
+async fn test_dag_add_delta_with_outcome_tri_state() {
+    use crate::AddDeltaOutcome;
+
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    let delta1 = CausalDelta::new_test([1; 32], vec![[0; 32]], TestPayload { value: 1 });
+    let delta2 = CausalDelta::new_test([2; 32], vec![[1; 32]], TestPayload { value: 2 });
+    // delta3 has a parent we will never deliver, so it stays pending.
+    let delta3 = CausalDelta::new_test([3; 32], vec![[99; 32]], TestPayload { value: 3 });
+
+    assert_eq!(
+        dag.add_delta_with_outcome(delta1.clone(), &applier)
+            .await
+            .unwrap(),
+        AddDeltaOutcome::Applied,
+        "fresh delta with present parent applies immediately",
+    );
+
+    assert_eq!(
+        dag.add_delta_with_outcome(delta1, &applier).await.unwrap(),
+        AddDeltaOutcome::Duplicate,
+        "re-submitting the same delta must report Duplicate, NOT Pending",
+    );
+
+    assert_eq!(
+        dag.add_delta_with_outcome(delta2, &applier).await.unwrap(),
+        AddDeltaOutcome::Applied,
+        "chained delta with applied parent also applies immediately",
+    );
+
+    assert_eq!(
+        dag.add_delta_with_outcome(delta3.clone(), &applier)
+            .await
+            .unwrap(),
+        AddDeltaOutcome::Pending,
+        "delta with missing parent must report Pending",
+    );
+
+    assert_eq!(
+        dag.add_delta_with_outcome(delta3, &applier).await.unwrap(),
+        AddDeltaOutcome::Duplicate,
+        "re-submitting a pending delta must report Duplicate (already queued), not Pending again",
+    );
+}
+
 // ============================================================
 // Out-of-Order Delivery Tests
 // ============================================================

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -2,9 +2,11 @@ use std::collections::HashSet;
 
 use actix::{AsyncContext, WrapFuture};
 use calimero_context_client::local_governance::SignedNamespaceOp;
+use calimero_network_primitives::client::NetworkClient;
 use calimero_node_primitives::sync::{BroadcastMessage, MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES};
 use tracing::{debug, info, warn};
 
+use crate::sync::parent_pull::{NextPeer, ParentPullBudget};
 use crate::NodeManager;
 
 pub(super) fn handle_namespace_governance_delta(
@@ -42,13 +44,47 @@ pub(super) fn handle_namespace_governance_delta(
 
     let context_client = this.clients.context.clone();
     let node_client = this.clients.node.clone();
+    let network_client = this.managers.sync.network_client.clone();
+    let sync_timeout = this.managers.sync.sync_config.timeout;
+    let pull_budget_max_peers = this.managers.sync.sync_config.parent_pull_additional_peers;
+    let pull_budget_duration = this.managers.sync.sync_config.parent_pull_budget;
     let op_for_delivery = op.clone();
+
     let _ignored = ctx.spawn(
         async move {
-            if let Err(err) = context_client.apply_signed_namespace_op(op).await {
-                warn!(?err, %source, "failed to apply namespace governance delta");
-                return;
+            let apply_outcome = context_client.apply_signed_namespace_op(op).await;
+            let applied = match apply_outcome {
+                Ok(applied) => applied,
+                Err(err) => {
+                    warn!(?err, %source, "failed to apply namespace governance delta");
+                    return;
+                }
+            };
+
+            // Proactive backfill (#2198): if the op went pending (missing
+            // parents), don't wait for the next periodic namespace heartbeat.
+            // Immediately fetch the namespace DAG from the gossip source so
+            // downstream checks like join_context's membership read see a
+            // converged state within sub-second latency. If the first peer
+            // cannot resolve everything, fall through to cross-peer retry.
+            if !applied {
+                debug!(
+                    %source,
+                    namespace_id = %hex::encode(namespace_id),
+                    "gossip governance op is pending; triggering proactive backfill"
+                );
+                resolve_namespace_pending(
+                    &context_client,
+                    &network_client,
+                    source,
+                    namespace_id,
+                    sync_timeout,
+                    pull_budget_max_peers,
+                    pull_budget_duration,
+                )
+                .await;
             }
+
             crate::key_delivery::maybe_publish_key_delivery(
                 &context_client,
                 &node_client,
@@ -81,6 +117,8 @@ pub(super) fn handle_namespace_state_heartbeat(
     let context_client = this.clients.context.clone();
     let network_client = this.managers.sync.network_client.clone();
     let sync_timeout = this.managers.sync.sync_config.timeout;
+    let pull_budget_max_peers = this.managers.sync.sync_config.parent_pull_additional_peers;
+    let pull_budget_duration = this.managers.sync.sync_config.parent_pull_budget;
 
     let _ignored = ctx.spawn(
         async move {
@@ -145,59 +183,178 @@ pub(super) fn handle_namespace_state_heartbeat(
                 "namespace heartbeat divergence: requesting missing deltas"
             );
 
-            let Ok(mut stream) = network_client.open_stream(source).await else {
-                debug!(
-                    %source,
-                    "failed to open stream for namespace delta catch-up"
-                );
-                return;
-            };
+            // First attempt: the peer that advertised its heads.
+            fetch_and_apply_namespace_backfill(
+                &context_client,
+                &network_client,
+                source,
+                namespace_id,
+                we_need,
+                sync_timeout,
+            )
+            .await;
 
-            let msg = calimero_node_primitives::sync::StreamMessage::Init {
-                context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
-                party_id: calimero_primitives::identity::PublicKey::from([0u8; 32]),
-                payload: calimero_node_primitives::sync::InitPayload::NamespaceBackfillRequest {
-                    namespace_id,
-                    delta_ids: we_need,
-                },
-                next_nonce: {
-                    use rand::Rng;
-                    rand::thread_rng().gen()
-                },
-            };
-
-            if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {
-                debug!(%err, "failed to send NamespaceBackfillRequest");
-                return;
-            }
-
-            match crate::sync::stream::recv(&mut stream, None, sync_timeout).await {
-                Ok(Some(calimero_node_primitives::sync::StreamMessage::Message {
-                    payload:
-                        calimero_node_primitives::sync::MessagePayload::NamespaceBackfillResponse {
-                            deltas,
-                        },
-                    ..
-                })) => {
-                    for (delta_id, op_bytes) in deltas {
-                        if let Ok(op) = borsh::from_slice::<SignedNamespaceOp>(&op_bytes) {
-                            if let Err(err) = context_client.apply_signed_namespace_op(op).await {
-                                warn!(
-                                    %source,
-                                    namespace_id = %hex::encode(namespace_id),
-                                    delta_id = %hex::encode(delta_id),
-                                    ?err,
-                                    "failed to apply namespace backfill op from heartbeat catch-up"
-                                );
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    debug!("unexpected response to NamespaceBackfillRequest");
-                }
-            }
+            // Cross-peer fallback (#2198): if the first peer did not fully
+            // resolve our pending chain, iterate other namespace-mesh peers
+            // until the DAG drains or the budget is exhausted.
+            resolve_namespace_pending(
+                &context_client,
+                &network_client,
+                source,
+                namespace_id,
+                sync_timeout,
+                pull_budget_max_peers,
+                pull_budget_duration,
+            )
+            .await;
         }
         .into_actor(this),
     );
+}
+
+/// Iterate other namespace-mesh peers asking for backfill until the local
+/// governance DAG has no more pending ops for this namespace, or the retry
+/// budget is exhausted.
+///
+/// Uses empty-body `NamespaceBackfillRequest` (semantics: "give me everything
+/// for this namespace", per `handle_namespace_backfill_request`) because
+/// callers don't know which specific ancestor ids are still missing — the
+/// pending chain can be arbitrarily deep, and the responder caps at
+/// `MAX_BACKFILL_OPS` per response anyway.
+async fn resolve_namespace_pending(
+    context_client: &calimero_context_client::client::ContextClient,
+    network_client: &NetworkClient,
+    initial_peer: libp2p::PeerId,
+    namespace_id: [u8; 32],
+    sync_timeout: tokio::time::Duration,
+    max_additional_peers: usize,
+    budget: tokio::time::Duration,
+) {
+    let topic = libp2p::gossipsub::TopicHash::from_raw(format!("ns/{}", hex::encode(namespace_id)));
+    let mut mesh_peers = network_client.mesh_peers(topic.clone()).await;
+    let mut scheduler = ParentPullBudget::new(initial_peer, max_additional_peers, budget);
+
+    loop {
+        if !namespace_has_pending(context_client, namespace_id).await {
+            break;
+        }
+
+        let next_peer = match scheduler.next(&mesh_peers) {
+            NextPeer::Peer(p) => p,
+            NextPeer::RefetchMesh => {
+                mesh_peers = network_client.mesh_peers(topic.clone()).await;
+                scheduler.record_refetch();
+                match scheduler.next(&mesh_peers) {
+                    NextPeer::Peer(p) => p,
+                    other => {
+                        debug!(
+                            namespace_id = %hex::encode(namespace_id),
+                            ?other,
+                            "no additional ns mesh peers for parent pull"
+                        );
+                        break;
+                    }
+                }
+            }
+            NextPeer::BudgetExhausted => {
+                warn!(
+                    namespace_id = %hex::encode(namespace_id),
+                    "namespace parent-pull budget exhausted"
+                );
+                break;
+            }
+            NextPeer::MaxPeersReached | NextPeer::NoMorePeers => break,
+        };
+
+        scheduler.record_attempt(next_peer);
+        info!(
+            namespace_id = %hex::encode(namespace_id),
+            ?next_peer,
+            attempt = scheduler.attempts(),
+            "retrying namespace backfill against additional mesh peer"
+        );
+
+        fetch_and_apply_namespace_backfill(
+            context_client,
+            network_client,
+            next_peer,
+            namespace_id,
+            Vec::new(),
+            sync_timeout,
+        )
+        .await;
+    }
+}
+
+async fn fetch_and_apply_namespace_backfill(
+    context_client: &calimero_context_client::client::ContextClient,
+    network_client: &NetworkClient,
+    peer: libp2p::PeerId,
+    namespace_id: [u8; 32],
+    delta_ids: Vec<[u8; 32]>,
+    sync_timeout: tokio::time::Duration,
+) {
+    let Ok(mut stream) = network_client.open_stream(peer).await else {
+        debug!(
+            %peer,
+            "failed to open stream for namespace backfill"
+        );
+        return;
+    };
+
+    let msg = calimero_node_primitives::sync::StreamMessage::Init {
+        context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
+        party_id: calimero_primitives::identity::PublicKey::from([0u8; 32]),
+        payload: calimero_node_primitives::sync::InitPayload::NamespaceBackfillRequest {
+            namespace_id,
+            delta_ids,
+        },
+        next_nonce: {
+            use rand::Rng;
+            rand::thread_rng().gen()
+        },
+    };
+
+    if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {
+        debug!(%err, "failed to send NamespaceBackfillRequest");
+        return;
+    }
+
+    match crate::sync::stream::recv(&mut stream, None, sync_timeout).await {
+        Ok(Some(calimero_node_primitives::sync::StreamMessage::Message {
+            payload:
+                calimero_node_primitives::sync::MessagePayload::NamespaceBackfillResponse { deltas },
+            ..
+        })) => {
+            for (delta_id, op_bytes) in deltas {
+                if let Ok(op) = borsh::from_slice::<SignedNamespaceOp>(&op_bytes) {
+                    if let Err(err) = context_client.apply_signed_namespace_op(op).await {
+                        warn!(
+                            %peer,
+                            namespace_id = %hex::encode(namespace_id),
+                            delta_id = %hex::encode(delta_id),
+                            ?err,
+                            "failed to apply namespace backfill op"
+                        );
+                    }
+                }
+            }
+        }
+        _ => {
+            debug!("unexpected response to NamespaceBackfillRequest");
+        }
+    }
+}
+
+/// Returns `true` if this node's governance DAG has ops whose parents are
+/// not yet local (the pending queue is non-empty).
+async fn namespace_has_pending(
+    context_client: &calimero_context_client::client::ContextClient,
+    namespace_id: [u8; 32],
+) -> bool {
+    context_client
+        .namespace_pending_op_count(namespace_id)
+        .await
+        .unwrap_or(0)
+        > 0
 }

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use actix::{AsyncContext, WrapFuture};
 use calimero_context_client::local_governance::SignedNamespaceOp;
+use calimero_context_client::messages::NamespaceApplyOutcome;
 use calimero_network_primitives::client::NetworkClient;
 use calimero_node_primitives::sync::{BroadcastMessage, MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES};
 use tracing::{debug, info, warn};
@@ -52,21 +53,21 @@ pub(super) fn handle_namespace_governance_delta(
 
     let _ignored = ctx.spawn(
         async move {
-            let apply_outcome = context_client.apply_signed_namespace_op(op).await;
-            let applied = match apply_outcome {
-                Ok(applied) => applied,
+            let outcome = match context_client.apply_signed_namespace_op(op).await {
+                Ok(outcome) => outcome,
                 Err(err) => {
                     warn!(?err, %source, "failed to apply namespace governance delta");
                     return;
                 }
             };
 
-            // Proactive backfill (#2198): if the op went pending (missing
-            // parents), don't wait for the next periodic namespace heartbeat.
-            // Immediately fetch the namespace DAG from the gossip source so
-            // downstream checks like join_context's membership read see a
-            // converged state within sub-second latency. If the first peer
-            // cannot resolve everything, fall through to cross-peer retry.
+            // Proactive backfill (#2198) fires ONLY for `Pending` — the
+            // DAG accepted the op but can't apply it until missing parents
+            // arrive. `Applied` is the steady-state happy path; `Duplicate`
+            // means we already have the op (very common on gossip, since
+            // every mesh peer rebroadcasts), and triggering a backfill for
+            // it would open a stream and request the full namespace state
+            // for nothing.
             //
             // NOTE: we MUST ask `source` first before handing off to
             // `resolve_namespace_pending`. That helper seeds its
@@ -76,7 +77,7 @@ pub(super) fn handle_namespace_governance_delta(
             // a 2-node mesh (where no other peers exist) silently does
             // nothing. Empty `delta_ids` means "give me everything for
             // this namespace" on the responder side.
-            if !applied {
+            if matches!(outcome, NamespaceApplyOutcome::Pending) {
                 debug!(
                     %source,
                     namespace_id = %hex::encode(namespace_id),
@@ -253,8 +254,22 @@ async fn resolve_namespace_pending(
     let mut scheduler = ParentPullBudget::new(initial_peer, max_additional_peers, budget);
 
     loop {
-        if !namespace_has_pending(context_client, namespace_id).await {
-            break;
+        match namespace_has_pending(context_client, namespace_id).await {
+            Ok(false) => break,
+            Ok(true) => {}
+            Err(err) => {
+                // Fail loud rather than pretend convergence: a query error is
+                // unknown state, not "zero pending". Spinning on the same
+                // error is pointless, so we exit the retry loop; the next
+                // heartbeat-triggered `resolve_namespace_pending` pass will
+                // retry the check naturally.
+                warn!(
+                    ?err,
+                    namespace_id = %hex::encode(namespace_id),
+                    "namespace_pending_op_count failed; aborting cross-peer retry"
+                );
+                break;
+            }
         }
 
         let next_peer = match scheduler.next(&mesh_peers) {
@@ -364,15 +379,21 @@ async fn fetch_and_apply_namespace_backfill(
     }
 }
 
-/// Returns `true` if this node's governance DAG has ops whose parents are
-/// not yet local (the pending queue is non-empty).
+/// Returns `Ok(true)` if this node's governance DAG has ops whose parents
+/// are not yet local (the pending queue is non-empty).
+///
+/// Surfaces query errors to the caller rather than swallowing them with
+/// `unwrap_or(0)` — an error here is *not* the same signal as "zero pending
+/// ops", and collapsing the two caused the cross-peer retry loop to exit as
+/// if the DAG were fully resolved when the real state was unknown. Mirrors
+/// the data-delta path's `get_missing_parents()`, where a query failure is
+/// equally observable rather than silenced.
 async fn namespace_has_pending(
     context_client: &calimero_context_client::client::ContextClient,
     namespace_id: [u8; 32],
-) -> bool {
-    context_client
+) -> eyre::Result<bool> {
+    Ok(context_client
         .namespace_pending_op_count(namespace_id)
-        .await
-        .unwrap_or(0)
-        > 0
+        .await?
+        > 0)
 }

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -67,12 +67,30 @@ pub(super) fn handle_namespace_governance_delta(
             // downstream checks like join_context's membership read see a
             // converged state within sub-second latency. If the first peer
             // cannot resolve everything, fall through to cross-peer retry.
+            //
+            // NOTE: we MUST ask `source` first before handing off to
+            // `resolve_namespace_pending`. That helper seeds its
+            // `ParentPullBudget` with the initial peer marked as already
+            // tried, so passing `source` to it directly without a prior
+            // fetch means `source` never actually gets queried — which in
+            // a 2-node mesh (where no other peers exist) silently does
+            // nothing. Empty `delta_ids` means "give me everything for
+            // this namespace" on the responder side.
             if !applied {
                 debug!(
                     %source,
                     namespace_id = %hex::encode(namespace_id),
                     "gossip governance op is pending; triggering proactive backfill"
                 );
+                fetch_and_apply_namespace_backfill(
+                    &context_client,
+                    &network_client,
+                    source,
+                    namespace_id,
+                    Vec::new(),
+                    sync_timeout,
+                )
+                .await;
                 resolve_namespace_pending(
                     &context_client,
                     &network_client,

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -65,6 +65,20 @@ pub const DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED: u64 = 1_000;
 /// it does not risk racing on per-context sync state.
 pub const DEFAULT_PEER_STATE_PROBE_CONCURRENCY: usize = 4;
 
+/// Maximum number of *additional* mesh peers to try for missing-parent
+/// fetches after the initial sync peer returns without fully resolving
+/// the DAG. The initial peer attempt is not counted toward this budget.
+///
+/// Applies to both data-delta parent pulls (cold-start join_context, #2198)
+/// and governance-op parent pulls (subgroup MemberAdded propagation, #2209).
+pub const DEFAULT_PARENT_PULL_ADDITIONAL_PEERS: usize = 3;
+
+/// Total wall-clock budget (milliseconds) for the cross-peer
+/// missing-parent fetch loop, including the initial peer attempt.
+/// When exhausted, the sync session returns an error rather than
+/// reporting silent success on a partially-applied DAG.
+pub const DEFAULT_PARENT_PULL_BUDGET_MS: u64 = 10_000;
+
 /// Synchronization configuration.
 ///
 /// Controls timing, concurrency, and protocol behavior for node synchronization.
@@ -90,6 +104,15 @@ pub struct SyncConfig {
 
     /// Max concurrent peer probes in `find_peer_with_state`.
     pub peer_state_probe_concurrency: usize,
+
+    /// Max additional mesh peers to try for missing-parent fetches
+    /// after the initial sync peer returns without fully resolving
+    /// the DAG. See [`DEFAULT_PARENT_PULL_ADDITIONAL_PEERS`].
+    pub parent_pull_additional_peers: usize,
+
+    /// Wall-clock budget for the cross-peer missing-parent fetch loop.
+    /// See [`DEFAULT_PARENT_PULL_BUDGET_MS`].
+    pub parent_pull_budget: time::Duration,
 }
 
 impl Default for SyncConfig {
@@ -102,6 +125,8 @@ impl Default for SyncConfig {
             snapshot_chunk_size: DEFAULT_SNAPSHOT_CHUNK_SIZE,
             delta_sync_threshold: DEFAULT_DELTA_SYNC_THRESHOLD,
             peer_state_probe_concurrency: DEFAULT_PEER_STATE_PROBE_CONCURRENCY,
+            parent_pull_additional_peers: DEFAULT_PARENT_PULL_ADDITIONAL_PEERS,
+            parent_pull_budget: time::Duration::from_millis(DEFAULT_PARENT_PULL_BUDGET_MS),
         }
     }
 }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1828,19 +1828,100 @@ impl SyncManager {
                     );
                 }
 
-                if !missing_result.missing_ids.is_empty() {
+                // Steady-state: the initial DAG-heads response matched local
+                // state, so there are no missing parents to chase. Skip the
+                // entire retry-and-final-check machinery on the common path.
+                if missing_result.missing_ids.is_empty() {
+                    return Ok(SyncProtocol::DeltaSync {
+                        missing_delta_ids: vec![],
+                    });
+                }
+
+                info!(
+                    %context_id,
+                    missing_count = missing_result.missing_ids.len(),
+                    "DAG heads have missing parents, requesting them recursively"
+                );
+
+                // First attempt: the peer that served DAG heads.
+                if let Err(e) = self
+                    .request_missing_deltas(
+                        context_id,
+                        missing_result.missing_ids,
+                        peer_id,
+                        delta_store_ref.clone(),
+                        our_identity,
+                    )
+                    .await
+                {
+                    warn!(
+                        ?e,
+                        %context_id,
+                        "Failed to request missing parent deltas from initial peer"
+                    );
+                }
+
+                // Cross-peer fallback for cold-start race (#2198): if the
+                // initial peer did not resolve every missing parent, iterate
+                // other mesh peers for this context until the DAG is whole
+                // or the retry budget is exhausted.
+                let topic = TopicHash::from_raw(context_id);
+                let mut budget = super::parent_pull::ParentPullBudget::new(
+                    peer_id,
+                    self.sync_config.parent_pull_additional_peers,
+                    self.sync_config.parent_pull_budget,
+                );
+                let mut mesh_peers = self.network_client.mesh_peers(topic.clone()).await;
+
+                loop {
+                    let after = delta_store_ref.get_missing_parents().await;
+                    if after.missing_ids.is_empty() {
+                        break; // fully resolved
+                    }
+
+                    let next_peer = match budget.next(&mesh_peers) {
+                        super::parent_pull::NextPeer::Peer(p) => p,
+                        super::parent_pull::NextPeer::RefetchMesh => {
+                            mesh_peers = self.network_client.mesh_peers(topic.clone()).await;
+                            budget.record_refetch();
+                            match budget.next(&mesh_peers) {
+                                super::parent_pull::NextPeer::Peer(p) => p,
+                                other => {
+                                    debug!(
+                                        %context_id,
+                                        ?other,
+                                        "no additional mesh peers available for parent pull"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        super::parent_pull::NextPeer::BudgetExhausted => {
+                            warn!(
+                                %context_id,
+                                "parent-pull budget exhausted"
+                            );
+                            break;
+                        }
+                        super::parent_pull::NextPeer::MaxPeersReached
+                        | super::parent_pull::NextPeer::NoMorePeers => break,
+                    };
+
+                    budget.record_attempt(next_peer);
+
                     info!(
                         %context_id,
-                        missing_count = missing_result.missing_ids.len(),
-                        "DAG heads have missing parents, requesting them recursively"
+                        ?next_peer,
+                        attempt = budget.attempts(),
+                        still_missing = after.missing_ids.len(),
+                        "retrying missing-parent fetch against additional mesh peer"
                     );
 
-                    // Request missing parents (this uses recursive topological fetching)
                     if let Err(e) = self
                         .request_missing_deltas(
                             context_id,
-                            missing_result.missing_ids,
-                            peer_id,
+                            after.missing_ids,
+                            next_peer,
                             delta_store_ref.clone(),
                             our_identity,
                         )
@@ -1849,12 +1930,33 @@ impl SyncManager {
                         warn!(
                             ?e,
                             %context_id,
-                            "Failed to request missing parent deltas during DAG catchup"
+                            ?next_peer,
+                            "cross-peer parent-pull attempt failed"
                         );
                     }
                 }
 
-                // Return a non-None protocol to signal success (prevents trying next peer)
+                // Final check: if pending parents still remain, the sync did
+                // NOT fully restore the DAG. Return an error so the caller
+                // (e.g. join_context) surfaces a real failure instead of
+                // silent success on a partially-applied DAG.
+                let final_missing = delta_store_ref.get_missing_parents().await;
+                if !final_missing.missing_ids.is_empty() {
+                    warn!(
+                        %context_id,
+                        remaining = final_missing.missing_ids.len(),
+                        peer_attempts = budget.total_attempts(),
+                        "DAG sync ended with unresolved missing parents"
+                    );
+                    bail!(
+                        "pending parents unresolved for context {}: {} remaining after {} peer attempt(s)",
+                        context_id,
+                        final_missing.missing_ids.len(),
+                        budget.total_attempts(),
+                    );
+                }
+
+                // Success: DAG is fully resolved.
                 Ok(SyncProtocol::DeltaSync {
                     missing_delta_ids: vec![],
                 })
@@ -2205,7 +2307,23 @@ impl SyncManager {
         }
 
         let Some(context) = self.context_client.get_context(&context_id)? else {
-            bail!("context not found: {}", context_id);
+            // An inbound stream for a context this node does not know about
+            // must not tear down unrelated in-flight sync activity. This
+            // happens during cold-start `join_context` when a subgroup /
+            // app-internal context leaks onto the sync channel before the
+            // joining node has materialised it. Close the stream cleanly
+            // and let the concurrent legitimate sync continue. (#2198)
+            warn!(
+                %context_id,
+                ?their_identity,
+                "inbound stream for unknown context, closing cleanly"
+            );
+
+            if let Err(err) = self.send(stream, &StreamMessage::OpaqueError, None).await {
+                error!(%err, %context_id, "failed to send OpaqueError for unknown context");
+            }
+
+            return Ok(None);
         };
 
         let mut _updated = None;

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod helpers;
 pub mod level_sync;
 mod manager;
 pub mod metrics;
+pub(crate) mod parent_pull;
 pub mod prometheus_metrics;
 mod snapshot;
 pub(crate) mod stream;

--- a/crates/node/src/sync/parent_pull.rs
+++ b/crates/node/src/sync/parent_pull.rs
@@ -1,0 +1,214 @@
+//! Pure-function helpers for the cross-peer missing-parent fetch loop.
+//!
+//! Used by both the data-delta parent-pull (in `sync/manager/mod.rs`
+//! `request_dag_heads_and_sync`) and the governance-op parent-pull
+//! (in `handlers/network_event/namespace.rs`) to decide which peer
+//! to try next and when to stop.
+//!
+//! Extracting this decision as a plain state machine keeps the real
+//! network and store calls out of the test surface while letting us
+//! verify the scheduling logic in isolation.
+//!
+//! See issue #2198 for the original failure mode.
+
+use std::collections::HashSet;
+
+use libp2p::PeerId;
+use tokio::time::{Duration, Instant};
+
+/// Outcome of asking the budget for the next peer to try.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NextPeer {
+    /// Try this peer.
+    Peer(PeerId),
+    /// No untried peer is available in the current mesh snapshot.
+    /// Caller should re-fetch the mesh once and retry; if still
+    /// empty, caller should give up.
+    RefetchMesh,
+    /// `max_additional_peers` has been reached.
+    MaxPeersReached,
+    /// `budget` wall-clock has elapsed.
+    BudgetExhausted,
+    /// Mesh has been re-fetched and still yields no untried peers.
+    NoMorePeers,
+}
+
+/// Bookkeeping for the cross-peer parent-pull loop.
+#[derive(Debug)]
+pub(crate) struct ParentPullBudget {
+    tried: HashSet<PeerId>,
+    attempts: usize,
+    max_additional: usize,
+    started: Instant,
+    budget: Duration,
+    refetched: bool,
+}
+
+impl ParentPullBudget {
+    /// Seed with the peer that served DAG heads / initial backfill.
+    /// That peer is considered "already tried" and is never re-attempted.
+    pub(crate) fn new(initial_peer: PeerId, max_additional: usize, budget: Duration) -> Self {
+        let mut tried = HashSet::new();
+        let _ = tried.insert(initial_peer);
+        Self {
+            tried,
+            attempts: 0,
+            max_additional,
+            started: Instant::now(),
+            budget,
+            refetched: false,
+        }
+    }
+
+    /// How many additional peers have been attempted (not counting the initial peer).
+    pub(crate) fn attempts(&self) -> usize {
+        self.attempts
+    }
+
+    /// Total peer attempts including the initial peer.
+    pub(crate) fn total_attempts(&self) -> usize {
+        self.attempts + 1
+    }
+
+    /// Decide what to do next given the current mesh snapshot.
+    ///
+    /// The caller supplies `mesh_peers` already fetched from the network
+    /// stack. The budget does not perform I/O.
+    pub(crate) fn next(&mut self, mesh_peers: &[PeerId]) -> NextPeer {
+        if self.attempts >= self.max_additional {
+            return NextPeer::MaxPeersReached;
+        }
+        if self.started.elapsed() >= self.budget {
+            return NextPeer::BudgetExhausted;
+        }
+
+        let untried = mesh_peers.iter().find(|p| !self.tried.contains(p)).copied();
+        match untried {
+            Some(peer) => NextPeer::Peer(peer),
+            None if !self.refetched => NextPeer::RefetchMesh,
+            None => NextPeer::NoMorePeers,
+        }
+    }
+
+    /// Mark a peer as tried. Call after `next()` returned `Peer(p)` and
+    /// before issuing the network request to that peer.
+    pub(crate) fn record_attempt(&mut self, peer: PeerId) {
+        let _ = self.tried.insert(peer);
+        self.attempts += 1;
+    }
+
+    /// Record that the caller re-fetched the mesh after a `RefetchMesh` hint.
+    /// The budget will then fall through to `NoMorePeers` on the next empty pass.
+    pub(crate) fn record_refetch(&mut self) {
+        self.refetched = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(byte: u8) -> PeerId {
+        // Deterministic PeerIds for tests.
+        use libp2p::identity::Keypair;
+        let kp = Keypair::ed25519_from_bytes([byte; 32]).expect("ed25519 keypair");
+        kp.public().to_peer_id()
+    }
+
+    #[test]
+    fn initial_peer_is_never_suggested() {
+        let initial = peer(1);
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_secs(10));
+
+        let mesh = vec![initial];
+        assert_eq!(budget.next(&mesh), NextPeer::RefetchMesh);
+    }
+
+    #[test]
+    fn picks_untried_peer_from_mesh() {
+        let initial = peer(1);
+        let p2 = peer(2);
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_secs(10));
+
+        assert_eq!(budget.next(&[initial, p2]), NextPeer::Peer(p2));
+    }
+
+    #[test]
+    fn does_not_retry_same_peer() {
+        let initial = peer(1);
+        let p2 = peer(2);
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_secs(10));
+
+        let first = budget.next(&[initial, p2]);
+        assert_eq!(first, NextPeer::Peer(p2));
+        budget.record_attempt(p2);
+
+        // With the same mesh, p2 is now tried; should hint refetch.
+        assert_eq!(budget.next(&[initial, p2]), NextPeer::RefetchMesh);
+    }
+
+    #[test]
+    fn stops_at_max_additional_peers() {
+        let initial = peer(1);
+        let peers = [peer(2), peer(3), peer(4), peer(5)];
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_secs(10));
+
+        // Full mesh includes the initial + 4 others.
+        let mesh: Vec<PeerId> = std::iter::once(initial)
+            .chain(peers.iter().copied())
+            .collect();
+
+        for expected in &peers[..3] {
+            match budget.next(&mesh) {
+                NextPeer::Peer(p) => {
+                    assert_eq!(&p, expected, "scheduler returned wrong peer");
+                    budget.record_attempt(p);
+                }
+                other => panic!("expected Peer, got {:?}", other),
+            }
+        }
+
+        // 4th untried peer exists in the mesh, but budget caps at 3.
+        assert_eq!(budget.next(&mesh), NextPeer::MaxPeersReached);
+        assert_eq!(budget.attempts(), 3);
+        assert_eq!(budget.total_attempts(), 4);
+    }
+
+    #[test]
+    fn budget_exhausted_before_attempts_reached() {
+        let initial = peer(1);
+        let p2 = peer(2);
+        // Zero budget so elapsed is immediately >= budget.
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_millis(0));
+        // Give it a moment so `started.elapsed()` is non-zero.
+        std::thread::sleep(Duration::from_millis(1));
+
+        assert_eq!(budget.next(&[initial, p2]), NextPeer::BudgetExhausted);
+    }
+
+    #[test]
+    fn refetch_then_no_more_peers() {
+        let initial = peer(1);
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_secs(10));
+
+        // Empty mesh (other than initial): first ask suggests refetch.
+        assert_eq!(budget.next(&[initial]), NextPeer::RefetchMesh);
+        budget.record_refetch();
+
+        // After refetch, still empty: NoMorePeers.
+        assert_eq!(budget.next(&[initial]), NextPeer::NoMorePeers);
+    }
+
+    #[test]
+    fn refetch_followed_by_new_peer_is_accepted() {
+        let initial = peer(1);
+        let p2 = peer(2);
+        let mut budget = ParentPullBudget::new(initial, 3, Duration::from_secs(10));
+
+        assert_eq!(budget.next(&[initial]), NextPeer::RefetchMesh);
+        budget.record_refetch();
+
+        // A new peer joined the mesh after the hint; scheduler picks it up.
+        assert_eq!(budget.next(&[initial, p2]), NextPeer::Peer(p2));
+    }
+}


### PR DESCRIPTION
## Summary

Full fix for #2198, replacing the reverted #2205 with a version that addresses **both halves** of the cold-start race.

The original PR (#2205) fixed the data-delta half but left the governance-op half uncovered. That gap surfaced on the regression workflow as `list_group_members failed: "identity is not a member of the group"` even with a 45s wait (see evidence on #2209), because subgroup governance ops (`GroupCreated` / `KeyDelivery` / `MemberAdded`) had the same "gossip-before-sync, parents missing, stuck in pending" pattern — just for a different DAG. This PR extends the Fix B pattern to the governance DAG so the whole cold-start path converges deterministically.

## What's in the PR

**`feat(node/sync): add ParentPullBudget state machine + SyncConfig tunables`** (`f949f887`)
Pure-function scheduler for the cross-peer retry loop in `crates/node/src/sync/parent_pull.rs`. Used by both the data-delta and governance call sites. 7 focused unit tests (`cargo test -p calimero-node --lib sync::parent_pull` → 7 passed).
Adds `parent_pull_additional_peers` (default 3) and `parent_pull_budget` (default 10s) to `SyncConfig`.

**`fix(node/sync): cold-start join_context — Fix B + Fix C (#2198)`** (`69850248`)
- **Fix C:** `internal_handle_opened_stream` closes unknown-context inbound streams cleanly (`warn!` + `OpaqueError` + `Ok(None)`) instead of `bail!`-ing and tearing down the active sync.
- **Fix B:** `request_dag_heads_and_sync` iterates additional mesh peers via `ParentPullBudget` after the initial peer returns. Early-return on the common steady-state path so no extra work when there are no missing parents. Bails loud (`pending parents unresolved …`) on budget exhaustion instead of silently reporting success on a partial DAG.

**`feat(context): expose apply-outcome + pending-count for governance DAG`** (`b2877d66`)
- `apply_signed_namespace_op` now returns `Ok(bool)` — `true` = applied, `false` = pending/duplicate. Lets callers know when proactive backfill is needed. Existing callers use `if let Err(..)` and are unaffected.
- New `namespace_pending_op_count` ContextClient method → returns pending-ops count from the namespace's governance DAG. Used as the drain signal for the cross-peer retry loop.

**`fix(node/gov-sync): proactive + cross-peer backfill for namespace governance (#2198)`** (`e91238a6`)
The actual behaviour fix for the governance half of #2198, in `crates/node/src/handlers/network_event/namespace.rs`:
1. **Proactive trigger:** when a gossip governance op arrives and goes pending, immediately open a `NamespaceBackfillRequest` stream to the gossip source — no 30s wait for the next `NamespaceStateHeartbeat`.
2. **Cross-peer fallback:** new `resolve_namespace_pending` helper that reuses `ParentPullBudget` to iterate other `ns/<id>` mesh peers with empty-body backfill requests (responder returns up to `MAX_BACKFILL_OPS` of full namespace state) until `namespace_pending_op_count` reaches zero or the budget is exhausted. Wired into both the proactive path and the pre-existing heartbeat catch-up.

**`test(e2e): regression workflow for cold-start join_context (#2198) + doc`** (`b4d58a16`)
- Re-introduces `apps/e2e-kv-store/workflows/group-subgroup-queued-deltas.yml` with:
  - 3s gossipsub mesh warmup after `join_namespace` (the code fix can resolve pending ops once a gossip message arrives; it cannot recover from a mesh that hasn't GRAFTed yet).
  - Short governance wait (5s) then a `list_group_members` probe on node-2 — fails early and deterministically if the governance race ever regresses.
  - 20-delta burst on the subgroup-owned context → 10s gossip window → `join_context` → sentinel read proving DAG fully applied.
- Registered in the CI matrix (`.github/workflows/e2e-rust-apps.yml`).
- `architecture/error-flows.html` updated to describe the cross-peer retry for both data and governance DAGs.

## Behaviour-contract change (same as #2205, flagged for reviewer)

`request_dag_heads_and_sync` returning `Err("pending parents unresolved …")` on budget exhaustion is a behaviour change: previously the function always returned `Ok` even on partial-DAG. This propagates through `handle_dag_sync → initiate_sync_inner → perform_interval_sync` where the outer retry treats it like a connectivity failure and tries the next peer. That's correct but somewhat wasteful; a follow-up (#2210) will introduce a typed `SyncError::PendingParentsUnresolved` to let the outer loop short-circuit. Grep showed no callers relying on the silent-success behaviour.

## Test plan

- [x] `cargo check -p calimero-node`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p calimero-node -p calimero-context -p calimero-context-client -- -A warnings`
- [x] `cargo test -p calimero-node --lib` → **53 passed** (includes 7 new `sync::parent_pull::tests`)
- [x] `cargo test -p calimero-node --tests` → **303 passed**
- [x] `cargo test -p calimero-context --all-targets` → **150 passed**
- [x] YAML validation of new workflow + CI matrix
- [ ] CI `Test (group-subgroup-queued-deltas)` passes on **attempt 1** (the real regression signal) — once CI runs, we'll see whether proactive + cross-peer backfill closes the race deterministically or whether we need to iterate on the mesh-warmup approach.

## Cross-references

- Fixes #2198 (governance half, data-delta half both covered)
- Addresses #2209 (governance-propagation race) at the sync-layer it manifests through
- Supersedes #2205 (reverted in #2213 due to the governance-half gap exposed by the regression workflow)
- Follow-up still open: #2210 (typed error variant for loud failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync and gossip backfill behavior (both data deltas and namespace governance), adding new retry loops, time/peer budgets, and changing failure behavior to error on unresolved parents; regressions could affect convergence or increase network load in edge cases.
> 
> **Overview**
> Fixes a cold-start `join_context` race by **ensuring missing DAG parents are pulled from multiple mesh peers within a bounded budget** and by **preventing unrelated inbound streams from aborting an in-flight sync**.
> 
> Extends the same missing-parent strategy to **namespace governance gossip**: `apply_signed_namespace_op` now returns a tri-state (`Applied`/`Pending`/`Duplicate`), a new `namespace_pending_op_count` query gates retries, and the node proactively backfills from the gossip source then iterates additional namespace mesh peers using a shared `ParentPullBudget` scheduler.
> 
> Adds `SyncConfig` tunables (`parent_pull_additional_peers`, `parent_pull_budget`), updates DAG APIs/tests to expose `AddDeltaOutcome`, and introduces a new E2E regression workflow (`group-subgroup-queued-deltas`) wired into CI to reproduce queued-delta cold-start failures and assert deterministic first-attempt success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445360644a6ed267f94ef0347a7957d7e83dcde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->