### PR TITLE
fix(sync): request governance catch-up on unknown peer instead of closing

### DIFF
--- a/crates/node/src/handlers/stream_opened.rs
+++ b/crates/node/src/handlers/stream_opened.rs
@@ -42,7 +42,7 @@ pub fn handle_stream_opened(
         let sync_manager = node_manager.managers.sync.clone();
         let _ignored = ctx.spawn(
             async move {
-                sync_manager.handle_opened_stream(stream).await;
+                sync_manager.handle_opened_stream(peer_id, stream).await;
             }
             .into_actor(node_manager),
         );

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2285,9 +2285,12 @@ impl SyncManager {
         Ok(())
     }
 
-    pub async fn handle_opened_stream(&self, mut stream: Box<Stream>) {
+    pub async fn handle_opened_stream(&self, peer_id: PeerId, mut stream: Box<Stream>) {
         loop {
-            match self.internal_handle_opened_stream(&mut stream).await {
+            match self
+                .internal_handle_opened_stream(peer_id, &mut stream)
+                .await
+            {
                 Ok(None) => break,
                 Ok(Some(())) => {}
                 Err(err) => {
@@ -2304,7 +2307,11 @@ impl SyncManager {
         }
     }
 
-    async fn internal_handle_opened_stream(&self, stream: &mut Stream) -> eyre::Result<Option<()>> {
+    async fn internal_handle_opened_stream(
+        &self,
+        peer_id: PeerId,
+        stream: &mut Stream,
+    ) -> eyre::Result<Option<()>> {
         let Some(message) = self.recv(stream, None).await? else {
             return Ok(None);
         };
@@ -2385,26 +2392,35 @@ impl SyncManager {
                 .context_client
                 .has_member(&context_id, &their_identity)?
             {
-                // The joiner may have just published a governance op announcing
-                // their membership. Wait briefly for gossip propagation and retry.
-                debug!(
-                    %context_id,
-                    %their_identity,
-                    "member not found yet, waiting for governance gossip"
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                // The peer may have just published MemberAdded for themselves
+                // (or their side of the governance DAG is ahead of ours) and
+                // gossipsub hasn't delivered it yet. Instead of waiting and
+                // hoping the gossip arrives, ask this peer directly for the
+                // current namespace governance state on a separate stream —
+                // it's the fastest path out of the "unknown member" state and
+                // avoids a 30 s stall waiting for `NamespaceStateHeartbeat`.
+                //
+                // Fire-and-forget governance propagation (issue #2237) is the
+                // underlying bug; this is a narrower mitigation in the
+                // responder path that converts the terminal close into an
+                // active catch-up request.
+                self.request_governance_catchup_from_peer(peer_id, &context_id, &their_identity)
+                    .await;
 
                 if !self
                     .context_client
                     .has_member(&context_id, &their_identity)?
                 {
-                    // Still not found after waiting — close stream gracefully so the
-                    // initiator retries on its next sync interval rather than treating
-                    // this as a hard error. Governance gossip may still be in-flight.
-                    warn!(
+                    // Catch-up didn't resolve it (peer returned nothing, peer
+                    // also doesn't know, or the op chain isn't valid locally).
+                    // Close gracefully — the initiator retries on their next
+                    // sync interval. Demoted from warn to debug because this
+                    // is expected during mesh formation and would otherwise
+                    // spam logs on every cold join.
+                    debug!(
                         %context_id,
                         %their_identity,
-                        "unknown context member after governance sync, closing stream"
+                        "unknown context member after namespace backfill request, closing stream"
                     );
                     return Ok(Some(()));
                 }
@@ -2555,6 +2571,177 @@ impl SyncManager {
 }
 
 impl SyncManager {
+    /// Actively request governance catch-up from a specific peer whose
+    /// identity we don't yet recognize as a context member.
+    ///
+    /// Scenario: a peer opens a sync stream to us, but their identity isn't
+    /// in our local governance DAG yet because fire-and-forget `MemberAdded`
+    /// gossip (issue #2237) hasn't reached us. The legacy path waited 2 s
+    /// for gossip and then closed the stream, stalling the initiator for
+    /// up to 30 s (`NamespaceStateHeartbeat` cadence). Instead, open a
+    /// separate stream back to the peer with `NamespaceBackfillRequest`
+    /// (empty `delta_ids` = "send everything you have for this namespace"),
+    /// apply every op they return, and let the caller re-check membership.
+    ///
+    /// Best-effort: any failure (no group resolved, stream open fails,
+    /// peer returns no ops, ops fail to apply) is logged at debug and the
+    /// caller proceeds to close the stream as before. The real fix is the
+    /// three-phase contract in #2237; this is a responder-side bandaid
+    /// that turns a 30 s stall into at worst a second round-trip.
+    async fn request_governance_catchup_from_peer(
+        &self,
+        peer_id: PeerId,
+        context_id: &ContextId,
+        their_identity: &PublicKey,
+    ) {
+        let store = self.context_client.datastore();
+        let namespace_id =
+            match calimero_context::group_store::get_group_for_context(store, context_id) {
+                Ok(Some(group_id)) => {
+                    match calimero_context::group_store::resolve_namespace(store, &group_id) {
+                        Ok(ns) => ns.to_bytes(),
+                        Err(err) => {
+                            debug!(
+                                %context_id,
+                                %their_identity,
+                                %err,
+                                "failed to resolve namespace for governance catch-up"
+                            );
+                            return;
+                        }
+                    }
+                }
+                Ok(None) => {
+                    debug!(
+                        %context_id,
+                        %their_identity,
+                        "context not in a group — no namespace to request catch-up from"
+                    );
+                    return;
+                }
+                Err(err) => {
+                    debug!(
+                        %context_id,
+                        %their_identity,
+                        %err,
+                        "failed to resolve group for governance catch-up"
+                    );
+                    return;
+                }
+            };
+
+        let mut stream = match self.network_client.open_stream(peer_id).await {
+            Ok(s) => s,
+            Err(err) => {
+                debug!(
+                    %context_id,
+                    %their_identity,
+                    %peer_id,
+                    %err,
+                    "failed to open catch-up stream to peer"
+                );
+                return;
+            }
+        };
+
+        let msg = StreamMessage::Init {
+            context_id: ContextId::from([0u8; 32]),
+            party_id: PublicKey::from([0u8; 32]),
+            payload: InitPayload::NamespaceBackfillRequest {
+                namespace_id,
+                delta_ids: Vec::new(),
+            },
+            next_nonce: rand::thread_rng().gen(),
+        };
+
+        if let Err(err) = super::stream::send(&mut stream, &msg, None).await {
+            debug!(
+                %context_id,
+                %their_identity,
+                %peer_id,
+                %err,
+                "failed to send NamespaceBackfillRequest during catch-up"
+            );
+            return;
+        }
+
+        let response = match super::stream::recv(&mut stream, None, self.sync_config.timeout).await
+        {
+            Ok(Some(StreamMessage::Message {
+                payload: MessagePayload::NamespaceBackfillResponse { deltas },
+                ..
+            })) => deltas,
+            Ok(_) => {
+                debug!(
+                    %context_id,
+                    %their_identity,
+                    %peer_id,
+                    "unexpected response to NamespaceBackfillRequest during catch-up"
+                );
+                return;
+            }
+            Err(err) => {
+                debug!(
+                    %context_id,
+                    %their_identity,
+                    %peer_id,
+                    %err,
+                    "catch-up NamespaceBackfillRequest timed out or failed"
+                );
+                return;
+            }
+        };
+
+        if response.is_empty() {
+            debug!(
+                %context_id,
+                %their_identity,
+                %peer_id,
+                "peer returned no namespace ops for catch-up"
+            );
+            return;
+        }
+
+        let ops_count = response.len();
+        let mut applied = 0usize;
+        for (_delta_id, op_bytes) in response {
+            let op = match borsh::from_slice::<
+                calimero_context_client::local_governance::SignedNamespaceOp,
+            >(&op_bytes)
+            {
+                Ok(o) => o,
+                Err(err) => {
+                    debug!(
+                        %context_id,
+                        %their_identity,
+                        %err,
+                        "failed to decode catch-up op"
+                    );
+                    continue;
+                }
+            };
+            if let Err(err) = self.context_client.apply_signed_namespace_op(op).await {
+                debug!(
+                    %context_id,
+                    %their_identity,
+                    %err,
+                    "failed to apply catch-up op"
+                );
+                continue;
+            }
+            applied += 1;
+        }
+
+        debug!(
+            %context_id,
+            %their_identity,
+            %peer_id,
+            ops_received = ops_count,
+            ops_applied = applied,
+            "governance catch-up complete"
+        );
+    }
+
     /// Handle a namespace backfill request: look up full `SignedNamespaceOp`
     /// payloads for the requested delta IDs and send them back.
     ///


### PR DESCRIPTION
## Summary

Narrow mitigation for the fuzzy-test failures traced to #2237. The responder side of the sync handshake previously had a 2 s sleep-and-close fallback when the initiator's identity wasn't yet known as a context member. Replace that with an active \`NamespaceBackfillRequest\` to the peer, apply every returned op, and re-check membership. Only close if the catch-up also failed.

## Why

In fuzzy run [24891646958](https://github.com/calimero-network/core/actions/runs/24891646958) the last-joined node (\`fuzzy-handlers-node-4\`) hit 100 % request failure — every set/get/entries returned \`HandlerError(InternalError)\` for the full test. Traced to a cascade:

1. Node-4 joined the namespace; \`join_namespace\` returned Ok.
2. Fire-and-forget \`MemberAdded\` gossip for the existing members didn't reach node-4 before its 2 s sleep-retry window closed.
3. When existing members tried to push state deltas to node-4, node-4 rejected the inbound streams with:
   \`\`\`
   WARN calimero_node::sync::manager:
     unknown context member after governance sync, closing stream
   \`\`\`
4. Every subsequent sync opportunity from peers toward node-4 failed the same way. \`NamespaceStateHeartbeat\` (30 s cadence) didn't recover in time.

\`wait_for_sync\` missed this because it only checks DAG root-hash parity, which matches at genesis before any writes happen.

## What changed

\`crates/node/src/sync/manager/mod.rs\`:
- New \`request_governance_catchup_from_peer(peer_id, context_id, their_identity)\`: resolves the namespace from the context, opens a fresh stream to the peer, sends \`NamespaceBackfillRequest { namespace_id, delta_ids: vec![] }\` (= \"give me everything\"), and applies every \`SignedNamespaceOp\` in the response.
- Responder's \"unknown member\" branch now calls the catch-up helper **instead of** sleeping 2 s and closing.
- If membership still doesn't resolve after catch-up, close the stream (the initiator retries on its next sync interval, which is the correct fallback). Log demoted from \`warn\` to \`debug\` — this path is expected during mesh formation and would otherwise spam logs on every cold join.

\`crates/node/src/handlers/stream_opened.rs\` + \`sync/manager/mod.rs::handle_opened_stream\`:
- Threaded \`peer_id\` (already available at \`StreamOpened\` routing) into \`handle_opened_stream\` → \`internal_handle_opened_stream\` so the catch-up helper has a peer to open a reverse stream to.

## What this isn't

A fix for the underlying design flaw. Member-list propagation is still fire-and-forget: if the peer sending us the op chain also doesn't have the full history, catch-up returns nothing and we close just like before. The proper fix is #2237's three-phase contract (readiness-gate → ack-confirmed-publish → typed delivery report) applied to \`MemberAdded\` / \`KeyDelivery\` / delta broadcast. Once that lands, the responder should never see an unknown member in the first place.

In the meantime: turns a 30 s stall into at worst a second round-trip.

## Test plan

- [x] \`cargo test -p calimero-node --lib\` — all 54 tests pass
- [ ] Fuzzy \`kv-store\` test: confirm node-4 converges after seed writes (was stuck at pre-seed root hash)
- [ ] Fuzzy \`kv-store-with-handlers\` test: confirm node-4 stops returning \`InternalError\` on every request
- [ ] Re-measure perf on top of this + #2248 to establish a new baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync responder handshake and governance-op application paths; incorrect backfill or stream handling could cause sync stalls or unintended governance state changes, though the new logic is best-effort and falls back to prior close behavior.
> 
> **Overview**
> Prevents cold-join sync deadlocks by replacing the responder’s 2s *wait-and-close* behavior on “unknown member” with an active governance catch-up: it opens a reverse stream to the peer, sends an empty `NamespaceBackfillRequest` ("send all"), applies returned `SignedNamespaceOp`s, and then re-checks membership before deciding to close.
> 
> Threads `peer_id` through `handle_opened_stream` → `internal_handle_opened_stream` so the responder can target the initiating peer, and demotes the “still unknown member” log from `warn` to `debug` to reduce expected mesh-formation noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5731a9280f26b50fc8d5b67f227318b2a87f60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->