### PR TITLE
perf(node): trim byte-array Debug prints in delta-store hot paths

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -130,9 +130,9 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
         if is_merge_scenario {
             info!(
                 context_id = %self.context_id,
-                delta_id = ?delta.id,
-                current_root_hash = ?Hash::from(current_root_hash),
-                delta_expected_hash = ?Hash::from(delta.expected_root_hash),
+                delta_id = %Hash::from(delta.id),
+                current_root_hash = %Hash::from(current_root_hash),
+                delta_expected_hash = %Hash::from(delta.expected_root_hash),
                 "Concurrent branch detected - applying with CRDT merge semantics"
             );
         }
@@ -182,21 +182,26 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
         let wasm_elapsed_ms = wasm_start.elapsed().as_secs_f64() * 1000.0;
 
         // Hot path — prefer Display over Debug to skip per-byte formatting.
-        let (returns_ok, returns_len) = match &outcome.returns {
-            Ok(Some(v)) => (true, v.len()),
-            Ok(None) => (true, 0),
-            Err(_) => (false, 0),
-        };
-        debug!(
-            context_id = %self.context_id,
-            delta_id = %Hash::from(delta.id),
-            root_hash = %outcome.root_hash,
-            returns_ok,
-            returns_len,
-            is_merge = is_merge_scenario,
-            wasm_ms = format!("{:.2}", wasm_elapsed_ms),
-            "WASM sync completed execution"
-        );
+        // Gate the returns_ok/returns_len derivation behind the same
+        // level check the debug! expansion uses internally, matching
+        // the `tracing::enabled!` convention used above at line 143.
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let (returns_ok, returns_len) = match &outcome.returns {
+                Ok(Some(v)) => (true, v.len()),
+                Ok(None) => (true, 0),
+                Err(_) => (false, 0),
+            };
+            debug!(
+                context_id = %self.context_id,
+                delta_id = %Hash::from(delta.id),
+                root_hash = %outcome.root_hash,
+                returns_ok,
+                returns_len,
+                is_merge = is_merge_scenario,
+                wasm_ms = format!("{:.2}", wasm_elapsed_ms),
+                "WASM sync completed execution"
+            );
+        }
 
         if outcome.returns.is_err() {
             return Err(ApplyError::Application(format!(
@@ -219,9 +224,9 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
             if is_merge_scenario {
                 info!(
                     context_id = %self.context_id,
-                    delta_id = ?delta.id,
-                    computed_hash = ?computed_hash,
-                    delta_expected_hash = ?Hash::from(delta.expected_root_hash),
+                    delta_id = %Hash::from(delta.id),
+                    computed_hash = %computed_hash,
+                    delta_expected_hash = %Hash::from(delta.expected_root_hash),
                     merge_wasm_ms = format!("{:.2}", wasm_elapsed_ms),
                     "Merge produced new hash (expected - concurrent branches merged)"
                 );
@@ -231,9 +236,9 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
                 // a distributed CRDT system.
                 debug!(
                     context_id = %self.context_id,
-                    delta_id = ?delta.id,
-                    computed_hash = ?computed_hash,
-                    expected_hash = ?Hash::from(delta.expected_root_hash),
+                    delta_id = %Hash::from(delta.id),
+                    computed_hash = %computed_hash,
+                    expected_hash = %Hash::from(delta.expected_root_hash),
                     "Hash mismatch (concurrent state) - CRDT merge ensures consistency"
                 );
             }
@@ -299,9 +304,9 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
         // Log with unique marker for parsing: DELTA_APPLY_TIMING
         info!(
             context_id = %self.context_id,
-            delta_id = ?delta.id,
+            delta_id = %Hash::from(delta.id),
             action_count = delta.payload.len(),
-            final_root_hash = ?computed_hash,
+            final_root_hash = %computed_hash,
             was_merge = is_merge_scenario,
             wasm_ms = format!("{:.2}", wasm_elapsed_ms),
             total_ms = format!("{:.2}", total_elapsed_ms),
@@ -648,13 +653,15 @@ impl DeltaStore {
             }
         }
 
-        // Count + small hex sample rather than full-list Debug —
+        // Count + small bs58 sample rather than full-list Debug —
         // this warn fires every interval sync during mesh bootstrap.
+        // Match the bs58 encoding used by delta_id elsewhere so
+        // operators can cross-reference sample IDs against other logs.
         if !remaining.is_empty() {
             let sample = remaining
                 .keys()
                 .take(3)
-                .map(hex::encode)
+                .map(|id| Hash::from(*id).to_base58())
                 .collect::<Vec<_>>()
                 .join(",");
 

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -181,11 +181,18 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
 
         let wasm_elapsed_ms = wasm_start.elapsed().as_secs_f64() * 1000.0;
 
+        // Hot path — prefer Display over Debug to skip per-byte formatting.
+        let (returns_ok, returns_len) = match &outcome.returns {
+            Ok(Some(v)) => (true, v.len()),
+            Ok(None) => (true, 0),
+            Err(_) => (false, 0),
+        };
         debug!(
             context_id = %self.context_id,
-            delta_id = ?delta.id,
-            root_hash = ?outcome.root_hash,
-            return_registers = ?outcome.returns,
+            delta_id = %Hash::from(delta.id),
+            root_hash = %outcome.root_hash,
+            returns_ok,
+            returns_len,
             is_merge = is_merge_scenario,
             wasm_ms = format!("{:.2}", wasm_elapsed_ms),
             "WASM sync completed execution"
@@ -641,16 +648,21 @@ impl DeltaStore {
             }
         }
 
-        // Log any deltas that couldn't be loaded
+        // Count + small hex sample rather than full-list Debug —
+        // this warn fires every interval sync during mesh bootstrap.
         if !remaining.is_empty() {
-            // Collect the IDs of deltas that are still unloadable
-            let unloadable_ids: Vec<[u8; 32]> = remaining.keys().copied().collect();
+            let sample = remaining
+                .keys()
+                .take(3)
+                .map(hex::encode)
+                .collect::<Vec<_>>()
+                .join(",");
 
             warn!(
                 context_id = %self.applier.context_id,
                 remaining_count = remaining.len(),
                 loaded_count,
-                unloadable_deltas = ?unloadable_ids,
+                sample_unloadable = %sample,
                 "Some deltas could not be loaded - they will remain pending until parents arrive"
             );
 


### PR DESCRIPTION
## Problem

The post-Fix-3 flamegraph (kv-store fuzzy, node-1) shows ~1.6% of total CPU in `<u8 as Display>::fmt` under `tracing_core::field::ValueSet::record`. Two `tracing` sites in `delta_store.rs` are responsible — both Debug-format byte arrays, which expand to N × `u8::fmt` calls per log event.

### Hot offender #1: `unloadable_deltas = ?Vec<[u8; 32]>` at `delta_store.rs:649-655`

Fires every `perform_interval_sync` (~2s) while the mesh is bootstrapping (see #2236 cold-start race). Each warn expanded a Vec of 32-byte arrays to 32 × N `u8::fmt` invocations.

### Hot offender #2: per-delta `debug!` in `DeltaApplier::apply_delta`

Fires once per delta applied. Three byte-array Debug fields:
- `delta_id = ?delta.id` (32-byte array)
- `root_hash = ?outcome.root_hash` (same)
- `return_registers = ?outcome.returns` — this is `Result<Option<Vec<u8>>, _>`, which Debug-expands the **entire WASM return blob byte-by-byte**. Genuinely expensive when a delta produces non-trivial output.

## Fix

1. **`unloadable_deltas`** → `remaining_count` + `sample_unloadable` (first 3 IDs, hex-encoded once into a comma-joined string). Same debugging signal (correlate stuck deltas across nodes), a tiny fraction of the formatting work.
2. **Per-delta `apply_delta` debug!**:
   - `delta_id` → `%Hash::from(delta.id)` (Display, bs58 lazily into a stack buffer per #2242)
   - `root_hash` → `%outcome.root_hash` (it's already a `Hash`)
   - `return_registers` → `returns_ok` bool + `returns_len` — preserves "did it succeed, how much did it produce" without per-byte formatting

## Expected savings

~1.6% of total CPU, matching the `<u8 as Display>::fmt` aggregation from the flamegraph. Compounds with PR #2244 (prefix-iter + skip-applied rows).

## Plan context

- **PR #2244 (Stage 1)**: prefix-iter + skip-applied → cuts ~15pp of `load_persisted_deltas`'s 21%.
- **This PR (Stage 3.a)**: tracing cleanup → cuts ~1.6pp more.
- **PR-C (Stage 3.b, later)**: incremental DAG updates from `execute.rs` so the scan only runs on startup → eliminates the residual ~6%.

## Test plan

- [x] `cargo build -p calimero-node` clean
- [x] `cargo test -p calimero-node` — 398 pass, including the 303-test integration suite
- [ ] Flamegraph comparison on a successful CI perf run — expect `ValueSet::record` / `<u8 as Display>::fmt` to drop to near-zero in `load_persisted_deltas`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to `tracing` fields/log structure to reduce per-delta/per-interval formatting overhead; no business logic, persistence, or merge semantics are altered.
> 
> **Overview**
> Reduces CPU overhead in `delta_store.rs` hot-path logging by switching several 32-byte IDs/hashes from Debug (`?`) to Display (`%`) via `Hash`, and by avoiding byte-by-byte formatting of WASM return payloads.
> 
> The per-delta WASM completion log now emits `returns_ok`/`returns_len` instead of `return_registers`, and the persisted-delta restore warning now logs only `remaining_count` plus a small base58 sample of unloadable delta IDs rather than Debug-printing the full ID list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit affbd059dbd565247f1c3d91337d22cf5a468d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->