### PR TITLE
ci(fuzzy): cut routine runs to 15 min, add 60-min nightly soak at 00:00 UTC

### DIFF
--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -671,11 +671,19 @@ jobs:
     if: always()
     steps:
       - name: Generate summary
+        # Priority must match the duration-resolution blocks in both
+        # fuzzy-test jobs above: `duration_override` first (it wins when
+        # set, regardless of trigger), schedule second, routine last.
+        # The three conditions are mutually exclusive in practice today
+        # because `schedule` events carry no `inputs`, but keeping the
+        # priority consistent avoids a silent drift if GitHub ever lets
+        # scheduled runs accept dispatch inputs or if a future operator
+        # adds another trigger that can set both.
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            RUN_KIND="Nightly soak (60 min)"
-          elif [ -n "${{ github.event.inputs.duration_override }}" ]; then
+          if [ -n "${{ github.event.inputs.duration_override }}" ]; then
             RUN_KIND="Manual override (${{ github.event.inputs.duration_override }} min)"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            RUN_KIND="Nightly soak (60 min)"
           else
             RUN_KIND="Routine (15 min)"
           fi

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -29,21 +29,31 @@ on:
       - "apps/**"
       - "workflows/fuzzy-tests/**"
       - ".github/workflows/fuzzy-load-test.yml"
-  # No `pull_request` trigger — fuzzy-load-test is a 45-minute soak/perf
-  # run whose job needs `ghcr.io/calimero-network/merod:pr-<N>-profiling`,
-  # and the `release-merod-profiling-container` job that would publish
-  # that tag is gated `if: github.event_name != 'pull_request'` in
-  # release.yml. Any PR that modifies this workflow's own paths — e.g.
-  # this YAML or `workflows/fuzzy-tests/**` — would fire the test and
-  # fail on `docker pull ... "manifest unknown"`. Run this job on
-  # master pushes (where the profiling image IS published) or manually
-  # via `workflow_dispatch`.
+  # No `pull_request` trigger — fuzzy-load-test is a perf/soak run whose
+  # job needs `ghcr.io/calimero-network/merod:pr-<N>-profiling`, and the
+  # `release-merod-profiling-container` job that would publish that tag
+  # is gated `if: github.event_name != 'pull_request'` in release.yml.
+  # Any PR that modifies this workflow's own paths — e.g. this YAML or
+  # `workflows/fuzzy-tests/**` — would fire the test and fail on
+  # `docker pull ... "manifest unknown"`. Run this job on master pushes
+  # (where the profiling image IS published) or manually via
+  # `workflow_dispatch`.
+  #
+  # Nightly soak: a longer run (default 60 minutes per app vs the 15
+  # minutes used for routine triggers) fires at 00:00 UTC daily. The
+  # 15-minute baseline gives statistically usable CPU samples and
+  # exercises most code paths — enough for catching regressions on
+  # every push. The nightly extends the window so slow leaks, rare
+  # cascade orderings, and gradual degradation that need >15 min to
+  # materialize still get caught daily.
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       duration_override:
-        description: "Override test duration (minutes per app)"
+        description: "Override test duration (minutes per app). Empty = default (15 normally, 60 for scheduled nightly soak)."
         required: false
-        default: "45"
+        default: ""
         type: string
       test_app:
         description: "Run specific app test (kv-store, kv-store-with-handlers, or all)"
@@ -161,8 +171,19 @@ jobs:
         uses: ./.github/actions/setup-merobox
 
       - name: Override test duration
+        # Default is 15 minutes for routine triggers (push, workflow_run,
+        # workflow_dispatch with empty input) and 60 minutes for the
+        # nightly schedule. workflow_dispatch.inputs.duration_override
+        # wins over both when set.
         run: |
-          DURATION="${{ github.event.inputs.duration_override || '45' }}"
+          if [ -n "${{ github.event.inputs.duration_override }}" ]; then
+            DURATION="${{ github.event.inputs.duration_override }}"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            DURATION="60"
+          else
+            DURATION="15"
+          fi
+          echo "Using duration: ${DURATION} minutes (trigger: ${{ github.event_name }})"
           cd workflows/fuzzy-tests/kv-store
           sed -i "s/\(duration_minutes: \)[0-9]*/\1$DURATION/" fuzzy-test.yml
 
@@ -415,8 +436,18 @@ jobs:
         uses: ./.github/actions/setup-merobox
 
       - name: Override test duration
+        # Default is 15 minutes for routine triggers and 60 minutes for
+        # the nightly schedule. See the equivalent step in
+        # fuzzy-test-kv-store for details.
         run: |
-          DURATION="${{ github.event.inputs.duration_override || '45' }}"
+          if [ -n "${{ github.event.inputs.duration_override }}" ]; then
+            DURATION="${{ github.event.inputs.duration_override }}"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            DURATION="60"
+          else
+            DURATION="15"
+          fi
+          echo "Using duration: ${DURATION} minutes (trigger: ${{ github.event_name }})"
           cd workflows/fuzzy-tests/kv-store-with-handlers
           sed -i "s/\(duration_minutes: \)[0-9]*/\1$DURATION/" fuzzy-test.yml
 
@@ -641,8 +672,17 @@ jobs:
     steps:
       - name: Generate summary
         run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            RUN_KIND="Nightly soak (60 min)"
+          elif [ -n "${{ github.event.inputs.duration_override }}" ]; then
+            RUN_KIND="Manual override (${{ github.event.inputs.duration_override }} min)"
+          else
+            RUN_KIND="Routine (15 min)"
+          fi
           echo "## Fuzzy Load Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Run kind:** ${RUN_KIND}" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Profiling Enabled:** ${{ github.event.inputs.enable_profiling || 'true' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
@@ -60,9 +60,15 @@ steps:
 
   # Main fuzzy test for kv-store-with-handlers
   # Note: No seed data needed - fuzzy test generates its own data
+  #
+  # 15 min is the routine baseline used by every CI trigger (push,
+  # workflow_run, workflow_dispatch). The CI workflow overrides this to
+  # 60 min on the nightly schedule (cron 00:00 UTC) for soak coverage.
+  # Override on demand via the workflow_dispatch `duration_override`
+  # input. See `.github/workflows/fuzzy-load-test.yml`.
   - name: KV Store with Handlers Fuzzy Load Test
     type: fuzzy_test
-    duration_minutes: 45
+    duration_minutes: 15
     context_id: "{{handlers_context_id}}"
     summary_interval_seconds: 60
     operation_delay_ms: 50

--- a/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
@@ -83,9 +83,15 @@ steps:
     check_interval: 2
 
   # Main fuzzy test for kv-store
+  #
+  # 15 min is the routine baseline used by every CI trigger (push,
+  # workflow_run, workflow_dispatch). The CI workflow overrides this to
+  # 60 min on the nightly schedule (cron 00:00 UTC) for soak coverage.
+  # Override on demand via the workflow_dispatch `duration_override`
+  # input. See `.github/workflows/fuzzy-load-test.yml`.
   - name: KV Store Fuzzy Load Test
     type: fuzzy_test
-    duration_minutes: 45
+    duration_minutes: 15
     context_id: "{{kv_context_id}}"
     summary_interval_seconds: 60
     operation_delay_ms: 50


### PR DESCRIPTION
## Summary

Routine fuzzy runs (push, workflow_run, workflow_dispatch) drop from 45 → 15 min. Adds a nightly schedule (\`cron: \"0 0 * * *\"\`) that runs both apps for 60 min each to preserve soak coverage.

## Why 15 min is enough for routine iteration

| Signal | Useful sample size | Time to collect |
|---|---|---|
| \`perf record\` CPU samples on hot fns | ~10k samples per fn | ~5–10 min (4 nodes × 99 Hz × 1–10 % CPU/fn) |
| Prometheus histogram p50/p95/p99 | 100+ points at ~15 s scrape | ~25 min for tight p99, usable after ~15 min |
| Memory trend | visible across cycles | ~15–20 min |
| Cascade / sync edge cases | 4 nodes × 20 op/s × 900 s ≈ 270k ops | ~10 min |
| Slow leaks / rare orderings | over hours | **nightly territory** |

15 min hits everything except slow-drift and rare-ordering. Those are now handled by the nightly soak.

## Duration resolution (all three triggers)

| Trigger | Input | Duration |
|---|---|---|
| \`workflow_dispatch\` + \`duration_override=\"30\"\` | explicit | 30 min |
| \`schedule\` (00:00 UTC) | — | 60 min |
| \`push\`, \`workflow_run\`, \`workflow_dispatch\` (empty input) | — | 15 min |

Verified with a local shell dry-run of the conditional — every trigger resolves as intended.

## What changed

- \`.github/workflows/fuzzy-load-test.yml\`:
  - Added \`schedule: - cron: \"0 0 * * *\"\`.
  - Both \`Override test duration\` steps now branch on \`github.event_name == 'schedule'\` (→ 60) and fall through to 15 otherwise. \`workflow_dispatch.inputs.duration_override\` wins when non-empty.
  - Changed the \`duration_override\` default from \`\"45\"\` → \`\"\"\` (empty) so the conditional above drives the default; updated its description.
  - Updated the trigger-comment block (was \"a 45-minute soak/perf run\").
  - Added a \"Run kind\" line to the GitHub step summary (Routine / Nightly soak / Manual override).
- \`workflows/fuzzy-tests/kv-store/fuzzy-test.yml\` and \`kv-store-with-handlers/fuzzy-test.yml\`:
  - In-tree \`duration_minutes: 45\` → \`15\` so local \`merobox bootstrap run\` uses the new baseline.
  - Added comments pointing back to \`.github/workflows/fuzzy-load-test.yml\` for the full override table.

## Net impact

- ~3.5× faster iteration on PRs / master pushes (15 min vs ~50 min wall-clock).
- No loss of soak coverage — moved to the daily schedule.
- Manual override still available for targeted investigations (e.g. \`gh workflow run ... -f duration_override=5\` for a quick smoke).

## Test plan

- [x] Both \`fuzzy-test.yml\` files still parse (pyyaml)
- [x] \`fuzzy-load-test.yml\` parses
- [x] Conditional dry-run confirms correct duration for all 5 trigger scenarios
- [ ] Land + watch the first routine master push to confirm 15 min wall-clock
- [ ] Watch first nightly firing at 00:00 UTC to confirm 60 min and the \"Nightly soak\" label in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/workflow-only changes that adjust scheduling and default test durations, with no production code impact. Main risk is reduced routine coverage if 15 minutes is insufficient to catch some regressions.
> 
> **Overview**
> Routine `fuzzy-load-test` runs now default to **15 minutes per app**, while a new **nightly scheduled soak** runs at `0 0 * * *` with **60 minutes per app**.
> 
> `workflow_dispatch` no longer hard-defaults `duration_override`; instead, duration is resolved by priority (`duration_override` input > scheduled nightly > routine) and the chosen run kind is surfaced in the GitHub step summary. Both `workflows/fuzzy-tests/*/fuzzy-test.yml` files update their in-repo `duration_minutes` baseline from `45` to `15` to match CI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb3f823877ad17c32c8942a069ac77d0f0df4f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->