### PR TITLE
perf(storage): collapse find_by_id's two index reads into one

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -822,13 +822,10 @@ impl<S: StorageAdaptor> Interface<S> {
 
         let mut item = from_slice::<D>(&slice).map_err(StorageError::DeserializationError)?;
 
-        let (full_hash, _) =
-            <Index<S>>::get_hashes_for(id)?.ok_or(StorageError::IndexNotFound(id))?;
-
-        item.element_mut().merkle_hash = full_hash;
-
-        item.element_mut().metadata =
-            <Index<S>>::get_metadata(id)?.ok_or(StorageError::IndexNotFound(id))?;
+        // Single `EntityIndex` read for both merkle_hash and metadata.
+        let index = <Index<S>>::get_index(id)?.ok_or(StorageError::IndexNotFound(id))?;
+        item.element_mut().merkle_hash = index.full_hash();
+        item.element_mut().metadata = index.metadata;
 
         Ok(Some(item))
     }


### PR DESCRIPTION
## Summary

\`Interface::find_by_id\` called \`Index::get_hashes_for\` and \`Index::get_metadata\` back-to-back. Each of those internally calls \`Index::get_index\`, which reads the entity's \`EntityIndex\` record from storage and borsh-decodes it — so every lookup did two reads and two decodes, using just \`full_hash\` from the first and \`metadata\` from the second.

Call \`get_index\` once, read both fields off the decoded \`EntityIndex\`.

\`find_by_id\` is called on every delta apply (and on every read through the Collection iterator). Fuzzy-run CPU profile showed it aggregating ~12 % inclusive across three call stacks.

## Changes

\`crates/storage/src/interface.rs\` — 3 lines replacing 6. Public \`EntityIndex::full_hash()\` accessor + public \`metadata\` field are already in place; no API changes elsewhere.

## Verification

- \`cargo test -p calimero-storage\` — 405 lib tests + 4 doc tests pass.
- Behavior identical: both old call sites produced \`IndexNotFound(id)\` on missing index; the single call produces the same error in the same spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor limited to `find_by_id`, with no behavioral or API changes expected beyond fewer storage reads/decodes.
> 
> **Overview**
> `Interface::find_by_id` now performs a single `Index::get_index` lookup and uses the returned `EntityIndex` to fill in both `merkle_hash` and `metadata`, replacing the prior back-to-back calls that each reloaded/decoded the index.
> 
> This reduces per-lookup storage reads/decodes on a hot path without changing error behavior (`IndexNotFound` still occurs when the index record is missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611cdacf66867757175bb3c841861506fdb4efbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->