### PR TITLE
fix(context): write ContextGroupRef directly during join instead of relying on governance ops

### DIFF
--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -1464,6 +1464,48 @@ fn register_and_unregister_context() {
     assert!(get_group_for_context(&store, &cid).unwrap().is_none());
 }
 
+/// The `join_group` handler registers every context listed in the
+/// received `JoinBundle` by calling `register_context_in_group`
+/// directly, rather than relying on the bundle's governance-op stream
+/// to apply a `ContextRegistered` op. This test pins the invariant:
+/// after that direct-register call, `get_group_for_context` resolves
+/// the mapping with no governance op applied. Removing the
+/// direct-register call from the handler would leave the mapping empty
+/// and break every downstream caller that resolves namespace from
+/// context (e.g. the unknown-member catch-up on the sync path).
+#[test]
+fn join_bundle_registration_writes_context_group_ref_without_governance_op() {
+    let store = test_store();
+    let gid = test_group_id();
+
+    let context_ids = [
+        ContextId::from([0x11; 32]),
+        ContextId::from([0x22; 32]),
+        ContextId::from([0x33; 32]),
+    ];
+
+    for cid in &context_ids {
+        assert!(
+            get_group_for_context(&store, cid).unwrap().is_none(),
+            "precondition: no mapping before register",
+        );
+    }
+
+    // Same call the join handler makes for each context in the bundle.
+    for cid in &context_ids {
+        register_context_in_group(&store, &gid, cid).unwrap();
+    }
+
+    for cid in &context_ids {
+        assert_eq!(
+            get_group_for_context(&store, cid).unwrap(),
+            Some(gid),
+            "every bundled context must have its group mapping after join \
+             registration, independent of governance-op application",
+        );
+    }
+}
+
 #[test]
 fn re_register_context_cleans_old_group() {
     let store = test_store();

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -218,6 +218,27 @@ impl Handler<JoinGroupRequest> for ContextManager {
                             }
                         }
 
+                        // Register the context-under-group mapping
+                        // (`ContextGroupRef`) directly from the bundle's
+                        // `context_ids`. The bundle's `governance_ops`
+                        // normally include a `ContextRegistered` op
+                        // that would write the same mapping on apply,
+                        // but the op list can be an incomplete snapshot
+                        // — missing the op leaves the mapping unwritten
+                        // and `get_group_for_context` returns `None`.
+                        // Idempotent with the governance-op path.
+                        for context_id in contexts {
+                            if let Err(err) = group_store::register_context_in_group(
+                                &datastore, &group_id, context_id,
+                            ) {
+                                warn!(
+                                    %context_id,
+                                    ?err,
+                                    "failed to register context under group during join"
+                                );
+                            }
+                        }
+
                         for context_id in contexts {
                             let config = if !context_client.has_context(context_id)? {
                                 let zero_app =


### PR DESCRIPTION
## Summary

The `join_group` handler's auto-join loop writes `ContextIdentity`, subscribes to the context topic, and triggers sync for every context in the received `JoinBundle`. It does **not** write `ContextGroupRef` — the context-to-group mapping — directly, relying instead on a `ContextRegistered` governance op being present in the bundle's `governance_ops` snapshot.

That snapshot can be incomplete. If `ContextRegistered` was published after the responder took the snapshot, the mapping never gets written, and every downstream caller that goes through `get_group_for_context` returns `None` — observed as a 30 s stall on the last-joined fuzzy node, where peer sync rejections cascaded from a missing mapping.

Fix: call `register_context_in_group` for every `context_id` in the bundle directly. The bundle explicitly lists them under `group_id`; we treat that as the source of truth. Idempotent with whatever the governance-op path may also write.

## Changes

- `crates/context/src/handlers/join_group.rs` — one new loop (inside the existing `auto_join` block) that calls `group_store::register_context_in_group(&datastore, &group_id, context_id)` for each `context_id` before any `sync_context_config`/subscribe work. Placed early so later code that reads the mapping sees it.

- `crates/context/src/group_store/tests.rs` — new regression test `join_bundle_registration_writes_context_group_ref_without_governance_op` that simulates the handler's registration loop with three context IDs and no governance ops applied, then asserts `get_group_for_context` resolves for each.

## Verification

- `cargo test -p calimero-context --lib` — 131/131 pass (130 existing + 1 new).
- `cargo test -p calimero-node --lib` — 54/54 pass.

## Scope notes

- Does not change the bundle producer on the responder side. If the producer's `governance_ops` snapshot is incomplete for other reasons, that's separate.
- Does not change the unknown-peer catch-up helper from the previous fix. With this change its primary path (`get_group_for_context` → namespace lookup) resolves correctly; the fallback additions I explored are no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `join_group` auto-join path and store writes for context/group indexing; risk is mainly around potential inconsistencies or unexpected overwrites during join, though the operation is intended to be idempotent.
> 
> **Overview**
> `join_group` now **directly writes the `ContextGroupRef` mapping** by calling `group_store::register_context_in_group` for every `context_id` in the join response before syncing/subscribing contexts, rather than implicitly relying on a `ContextRegistered` governance op to have been included and applied.
> 
> Adds a regression test (`join_bundle_registration_writes_context_group_ref_without_governance_op`) that asserts `get_group_for_context` resolves immediately after the direct registration step, even with *no governance ops applied*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2764575e1531d343197790ad8c879ed5cb84389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->