### PR TITLE
perf(primitives): make Hash base58 lazy, drop eager cache

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -39,7 +39,7 @@ pub trait UrlFragment: ScopedAlias + AliasKind {
 
     fn create(self) -> Self::Value;
 
-    fn scoped(scope: Option<&Self::Scope>) -> Option<&str>;
+    fn scoped(scope: Option<&Self::Scope>) -> Option<String>;
 }
 
 impl UrlFragment for ContextId {
@@ -49,7 +49,7 @@ impl UrlFragment for ContextId {
         CreateContextIdAlias { context_id: self }
     }
 
-    fn scoped(_: Option<&Self::Scope>) -> Option<&str> {
+    fn scoped(_: Option<&Self::Scope>) -> Option<String> {
         None
     }
 }
@@ -61,8 +61,8 @@ impl UrlFragment for PublicKey {
         CreateContextIdentityAlias { identity: self }
     }
 
-    fn scoped(context: Option<&Self::Scope>) -> Option<&str> {
-        context.map(ContextId::as_str)
+    fn scoped(context: Option<&Self::Scope>) -> Option<String> {
+        context.map(ContextId::to_string)
     }
 }
 
@@ -75,7 +75,7 @@ impl UrlFragment for ApplicationId {
         }
     }
 
-    fn scoped(_: Option<&Self::Scope>) -> Option<&str> {
+    fn scoped(_: Option<&Self::Scope>) -> Option<String> {
         None
     }
 }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1167,7 +1167,13 @@ fn substitute_aliases_in_payload(
                 .map_err(|_| ExecuteError::InternalError)?
                 .ok_or_else(|| ExecuteError::AliasResolutionFailed { alias: *alias })?;
 
-            result.extend_from_slice(public_key.as_str().as_bytes());
+            // Substitution hot path: bs58-encode the 32-byte key into a
+            // stack buffer rather than allocating a fresh String per alias.
+            let mut buf = [0u8; 45];
+            let len = bs58::encode(public_key.as_ref() as &[u8; 32])
+                .onto(&mut buf[..])
+                .expect("base58 encoding cannot fail for fixed 32-byte input");
+            result.extend_from_slice(&buf[..len]);
 
             remaining = &remaining[pos + needle.len()..];
         }

--- a/crates/network/src/handlers/commands/query_blob.rs
+++ b/crates/network/src/handlers/commands/query_blob.rs
@@ -26,7 +26,7 @@ impl Handler<QueryBlob> for NetworkManager {
 
             debug!(
                 blob_id = %request.blob_id,
-                context_id = context_id.as_str(),
+                context_id = %context_id,
                 key_len = key.as_ref().len(),
                 "QUERY: searching for blob"
             );

--- a/crates/node/src/handlers/blob_protocol.rs
+++ b/crates/node/src/handlers/blob_protocol.rs
@@ -93,8 +93,8 @@ async fn handle_blob_request_stream(
 ) -> eyre::Result<()> {
     info!(
         %peer_id,
-        blob_id = blob_request.blob_id.as_str(),
-        context_id = blob_request.context_id.as_str(),
+        blob_id = %blob_request.blob_id,
+        context_id = %blob_request.context_id,
         "Processing blob request stream using binary chunk protocol"
     );
 
@@ -234,7 +234,7 @@ async fn handle_blob_request_stream(
         Err(_) => {
             warn!(
                 %peer_id,
-                blob_id = blob_request.blob_id.as_str(),
+                blob_id = %blob_request.blob_id,
                 timeout_secs = BLOB_SERVE_TIMEOUT.as_secs(),
                 "Blob serving timed out"
             );

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -50,11 +50,6 @@ impl Deref for ApplicationId {
 }
 
 impl ApplicationId {
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
     /// Sentinel value: no application / uninitialized application ID (all-zero hash).
     #[must_use]
     pub const fn zero() -> Self {
@@ -67,19 +62,19 @@ pub const ZERO_APPLICATION_ID: ApplicationId = ApplicationId::zero();
 
 impl Display for ApplicationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.pad(self.as_str())
+        Display::fmt(&self.0, f)
     }
 }
 
 impl From<ApplicationId> for String {
     fn from(id: ApplicationId) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 
 impl From<&ApplicationId> for String {
     fn from(id: &ApplicationId) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 

--- a/crates/primitives/src/blobs.rs
+++ b/crates/primitives/src/blobs.rs
@@ -16,11 +16,6 @@ use crate::hash::{Hash, HashError};
 pub struct BlobId(Hash);
 
 impl BlobId {
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
     // Returns BlobId represented as a 32-byte array.
     pub fn digest(&self) -> &[u8; DIGEST_SIZE] {
         &self.0
@@ -49,19 +44,19 @@ impl Deref for BlobId {
 
 impl Display for BlobId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.pad(self.as_str())
+        Display::fmt(&self.0, f)
     }
 }
 
 impl From<BlobId> for String {
     fn from(id: BlobId) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 
 impl From<&BlobId> for String {
     fn from(id: &BlobId) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -1,7 +1,7 @@
 // We get this warning as we allow to reimport self crate (`calimero_primitives`) inside the tests with a `borsh` feature.
 #![cfg_attr(test, allow(unused_extern_crates))]
 
-use core::fmt;
+use core::fmt::{self, Display};
 use core::ops::Deref;
 use core::str::FromStr;
 use core::time::Duration;
@@ -45,11 +45,6 @@ impl Deref for ContextId {
 }
 
 impl ContextId {
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
     /// Creates a special ContextID that contains all zeroes inside.
     ///
     /// This is useful as some modules use the zero context for special functions.
@@ -68,19 +63,19 @@ impl ContextId {
 
 impl fmt::Display for ContextId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad(self.as_str())
+        Display::fmt(&self.0, f)
     }
 }
 
 impl From<ContextId> for String {
     fn from(id: ContextId) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 
 impl From<&ContextId> for String {
     fn from(id: &ContextId) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -24,11 +24,19 @@ const BYTES_LEN: usize = 32;
 // https://github.com/bitcoin/libbase58/blob/master/base58.c#L155
 const MAX_STR_LEN: usize = (BYTES_LEN * 138 / 100) + 1;
 
+/// A 32-byte cryptographic digest that displays as base58.
+///
+/// The base58 representation is computed on demand rather than cached on
+/// construction. This makes `Hash::from([u8; 32])` a cheap memcpy and
+/// shrinks the struct from ~80 bytes to 32, which matters on hot paths
+/// that construct IDs just to compare or hash them (delta-store
+/// iteration, RocksDB key parsing, etc.). Call sites that need the
+/// string form can use [`Display`] (zero-alloc) or [`Self::to_base58`]
+/// (allocates). For writing the string into an existing buffer without
+/// allocating, see [`Self::encode_base58`].
 #[derive(Clone, Copy)]
 pub struct Hash {
     bytes: [u8; BYTES_LEN],
-    bs58_cache: [u8; MAX_STR_LEN],
-    bs58_len: u8,
 }
 
 impl Hash {
@@ -37,28 +45,18 @@ impl Hash {
         &self.bytes
     }
 
-    /// All-zero digest, with base58 cache matching [`From<[u8; BYTES_LEN]>`](Self).
+    /// All-zero digest. Cheap — no base58 work on construction.
     #[must_use]
     pub const fn zero() -> Self {
-        const ZERO_BS58: &[u8] = b"11111111111111111111111111111111";
-        let mut bs58_cache = [0u8; MAX_STR_LEN];
-        let mut i = 0;
-        while i < ZERO_BS58.len() {
-            bs58_cache[i] = ZERO_BS58[i];
-            i += 1;
-        }
         Self {
             bytes: [0u8; BYTES_LEN],
-            bs58_cache,
-            bs58_len: ZERO_BS58.len() as u8,
         }
     }
 
     #[must_use]
     pub fn new(data: &[u8]) -> Self {
         let hash_bytes: [u8; BYTES_LEN] = Sha256::digest(data).into();
-        // Will call `From<[u8; 32]>` which computes the cache
-        hash_bytes.into()
+        Self { bytes: hash_bytes }
     }
 
     pub fn is_zero(&self) -> bool {
@@ -67,58 +65,54 @@ impl Hash {
 
     pub fn hash_json<T: Serialize>(data: &T) -> JsonResult<Self> {
         let mut hasher = Sha256::default();
-
         to_json_writer(&mut hasher, data)?;
-
-        // Get the raw [u8; 32] bytes from the hasher
         let hash_bytes: [u8; BYTES_LEN] = hasher.finalize().into();
-
-        // Let `From<[u8; 32]>` handle construction and caching
-        Ok(hash_bytes.into())
+        Ok(Self { bytes: hash_bytes })
     }
 
     #[cfg(feature = "borsh")]
     pub fn hash_borsh<T: BorshSerialize>(data: &T) -> io::Result<Self> {
         let mut hasher = Sha256::default();
-
         data.serialize(&mut hasher)?;
-
-        // Get the raw [u8; 32] bytes from the hasher
         let hash_bytes: [u8; BYTES_LEN] = hasher.finalize().into();
-
-        // Let `From<[u8; 32]>` handle construction and caching
-        Ok(hash_bytes.into())
+        Ok(Self { bytes: hash_bytes })
     }
 
+    /// Returns the base58 representation as a freshly allocated
+    /// `String`. Use [`Self::encode_base58`] when you already have a
+    /// stack buffer and want to avoid the allocation.
     #[must_use]
-    pub fn as_str(&self) -> &str {
-        // Safe: Read from the pre-computed cache.
-        let s = &self.bs58_cache[..self.bs58_len as usize];
+    pub fn to_base58(&self) -> String {
+        let mut buf = [0u8; MAX_STR_LEN];
+        let s = self.encode_base58(&mut buf);
+        s.to_owned()
+    }
 
-        // We can trust this is valid UTF-8 because we are the ones
-        // who put it there during initialization.
-        // Using from_utf8().unwrap() is also perfectly fine.
-        unsafe { from_utf8_unchecked(s) }
+    /// Writes the base58 representation into `buf` and returns it as a
+    /// `&str` borrowing from `buf`. Zero allocation; intended for hot
+    /// paths that can bring their own buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if base58 encoding fails, which cannot happen given the
+    /// fixed 32-byte input and correctly-sized output buffer.
+    #[must_use]
+    pub fn encode_base58<'a>(&self, buf: &'a mut [u8; MAX_STR_LEN]) -> &'a str {
+        let len = bs58::encode(&self.bytes)
+            .onto(&mut buf[..])
+            .expect("Base58 encoding failed");
+        // SAFETY: bs58 alphabet is pure ASCII.
+        unsafe { from_utf8_unchecked(&buf[..len]) }
     }
 
     fn from_str(s: &str) -> Result<Self, Option<Bs58Error>> {
-        let s_len = s.len();
-        if s_len > MAX_STR_LEN {
+        if s.len() > MAX_STR_LEN {
             return Err(Some(Bs58Error::BufferTooSmall));
         }
 
         let mut bytes = [0; BYTES_LEN];
         match bs58::decode(s).onto(&mut bytes) {
-            Ok(len) if len == bytes.len() => {
-                let mut bs58_cache = [0; MAX_STR_LEN];
-                bs58_cache[..s_len].copy_from_slice(s.as_bytes());
-
-                Ok(Self {
-                    bytes,
-                    bs58_cache,
-                    bs58_len: s_len.try_into().expect("infallible conversion: checked before string length is less than MAX_STR_LEN"),
-                })
-            }
+            Ok(len) if len == bytes.len() => Ok(Self { bytes }),
             Ok(_) => Err(None),
             Err(err) => Err(Some(err)),
         }
@@ -127,20 +121,7 @@ impl Hash {
 
 impl From<[u8; BYTES_LEN]> for Hash {
     fn from(bytes: [u8; BYTES_LEN]) -> Self {
-        let mut bs58_cache = [0; MAX_STR_LEN];
-        let len = bs58::encode(&bytes)
-            .onto(&mut bs58_cache[..])
-            // Panics if MAX_STR_LEN is wrong, which is good.
-            .expect("Base58 encoding failed");
-
-        Self {
-            bytes,
-            bs58_cache,
-            // Safe: max len is 45
-            bs58_len: len
-                .try_into()
-                .expect("infaliible conversion: bs58_len conversion failed, but shouldn't have"),
-        }
+        Self { bytes }
     }
 }
 
@@ -166,11 +147,7 @@ impl Deref for Hash {
 
 impl Default for Hash {
     fn default() -> Self {
-        // Create the default byte array
-        const DEFAULT_BYTES: [u8; BYTES_LEN] = [0; BYTES_LEN];
-
-        // Let `From<[u8; 32]>` handle construction and caching
-        DEFAULT_BYTES.into()
+        Self::zero()
     }
 }
 
@@ -202,13 +179,17 @@ impl Ord for Hash {
 
 impl Display for Hash {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.pad(self.as_str())
+        let mut buf = [0u8; MAX_STR_LEN];
+        f.pad(self.encode_base58(&mut buf))
     }
 }
 
 impl Debug for Hash {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Hash").field(&self.as_str()).finish()
+        let mut buf = [0u8; MAX_STR_LEN];
+        f.debug_tuple("Hash")
+            .field(&self.encode_base58(&mut buf))
+            .finish()
     }
 }
 
@@ -246,15 +227,14 @@ impl BorshDeserialize for Hash {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
         let mut bytes = [0; BYTES_LEN];
         reader.read_exact(&mut bytes)?;
-
-        // Let `From<[u8; 32]>` handle construction and caching
-        Ok(bytes.into())
+        Ok(Self { bytes })
     }
 }
 
 impl Serialize for Hash {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
+        let mut buf = [0u8; MAX_STR_LEN];
+        serializer.serialize_str(self.encode_base58(&mut buf))
     }
 }
 

--- a/crates/primitives/src/identity.rs
+++ b/crates/primitives/src/identity.rs
@@ -121,11 +121,6 @@ impl Deref for PublicKey {
 }
 
 impl PublicKey {
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
     /// Verify a signature against this public key.
     pub fn verify(&self, message: &[u8], signature: &Signature) -> Result<(), SignatureError> {
         VerifyingKey::from_bytes(self.as_ref())?.verify(message, signature)
@@ -149,19 +144,19 @@ impl PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad(self.as_str())
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl From<PublicKey> for String {
     fn from(id: PublicKey) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 
 impl From<&PublicKey> for String {
     fn from(id: &PublicKey) -> Self {
-        id.as_str().to_owned()
+        id.0.to_base58()
     }
 }
 

--- a/crates/primitives/src/tests/hash.rs
+++ b/crates/primitives/src/tests/hash.rs
@@ -6,7 +6,7 @@ use super::*;
 fn zero_hash_matches_from_bytes() {
     let from_bytes: Hash = [0u8; 32].into();
     assert_eq!(Hash::zero(), from_bytes);
-    assert_eq!(from_bytes.as_str(), "11111111111111111111111111111111");
+    assert_eq!(from_bytes.to_string(), "11111111111111111111111111111111");
 }
 
 #[test]
@@ -18,9 +18,12 @@ fn test_hash_43() {
         "03675ac53ff9cd1535ccc7dfcdfa2c458c5218371f418dc136f2d19ac1fbe8a5"
     );
 
-    assert_eq!(hash.as_str(), "EHdZfnzn717B56XYH8sWLAHfDC3icGEkccNzpAF4PwS");
     assert_eq!(
-        (*&*&*&*&*&*&hash).as_str(),
+        hash.to_string(),
+        "EHdZfnzn717B56XYH8sWLAHfDC3icGEkccNzpAF4PwS"
+    );
+    assert_eq!(
+        hash.to_base58(),
         "EHdZfnzn717B56XYH8sWLAHfDC3icGEkccNzpAF4PwS"
     );
 }
@@ -35,14 +38,22 @@ fn test_hash_44() {
     );
 
     assert_eq!(
-        hash.as_str(),
+        hash.to_string(),
         "C9K5weED8iiEgM6bkU6gZSgGsV6DW2igMtNtL1sjfFKK"
     );
 
     assert_eq!(
-        (*&*&*&*&*&*&hash).as_str(),
+        hash.to_base58(),
         "C9K5weED8iiEgM6bkU6gZSgGsV6DW2igMtNtL1sjfFKK"
     );
+}
+
+#[test]
+fn encode_base58_into_stack_buf() {
+    let hash = Hash::new(b"Hello World");
+    let mut buf = [0u8; 45];
+    let s = hash.encode_base58(&mut buf);
+    assert_eq!(s, "C9K5weED8iiEgM6bkU6gZSgGsV6DW2igMtNtL1sjfFKK");
 }
 
 #[test]

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -425,7 +425,7 @@ impl FileSystem {
     }
 
     fn path(&self, id: BlobId) -> Utf8PathBuf {
-        self.root.join(id.as_str())
+        self.root.join(id.to_string())
     }
 
     /// Get the path for a blob stored in a package/version directory
@@ -438,7 +438,7 @@ impl FileSystem {
             .join(package)
             .join(version)
             .join("blobs")
-            .join(id.as_str())
+            .join(id.to_string())
     }
 
     /// Get the package directory path


### PR DESCRIPTION
## Problem

On the sync hot path, `DeltaStore::load_persisted_deltas` iterates every persisted delta from RocksDB and calls `.context_id()` on each row. That goes through `Hash::from([u8; 32])`, which bs58-encoded the bytes into a 45-byte cache on every construction — even though ~nothing on that path reads the string form.

Post-Fix-2 CPU flamegraph (kv-store fuzzy, node-1) measured **~4.4% of total CPU** in `bs58::encode_into` under this single caller:

```
load_persisted_deltas
  → ContextPrivateState::context_id()
    → ApplicationId::from([u8; 32])
      → Hash::from([u8; 32])
        → bs58::encode_into        ← 4.43% of runtime
```

## Fix

Strip the eager base58 cache from `Hash`. The struct goes from ~80 bytes to 32; `From<[u8; 32]>` becomes a cheap memcpy. `Hash` stays `Copy`, so all wrapper types (`ContextId`, `ApplicationId`, `BlobId`, `PublicKey`) stay `Copy` — no `.clone()` cascade through the codebase.

## API changes

- `Hash::as_str() -> &str` is **removed** — there's no backing store for the borrow anymore.
- Replacements:
  - `Display` / `to_string()` — zero-alloc: encodes into a stack buffer, then `Formatter::pad`.
  - `Hash::to_base58() -> String` — when an owned value is wanted.
  - `Hash::encode_base58(&mut [u8; 45]) -> &str` — for hot paths that can bring their own buffer.
- `Serialize` uses the stack-buffer path too — zero alloc.
- Wrapper types' `.as_str()` methods are removed; their `Display` / `From<_> for String` go through `Hash` directly.

## Call-site updates

- **tracing macros**: `context_id = context_id.as_str()` → `context_id = %context_id` (uses Display, zero alloc).
- **`UrlFragment::scoped` trait** in `crates/client/src/client.rs`: return type flips `Option<&str>` → `Option<String>`. Caller immediately formats it into a URL path, so no practical change.
- **Alias substitution hot path** in `context::handlers::execute`: uses `bs58::encode(&bytes).onto(&mut [u8; 45])` directly — zero allocation per alias substitution (previously relied on the cache).
- **`BlobId` filesystem paths**: `id.as_str()` → `id.to_string()` (PathBuf owns its data anyway).

## Why not keep the cache but make it lazy

Would require dropping `Copy` from `Hash` (`OnceCell` / `Cell` aren't `Copy`). That cascades through `ContextId`, `ApplicationId`, `BlobId`, `PublicKey` — 500+ ContextId mentions alone, all passed by value. The eager cache was a worst-case optimization: every Hash construction paid for a potential Display call that almost never came. For the rare hot caller that needs repeated string reads, caching externally is cheaper than paying the tax on every Hash in the system.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo test -p calimero-primitives` — all 65 tests pass (including new `encode_base58_into_stack_buf`)
- [x] `cargo test --workspace --exclude=merod` — no failures
- [ ] Rerun the fuzzy-load perf pipeline on this branch to confirm the ~4.4% bs58 cost disappears from `load_persisted_deltas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `Hash`/ID string API surface (`as_str` removed) and updates multiple call sites (URLs, logging, filesystem paths), so any missed conversion could cause compile/runtime formatting differences.
> 
> **Overview**
> **Removes the eager base58 cache from `Hash` and all `Hash`-backed IDs**, making construction/`From<[u8;32]>` a cheap copy and computing base58 only when formatting.
> 
> This deletes `as_str()` on `Hash`, `ContextId`, `ApplicationId`, `BlobId`, and `PublicKey`, replacing it with `Display`/`to_string()`, a new allocating `Hash::to_base58()`, and a zero-alloc `Hash::encode_base58()` for hot paths. Call sites are updated accordingly: tracing fields switch to `%id`, client alias URL scoping now returns `Option<String>`, blob store paths now use owned strings, and alias substitution in `execute` base58-encodes into a stack buffer to avoid per-alias allocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1332f0fb3a4adfea5b0324595b20150ea02be4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->