### PR TITLE
fix(profiling): chmod go+rX on preserved dump so harvest can read .data

### DIFF
--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -340,6 +340,18 @@ preserve_to_host_mount() {
             echo "[Profiling] WARNING: cp from $reports_dir may be incomplete: $(head -3 "$err_file" 2>/dev/null | tr '\n' ' ')"
         fi
     fi
+    # Make preserved files readable by the host runner user. Merobox's
+    # container runs as root, so `perf record` writes perf-*.data with
+    # mode 600 — when harvest-host-profiling.sh runs on the GHA runner
+    # (unprivileged user), cp silently skips those files with EACCES.
+    # Non-.data files (jemalloc heaps, perf.map, logs) are already 644
+    # so they harvest fine; this brings .data in line with them.
+    # Use go+rX: adds read for non-owners, conditional-execute only on
+    # directories (not regular files) — never makes a data file
+    # executable. Doesn't remove owner write/execute.
+    chmod -R go+rX "$dest" 2>"$err_file" || {
+        echo "[Profiling] WARNING: chmod on $dest failed: $(head -1 "$err_file" 2>/dev/null)"
+    }
     [ "$err_file" != /dev/null ] && rm -f "$err_file"
     local size
     size=$(du -sh "$dest" 2>/dev/null | awk '{print $1}')


### PR DESCRIPTION
## Root cause (finally)

PR #2228's `preserve.log` diagnostics told us exactly what's going on:

```
--- ls -la /profiling/data (source) ---
-rw-r--r-- 1 root root  53362 perf-fuzzy-kv-node-1-247.map
-rw------- 1 root root 152224 perf-fuzzy-kv-node-1.data    ← mode 600, owner-only
-rw-r--r-- 1 root root    775 perf-fuzzy-kv-node-1.log
...
'/profiling/data/./perf-fuzzy-kv-node-1.data' -> '/app/data/profiling-dump/./perf-fuzzy-kv-node-1.data'
--- ls -la /app/data/profiling-dump (after cp) ---
-rw------- 1 root root 152224 perf-fuzzy-kv-node-1.data    ← still 600 on bind mount
```

`perf record` writes its `.data` file with mode **600** (owner-only). Every other file in the dir is 644. `preserve_to_host_mount`'s `cp` runs inside the container as root, so it copies fine and the 600 file lands on the bind mount.

Then `harvest-host-profiling.sh` runs on the GHA runner **as the unprivileged runner user**, tries to `cp -r` from the bind mount on the host. It reads the 644 files fine, silently skips the 600 one with `EACCES` — and `cp -r` returns exit code 0 even when it skipped one file, so harvest's failure WARNING never fires. The `.data` file just quietly vanishes.

## Fix

One line at the end of `preserve_to_host_mount`, after both `cp`s:

```bash
chmod -R go+rX "$dest"
```

- `go+rX` — adds read for group and others.
- `X` (capital) — applies execute ONLY to directories (never to regular files), so `perf.data` doesn't get executable bits.
- Owner permissions untouched.

Runs inside the container as root, which owns all the files, so the chmod is unconditional.

Scope justification: we're widening perms inside the profiling dump on an ephemeral CI container. Not a shared multi-tenant service.

## Why not fix on the harvest side

The natural alternative — `sudo cp` in harvest-host-profiling.sh — would require passwordless-sudo setup on the GHA runner for the runner user, which is more infrastructure than it's worth for what's fundamentally a CI-only perms problem. Fixing at preserve time is narrower and closer to the actual mismatch.

## Test plan

- [ ] Merge → Release rebuilds `edge-profiling` with the new entrypoint.
- [ ] Workflow_run (from #2220) fires fuzzy-load-test, or dispatch a short verification run.
- [ ] Check artifact `profiling-data-kv-store-*/fuzzy-kv-node-N/perf-fuzzy-kv-node-N.data` exists with non-trivial size.
- [ ] Run `perf report -i that-file.data --stdio` locally, confirm real call stacks (and WASM frames via the matching `perf-*.map`).

## Related

- #2217, #2218, #2220, #2223, #2224, #2228 — full chain of CI plumbing fixes that got us here.
- merobox #210 — CAP_PERFMON fix that got `perf record` actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts file permissions on preserved profiling artifacts to avoid CI harvest failures; no runtime logic or security-sensitive paths beyond widening read access in the dump directory.
> 
> **Overview**
> Ensures preserved profiling artifacts are readable by the GitHub Actions runner by `chmod -R go+rX` on the `profiling-dump` directory after copying profiling data/reports.
> 
> This prevents `perf-*.data` files (often written as mode `600` in the root-run container) from being silently skipped during host-side collection, and logs a warning if the permission fix fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de09f8013e6191cb2791a2855ada066e598e0f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->