### PR TITLE
fix(dag): flatten cascade recursion to prevent stack overflow

### DIFF
--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -419,6 +419,12 @@ impl<T: Clone> DagStore<T> {
         // Check if we can apply immediately
         if self.can_apply(&delta) {
             self.apply_delta(delta, applier).await?;
+            // Cascade any pending children that this delta unblocked.
+            // Cascading is now done iteratively at the call site rather
+            // than recursively from inside `apply_delta` so the stack
+            // depth stays constant regardless of cascade length. See
+            // `test_cascade_does_not_grow_stack`.
+            self.apply_pending(applier).await?;
             Ok(AddDeltaOutcome::Applied)
         } else {
             // Missing parents - store as pending
@@ -465,8 +471,14 @@ impl<T: Clone> DagStore<T> {
             }
             self.heads.insert(delta.id);
 
-            // Try to apply pending deltas
-            self.apply_pending(applier).await?;
+            // Cascade is intentionally NOT triggered here. Doing so made
+            // `apply_delta` and `apply_pending` mutually recursive: each
+            // cascaded child added another `apply_delta` frame on the
+            // stack, overflowing the (default 2 MB) tokio test thread
+            // stack at ~1000-deep linear chains. Callers
+            // (`add_delta_with_outcome`, `apply_pending`,
+            // `try_process_pending`) drive the cascade iteratively
+            // instead. See `test_cascade_does_not_grow_stack`.
 
             Ok(())
         })

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -1075,6 +1075,61 @@ async fn test_extreme_random_order_1000_deltas() {
     assert_eq!(dag.get_heads(), vec![final_head]);
 }
 
+/// Deterministic worst-case for the cascade-recursion stack-overflow that
+/// `test_extreme_random_order_1000_deltas` was hitting flakily.
+///
+/// Build a 2000-delta linear chain and feed it in **strict reverse order**
+/// (delta 2000 first, root-child last). Every arrival before the last is
+/// missing its parent, so 1999 entries stack up in `pending`. When delta 1
+/// finally arrives, the cascade must apply 1999 children. With the legacy
+/// `apply_delta → apply_pending → apply_delta` mutual recursion the cascade
+/// nests stack frames per child and overflows the default 2 MB tokio test
+/// thread stack. With the flattened iteration, depth is constant.
+///
+/// Using `tokio::test(flavor = "current_thread")` and an explicit chain
+/// length guarantees the failure is reproducible — the existing
+/// `test_extreme_random_order_1000_deltas` shuffles randomly and only
+/// overflows when the shuffle happens to land on a long tail.
+#[tokio::test(flavor = "current_thread")]
+async fn test_cascade_does_not_grow_stack() {
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    const N: u64 = 2000;
+    let mut deltas = Vec::with_capacity(N as usize);
+    for i in 1..=N {
+        let id = {
+            let mut bytes = [0u8; 32];
+            bytes[0..8].copy_from_slice(&i.to_le_bytes());
+            bytes
+        };
+        let parent_id = {
+            let mut bytes = [0u8; 32];
+            bytes[0..8].copy_from_slice(&(i - 1).to_le_bytes());
+            bytes
+        };
+        deltas.push(CausalDelta::new_test(
+            id,
+            vec![parent_id],
+            TestPayload { value: i as u32 },
+        ));
+    }
+
+    // Reverse order: every arrival except the last goes pending.
+    for delta in deltas.into_iter().rev() {
+        dag.add_delta(delta, &applier).await.unwrap();
+    }
+
+    assert_eq!(dag.pending_stats().count, 0);
+    assert_eq!(dag.stats().applied_deltas, (N + 1) as usize);
+    let final_head = {
+        let mut bytes = [0u8; 32];
+        bytes[0..8].copy_from_slice(&N.to_le_bytes());
+        bytes
+    };
+    assert_eq!(dag.get_heads(), vec![final_head]);
+}
+
 #[tokio::test]
 async fn test_extreme_mixed_topology_500_deltas() {
     let applier = TestApplier::new();


### PR DESCRIPTION
## Summary

\`apply_delta\` and \`apply_pending\` were mutually recursive. With a deep linear chain applied in reverse order (e.g. delta 1000 → 999 → ... → 1, where each arrival is missing its parent until the last), the cascade nested an \`apply_delta\` frame per child on top of the previous, overflowing the default 2 MB tokio test thread stack at around 1000 deltas. Surfaced as the flaky \`test_extreme_random_order_1000_deltas\` failure — flaky because the test shuffles randomly and only hits the worst case sometimes.

Fix: move the cascade out of \`apply_delta\`. Callers already drive cascades iteratively in their own \`while applied_any\` loops; only \`add_delta_with_outcome\` needed an explicit \`apply_pending\` call after the immediate-apply branch to preserve the previous \"apply triggers cascade\" behavior. Stack depth is now constant regardless of cascade length.

## What changed

\`crates/dag/src/lib.rs\`:
- Removed the \`self.apply_pending(applier).await?\` call from inside \`apply_delta\`. Comment explains why.
- Added \`self.apply_pending(applier).await?\` after \`apply_delta\` in \`add_delta_with_outcome\`'s immediate-apply branch.
- \`apply_pending\` and \`try_process_pending\` were already iterative — no behavior change for those.

\`crates/dag/src/tests.rs\`:
- New \`test_cascade_does_not_grow_stack\` — deterministic 2000-delta reverse-order stress test, pinned to \`flavor = \"current_thread\"\`. Overflows on the recursive implementation; passes on the flat one. Replaces relying on \`test_extreme_random_order_1000_deltas\`'s random shuffle to hit the bad ordering.

## Verification

- New test reproduces the overflow before the fix (verified by running it on master without the lib.rs change — instant SIGABRT).
- After the fix: 10/10 stable runs of \`test_cascade_does_not_grow_stack\`.
- \`cargo test -p calimero-dag --lib\` — 49/49 pass.
- \`cargo test -p calimero-node --lib\` — 54/54 pass.
- \`cargo test -p calimero-context --lib\` — 130/130 pass.

## Bonus: micro-perf win

Flat iteration is faster than nested recursion (no per-cascade async-frame setup teardown). Not measured here — the goal was correctness — but should show up as a small drop in \`record_dag_write_lock_hold\` tail times under bursty cascades.

## Test plan

- [x] Deterministic stack-overflow repro added and passes after fix
- [x] All dag/node/context lib tests pass
- [ ] Re-run flaky CI \`test_extreme_random_order_1000_deltas\` 20+ times to confirm no regression on the random-order side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/where pending cascades are triggered during delta application; incorrect sequencing could leave pending deltas unapplied or change apply ordering. Adds a large deterministic stress test that could be sensitive to runtime differences but should reduce flakiness.
> 
> **Overview**
> Prevents deep-cascade stack overflows by **removing cascade triggering from inside** `DagStore::apply_delta` (eliminating `apply_delta`↔`apply_pending` mutual recursion) and instead **driving cascades iteratively at call sites**.
> 
> To preserve prior behavior, `add_delta_with_outcome` now explicitly calls `apply_pending` after an immediate apply.
> 
> Adds a deterministic regression test (`test_cascade_does_not_grow_stack`) that feeds a 2000-delta linear chain in strict reverse order on a `current_thread` tokio runtime to ensure cascades complete without growing stack depth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58db48954d465ca33a30422919d1a052d4158d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->