### PR TITLE
perf(storage): binary-search insert into children Vec (#2238 Fix 3)

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -316,19 +316,27 @@ impl<S: StorageAdaptor> Index<S> {
             Self::calculate_full_hash_for_children(child_index.own_hash, &child_index.children)?;
         Self::save_index(&child_index)?;
 
-        // Get or create the children list
-        // Collection name param is ignored - entity can only have one collection
+        // Insert into parent's children list, keeping it sorted by `ChildInfo`'s
+        // Ord (primary: created_at, tiebreaker: id). The list is always sorted
+        // by construction — binary search both finds the existing entry (to
+        // replace if present) and the correct insertion point (otherwise) in
+        // O(log K) without rebuilding a BTreeSet + Vec each call (#2238 Fix 3).
+        //
+        // Prior implementation:
+        //     let mut ordered = children_vec.drain(..).collect::<BTreeSet<_>>();
+        //     ordered.replace(new_entry);
+        //     *children_vec = ordered.into_iter().collect();
+        // Allocated a BTreeSet, inserted K entries to re-sort an already-sorted
+        // list, then re-materialized a Vec — two transient allocations and
+        // O(K log K) sort work per call. `dlmalloc::malloc` was 13.06% of
+        // inclusive CPU in the baseline flamegraph; a real chunk of that lives
+        // here on the merge hot path.
         let children_vec = parent_index.children.get_or_insert_with(Vec::new);
-
-        let mut ordered = children_vec.drain(..).collect::<BTreeSet<_>>();
-
-        let _ignored = ordered.replace(ChildInfo::new(
-            child.id(),
-            child_index.full_hash,
-            child.metadata,
-        ));
-
-        *children_vec = ordered.into_iter().collect();
+        let new_entry = ChildInfo::new(child.id(), child_index.full_hash, child.metadata);
+        match children_vec.binary_search(&new_entry) {
+            Ok(pos) => children_vec[pos] = new_entry,
+            Err(pos) => children_vec.insert(pos, new_entry),
+        }
 
         parent_index.full_hash =
             Self::calculate_full_hash_for_children(parent_index.own_hash, &parent_index.children)?;

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -595,3 +595,79 @@ fn deferred_scope_of_different_adaptor_does_not_cross_contaminate() {
 
     foreign_scope.finish().unwrap();
 }
+
+// ============================================================
+// #2238 Fix 3 — sorted-insert path produces identical hashes
+// ============================================================
+
+#[test]
+fn sorted_insert_path_preserves_hash_semantics() {
+    // Add multiple children out of creation order; the binary_search + insert
+    // path must land them in the same sorted position a BTreeSet would have
+    // chosen. The final parent full_hash must equal a fresh recompute
+    // from the (ordered) children list — enforced by the existing merkle
+    // invariants, but we assert here to lock in the sort-order guarantee.
+    use crate::index::Index;
+
+    crate::env::reset_for_testing();
+    crate::tests::common::register_test_merge_functions();
+
+    let mut parent = Page::new_from_element("Parent", Element::root());
+    TestInterface::save(&mut parent).unwrap();
+
+    // Add children with interleaved names so the string-derived created_at
+    // / id hashes don't arrive in any particular sorted order.
+    let names = ["delta", "alpha", "gamma", "beta", "epsilon"];
+    for name in names {
+        let mut child = Paragraph::new_from_element(name, Element::new(None));
+        TestInterface::add_child_to(parent.id(), &mut child).unwrap();
+    }
+
+    // The children list must be sorted after every insert (preserved by
+    // binary_search + insert). Read it back and verify.
+    let children = Index::<TestStorage>::get_children_of(parent.id()).unwrap();
+    assert_eq!(children.len(), 5);
+    for pair in children.windows(2) {
+        assert!(
+            pair[0] <= pair[1],
+            "children must stay sorted across binary-search inserts"
+        );
+    }
+
+    // Parent's stored full_hash matches fresh recompute (proves nothing
+    // was reshuffled between save and read).
+    let stored = Index::<TestStorage>::get_hashes_for(parent.id())
+        .unwrap()
+        .unwrap()
+        .0;
+    let fresh = Index::<TestStorage>::calculate_full_merkle_hash_for(parent.id()).unwrap();
+    assert_eq!(stored, fresh);
+}
+
+#[test]
+fn sorted_insert_replaces_existing_child_in_place() {
+    // Re-adding a child with the same (created_at, id) but updated hash
+    // should replace the existing entry, not duplicate it.
+    use crate::entities::ChildInfo;
+    use crate::index::Index;
+
+    crate::env::reset_for_testing();
+    crate::tests::common::register_test_merge_functions();
+
+    let mut parent = Page::new_from_element("Parent", Element::root());
+    TestInterface::save(&mut parent).unwrap();
+
+    let mut child = Paragraph::new_from_element("Child", Element::new(None));
+    TestInterface::add_child_to(parent.id(), &mut child).unwrap();
+
+    // Second add_child_to with the same child but a new own_hash should
+    // replace the entry at the same position.
+    let initial_children = Index::<TestStorage>::get_children_of(parent.id()).unwrap();
+    assert_eq!(initial_children.len(), 1);
+
+    let replacement = ChildInfo::new(child.id(), [99_u8; 32], child.element().metadata.clone());
+    Index::<TestStorage>::add_child_to(parent.id(), replacement).unwrap();
+
+    let after_children = Index::<TestStorage>::get_children_of(parent.id()).unwrap();
+    assert_eq!(after_children.len(), 1, "replace should not duplicate");
+}


### PR DESCRIPTION
## Summary

Third of three fixes planned under #2238. `add_child_to` rebuilds the parent's sorted children list on every call via `drain → BTreeSet → collect` — two transient allocations + O(K log K) sort work on a list that was already sorted. On the merge hot path, `dlmalloc::malloc` was **13.06% of inclusive CPU** in the baseline flamegraph from run [24837560329](https://github.com/calimero-network/core/actions/runs/24837560329); a real chunk of that churn lives here.

## Change

Replace the rebuild dance with `binary_search` + `Vec::insert`:

```rust
// Before: O(K log K) + two transient allocations
let mut ordered = children_vec.drain(..).collect::<BTreeSet<_>>();
ordered.replace(new_entry);
*children_vec = ordered.into_iter().collect();

// After: O(log K) find + O(K) amortized shift, no new containers
match children_vec.binary_search(&new_entry) {
    Ok(pos)  => children_vec[pos] = new_entry,
    Err(pos) => children_vec.insert(pos, new_entry),
}
```

Safe because the Vec is maintained in sorted order by `ChildInfo`'s `Ord` impl (created_at first, id tiebreaker) across all insert sites. Binary search locates both existing entries (replace in place) and the correct insertion position (shift-in) with identical semantics to the BTreeSet round-trip.

## Composition with #2239 and #2240

- **#2239 Fix 2 — batched ancestor recompute**: collapsed N walks per merge to 1 per unique starting id.
- **#2240 Fix 1 — stored full_hash is authoritative**: cost per visited ancestor from O(K) to O(1).
- **This PR Fix 3 — no-realloc insert**: eliminates the allocator churn on the per-child add path.

Each fix targets a different slice of the merge-apply hot path identified in #2238. Stacked, they should bring the merkle-related CPU share well below the acceptance target.

## Tests

- 391 storage lib tests pass (+2 new invariant tests).
- Byte-identical hashes across the entire existing test suite — proves the new path produces the same children ordering the BTreeSet did.
- New tests:
  - `sorted_insert_path_preserves_hash_semantics` — adds 5 children with interleaved names, asserts post-sort invariant holds + stored/fresh full_hash agreement.
  - `sorted_insert_replaces_existing_child_in_place` — re-adds the same child with a new hash, asserts the entry is replaced (not duplicated).
- One pre-existing flaky test (`test_merge_nested_document_with_rga`) fires ~1 in 3 runs — not caused by this PR, same race flagged on #2240.

## Related

- #2238 — root issue; this is Fix 3.
- #2239 — Fix 2 (merged).
- #2240 — Fix 1 (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Merkle index update path (`Index::add_child_to`) where ordering affects persisted hashes; a bug could corrupt sync/hash semantics despite added invariant tests.
> 
> **Overview**
> Improves `Index::add_child_to` performance by replacing the per-call `drain → BTreeSet → collect` rebuild of a parent’s children list with an in-place `binary_search` + `Vec::insert`/replace, preserving the same sorted order semantics.
> 
> Adds two Merkle tests to lock in behavior: children remain sorted after repeated inserts and re-adding an existing child replaces the entry (no duplicates), while stored `full_hash` remains byte-identical to a fresh recompute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0d539839743a7816402af1316570153e4bb104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->