### PR TITLE
fix(context): match resolve_service_blob semantics in module-cache staleness check

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -870,13 +870,44 @@ impl ContextManager {
                     //    writeback and module cache insert so we don't
                     //    stomp the fresh state.
                     if let Some(app) = act.applications.get_mut(&application_id) {
+                        // Both the staleness lookup and the writeback
+                        // must mirror `Application::resolve_service_blob`
+                        // exactly — that's where `blob` came from at
+                        // load time. For single-service bundles called
+                        // with `svc_name = None`, `resolve_service_blob`
+                        // returns `services.values().next()`, *not*
+                        // `app.blob`. Reading `app.blob.compiled` for
+                        // the staleness check would fail every time on
+                        // such bundles (the two blob_ids would never
+                        // match), defeating both the cache and the
+                        // recompile writeback.
                         let current_blob_id = match svc_name.as_deref() {
+                            None if app.services.is_empty() => Some(app.blob.compiled),
+                            None if app.services.len() == 1 => {
+                                app.services.values().next().map(|b| b.compiled)
+                            }
+                            // Multi-service with no name is ambiguous —
+                            // `resolve_service_blob` returns None so we
+                            // never get here via the happy path. Treat
+                            // as stale.
+                            None => None,
                             Some(name) => app.services.get(name).map(|b| b.compiled),
-                            None => Some(app.blob.compiled),
                         };
 
                         if current_blob_id == Some(original_blob_id) {
-                            match svc_name.as_deref() {
+                            // Writeback target must match the same
+                            // resolution. `services.len() == 1` with
+                            // `svc_name = None` means the single
+                            // service entry is the owner — pull its
+                            // key so we can `get_mut` into it without
+                            // iterating twice.
+                            let target_service_key =
+                                if svc_name.is_none() && app.services.len() == 1 {
+                                    app.services.keys().next().cloned()
+                                } else {
+                                    svc_name.clone()
+                                };
+                            match target_service_key.as_deref() {
                                 Some(name) => {
                                     if let Some(svc_blob) = app.services.get_mut(name) {
                                         *svc_blob = blob;


### PR DESCRIPTION
## Problem

Post-landing bug in the module cache from PR #2243. The staleness check (and mirror writeback) in `ContextManager::get_module`'s `map_ok` closure doesn't match `Application::resolve_service_blob`'s three-case behaviour.

`resolve_service_blob(svc_name)` resolves where the compiled blob lives:

```rust
match service_name {
    None if self.services.is_empty() => Some(self.blob),
    None if self.services.len() == 1 => self.services.values().next().copied(),
    None                              => None,  // multi-service, no name
    Some(name)                        => self.services.get(name).copied(),
}
```

My post-task staleness lookup only handled two of the three cases:

```rust
let current_blob_id = match svc_name.as_deref() {
    Some(name) => app.services.get(name).map(|b| b.compiled),
    None       => Some(app.blob.compiled),   // <-- wrong for bundles
};
```

For single-service bundles called with `svc_name = None`, `original_blob_id` comes from `services.values().next()` (at `resolve_service_blob` time), but `current_blob_id` reads `app.blob`. The two never match for those apps:

- **Staleness check always fails** → module-cache insert always skipped → no caching for single-service bundles.
- **Recompile writeback** targets `app.blob` instead of the service entry → even if the check passed, the wrong field would be updated → subsequent `get_module` calls would re-read the stale service-entry blob_id from the DB.

Net effect: the cache PR landed as a no-op for apps packaged as bundles-with-one-service.

## Fix

Mirror `resolve_service_blob`'s three-arm match exactly, in both the staleness lookup and the writeback target:

- `None` + `services.is_empty()` → `app.blob`
- `None` + `services.len() == 1` → the single service entry (`services.get_mut(only_key)`)
- `Some(name)` → `services[name]`
- `None` + multi-service → treated as stale (unreachable via the happy path, but safe fallback — `resolve_service_blob` would have returned `None` at load time)

For the writeback I first find the target service key (for the `None` + single-service case), then `get_mut` into that key. Avoids iterating the services map twice.

## No behaviour change for

- Apps with no services (single-binary, pre-bundle apps) — `None` + empty → `app.blob` (same as before)
- Apps invoked with an explicit `service_name` — `Some(name)` (same as before)

## Test plan

- [x] `cargo build -p calimero-context` clean
- [x] `cargo test -p calimero-context -p calimero-primitives` green
- [ ] End-to-end verification: invoke `get_module` repeatedly on a bundled single-service app, confirm the module cache is populated and subsequent calls hit the cache (currently they never do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `ContextManager::get_module` cache staleness and compiled-blob writeback logic; a mistake here could cause missed caching or incorrect compiled blob pointers for bundled apps.
> 
> **Overview**
> Fixes `ContextManager::get_module`’s post-load staleness check and compiled-blob writeback to **match `Application::resolve_service_blob` semantics**.
> 
> This correctly handles the `svc_name = None` cases for *empty services*, *single-service bundles* (use the sole service entry rather than `app.blob`), and treats *multi-service without a name* as stale, ensuring module-cache inserts and recompile writebacks target the right blob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f73dc19eb230d11924952e8cf95afb87758f7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->