### PR TITLE
fix(context): implement delete_namespace actor handler (#2226)

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -22,19 +22,20 @@ use crate::group::{
     AddGroupMembersRequest, AdmitTeeNodeRequest, BroadcastGroupAliasesRequest,
     BroadcastGroupLocalStateRequest, CreateGroupInvitationRequest, CreateGroupInvitationResponse,
     CreateGroupRequest, CreateGroupResponse, DeleteGroupRequest, DeleteGroupResponse,
-    DetachContextFromGroupRequest, GetGroupForContextRequest, GetGroupInfoRequest,
-    GetGroupUpgradeStatusRequest, GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse,
-    GetNamespaceIdentityRequest, GroupContextEntry, GroupInfoResponse, GroupSummary,
-    GroupUpgradeInfo, JoinContextRequest, JoinContextResponse, JoinGroupRequest, JoinGroupResponse,
-    ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
-    ListGroupMembersResponse, ListNamespacesForApplicationRequest, ListNamespacesRequest,
-    NamespaceSummary, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
-    SetDefaultCapabilitiesRequest, SetDefaultVisibilityRequest, SetGroupAliasRequest,
-    SetMemberAliasRequest, SetMemberCapabilitiesRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreDefaultVisibilityRequest,
-    StoreGroupAliasRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
-    StoreMemberAliasRequest, StoreMemberCapabilityRequest, SyncGroupRequest, SyncGroupResponse,
-    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest, UpgradeGroupResponse,
+    DeleteNamespaceRequest, DeleteNamespaceResponse, DetachContextFromGroupRequest,
+    GetGroupForContextRequest, GetGroupInfoRequest, GetGroupUpgradeStatusRequest,
+    GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse, GetNamespaceIdentityRequest,
+    GroupContextEntry, GroupInfoResponse, GroupSummary, GroupUpgradeInfo, JoinContextRequest,
+    JoinContextResponse, JoinGroupRequest, JoinGroupResponse, ListAllGroupsRequest,
+    ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
+    ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
+    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest,
+    SetDefaultVisibilityRequest, SetGroupAliasRequest, SetMemberAliasRequest,
+    SetMemberCapabilitiesRequest, SetTeeAdmissionPolicyRequest, StoreContextAliasRequest,
+    StoreDefaultCapabilitiesRequest, StoreDefaultVisibilityRequest, StoreGroupAliasRequest,
+    StoreGroupContextRequest, StoreGroupMetaRequest, StoreMemberAliasRequest,
+    StoreMemberCapabilityRequest, SyncGroupRequest, SyncGroupResponse, UpdateGroupSettingsRequest,
+    UpdateMemberRoleRequest, UpgradeGroupRequest, UpgradeGroupResponse,
 };
 use crate::messages::{
     ApplySignedGroupOpRequest, ApplySignedNamespaceOpRequest, ContextMessage, CreateContextRequest,
@@ -1043,6 +1044,12 @@ impl ContextClient {
         DeleteGroup,
         DeleteGroupRequest,
         eyre::Result<DeleteGroupResponse>
+    );
+    forward_to_actor!(
+        delete_namespace,
+        DeleteNamespace,
+        DeleteNamespaceRequest,
+        eyre::Result<DeleteNamespaceResponse>
     );
     forward_to_actor!(
         add_group_members,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -64,6 +64,29 @@ pub struct DeleteGroupResponse {
     pub deleted: bool,
 }
 
+/// Request to tear down a namespace and its entire subtree (all descendant
+/// groups + contexts + namespace-level state) on the local node.
+///
+/// Namespace deletion is purely local — it has no DAG-replicated op
+/// counterpart. Each node independently tears down its own namespace state.
+/// `RootOp::GroupDeleted` explicitly rejects the namespace root (see
+/// `execute_group_deleted`), mirroring how namespace *creation* is also
+/// local-only.
+#[derive(Clone, Debug)]
+pub struct DeleteNamespaceRequest {
+    pub namespace_id: ContextGroupId,
+    pub requester: Option<PublicKey>,
+}
+
+impl Message for DeleteNamespaceRequest {
+    type Result = eyre::Result<DeleteNamespaceResponse>;
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct DeleteNamespaceResponse {
+    pub deleted: bool,
+}
+
 #[derive(Debug)]
 pub struct AddGroupMembersRequest {
     pub group_id: ContextGroupId,

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -12,16 +12,16 @@ use tokio::sync::oneshot;
 use crate::group::{
     AddGroupMembersRequest, AdmitTeeNodeRequest, BroadcastGroupAliasesRequest,
     BroadcastGroupLocalStateRequest, CreateGroupInvitationRequest, CreateGroupRequest,
-    DeleteGroupRequest, DetachContextFromGroupRequest, GetGroupForContextRequest,
-    GetGroupInfoRequest, GetGroupUpgradeStatusRequest, GetMemberCapabilitiesRequest,
-    GetNamespaceIdentityRequest, JoinContextRequest, JoinGroupRequest, ListAllGroupsRequest,
-    ListGroupContextsRequest, ListGroupMembersRequest, ListNamespacesForApplicationRequest,
-    ListNamespacesRequest, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
-    SetDefaultCapabilitiesRequest, SetDefaultVisibilityRequest, SetGroupAliasRequest,
-    SetMemberAliasRequest, SetMemberCapabilitiesRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreDefaultVisibilityRequest,
-    StoreGroupAliasRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
-    StoreMemberAliasRequest, StoreMemberCapabilityRequest, SyncGroupRequest,
+    DeleteGroupRequest, DeleteNamespaceRequest, DetachContextFromGroupRequest,
+    GetGroupForContextRequest, GetGroupInfoRequest, GetGroupUpgradeStatusRequest,
+    GetMemberCapabilitiesRequest, GetNamespaceIdentityRequest, JoinContextRequest,
+    JoinGroupRequest, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
+    ListNamespacesForApplicationRequest, ListNamespacesRequest, RemoveGroupMembersRequest,
+    RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest, SetDefaultVisibilityRequest,
+    SetGroupAliasRequest, SetMemberAliasRequest, SetMemberCapabilitiesRequest,
+    SetTeeAdmissionPolicyRequest, StoreContextAliasRequest, StoreDefaultCapabilitiesRequest,
+    StoreDefaultVisibilityRequest, StoreGroupAliasRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreMemberAliasRequest, StoreMemberCapabilityRequest, SyncGroupRequest,
     UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
@@ -201,6 +201,10 @@ pub enum ContextMessage {
     DeleteGroup {
         request: DeleteGroupRequest,
         outcome: oneshot::Sender<<DeleteGroupRequest as Message>::Result>,
+    },
+    DeleteNamespace {
+        request: DeleteNamespaceRequest,
+        outcome: oneshot::Sender<<DeleteNamespaceRequest as Message>::Result>,
     },
     AddGroupMembers {
         request: AddGroupMembersRequest,

--- a/crates/context/src/group_store/local_state.rs
+++ b/crates/context/src/group_store/local_state.rs
@@ -3,7 +3,8 @@ use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use calimero_store::key::{
     GroupLocalGovNonce, GroupMemberContext, GroupOpHead, GroupOpHeadValue, GroupOpLog,
-    GROUP_MEMBER_CONTEXT_PREFIX, GROUP_OP_LOG_PREFIX,
+    NamespaceGovHead, NamespaceGovOp, NamespaceIdentity, GROUP_MEMBER_CONTEXT_PREFIX,
+    GROUP_OP_LOG_PREFIX, NAMESPACE_GOV_OP_PREFIX,
 };
 use calimero_store::Store;
 use eyre::Result as EyreResult;
@@ -270,5 +271,47 @@ pub fn delete_group_local_rows(store: &Store, group_id: &ContextGroupId) -> Eyre
     delete_all_group_signing_keys(store, group_id)?;
     delete_op_log_and_head(store, group_id)?;
     delete_group_meta(store, group_id)?;
+    Ok(())
+}
+
+/// Remove this node's namespace-level state: the signing identity, the
+/// governance DAG head, and every stored governance op for the namespace.
+///
+/// Complements [`delete_group_local_rows`], which handles per-group rows.
+/// The namespace root is itself a group, so a full namespace teardown calls
+/// `delete_group_local_rows` for every group in the subtree (including the
+/// root) and then this function to remove the namespace-scoped rows.
+///
+/// Ops are swept in batches to avoid materializing a large namespace log at
+/// once. Each batch opens its own store handle so the iterator sees the
+/// previous deletes committed.
+pub fn delete_namespace_local_state(
+    store: &Store,
+    namespace_id: &ContextGroupId,
+) -> EyreResult<()> {
+    const BATCH_SIZE: usize = 1000;
+    let ns_bytes = namespace_id.to_bytes();
+
+    loop {
+        let batch = super::collect_keys_with_prefix_paginated::<NamespaceGovOp>(
+            store,
+            NamespaceGovOp::new(ns_bytes, [0u8; 32]),
+            NAMESPACE_GOV_OP_PREFIX,
+            |k| k.namespace_id() == ns_bytes,
+            0,
+            BATCH_SIZE,
+        )?;
+        if batch.is_empty() {
+            break;
+        }
+        let mut handle = store.handle();
+        for key in batch {
+            handle.delete(&key)?;
+        }
+    }
+
+    let mut handle = store.handle();
+    handle.delete(&NamespaceGovHead::new(ns_bytes))?;
+    handle.delete(&NamespaceIdentity::new(ns_bytes))?;
     Ok(())
 }

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -66,9 +66,9 @@ pub use self::group_keys::{
 };
 pub use self::group_settings::GroupSettingsService;
 pub use self::local_state::{
-    delete_group_local_rows, get_local_gov_nonce, get_member_context_joins, get_op_head,
-    read_op_log_after, remove_all_member_context_joins, set_local_gov_nonce,
-    track_member_context_join,
+    delete_group_local_rows, delete_namespace_local_state, get_local_gov_nonce,
+    get_member_context_joins, get_op_head, read_op_log_after, remove_all_member_context_joins,
+    set_local_gov_nonce, track_member_context_join,
 };
 pub use self::membership::{
     add_group_member, add_group_member_with_keys, check_group_membership, count_group_admins,

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3280,6 +3280,234 @@ fn collect_subtree_for_cascade_includes_contexts_from_all_groups() {
 }
 
 // ---------------------------------------------------------------------------
+// Namespace-level teardown (issue #2226)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_namespace_local_state_clears_identity_head_and_ops() {
+    use calimero_primitives::identity::PublicKey;
+    use calimero_store::key::{
+        NamespaceGovHead, NamespaceGovHeadValue, NamespaceGovOp, NamespaceGovOpValue,
+        NamespaceIdentity,
+    };
+
+    let store = test_store();
+    let ns_id = ContextGroupId::from([0xA1; 32]);
+    let ns_bytes = ns_id.to_bytes();
+
+    let ns_pk = PublicKey::from([0x11; 32]);
+    store_namespace_identity(&store, &ns_id, &ns_pk, &[0x22; 32], &[0x33; 32]).unwrap();
+
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &NamespaceGovHead::new(ns_bytes),
+                &NamespaceGovHeadValue {
+                    sequence: 7,
+                    dag_heads: vec![[0x44; 32]],
+                },
+            )
+            .unwrap();
+        for i in 0u8..5 {
+            let mut delta = [0u8; 32];
+            delta[0] = i;
+            handle
+                .put(
+                    &NamespaceGovOp::new(ns_bytes, delta),
+                    &NamespaceGovOpValue {
+                        skeleton_bytes: vec![i],
+                    },
+                )
+                .unwrap();
+        }
+    }
+
+    // A second namespace must be left alone.
+    let other_ns_id = ContextGroupId::from([0xB2; 32]);
+    let other_ns_bytes = other_ns_id.to_bytes();
+    let other_pk = PublicKey::from([0x55; 32]);
+    store_namespace_identity(&store, &other_ns_id, &other_pk, &[0x66; 32], &[0x77; 32]).unwrap();
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &NamespaceGovOp::new(other_ns_bytes, [0x88; 32]),
+                &NamespaceGovOpValue {
+                    skeleton_bytes: vec![0x99],
+                },
+            )
+            .unwrap();
+    }
+
+    delete_namespace_local_state(&store, &ns_id).unwrap();
+
+    let handle = store.handle();
+    assert!(
+        handle
+            .get::<NamespaceIdentity>(&NamespaceIdentity::new(ns_bytes))
+            .unwrap()
+            .is_none(),
+        "namespace identity should be cleared"
+    );
+    assert!(
+        handle
+            .get::<NamespaceGovHead>(&NamespaceGovHead::new(ns_bytes))
+            .unwrap()
+            .is_none(),
+        "namespace gov head should be cleared"
+    );
+    for i in 0u8..5 {
+        let mut delta = [0u8; 32];
+        delta[0] = i;
+        assert!(
+            handle
+                .get::<NamespaceGovOp>(&NamespaceGovOp::new(ns_bytes, delta))
+                .unwrap()
+                .is_none(),
+            "namespace gov op {i} should be cleared"
+        );
+    }
+
+    // Other namespace untouched.
+    assert!(
+        handle
+            .get::<NamespaceIdentity>(&NamespaceIdentity::new(other_ns_bytes))
+            .unwrap()
+            .is_some(),
+        "other namespace identity must survive"
+    );
+    assert!(
+        handle
+            .get::<NamespaceGovOp>(&NamespaceGovOp::new(other_ns_bytes, [0x88; 32]))
+            .unwrap()
+            .is_some(),
+        "other namespace op must survive"
+    );
+}
+
+/// Simulates the full teardown that `Handler<DeleteNamespaceRequest>`
+/// performs locally: per-group `delete_group_local_rows` for every group in
+/// the subtree (children-first) + parent/child edge cleanup, plus
+/// `delete_namespace_local_state` for namespace-scoped rows. Exercises the
+/// contract the HTTP `DELETE /admin-api/namespaces/:id` endpoint depends on
+/// after the fix for issue #2226.
+#[test]
+fn delete_namespace_full_cascade_clears_subtree_and_namespace_state() {
+    use calimero_primitives::identity::PublicKey;
+    use calimero_store::key::{
+        GroupChildIndex, GroupParentRef, NamespaceGovHead, NamespaceGovHeadValue, NamespaceGovOp,
+        NamespaceGovOpValue, NamespaceIdentity,
+    };
+
+    let store = test_store();
+    let ns_id = ContextGroupId::from([0xF0; 32]);
+    let child = ContextGroupId::from([0xF1; 32]);
+    let grandchild = ContextGroupId::from([0xF2; 32]);
+
+    save_group_meta(&store, &ns_id, &test_meta()).unwrap();
+    save_group_meta(&store, &child, &test_meta()).unwrap();
+    save_group_meta(&store, &grandchild, &test_meta()).unwrap();
+    nest_group(&store, &ns_id, &child).unwrap();
+    nest_group(&store, &child, &grandchild).unwrap();
+
+    let ctx_root = ContextId::from([0x10; 32]);
+    let ctx_child = ContextId::from([0x11; 32]);
+    let ctx_gc = ContextId::from([0x12; 32]);
+    register_context_in_group(&store, &ns_id, &ctx_root).unwrap();
+    register_context_in_group(&store, &child, &ctx_child).unwrap();
+    register_context_in_group(&store, &grandchild, &ctx_gc).unwrap();
+
+    let admin_pk = PublicKey::from([0xAA; 32]);
+    add_group_member(&store, &ns_id, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &child, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &grandchild, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    let ns_bytes = ns_id.to_bytes();
+    store_namespace_identity(&store, &ns_id, &admin_pk, &[0x22; 32], &[0x33; 32]).unwrap();
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &NamespaceGovHead::new(ns_bytes),
+                &NamespaceGovHeadValue {
+                    sequence: 3,
+                    dag_heads: vec![[0xCC; 32]],
+                },
+            )
+            .unwrap();
+        handle
+            .put(
+                &NamespaceGovOp::new(ns_bytes, [0x01; 32]),
+                &NamespaceGovOpValue {
+                    skeleton_bytes: vec![1],
+                },
+            )
+            .unwrap();
+    }
+
+    // Execute the same children-first teardown the handler performs.
+    let payload = collect_subtree_for_cascade(&store, &ns_id).unwrap();
+    let all = payload
+        .descendant_groups
+        .iter()
+        .copied()
+        .chain(std::iter::once(ns_id));
+    for gid in all {
+        for ctx in enumerate_group_contexts(&store, &gid, 0, usize::MAX).unwrap() {
+            unregister_context_from_group(&store, &gid, &ctx).unwrap();
+        }
+        let parent = get_parent_group(&store, &gid).unwrap();
+        delete_group_local_rows(&store, &gid).unwrap();
+        if let Some(parent) = parent {
+            let mut handle = store.handle();
+            handle.delete(&GroupParentRef::new(gid.to_bytes())).unwrap();
+            handle
+                .delete(&GroupChildIndex::new(parent.to_bytes(), gid.to_bytes()))
+                .unwrap();
+        }
+    }
+    delete_namespace_local_state(&store, &ns_id).unwrap();
+
+    // Every group's meta must be gone.
+    for gid in [ns_id, child, grandchild] {
+        assert!(
+            load_group_meta(&store, &gid).unwrap().is_none(),
+            "group {gid:?} meta should be gone"
+        );
+    }
+
+    // Every context must be unregistered from its owning group.
+    for (gid, ctx) in [(ns_id, ctx_root), (child, ctx_child), (grandchild, ctx_gc)] {
+        assert!(
+            get_group_for_context(&store, &ctx).unwrap().is_none(),
+            "context {ctx:?} should no longer resolve to group {gid:?}"
+        );
+    }
+
+    // Edges must be gone.
+    assert!(get_parent_group(&store, &child).unwrap().is_none());
+    assert!(get_parent_group(&store, &grandchild).unwrap().is_none());
+    assert!(list_child_groups(&store, &ns_id).unwrap().is_empty());
+    assert!(list_child_groups(&store, &child).unwrap().is_empty());
+
+    // Namespace-level rows must be gone.
+    let handle = store.handle();
+    assert!(handle
+        .get::<NamespaceIdentity>(&NamespaceIdentity::new(ns_bytes))
+        .unwrap()
+        .is_none());
+    assert!(handle
+        .get::<NamespaceGovHead>(&NamespaceGovHead::new(ns_bytes))
+        .unwrap()
+        .is_none());
+    assert!(handle
+        .get::<NamespaceGovOp>(&NamespaceGovOp::new(ns_bytes, [0x01; 32]))
+        .unwrap()
+        .is_none());
+}
+
+// ---------------------------------------------------------------------------
 // MemberSetAutoFollow (the auto-follow architecture doc)
 // ---------------------------------------------------------------------------
 

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -15,6 +15,7 @@ pub mod create_group;
 pub mod create_group_invitation;
 pub mod delete_context;
 pub mod delete_group;
+pub mod delete_namespace;
 pub mod detach_context_from_group;
 pub mod execute;
 pub mod get_group_for_context;
@@ -76,6 +77,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::DeleteGroup { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::DeleteNamespace { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::AddGroupMembers { request, outcome } => {

--- a/crates/context/src/handlers/delete_namespace.rs
+++ b/crates/context/src/handlers/delete_namespace.rs
@@ -1,0 +1,125 @@
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::group::{DeleteNamespaceRequest, DeleteNamespaceResponse};
+use eyre::bail;
+use tracing::info;
+
+use crate::group_store;
+use crate::ContextManager;
+
+impl Handler<DeleteNamespaceRequest> for ContextManager {
+    type Result = ActorResponse<Self, <DeleteNamespaceRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        DeleteNamespaceRequest {
+            namespace_id,
+            requester,
+        }: DeleteNamespaceRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        // Namespace deletion is a purely local teardown — no DAG-replicated
+        // op, symmetric with namespace creation. `RootOp::GroupDeleted`
+        // explicitly rejects the namespace root (see `execute_group_deleted`),
+        // so we can't fall through `delete_group` for this.
+        //
+        // Each node that wishes to tear down its local namespace state calls
+        // this handler; peers continue to hold their own namespace state
+        // until they do the same.
+        let requester = match requester {
+            Some(pk) => pk,
+            None => match self.node_namespace_identity(&namespace_id) {
+                Some((pk, _)) => pk,
+                None => {
+                    return ActorResponse::reply(Err(eyre::eyre!(
+                        "requester not provided and node has no configured namespace identity"
+                    )))
+                }
+            },
+        };
+
+        let result = (|| -> eyre::Result<(usize, usize)> {
+            // Only a namespace root is a valid target — resolve and compare.
+            let resolved = group_store::resolve_namespace(&self.datastore, &namespace_id)?;
+            if resolved != namespace_id {
+                bail!(
+                    "group '{namespace_id:?}' is not a namespace root; \
+                     resolved namespace is '{resolved:?}' — use delete_group instead"
+                );
+            }
+
+            if group_store::load_group_meta(&self.datastore, &namespace_id)?.is_none() {
+                bail!("namespace '{namespace_id:?}' not found");
+            }
+
+            // Admin authorization against the namespace root.
+            group_store::require_group_admin(&self.datastore, &namespace_id, &requester)?;
+
+            // Enumerate the full subtree so we can tear down children-first.
+            let payload = group_store::collect_subtree_for_cascade(&self.datastore, &namespace_id)?;
+            let total_groups = payload.descendant_groups.len() + 1;
+            let total_contexts = payload.contexts.len();
+
+            // Children-first: every descendant, then the namespace root itself.
+            // For each group: unregister contexts, delete_group_local_rows
+            // (members, signing keys, caps, aliases, upgrades, op-log + head,
+            // meta, nonces, member-context joins), then remove its parent
+            // edge + child-index entry on the parent. Mirrors the cascade
+            // arm in `execute_group_deleted`.
+            let all_groups_iter = payload
+                .descendant_groups
+                .iter()
+                .copied()
+                .chain(std::iter::once(namespace_id));
+            for gid in all_groups_iter {
+                for ctx in
+                    group_store::enumerate_group_contexts(&self.datastore, &gid, 0, usize::MAX)?
+                {
+                    group_store::unregister_context_from_group(&self.datastore, &gid, &ctx)?;
+                }
+                let parent_for_cleanup = group_store::get_parent_group(&self.datastore, &gid)?;
+                group_store::delete_group_local_rows(&self.datastore, &gid)?;
+                if let Some(parent) = parent_for_cleanup {
+                    let mut handle = self.datastore.handle();
+                    handle.delete(&calimero_store::key::GroupParentRef::new(gid.to_bytes()))?;
+                    handle.delete(&calimero_store::key::GroupChildIndex::new(
+                        parent.to_bytes(),
+                        gid.to_bytes(),
+                    ))?;
+                }
+            }
+
+            // Namespace-level rows: identity, DAG head, and every stored
+            // governance op for this namespace.
+            group_store::delete_namespace_local_state(&self.datastore, &namespace_id)?;
+
+            Ok((total_groups, total_contexts))
+        })();
+
+        let (total_groups, total_contexts) = match result {
+            Ok(v) => v,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+
+        let node_client = self.node_client.clone();
+        let namespace_id_bytes = namespace_id.to_bytes();
+
+        ActorResponse::r#async(
+            async move {
+                // Best-effort unsubscribe — the namespace is gone locally,
+                // no point staying on its governance topic.
+                let _ = node_client.unsubscribe_namespace(namespace_id_bytes).await;
+
+                info!(
+                    ?namespace_id,
+                    %requester,
+                    total_groups,
+                    total_contexts,
+                    "deleted namespace and subtree"
+                );
+
+                Ok(DeleteNamespaceResponse { deleted: true })
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/server/src/admin/handlers/namespaces/delete_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/delete_namespace.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
-use calimero_context_client::group::DeleteGroupRequest;
+use calimero_context_client::group::DeleteNamespaceRequest;
 use calimero_server_primitives::admin::{
     DeleteNamespaceApiRequest, DeleteNamespaceApiResponse, DeleteNamespaceApiResponseData,
 };
@@ -21,19 +21,21 @@ pub async fn handler(
     auth_key: Option<Extension<AuthenticatedKey>>,
     ValidatedJson(req): ValidatedJson<DeleteNamespaceApiRequest>,
 ) -> impl IntoResponse {
-    let group_id = match parse_group_id(&namespace_id_str) {
+    let namespace_id = match parse_group_id(&namespace_id_str) {
         Ok(id) => id,
         Err(err) => return err.into_response(),
     };
 
     info!(namespace_id=%namespace_id_str, "Deleting namespace");
 
+    // Prefer the authenticated identity over the caller-supplied requester to
+    // prevent authorization bypass via a spoofed public key in the request body.
     let requester = auth_key.map(|Extension(k)| k.0).or(req.requester);
 
     let result = state
         .ctx_client
-        .delete_group(DeleteGroupRequest {
-            group_id,
+        .delete_namespace(DeleteNamespaceRequest {
+            namespace_id,
             requester,
         })
         .await


### PR DESCRIPTION
## Summary

Fixes #2226 — `DELETE /admin-api/namespaces/:id` was dead end-to-end. The HTTP handler forwarded to `ctx_client.delete_group(...)`, which at `crates/context/src/handlers/delete_group.rs:67-71` rejects the namespace root with *"use delete_namespace instead"* — but that path did not exist. The apply-side `execute_group_deleted` applies the same guard at `crates/context/src/group_store/namespace_governance.rs:604-608` by design: namespace deletion is a **local** teardown (symmetric with namespace creation), not a DAG-replicated op.

This PR implements Option A from the issue — a dedicated `DeleteNamespaceRequest` + handler — rather than Option B (flag on `DeleteGroupRequest`), because the apply-side guard means `RootOp::GroupDeleted` with `root_group_id == namespace_id` cannot be published in any case. Option A also matches the separation the existing code comments already assume.

## What changed

- **Primitives** (`crates/context/primitives/src/group.rs`): `DeleteNamespaceRequest { namespace_id, requester }` + `DeleteNamespaceResponse`.
- **Actor wiring** (`context/primitives/src/messages.rs`, `context/primitives/src/client/mod.rs`, `context/src/handlers.rs`): `ContextMessage::DeleteNamespace` variant, client `delete_namespace(...)` forwarder, dispatch arm, module registration.
- **Handler** (`crates/context/src/handlers/delete_namespace.rs`): resolves the namespace root, admin-checks via `require_group_admin`, cascade-tears-down children-first (unregister contexts → `delete_group_local_rows` → remove parent-ref + child-index) — mirroring the cascade arm in `execute_group_deleted` — then tears down namespace-scoped rows and best-effort unsubscribes from the governance topic.
- **Namespace-rows primitive** (`context/src/group_store/local_state.rs` + re-export in `mod.rs`): new `delete_namespace_local_state(store, namespace_id)` that batched-deletes `NamespaceGovOp` keys, then `NamespaceGovHead` and `NamespaceIdentity`. Reuses the `collect_keys_with_prefix_paginated` helper used by the group op-log teardown to avoid materializing large namespace logs at once.
- **HTTP handler** (`crates/server/src/admin/handlers/namespaces/delete_namespace.rs`): now dispatches to `ctx_client.delete_namespace(DeleteNamespaceRequest { namespace_id, requester })`.
- **Tests** (`context/src/group_store/tests.rs`):
  - `delete_namespace_local_state_clears_identity_head_and_ops` — isolates the new primitive and verifies a second namespace is untouched.
  - `delete_namespace_full_cascade_clears_subtree_and_namespace_state` — exercises the full cascade teardown the handler performs against a three-level tree with contexts, asserting every group meta / parent edge / child index / namespace row is gone.

## Impact

Unblocks end-to-end namespace teardown from every client — `meroctl`, `calimero-client-py`, and `merobox` (see [merobox PR #209](https://github.com/calimero-network/merobox/pull/209) where `delete_namespace` was dropped from the group-admin workflow with a code comment pointing at this issue).

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p calimero-context -p calimero-context-client -p calimero-server` — 130/130 + 22/22 + 12/12 + 10/10 pass, including the two new tests
- [x] `cargo fmt --check` — clean on touched crates
- [x] `cargo clippy -- -A warnings` — clean on touched crates
- [ ] End-to-end smoke via merobox PR #209 CI (follow-up: un-skip `delete_namespace` in the group-admin workflow once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new deletion pathway that cascades through namespace/group/context state and purges namespace-scoped governance rows; mistakes could cause unintended local data loss or incomplete cleanup. Authorization is enforced via admin checks and the HTTP layer prefers authenticated keys to reduce spoofing risk.
> 
> **Overview**
> Fixes `DELETE /admin-api/namespaces/:id` by introducing a dedicated `DeleteNamespace` request/actor path instead of routing through `delete_group`, enabling **local-only namespace teardown**.
> 
> The new handler validates the target is a namespace root, requires admin authorization, then performs a children-first cascade to unregister contexts, delete per-group local rows, remove parent/child edges, and finally delete namespace-scoped rows (namespace identity, governance DAG head, and all stored namespace governance ops) with batched key sweeps; it also best-effort unsubscribes from the namespace gossip topic.
> 
> Server admin routing now calls `ctx_client.delete_namespace(...)` and prefers the authenticated requester over a body-supplied key, and new tests cover both namespace-row cleanup isolation and full subtree cascade deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1508cca55debb655576c65f0b01dcb439a31c179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->