### PR TITLE
fix(server): store admin signing key when creating subgroup; bump rc.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.30"
+version = "0.10.1-rc.31"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -106,6 +106,29 @@ pub async fn handler(
         Ok(()) => {
             let group_id = calimero_context_config::types::ContextGroupId::from(group_id);
 
+            // Store the creator's signing key for the new subgroup. Without
+            // this, any subsequent group-scoped op that needs to sign a
+            // local governance message (delete_context -> ContextDetached,
+            // add_group_members -> MemberAdded, etc.) fails with
+            // "signing key not found for requester in group '...'".
+            //
+            // The direct create_group handler already stores the signing
+            // key at crates/context/src/handlers/create_group.rs:85-94;
+            // this keeps subgroups created via create_group_in_namespace in
+            // sync with that invariant.
+            if let Err(err) = calimero_context::group_store::store_group_signing_key(
+                &state.store,
+                &group_id,
+                &signer_pk,
+                &sk_bytes,
+            ) {
+                warn!(
+                    group_id=%hex::encode(group_id.to_bytes()),
+                    ?err,
+                    "Group created but failed to store admin signing key"
+                );
+            }
+
             // Generate a group key for the subgroup so that encrypted
             // group-scoped governance ops (MemberAdded, ContextRegistered)
             // can be published and later decrypted by members.


### PR DESCRIPTION
## Summary

- Fixes a missing side-effect in the `create_group_in_namespace` HTTP handler: after publishing `RootOp::GroupCreated` and generating the encrypted group key, it never stored the creator's signing key for the new subgroup. Adds the `store_group_signing_key` call right after the op succeeds, mirroring what the direct `create_group` actor handler at `crates/context/src/handlers/create_group.rs:85-94` already does for root-level group creation.
- Bumps workspace version `0.10.1-rc.30 -> 0.10.1-rc.31` so consumers pick up the fix on release.

## Symptom

After creating a subgroup via `POST /admin-api/namespaces/:id/groups` and later trying to delete any context registered in that subgroup (even as the creator who IS the group admin):

\`\`\`
delete_context failed on calimero-node-1:
    signing key not found for requester in group '...';
    cannot publish local detach op
\`\`\`

Source: `crates/context/src/handlers/delete_context.rs` reads the signing key via `group_store::get_group_signing_key(..., group_id, requester)` to sign a local `GroupOp::ContextDetached`. Because the handler that created the subgroup never stored the creator's signing key under `(subgroup_id, creator_pk)`, the lookup returns `None` and the op can't be signed.

## Why this wasn't caught before

- Root groups created via `create_namespace` go through the direct `create_group` handler, which already stores the signing key at line 85-94 of that file.
- Subgroups created via `upgrade_group`'s fallback path also store it (`handlers/upgrade_group.rs:80`).
- Subgroups created via `join_group` store the joiner's key (`handlers/join_group.rs:68`).
- `create_group_in_namespace` (REST `POST /admin-api/namespaces/:id/groups`) was the odd one out — it publishes the governance op but skips the sidecar key-storage step.

Any test that creates a subgroup via the REST API and then calls an op requiring the signer's key hits this. The upgrade-example works because the subsequent `upgrade_group` call stores the key; the admin-example fails because it never calls `upgrade_group`.

## The fix

One paragraph in `crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs`, right after `sign_apply_and_publish_namespace_op` returns `Ok(())` and before `store_group_key`:

\`\`\`rust
if let Err(err) = calimero_context::group_store::store_group_signing_key(
    &state.store,
    &group_id,
    &signer_pk,
    &sk_bytes,
) {
    warn!(
        group_id=%hex::encode(group_id.to_bytes()),
        ?err,
        "Group created but failed to store admin signing key"
    );
}
\`\`\`

`signer_pk` and `sk_bytes` already come from the earlier `get_or_create_namespace_identity` call — no new lookups.

## Test Plan

- [x] \`cargo check -p calimero-server\` passes.
- [ ] \`cargo test -p calimero-context\` (existing signing-key tests) passes.
- [ ] Merobox [#209](https://github.com/calimero-network/merobox/pull/209) CI, which exercises the \`delete_context\` on a subgroup-registered context, goes green once rc.31 is released.

## Release

Version bumped to \`0.10.1-rc.31\` in the same PR so the fix ships immediately on merge. Follows the same pattern as rc.28 (fix bundled with bump) — some RCs bundle fixes, some are standalone bumps. Either way the release CI picks it up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subgroup creation side effects in the admin API path; while small, it impacts how future group-scoped governance ops are signed and could surface store/write issues (now logged as warnings).
> 
> **Overview**
> Fixes subgroup creation via `create_group_in_namespace` to also persist the creator/admin signing key (matching the behavior of the direct `create_group` path), preventing later group-scoped governance operations from failing due to missing signer material.
> 
> Bumps the shared workspace release-candidate version from `0.10.1-rc.30` to `0.10.1-rc.31` to ship the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562c09d91da2242e7ceec774549249a66726b683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->