### PR TITLE
perf(context): cache compiled WASM modules in ContextManager

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -698,7 +698,23 @@ impl ContextManager {
         service_name: Option<String>,
     ) -> impl ActorFuture<Self, Output = eyre::Result<calimero_runtime::Module>> + 'static {
         let service_name_for_bytes = service_name.clone();
+        let service_name_for_cache = service_name.clone();
         let blob_task = async {}.into_actor(self).map(move |_, act, _ctx| {
+            // Fast path: a compiled module is already cached for this
+            // (application_id, service_name) key. Every `get_module`
+            // call previously paid ~5% CPU to run
+            // `Engine::from_precompiled` (wasmer artifact deserialize)
+            // even though the same bytes were being deserialized. Serve
+            // the cached Module (cheap Arc clone) and skip the entire
+            // blob-fetch / deserialize path. Cache entries are
+            // invalidated in `update_application` / migration sites.
+            if let Some(cached) = act
+                .modules
+                .get(&(application_id, service_name_for_cache.clone()))
+            {
+                return Ok(CachedOrBlob::Cached(cached.clone()));
+            }
+
             let app = match act.applications.entry(application_id) {
                 btree_map::Entry::Vacant(vacant) => {
                     let Some(app) = act.node_client.get_application(&application_id)? else {
@@ -729,19 +745,30 @@ impl ContextManager {
                     )
                 })?;
 
-            Ok(blob)
+            Ok(CachedOrBlob::Blob(blob))
         });
 
-        let module_task = blob_task.and_then(move |mut blob, act, _ctx| {
+        let module_task = blob_task.and_then(move |cached_or_blob, act, _ctx| {
             let node_client = act.node_client.clone();
 
             async move {
+                let mut blob = match cached_or_blob {
+                    // Fast path: cache hit. Skip blob fetch + deserialize
+                    // + compile. `blob_info = None` signals the post-task
+                    // closure below that there's nothing new to write
+                    // back into `applications` or the module cache.
+                    CachedOrBlob::Cached(module) => return Ok((module, None)),
+                    CachedOrBlob::Blob(blob) => blob,
+                };
+
                 if let Some(compiled) = node_client.get_blob_bytes(&blob.compiled, None).await? {
                     let module =
                         unsafe { calimero_runtime::Engine::headless().from_precompiled(&compiled) };
 
                     match module {
-                        Ok(module) => return Ok((module, None)),
+                        Ok(module) => {
+                            return Ok((module, Some((blob, service_name_for_bytes, false))))
+                        }
                         Err(err) => {
                             debug!(
                                 ?err,
@@ -788,14 +815,16 @@ impl ContextManager {
                     service_name_for_bytes.as_deref(),
                 )?;
 
-                Ok((module, Some((blob, service_name_for_bytes))))
+                // `recompiled = true`: the old cached entry (if any) is
+                // stale since the underlying blob_id just changed.
+                Ok((module, Some((blob, service_name_for_bytes, true))))
             }
             .into_actor(act)
         });
 
         module_task
             .map_ok(move |(module, blob_info), act, _ctx| {
-                if let Some((blob, svc_name)) = blob_info {
+                if let Some((blob, svc_name, recompiled)) = blob_info {
                     if let Some(app) = act.applications.get_mut(&application_id) {
                         match svc_name.as_deref() {
                             Some(name) => {
@@ -808,6 +837,16 @@ impl ContextManager {
                             }
                         }
                     }
+
+                    // Populate the module cache on cache miss. When a
+                    // recompile happened, the previous cached entry (if
+                    // any, for this same key) was stale; overwriting it
+                    // here keeps the cache aligned with the latest
+                    // compiled blob. `insert` is idempotent either way.
+                    let _ = recompiled;
+                    let _ = act
+                        .modules
+                        .insert((application_id, svc_name), module.clone());
                 }
 
                 module
@@ -818,6 +857,16 @@ impl ContextManager {
                 err
             })
     }
+}
+
+/// Result of the blob-resolution / cache-lookup phase inside
+/// [`ContextManager::get_module`]. Either we already have the compiled
+/// module (fast path — skip deserialize), or we have the blob metadata
+/// pointing at where the compiled bytes live and need to fetch +
+/// deserialize.
+enum CachedOrBlob {
+    Cached(calimero_runtime::Module),
+    Blob(calimero_primitives::application::ApplicationBlob),
 }
 
 async fn internal_execute(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -48,6 +48,18 @@ pub mod storage;
 
 use storage::{ContextPrivateStorage, ContextStorage};
 
+/// Upper bound on entries in `ContextManager::modules` to prevent
+/// unbounded growth on nodes that cycle through many distinct
+/// applications (multi-tenant / churn-heavy workloads). Each entry
+/// holds native machine code that's 2–10× the WASM source size, so
+/// a cap here matters even if the peer `applications` map is larger.
+///
+/// TODO: this is a simple size cap with first-entry eviction — not
+/// true LRU. When the hot-path behaviour is understood better,
+/// upgrade to LRU or TTL-based eviction (tracked alongside the
+/// existing TODOs on `contexts` / `applications` in `lib.rs`).
+const MAX_CACHED_MODULES: usize = 32;
+
 impl Handler<ExecuteRequest> for ContextManager {
     type Result = ActorResponse<Self, <ExecuteRequest as Message>::Result>;
 
@@ -761,13 +773,26 @@ impl ContextManager {
                     CachedOrBlob::Blob(blob) => blob,
                 };
 
+                // Staleness anchor for the `map_ok` below. Captures the
+                // blob_id we loaded from *before* any recompile rewrites
+                // `blob.compiled`. A concurrent `update_application`
+                // migration between now and `map_ok` would evict and
+                // repopulate `applications[app_id]` with a different
+                // blob_id — the post-task closure compares against this
+                // anchor and drops both the blob writeback and the
+                // module cache insert when they disagree.
+                let original_blob_id = blob.compiled;
+
                 if let Some(compiled) = node_client.get_blob_bytes(&blob.compiled, None).await? {
                     let module =
                         unsafe { calimero_runtime::Engine::headless().from_precompiled(&compiled) };
 
                     match module {
                         Ok(module) => {
-                            return Ok((module, Some((blob, service_name_for_bytes, false))))
+                            return Ok((
+                                module,
+                                Some((blob, service_name_for_bytes, original_blob_id)),
+                            ))
                         }
                         Err(err) => {
                             debug!(
@@ -815,47 +840,76 @@ impl ContextManager {
                     service_name_for_bytes.as_deref(),
                 )?;
 
-                // `recompiled = true`: the old cached entry (if any) is
-                // stale since the underlying blob_id just changed.
-                Ok((module, Some((blob, service_name_for_bytes, true))))
+                Ok((
+                    module,
+                    Some((blob, service_name_for_bytes, original_blob_id)),
+                ))
             }
             .into_actor(act)
         });
 
         module_task
             .map_ok(move |(module, blob_info), act, _ctx| {
-                if let Some((blob, svc_name, _recompiled)) = blob_info {
+                if let Some((blob, svc_name, original_blob_id)) = blob_info {
                     // The `applications` map is the source of truth for
-                    // whether this app is still live. If an
-                    // `update_application` (migration) message landed
-                    // while our async compile/load was awaiting, it
-                    // would have evicted both `applications[app_id]`
-                    // and `modules[(app_id, *)]`. In that case the
-                    // module we just finished loading is from the
-                    // pre-migration WASM and must NOT be re-cached —
-                    // otherwise every subsequent execute would serve
-                    // the stale module until the next migration.
+                    // whether this app is still live. Tie both the blob
+                    // writeback and the module cache update to the same
+                    // guard, plus a staleness check on `original_blob_id`.
                     //
-                    // Tie both the blob writeback and the module cache
-                    // update to the same `Some(app)` guard so they
-                    // stay consistent: either the app is still present
-                    // (our work is fresh, write both) or it's been
-                    // evicted (our work is stale, write neither).
+                    // Three cases we need to handle correctly:
+                    //
+                    // 1. App still present with the same blob_id we
+                    //    loaded from → our module is current, write
+                    //    back and cache.
+                    // 2. App evicted (`get_mut` → None) — an
+                    //    `update_application` migration ran and hasn't
+                    //    repopulated yet → our work is stale, drop.
+                    // 3. App repopulated with a different blob_id —
+                    //    another `get_module` call beat us to it with
+                    //    fresher data → our work is stale, drop both
+                    //    writeback and module cache insert so we don't
+                    //    stomp the fresh state.
                     if let Some(app) = act.applications.get_mut(&application_id) {
-                        match svc_name.as_deref() {
-                            Some(name) => {
-                                if let Some(svc_blob) = app.services.get_mut(name) {
-                                    *svc_blob = blob;
+                        let current_blob_id = match svc_name.as_deref() {
+                            Some(name) => app.services.get(name).map(|b| b.compiled),
+                            None => Some(app.blob.compiled),
+                        };
+
+                        if current_blob_id == Some(original_blob_id) {
+                            match svc_name.as_deref() {
+                                Some(name) => {
+                                    if let Some(svc_blob) = app.services.get_mut(name) {
+                                        *svc_blob = blob;
+                                    }
+                                }
+                                None => {
+                                    app.blob = blob;
                                 }
                             }
-                            None => {
-                                app.blob = blob;
-                            }
-                        }
 
-                        let _ = act
-                            .modules
-                            .insert((application_id, svc_name), module.clone());
+                            // Bounded insert: drop the oldest entry
+                            // before adding a new one when at capacity.
+                            // BTreeMap iteration order isn't LRU; this
+                            // is a simple size cap to prevent unbounded
+                            // growth on multi-tenant nodes. Upgrading
+                            // to proper LRU is a follow-up (see the
+                            // `modules` field doc in `lib.rs`).
+                            if !act.modules.contains_key(&(application_id, svc_name.clone()))
+                                && act.modules.len() >= MAX_CACHED_MODULES
+                            {
+                                let _ = act.modules.pop_first();
+                            }
+                            let _ = act
+                                .modules
+                                .insert((application_id, svc_name), module.clone());
+                        } else {
+                            debug!(
+                                %application_id,
+                                loaded_blob = %original_blob_id,
+                                current_blob = ?current_blob_id,
+                                "module load result stale — applications was repopulated while loading, dropping"
+                            );
+                        }
                     }
                 }
 

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -824,7 +824,23 @@ impl ContextManager {
 
         module_task
             .map_ok(move |(module, blob_info), act, _ctx| {
-                if let Some((blob, svc_name, recompiled)) = blob_info {
+                if let Some((blob, svc_name, _recompiled)) = blob_info {
+                    // The `applications` map is the source of truth for
+                    // whether this app is still live. If an
+                    // `update_application` (migration) message landed
+                    // while our async compile/load was awaiting, it
+                    // would have evicted both `applications[app_id]`
+                    // and `modules[(app_id, *)]`. In that case the
+                    // module we just finished loading is from the
+                    // pre-migration WASM and must NOT be re-cached —
+                    // otherwise every subsequent execute would serve
+                    // the stale module until the next migration.
+                    //
+                    // Tie both the blob writeback and the module cache
+                    // update to the same `Some(app)` guard so they
+                    // stay consistent: either the app is still present
+                    // (our work is fresh, write both) or it's been
+                    // evicted (our work is stale, write neither).
                     if let Some(app) = act.applications.get_mut(&application_id) {
                         match svc_name.as_deref() {
                             Some(name) => {
@@ -836,17 +852,11 @@ impl ContextManager {
                                 app.blob = blob;
                             }
                         }
-                    }
 
-                    // Populate the module cache on cache miss. When a
-                    // recompile happened, the previous cached entry (if
-                    // any, for this same key) was stale; overwriting it
-                    // here keeps the cache aligned with the latest
-                    // compiled blob. `insert` is idempotent either way.
-                    let _ = recompiled;
-                    let _ = act
-                        .modules
-                        .insert((application_id, svc_name), module.clone());
+                        let _ = act
+                            .modules
+                            .insert((application_id, svc_name), module.clone());
+                    }
                 }
 
                 module

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -87,6 +87,9 @@ impl Handler<UpdateApplicationRequest> for ContextManager {
                     "Invalidated stale cached application before migration module load"
                 );
             }
+            // Same reason for the compiled-module cache: every service
+            // under this application_id is now potentially stale.
+            self.modules.retain(|(id, _), _| *id != application_id);
 
             // Clone values needed for migration
             let datastore = self.datastore.clone();
@@ -131,6 +134,7 @@ impl Handler<UpdateApplicationRequest> for ContextManager {
                     if act.applications.remove(&application_id).is_some() {
                         debug!(%context_id, %application_id, "Invalidated cached application module after migration");
                     }
+                    act.modules.retain(|(id, _), _| *id != application_id);
 
                     if let Some(cached) = act.contexts.get_mut(&context_id) {
                         debug!(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -84,6 +84,14 @@ pub struct ContextManager {
     /// Without this, every execute request paid ~5% CPU to re-run
     /// `Engine::from_precompiled` (observed in #2238 follow-up
     /// profiling).
+    ///
+    /// Size-capped to `MAX_CACHED_MODULES` (see
+    /// `handlers/execute/mod.rs`). Compiled modules are 2–10× larger
+    /// than the source WASM, so we cap to prevent unbounded growth on
+    /// multi-tenant nodes that rotate through many applications.
+    /// Eviction is currently first-entry-by-key-order rather than
+    /// true LRU — good enough as a safety valve; upgrade tracked
+    /// alongside the `contexts` LRU TODO above.
     modules: BTreeMap<(ApplicationId, Option<String>), calimero_runtime::Module>,
 
     /// Prometheus metrics for monitoring the health and performance of the manager,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -74,6 +74,18 @@ pub struct ContextManager {
     /// so we cannot blindly reuse compiled blobs across apps.
     applications: BTreeMap<ApplicationId, Application>,
 
+    /// In-memory cache of compiled WASM modules, keyed by
+    /// `(application_id, service_name)`. Populated on the first
+    /// `get_module` call for a given key; reused on every subsequent
+    /// execute. Cheap to clone (Arc-backed inside wasmer).
+    ///
+    /// Invalidated alongside `applications` on application updates or
+    /// migrations, and replaced when `get_module` has to recompile.
+    /// Without this, every execute request paid ~5% CPU to re-run
+    /// `Engine::from_precompiled` (observed in #2238 follow-up
+    /// profiling).
+    modules: BTreeMap<(ApplicationId, Option<String>), calimero_runtime::Module>,
+
     /// Prometheus metrics for monitoring the health and performance of the manager,
     /// such as number of active contexts, message processing latency, etc.
     metrics: Option<Metrics>,
@@ -110,6 +122,7 @@ impl ContextManager {
 
             contexts: BTreeMap::new(),
             applications: BTreeMap::new(),
+            modules: BTreeMap::new(),
 
             metrics: prometheus_registry.map(Metrics::new),
             active_propagators: HashSet::new(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -214,7 +214,14 @@ impl Engine {
     }
 }
 
-#[derive(Debug)]
+/// A compiled WASM module ready for execution.
+///
+/// Cheap to clone: `wasmer::Engine` and `wasmer::Module` are both
+/// `Arc`-backed internally, so cloning shares the compiled artifact
+/// rather than re-deserializing it. Used by the `ContextManager`
+/// module cache to serve repeat execute requests without paying the
+/// `Engine::from_precompiled` cost each time.
+#[derive(Clone, Debug)]
 pub struct Module {
     limits: VMLimits,
     engine: wasmer::Engine,


### PR DESCRIPTION
Every execute request went through `ContextManager::get_module`, which fetched the compiled blob and called
`Engine::headless().from_precompiled(&compiled)` — i.e. deserialized the wasmer artifact afresh every single time. Measured on the post-Fix-3 kv-store fuzzy flamegraph (node-1):

  - Artifact::from_parts: 5.48%
  - Engine::from_precompiled (inclusive): 13.72%

Plus a tail of ~2.7% in `hashmap_random_keys` under `__calimero_register_merge`, which runs on every module instantiation.

Changes:

- `calimero_runtime::Module` gains `Clone` — cheap, since `wasmer::Engine` and `wasmer::Module` are Arc-backed internally.
- `ContextManager` gains `modules: BTreeMap<(ApplicationId, Option<String>), Module>`. Keyed by (app_id, service_name) so multi-service bundles don't collide.
- `get_module` checks the cache first via a small `CachedOrBlob` enum: hit → return a cloned `Module`, skip the fetch + deserialize entirely. Miss → existing blob-fetch / deserialize / recompile path, populate cache on success.
- Recompile path also updates the cache entry (the blob_id has changed, so the prior entry would be stale).
- Invalidation in `update_application`: both the pre-migration module-load site and the post-migration completion site now run `modules.retain(|(id, _), _| *id != application_id)` alongside the existing `applications.remove`. Every service under that app_id is potentially stale, so drop them all — the next execute will repopulate.

Follow-up opportunity (not in this PR): `DeltaStore:: load_persisted_deltas` is still ~21% CPU and does a full RocksDB scan per sync interval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot-path `ContextManager::get_module` used for every execute, adding caching and eviction plus staleness checks; bugs here could cause stale code execution or increased memory usage. Changes are localized and include explicit invalidation on application updates/migrations, reducing overall risk.
> 
> **Overview**
> Adds an in-memory, size-capped cache of compiled WASM `Module`s in `ContextManager`, keyed by `(application_id, service_name)`, so repeat `execute` calls can reuse the already-deserialized artifact.
> 
> Updates `get_module` to short-circuit on cache hits, and on cache misses to populate the cache only when the loaded blob is still current (staleness-checked against the `applications` entry); also adds a simple eviction cap (`MAX_CACHED_MODULES`).
> 
> Extends `update_application` migration flow to invalidate all cached modules for the updated `application_id`, and makes `calimero_runtime::Module` `Clone` to enable cheap reuse from the cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f9541793ee89edbb0c1ccf804f74bbc72a71f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->