### PR TITLE
perf(node/governance): drop redundant serialize round-trip in heartbeat republish

### DIFF
--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -182,25 +182,14 @@ pub(super) fn handle_namespace_state_heartbeat(
                 for delta_id in &peer_needs {
                     let key = calimero_store::key::NamespaceGovOp::new(namespace_id, *delta_id);
                     if let Ok(Some(value)) = handle_inner.get(&key) {
-                        let Some(signed_bytes) =
-                            crate::sync::helpers::extract_signed_op_bytes(&value.skeleton_bytes)
+                        // Decode straight to the typed op so we can wrap it in
+                        // `NamespaceTopicMsg::Op` and serialize once. Going via
+                        // `extract_signed_op_bytes` would force a redundant
+                        // serialize/deserialize round-trip on every republish.
+                        let Some(signed_op) =
+                            crate::sync::helpers::extract_signed_op(&value.skeleton_bytes)
                         else {
                             continue;
-                        };
-                        // `extract_signed_op_bytes` returns raw `SignedNamespaceOp`
-                        // borsh (the storage form). Phase 2 of #2237 requires the
-                        // gossip-topic payload to be `NamespaceTopicMsg::Op(op)`,
-                        // so re-decode here and wrap before publishing.
-                        let signed_op: SignedNamespaceOp = match borsh::from_slice(&signed_bytes) {
-                            Ok(op) => op,
-                            Err(err) => {
-                                warn!(
-                                    %err,
-                                    delta_id = %hex::encode(delta_id),
-                                    "heartbeat republish: failed to decode stored op; skipping"
-                                );
-                                continue;
-                            }
                         };
                         let Ok(wrapped) = borsh::to_vec(&NamespaceTopicMsg::Op(signed_op)) else {
                             continue;

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -167,6 +167,30 @@ pub fn handle_entity_push(
     })
 }
 
+/// Extract a [`SignedNamespaceOp`](calimero_context_client::local_governance::SignedNamespaceOp)
+/// from a `skeleton_bytes` store value.
+///
+/// The store encodes entries as `StoredNamespaceEntry::Signed(op)`. Returns
+/// `None` for opaque skeletons (non-member rows) or if the bytes do not
+/// decode as either form.
+///
+/// Prefer this over [`extract_signed_op_bytes`] when the caller needs the
+/// typed op (e.g. to wrap in `NamespaceTopicMsg::Op` for gossip publish) —
+/// it avoids a redundant `borsh::to_vec` + `borsh::from_slice` round-trip.
+pub fn extract_signed_op(
+    skeleton_bytes: &[u8],
+) -> Option<calimero_context_client::local_governance::SignedNamespaceOp> {
+    use calimero_context_client::local_governance::{SignedNamespaceOp, StoredNamespaceEntry};
+
+    if let Ok(StoredNamespaceEntry::Signed(op)) =
+        borsh::from_slice::<StoredNamespaceEntry>(skeleton_bytes)
+    {
+        return Some(op);
+    }
+    // Fallback: already raw SignedNamespaceOp bytes (legacy / direct-publish path).
+    borsh::from_slice::<SignedNamespaceOp>(skeleton_bytes).ok()
+}
+
 /// Extract raw `SignedNamespaceOp` bytes from a `skeleton_bytes` store value.
 ///
 /// The store encodes entries as `StoredNamespaceEntry::Signed(op)`. The
@@ -176,21 +200,10 @@ pub fn handle_entity_push(
 ///
 /// The **gossip** publish path (`BroadcastMessage::NamespaceGovernanceDelta`)
 /// requires its payload to be a `NamespaceTopicMsg::Op(op)` envelope after
-/// Phase 2 of #2237 — callers re-publishing on gossip must decode the bytes
-/// returned here back to `SignedNamespaceOp` and wrap before publishing.
+/// Phase 2 of #2237 — gossip callers should prefer [`extract_signed_op`]
+/// to avoid an unnecessary serialization round-trip.
 pub fn extract_signed_op_bytes(skeleton_bytes: &[u8]) -> Option<Vec<u8>> {
-    use calimero_context_client::local_governance::{SignedNamespaceOp, StoredNamespaceEntry};
-
-    if let Ok(StoredNamespaceEntry::Signed(op)) =
-        borsh::from_slice::<StoredNamespaceEntry>(skeleton_bytes)
-    {
-        return borsh::to_vec(&op).ok();
-    }
-    // Fallback: already raw SignedNamespaceOp bytes (legacy / direct-publish path).
-    if borsh::from_slice::<SignedNamespaceOp>(skeleton_bytes).is_ok() {
-        return Some(skeleton_bytes.to_vec());
-    }
-    None
+    extract_signed_op(skeleton_bytes).and_then(|op| borsh::to_vec(&op).ok())
 }
 
 // =============================================================================


### PR DESCRIPTION
Follow-up to #2260 addressing the meroreviewer perf finding on commit `625af72` ([review](https://github.com/calimero-network/core/pull/2260#pullrequestreview-4176911372)).

## What was wrong

The post-Phase-2 heartbeat republish path in `handle_namespace_state_heartbeat` was doing three borsh round-trips per stored op:

1. read `skeleton_bytes` from the store
2. `extract_signed_op_bytes`: borsh-decode `StoredNamespaceEntry` + borsh-encode `SignedNamespaceOp`
3. caller borsh-decodes those bytes back to `SignedNamespaceOp`
4. caller borsh-encodes `NamespaceTopicMsg::Op(signed_op)` for publish

Steps 2 and 3 cancel out — the bytes-form was a transient that existed only to be immediately re-decoded. On a cold-joining node where the heartbeat catches up many missed deltas, this is `N` pointless encode + `N` pointless decode operations per peer per heartbeat tick.

## What changes

- Add `extract_signed_op(skeleton_bytes) -> Option<SignedNamespaceOp>` — the new primitive that decodes once and returns the typed op.
- Reimplement `extract_signed_op_bytes` as `extract_signed_op + borsh::to_vec`. Stream-path callers (`NamespaceBackfillResponse`, `NamespaceJoinResponse`) keep their current behavior with **no change at the call sites**.
- Heartbeat republish call site switches to `extract_signed_op` and wraps once in `NamespaceTopicMsg::Op`. Net per op: 1 decode + 1 encode, down from 2 of each.

## Tests

- [x] `cargo build -p calimero-node` clean
- [x] `cargo test -p calimero-node --lib`: 54/54 pass
- [x] `cargo test -p calimero-context --lib`: 131/131 pass
- [x] `cargo test -p calimero-context --tests`: 22/22 pass (incl. `local_group_governance_convergence` + cold-sync round-trips)
- [x] `cargo test -p calimero-context-client`: 22/22 pass (10 wire tests still cover ack/beacon verify + tampering)
- [x] `cargo fmt --check` clean

## Notes

- This is a pure refactor inside calimero-node + the `extract_signed_op_bytes` helper. No wire-format change, no public API surface change at the consumer level.
- The 3 stream-path callers in `crates/node/src/sync/manager/mod.rs` continue to use `extract_signed_op_bytes` since they hand the bytes directly to a stream message — no benefit to switching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk perf refactor: changes how stored namespace governance ops are decoded for gossip republish without altering wire formats or stream/backfill behavior.
> 
> **Overview**
> Removes an unnecessary borsh serialize/deserialize round-trip when re-publishing stored namespace governance ops during `handle_namespace_state_heartbeat` by decoding `skeleton_bytes` directly into a typed `SignedNamespaceOp` and wrapping once in `NamespaceTopicMsg::Op` before publish.
> 
> Introduces `extract_signed_op()` in `sync/helpers.rs` and rewrites `extract_signed_op_bytes()` to build on it, preserving existing stream/backfill callers while letting gossip paths avoid redundant work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df539ca1f179e3c664d6d87e42f2a74fc28c8a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->