### PR TITLE
fix(profiling): log preserve_to_host_mount actions to the bind mount

### DIFF
--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -307,10 +307,30 @@ preserve_to_host_mount() {
         [ "$err_file" != /dev/null ] && rm -f "$err_file"
         return 0
     fi
+    # Diagnostics log — runtime-container stdout is not captured by the
+    # GHA collector (containers are removed before docker logs is called),
+    # so mirror preserve's view of the world onto the bind mount where
+    # harvest-host-profiling.sh can pick it up. Otherwise investigating
+    # "file X wasn't preserved" is blind.
+    local preserve_log="$dest/preserve.log"
+    {
+        echo "=== preserve_to_host_mount @ $(date -Iseconds) ==="
+        echo "PROFILING_OUTPUT_DIR=$PROFILING_OUTPUT_DIR"
+        echo "dest=$dest"
+        echo "--- ls -la $PROFILING_OUTPUT_DIR (source) ---"
+        ls -la "$PROFILING_OUTPUT_DIR" 2>&1 || true
+    } >> "$preserve_log" 2>&1
     if [ -d "$PROFILING_OUTPUT_DIR" ]; then
-        if ! cp -r "$PROFILING_OUTPUT_DIR/." "$dest/" 2>"$err_file"; then
+        # Log cp stderr to both the preserve log (always) and err_file (for
+        # the summary WARNING below). Capture via tee so we see partial
+        # progress even if cp trips on one specific file.
+        if ! cp -rv "$PROFILING_OUTPUT_DIR/." "$dest/" >>"$preserve_log" 2> >(tee -a "$preserve_log" > "$err_file"); then
             echo "[Profiling] WARNING: cp from $PROFILING_OUTPUT_DIR may be incomplete: $(head -3 "$err_file" 2>/dev/null | tr '\n' ' ')"
         fi
+        {
+            echo "--- ls -la $dest (after cp) ---"
+            ls -la "$dest" 2>&1 || true
+        } >> "$preserve_log" 2>&1
     fi
     local reports_dir="${PROFILING_REPORTS_DIR:-/profiling/reports}"
     if [ -d "$reports_dir" ]; then


### PR DESCRIPTION
## Context

After merobox #210 (CAP_PERFMON) landed and the profiling image was rebuilt, `perf record` now runs successfully inside the runtime container and writes `/profiling/data/perf-fuzzy-kv-node-N.data`. Confirmed from `perf-fuzzy-kv-node-1.log` (preserved in the artifact):

```
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 2.194 MB /profiling/data/perf-fuzzy-kv-node-1.data (7872 samples) ]
```

But **the `.data` file itself is never in the artifact**, even though every other file in `/profiling/data/` (jemalloc heaps, `perf.map`, `perf.log`) gets preserved successfully. Same pattern on both 1-min and 45-min runs — not a timing issue.

See runs [24826503339](https://github.com/calimero-network/core/actions/runs/24826503339) (1 min) and [24827323347](https://github.com/calimero-network/core/actions/runs/24827323347) (45 min).

## Why we can't diagnose this today

`preserve_to_host_mount` runs inside the runtime container, and that container's stdout is lost when merobox's graceful shutdown removes the container — `collect-from-containers.sh` only captures `docker logs` from containers that still exist at collection time (which is the init containers, not the runtime ones). So any warning `preserve_to_host_mount` might be emitting is gone before we can read it.

## Fix (observability only)

Write `preserve_to_host_mount`'s actions to `$dest/preserve.log`, where `$dest` is on the host bind mount. `harvest-host-profiling.sh` then copies this log into the artifact. Contents:

- source directory listing (`ls -la $PROFILING_OUTPUT_DIR`) before `cp`
- `cp -rv` output (file-by-file stdout AND stderr)
- dest directory listing (`ls -la $dest`) after `cp`

Once this reaches a fuzzy run, we'll see exactly whether:
1. `perf.data` was actually in the source dir at preserve time
2. `cp` silently skipped it (e.g. permission or device error)
3. It landed in `$dest` but got lost downstream

No behaviour change — this doesn't make `perf.data` land in the artifact. Pure diagnostics so the next run gives us a clear story.

## Test plan

- [ ] Merge. Release rebuilds `edge-profiling` with the new entrypoint.
- [ ] Workflow_run (from #2220) fires fuzzy-load-test, or manually dispatch.
- [ ] Download `profiling-data-kv-store-*/fuzzy-kv-node-N/preserve.log` — diagnose from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change: adds logging around the profiling data copy step without altering what files are copied or the exit flow. Main risk is increased I/O/log volume during preservation in CI containers.
> 
> **Overview**
> Adds a persistent `preserve.log` under the host bind mount (`$CALIMERO_HOME/profiling-dump`) so `preserve_to_host_mount` actions survive runtime container removal in CI.
> 
> The preserve step now logs a pre-copy source listing, verbose `cp -rv` output (stdout+stderr via `tee`), and a post-copy destination listing, while keeping the existing non-fatal warning behavior on partial copy failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f0cefe6c8709f7a073c4b330170a1650034e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->