### PR TITLE
ci(fuzzy): settle KeyDelivery gossip before handlers test starts

### DIFF
--- a/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
@@ -45,9 +45,25 @@ steps:
       - fuzzy-handlers-node-2
       - fuzzy-handlers-node-3
       - fuzzy-handlers-node-4
-    timeout: 60
+    timeout: 120
     check_interval: 2
     trigger_sync: true
+
+  # Temporary mitigation for #2237 (fire-and-forget gossip → no delivery guarantee).
+  # `wait_for_sync` only proves the DAG root-hash converged; it does NOT prove
+  # that KeyDelivery messages reached every member. On fast mesh formation the
+  # last joiner can reach root-hash parity before it has received the group's
+  # sender key, causing every execute to fail at
+  # `context/src/handlers/execute/mod.rs:180` (silent InternalError, "group
+  # known but group key not yet loaded AND identity.sender_key == None").
+  # Observed as 100% failure on fuzzy-handlers-node-4 in run 24891646958.
+  #
+  # 30 s is conservative: gossipsub GRAFT + key-delivery round-trip fits well
+  # under that on a healthy mesh. Remove once #2237's three-phase contract
+  # (readiness-gate + ack-confirmed publish) covers KeyDelivery.
+  - name: Settle KeyDelivery gossip before fuzzy start
+    type: wait
+    seconds: 30
 
   - name: Verify handlers mesh synced
     type: assert


### PR DESCRIPTION
## Summary

Short-term mitigation for a 100% repro of handler-test failure observed in fuzzy run [24891646958](https://github.com/calimero-network/core/actions/runs/24891646958). Adds a 30 s wait between mesh formation and the fuzzy phase, and bumps \`wait_for_sync\` timeout from 60 s to 120 s.

## Root cause (not a regression from this PR family)

Every request on \`fuzzy-handlers-node-4\` returned \`HandlerError(InternalError)\` within ~77µs of receipt — before WASM runs. Traced to \`crates/context/src/handlers/execute/mod.rs:180\`, the silent branch where the context is known to be in a group (\`get_group_for_context\` → \`Some(gid)\`), the current group key isn't loaded yet (\`load_current_group_key\` → \`None\`/\`Err\`), and \`identity.sender_key\` is \`None\`. Both fallbacks miss → \`InternalError\` with no log.

Timeline on node-4:
- \`T0 = 13:23:13\`: context identity generated
- \`T0 + 2 s\`: \"member joined group via direct request-response\"
- \`T0 + 2.01 s\`: node-4 publishes its own KeyDelivery
- \`T0 + 3 s\`: \`wait_for_sync\` passes (DAG root parity reached)
- \`T0 + 3 s\`: fuzzy test fires first \`set\` → fails, every subsequent request fails
- 356/356 requests failed; other nodes 0/876.

\`wait_for_sync\` only checks DAG root-hash convergence. It doesn't prove that every new member has received the **group's sender key** via KeyDelivery gossip. Under the faster mesh-formation timings after PR #2244 onward, the window between \"DAG in sync\" and \"group key delivered\" widened enough to repro 100% on the last-joined node.

## Why this is a workflow-side patch

The real fix belongs to #2237 (\"three-phase contract: readiness-gate → ack-confirmed publish → typed delivery report\"). That issue currently scopes governance endpoints; KeyDelivery is the same fire-and-forget pattern and should be the next consumer once the contract lands. See my comment on #2237.

This PR just buys the handlers test a reliable green until #2237 covers KeyDelivery.

## Test plan

- [ ] CI: fuzzy-load-test passes on both kv-store and kv-store-with-handlers variants
- [ ] Run is green end-to-end (45 min handlers test completes)
- [ ] Track remove-this-wait follow-up in #2237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow-only timing changes that may slightly increase test runtime but don’t affect production code paths.
> 
> **Overview**
> Improves reliability of the `kv-store-with-handlers` fuzzy workflow by increasing the `wait_for_sync` timeout from 60s to 120s and inserting a 30s `wait` before the fuzzy phase to allow KeyDelivery gossip to propagate.
> 
> Adds explicit comments documenting the mitigation and linking it to the underlying delivery-guarantee gap tracked in `#2237`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a532e5ee5357d585dedffadd3dd9487a0fe06f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->