### PR TITLE
chore: bump 0.10.1 rc.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.29"
+version = "0.10.1-rc.30"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
## Summary

Bumps the workspace release version from `0.10.1-rc.29` → `0.10.1-rc.30`. Follows the same release-cutting pattern as [#2193](https://github.com/calimero-network/core/pull/2193) (rc.29).

## Why now

Cuts an RC that surfaces the `delete_namespace` actor handler fix (#2226 / #2227, merged 2026-04-23 at `e272b92d`) to downstream consumers.

`rc.29` was tagged on **2026-04-21** — ~40 hours before the fix merged. Any consumer that pulls the latest core *release* (rather than master) is still running without the fix. Concrete example: [merobox's `ci.yml`](https://github.com/calimero-network/merobox/blob/master/.github/workflows/ci.yml) downloads the latest core release binary, and its CI is currently failing on any workflow that calls `delete_namespace` on a namespace root because the bundled merod still has the old circular-dispatch bug:

\`\`\`
delete_namespace failed on calimero-node-1: Client error: cannot delete the namespace root '...': use delete_namespace instead
\`\`\`

Downstream blocker: [merobox#209](https://github.com/calimero-network/merobox/pull/209) end-to-end teardown in two example workflows.

## Other changes since rc.29

Commits on master not yet in a release:

\`\`\`
1bbc22f  fix(profiling): log preserve_to_host_mount actions to the bind mount (#2228)
e272b92  fix(context): implement delete_namespace actor handler (#2226) (#2227)
32e963a  fix(profiling): surface real perf error instead of swallowing stderr (#2224)
343c87d  chore(deps): bump openssl from 0.10.75 to 0.10.78 (#2221)
76cb61f  fix(profiling): fall back to linux-tools-generic when version match fails (#2223)
84e3092  fix(e2e): bump subgroup-queued-deltas governance wait 15s -> 45s
\`\`\`

Two bug fixes for real functionality (`delete_namespace`, `openssl` deps) plus profiling/CI tweaks — a standard RC.

## Test Plan

- [x] \`Cargo.toml\` diff is exactly the version-string change (matches rc.29's bump commit \`2f829de\`).
- [ ] Release CI succeeds and publishes \`0.10.1-rc.30\` artifacts on merge.
- [ ] After release lands, merobox#209 CI re-run exercises \`delete_namespace\` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a metadata-only version bump in `Cargo.toml` with no code or dependency changes.
> 
> **Overview**
> Bumps the workspace shared release version in `Cargo.toml` from `0.10.1-rc.29` to `0.10.1-rc.30` to cut the next RC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e899ad97873959d5b2b3e8494743e6c723523dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->