### PR TITLE
ci(fuzzy): stream docker container logs live to disk during runs

### DIFF
--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -223,6 +223,7 @@ jobs:
         id: kv-test
         run: |
           chmod +x scripts/run-vmagent.sh scripts/cleanup-vmagent.sh
+          mkdir -p fuzzy-test-logs/kv-store/docker-logs
           cd workflows/fuzzy-tests/kv-store
 
           echo "start_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
@@ -250,8 +251,37 @@ jobs:
             UPDATE_PID=$(grep "^update_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
             VMAGENT_PID=$(grep "^vmagent_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
           fi
+
+          # Stream docker logs live to disk so we keep them even when
+          # `merobox bootstrap run` tears containers down on exit — a
+          # post-run `docker logs` loop loses everything because the
+          # containers are already gone. Mirrors the pattern we settled
+          # on in e2e-rust-apps.yml (see merobox#207, #2179).
+          LOGDIR="$GITHUB_WORKSPACE/fuzzy-test-logs/kv-store/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+              # Label filter matches merobox-started containers; exclude
+              # short-lived `*-init` containers (setup-only, torn down
+              # quickly and not useful for diagnosing steady-state).
+              for c in $(docker ps --filter "label=calimero.node=true" \
+                                   --format "{{.Names}}" 2>/dev/null \
+                         | grep -v -- '-init$' || true); do
+                mark="$WATCHER_STATE_DIR/${c}"
+                if [ ! -f "$mark" ]; then
+                  touch "$mark"
+                  echo "[log-watcher] following $c"
+                  docker logs -f --timestamps "$c" \
+                    > "$LOGDIR/${c}.log" 2>&1 &
+                fi
+              done
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
           set +e
-          set -o pipefail 
+          set -o pipefail
           merobox bootstrap run \
               fuzzy-test.yml \
               --image "$IMAGE" \
@@ -260,6 +290,14 @@ jobs:
 
           exit_code=$?
           set +o pipefail
+
+          # Signal the watcher to stop and let the `docker logs -f`
+          # followers flush their final output before we move on.
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
 
           echo "end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
@@ -439,6 +477,7 @@ jobs:
         id: handlers-test
         run: |
           chmod +x scripts/run-vmagent.sh scripts/cleanup-vmagent.sh
+          mkdir -p fuzzy-test-logs/kv-store-with-handlers/docker-logs
           cd workflows/fuzzy-tests/kv-store-with-handlers
 
           echo "start_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
@@ -466,8 +505,31 @@ jobs:
             UPDATE_PID=$(grep "^update_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
             VMAGENT_PID=$(grep "^vmagent_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
           fi
+
+          # Live docker-logs watcher — see the kv-store job for the
+          # rationale (merobox tears containers down on exit).
+          LOGDIR="$GITHUB_WORKSPACE/fuzzy-test-logs/kv-store-with-handlers/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+              for c in $(docker ps --filter "label=calimero.node=true" \
+                                   --format "{{.Names}}" 2>/dev/null \
+                         | grep -v -- '-init$' || true); do
+                mark="$WATCHER_STATE_DIR/${c}"
+                if [ ! -f "$mark" ]; then
+                  touch "$mark"
+                  echo "[log-watcher] following $c"
+                  docker logs -f --timestamps "$c" \
+                    > "$LOGDIR/${c}.log" 2>&1 &
+                fi
+              done
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
           set +e
-          set -o pipefail 
+          set -o pipefail
           merobox bootstrap run \
               fuzzy-test.yml \
               --image "$IMAGE" \
@@ -476,6 +538,12 @@ jobs:
 
           exit_code=$?
           set +o pipefail
+
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
 
           echo "end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The fuzzy-load-test jobs upload `fuzzy-test-logs/<app>/` as an artifact, but it only contains merobox's own log redirect (under `logs/` inside the workflow dir). When a test aborts early — e.g. `wait_for_sync` timing out at 60s during the governance cold-start race (#2236 / #2237) — merobox's redirect never populates and we get a near-empty artifact with no node-side tracing.

A post-run `docker logs` loop doesn't work either: `merobox bootstrap run` tears the runtime containers down on exit (regardless of `stop_all_nodes`), leaving only init-container names by the time the shell regains control. `e2e-rust-apps.yml` hit the same wall and settled on a live-streaming watcher (merobox#207, #2179).

I tried the post-run `docker logs` approach first and realized it's exactly what the e2e team already ruled out — thanks for the heads-up in review.

## Fix

Adopt the e2e pattern here:

1. Before `merobox bootstrap run`, spawn a background watcher that polls `docker ps` every second.
2. For each new `label=calimero.node=true` container (excluding `*-init`), fork a `docker logs -f --timestamps` follower into `fuzzy-test-logs/<app>/docker-logs/<container>.log`.
3. After merobox returns, `touch` a stop marker, `sleep 2` so followers flush, kill any leftover background processes, and proceed.

The follower processes capture output while containers are live; by the time merobox tears them down the logs are already on disk. Same treatment for both the kv-store and handlers jobs.

The new files land inside the existing `fuzzy-test-logs/<app>/` artifact — no new uploads, no retention tweaks.

## Why this matters right now

We've been hitting this pattern repeatedly on recent master runs (2 of the last 2 b83f924d runs failed at setup with 0-byte log artifacts). With this PR, the next failure will include per-node debug tracing so we can actually diagnose whether nodes are failing to receive the context registration, failing to persist it, or receiving it but losing it later.

## Test plan

- [ ] Trigger a dispatch run on this branch and confirm `fuzzy-test-logs/kv-store/docker-logs/fuzzy-kv-node-{1..4}.log` are populated on both success and early-abort outcomes
- [ ] Confirm the watcher shuts down cleanly (no dangling background processes at step exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects how workflow artifacts are collected; main risk is flakiness from added background `docker logs -f` processes or missed cleanup in the GitHub Actions runner.
> 
> **Overview**
> Adds a live Docker log streaming watcher to the `fuzzy-load-test.yml` kv-store and handlers fuzzy-test jobs, writing per-container logs to `fuzzy-test-logs/<app>/docker-logs/` while `merobox bootstrap run` is executing so logs survive container teardown.
> 
> The workflow now creates the new log directories up front and performs explicit watcher shutdown/cleanup after the run (stop marker, brief flush delay, kill/wait) before continuing with existing metrics/profiling collection and artifact upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a0d2b1b4361e129c9f8671ecc5a577008e8e244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->