### PR TITLE
feat(storage): DAG-causal Shared verification (#2233 P1-P5)

### DIFF
--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -213,6 +213,9 @@ mod tests {
                 },
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             )
         });

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -192,7 +192,7 @@ mod tests {
     fn test_write_and_read_entity_via_bridge() {
         use calimero_storage::address::Id;
         use calimero_storage::entities::Metadata;
-        use calimero_storage::interface::{Action, Interface};
+        use calimero_storage::interface::{Action, ApplyContext, Interface};
 
         let db = InMemoryDB::owned();
         let store = Store::new(Arc::new(db));
@@ -204,12 +204,17 @@ mod tests {
         // Write: create root entity
         let root_id = Id::new(*context_id.as_ref());
         let write_result = with_runtime_env(env.clone(), || {
-            Interface::<MainStorage>::apply_action(Action::Update {
-                id: root_id,
-                data: vec![],
-                ancestors: vec![],
-                metadata: Metadata::default(),
-            })
+            Interface::<MainStorage>::apply_action(
+                Action::Update {
+                    id: root_id,
+                    data: vec![],
+                    ancestors: vec![],
+                    metadata: Metadata::default(),
+                },
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            )
         });
         assert!(write_result.is_ok(), "apply_action should succeed");
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -8,7 +8,7 @@ use calimero_primitives::context::ContextId;
 use calimero_storage::address::Id;
 use calimero_storage::entities::{ChildInfo, Metadata};
 use calimero_storage::index::Index;
-use calimero_storage::interface::{Action, Interface};
+use calimero_storage::interface::{Action, ApplyContext, Interface};
 use calimero_storage::store::MainStorage;
 use eyre::{bail, Result};
 use rand::Rng;
@@ -88,7 +88,13 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
                 ancestors: vec![],
                 metadata: Metadata::default(),
             };
-            Interface::<MainStorage>::apply_action(root_action)?;
+            // P1 of #2233: snapshot leaf push has no DAG-causal context.
+            Interface::<MainStorage>::apply_action(
+                root_action,
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            )?;
         }
 
         // Get root info for ancestor chain
@@ -113,7 +119,13 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
         }
     };
 
-    Interface::<MainStorage>::apply_action(action)?;
+    // P1 of #2233: snapshot leaf push has no DAG-causal context.
+    Interface::<MainStorage>::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )?;
     Ok(())
 }
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -93,6 +93,9 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
                 root_action,
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             )?;
         }
@@ -124,6 +127,9 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )?;
     Ok(())

--- a/crates/node/tests/dag_storage_integration.rs
+++ b/crates/node/tests/dag_storage_integration.rs
@@ -19,7 +19,7 @@ use calimero_storage::address::Id;
 use calimero_storage::entities::{ChildInfo, Metadata};
 use calimero_storage::env::time_now;
 use calimero_storage::index::Index;
-use calimero_storage::interface::Interface;
+use calimero_storage::interface::{ApplyContext, Interface};
 use calimero_storage::store::MainStorage;
 use tokio::sync::Mutex;
 
@@ -61,8 +61,13 @@ impl DeltaApplier<Vec<Action>> for StorageApplier {
 
         // Actually apply each action to storage
         for action in &delta.payload {
-            Interface::<MainStorage>::apply_action(action.clone())
-                .map_err(|e| ApplyError::Application(e.to_string()))?;
+            Interface::<MainStorage>::apply_action(
+                action.clone(),
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            )
+            .map_err(|e| ApplyError::Application(e.to_string()))?;
         }
 
         // Track that this delta was applied

--- a/crates/node/tests/dag_storage_integration.rs
+++ b/crates/node/tests/dag_storage_integration.rs
@@ -65,6 +65,9 @@ impl DeltaApplier<Vec<Action>> for StorageApplier {
                 action.clone(),
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             )
             .map_err(|e| ApplyError::Application(e.to_string()))?;

--- a/crates/node/tests/sync_protocols.rs
+++ b/crates/node/tests/sync_protocols.rs
@@ -51,6 +51,9 @@ impl DeltaApplier<Vec<Action>> for TestApplier {
                 action.clone(),
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             )
             .map_err(|e| ApplyError::Application(e.to_string()))?;

--- a/crates/node/tests/sync_protocols.rs
+++ b/crates/node/tests/sync_protocols.rs
@@ -15,6 +15,7 @@ use calimero_dag::{ApplyError, CausalDelta, DagStore, DeltaApplier, MAX_DELTA_QU
 use calimero_primitives::hash::Hash;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
+use calimero_storage::interface::ApplyContext;
 use calimero_storage::snapshot::Snapshot;
 use calimero_storage::store::MainStorage;
 use calimero_storage::Interface;
@@ -46,8 +47,13 @@ impl DeltaApplier<Vec<Action>> for TestApplier {
     async fn apply(&self, delta: &CausalDelta<Vec<Action>>) -> Result<(), ApplyError> {
         // Apply actions to storage
         for action in &delta.payload {
-            Interface::<MainStorage>::apply_action(action.clone())
-                .map_err(|e| ApplyError::Application(e.to_string()))?;
+            Interface::<MainStorage>::apply_action(
+                action.clone(),
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            )
+            .map_err(|e| ApplyError::Application(e.to_string()))?;
         }
 
         self.applied.write().await.push(delta.id);

--- a/crates/node/tests/sync_sim/storage.rs
+++ b/crates/node/tests/sync_sim/storage.rs
@@ -49,7 +49,7 @@ use calimero_storage::address::Id;
 use calimero_storage::entities::{ChildInfo, Metadata};
 use calimero_storage::env::{with_runtime_env, RuntimeEnv};
 use calimero_storage::index::{EntityIndex, Index};
-use calimero_storage::interface::{Action, Interface};
+use calimero_storage::interface::{Action, ApplyContext, Interface};
 use calimero_storage::store::{Key, MainStorage};
 use calimero_store::db::InMemoryDB;
 use calimero_store::{key, types, Store};
@@ -336,13 +336,18 @@ impl SimStorage {
                 ancestors: vec![],
                 metadata: Metadata::default(),
             };
-            let _ = Interface::<MainStorage>::apply_action(action);
+            let _ = Interface::<MainStorage>::apply_action(
+                action,
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            );
         });
     }
 
     /// Add an entity with a parent relationship.
     ///
-    /// Uses `Interface::apply_action(Action::Update)` which is the public API
+    /// Uses `Interface::apply_action(Action::Update, ctx)` which is the public API
     /// for creating/updating entities in the Merkle tree.
     pub fn add_entity_with_parent(&self, id: Id, parent_id: Id, data: &[u8], metadata: Metadata) {
         self.with_index(|| {
@@ -367,7 +372,12 @@ impl SimStorage {
                 ancestors: vec![ancestor],
                 metadata,
             };
-            let _ = Interface::<MainStorage>::apply_action(action);
+            let _ = Interface::<MainStorage>::apply_action(
+                action,
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            );
         });
     }
 
@@ -407,7 +417,12 @@ impl SimStorage {
                     ancestors: vec![],
                     metadata: Metadata::default(),
                 };
-                let _ = Interface::<MainStorage>::apply_action(action);
+                let _ = Interface::<MainStorage>::apply_action(
+                    action,
+                    ApplyContext {
+                        causal_parents: &[],
+                    },
+                );
             } else {
                 // Create new entity as child of root
                 // First ensure root exists
@@ -423,7 +438,12 @@ impl SimStorage {
                         ancestors: vec![],
                         metadata: Metadata::default(),
                     };
-                    let _ = Interface::<MainStorage>::apply_action(root_action);
+                    let _ = Interface::<MainStorage>::apply_action(
+                        root_action,
+                        ApplyContext {
+                            causal_parents: &[],
+                        },
+                    );
                 }
 
                 // Add new entity under root
@@ -433,7 +453,12 @@ impl SimStorage {
                     ancestors: vec![ChildInfo::new(root_id, [0; 32], Metadata::default())],
                     metadata: Metadata::default(),
                 };
-                let _ = Interface::<MainStorage>::apply_action(action);
+                let _ = Interface::<MainStorage>::apply_action(
+                    action,
+                    ApplyContext {
+                        causal_parents: &[],
+                    },
+                );
             }
         });
     }
@@ -447,7 +472,12 @@ impl SimStorage {
                     deleted_at: calimero_storage::env::time_now(),
                     metadata: index.metadata.clone(),
                 };
-                let _ = Interface::<MainStorage>::apply_action(action);
+                let _ = Interface::<MainStorage>::apply_action(
+                    action,
+                    ApplyContext {
+                        causal_parents: &[],
+                    },
+                );
             }
         });
     }

--- a/crates/node/tests/sync_sim/storage.rs
+++ b/crates/node/tests/sync_sim/storage.rs
@@ -340,6 +340,9 @@ impl SimStorage {
                 action,
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             );
         });
@@ -376,6 +379,9 @@ impl SimStorage {
                 action,
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             );
         });
@@ -421,6 +427,9 @@ impl SimStorage {
                     action,
                     ApplyContext {
                         causal_parents: &[],
+                        delta_id: None,
+                        delta_hlc: None,
+                        happens_before: None,
                     },
                 );
             } else {
@@ -442,6 +451,9 @@ impl SimStorage {
                         root_action,
                         ApplyContext {
                             causal_parents: &[],
+                            delta_id: None,
+                            delta_hlc: None,
+                            happens_before: None,
                         },
                     );
                 }
@@ -457,6 +469,9 @@ impl SimStorage {
                     action,
                     ApplyContext {
                         causal_parents: &[],
+                        delta_id: None,
+                        delta_hlc: None,
+                        happens_before: None,
                     },
                 );
             }
@@ -476,6 +491,9 @@ impl SimStorage {
                     action,
                     ApplyContext {
                         causal_parents: &[],
+                        delta_id: None,
+                        delta_hlc: None,
+                        happens_before: None,
                     },
                 );
             }

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -932,6 +932,9 @@ impl VMHostFunctions<'_> {
                 // the ABI to pass CausalDelta.parents through to apply_action.
                 let sync_ctx = calimero_storage::interface::ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 };
                 calimero_storage::collections::Root::<Vec<u8>>::sync(&payload, sync_ctx)
             })

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -928,7 +928,12 @@ impl VMHostFunctions<'_> {
             );
 
             with_runtime_env(env.clone(), || {
-                calimero_storage::collections::Root::<Vec<u8>>::sync(&payload)
+                // P1 of #2233: causal_parents is empty here. P3 will extend
+                // the ABI to pass CausalDelta.parents through to apply_action.
+                let sync_ctx = calimero_storage::interface::ApplyContext {
+                    causal_parents: &[],
+                };
+                calimero_storage::collections::Root::<Vec<u8>>::sync(&payload, sync_ctx)
             })
             .map_err(|err| {
                 VMLogicError::from(HostError::Panic {

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -182,6 +182,9 @@ impl ToTokens for PublicLogicMethod<'_> {
                     // CausalDelta.parents through the WASM ABI is part of P3.
                     let __sync_ctx = ::calimero_storage::interface::ApplyContext {
                         causal_parents: &[],
+                        delta_id: None,
+                        delta_hlc: None,
+                        happens_before: None,
                     };
                     ::calimero_storage::collections::Root::<#self_>::sync(&args, __sync_ctx).expect("fatal: sync failed");
                 }

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -178,7 +178,12 @@ impl ToTokens for PublicLogicMethod<'_> {
                         ::calimero_sdk::env::panic_str("Expected payload to sync method.")
                     };
 
-                    ::calimero_storage::collections::Root::<#self_>::sync(&args).expect("fatal: sync failed");
+                    // P1 of #2233: causal_parents is empty here. Wiring the
+                    // CausalDelta.parents through the WASM ABI is part of P3.
+                    let __sync_ctx = ::calimero_storage::interface::ApplyContext {
+                        causal_parents: &[],
+                    };
+                    ::calimero_storage::collections::Root::<#self_>::sync(&args, __sync_ctx).expect("fatal: sync failed");
                 }
 
                 impl ::calimero_sdk::state::AppStateInit for #self_ {

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -123,8 +123,12 @@ where
     }
 
     /// Syncs the root collection.
+    ///
+    /// `ctx` is the apply-time context for the inner [`Interface::apply_action`]
+    /// calls (DAG-causal parents of the delta the artifact came from). In phase
+    /// P1 of #2233 it is plumbed through but not consulted.
     #[expect(clippy::missing_errors_doc, reason = "NO")]
-    pub fn sync(args: &[u8]) -> Result<(), StorageError> {
+    pub fn sync(args: &[u8], ctx: crate::interface::ApplyContext<'_>) -> Result<(), StorageError> {
         let artifact =
             from_slice::<StorageDelta>(args).map_err(StorageError::DeserializationError)?;
 
@@ -188,12 +192,15 @@ where
                                     updated_at = metadata.updated_at(),
                                     "SYNC CHILD: Applying Action::Add for child entity"
                                 );
-                                <Interface<S>>::apply_action(Action::Add {
-                                    id,
-                                    data,
-                                    metadata,
-                                    ancestors,
-                                })?;
+                                <Interface<S>>::apply_action(
+                                    Action::Add {
+                                        id,
+                                        data,
+                                        metadata,
+                                        ancestors,
+                                    },
+                                    ctx,
+                                )?;
                             }
                         }
                         Action::Update {
@@ -213,16 +220,19 @@ where
                                     updated_at = metadata.updated_at(),
                                     "SYNC CHILD: Applying Action::Update for child entity"
                                 );
-                                <Interface<S>>::apply_action(Action::Update {
-                                    id,
-                                    data,
-                                    metadata,
-                                    ancestors,
-                                })?;
+                                <Interface<S>>::apply_action(
+                                    Action::Update {
+                                        id,
+                                        data,
+                                        metadata,
+                                        ancestors,
+                                    },
+                                    ctx,
+                                )?;
                             }
                         }
                         Action::DeleteRef { .. } => {
-                            <Interface<S>>::apply_action(action)?;
+                            <Interface<S>>::apply_action(action, ctx)?;
                         }
                     };
                 }
@@ -254,7 +264,7 @@ where
                     comparison_data,
                 } in comparisons
                 {
-                    <Interface<S>>::compare_affective(data, comparison_data)?;
+                    <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
                 }
             }
         }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -78,6 +78,18 @@ pub enum StorageError {
     /// An unexpected ID was encountered.
     #[error("Unexpected ID: {0}")]
     UnexpectedId(Id),
+
+    /// A second rotation-log entry for the same `delta_id` was attempted with
+    /// contents that differ from the entry already on file. The rotation log
+    /// dedups on `delta_id` alone, so multiple rotations on the same entity
+    /// inside one `CausalDelta` are not supported and must be split into
+    /// separate deltas at construction time. See [`crate::rotation_log::append`]
+    /// for the invariant. Tracked in #2233 P3.
+    #[error(
+        "Duplicate rotation entries for delta_id {0:?} with differing contents \
+         (multi-rotation-per-entity-per-delta is not supported)"
+    )]
+    DuplicateRotationInDelta([u8; 32]),
 }
 
 impl Serialize for StorageError {
@@ -103,6 +115,9 @@ impl Serialize for StorageError {
                 serializer.serialize_str(&format!("Nonce replay for {}: {}", pk, nonce))
             }
             Self::StoreError(ref err) => serializer.serialize_str(&err.to_string()),
+            Self::DuplicateRotationInDelta(delta_id) => serializer.serialize_str(&format!(
+                "Duplicate rotation entries for delta_id {delta_id:?} with differing contents"
+            )),
         }
     }
 }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -62,28 +62,77 @@ pub type MainInterface = Interface<MainStorage>;
 /// Apply-time context passed to [`Interface::apply_action`].
 ///
 /// Centralizes apply-time metadata so the call signature doesn't accumulate
-/// positional parameters. Currently carries DAG-causal parent hashes for the
-/// delta the action belongs to; future fields (delta hash, sender id, etc.)
-/// plug in here without re-touching every call site.
+/// positional parameters. P1 of #2233 introduced the struct with
+/// `causal_parents`; **P3** extends it with `delta_id`, `delta_hlc`, and
+/// `happens_before` so the rotation-log write hook can capture entries and
+/// the verifier can resolve `writers_at(causal_point)` per ADR 0001.
 ///
-/// In phase P1 of #2233 the field is collected and threaded through but not
-/// consulted by the verifier. P2/P3 wire it into per-entity writer-set
-/// resolution at the causal point.
+/// Construct explicitly at every call site — no `Default` on purpose so a
+/// future new field is a compile error everywhere, not a silent semantic
+/// change. For paths that genuinely have no causal context (snapshot leaf
+/// push, local apply, tests, P1-era code), construct as:
 ///
-/// Construct explicitly at every call site:
-/// - When no causal context is available (local apply, snapshot leaf push,
-///   tests): `ApplyContext { causal_parents: &[] }`.
-/// - In sync paths with a `CausalDelta` in scope:
-///   `ApplyContext { causal_parents: &delta.parents }`.
+/// ```ignore
+/// ApplyContext {
+///     causal_parents: &[],
+///     delta_id: None,
+///     delta_hlc: None,
+///     happens_before: None,
+/// }
+/// ```
 ///
-/// No `Default` / shorthand constructor on purpose — when a new field lands,
-/// every call site should be a compile error so we don't silently default a
-/// new piece of context.
-#[derive(Clone, Copy, Debug)]
+/// Sync paths with a `CausalDelta` in scope should populate the matching
+/// fields. Wiring the WASM ABI to thread `CausalDelta.{id,hlc,parents}` and
+/// a DAG-ancestry closure through `__calimero_sync_next` to here is a
+/// separate follow-up — see the `// P3 of #2233:` markers at production
+/// call sites.
+///
+/// # Field semantics
+///
+/// All new fields are `Option`. Convention:
+/// - `None` → "this caller doesn't have it"; the verifier and write hook
+///   degrade gracefully (skip writes, fall back to v2 stored writers).
+/// - `Some(_)` → "this caller has it"; verifier MUST consult the new
+///   path, write hook MAY append a rotation entry.
+///
+/// `happens_before` is a closure rather than a precomputed set because the
+/// DAG is owned by the node sync layer; storage shouldn't need to pull it
+/// in. Caller closes over its DAG view and passes the predicate.
+#[derive(Clone, Copy)]
 pub struct ApplyContext<'a> {
     /// Hashes of the parent deltas in the DAG. Empty when no causal context
     /// is available.
     pub causal_parents: &'a [[u8; 32]],
+
+    /// Hash of the `CausalDelta` containing the action being applied. Used
+    /// by the rotation-log write hook to record the originating delta on
+    /// detected rotations. `None` for local apply / snapshot leaf push.
+    pub delta_id: Option<[u8; 32]>,
+
+    /// Hybrid timestamp of the containing `CausalDelta`. Used by the
+    /// rotation-log write hook (sibling tiebreak per ADR 0001). `None` for
+    /// callers without a `CausalDelta` in scope.
+    pub delta_hlc: Option<crate::logical_clock::HybridTimestamp>,
+
+    /// DAG-ancestry predicate: `happens_before(a, b)` returns `true` iff
+    /// delta `a` is in the transitive ancestry of delta `b`. Provided by
+    /// the caller (typically the node sync layer with DAG access). `None`
+    /// when no DAG is available — the verifier then falls back to
+    /// [`rotation_log::latest_writers`](crate::rotation_log::latest_writers).
+    pub happens_before: Option<&'a dyn Fn(&[u8; 32], &[u8; 32]) -> bool>,
+}
+
+impl core::fmt::Debug for ApplyContext<'_> {
+    // Manual impl: `&dyn Fn` doesn't implement Debug. Print the rest and
+    // mark `happens_before` by presence only.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ApplyContext")
+            .field("causal_parents", &self.causal_parents)
+            .field("delta_id", &self.delta_id)
+            .field("delta_hlc", &self.delta_hlc)
+            .field("happens_before", &self.happens_before.map(|_| "<closure>"))
+            .finish()
+    }
 }
 
 /// The primary interface for the storage system.
@@ -130,18 +179,22 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Generates Compare action for hash verification after applying changes.
     ///
     /// `ctx` carries DAG-causal apply-time context (parents of the delta
-    /// this action belongs to). In phase P1 of #2233 it is plumbed through
-    /// but not consulted; P2/P3 will use it to resolve the writer set at
-    /// the causal point for `Shared`-storage verification.
+    /// this action belongs to, plus the delta's id/HLC and a DAG-ancestry
+    /// closure). For `Shared`-storage actions, **P3** of #2233 swaps the
+    /// signature verifier from "stored writers" to
+    /// `writers_at(id, ctx.causal_parents)` per ADR 0001, and appends a
+    /// [`RotationLogEntry`](crate::rotation_log::RotationLogEntry) on
+    /// detected rotations. Both behaviors degrade gracefully when ctx
+    /// fields are `None` / empty (callers without DAG context behave
+    /// identically to v2).
     ///
     /// # Errors
     /// - `DeserializationError` if action data is invalid
     /// - `ActionNotAllowed` if Compare action is passed directly
     ///
     pub fn apply_action(action: Action, ctx: ApplyContext<'_>) -> Result<(), StorageError> {
-        let _ = ctx; // P1: collected and forwarded only; verifier behavior unchanged.
-                     // Verify that the action timestamp is not too far in the future
-                     // to prevent LWW Time Drift attacks.
+        // Verify that the action timestamp is not too far in the future
+        // to prevent LWW Time Drift attacks.
         verify_action_timestamp(&action)?;
 
         // TODO: refactor to a separate function.
@@ -234,22 +287,71 @@ impl<S: StorageAdaptor> Interface<S> {
                             "Remote Shared action must be signed".to_owned(),
                         ))?;
 
-                        // Determine the authoritative writer set: stored if present,
-                        // else the action's claim (bootstrap).
+                        // Snapshot of stored state. Used both for the v2-style
+                        // bootstrap fallback below and for the rotation-log write
+                        // hook (post-apply, in the Add/Update branch).
                         let stored_metadata = <Index<S>>::get_metadata(*id)?;
+                        let stored_writers = match stored_metadata.as_ref().map(|m| &m.storage_type)
+                        {
+                            Some(StorageType::Shared {
+                                writers: stored_w, ..
+                            }) => Some(stored_w.clone()),
+                            _ => None,
+                        };
+
+                        // P3 of #2233: resolve the *effective* writer set the
+                        // signature must verify against.
+                        //
+                        // ADR 0001 says the verifier consults `writers_at(causal
+                        // parents)` — the writer set as of the apply context's
+                        // causal point — instead of the currently-stored writers.
+                        // That's the partition-correctness fix.
+                        //
+                        // Graceful degradation: when ctx lacks the DAG-ancestry
+                        // closure or the rotation log has nothing reachable,
+                        // fall through to the v2 stored set. Callers without
+                        // DAG context (snapshot leaf push, local apply, P1-era
+                        // code) continue to behave exactly as v2.
+                        let dag_causal_writers = if let Some(hb) = ctx.happens_before {
+                            crate::rotation_log::writers_at::<S, _>(*id, ctx.causal_parents, hb)?
+                        } else {
+                            None
+                        };
+
                         let authoritative_writers =
-                            match stored_metadata.as_ref().map(|m| &m.storage_type) {
-                                Some(StorageType::Shared {
-                                    writers: stored_w, ..
-                                }) => stored_w.clone(),
-                                // Bootstrap (or non-Shared existing — rejected by
-                                // verify_action_update; treat defensively as bootstrap).
-                                _ => writers.clone(),
+                            match (dag_causal_writers.as_ref(), stored_writers.as_ref()) {
+                                (Some(causal), Some(stored)) => {
+                                    // Both paths returned a set. Telemetry hook for
+                                    // rollout: warn on divergence so it's visible in
+                                    // production logs before we commit to dropping
+                                    // the v2 nonce check (epic exit criterion).
+                                    if causal != stored {
+                                        warn!(
+                                            target: "storage::p3_verifier",
+                                            %id,
+                                            stored_count = stored.len(),
+                                            causal_count = causal.len(),
+                                            "P3 verifier divergence: DAG-causal writer set \
+                                             differs from stored. Using DAG-causal per #2233."
+                                        );
+                                    }
+                                    causal.clone()
+                                }
+                                (Some(causal), None) => causal.clone(),
+                                // No DAG-causal answer → v2 fallback to stored, then
+                                // to the action's claim for bootstrap (preserves the
+                                // pre-P3 behavior exactly).
+                                (None, Some(stored)) => stored.clone(),
+                                (None, None) => writers.clone(),
                             };
 
                         // Replay protection (per-entity monotonic nonce). Done BEFORE
                         // signature verification so replays are O(1)-rejected without
                         // iterating Ed25519 verifies over each writer (matches User arm).
+                        //
+                        // P3 keeps the nonce check unchanged. Per the epic exit
+                        // criterion, the nonce check is removed only after weeks
+                        // of zero-divergence telemetry between nonce + DAG-causal.
                         let new_nonce = sig_data.nonce;
                         let last_nonce =
                             stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);
@@ -271,6 +373,11 @@ impl<S: StorageAdaptor> Interface<S> {
                         // Fast path: if the action carries a `signer` hint and that
                         // signer is in the authoritative set, do exactly one verify.
                         // Slow path (no hint): linear scan over authoritative writers.
+                        //
+                        // Per the #2233 epic compatibility rule, the signer hint is
+                        // validated against the *causal* writer set above, not stored —
+                        // that's already how it works here since `authoritative_writers`
+                        // is now the DAG-causal answer when available.
                         let payload = action.payload_for_signing();
                         let verified = match sig_data.signer {
                             Some(hint) if authoritative_writers.contains(&hint) => {
@@ -496,6 +603,23 @@ impl<S: StorageAdaptor> Interface<S> {
                     <Index<S>>::add_child_to(parent.id(), this.clone())?;
                 }
 
+                // P3 of #2233: snapshot the pre-apply writer set for Shared
+                // entities BEFORE the placeholder-index creation below overwrites
+                // the entry with `metadata` (which is the action's own metadata,
+                // not the pre-apply state). `None` here means bootstrap — the
+                // entity genuinely didn't exist. The write hook interprets
+                // `None` as "first rotation, append".
+                let pre_apply_shared_writers: Option<
+                    std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
+                > = if matches!(metadata.storage_type, StorageType::Shared { .. }) {
+                    match <Index<S>>::get_metadata(id)?.map(|m| m.storage_type) {
+                        Some(StorageType::Shared { writers, .. }) => Some(writers),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+
                 // For new entities, create a minimal index entry first to avoid orphan errors
                 if !<Index<S>>::has_index(id) {
                     if id.is_root() {
@@ -527,6 +651,20 @@ impl<S: StorageAdaptor> Interface<S> {
                     // we didn't save anything, so we skip updating the ancestors
                     return Ok(());
                 };
+
+                // P3 of #2233: rotation-log write hook. Appends a
+                // RotationLogEntry when applying a Shared rotation, so the
+                // verifier (this same function, on a future apply with DAG
+                // context) can resolve writers_at(causal point).
+                //
+                // Skips silently if:
+                // - the action isn't Shared,
+                // - the writer set didn't change (this is a value-write, not a
+                //   rotation),
+                // - the apply context lacks delta_id/delta_hlc (P3-era code
+                //   without WASM ABI extensions; the production sync path
+                //   doesn't yet thread CausalDelta.{id,hlc} through here).
+                Self::maybe_append_rotation_log(id, &metadata, &ctx, pre_apply_shared_writers)?;
 
                 debug!(
                     %id,
@@ -574,6 +712,79 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Uses guard clauses for clarity (KISS principle).
     /// Handles three cases:
     /// 1. Already deleted - update tombstone if newer
+    /// Append to the rotation log when applying a Shared rotation.
+    ///
+    /// P3 of #2233 write hook. Called from [`apply_action`] after
+    /// `save_internal` succeeds. No-op for non-Shared actions, for
+    /// value-writes (writers unchanged), or when ctx lacks the delta
+    /// id/hlc the entry needs.
+    ///
+    /// `pre_apply_writers` is the writer set in the index *before* this
+    /// action mutated it — `Some` for an existing Shared entity, `None`
+    /// for bootstrap (first time we see this entity). Bootstrap counts as
+    /// the first rotation.
+    ///
+    /// Skips silently rather than erroring on missing context: P3-era
+    /// production paths don't yet thread `CausalDelta.{id,hlc}` through
+    /// the WASM ABI, so the hook is dormant in production until that
+    /// follow-up lands. Tests construct full ctx explicitly.
+    fn maybe_append_rotation_log(
+        id: Id,
+        metadata: &Metadata,
+        ctx: &ApplyContext<'_>,
+        pre_apply_writers: Option<
+            std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
+        >,
+    ) -> Result<(), StorageError> {
+        // Only Shared entities have a rotation log.
+        let StorageType::Shared {
+            writers,
+            signature_data,
+        } = &metadata.storage_type
+        else {
+            return Ok(());
+        };
+
+        // Only append on rotation: bootstrap (no prior entry) OR writers changed.
+        // Value-writes that don't touch the writer set don't need to log.
+        let is_rotation = match &pre_apply_writers {
+            Some(stored) => stored != writers,
+            None => true,
+        };
+        if !is_rotation {
+            return Ok(());
+        }
+
+        // Need the originating delta's identity to record an entry the
+        // verifier can later look up. P3-era callers without WASM ABI
+        // extensions pass None here; the hook then silently no-ops so the
+        // log stays empty and writers_at falls back to v2 stored writers.
+        let (Some(delta_id), Some(delta_hlc)) = (ctx.delta_id, ctx.delta_hlc) else {
+            return Ok(());
+        };
+
+        let signer = signature_data.as_ref().and_then(|s| s.signer);
+        let nonce = signature_data.as_ref().map(|s| s.nonce).unwrap_or(0);
+
+        crate::rotation_log::append::<S>(
+            id,
+            crate::rotation_log::RotationLogEntry {
+                delta_id,
+                delta_hlc,
+                signer,
+                new_writers: writers.clone(),
+                writers_nonce: nonce,
+            },
+        )?;
+        debug!(
+            target: "storage::p3_write_hook",
+            %id,
+            writer_count = writers.len(),
+            "Rotation log entry appended"
+        );
+        Ok(())
+    }
+
     /// 2. Exists locally - compare timestamps (LWW)
     /// 3. Never seen - ignore (could create tombstone in future)
     ///

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -801,7 +801,10 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Must not be called twice for the same entity within one delta —
     /// see [`rotation_log::append`](crate::rotation_log::append) for why
     /// (delta_id-only dedup). Multi-action deltas with two rotations on
-    /// the same entity are not supported and will trip a debug assertion.
+    /// the same entity are not supported: a second call with differing
+    /// entry contents returns
+    /// [`StorageError::DuplicateRotationInDelta`](crate::error::StorageError::DuplicateRotationInDelta);
+    /// a replay with identical contents is idempotent.
     ///
     /// # Log may diverge from stored state
     ///

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -135,6 +135,59 @@ impl core::fmt::Debug for ApplyContext<'_> {
     }
 }
 
+// ----- Test-only hook: bypass the v2 monotonic-nonce check -----------------
+//
+// The v2 nonce check rejects out-of-order delivery of concurrent deltas —
+// exactly the cases #2233's DAG-causal verifier is designed to accept. Per
+// the epic exit criterion the nonce check is removed only after 4 weeks of
+// production telemetry confirming DAG-causal subsumes it. Tests that need
+// to exercise the v3 target behavior (post-removal) can opt out here.
+//
+// Production code uses `cfg(not(test))` and always returns `false` so the
+// nonce check stays live. Test code uses the thread-local toggle.
+
+#[cfg(test)]
+thread_local! {
+    static SKIP_NONCE_CHECK: core::cell::Cell<bool> = const { core::cell::Cell::new(false) };
+}
+
+/// Disable the v2 monotonic-nonce check on this thread. Returns a guard
+/// that re-enables on drop, so a single test can scope the bypass without
+/// leaking it to the next test on the same thread.
+///
+/// Tests should use this only when validating the **v3 target behavior**
+/// — i.e., the cross-node convergence properties that DAG-causal
+/// verification provides once the nonce check is retired. Tests of the
+/// nonce check itself (or of behavior expected to hold under the v2
+/// regime) should NOT bypass.
+#[cfg(test)]
+#[must_use]
+pub fn disable_nonce_check_for_testing() -> NonceCheckGuard {
+    SKIP_NONCE_CHECK.with(|c| c.set(true));
+    NonceCheckGuard
+}
+
+/// RAII guard returned by [`disable_nonce_check_for_testing`].
+#[cfg(test)]
+pub struct NonceCheckGuard;
+
+#[cfg(test)]
+impl Drop for NonceCheckGuard {
+    fn drop(&mut self) {
+        SKIP_NONCE_CHECK.with(|c| c.set(false));
+    }
+}
+
+#[cfg(test)]
+fn nonce_check_disabled_for_testing() -> bool {
+    SKIP_NONCE_CHECK.with(core::cell::Cell::get)
+}
+
+#[cfg(not(test))]
+const fn nonce_check_disabled_for_testing() -> bool {
+    false
+}
+
 /// The primary interface for the storage system.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
@@ -352,10 +405,14 @@ impl<S: StorageAdaptor> Interface<S> {
                         // P3 keeps the nonce check unchanged. Per the epic exit
                         // criterion, the nonce check is removed only after weeks
                         // of zero-divergence telemetry between nonce + DAG-causal.
+                        // Tests that need to validate the v3 target behavior
+                        // (post-nonce-removal) can opt out via the test-only
+                        // [`disable_nonce_check_for_testing`] hook.
                         let new_nonce = sig_data.nonce;
                         let last_nonce =
                             stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);
-                        if new_nonce <= last_nonce {
+                        let skip_nonce = nonce_check_disabled_for_testing();
+                        if !skip_nonce && new_nonce <= last_nonce {
                             // Use the first authoritative writer as a placeholder identity
                             // for the error since the signer hasn't been identified yet.
                             let placeholder = authoritative_writers
@@ -398,6 +455,27 @@ impl<S: StorageAdaptor> Interface<S> {
                         if !verified {
                             return Err(StorageError::InvalidSignature);
                         }
+
+                        // P3 of #2233: rotation-log write hook.
+                        //
+                        // Fires here — right after signature verification, BEFORE
+                        // the apply branch — so the log captures every
+                        // signature-verified Shared rotation regardless of
+                        // whether `save_internal` later chooses to skip the
+                        // write under v2's LWW-by-HLC. Cross-node convergence
+                        // (P5) depends on this: the rotation log must reflect
+                        // *received causal facts*, not the local node's
+                        // storage-merge decisions.
+                        //
+                        // Idempotent: `rotation_log::append` dedups on
+                        // `delta_id`, so a replayed delta produces no extra
+                        // entry.
+                        Self::maybe_append_rotation_log(
+                            *id,
+                            metadata,
+                            &ctx,
+                            stored_writers.clone(),
+                        )?;
                     }
                     StorageType::Public => { /* No special checks */ }
                 }
@@ -603,23 +681,6 @@ impl<S: StorageAdaptor> Interface<S> {
                     <Index<S>>::add_child_to(parent.id(), this.clone())?;
                 }
 
-                // P3 of #2233: snapshot the pre-apply writer set for Shared
-                // entities BEFORE the placeholder-index creation below overwrites
-                // the entry with `metadata` (which is the action's own metadata,
-                // not the pre-apply state). `None` here means bootstrap — the
-                // entity genuinely didn't exist. The write hook interprets
-                // `None` as "first rotation, append".
-                let pre_apply_shared_writers: Option<
-                    std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
-                > = if matches!(metadata.storage_type, StorageType::Shared { .. }) {
-                    match <Index<S>>::get_metadata(id)?.map(|m| m.storage_type) {
-                        Some(StorageType::Shared { writers, .. }) => Some(writers),
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-
                 // For new entities, create a minimal index entry first to avoid orphan errors
                 if !<Index<S>>::has_index(id) {
                     if id.is_root() {
@@ -651,20 +712,6 @@ impl<S: StorageAdaptor> Interface<S> {
                     // we didn't save anything, so we skip updating the ancestors
                     return Ok(());
                 };
-
-                // P3 of #2233: rotation-log write hook. Appends a
-                // RotationLogEntry when applying a Shared rotation, so the
-                // verifier (this same function, on a future apply with DAG
-                // context) can resolve writers_at(causal point).
-                //
-                // Skips silently if:
-                // - the action isn't Shared,
-                // - the writer set didn't change (this is a value-write, not a
-                //   rotation),
-                // - the apply context lacks delta_id/delta_hlc (P3-era code
-                //   without WASM ABI extensions; the production sync path
-                //   doesn't yet thread CausalDelta.{id,hlc} through here).
-                Self::maybe_append_rotation_log(id, &metadata, &ctx, pre_apply_shared_writers)?;
 
                 debug!(
                     %id,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -394,6 +394,19 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // No DAG-causal answer → v2 fallback to stored, then
                                 // to the action's claim for bootstrap (preserves the
                                 // pre-P3 behavior exactly).
+                                //
+                                // Caveat: `stored` here is `metadata.storage_type.writers`
+                                // from the entity index, which `Index::update_hash_for`
+                                // never updates after a rotation (it only refreshes
+                                // own_hash/full_hash/updated_at). So this fallback
+                                // always returns the *bootstrap* writer set, regardless
+                                // of how many rotations have applied. Production WASM
+                                // paths land here today (until the ABI threads
+                                // CausalDelta.{id,hlc,parents} through), which means
+                                // post-rotation writers cannot bootstrap a signature
+                                // and pre-rotation writers can still sign forever.
+                                // Same root cause as the rotation-log write hook's
+                                // stale-stored-writers fragility (#2233 P3 follow-up).
                                 (None, Some(stored)) => stored.clone(),
                                 (None, None) => writers.clone(),
                             };
@@ -572,9 +585,16 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // Replay protection (per-entity monotonic nonce).
                                 // Done BEFORE per-writer Ed25519 scan so replays are
                                 // O(1)-rejected (matches User arm + upsert arm).
+                                //
+                                // Mirrors the upsert arm's [`disable_nonce_check_for_testing`]
+                                // bypass so DAG-causal P5 tests that exercise out-of-order
+                                // delivery of Shared deletes can opt into the v3 target
+                                // behavior. Production codepath unchanged — the const fn
+                                // returns false outside cfg(test).
                                 let new_nonce = sig_data.nonce;
                                 let last_nonce = *existing_metadata.updated_at;
-                                if new_nonce <= last_nonce {
+                                let skip_nonce = nonce_check_disabled_for_testing();
+                                if !skip_nonce && new_nonce <= last_nonce {
                                     let placeholder = existing_writers
                                         .iter()
                                         .copied()
@@ -782,6 +802,19 @@ impl<S: StorageAdaptor> Interface<S> {
     /// see [`rotation_log::append`](crate::rotation_log::append) for why
     /// (delta_id-only dedup). Multi-action deltas with two rotations on
     /// the same entity are not supported and will trip a debug assertion.
+    ///
+    /// # Log may diverge from stored state
+    ///
+    /// This hook fires right after signature verification but BEFORE the
+    /// `save_internal` apply branch, so it records every signature-verified
+    /// rotation regardless of whether `save_internal` later drops the data
+    /// write under v2's LWW-by-HLC. This is intentional — cross-node
+    /// convergence (P5) requires the rotation log to reflect *received
+    /// causal facts*, not the local node's storage-merge decisions. The
+    /// consequence is that `RotationLog::entries` may contain rotations
+    /// whose data write was dropped; downstream readers (`writers_at`,
+    /// future P6 compaction, audit tools) must treat the log as the
+    /// authoritative writer-set history independent of stored data.
     fn maybe_append_rotation_log(
         id: Id,
         metadata: &Metadata,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -59,6 +59,33 @@ pub use crate::error::StorageError;
 /// Convenient type alias for the main storage system.
 pub type MainInterface = Interface<MainStorage>;
 
+/// Apply-time context passed to [`Interface::apply_action`].
+///
+/// Centralizes apply-time metadata so the call signature doesn't accumulate
+/// positional parameters. Currently carries DAG-causal parent hashes for the
+/// delta the action belongs to; future fields (delta hash, sender id, etc.)
+/// plug in here without re-touching every call site.
+///
+/// In phase P1 of #2233 the field is collected and threaded through but not
+/// consulted by the verifier. P2/P3 wire it into per-entity writer-set
+/// resolution at the causal point.
+///
+/// Construct explicitly at every call site:
+/// - When no causal context is available (local apply, snapshot leaf push,
+///   tests): `ApplyContext { causal_parents: &[] }`.
+/// - In sync paths with a `CausalDelta` in scope:
+///   `ApplyContext { causal_parents: &delta.parents }`.
+///
+/// No `Default` / shorthand constructor on purpose — when a new field lands,
+/// every call site should be a compile error so we don't silently default a
+/// new piece of context.
+#[derive(Clone, Copy, Debug)]
+pub struct ApplyContext<'a> {
+    /// Hashes of the parent deltas in the DAG. Empty when no causal context
+    /// is available.
+    pub causal_parents: &'a [[u8; 32]],
+}
+
 /// The primary interface for the storage system.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
@@ -102,13 +129,19 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Handles Add/Update/Delete actions, creating missing ancestors if needed.
     /// Generates Compare action for hash verification after applying changes.
     ///
+    /// `ctx` carries DAG-causal apply-time context (parents of the delta
+    /// this action belongs to). In phase P1 of #2233 it is plumbed through
+    /// but not consulted; P2/P3 will use it to resolve the writer set at
+    /// the causal point for `Shared`-storage verification.
+    ///
     /// # Errors
     /// - `DeserializationError` if action data is invalid
     /// - `ActionNotAllowed` if Compare action is passed directly
     ///
-    pub fn apply_action(action: Action) -> Result<(), StorageError> {
-        // Verify that the action timestamp is not too far in the future
-        // to prevent LWW Time Drift attacks.
+    pub fn apply_action(action: Action, ctx: ApplyContext<'_>) -> Result<(), StorageError> {
+        let _ = ctx; // P1: collected and forwarded only; verifier behavior unchanged.
+                     // Verify that the action timestamp is not too far in the future
+                     // to prevent LWW Time Drift attacks.
         verify_action_timestamp(&action)?;
 
         // TODO: refactor to a separate function.
@@ -782,6 +815,7 @@ impl<S: StorageAdaptor> Interface<S> {
     pub fn compare_affective(
         data: Option<Vec<u8>>,
         comparison_data: ComparisonData,
+        ctx: ApplyContext<'_>,
     ) -> Result<(), StorageError> {
         let (local, remote) = <Interface<S>>::compare_trees(data, comparison_data)?;
 
@@ -790,7 +824,7 @@ impl<S: StorageAdaptor> Interface<S> {
                 continue;
             }
 
-            <Interface<S>>::apply_action(action)?;
+            <Interface<S>>::apply_action(action, ctx)?;
         }
 
         for action in remote {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -775,6 +775,13 @@ impl<S: StorageAdaptor> Interface<S> {
     /// production paths don't yet thread `CausalDelta.{id,hlc}` through
     /// the WASM ABI, so the hook is dormant in production until that
     /// follow-up lands. Tests construct full ctx explicitly.
+    ///
+    /// # Caller invariant
+    ///
+    /// Must not be called twice for the same entity within one delta —
+    /// see [`rotation_log::append`](crate::rotation_log::append) for why
+    /// (delta_id-only dedup). Multi-action deltas with two rotations on
+    /// the same entity are not supported and will trip a debug assertion.
     fn maybe_append_rotation_log(
         id: Id,
         metadata: &Metadata,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -113,6 +113,8 @@ pub mod tests {
     pub mod merkle;
     /// P3 (DAG-causal) verifier swap + rotation-log write hook tests.
     pub mod p3_dag_causal;
+    /// P5 (DAG-causal) cross-node partition scenario tests.
+    pub mod p5_partition_scenarios;
     /// RGA (Replicated Growable Array) CRDT tests.
     pub mod rga;
     // TODO: Re-enable once Clone is implemented for collections

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -111,6 +111,8 @@ pub mod tests {
     pub mod merge_integration;
     /// Merkle hash propagation tests.
     pub mod merkle;
+    /// P3 (DAG-causal) verifier swap + rotation-log write hook tests.
+    pub mod p3_dag_causal;
     /// RGA (Replicated Growable Array) CRDT tests.
     pub mod rga;
     // TODO: Re-enable once Clone is implemented for collections

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -70,6 +70,7 @@ pub mod interface;
 pub mod js;
 pub mod logical_clock;
 pub mod merge;
+pub mod rotation_log;
 pub mod snapshot;
 pub mod store;
 

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -194,11 +194,17 @@ pub fn latest_writers<S: StorageAdaptor>(
 
 /// Returns the writer set as-of a causal point in the DAG.
 ///
-/// Implements ADR 0001's merge rule:
+/// Implements ADR 0001's merge rule end-to-end:
 /// 1. Filter entries to those reachable from `causal_parents`.
 /// 2. Among reachable entries, pick the causally latest.
 /// 3. Truly-concurrent tie → larger `delta_hlc` wins.
 /// 4. HLC tie → smaller `signer` pubkey bytes win (`None` treated as larger).
+///
+/// **P4-impl** of #2233 is a no-op for the chosen rule — there's no
+/// intermediate state to materialise, no convergence reduction step.
+/// The whole rule lives here, with the per-entity write hook in
+/// [`Interface::apply_action`](crate::interface::Interface::apply_action)
+/// (P3) keeping the log fed.
 ///
 /// `happens_before(a, b)` is the caller-provided DAG-ancestry predicate:
 /// returns true iff delta `a` is in the transitive ancestry of delta `b`

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -1,0 +1,500 @@
+//! Per-entity writer-set rotation log for `SharedStorage<T>`.
+//!
+//! Phase **P2** of [#2233](https://github.com/calimero-network/core/issues/2233)
+//! (DAG-causal Shared verification). Provides the storage shape and read API
+//! that P3's verifier uses to resolve "what was the writer set as of this
+//! causal point in the DAG?" — answering the partition-race scenarios called
+//! out in #2197.
+//!
+//! # Design
+//!
+//! Per [ADR 0001](../../../docs/adr/0001-shared-storage-concurrent-rotation.md):
+//! every accepted rotation appends an entry; reads compare entries by
+//! **causal-first → HLC → signer-pubkey** ordering.
+//!
+//! The log is stored separately from `EntityIndex` under a dedicated
+//! [`Key::RotationLog`] so reading the index doesn't pull in the full
+//! rotation history.
+//!
+//! # P2 scope (this module)
+//!
+//! - Schema: [`RotationLogEntry`], [`RotationSnapshot`], [`RotationLog`]
+//! - Persistence: [`load`], [`save`], [`append`]
+//! - Read APIs: [`latest_writers`], [`writers_at`]
+//!
+//! Wiring into [`Interface::apply_action`](crate::interface::Interface::apply_action)
+//! and the verifier is **P3**. In P2 the module is callable but not yet invoked
+//! by the apply pipeline; standalone unit tests cover the schema and ordering.
+//!
+//! # Compaction (shape locked in, not implemented)
+//!
+//! The [`RotationLog::snapshot`] field is reserved for P6 compaction: a sliding
+//! window of recent entries plus a snapshot of the writer set at the cutoff.
+//! The threshold (epic suggests 1000 entries) is a P6 measurement; the shape
+//! is fixed here so the on-disk format doesn't need a breaking change later.
+
+use std::collections::BTreeSet;
+
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
+use calimero_primitives::identity::PublicKey;
+
+use crate::address::Id;
+use crate::error::StorageError;
+use crate::logical_clock::HybridTimestamp;
+use crate::store::{Key, StorageAdaptor};
+
+/// One accepted rotation, captured at apply-time.
+///
+/// Fields chosen to be sufficient for the ADR ordering rule without needing
+/// to consult any other state:
+/// - `delta_id` identifies the `CausalDelta` so the caller's DAG-ancestry
+///   predicate can locate it.
+/// - `delta_hlc` is the sibling tiebreak when two rotations are concurrent.
+/// - `signer` is the final tiebreak for HLC ties (vanishingly rare but
+///   pinned for spec completeness).
+/// - `new_writers` is the resolved writer set after this rotation.
+/// - `writers_nonce` is preserved for v2 compatibility / debugging; not
+///   consulted by the ADR rule but useful when reading exported logs.
+#[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct RotationLogEntry {
+    /// Hash of the `CausalDelta` containing this rotation.
+    pub delta_id: [u8; 32],
+
+    /// Hybrid timestamp of the `CausalDelta`. Used as the sibling tiebreak
+    /// when two rotations are causally concurrent.
+    pub delta_hlc: HybridTimestamp,
+
+    /// Public key that signed the rotation action.
+    ///
+    /// `None` only for legacy / unsigned-bootstrap entries — see
+    /// [`writers_at`] for how those participate in ordering (they sort
+    /// after any `Some(...)` entry at equal HLC, mirroring the
+    /// "smaller bytes win" rule with `None` treated as "larger than any").
+    pub signer: Option<PublicKey>,
+
+    /// Resolved writer set after this rotation. `BTreeSet` so the on-wire
+    /// representation is canonical (sorted), matching the rest of the
+    /// `Shared` storage path.
+    pub new_writers: BTreeSet<PublicKey>,
+
+    /// Per-entity monotonic counter at the time of rotation. Preserved for
+    /// debugging and v2 compatibility; the ADR rule does not depend on it.
+    pub writers_nonce: u64,
+}
+
+/// A compacted prefix of the rotation log — the writer set at the boundary
+/// plus the index of the entry that boundary corresponds to.
+///
+/// **Not produced in P2** — the field exists so the on-disk shape doesn't
+/// need a migration when P6 turns compaction on.
+#[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct RotationSnapshot {
+    /// Writer set as-of the boundary. When a query's `causal_parents` only
+    /// reach into the compacted region, this is the answer.
+    pub writers: BTreeSet<PublicKey>,
+
+    /// Index into the original (uncompacted) entry stream that the snapshot
+    /// represents. Compacted entries had indices `[0, cutoff_index)`; live
+    /// entries in [`RotationLog::entries`] start at `cutoff_index`. Stored
+    /// as `u64` so the field doesn't bottleneck on `usize` portability.
+    pub cutoff_index: u64,
+}
+
+/// Persistent rotation log for a single Shared entity.
+///
+/// `entries` is append-only; new rotations push to the end. Order in the
+/// vector is **insertion order** (which is the order the receiver applied
+/// them), not causal order — `writers_at` is responsible for resolving
+/// causal precedence at read time, since insertion order differs across
+/// nodes when sync delivers concurrent rotations in different orders.
+#[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct RotationLog {
+    /// Compacted prefix; `None` until P6 compaction runs.
+    pub snapshot: Option<RotationSnapshot>,
+
+    /// Live entries past the snapshot (or the full history if
+    /// `snapshot.is_none()`).
+    pub entries: Vec<RotationLogEntry>,
+}
+
+impl RotationLog {
+    /// Empty log (no rotations recorded yet).
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            snapshot: None,
+            entries: Vec::new(),
+        }
+    }
+}
+
+/// Load the rotation log for `id`, if any.
+///
+/// Returns `Ok(None)` when no log has been written yet (entity exists but
+/// no rotation has been recorded). Returns `Err` only on deserialization
+/// failure — corruption is loud, never silent.
+pub fn load<S: StorageAdaptor>(id: Id) -> Result<Option<RotationLog>, StorageError> {
+    let Some(bytes) = S::storage_read(Key::RotationLog(id)) else {
+        return Ok(None);
+    };
+    let log = from_slice::<RotationLog>(&bytes).map_err(StorageError::DeserializationError)?;
+    Ok(Some(log))
+}
+
+/// Persist `log` for `id`, overwriting any existing log.
+///
+/// Callers should reach for [`append`] in the common case; `save` is exposed
+/// for tests and future P6 compaction that rewrites the log shape.
+pub fn save<S: StorageAdaptor>(id: Id, log: &RotationLog) -> Result<(), StorageError> {
+    let bytes = to_vec(log).map_err(|e| StorageError::SerializationError(e.into()))?;
+    let _ = S::storage_write(Key::RotationLog(id), &bytes);
+    Ok(())
+}
+
+/// Append a rotation entry.
+///
+/// Reads the existing log (creating an empty one if absent), pushes the new
+/// entry to the live tail, and writes back. Order in storage matches
+/// insertion order; causal resolution happens at read time.
+pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), StorageError> {
+    let mut log = load::<S>(id)?.unwrap_or_else(RotationLog::empty);
+    log.entries.push(entry);
+    save::<S>(id, &log)
+}
+
+/// Returns the writer set from the most recently *appended* entry.
+///
+/// "Most recently appended" is **insertion order on this node**, not causal
+/// order — concurrent rotations applied in different orders across nodes
+/// can produce different answers from this function. Use it only when no
+/// causal context is available:
+/// - snapshot leaf push (no `CausalDelta` in scope)
+/// - local apply paths
+/// - P1-era code that hasn't been wired through P3 yet
+///
+/// Matches v2's LWW-by-`writers_nonce` behavior in practice (the latest
+/// inserted entry tends to also be the highest nonce on the local node),
+/// preserving backward compatibility.
+///
+/// Returns `Ok(None)` if the log is empty or absent.
+pub fn latest_writers<S: StorageAdaptor>(
+    id: Id,
+) -> Result<Option<BTreeSet<PublicKey>>, StorageError> {
+    let Some(log) = load::<S>(id)? else {
+        return Ok(None);
+    };
+    if let Some(entry) = log.entries.last() {
+        return Ok(Some(entry.new_writers.clone()));
+    }
+    if let Some(snap) = log.snapshot {
+        return Ok(Some(snap.writers));
+    }
+    Ok(None)
+}
+
+/// Returns the writer set as-of a causal point in the DAG.
+///
+/// Implements ADR 0001's merge rule:
+/// 1. Filter entries to those reachable from `causal_parents`.
+/// 2. Among reachable entries, pick the causally latest.
+/// 3. Truly-concurrent tie → larger `delta_hlc` wins.
+/// 4. HLC tie → smaller `signer` pubkey bytes win (`None` treated as larger).
+///
+/// `happens_before(a, b)` is the caller-provided DAG-ancestry predicate:
+/// returns true iff delta `a` is in the transitive ancestry of delta `b`
+/// (i.e., `a` happens-before `b` in the DAG-causal sense). Storage cannot
+/// answer this on its own — it doesn't have the DAG — so the node sync
+/// layer (which does) provides the closure at the call site.
+///
+/// `causal_parents` is the parent set of the apply context's delta (i.e.,
+/// `CausalDelta.parents` of the delta whose action is being applied).
+///
+/// # Reachability
+///
+/// An entry `e` is reachable iff
+/// `causal_parents.iter().any(|p| e.delta_id == *p || happens_before(&e.delta_id, p))`.
+/// In words: the rotation's delta is one of the apply-context's parents, or
+/// is in the transitive ancestry of one of them.
+///
+/// # When `causal_parents` is empty
+///
+/// Returns the same answer as [`latest_writers`] — the v2-compatible
+/// fallback for paths without DAG context.
+///
+/// Returns `Ok(None)` if no log entry is reachable (or the log is absent).
+pub fn writers_at<S: StorageAdaptor, F>(
+    id: Id,
+    causal_parents: &[[u8; 32]],
+    happens_before: F,
+) -> Result<Option<BTreeSet<PublicKey>>, StorageError>
+where
+    F: Fn(&[u8; 32], &[u8; 32]) -> bool,
+{
+    if causal_parents.is_empty() {
+        return latest_writers::<S>(id);
+    }
+
+    let Some(log) = load::<S>(id)? else {
+        return Ok(None);
+    };
+
+    // Filter to entries reachable from any of the apply context's parents.
+    let reachable: Vec<&RotationLogEntry> = log
+        .entries
+        .iter()
+        .filter(|e| {
+            causal_parents
+                .iter()
+                .any(|p| e.delta_id == *p || happens_before(&e.delta_id, p))
+        })
+        .collect();
+
+    // ADR 0001 ordering. We want the *latest* entry, so define cmp such that
+    // "later" is `Greater`, then take the max.
+    let latest = reachable.into_iter().max_by(|a, b| {
+        // 1. Causal precedence wins: if a happens-before b, b is later.
+        if happens_before(&a.delta_id, &b.delta_id) {
+            return std::cmp::Ordering::Less;
+        }
+        if happens_before(&b.delta_id, &a.delta_id) {
+            return std::cmp::Ordering::Greater;
+        }
+        // 2. Truly concurrent → larger HLC wins.
+        match a.delta_hlc.cmp(&b.delta_hlc) {
+            std::cmp::Ordering::Equal => {}
+            non_eq => return non_eq,
+        }
+        // 3. HLC tie → smaller signer bytes win, so the smaller one is "later"
+        //    in our cmp (since we take max). `None` is treated as larger than
+        //    any `Some(_)` so it sorts last and loses ties.
+        match (&a.signer, &b.signer) {
+            (Some(sa), Some(sb)) => sb.digest().cmp(sa.digest()),
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    });
+
+    if let Some(entry) = latest {
+        return Ok(Some(entry.new_writers.clone()));
+    }
+
+    // Nothing in `entries` was reachable. If the log has been compacted
+    // (P6), the snapshot's writer set is the answer for any apply context
+    // whose history pre-dates the cutoff. For now `snapshot` is always
+    // `None`, so this falls through to `Ok(None)`.
+    if let Some(snap) = log.snapshot {
+        return Ok(Some(snap.writers));
+    }
+    Ok(None)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::MockedStorage;
+
+    type Store = MockedStorage<300>;
+
+    fn pk(b: u8) -> PublicKey {
+        PublicKey::from([b; 32])
+    }
+
+    fn entry(
+        delta_id: u8,
+        hlc_time: u64,
+        signer: u8,
+        writers: &[u8],
+        nonce: u64,
+    ) -> RotationLogEntry {
+        use core::num::NonZeroU128;
+
+        use crate::logical_clock::{Timestamp, ID, NTP64};
+
+        // Distinct non-zero ID per signer keeps HLCs ordered by `hlc_time` first
+        // (the `time` component dominates the derived `Ord`); the ID component
+        // only kicks in when `time` collides, which is exactly the tiebreak case
+        // we want to test independently via `signer`.
+        let id_u128 = NonZeroU128::new(u128::from(signer) + 1).unwrap();
+        let ts = Timestamp::new(NTP64(hlc_time), ID::from(id_u128));
+        RotationLogEntry {
+            delta_id: [delta_id; 32],
+            delta_hlc: HybridTimestamp::new(ts),
+            signer: Some(pk(signer)),
+            new_writers: writers.iter().copied().map(pk).collect(),
+            writers_nonce: nonce,
+        }
+    }
+
+    fn id(b: u8) -> Id {
+        Id::new([b; 32])
+    }
+
+    #[test]
+    fn empty_when_no_log_written() {
+        let id = id(1);
+        assert_eq!(load::<Store>(id).unwrap(), None);
+        assert_eq!(latest_writers::<Store>(id).unwrap(), None);
+        assert_eq!(
+            writers_at::<Store, _>(id, &[[0; 32]], |_, _| false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn append_round_trips_through_storage() {
+        let id = id(2);
+        let e = entry(1, 100, 0xAA, &[0xAA, 0xBB], 1);
+        append::<Store>(id, e.clone()).unwrap();
+        let loaded = load::<Store>(id).unwrap().unwrap();
+        assert_eq!(loaded.entries, vec![e]);
+        assert_eq!(loaded.snapshot, None);
+    }
+
+    #[test]
+    fn latest_writers_returns_last_appended() {
+        let id = id(3);
+        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA], 1)).unwrap();
+        append::<Store>(id, entry(2, 200, 0xBB, &[0xBB], 2)).unwrap();
+        assert_eq!(
+            latest_writers::<Store>(id).unwrap(),
+            Some([0xBB].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn writers_at_with_empty_parents_falls_back_to_latest() {
+        // ADR: empty causal_parents → match latest_writers (v2 LWW compat).
+        let id = id(4);
+        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA], 1)).unwrap();
+        append::<Store>(id, entry(2, 200, 0xBB, &[0xBB], 2)).unwrap();
+        assert_eq!(
+            writers_at::<Store, _>(id, &[], |_, _| false).unwrap(),
+            Some([0xBB].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn writers_at_returns_only_reachable_entries() {
+        // ADR Example A: sequential rotations. R1 is the parent, R2 builds on it.
+        // Querying with causal_parents = [R1.delta_id] should pick R1, NOT R2,
+        // because R2 hasn't happened yet from the perspective of someone
+        // looking at R1's frontier.
+        let id = id(5);
+        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA, 0xBB], 1)).unwrap();
+        append::<Store>(id, entry(2, 200, 0xBB, &[0xBB, 0xCC], 2)).unwrap();
+
+        // happens_before(a, b): R1 (id=[1;32]) happens-before R2 (id=[2;32]).
+        let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
+
+        // Query as-of R1: only R1 is reachable.
+        let writers = writers_at::<Store, _>(id, &[[1; 32]], happens_before).unwrap();
+        assert_eq!(writers, Some([0xAA, 0xBB].into_iter().map(pk).collect()));
+
+        // Query as-of R2: both reachable, R2 is causally later → R2 wins.
+        let writers = writers_at::<Store, _>(id, &[[2; 32]], happens_before).unwrap();
+        assert_eq!(writers, Some([0xBB, 0xCC].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_concurrent_siblings_resolved_by_hlc() {
+        // ADR Example B: two concurrent siblings with different HLCs.
+        // Larger HLC wins.
+        let id = id(6);
+        // R1 by Alice at HLC=20, removes Bob.
+        append::<Store>(id, entry(1, 20, 0xAA, &[0xAA], 10)).unwrap();
+        // R2 by Bob at HLC=21, removes Alice. Concurrent with R1.
+        append::<Store>(id, entry(2, 21, 0xBB, &[0xBB], 10)).unwrap();
+
+        // Apply context's parents reference both rotations as siblings of D_root.
+        // Our happens_before says neither precedes the other.
+        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
+
+        // Query reaching both: HLC=21 > HLC=20 → R2 (writers={Bob}) wins.
+        let writers = writers_at::<Store, _>(id, &[[1; 32], [2; 32]], none_precede).unwrap();
+        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_hlc_tie_resolved_by_signer_bytes() {
+        // ADR Example C: HLC tie (same time AND same node ID, which is
+        // vanishingly rare in production but pinned in the spec).
+        // Smaller signer pubkey bytes win.
+        use core::num::NonZeroU128;
+
+        use crate::logical_clock::{Timestamp, ID, NTP64};
+
+        let id = id(7);
+        // Build two entries with IDENTICAL HLCs (same time, same node ID).
+        let identical_ts = HybridTimestamp::new(Timestamp::new(
+            NTP64(50),
+            ID::from(NonZeroU128::new(1).unwrap()),
+        ));
+        let mk = |delta_id: u8, signer: u8, writers: &[u8]| RotationLogEntry {
+            delta_id: [delta_id; 32],
+            delta_hlc: identical_ts,
+            signer: Some(pk(signer)),
+            new_writers: writers.iter().copied().map(pk).collect(),
+            writers_nonce: 10,
+        };
+        // signer 0xAA < signer 0xBB byte-wise.
+        append::<Store>(id, mk(1, 0xAA, &[0xAA, 0xCC])).unwrap();
+        append::<Store>(id, mk(2, 0xBB, &[0xBB, 0xDD])).unwrap();
+
+        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
+        let writers = writers_at::<Store, _>(id, &[[1; 32], [2; 32]], none_precede).unwrap();
+        // 0xAA is smaller → wins.
+        assert_eq!(writers, Some([0xAA, 0xCC].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_causal_precedence_overrides_hlc() {
+        // R1 happens-before R2, but R1.hlc > R2.hlc (clock skew). Causal
+        // wins: R2's author saw R1's reality and chose to rotate from there.
+        let id = id(8);
+        append::<Store>(id, entry(1, 999, 0xAA, &[0xAA], 1)).unwrap(); // huge HLC
+        append::<Store>(id, entry(2, 100, 0xBB, &[0xBB], 2)).unwrap(); // smaller HLC
+
+        // R1 happens-before R2 in the DAG.
+        let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
+
+        let writers = writers_at::<Store, _>(id, &[[2; 32]], happens_before).unwrap();
+        // R2 wins despite smaller HLC, because it's causally later.
+        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_unreachable_entries_ignored() {
+        // Entry exists but isn't reachable from the queried parents.
+        // Returns None (not the latest) — verifier can fall back as it sees fit.
+        let id = id(9);
+        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA], 1)).unwrap();
+
+        // Different parent that doesn't reach delta 1.
+        let writers = writers_at::<Store, _>(id, &[[42; 32]], |_, _| false).unwrap();
+        assert_eq!(writers, None);
+    }
+
+    #[test]
+    fn writers_at_falls_back_to_snapshot_when_entries_unreachable() {
+        // P6 compaction wrote a snapshot but no live entries reach the query.
+        let id = id(10);
+        let snap_writers: BTreeSet<PublicKey> = [0xEE].into_iter().map(pk).collect();
+        let log = RotationLog {
+            snapshot: Some(RotationSnapshot {
+                writers: snap_writers.clone(),
+                cutoff_index: 5,
+            }),
+            entries: vec![entry(99, 100, 0xFF, &[0xFF], 99)],
+        };
+        save::<Store>(id, &log).unwrap();
+
+        // happens_before never matches: live entry at delta 99 is unreachable.
+        let writers = writers_at::<Store, _>(id, &[[1; 32]], |_, _| false).unwrap();
+        assert_eq!(writers, Some(snap_writers));
+    }
+}

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -133,6 +133,11 @@ impl RotationLog {
 /// Returns `Ok(None)` when no log has been written yet (entity exists but
 /// no rotation has been recorded). Returns `Err` only on deserialization
 /// failure — corruption is loud, never silent.
+///
+/// # Errors
+///
+/// Returns [`StorageError::DeserializationError`] if the stored bytes
+/// cannot be decoded as a `RotationLog`.
 pub fn load<S: StorageAdaptor>(id: Id) -> Result<Option<RotationLog>, StorageError> {
     let Some(bytes) = S::storage_read(Key::RotationLog(id)) else {
         return Ok(None);
@@ -145,6 +150,10 @@ pub fn load<S: StorageAdaptor>(id: Id) -> Result<Option<RotationLog>, StorageErr
 ///
 /// Callers should reach for [`append`] in the common case; `save` is exposed
 /// for tests and future P6 compaction that rewrites the log shape.
+///
+/// # Errors
+///
+/// Returns [`StorageError::SerializationError`] if `log` cannot be encoded.
 pub fn save<S: StorageAdaptor>(id: Id, log: &RotationLog) -> Result<(), StorageError> {
     let bytes = to_vec(log).map_err(|e| StorageError::SerializationError(e.into()))?;
     let _ = S::storage_write(Key::RotationLog(id), &bytes);
@@ -161,6 +170,11 @@ pub fn save<S: StorageAdaptor>(id: Id, log: &RotationLog) -> Result<(), StorageE
 /// retransmit) only produces one log entry. The duplicate is silently
 /// dropped — no error. This matches the broader CRDT model where applying
 /// the same operation twice is safe.
+///
+/// # Errors
+///
+/// Propagates [`load`] / [`save`] errors (deserialization on read,
+/// serialization on write).
 pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), StorageError> {
     let mut log = load::<S>(id)?.unwrap_or_else(RotationLog::empty);
     if log.entries.iter().any(|e| e.delta_id == entry.delta_id) {
@@ -185,6 +199,10 @@ pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), 
 /// preserving backward compatibility.
 ///
 /// Returns `Ok(None)` if the log is empty or absent.
+///
+/// # Errors
+///
+/// Propagates [`load`] errors (deserialization on read).
 pub fn latest_writers<S: StorageAdaptor>(
     id: Id,
 ) -> Result<Option<BTreeSet<PublicKey>>, StorageError> {
@@ -236,6 +254,10 @@ pub fn latest_writers<S: StorageAdaptor>(
 /// fallback for paths without DAG context.
 ///
 /// Returns `Ok(None)` if no log entry is reachable (or the log is absent).
+///
+/// # Errors
+///
+/// Propagates [`load`] errors (deserialization on read).
 pub fn writers_at<S: StorageAdaptor, F>(
     id: Id,
     causal_parents: &[[u8; 32]],

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -326,9 +326,12 @@ where
             std::cmp::Ordering::Equal => {}
             non_eq => return non_eq,
         }
-        // 3. HLC tie → smaller signer bytes win, so the smaller one is "later"
-        //    in our cmp (since we take max). `None` is treated as larger than
-        //    any `Some(_)` so it sorts last and loses ties.
+        // 3. HLC tie → entry with the smaller signer bytes is the WINNER
+        //    (per ADR 0001). We're computing `max_by`, so the comparator
+        //    must return `Greater` for the entry whose signer is smaller —
+        //    that makes `max_by` pick it. `None` signers compare as
+        //    `Greater` than any `Some(_)`, so unsigned legacy entries lose
+        //    HLC ties to signed ones.
         match (&a.signer, &b.signer) {
             (Some(sa), Some(sb)) => sb.digest().cmp(sa.digest()),
             (Some(_), None) => std::cmp::Ordering::Greater,

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -156,8 +156,16 @@ pub fn save<S: StorageAdaptor>(id: Id, log: &RotationLog) -> Result<(), StorageE
 /// Reads the existing log (creating an empty one if absent), pushes the new
 /// entry to the live tail, and writes back. Order in storage matches
 /// insertion order; causal resolution happens at read time.
+///
+/// **Idempotent on `delta_id`**: a delta delivered twice (out-of-order sync,
+/// retransmit) only produces one log entry. The duplicate is silently
+/// dropped — no error. This matches the broader CRDT model where applying
+/// the same operation twice is safe.
 pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), StorageError> {
     let mut log = load::<S>(id)?.unwrap_or_else(RotationLog::empty);
+    if log.entries.iter().any(|e| e.delta_id == entry.delta_id) {
+        return Ok(());
+    }
     log.entries.push(entry);
     save::<S>(id, &log)
 }

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -45,6 +45,12 @@ use crate::store::{Key, StorageAdaptor};
 
 /// One accepted rotation, captured at apply-time.
 ///
+/// **Caller invariant**: at most one entry per `(entity_id, delta_id)`. The
+/// log dedups on `delta_id` alone and silently drops a second [`append`] for
+/// the same delta (see that fn for rationale + debug assertion). Multi-action
+/// `CausalDelta`s with two rotations on the same entity are not supported;
+/// callers must split them into separate deltas. Tracked in #2233 P3.
+///
 /// Fields chosen to be sufficient for the ADR ordering rule without needing
 /// to consult any other state:
 /// - `delta_id` identifies the `CausalDelta` so the caller's DAG-ancestry
@@ -171,13 +177,33 @@ pub fn save<S: StorageAdaptor>(id: Id, log: &RotationLog) -> Result<(), StorageE
 /// dropped — no error. This matches the broader CRDT model where applying
 /// the same operation twice is safe.
 ///
+/// **Caller invariant — one rotation per entity per delta**: dedup keys on
+/// `delta_id` only. If a single `CausalDelta` carries two rotation actions
+/// on the same entity, only the first reaches the log; the second is
+/// silently dropped while `save_internal` still applies its data. This
+/// would diverge log from stored state. A `debug_assert!` below catches the
+/// case where the silent drop would discard *different* contents (replays
+/// pass it because contents match). Multi-action deltas with multiple
+/// rotations on the same entity must be split into separate deltas at
+/// construction time. Tracked in #2233 P3.
+///
 /// # Errors
 ///
 /// Propagates [`load`] / [`save`] errors (deserialization on read,
 /// serialization on write).
 pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), StorageError> {
     let mut log = load::<S>(id)?.unwrap_or_else(RotationLog::empty);
-    if log.entries.iter().any(|e| e.delta_id == entry.delta_id) {
+    if let Some(existing) = log.entries.iter().find(|e| e.delta_id == entry.delta_id) {
+        debug_assert_eq!(
+            (
+                &existing.new_writers,
+                existing.signer,
+                existing.writers_nonce
+            ),
+            (&entry.new_writers, entry.signer, entry.writers_nonce),
+            "rotation_log::append called twice for delta_id with differing contents — \
+             multi-rotation-per-entity-per-delta is not supported (#2233 P3)"
+        );
         return Ok(());
     }
     log.entries.push(entry);

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -46,10 +46,12 @@ use crate::store::{Key, StorageAdaptor};
 /// One accepted rotation, captured at apply-time.
 ///
 /// **Caller invariant**: at most one entry per `(entity_id, delta_id)`. The
-/// log dedups on `delta_id` alone and silently drops a second [`append`] for
-/// the same delta (see that fn for rationale + debug assertion). Multi-action
-/// `CausalDelta`s with two rotations on the same entity are not supported;
-/// callers must split them into separate deltas. Tracked in #2233 P3.
+/// log dedups on `delta_id` alone:
+/// - Replaying a delta with **identical** entry contents is a no-op (idempotent).
+/// - Calling [`append`] a second time with **differing** contents returns
+///   [`StorageError::DuplicateRotationInDelta`] — multi-action `CausalDelta`s
+///   with two rotations on the same entity are not supported; callers must
+///   split them into separate deltas. Tracked in #2233 P3.
 ///
 /// Fields chosen to be sufficient for the ADR ordering rule without needing
 /// to consult any other state:
@@ -173,37 +175,38 @@ pub fn save<S: StorageAdaptor>(id: Id, log: &RotationLog) -> Result<(), StorageE
 /// insertion order; causal resolution happens at read time.
 ///
 /// **Idempotent on `delta_id`**: a delta delivered twice (out-of-order sync,
-/// retransmit) only produces one log entry. The duplicate is silently
-/// dropped — no error. This matches the broader CRDT model where applying
-/// the same operation twice is safe.
+/// retransmit) only produces one log entry, provided the entry contents
+/// match. This matches the broader CRDT model where applying the same
+/// operation twice is safe.
 ///
 /// **Caller invariant — one rotation per entity per delta**: dedup keys on
 /// `delta_id` only. If a single `CausalDelta` carries two rotation actions
-/// on the same entity, only the first reaches the log; the second is
-/// silently dropped while `save_internal` still applies its data. This
-/// would diverge log from stored state. A `debug_assert!` below catches the
-/// case where the silent drop would discard *different* contents (replays
-/// pass it because contents match). Multi-action deltas with multiple
-/// rotations on the same entity must be split into separate deltas at
-/// construction time. Tracked in #2233 P3.
+/// on the same entity, only the first reaches the log; the second would
+/// silently be dropped while `save_internal` still applies its data,
+/// diverging log from stored state. To prevent that, a second [`append`]
+/// for the same `delta_id` whose entry contents differ from the existing
+/// entry returns [`StorageError::DuplicateRotationInDelta`] instead of
+/// being silently dropped. Multi-action deltas with multiple rotations on
+/// the same entity must be split into separate deltas at construction time.
+/// Tracked in #2233 P3.
 ///
 /// # Errors
 ///
-/// Propagates [`load`] / [`save`] errors (deserialization on read,
-/// serialization on write).
+/// - [`StorageError::DuplicateRotationInDelta`] if a prior entry exists for
+///   `entry.delta_id` with differing `(new_writers, signer, writers_nonce)`.
+/// - Propagates [`load`] / [`save`] errors (deserialization on read,
+///   serialization on write).
 pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), StorageError> {
     let mut log = load::<S>(id)?.unwrap_or_else(RotationLog::empty);
     if let Some(existing) = log.entries.iter().find(|e| e.delta_id == entry.delta_id) {
-        debug_assert_eq!(
-            (
-                &existing.new_writers,
-                existing.signer,
-                existing.writers_nonce
-            ),
-            (&entry.new_writers, entry.signer, entry.writers_nonce),
-            "rotation_log::append called twice for delta_id with differing contents — \
-             multi-rotation-per-entity-per-delta is not supported (#2233 P3)"
-        );
+        if (
+            &existing.new_writers,
+            existing.signer,
+            existing.writers_nonce,
+        ) != (&entry.new_writers, entry.signer, entry.writers_nonce)
+        {
+            return Err(StorageError::DuplicateRotationInDelta(entry.delta_id));
+        }
         return Ok(());
     }
     log.entries.push(entry);
@@ -542,6 +545,37 @@ mod tests {
         // Different parent that doesn't reach delta 1.
         let writers = writers_at::<Store, _>(id, &[[42; 32]], |_, _| false).unwrap();
         assert_eq!(writers, None);
+    }
+
+    #[test]
+    fn append_is_idempotent_when_replayed_with_identical_contents() {
+        // CRDT replay safety: re-appending the exact same entry is a no-op
+        // (only one log row, no error).
+        let id = id(11);
+        let e = entry(1, 100, 0xAA, &[0xAA, 0xBB], 1);
+        append::<Store>(id, e.clone()).unwrap();
+        append::<Store>(id, e.clone()).unwrap();
+        let log = load::<Store>(id).unwrap().unwrap();
+        assert_eq!(log.entries, vec![e]);
+    }
+
+    #[test]
+    fn append_rejects_duplicate_delta_with_divergent_contents() {
+        // Caller invariant violation: same delta_id, different new_writers.
+        // Was previously a debug_assert; promoted to a hard error so release
+        // builds also surface multi-rotation-per-entity-per-delta misuse.
+        let id = id(12);
+        let e1 = entry(1, 100, 0xAA, &[0xAA], 1);
+        let e2 = entry(1, 100, 0xAA, &[0xBB], 1); // same delta_id, different writers
+        append::<Store>(id, e1.clone()).unwrap();
+        let err = append::<Store>(id, e2).unwrap_err();
+        assert!(
+            matches!(err, StorageError::DuplicateRotationInDelta(d) if d == [1; 32]),
+            "expected DuplicateRotationInDelta, got {err:?}"
+        );
+        // The original entry stays put; nothing was overwritten.
+        let log = load::<Store>(id).unwrap().unwrap();
+        assert_eq!(log.entries, vec![e1]);
     }
 
     #[test]

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -17,6 +17,14 @@ pub enum Key {
 
     /// Sync state key for tracking last sync time with a remote node.
     SyncState(Id),
+
+    /// Rotation log key for `SharedStorage<T>` writer-set history.
+    ///
+    /// Stores a [`RotationLog`](crate::rotation_log::RotationLog) per Shared
+    /// entity so the verifier (P3 of #2233) can resolve `writers_at(causal_point)`
+    /// for actions that pre-date the current writer set. Tag `3` to keep the
+    /// existing `Index`/`Entry`/`SyncState` byte layout stable.
+    RotationLog(Id),
 }
 
 impl Key {
@@ -35,6 +43,10 @@ impl Key {
             }
             Self::SyncState(id) => {
                 bytes[0] = 2;
+                bytes[1..33].copy_from_slice(id.as_bytes());
+            }
+            Self::RotationLog(id) => {
+                bytes[0] = 3;
                 bytes[1..33].copy_from_slice(id.as_bytes());
             }
         }

--- a/crates/storage/src/tests/authored_primitives.rs
+++ b/crates/storage/src/tests/authored_primitives.rs
@@ -16,7 +16,7 @@ use crate::collections::{AuthoredMap, AuthoredVector, Root};
 use crate::entities::{Metadata, SignatureData, StorageType};
 use crate::env;
 use crate::error::StorageError;
-use crate::interface::Interface;
+use crate::interface::{ApplyContext, Interface};
 use crate::store::MainStorage;
 use crate::tests::common::{create_test_keypair, sign_action};
 
@@ -164,7 +164,12 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(forged) {
+    match MainInterface::apply_action(
+        forged,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    ) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }
@@ -200,7 +205,12 @@ fn authored_map_delete_by_non_owner_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(forged) {
+    match MainInterface::apply_action(
+        forged,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    ) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }
@@ -232,7 +242,12 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(forged) {
+    match MainInterface::apply_action(
+        forged,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    ) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }
@@ -263,7 +278,12 @@ fn authored_vector_delete_by_non_owner_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(forged) {
+    match MainInterface::apply_action(
+        forged,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    ) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }

--- a/crates/storage/src/tests/authored_primitives.rs
+++ b/crates/storage/src/tests/authored_primitives.rs
@@ -168,6 +168,9 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
         forged,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     ) {
         Err(StorageError::InvalidSignature) => {}
@@ -209,6 +212,9 @@ fn authored_map_delete_by_non_owner_is_rejected() {
         forged,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     ) {
         Err(StorageError::InvalidSignature) => {}
@@ -246,6 +252,9 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
         forged,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     ) {
         Err(StorageError::InvalidSignature) => {}
@@ -282,6 +291,9 @@ fn authored_vector_delete_by_non_owner_is_rejected() {
         forged,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     ) {
         Err(StorageError::InvalidSignature) => {}

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
@@ -275,6 +275,74 @@ pub fn create_signed_user_add_action(
         }
     }
 
+    action
+}
+
+/// Returns the `PublicKey` corresponding to a `SigningKey`.
+pub fn pubkey_of(sk: &SigningKey) -> PublicKey {
+    PublicKey::from(*sk.verifying_key().as_bytes())
+}
+
+/// Build a signed `Shared` storage action (Add or Update).
+///
+/// `hlc_ns` populates BOTH the action's `updated_at` and the signature's
+/// `nonce` — matching production where `sign_authorized_actions` stamps both
+/// with the action's HLC. Tests must pass strictly increasing values across
+/// sequential calls to satisfy per-entity replay protection.
+///
+/// `signer_sk` must be in `writers` (or the caller is intentionally testing
+/// a forged action).
+pub fn build_signed_shared_action(
+    add: bool,
+    id: Id,
+    data: Vec<u8>,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let metadata = Metadata {
+        created_at: hlc_ns,
+        updated_at: hlc_ns.into(),
+        storage_type: StorageType::Shared {
+            writers,
+            signature_data: Some(SignatureData {
+                signature: [0; 64],
+                nonce: hlc_ns,
+                signer: Some(pubkey_of(signer_sk)),
+            }),
+        },
+        crdt_type: None,
+        field_name: None,
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::Shared {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
     action
 }
 

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -121,6 +121,9 @@ fn tombstone_marks_deleted() {
         delete_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -156,6 +159,9 @@ fn tombstone_prevents_old_resurrection() {
         resurrect_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -195,6 +201,9 @@ fn tombstone_allows_newer_update() {
         update_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -242,6 +251,9 @@ fn delete_vs_update_conflict() {
         delete_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -249,6 +261,9 @@ fn delete_vs_update_conflict() {
         update_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -292,6 +307,9 @@ fn update_vs_delete_conflict() {
         update_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -299,6 +317,9 @@ fn update_vs_delete_conflict() {
         delete_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -383,6 +404,9 @@ fn concurrent_update_same_entity_different_fields() {
         action1,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -390,6 +414,9 @@ fn concurrent_update_same_entity_different_fields() {
         action2,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -422,6 +449,9 @@ fn actions_idempotent() {
         action.clone(),
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -429,6 +459,9 @@ fn actions_idempotent() {
         action.clone(),
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -436,6 +469,9 @@ fn actions_idempotent() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -461,6 +497,9 @@ fn update_before_add_creates_entity() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -488,6 +527,9 @@ fn delete_prevents_old_add() {
         delete_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -504,6 +546,9 @@ fn delete_prevents_old_add() {
         add_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -555,6 +600,9 @@ fn same_timestamp_lww_behavior() {
         action1,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -562,6 +610,9 @@ fn same_timestamp_lww_behavior() {
         action2,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -588,6 +639,9 @@ fn empty_entity_data() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     );
     // Just verify it doesn't panic - result may vary
@@ -610,6 +664,9 @@ fn malformed_entity_data() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     );
     assert!(result.is_err());
@@ -631,6 +688,9 @@ fn multiple_deletes_idempotent() {
         delete_action.clone(),
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -638,6 +698,9 @@ fn multiple_deletes_idempotent() {
         delete_action.clone(),
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -645,6 +708,9 @@ fn multiple_deletes_idempotent() {
         delete_action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();
@@ -685,6 +751,9 @@ fn many_sequential_updates() {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         )
         .unwrap();
@@ -721,6 +790,9 @@ fn rapid_add_delete_cycles() {
                 action,
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             )
             .unwrap();
@@ -739,6 +811,9 @@ fn rapid_add_delete_cycles() {
                 action,
                 ApplyContext {
                     causal_parents: &[],
+                    delta_id: None,
+                    delta_hlc: None,
+                    happens_before: None,
                 },
             )
             .unwrap();
@@ -770,6 +845,9 @@ fn test_future_timestamp_rejected() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     );
 
@@ -806,7 +884,10 @@ fn test_near_future_timestamp_accepted() {
         TestInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok(),
@@ -836,7 +917,10 @@ fn test_past_timestamp_accepted() {
         TestInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok(),
@@ -863,6 +947,9 @@ fn test_delete_future_timestamp_rejected() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     );
     assert!(
@@ -894,7 +981,10 @@ fn test_delete_near_future_accepted() {
         TestInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok(),

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -17,7 +17,7 @@ use crate::constants::DRIFT_TOLERANCE_NANOS;
 use crate::entities::{Data, Element, Metadata};
 use crate::env::time_now;
 use crate::index::Index;
-use crate::interface::Interface;
+use crate::interface::{ApplyContext, Interface};
 use crate::store::MockedStorage;
 
 type TestStorage = MockedStorage<5000>;
@@ -117,7 +117,13 @@ fn tombstone_marks_deleted() {
         metadata: Metadata::default(),
     };
 
-    TestInterface::apply_action(delete_action).unwrap();
+    TestInterface::apply_action(
+        delete_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Entity should be gone
     assert!(TestInterface::find_by_id::<Page>(id).unwrap().is_none());
@@ -146,7 +152,13 @@ fn tombstone_prevents_old_resurrection() {
         metadata: save_meta, // Old metadata from before deletion
     };
 
-    TestInterface::apply_action(resurrect_action).unwrap();
+    TestInterface::apply_action(
+        resurrect_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Should remain deleted (tombstone is newer)
     assert!(TestInterface::find_by_id::<Page>(id).unwrap().is_none());
@@ -179,7 +191,13 @@ fn tombstone_allows_newer_update() {
         metadata: new_page.element().metadata.clone(),
     };
 
-    TestInterface::apply_action(update_action).unwrap();
+    TestInterface::apply_action(
+        update_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Should be resurrected (if the add timestamp is newer than delete)
     let retrieved = TestInterface::find_by_id::<Page>(id).unwrap();
@@ -220,8 +238,20 @@ fn delete_vs_update_conflict() {
     };
 
     // Apply delete first, then update
-    TestInterface::apply_action(delete_action).unwrap();
-    TestInterface::apply_action(update_action).unwrap();
+    TestInterface::apply_action(
+        delete_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        update_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Behavior depends on implementation
     // Just verify no panic
@@ -258,8 +288,20 @@ fn update_vs_delete_conflict() {
     };
 
     // Apply update first, then delete
-    TestInterface::apply_action(update_action).unwrap();
-    TestInterface::apply_action(delete_action).unwrap();
+    TestInterface::apply_action(
+        update_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        delete_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Delete wins (newer timestamp)
     let retrieved = TestInterface::find_by_id::<Page>(id).unwrap();
@@ -337,8 +379,20 @@ fn concurrent_update_same_entity_different_fields() {
     };
 
     // Apply both
-    TestInterface::apply_action(action1).unwrap();
-    TestInterface::apply_action(action2).unwrap();
+    TestInterface::apply_action(
+        action1,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        action2,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Later timestamp wins
     let retrieved = TestInterface::find_by_id::<Page>(page.id())
@@ -364,9 +418,27 @@ fn actions_idempotent() {
     };
 
     // Apply multiple times
-    TestInterface::apply_action(action.clone()).unwrap();
-    TestInterface::apply_action(action.clone()).unwrap();
-    TestInterface::apply_action(action).unwrap();
+    TestInterface::apply_action(
+        action.clone(),
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        action.clone(),
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Should only exist once
     let retrieved = TestInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -385,7 +457,13 @@ fn update_before_add_creates_entity() {
         metadata: page.element().metadata.clone(),
     };
 
-    TestInterface::apply_action(action).unwrap();
+    TestInterface::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Should be created
     let retrieved = TestInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -406,7 +484,13 @@ fn delete_prevents_old_add() {
         deleted_at: time_now(),
         metadata: Metadata::default(),
     };
-    TestInterface::apply_action(delete_action).unwrap();
+    TestInterface::apply_action(
+        delete_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Try to add with older timestamp (from before deletion)
     let add_action = Action::Add {
@@ -416,7 +500,13 @@ fn delete_prevents_old_add() {
         metadata: old_meta,
     };
 
-    TestInterface::apply_action(add_action).unwrap();
+    TestInterface::apply_action(
+        add_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Should remain deleted (tombstone wins)
     assert!(TestInterface::find_by_id::<Page>(page.id())
@@ -461,8 +551,20 @@ fn same_timestamp_lww_behavior() {
     };
 
     // Apply both - later one wins
-    TestInterface::apply_action(action1).unwrap();
-    TestInterface::apply_action(action2).unwrap();
+    TestInterface::apply_action(
+        action1,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        action2,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     let result = TestInterface::find_by_id::<Page>(id).unwrap().unwrap();
     assert_eq!(result.title, "Update 2");
@@ -482,7 +584,12 @@ fn empty_entity_data() {
     };
 
     // Should handle gracefully - expect deserialization to fail
-    let result = TestInterface::apply_action(action);
+    let result = TestInterface::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    );
     // Just verify it doesn't panic - result may vary
     drop(result);
 }
@@ -499,7 +606,12 @@ fn malformed_entity_data() {
     };
 
     // Should fail gracefully
-    let result = TestInterface::apply_action(action);
+    let result = TestInterface::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    );
     assert!(result.is_err());
 }
 
@@ -515,9 +627,27 @@ fn multiple_deletes_idempotent() {
     };
 
     // Delete multiple times
-    TestInterface::apply_action(delete_action.clone()).unwrap();
-    TestInterface::apply_action(delete_action.clone()).unwrap();
-    TestInterface::apply_action(delete_action).unwrap();
+    TestInterface::apply_action(
+        delete_action.clone(),
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        delete_action.clone(),
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
+    TestInterface::apply_action(
+        delete_action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // Should still be deleted
     assert!(TestInterface::find_by_id::<Page>(page.id())
@@ -551,7 +681,13 @@ fn many_sequential_updates() {
             metadata: page.element().metadata.clone(),
         };
 
-        TestInterface::apply_action(action).unwrap();
+        TestInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        )
+        .unwrap();
     }
 
     // Latest version should win
@@ -581,7 +717,13 @@ fn rapid_add_delete_cycles() {
                 deleted_at: time_now(),
                 metadata: Metadata::default(),
             };
-            TestInterface::apply_action(action).unwrap();
+            TestInterface::apply_action(
+                action,
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            )
+            .unwrap();
         } else {
             // Update (resurrect if was deleted)
             page.title = format!("Version {}", i);
@@ -593,7 +735,13 @@ fn rapid_add_delete_cycles() {
                 ancestors: vec![],
                 metadata: page.element().metadata.clone(),
             };
-            TestInterface::apply_action(action).unwrap();
+            TestInterface::apply_action(
+                action,
+                ApplyContext {
+                    causal_parents: &[],
+                },
+            )
+            .unwrap();
         }
     }
 
@@ -618,7 +766,12 @@ fn test_future_timestamp_rejected() {
         metadata: page.element().metadata.clone(),
     };
 
-    let result = TestInterface::apply_action(action);
+    let result = TestInterface::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    );
 
     assert!(
         result.is_err(),
@@ -650,7 +803,13 @@ fn test_near_future_timestamp_accepted() {
     };
 
     assert!(
-        TestInterface::apply_action(action).is_ok(),
+        TestInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok(),
         "Should accept timestamp within drift tolerance"
     );
 }
@@ -674,7 +833,13 @@ fn test_past_timestamp_accepted() {
     };
 
     assert!(
-        TestInterface::apply_action(action).is_ok(),
+        TestInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok(),
         "Should accept valid past timestamps"
     );
 }
@@ -694,7 +859,12 @@ fn test_delete_future_timestamp_rejected() {
         metadata: Metadata::default(),
     };
 
-    let result = TestInterface::apply_action(action);
+    let result = TestInterface::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    );
     assert!(
         result.is_err(),
         "Should reject delete timestamp too far in the future"
@@ -721,7 +891,13 @@ fn test_delete_near_future_accepted() {
     };
 
     assert!(
-        TestInterface::apply_action(action).is_ok(),
+        TestInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok(),
         "Should accept delete timestamp within tolerance"
     );
 }

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -4,7 +4,7 @@ use crate::store::MainStorage;
 mod index__public_methods {
     use super::*;
     use crate::entities::StorageType;
-    use crate::interface::{Action, Interface};
+    use crate::interface::{Action, ApplyContext, Interface};
     use crate::store::MockedStorage;
 
     #[test]
@@ -51,7 +51,13 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying just the root, what do we find? just the root, simple
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<0>>>::apply_action(a1.clone()).is_ok());
+        assert!(<Interface<MockedStorage<0>>>::apply_action(
+            a1.clone(),
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         let e1 = <Index<MockedStorage<0>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<0>>>::get_index(p1_id).unwrap();
@@ -69,7 +75,13 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying just a2, what do we find? a2 + a1 (sparse)
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<1>>>::apply_action(a2.clone()).is_ok());
+        assert!(<Interface<MockedStorage<1>>>::apply_action(
+            a2.clone(),
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         let e1 = <Index<MockedStorage<1>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<1>>>::get_index(p1_id).unwrap();
@@ -94,8 +106,20 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying a1, and then a2, what do we find?
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<2>>>::apply_action(a1.clone()).is_ok());
-        assert!(<Interface<MockedStorage<2>>>::apply_action(a2.clone()).is_ok());
+        assert!(<Interface<MockedStorage<2>>>::apply_action(
+            a1.clone(),
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
+        assert!(<Interface<MockedStorage<2>>>::apply_action(
+            a2.clone(),
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         let e1 = <Index<MockedStorage<2>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<2>>>::get_index(p1_id).unwrap();
@@ -120,8 +144,20 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying a2, and then a1, what do we find?
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<3>>>::apply_action(a2.clone()).is_ok());
-        assert!(<Interface<MockedStorage<3>>>::apply_action(a1.clone()).is_ok());
+        assert!(<Interface<MockedStorage<3>>>::apply_action(
+            a2.clone(),
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
+        assert!(<Interface<MockedStorage<3>>>::apply_action(
+            a1.clone(),
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         let e1 = <Index<MockedStorage<3>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<3>>>::get_index(p1_id).unwrap();

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -54,7 +54,10 @@ mod index__public_methods {
         assert!(<Interface<MockedStorage<0>>>::apply_action(
             a1.clone(),
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -78,7 +81,10 @@ mod index__public_methods {
         assert!(<Interface<MockedStorage<1>>>::apply_action(
             a2.clone(),
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -109,14 +115,20 @@ mod index__public_methods {
         assert!(<Interface<MockedStorage<2>>>::apply_action(
             a1.clone(),
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
         assert!(<Interface<MockedStorage<2>>>::apply_action(
             a2.clone(),
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -147,14 +159,20 @@ mod index__public_methods {
         assert!(<Interface<MockedStorage<3>>>::apply_action(
             a2.clone(),
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
         assert!(<Interface<MockedStorage<3>>>::apply_action(
             a1.clone(),
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -168,7 +168,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -198,7 +201,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -224,7 +230,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -250,7 +259,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -286,7 +298,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             old_delete,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -306,7 +321,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             new_delete,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -325,7 +343,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_err());
@@ -346,7 +367,10 @@ mod interface__apply_actions {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -777,7 +801,10 @@ mod user_storage_signature_verification {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -811,6 +838,9 @@ mod user_storage_signature_verification {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -855,6 +885,9 @@ mod user_storage_signature_verification {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -907,6 +940,9 @@ mod user_storage_signature_verification {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -935,7 +971,10 @@ mod user_storage_signature_verification {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -961,7 +1000,10 @@ mod user_storage_signature_verification {
         assert!(MainInterface::apply_action(
             action2,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1009,7 +1051,10 @@ mod user_storage_replay_protection {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1030,6 +1075,9 @@ mod user_storage_replay_protection {
             action2,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1062,7 +1110,10 @@ mod user_storage_replay_protection {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1084,6 +1135,9 @@ mod user_storage_replay_protection {
             action2,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1111,7 +1165,10 @@ mod user_storage_replay_protection {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1135,7 +1192,10 @@ mod user_storage_replay_protection {
                 MainInterface::apply_action(
                     action,
                     ApplyContext {
-                        causal_parents: &[]
+                        causal_parents: &[],
+                        delta_id: None,
+                        delta_hlc: None,
+                        happens_before: None,
                     }
                 )
                 .is_ok(),
@@ -1173,7 +1233,10 @@ mod user_storage_replay_protection {
         assert!(MainInterface::apply_action(
             action_first,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1196,6 +1259,9 @@ mod user_storage_replay_protection {
             action_old,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1266,7 +1332,10 @@ mod frozen_storage_verification {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1303,6 +1372,9 @@ mod frozen_storage_verification {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1344,7 +1416,10 @@ mod frozen_storage_verification {
         assert!(MainInterface::apply_action(
             add_action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1373,6 +1448,9 @@ mod frozen_storage_verification {
             update_action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1414,7 +1492,10 @@ mod frozen_storage_verification {
         assert!(MainInterface::apply_action(
             add_action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1432,6 +1513,9 @@ mod frozen_storage_verification {
             delete_action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1475,6 +1559,9 @@ mod frozen_storage_verification {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1522,7 +1609,10 @@ mod frozen_storage_verification {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1566,6 +1656,9 @@ mod timestamp_drift_protection {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1605,7 +1698,10 @@ mod timestamp_drift_protection {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1639,7 +1735,10 @@ mod timestamp_drift_protection {
         assert!(MainInterface::apply_action(
             action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1666,6 +1765,9 @@ mod timestamp_drift_protection {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1770,7 +1872,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1792,6 +1897,9 @@ mod storage_type_edge_cases {
             action2,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1821,7 +1929,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1835,7 +1946,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             delete_action,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1864,7 +1978,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1879,6 +1996,9 @@ mod storage_type_edge_cases {
             delete_action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1906,7 +2026,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -1933,6 +2056,9 @@ mod storage_type_edge_cases {
             delete_action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -1975,6 +2101,9 @@ mod storage_type_edge_cases {
             action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -2013,7 +2142,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -2039,6 +2171,9 @@ mod storage_type_edge_cases {
             action2,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());
@@ -2078,7 +2213,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action1,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -2098,7 +2236,10 @@ mod storage_type_edge_cases {
         assert!(MainInterface::apply_action(
             action2,
             ApplyContext {
-                causal_parents: &[]
+                causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             }
         )
         .is_ok());
@@ -2112,6 +2253,9 @@ mod storage_type_edge_cases {
             delete_action,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         );
         assert!(result.is_err());

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -165,7 +165,13 @@ mod interface__apply_actions {
             metadata: page.element().metadata.clone(),
         };
 
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the page was added
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -189,7 +195,13 @@ mod interface__apply_actions {
             metadata: page.element().metadata.clone(),
         };
 
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the page was updated
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id())
@@ -209,7 +221,13 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the page was deleted
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -229,7 +247,13 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the page was deleted (tombstone)
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -259,7 +283,13 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(old_delete).is_ok());
+        assert!(MainInterface::apply_action(
+            old_delete,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Page should still exist (update wins)
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -273,7 +303,13 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(new_delete).is_ok());
+        assert!(MainInterface::apply_action(
+            new_delete,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Page should be deleted (deletion wins)
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -286,7 +322,13 @@ mod interface__apply_actions {
         let action = Action::Compare { id: page.id() };
 
         // Compare should fail
-        assert!(MainInterface::apply_action(action).is_err());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_err());
     }
 
     #[test]
@@ -301,7 +343,13 @@ mod interface__apply_actions {
         };
 
         // Updating a non-existent page should still succeed (it will be added)
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the page was added
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -726,7 +774,13 @@ mod user_storage_signature_verification {
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce);
 
         // Valid signature should succeed
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the page was added
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -753,7 +807,12 @@ mod user_storage_signature_verification {
             create_signed_user_add_action(&wrong_signing_key, owner, page.id(), serialized, nonce);
 
         // Invalid signature should fail
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -792,7 +851,12 @@ mod user_storage_signature_verification {
         };
 
         // Missing signature should fail
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -839,7 +903,12 @@ mod user_storage_signature_verification {
         }
 
         // Corrupted signature should fail
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -863,7 +932,13 @@ mod user_storage_signature_verification {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Wait a bit to ensure different timestamp
         sleep(Duration::from_millis(2));
@@ -883,7 +958,13 @@ mod user_storage_signature_verification {
             page.element().created_at(),
         );
 
-        assert!(MainInterface::apply_action(action2).is_ok());
+        assert!(MainInterface::apply_action(
+            action2,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify the update
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -925,7 +1006,13 @@ mod user_storage_replay_protection {
             serialized.clone(),
             nonce,
         );
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -939,7 +1026,12 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action2);
+        let result = MainInterface::apply_action(
+            action2,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -967,7 +1059,13 @@ mod user_storage_replay_protection {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -982,7 +1080,12 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action2);
+        let result = MainInterface::apply_action(
+            action2,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -1005,7 +1108,13 @@ mod user_storage_replay_protection {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Multiple updates with increasing nonces
         for i in 2..=5 {
@@ -1023,7 +1132,13 @@ mod user_storage_replay_protection {
                 page.element().created_at(),
             );
             assert!(
-                MainInterface::apply_action(action).is_ok(),
+                MainInterface::apply_action(
+                    action,
+                    ApplyContext {
+                        causal_parents: &[]
+                    }
+                )
+                .is_ok(),
                 "Update {} should succeed",
                 i
             );
@@ -1055,7 +1170,13 @@ mod user_storage_replay_protection {
             serialized1.clone(),
             first_nonce,
         );
-        assert!(MainInterface::apply_action(action_first).is_ok());
+        assert!(MainInterface::apply_action(
+            action_first,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(10));
 
@@ -1071,7 +1192,12 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action_old);
+        let result = MainInterface::apply_action(
+            action_old,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -1137,7 +1263,13 @@ mod frozen_storage_verification {
             },
         };
 
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify it was stored
         let stored = MainInterface::get(id);
@@ -1167,7 +1299,12 @@ mod frozen_storage_verification {
             },
         };
 
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -1204,7 +1341,13 @@ mod frozen_storage_verification {
                 field_name: None,
             },
         };
-        assert!(MainInterface::apply_action(add_action).is_ok());
+        assert!(MainInterface::apply_action(
+            add_action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1226,7 +1369,12 @@ mod frozen_storage_verification {
             },
         };
 
-        let result = MainInterface::apply_action(update_action);
+        let result = MainInterface::apply_action(
+            update_action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1263,7 +1411,13 @@ mod frozen_storage_verification {
                 field_name: None,
             },
         };
-        assert!(MainInterface::apply_action(add_action).is_ok());
+        assert!(MainInterface::apply_action(
+            add_action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1274,7 +1428,12 @@ mod frozen_storage_verification {
             metadata: Metadata::default(),
         };
 
-        let result = MainInterface::apply_action(delete_action);
+        let result = MainInterface::apply_action(
+            delete_action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1312,7 +1471,12 @@ mod frozen_storage_verification {
             },
         };
 
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -1355,7 +1519,13 @@ mod frozen_storage_verification {
         };
 
         // This should succeed since the hash of empty [] matches
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
     }
 }
 
@@ -1392,7 +1562,12 @@ mod timestamp_drift_protection {
             },
         };
 
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidTimestamp(ts, local)) => {
@@ -1427,7 +1602,13 @@ mod timestamp_drift_protection {
         };
 
         // Should succeed since within tolerance
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
     }
 
     #[test]
@@ -1455,7 +1636,13 @@ mod timestamp_drift_protection {
         };
 
         // Past timestamps are fine
-        assert!(MainInterface::apply_action(action).is_ok());
+        assert!(MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
     }
 
     #[test]
@@ -1475,7 +1662,12 @@ mod timestamp_drift_protection {
             metadata: Metadata::default(),
         };
 
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidTimestamp(_, _)) => {}
@@ -1575,7 +1767,13 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1590,7 +1788,12 @@ mod storage_type_edge_cases {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action2);
+        let result = MainInterface::apply_action(
+            action2,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1615,7 +1818,13 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1623,7 +1832,13 @@ mod storage_type_edge_cases {
         let nonce2 = env::time_now();
         let delete_action = create_signed_delete_action(&signing_key, owner, page.id(), nonce2);
 
-        assert!(MainInterface::apply_action(delete_action).is_ok());
+        assert!(MainInterface::apply_action(
+            delete_action,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         // Verify entity is deleted
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -1646,7 +1861,13 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key1, owner1, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1654,7 +1875,12 @@ mod storage_type_edge_cases {
         let nonce2 = env::time_now();
         let delete_action = create_signed_delete_action(&signing_key2, owner2, page.id(), nonce2);
 
-        let result = MainInterface::apply_action(delete_action);
+        let result = MainInterface::apply_action(
+            delete_action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -1677,7 +1903,13 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1697,7 +1929,12 @@ mod storage_type_edge_cases {
             },
         };
 
-        let result = MainInterface::apply_action(delete_action);
+        let result = MainInterface::apply_action(
+            delete_action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -1734,7 +1971,12 @@ mod storage_type_edge_cases {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action);
+        let result = MainInterface::apply_action(
+            action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1768,7 +2010,13 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce,
         );
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1787,7 +2035,12 @@ mod storage_type_edge_cases {
             },
         };
 
-        let result = MainInterface::apply_action(action2);
+        let result = MainInterface::apply_action(
+            action2,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1822,7 +2075,13 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1).is_ok());
+        assert!(MainInterface::apply_action(
+            action1,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1836,14 +2095,25 @@ mod storage_type_edge_cases {
             nonce2,
             page.element().created_at(),
         );
-        assert!(MainInterface::apply_action(action2).is_ok());
+        assert!(MainInterface::apply_action(
+            action2,
+            ApplyContext {
+                causal_parents: &[]
+            }
+        )
+        .is_ok());
 
         sleep(Duration::from_millis(2));
 
         // Try to delete with old nonce (replay attack)
         let delete_action = create_signed_delete_action(&signing_key, owner, page.id(), nonce1);
 
-        let result = MainInterface::apply_action(delete_action);
+        let result = MainInterface::apply_action(
+            delete_action,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        );
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1153,6 +1153,9 @@ fn test_e2e_sync_flow_with_isolated_storage() {
             &sync_artifact,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         )
         .unwrap();
@@ -1456,6 +1459,9 @@ fn test_e2e_counter_sync_with_isolated_storage() {
             &sync_payload,
             ApplyContext {
                 causal_parents: &[],
+                delta_id: None,
+                delta_hlc: None,
+                happens_before: None,
             },
         )
         .unwrap();

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1044,7 +1044,7 @@ fn test_e2e_sync_flow_with_isolated_storage() {
     use crate::collections::Root;
     use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads};
     use crate::index::Index;
-    use crate::interface::Interface;
+    use crate::interface::{ApplyContext, Interface};
     use crate::store::MockedStorage;
 
     // Use a single storage scope - the test simulates nodes sharing state via delta sync
@@ -1149,7 +1149,13 @@ fn test_e2e_sync_flow_with_isolated_storage() {
         // Apply actions to Node-2's storage via sync
         let sync_artifact =
             borsh::to_vec(&crate::delta::StorageDelta::Actions(delta.actions)).unwrap();
-        Root::<LwwRegister<String>, NodeStorage>::sync(&sync_artifact).unwrap();
+        Root::<LwwRegister<String>, NodeStorage>::sync(
+            &sync_artifact,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        )
+        .unwrap();
     }
 
     // Get Node-2's hash after sync
@@ -1201,7 +1207,7 @@ fn test_e2e_counter_sync_with_isolated_storage() {
     use crate::collections::Root;
     use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
     use crate::index::Index;
-    use crate::interface::Interface;
+    use crate::interface::{ApplyContext, Interface};
     use crate::store::MainStorage;
 
     // Use MainStorage directly - Counter::new() requires MainStorage
@@ -1446,7 +1452,13 @@ fn test_e2e_counter_sync_with_isolated_storage() {
     // Apply delta via sync
     if let Some(delta) = update_delta {
         let sync_payload = borsh::to_vec(&StorageDelta::Actions(delta.actions)).unwrap();
-        Root::<Counter, NodeStorage>::sync(&sync_payload).unwrap();
+        Root::<Counter, NodeStorage>::sync(
+            &sync_payload,
+            ApplyContext {
+                causal_parents: &[],
+            },
+        )
+        .unwrap();
         println!("Update delta applied to Node-2");
     }
 

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -9,7 +9,7 @@ use super::common::{Page, Paragraph};
 use crate::address::Id;
 use crate::entities::{Data, Element};
 use crate::index::Index;
-use crate::interface::Interface;
+use crate::interface::{ApplyContext, Interface};
 use crate::store::{MockedStorage, StorageAdaptor};
 
 type TestStorage = MockedStorage<8000>;
@@ -253,7 +253,13 @@ fn merkle_hash_convergence_after_sync() {
         metadata: page1.element().metadata.clone(),
     };
 
-    Interface::<Storage2>::apply_action(action).unwrap();
+    Interface::<Storage2>::apply_action(
+        action,
+        ApplyContext {
+            causal_parents: &[],
+        },
+    )
+    .unwrap();
 
     // After sync, hashes should match
     let page2 = Interface::<Storage2>::find_by_id::<Page>(page1.id())

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -257,6 +257,9 @@ fn merkle_hash_convergence_after_sync() {
         action,
         ApplyContext {
             causal_parents: &[],
+            delta_id: None,
+            delta_hlc: None,
+            happens_before: None,
         },
     )
     .unwrap();

--- a/crates/storage/src/tests/p3_dag_causal.rs
+++ b/crates/storage/src/tests/p3_dag_causal.rs
@@ -285,7 +285,8 @@ fn verifier_with_dag_context_uses_rotation_log() {
         vec![],
     );
     let parents = [d1];
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| a == &d1 && b == &d1;
+    // Direct parent-match in writers_at handles `delta_id == d1`; no DAG ancestry needed here.
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
     let ctx = dag_ctx(&parents, [0xD2; 32], hlc_at(2), happens_before);
 
     // Without P3 this would be rejected (sig vs stored {Bob} fails).
@@ -343,7 +344,8 @@ fn verifier_with_dag_context_rejects_non_causal_writer() {
         vec![],
     );
     let parents = [d1];
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| a == &d1 && b == &d1;
+    // Direct parent-match in writers_at handles `delta_id == d1`; no DAG ancestry needed here.
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
     let ctx = dag_ctx(&parents, [0xD2; 32], hlc_at(2), happens_before);
 
     let result = Interface::<S<403>>::apply_action(forged, ctx);

--- a/crates/storage/src/tests/p3_dag_causal.rs
+++ b/crates/storage/src/tests/p3_dag_causal.rs
@@ -458,6 +458,115 @@ fn write_hook_appends_on_writer_set_change() {
     );
 }
 
+/// Documents a known design fragility flagged in PR #2265 review.
+///
+/// `maybe_append_rotation_log` decides whether to append by comparing the
+/// action's claimed `writers` against the currently-stored writers. But
+/// `Index::update_hash_for` only touches `own_hash`/`full_hash`/`updated_at`
+/// — it never updates `metadata.storage_type`, so the stored writers stay
+/// frozen at the bootstrap set forever.
+///
+/// As a result, a value-write that *happens* to claim the bootstrap writers
+/// (e.g., authored by a peer with stale view) is correctly NOT logged as a
+/// rotation, even after a real rotation has updated the writer set logically.
+/// The rotation-detection logic depends on this stale-stored-writers behavior
+/// to avoid false positives.
+///
+/// If `update_hash_for` is ever changed to also update `storage_type`, the
+/// rotation-detection logic must switch to comparing against
+/// `writers_at(causal_parents)` instead, or stale value-writes will be
+/// falsely flagged as rotations. Same root cause underlies the v2 fallback
+/// verifier's reliance on stored writers for signature checks; both are
+/// tracked as #2233 P3 follow-up.
+#[test]
+fn write_hook_relies_on_stale_stored_writers_for_rotation_detection() {
+    env::reset_for_testing();
+    let root = setup_root::<S<408>>();
+
+    let alice_sk = make_signing_key(0xAB);
+    let bob_sk = make_signing_key(0xBB);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x48);
+
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+
+    // Bootstrap with {Alice, Bob}.
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice, bob].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<408>>::apply_action(
+        bootstrap,
+        dag_ctx(&[], [0xE0; 32], hlc_at(0), happens_before),
+    )
+    .unwrap();
+
+    // D1: Alice rotates Bob out → writers = {Alice}. Logged as a rotation.
+    let rotation = build_signed_shared_action(
+        false,
+        id,
+        b"v1".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<408>>::apply_action(
+        rotation,
+        dag_ctx(&[[0xE0; 32]], [0xE1; 32], hlc_at(1), happens_before),
+    )
+    .unwrap();
+    assert_eq!(
+        rotation_log::load::<S<408>>(id)
+            .unwrap()
+            .unwrap()
+            .entries
+            .len(),
+        2,
+        "post-D1 baseline: bootstrap + rotation"
+    );
+
+    // D2: Alice value-write claiming the BOOTSTRAP writers {Alice, Bob}.
+    // She's authorized (signature verifies against the authoritative set),
+    // so the write itself is accepted. The rotation-detection compares
+    // action.writers `{Alice, Bob}` against `pre_apply_writers` — which is
+    // STILL `{Alice, Bob}` because `Index::update_hash_for` never updated
+    // `storage_type` after D1. So `is_rotation = false` and no log entry
+    // is appended.
+    //
+    // If the index had updated to `{Alice}` after D1, this comparison would
+    // be `{Alice, Bob} != {Alice}` → IS rotation → falsely append. This
+    // assertion catches that future regression.
+    let value_write_with_stale_writers = build_signed_shared_action(
+        false,
+        id,
+        b"v2".to_vec(),
+        [alice, bob].into_iter().collect(), // claims bootstrap writers
+        hlc_at(2),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<408>>::apply_action(
+        value_write_with_stale_writers,
+        dag_ctx(&[[0xE1; 32]], [0xE2; 32], hlc_at(2), happens_before),
+    )
+    .unwrap();
+
+    let log = rotation_log::load::<S<408>>(id).unwrap().unwrap();
+    assert_eq!(
+        log.entries.len(),
+        2,
+        "value-write with stale writer claim must NOT append \
+         (relies on stored writers staying frozen at bootstrap)"
+    );
+}
+
 // =============================================================================
 // P4-impl coverage: ADR Example D (write vs rotate on the same entity)
 // =============================================================================

--- a/crates/storage/src/tests/p3_dag_causal.rs
+++ b/crates/storage/src/tests/p3_dag_causal.rs
@@ -1,0 +1,524 @@
+//! Tests for phase **P3** of [#2233](https://github.com/calimero-network/core/issues/2233):
+//!
+//! - **Verifier swap.** When `ApplyContext` carries DAG-causal information,
+//!   `Interface::apply_action` validates `Shared` signatures against
+//!   `writers_at(causal_parents)` (per ADR 0001) instead of stored writers.
+//!   When the context is empty, behavior matches v2 exactly.
+//! - **Write hook.** Successful applies of `Shared` rotations append a
+//!   [`RotationLogEntry`]. Value-writes (writers unchanged) and ctx without
+//!   `delta_id`/`delta_hlc` are no-ops.
+
+use core::num::NonZeroU128;
+use std::collections::BTreeSet;
+
+use calimero_primitives::identity::PublicKey;
+use ed25519_dalek::{Signer, SigningKey};
+
+use crate::action::Action;
+use crate::address::Id;
+use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use crate::env;
+use crate::index::Index;
+use crate::interface::{ApplyContext, Interface};
+use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use crate::rotation_log::{self, RotationLogEntry};
+use crate::store::{MockedStorage, StorageAdaptor};
+
+// Each test uses a unique mocked-storage scope so they don't bleed into each
+// other (the mock store is a thread-local BTreeMap keyed on (scope, key)).
+type S<const SCOPE: usize> = MockedStorage<SCOPE>;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn pubkey_of(sk: &SigningKey) -> PublicKey {
+    PublicKey::from(*sk.verifying_key().as_bytes())
+}
+
+fn hlc(ns: u64) -> HybridTimestamp {
+    let node_id = ID::from(NonZeroU128::new(1).unwrap());
+    HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
+}
+
+/// Returns an HLC nanosecond value rooted at "now" plus `step` seconds.
+/// Use this so sequential actions in a test always have strictly-increasing
+/// nonces without depending on wall-clock advancement between calls.
+fn hlc_at(step: u64) -> u64 {
+    env::time_now().saturating_add(step.saturating_mul(1_000_000_000))
+}
+
+/// Pre-create the root index entry so non-root child entities can be
+/// added/updated by `apply_action` without tripping `IndexNotFound`.
+/// Returns the root `ChildInfo` ready to embed in an action's `ancestors`.
+fn setup_root<S: StorageAdaptor>() -> ChildInfo {
+    let root_id = Id::root();
+    let root_meta = Metadata::default();
+    Index::<S>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
+    ChildInfo::new(root_id, [0; 32], root_meta)
+}
+
+/// Construct a signed Shared action. `signer_sk` must be in `writers` (or the
+/// caller is intentionally testing a forged action).
+///
+/// `hlc_ns` is used as BOTH the action's `updated_at` and the signature's
+/// `nonce` — matching production where `sign_authorized_actions` stamps both
+/// with the action's HLC. Tests must pass strictly increasing values across
+/// sequential calls to satisfy the per-entity replay-protection check.
+fn build_signed_shared_action(
+    add: bool,
+    id: Id,
+    data: Vec<u8>,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let metadata = Metadata {
+        created_at: hlc_ns,
+        updated_at: hlc_ns.into(),
+        storage_type: StorageType::Shared {
+            writers,
+            signature_data: Some(SignatureData {
+                signature: [0; 64], // placeholder, filled in below
+                nonce: hlc_ns,
+                signer: Some(pubkey_of(signer_sk)),
+            }),
+        },
+        crdt_type: None,
+        field_name: None,
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::Shared {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
+    action
+}
+
+fn empty_ctx<'a>() -> ApplyContext<'a> {
+    ApplyContext {
+        causal_parents: &[],
+        delta_id: None,
+        delta_hlc: None,
+        happens_before: None,
+    }
+}
+
+fn dag_ctx<'a>(
+    parents: &'a [[u8; 32]],
+    delta_id: [u8; 32],
+    delta_hlc_ns: u64,
+    happens_before: &'a dyn Fn(&[u8; 32], &[u8; 32]) -> bool,
+) -> ApplyContext<'a> {
+    ApplyContext {
+        causal_parents: parents,
+        delta_id: Some(delta_id),
+        delta_hlc: Some(hlc(delta_hlc_ns)),
+        happens_before: Some(happens_before),
+    }
+}
+
+// Convenient per-test entity id derived from the scope so each test gets a
+// distinct, deterministic id (avoids any cross-test interference even if
+// scopes were reused).
+fn entity_id(seed: u8) -> Id {
+    Id::new([seed; 32])
+}
+
+// =============================================================================
+// Verifier-swap tests
+// =============================================================================
+
+/// Baseline: with no DAG context, the verifier behaves exactly like v2 — sig
+/// must verify against the stored writer set, falling back to the action's
+/// claim when the entity doesn't exist yet (bootstrap).
+#[test]
+fn verifier_without_dag_context_uses_stored_writers() {
+    env::reset_for_testing();
+    let root = setup_root::<S<400>>();
+
+    let alice_sk = make_signing_key(0xA1);
+    let alice = pubkey_of(&alice_sk);
+    let id = entity_id(0x40);
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"hello".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<400>>::apply_action(bootstrap, empty_ctx())
+        .expect("bootstrap accepted with v2 fallback");
+
+    let update = build_signed_shared_action(
+        false,
+        id,
+        b"world".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<400>>::apply_action(update, empty_ctx()).expect("update by writer accepted");
+}
+
+/// Action signed by a non-writer is rejected by the v2 path.
+#[test]
+fn verifier_without_dag_context_rejects_non_writer() {
+    env::reset_for_testing();
+    let root = setup_root::<S<401>>();
+
+    let alice_sk = make_signing_key(0xA2);
+    let bob_sk = make_signing_key(0xB2);
+    let alice = pubkey_of(&alice_sk);
+    let id = entity_id(0x41);
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<401>>::apply_action(bootstrap, empty_ctx()).unwrap();
+
+    // Bob is not in the stored writer set — must reject.
+    let forged = build_signed_shared_action(
+        false,
+        id,
+        b"v1".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(1),
+        &bob_sk,
+        vec![],
+    );
+    let result = Interface::<S<401>>::apply_action(forged, empty_ctx());
+    assert!(matches!(
+        result,
+        Err(crate::interface::StorageError::InvalidSignature)
+    ));
+}
+
+/// **The partition-correctness fix.** A pre-populated rotation log says the
+/// writer set as-of `D1` is `{Alice}`. The stored entity (simulating
+/// divergent state from a partition) has `{Bob}`. An action signed by Alice
+/// with `causal_parents = [D1]` must be accepted: per ADR 0001 the verifier
+/// consults the rotation log, not stored.
+#[test]
+fn verifier_with_dag_context_uses_rotation_log() {
+    env::reset_for_testing();
+    let root = setup_root::<S<402>>();
+
+    let alice_sk = make_signing_key(0xA3);
+    let bob_sk = make_signing_key(0xB3);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x42);
+
+    // Bootstrap with Bob as the stored writer.
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"divergent".to_vec(),
+        [bob].into_iter().collect(),
+        hlc_at(0),
+        &bob_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<402>>::apply_action(bootstrap, empty_ctx()).unwrap();
+
+    // Pre-populate the rotation log: as-of delta D1, the writer set was {Alice}.
+    let d1 = [0xD1; 32];
+    rotation_log::append::<S<402>>(
+        id,
+        RotationLogEntry {
+            delta_id: d1,
+            delta_hlc: hlc(hlc_at(0)),
+            signer: Some(alice),
+            new_writers: [alice].into_iter().collect(),
+            writers_nonce: 1,
+        },
+    )
+    .unwrap();
+
+    // Alice signs an Update; ctx points at D1 as a causal parent.
+    let action = build_signed_shared_action(
+        false,
+        id,
+        b"alice-update".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(2),
+        &alice_sk,
+        vec![],
+    );
+    let parents = [d1];
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| a == &d1 && b == &d1;
+    let ctx = dag_ctx(&parents, [0xD2; 32], hlc_at(2), happens_before);
+
+    // Without P3 this would be rejected (sig vs stored {Bob} fails).
+    // With P3 it's accepted because writers_at returns {Alice}.
+    Interface::<S<402>>::apply_action(action, ctx)
+        .expect("DAG-causal verifier accepts Alice — she's the writer as-of D1");
+}
+
+/// Even with DAG context, an action signed by someone *outside* the causal
+/// writer set is rejected.
+#[test]
+fn verifier_with_dag_context_rejects_non_causal_writer() {
+    env::reset_for_testing();
+    let root = setup_root::<S<403>>();
+
+    let alice_sk = make_signing_key(0xA4);
+    let bob_sk = make_signing_key(0xB4);
+    let mallory_sk = make_signing_key(0xC4);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x43);
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [bob].into_iter().collect(),
+        hlc_at(0),
+        &bob_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<403>>::apply_action(bootstrap, empty_ctx()).unwrap();
+
+    let d1 = [0xD1; 32];
+    rotation_log::append::<S<403>>(
+        id,
+        RotationLogEntry {
+            delta_id: d1,
+            delta_hlc: hlc(hlc_at(0)),
+            signer: Some(alice),
+            new_writers: [alice].into_iter().collect(),
+            writers_nonce: 1,
+        },
+    )
+    .unwrap();
+
+    // Mallory is in neither stored {Bob} nor causal {Alice}.
+    let forged = build_signed_shared_action(
+        false,
+        id,
+        b"forged".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(2),
+        &mallory_sk,
+        vec![],
+    );
+    let parents = [d1];
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| a == &d1 && b == &d1;
+    let ctx = dag_ctx(&parents, [0xD2; 32], hlc_at(2), happens_before);
+
+    let result = Interface::<S<403>>::apply_action(forged, ctx);
+    assert!(matches!(
+        result,
+        Err(crate::interface::StorageError::InvalidSignature)
+    ));
+}
+
+// =============================================================================
+// Write-hook tests
+// =============================================================================
+
+/// Bootstrap with full DAG context appends one rotation log entry.
+#[test]
+fn write_hook_appends_on_bootstrap_with_ctx() {
+    env::reset_for_testing();
+    let root = setup_root::<S<404>>();
+
+    let alice_sk = make_signing_key(0xA5);
+    let alice = pubkey_of(&alice_sk);
+    let id = entity_id(0x44);
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+    let ctx = dag_ctx(&[], [0xAA; 32], hlc_at(0), happens_before);
+    Interface::<S<404>>::apply_action(bootstrap, ctx).unwrap();
+
+    let log = rotation_log::load::<S<404>>(id)
+        .unwrap()
+        .expect("rotation log exists after Shared apply with delta ctx");
+    assert_eq!(log.entries.len(), 1);
+    assert_eq!(log.entries[0].delta_id, [0xAA; 32]);
+    assert_eq!(log.entries[0].signer, Some(alice));
+    assert_eq!(log.entries[0].new_writers, [alice].into_iter().collect());
+}
+
+/// Same bootstrap but with empty ctx (no delta_id) — the log stays empty.
+/// Production sync paths behave like this until the WASM ABI extension lands.
+#[test]
+fn write_hook_skips_when_ctx_lacks_delta_id() {
+    env::reset_for_testing();
+    let root = setup_root::<S<405>>();
+
+    let alice_sk = make_signing_key(0xA6);
+    let alice = pubkey_of(&alice_sk);
+    let id = entity_id(0x45);
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<405>>::apply_action(bootstrap, empty_ctx()).unwrap();
+
+    assert_eq!(rotation_log::load::<S<405>>(id).unwrap(), None);
+}
+
+/// Value-write (writer set unchanged) does not append an entry.
+#[test]
+fn write_hook_skips_when_writers_unchanged() {
+    env::reset_for_testing();
+    let root = setup_root::<S<406>>();
+
+    let alice_sk = make_signing_key(0xA7);
+    let alice = pubkey_of(&alice_sk);
+    let id = entity_id(0x46);
+
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<406>>::apply_action(
+        bootstrap,
+        dag_ctx(&[], [0xBB; 32], hlc_at(0), happens_before),
+    )
+    .unwrap();
+    assert_eq!(
+        rotation_log::load::<S<406>>(id)
+            .unwrap()
+            .unwrap()
+            .entries
+            .len(),
+        1
+    );
+
+    // Value-write with the same writer set → log stays at 1 entry.
+    let value_write = build_signed_shared_action(
+        false,
+        id,
+        b"v1".to_vec(),
+        [alice].into_iter().collect(), // same set
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<406>>::apply_action(
+        value_write,
+        dag_ctx(&[], [0xCC; 32], hlc_at(1), happens_before),
+    )
+    .unwrap();
+
+    let log = rotation_log::load::<S<406>>(id).unwrap().unwrap();
+    assert_eq!(log.entries.len(), 1, "value-write did not append");
+}
+
+/// Genuine rotation (writer set changes) appends a second entry.
+#[test]
+fn write_hook_appends_on_writer_set_change() {
+    env::reset_for_testing();
+    let root = setup_root::<S<407>>();
+
+    let alice_sk = make_signing_key(0xA8);
+    let bob_sk = make_signing_key(0xB8);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x47);
+
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<407>>::apply_action(
+        bootstrap,
+        dag_ctx(&[], [0xD0; 32], hlc_at(0), happens_before),
+    )
+    .unwrap();
+
+    // Alice rotates: now writers = {Alice, Bob}.
+    let rotation = build_signed_shared_action(
+        false,
+        id,
+        b"v0".to_vec(),
+        [alice, bob].into_iter().collect(),
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<407>>::apply_action(
+        rotation,
+        dag_ctx(&[[0xD0; 32]], [0xD1; 32], hlc_at(1), happens_before),
+    )
+    .unwrap();
+
+    let log = rotation_log::load::<S<407>>(id).unwrap().unwrap();
+    assert_eq!(log.entries.len(), 2);
+    assert_eq!(log.entries[1].delta_id, [0xD1; 32]);
+    assert_eq!(
+        log.entries[1].new_writers,
+        [alice, bob].into_iter().collect()
+    );
+}

--- a/crates/storage/src/tests/p3_dag_causal.rs
+++ b/crates/storage/src/tests/p3_dag_causal.rs
@@ -522,3 +522,188 @@ fn write_hook_appends_on_writer_set_change() {
         [alice, bob].into_iter().collect()
     );
 }
+
+// =============================================================================
+// P4-impl coverage: ADR Example D (write vs rotate on the same entity)
+// =============================================================================
+//
+// The other ADR examples (A sequential, B concurrent siblings HLC, C HLC tie)
+// are exercised in `rotation_log::tests`. Example D — a value-write signed by
+// a pre-rotation writer must still verify after the rotation lands locally —
+// is the central guarantee that makes concurrent operation safe, and it
+// involves the full apply_action verifier swap, so it lives here next to
+// the rest of the P3 verifier coverage.
+
+/// ADR Example D: pre-rotation value-write is accepted even after the
+/// rotation that removes the signer is applied locally. The verifier must
+/// consult `writers_at(value_write.parents)`, NOT the post-merge writer set.
+#[test]
+fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
+    env::reset_for_testing();
+    let root = setup_root::<S<420>>();
+
+    let alice_sk = make_signing_key(0xA9);
+    let bob_sk = make_signing_key(0xB9);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x60);
+
+    // D_root: writers = {Alice, Bob}. Bootstrap so the entity exists locally.
+    let d_root = [0xD0; 32];
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"hello".to_vec(),
+        [alice, bob].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    let happens_before_simple: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+    Interface::<S<420>>::apply_action(
+        bootstrap,
+        dag_ctx(&[], d_root, hlc_at(0), happens_before_simple),
+    )
+    .unwrap();
+
+    // D1 (concurrent sibling of D_root from D2's perspective): Alice rotates
+    // Bob out → writers = {Alice}. Apply this first.
+    let d1 = [0xD1; 32];
+    let rotation = build_signed_shared_action(
+        false,
+        id,
+        b"hello".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<420>>::apply_action(
+        rotation,
+        dag_ctx(&[d_root], d1, hlc_at(1), happens_before_simple),
+    )
+    .unwrap();
+
+    // Sanity: the local stored writer set is now {Alice} and the rotation log
+    // has two entries (bootstrap + rotation).
+    let log = rotation_log::load::<S<420>>(id).unwrap().unwrap();
+    assert_eq!(log.entries.len(), 2);
+
+    // D2 (concurrent sibling of D1): Bob writes "world" against the writer
+    // set he saw — {Alice, Bob}. From Bob's local view this is valid; D2's
+    // parent is D_root, NOT D1. Carry that into ctx.causal_parents.
+    let d2 = [0xD2; 32];
+    let bob_write = build_signed_shared_action(
+        false,
+        id,
+        b"world".to_vec(),
+        [alice, bob].into_iter().collect(), // Bob's view of writers
+        hlc_at(2),
+        &bob_sk,
+        vec![],
+    );
+
+    // happens_before: D_root precedes everything; D1 and D2 are siblings so
+    // neither precedes the other.
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| {
+        // D_root happens-before D1 and D2.
+        if *a == d_root && (*b == d1 || *b == d2) {
+            return true;
+        }
+        false
+    };
+    let parents = [d_root];
+    let ctx = dag_ctx(&parents, d2, hlc_at(2), happens_before);
+
+    // Crucial: even though stored writers (post-D1) is {Alice}, D2 is causally
+    // a sibling of D1 — it never saw the rotation. writers_at(D2.parents=[D_root])
+    // returns the bootstrap writer set {Alice, Bob}, so Bob's signature
+    // verifies. Without P3 this would fail (sig vs stored {Alice}).
+    Interface::<S<420>>::apply_action(bob_write, ctx).expect(
+        "ADR Example D: pre-rotation write by Bob accepted because writers_at \
+         (causal parents of D2) includes Bob, even though stored writers no longer do",
+    );
+}
+
+/// Inverse of Example D: a write whose causal parents *include* the rotation
+/// (i.e., the writer saw the rotation and chose to write anyway) must be
+/// rejected if the signer is no longer in the writer set as-of those parents.
+#[test]
+fn write_post_rotation_by_removed_writer_rejected() {
+    env::reset_for_testing();
+    let root = setup_root::<S<421>>();
+
+    let alice_sk = make_signing_key(0xAA);
+    let bob_sk = make_signing_key(0xBA);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x61);
+
+    let d_root = [0xD0; 32];
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"hello".to_vec(),
+        [alice, bob].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    let happens_before_simple: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+    Interface::<S<421>>::apply_action(
+        bootstrap,
+        dag_ctx(&[], d_root, hlc_at(0), happens_before_simple),
+    )
+    .unwrap();
+
+    // D1: Alice rotates Bob out.
+    let d1 = [0xD1; 32];
+    let rotation = build_signed_shared_action(
+        false,
+        id,
+        b"hello".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<421>>::apply_action(
+        rotation,
+        dag_ctx(&[d_root], d1, hlc_at(1), happens_before_simple),
+    )
+    .unwrap();
+
+    // D2 has D1 as a parent — Bob saw the rotation and tries to write anyway.
+    let d2 = [0xD2; 32];
+    let bob_write_post = build_signed_shared_action(
+        false,
+        id,
+        b"world".to_vec(),
+        [alice].into_iter().collect(), // Bob acknowledges the rotation in his claim
+        hlc_at(2),
+        &bob_sk,
+        vec![],
+    );
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| {
+        // D_root → D1 → D2. (D_root → D2 transitively.)
+        matches!(
+            (*a, *b),
+            (x, y) if x == d_root && (y == d1 || y == d2)
+                || (x == d1 && y == d2)
+        )
+    };
+    let parents = [d1];
+    let ctx = dag_ctx(&parents, d2, hlc_at(2), happens_before);
+
+    // writers_at(D2.parents=[D1]) returns {Alice} — Bob is no longer a writer
+    // and his signature must fail.
+    let result = Interface::<S<421>>::apply_action(bob_write_post, ctx);
+    assert!(
+        matches!(
+            result,
+            Err(crate::interface::StorageError::InvalidSignature)
+        ),
+        "post-rotation write by removed writer must be rejected; got {:?}",
+        result
+    );
+}

--- a/crates/storage/src/tests/p3_dag_causal.rs
+++ b/crates/storage/src/tests/p3_dag_causal.rs
@@ -9,20 +9,18 @@
 //!   `delta_id`/`delta_hlc` are no-ops.
 
 use core::num::NonZeroU128;
-use std::collections::BTreeSet;
 
-use calimero_primitives::identity::PublicKey;
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::SigningKey;
 
-use crate::action::Action;
 use crate::address::Id;
-use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use crate::entities::{ChildInfo, Metadata};
 use crate::env;
 use crate::index::Index;
 use crate::interface::{ApplyContext, Interface};
 use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 use crate::rotation_log::{self, RotationLogEntry};
 use crate::store::{MockedStorage, StorageAdaptor};
+use crate::tests::common::{build_signed_shared_action, pubkey_of};
 
 // Each test uses a unique mocked-storage scope so they don't bleed into each
 // other (the mock store is a thread-local BTreeMap keyed on (scope, key)).
@@ -34,10 +32,6 @@ type S<const SCOPE: usize> = MockedStorage<SCOPE>;
 
 fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
-}
-
-fn pubkey_of(sk: &SigningKey) -> PublicKey {
-    PublicKey::from(*sk.verifying_key().as_bytes())
 }
 
 fn hlc(ns: u64) -> HybridTimestamp {
@@ -60,67 +54,6 @@ fn setup_root<S: StorageAdaptor>() -> ChildInfo {
     let root_meta = Metadata::default();
     Index::<S>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
     ChildInfo::new(root_id, [0; 32], root_meta)
-}
-
-/// Construct a signed Shared action. `signer_sk` must be in `writers` (or the
-/// caller is intentionally testing a forged action).
-///
-/// `hlc_ns` is used as BOTH the action's `updated_at` and the signature's
-/// `nonce` — matching production where `sign_authorized_actions` stamps both
-/// with the action's HLC. Tests must pass strictly increasing values across
-/// sequential calls to satisfy the per-entity replay-protection check.
-fn build_signed_shared_action(
-    add: bool,
-    id: Id,
-    data: Vec<u8>,
-    writers: BTreeSet<PublicKey>,
-    hlc_ns: u64,
-    signer_sk: &SigningKey,
-    ancestors: Vec<ChildInfo>,
-) -> Action {
-    let metadata = Metadata {
-        created_at: hlc_ns,
-        updated_at: hlc_ns.into(),
-        storage_type: StorageType::Shared {
-            writers,
-            signature_data: Some(SignatureData {
-                signature: [0; 64], // placeholder, filled in below
-                nonce: hlc_ns,
-                signer: Some(pubkey_of(signer_sk)),
-            }),
-        },
-        crdt_type: None,
-        field_name: None,
-    };
-    let mut action = if add {
-        Action::Add {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    } else {
-        Action::Update {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    };
-    let payload = action.payload_for_signing();
-    let signature = signer_sk.sign(&payload).to_bytes();
-    let metadata_mut = match &mut action {
-        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
-        _ => unreachable!(),
-    };
-    if let StorageType::Shared {
-        signature_data: Some(sd),
-        ..
-    } = &mut metadata_mut.storage_type
-    {
-        sd.signature = signature;
-    }
-    action
 }
 
 fn empty_ctx<'a>() -> ApplyContext<'a> {

--- a/crates/storage/src/tests/p5_partition_scenarios.rs
+++ b/crates/storage/src/tests/p5_partition_scenarios.rs
@@ -1,0 +1,739 @@
+//! Phase **P5** of [#2233](https://github.com/calimero-network/core/issues/2233):
+//! cross-node integration tests for the four motivating partition scenarios.
+//!
+//! Each test simulates 2–3 "nodes" — each backed by its own
+//! [`MockedStorage`] scope — and feeds them the same [`CausalDelta`]s in
+//! different orders. With the P3 verifier swap and rotation-log write hook
+//! in place, the four #2197 scenarios should resolve correctly:
+//!
+//! - **Update-vs-rotation race** (Bob writes pre-rotation under partition;
+//!   rotation lands first on Carol; Bob's write must be accepted).
+//! - **Self-removal mid-flight** (writer rotates self out, in-flight updates
+//!   causally-before the rotation are accepted, after rejected).
+//! - **Concurrent conflicting rotations** (two writers issue rotations
+//!   concurrently — deterministic convergence per ADR 0001).
+//! - **Long-partition reconciliation** (many rotations + writes on each side,
+//!   then merge — both sides converge to the same final state).
+//!
+//! The fifth listed motivator (bootstrap race) is deferred per ADR 0001 —
+//! see "What we explicitly do NOT decide here".
+//!
+//! These tests run at the storage layer rather than via the WASM/sync
+//! harnesses because the production WASM ABI doesn't yet thread
+//! `CausalDelta.{id,hlc,parents}` through to `apply_action` — that's a
+//! separate follow-up. The storage-layer simulation gives us full control
+//! over delivery order and DAG ancestry, which is what the scenarios
+//! actually exercise.
+
+use core::num::NonZeroU128;
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use calimero_primitives::identity::PublicKey;
+use ed25519_dalek::{Signer, SigningKey};
+
+use crate::action::Action;
+use crate::address::Id;
+use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use crate::env;
+use crate::index::Index;
+use crate::interface::{disable_nonce_check_for_testing, ApplyContext, Interface, StorageError};
+use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use crate::rotation_log;
+use crate::store::{MockedStorage, StorageAdaptor};
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+/// Tracks a DAG of deltas by parent links. Tests build this incrementally as
+/// they author deltas; the `happens_before` predicate is then derived via
+/// reverse BFS from the second argument.
+struct Dag {
+    parents: HashMap<[u8; 32], Vec<[u8; 32]>>,
+}
+
+impl Dag {
+    fn new() -> Self {
+        Self {
+            parents: HashMap::new(),
+        }
+    }
+
+    /// Record a delta and its parents.
+    fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {
+        self.parents.insert(delta_id, parents);
+    }
+
+    /// `true` iff `ancestor` is in the transitive ancestry of `descendant`.
+    /// Same delta returns `false` (not strictly happens-before).
+    fn happens_before(&self, ancestor: &[u8; 32], descendant: &[u8; 32]) -> bool {
+        if ancestor == descendant {
+            return false;
+        }
+        let mut frontier: Vec<[u8; 32]> = self.parents.get(descendant).cloned().unwrap_or_default();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        while let Some(node) = frontier.pop() {
+            if !seen.insert(node) {
+                continue;
+            }
+            if node == *ancestor {
+                return true;
+            }
+            if let Some(ps) = self.parents.get(&node) {
+                frontier.extend(ps.iter().copied());
+            }
+        }
+        false
+    }
+}
+
+/// One delta authored on some node; gets delivered to one or more nodes.
+struct Delta {
+    id: [u8; 32],
+    parents: Vec<[u8; 32]>,
+    hlc_ns: u64,
+    action: Action,
+}
+
+fn hlc(ns: u64) -> HybridTimestamp {
+    let node_id = ID::from(NonZeroU128::new(1).unwrap());
+    HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
+}
+
+/// Apply `delta` to a node identified by const-generic `SCOPE`. The DAG
+/// closure is taken by reference so the caller controls its lifetime; the
+/// rotation-log write hook and verifier both consult it.
+fn deliver<S: StorageAdaptor>(delta: &Delta, dag: &Dag) -> Result<(), StorageError> {
+    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| dag.happens_before(a, b);
+    let ctx = ApplyContext {
+        causal_parents: &delta.parents,
+        delta_id: Some(delta.id),
+        delta_hlc: Some(hlc(delta.hlc_ns)),
+        happens_before: Some(happens_before),
+    };
+    Interface::<S>::apply_action(delta.action.clone(), ctx)
+}
+
+fn make_signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn pubkey_of(sk: &SigningKey) -> PublicKey {
+    PublicKey::from(*sk.verifying_key().as_bytes())
+}
+
+/// Build a signed Shared action. Parameters mirror the production stamping
+/// path: `hlc_ns` populates both `updated_at` and the signature `nonce`.
+fn build_signed(
+    add: bool,
+    id: Id,
+    data: Vec<u8>,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let metadata = Metadata {
+        created_at: hlc_ns,
+        updated_at: hlc_ns.into(),
+        storage_type: StorageType::Shared {
+            writers,
+            signature_data: Some(SignatureData {
+                signature: [0; 64],
+                nonce: hlc_ns,
+                signer: Some(pubkey_of(signer_sk)),
+            }),
+        },
+        crdt_type: None,
+        field_name: None,
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::Shared {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
+    action
+}
+
+fn setup_root<S: StorageAdaptor>() -> ChildInfo {
+    let root_id = Id::root();
+    let root_meta = Metadata::default();
+    Index::<S>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
+    ChildInfo::new(root_id, [0; 32], root_meta)
+}
+
+/// Read the current writer set from a node's index — convenience for asserts.
+fn stored_writers<S: StorageAdaptor>(id: Id) -> Option<BTreeSet<PublicKey>> {
+    Index::<S>::get_metadata(id).ok().flatten().and_then(|m| {
+        if let StorageType::Shared { writers, .. } = m.storage_type {
+            Some(writers)
+        } else {
+            None
+        }
+    })
+}
+
+/// Read the current value bytes from a node's index — convenience for asserts.
+fn stored_data<S: StorageAdaptor>(id: Id) -> Option<Vec<u8>> {
+    use crate::store::Key;
+    S::storage_read(Key::Entry(id))
+}
+
+fn one_sec(n: u64) -> u64 {
+    n.saturating_mul(1_000_000_000)
+}
+
+// =============================================================================
+// Scenario 1: Update-vs-rotation race (#2197 motivator 1)
+// =============================================================================
+
+/// Bob writes "world" against the writer set he sees ({Alice, Bob}) under
+/// a partition. Concurrently, Alice rotates Bob out. Both deltas reach a
+/// third peer Carol — first the rotation, then Bob's write. Carol must
+/// accept Bob's write because it's causally-before-or-concurrent-with the
+/// rotation; from Bob's view he was authoritatively a writer when he
+/// authored the action.
+///
+/// Without P3 this is the failure mode #2197 calls out: Carol's stored
+/// writer set after applying the rotation is {Alice}, so she'd reject
+/// Bob's signature against the stored set.
+#[test]
+fn update_vs_rotation_race_pre_rotation_write_accepted() {
+    env::reset_for_testing();
+    let _nonce_off = disable_nonce_check_for_testing();
+    type Carol = MockedStorage<500>;
+    let root = setup_root::<Carol>();
+
+    let alice_sk = make_signing_key(0xA1);
+    let bob_sk = make_signing_key(0xB1);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = Id::new([0x50; 32]);
+
+    let mut dag = Dag::new();
+
+    // D_root: Alice bootstraps the entity with writers = {Alice, Bob}.
+    let d_root_id = [0xD0; 32];
+    let d_root = Delta {
+        id: d_root_id,
+        parents: vec![],
+        hlc_ns: one_sec(10),
+        action: build_signed(
+            true,
+            id,
+            b"hello".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![root.clone()],
+        ),
+    };
+    dag.record(d_root.id, d_root.parents.clone());
+    deliver::<Carol>(&d_root, &dag).expect("bootstrap delivered to Carol");
+
+    // D1: Alice rotates Bob out. Parent = D_root.
+    let d1_id = [0xD1; 32];
+    let d1 = Delta {
+        id: d1_id,
+        parents: vec![d_root_id],
+        hlc_ns: one_sec(20),
+        action: build_signed(
+            false,
+            id,
+            b"hello".to_vec(),
+            [alice].into_iter().collect(), // Bob removed
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        ),
+    };
+    dag.record(d1.id, d1.parents.clone());
+
+    // D2: Bob writes "world" — concurrently with D1. Parent = D_root (Bob
+    // has no causal knowledge of D1).
+    let d2_id = [0xD2; 32];
+    let d2 = Delta {
+        id: d2_id,
+        parents: vec![d_root_id],
+        hlc_ns: one_sec(21),
+        action: build_signed(
+            false,
+            id,
+            b"world".to_vec(),
+            [alice, bob].into_iter().collect(), // Bob's view of writers
+            one_sec(21),
+            &bob_sk,
+            vec![],
+        ),
+    };
+    dag.record(d2.id, d2.parents.clone());
+
+    // Delivery to Carol: rotation first, then Bob's write.
+    deliver::<Carol>(&d1, &dag).expect("rotation delivered");
+    deliver::<Carol>(&d2, &dag).expect(
+        "Bob's pre-rotation write must be accepted — writers_at(D2.parents=[D_root]) \
+         includes Bob, even though stored writers post-D1 is {Alice}",
+    );
+
+    // The rotation log on Carol should have entries from D_root, D1, and D2's
+    // bootstrap-counts-as-rotation (D2 didn't change the writer set since
+    // Bob's claim was {Alice, Bob} — same as D_root). So the log has 2 entries
+    // (D_root and D1); D2 was a value-write.
+    let log = rotation_log::load::<Carol>(id).unwrap().unwrap();
+    assert_eq!(log.entries.len(), 2, "log has D_root and D1");
+    assert_eq!(log.entries[0].delta_id, d_root_id);
+    assert_eq!(log.entries[1].delta_id, d1_id);
+}
+
+// =============================================================================
+// Scenario 2: Self-removal mid-flight (#2197 motivator 3)
+// =============================================================================
+
+/// Alice rotates herself out (writers go from {Alice, Bob} to {Bob}). She
+/// has an in-flight update D2 that's *causally before* the rotation D1 in
+/// her own view. D2 should be accepted on a peer that sees both. A second
+/// in-flight update D3 that's causally *after* D1 (Alice saw the rotation
+/// and tried to write anyway) should be rejected.
+#[test]
+fn self_removal_mid_flight_pre_accepted_post_rejected() {
+    env::reset_for_testing();
+    let _nonce_off = disable_nonce_check_for_testing();
+    type Carol = MockedStorage<510>;
+    let root = setup_root::<Carol>();
+
+    let alice_sk = make_signing_key(0xA2);
+    let bob_sk = make_signing_key(0xB2);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = Id::new([0x51; 32]);
+
+    let mut dag = Dag::new();
+
+    // D_root: bootstrap with {Alice, Bob}.
+    let d_root_id = [0xE0; 32];
+    let d_root = Delta {
+        id: d_root_id,
+        parents: vec![],
+        hlc_ns: one_sec(10),
+        action: build_signed(
+            true,
+            id,
+            b"v0".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![root.clone()],
+        ),
+    };
+    dag.record(d_root.id, d_root.parents.clone());
+    deliver::<Carol>(&d_root, &dag).unwrap();
+
+    // D2: Alice's in-flight write — happens-before D1 in her local view.
+    let d2_id = [0xE2; 32];
+    let d2 = Delta {
+        id: d2_id,
+        parents: vec![d_root_id],
+        hlc_ns: one_sec(15),
+        action: build_signed(
+            false,
+            id,
+            b"alice-pre".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(15),
+            &alice_sk,
+            vec![],
+        ),
+    };
+    dag.record(d2.id, d2.parents.clone());
+
+    // D1: Alice rotates self out — its parent is D2 (Alice wrote, then rotated).
+    let d1_id = [0xE1; 32];
+    let d1 = Delta {
+        id: d1_id,
+        parents: vec![d2_id],
+        hlc_ns: one_sec(20),
+        action: build_signed(
+            false,
+            id,
+            b"alice-pre".to_vec(),
+            [bob].into_iter().collect(), // Alice removes self
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        ),
+    };
+    dag.record(d1.id, d1.parents.clone());
+
+    // D3: Alice tries to write AFTER her own rotation — has D1 as parent.
+    // Per ADR she's no longer a writer at this causal point and must be rejected.
+    let d3_id = [0xE3; 32];
+    let d3 = Delta {
+        id: d3_id,
+        parents: vec![d1_id],
+        hlc_ns: one_sec(25),
+        action: build_signed(
+            false,
+            id,
+            b"alice-post".to_vec(),
+            [bob].into_iter().collect(),
+            one_sec(25),
+            &alice_sk,
+            vec![],
+        ),
+    };
+    dag.record(d3.id, d3.parents.clone());
+
+    // Delivery: D1 first (rotation), then D2 (pre-rotation), then D3 (post).
+    deliver::<Carol>(&d1, &dag).expect("rotation accepted");
+    deliver::<Carol>(&d2, &dag).expect(
+        "Alice's pre-rotation write accepted — D2 happens-before D1 in DAG, \
+         writers_at(D2.parents=[D_root]) includes Alice",
+    );
+    let post_result = deliver::<Carol>(&d3, &dag);
+    assert!(
+        matches!(post_result, Err(StorageError::InvalidSignature)),
+        "post-rotation write by removed writer must be rejected; got {:?}",
+        post_result
+    );
+}
+
+// =============================================================================
+// Scenario 3: Concurrent conflicting rotations (#2197 motivator 2)
+// =============================================================================
+
+/// Two writers (Alice, Bob) issue conflicting rotations concurrently:
+/// Alice rotates Bob out; Bob rotates Alice out. Two peers (Carol, Dave)
+/// receive the deltas in opposite orders. Per ADR 0001 the deterministic
+/// winner is the rotation with the larger HLC. Both peers must converge to
+/// the same final writer set.
+#[test]
+fn concurrent_conflicting_rotations_deterministic_convergence() {
+    env::reset_for_testing();
+    let _nonce_off = disable_nonce_check_for_testing();
+    type Carol = MockedStorage<520>;
+    type Dave = MockedStorage<521>;
+    let carol_root = setup_root::<Carol>();
+    let dave_root = setup_root::<Dave>();
+
+    let alice_sk = make_signing_key(0xA3);
+    let bob_sk = make_signing_key(0xB3);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = Id::new([0x52; 32]);
+
+    let mut dag = Dag::new();
+
+    // Bootstrap with {Alice, Bob}.
+    let d_root_id = [0xF0; 32];
+    let d_root_carol = Delta {
+        id: d_root_id,
+        parents: vec![],
+        hlc_ns: one_sec(10),
+        action: build_signed(
+            true,
+            id,
+            b"v0".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![carol_root.clone()],
+        ),
+    };
+    let d_root_dave = Delta {
+        action: build_signed(
+            true,
+            id,
+            b"v0".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![dave_root.clone()],
+        ),
+        ..Delta {
+            id: d_root_id,
+            parents: vec![],
+            hlc_ns: one_sec(10),
+            action: Action::Compare { id: Id::root() },
+        }
+    };
+    dag.record(d_root_carol.id, d_root_carol.parents.clone());
+    deliver::<Carol>(&d_root_carol, &dag).unwrap();
+    deliver::<Dave>(&d_root_dave, &dag).unwrap();
+
+    // D1: Alice rotates Bob out. HLC = 20.
+    let d1_id = [0xF1; 32];
+    let d1 = Delta {
+        id: d1_id,
+        parents: vec![d_root_id],
+        hlc_ns: one_sec(20),
+        action: build_signed(
+            false,
+            id,
+            b"v0".to_vec(),
+            [alice].into_iter().collect(),
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        ),
+    };
+    dag.record(d1.id, d1.parents.clone());
+
+    // D2: Bob rotates Alice out — concurrent with D1. HLC = 21 (larger).
+    let d2_id = [0xF2; 32];
+    let d2 = Delta {
+        id: d2_id,
+        parents: vec![d_root_id],
+        hlc_ns: one_sec(21),
+        action: build_signed(
+            false,
+            id,
+            b"v0".to_vec(),
+            [bob].into_iter().collect(),
+            one_sec(21),
+            &bob_sk,
+            vec![],
+        ),
+    };
+    dag.record(d2.id, d2.parents.clone());
+
+    // Carol gets D1 then D2; Dave gets D2 then D1.
+    deliver::<Carol>(&d1, &dag).expect("D1 by Alice accepted on Carol");
+    deliver::<Carol>(&d2, &dag).expect("D2 by Bob accepted on Carol (concurrent with D1)");
+
+    deliver::<Dave>(&d2, &dag).expect("D2 by Bob accepted on Dave");
+    deliver::<Dave>(&d1, &dag).expect("D1 by Alice accepted on Dave (concurrent with D2)");
+
+    // Both nodes' rotation logs should now have D_root, D1, D2 (in delivery
+    // order, not causal order). The order DIFFERS by node, but writers_at
+    // applied to the same causal frontier should produce the same answer.
+    let carol_log = rotation_log::load::<Carol>(id).unwrap().unwrap();
+    let dave_log = rotation_log::load::<Dave>(id).unwrap().unwrap();
+    assert_eq!(carol_log.entries.len(), 3);
+    assert_eq!(dave_log.entries.len(), 3);
+
+    // Query the writer set as-of {D1, D2}. Per ADR: HLC tiebreak — D2 (21)
+    // beats D1 (20) — winner is {Bob}.
+    let causal_frontier = [d1_id, d2_id];
+    let happens_before = |a: &[u8; 32], b: &[u8; 32]| dag.happens_before(a, b);
+
+    let carol_writers = rotation_log::writers_at::<Carol, _>(id, &causal_frontier, &happens_before)
+        .unwrap()
+        .unwrap();
+    let dave_writers = rotation_log::writers_at::<Dave, _>(id, &causal_frontier, &happens_before)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(carol_writers, dave_writers, "deterministic convergence");
+    assert_eq!(
+        carol_writers,
+        [bob].into_iter().collect(),
+        "D2 (HLC 21) wins over D1 (HLC 20)"
+    );
+}
+
+// =============================================================================
+// Scenario 4: Long-partition reconciliation
+// =============================================================================
+
+/// Two nodes are partitioned for a "long time" — each accumulates a chain of
+/// writes and rotations. After the partition heals, both nodes deliver each
+/// other's deltas. Both should agree on the same final answer for
+/// `writers_at` queried over the merged causal frontier.
+///
+/// The chains here are small (3 deltas per side) but the structure exercises
+/// the same logic at any depth: a long chain of causally-ordered rotations
+/// reduces to "the latest in causal order wins" per ADR 0001.
+#[test]
+fn long_partition_reconciliation_converges() {
+    env::reset_for_testing();
+    let _nonce_off = disable_nonce_check_for_testing();
+    type Left = MockedStorage<530>;
+    type Right = MockedStorage<531>;
+    let left_root = setup_root::<Left>();
+    let right_root = setup_root::<Right>();
+
+    let alice_sk = make_signing_key(0xA4);
+    let bob_sk = make_signing_key(0xB4);
+    let carol_sk = make_signing_key(0xC4);
+    let dave_sk = make_signing_key(0xD4);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let carol = pubkey_of(&carol_sk);
+    let dave = pubkey_of(&dave_sk);
+    let id = Id::new([0x53; 32]);
+
+    let mut dag = Dag::new();
+
+    // Pre-partition bootstrap: writers = {Alice, Bob}.
+    let g0 = [0x10; 32];
+    let bootstrap_left = Delta {
+        id: g0,
+        parents: vec![],
+        hlc_ns: one_sec(10),
+        action: build_signed(
+            true,
+            id,
+            b"v0".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![left_root.clone()],
+        ),
+    };
+    let bootstrap_right = Delta {
+        action: build_signed(
+            true,
+            id,
+            b"v0".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![right_root.clone()],
+        ),
+        ..Delta {
+            id: g0,
+            parents: vec![],
+            hlc_ns: one_sec(10),
+            action: Action::Compare { id: Id::root() },
+        }
+    };
+    dag.record(g0, vec![]);
+    deliver::<Left>(&bootstrap_left, &dag).unwrap();
+    deliver::<Right>(&bootstrap_right, &dag).unwrap();
+
+    // Left side: g0 → L1 (Alice → {Alice, Carol}) → L2 (Carol writes "left").
+    let l1 = [0x11; 32];
+    let l1_delta = Delta {
+        id: l1,
+        parents: vec![g0],
+        hlc_ns: one_sec(20),
+        action: build_signed(
+            false,
+            id,
+            b"v0".to_vec(),
+            [alice, carol].into_iter().collect(),
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        ),
+    };
+    dag.record(l1, vec![g0]);
+    deliver::<Left>(&l1_delta, &dag).unwrap();
+
+    let l2 = [0x12; 32];
+    let l2_delta = Delta {
+        id: l2,
+        parents: vec![l1],
+        hlc_ns: one_sec(30),
+        action: build_signed(
+            false,
+            id,
+            b"left".to_vec(),
+            [alice, carol].into_iter().collect(),
+            one_sec(30),
+            &carol_sk,
+            vec![],
+        ),
+    };
+    dag.record(l2, vec![l1]);
+    deliver::<Left>(&l2_delta, &dag).unwrap();
+
+    // Right side: g0 → R1 (Bob → {Bob, Dave}) → R2 (Dave writes "right").
+    let r1 = [0x21; 32];
+    let r1_delta = Delta {
+        id: r1,
+        parents: vec![g0],
+        hlc_ns: one_sec(25),
+        action: build_signed(
+            false,
+            id,
+            b"v0".to_vec(),
+            [bob, dave].into_iter().collect(),
+            one_sec(25),
+            &bob_sk,
+            vec![],
+        ),
+    };
+    dag.record(r1, vec![g0]);
+    deliver::<Right>(&r1_delta, &dag).unwrap();
+
+    let r2 = [0x22; 32];
+    let r2_delta = Delta {
+        id: r2,
+        parents: vec![r1],
+        hlc_ns: one_sec(35),
+        action: build_signed(
+            false,
+            id,
+            b"right".to_vec(),
+            [bob, dave].into_iter().collect(),
+            one_sec(35),
+            &dave_sk,
+            vec![],
+        ),
+    };
+    dag.record(r2, vec![r1]);
+    deliver::<Right>(&r2_delta, &dag).unwrap();
+
+    // Partition heals: each side delivers the other side's chain.
+    deliver::<Left>(&r1_delta, &dag).expect("R1 (Bob's rotation) accepted on Left");
+    deliver::<Left>(&r2_delta, &dag).expect("R2 (Dave's write) accepted on Left");
+    deliver::<Right>(&l1_delta, &dag).expect("L1 (Alice's rotation) accepted on Right");
+    deliver::<Right>(&l2_delta, &dag).expect("L2 (Carol's write) accepted on Right");
+
+    // Both sides queried over the full merged frontier {L2, R2} should agree.
+    let frontier = [l2, r2];
+    let hb = |a: &[u8; 32], b: &[u8; 32]| dag.happens_before(a, b);
+
+    let left_writers = rotation_log::writers_at::<Left, _>(id, &frontier, &hb)
+        .unwrap()
+        .unwrap();
+    let right_writers = rotation_log::writers_at::<Right, _>(id, &frontier, &hb)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        left_writers, right_writers,
+        "both sides converge on the same writer set as-of {{L2, R2}}"
+    );
+
+    // Per ADR: between L1 (HLC=20) and R1 (HLC=25), neither happens-before the
+    // other (siblings of g0). HLC tiebreak picks R1 — winner is {Bob, Dave}.
+    assert_eq!(
+        left_writers,
+        [bob, dave].into_iter().collect(),
+        "R1 (HLC 25) wins HLC tiebreak vs L1 (HLC 20)"
+    );
+
+    // Sanity: each node's stored writer set after applying everything in
+    // delivery order matches what writers_at on the merged frontier reports.
+    // (In this scenario the apply path gates on the local view; convergence
+    // is the property we check via the rotation log, which IS the canonical
+    // post-merge writer set in v3.)
+    let _ = stored_writers::<Left>(id);
+    let _ = stored_writers::<Right>(id);
+    let _ = stored_data::<Left>(id);
+}

--- a/crates/storage/src/tests/p5_partition_scenarios.rs
+++ b/crates/storage/src/tests/p5_partition_scenarios.rs
@@ -26,20 +26,20 @@
 //! actually exercise.
 
 use core::num::NonZeroU128;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
-use calimero_primitives::identity::PublicKey;
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::SigningKey;
 
 use crate::action::Action;
 use crate::address::Id;
-use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use crate::entities::{ChildInfo, Metadata};
 use crate::env;
 use crate::index::Index;
 use crate::interface::{disable_nonce_check_for_testing, ApplyContext, Interface, StorageError};
 use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 use crate::rotation_log;
 use crate::store::{MockedStorage, StorageAdaptor};
+use crate::tests::common::{build_signed_shared_action, pubkey_of};
 
 // =============================================================================
 // Harness
@@ -118,66 +118,6 @@ fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
 }
 
-fn pubkey_of(sk: &SigningKey) -> PublicKey {
-    PublicKey::from(*sk.verifying_key().as_bytes())
-}
-
-/// Build a signed Shared action. Parameters mirror the production stamping
-/// path: `hlc_ns` populates both `updated_at` and the signature `nonce`.
-fn build_signed(
-    add: bool,
-    id: Id,
-    data: Vec<u8>,
-    writers: BTreeSet<PublicKey>,
-    hlc_ns: u64,
-    signer_sk: &SigningKey,
-    ancestors: Vec<ChildInfo>,
-) -> Action {
-    let metadata = Metadata {
-        created_at: hlc_ns,
-        updated_at: hlc_ns.into(),
-        storage_type: StorageType::Shared {
-            writers,
-            signature_data: Some(SignatureData {
-                signature: [0; 64],
-                nonce: hlc_ns,
-                signer: Some(pubkey_of(signer_sk)),
-            }),
-        },
-        crdt_type: None,
-        field_name: None,
-    };
-    let mut action = if add {
-        Action::Add {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    } else {
-        Action::Update {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    };
-    let payload = action.payload_for_signing();
-    let signature = signer_sk.sign(&payload).to_bytes();
-    let metadata_mut = match &mut action {
-        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
-        _ => unreachable!(),
-    };
-    if let StorageType::Shared {
-        signature_data: Some(sd),
-        ..
-    } = &mut metadata_mut.storage_type
-    {
-        sd.signature = signature;
-    }
-    action
-}
-
 fn setup_root<S: StorageAdaptor>() -> ChildInfo {
     let root_id = Id::root();
     let root_meta = Metadata::default();
@@ -224,7 +164,7 @@ fn update_vs_rotation_race_pre_rotation_write_accepted() {
         id: d_root_id,
         parents: vec![],
         hlc_ns: one_sec(10),
-        action: build_signed(
+        action: build_signed_shared_action(
             true,
             id,
             b"hello".to_vec(),
@@ -243,7 +183,7 @@ fn update_vs_rotation_race_pre_rotation_write_accepted() {
         id: d1_id,
         parents: vec![d_root_id],
         hlc_ns: one_sec(20),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"hello".to_vec(),
@@ -262,7 +202,7 @@ fn update_vs_rotation_race_pre_rotation_write_accepted() {
         id: d2_id,
         parents: vec![d_root_id],
         hlc_ns: one_sec(21),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"world".to_vec(),
@@ -321,7 +261,7 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
         id: d_root_id,
         parents: vec![],
         hlc_ns: one_sec(10),
-        action: build_signed(
+        action: build_signed_shared_action(
             true,
             id,
             b"v0".to_vec(),
@@ -340,7 +280,7 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
         id: d2_id,
         parents: vec![d_root_id],
         hlc_ns: one_sec(15),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"alice-pre".to_vec(),
@@ -358,7 +298,7 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
         id: d1_id,
         parents: vec![d2_id],
         hlc_ns: one_sec(20),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"alice-pre".to_vec(),
@@ -377,7 +317,7 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
         id: d3_id,
         parents: vec![d1_id],
         hlc_ns: one_sec(25),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"alice-post".to_vec(),
@@ -435,7 +375,7 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
         id: d_root_id,
         parents: vec![],
         hlc_ns: one_sec(10),
-        action: build_signed(
+        action: build_signed_shared_action(
             true,
             id,
             b"v0".to_vec(),
@@ -446,7 +386,7 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
         ),
     };
     let d_root_dave = Delta {
-        action: build_signed(
+        action: build_signed_shared_action(
             true,
             id,
             b"v0".to_vec(),
@@ -472,7 +412,7 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
         id: d1_id,
         parents: vec![d_root_id],
         hlc_ns: one_sec(20),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"v0".to_vec(),
@@ -490,7 +430,7 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
         id: d2_id,
         parents: vec![d_root_id],
         hlc_ns: one_sec(21),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"v0".to_vec(),
@@ -576,7 +516,7 @@ fn long_partition_reconciliation_converges() {
         id: g0,
         parents: vec![],
         hlc_ns: one_sec(10),
-        action: build_signed(
+        action: build_signed_shared_action(
             true,
             id,
             b"v0".to_vec(),
@@ -587,7 +527,7 @@ fn long_partition_reconciliation_converges() {
         ),
     };
     let bootstrap_right = Delta {
-        action: build_signed(
+        action: build_signed_shared_action(
             true,
             id,
             b"v0".to_vec(),
@@ -613,7 +553,7 @@ fn long_partition_reconciliation_converges() {
         id: l1,
         parents: vec![g0],
         hlc_ns: one_sec(20),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"v0".to_vec(),
@@ -631,7 +571,7 @@ fn long_partition_reconciliation_converges() {
         id: l2,
         parents: vec![l1],
         hlc_ns: one_sec(30),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"left".to_vec(),
@@ -650,7 +590,7 @@ fn long_partition_reconciliation_converges() {
         id: r1,
         parents: vec![g0],
         hlc_ns: one_sec(25),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"v0".to_vec(),
@@ -668,7 +608,7 @@ fn long_partition_reconciliation_converges() {
         id: r2,
         parents: vec![r1],
         hlc_ns: one_sec(35),
-        action: build_signed(
+        action: build_signed_shared_action(
             false,
             id,
             b"right".to_vec(),

--- a/crates/storage/src/tests/p5_partition_scenarios.rs
+++ b/crates/storage/src/tests/p5_partition_scenarios.rs
@@ -221,10 +221,22 @@ fn update_vs_rotation_race_pre_rotation_write_accepted() {
          includes Bob, even though stored writers post-D1 is {Alice}",
     );
 
-    // The rotation log on Carol should have entries from D_root, D1, and D2's
-    // bootstrap-counts-as-rotation (D2 didn't change the writer set since
-    // Bob's claim was {Alice, Bob} — same as D_root). So the log has 2 entries
-    // (D_root and D1); D2 was a value-write.
+    // The rotation log on Carol should have entries from D_root and D1; D2
+    // was a value-write whose claimed `{Alice, Bob}` matches the bootstrap
+    // set, so it doesn't trigger the rotation hook.
+    //
+    // KNOWN FRAGILITY (PR #2265 review): D2 is correctly skipped here only
+    // because the index's `storage_type.writers` is *frozen at bootstrap* —
+    // `Index::update_hash_for` updates `own_hash`/`full_hash`/`updated_at`
+    // but never touches `storage_type`. So `pre_apply_writers` returned to
+    // `maybe_append_rotation_log` is `{Alice, Bob}` (bootstrap), not the
+    // post-D1 `{Alice}`. The comparison `pre_apply_writers != action.writers`
+    // is thus `{A,B} != {A,B}` → not a rotation. If `update_hash_for` is
+    // ever changed to keep `storage_type` in sync, the rotation-detection
+    // logic must move to comparing against `writers_at(causal_parents)`
+    // instead of stored, or stale value-writes will be falsely logged.
+    // See `write_hook_relies_on_stale_stored_writers_for_rotation_detection`
+    // in p3_dag_causal.rs for the explicit demonstration. Tracked in #2233 P3.
     let log = rotation_log::load::<Carol>(id).unwrap().unwrap();
     assert_eq!(log.entries.len(), 2, "log has D_root and D1");
     assert_eq!(log.entries[0].delta_id, d_root_id);

--- a/crates/storage/src/tests/p5_partition_scenarios.rs
+++ b/crates/storage/src/tests/p5_partition_scenarios.rs
@@ -398,6 +398,9 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
         ),
     };
     let d_root_dave = Delta {
+        id: d_root_id,
+        parents: vec![],
+        hlc_ns: one_sec(10),
         action: build_signed_shared_action(
             true,
             id,
@@ -407,12 +410,6 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
             &alice_sk,
             vec![dave_root.clone()],
         ),
-        ..Delta {
-            id: d_root_id,
-            parents: vec![],
-            hlc_ns: one_sec(10),
-            action: Action::Compare { id: Id::root() },
-        }
     };
     dag.record(d_root_carol.id, d_root_carol.parents.clone());
     deliver::<Carol>(&d_root_carol, &dag).unwrap();
@@ -539,6 +536,9 @@ fn long_partition_reconciliation_converges() {
         ),
     };
     let bootstrap_right = Delta {
+        id: g0,
+        parents: vec![],
+        hlc_ns: one_sec(10),
         action: build_signed_shared_action(
             true,
             id,
@@ -548,12 +548,6 @@ fn long_partition_reconciliation_converges() {
             &alice_sk,
             vec![right_root.clone()],
         ),
-        ..Delta {
-            id: g0,
-            parents: vec![],
-            hlc_ns: one_sec(10),
-            action: Action::Compare { id: Id::root() },
-        }
     };
     dag.record(g0, vec![]);
     deliver::<Left>(&bootstrap_left, &dag).unwrap();

--- a/crates/storage/src/tests/p5_partition_scenarios.rs
+++ b/crates/storage/src/tests/p5_partition_scenarios.rs
@@ -185,23 +185,6 @@ fn setup_root<S: StorageAdaptor>() -> ChildInfo {
     ChildInfo::new(root_id, [0; 32], root_meta)
 }
 
-/// Read the current writer set from a node's index — convenience for asserts.
-fn stored_writers<S: StorageAdaptor>(id: Id) -> Option<BTreeSet<PublicKey>> {
-    Index::<S>::get_metadata(id).ok().flatten().and_then(|m| {
-        if let StorageType::Shared { writers, .. } = m.storage_type {
-            Some(writers)
-        } else {
-            None
-        }
-    })
-}
-
-/// Read the current value bytes from a node's index — convenience for asserts.
-fn stored_data<S: StorageAdaptor>(id: Id) -> Option<Vec<u8>> {
-    use crate::store::Key;
-    S::storage_read(Key::Entry(id))
-}
-
 fn one_sec(n: u64) -> u64 {
     n.saturating_mul(1_000_000_000)
 }
@@ -727,13 +710,4 @@ fn long_partition_reconciliation_converges() {
         [bob, dave].into_iter().collect(),
         "R1 (HLC 25) wins HLC tiebreak vs L1 (HLC 20)"
     );
-
-    // Sanity: each node's stored writer set after applying everything in
-    // delivery order matches what writers_at on the merged frontier reports.
-    // (In this scenario the apply path gates on the local view; convergence
-    // is the property we check via the rotation log, which IS the canonical
-    // post-merge writer set in v3.)
-    let _ = stored_writers::<Left>(id);
-    let _ = stored_writers::<Right>(id);
-    let _ = stored_data::<Left>(id);
 }

--- a/docs/adr/0001-shared-storage-concurrent-rotation.md
+++ b/docs/adr/0001-shared-storage-concurrent-rotation.md
@@ -1,0 +1,195 @@
+# ADR 0001 — Concurrent rotation semantics for `SharedStorage<T>`
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Date** | 2026-04-24 |
+| **Deciders** | Calimero core team |
+| **Context** | [#2233](https://github.com/calimero-network/core/issues/2233) — DAG-causal Shared verification, phase **P4 (design)** |
+| **Constrains** | [#2233](https://github.com/calimero-network/core/issues/2233) phase **P2** (rotation history schema) |
+
+> First ADR in this repo. Convention: `docs/adr/NNNN-kebab-title.md`, monotonically numbered, "Proposed → Accepted → Superseded" lifecycle.
+
+## Context
+
+`SharedStorage<T>` is group-writable storage with a mutable writer set. Any current writer can rotate the writer set via `rotate_writers(new_writers)`. v2 (#2230) ships with monotonic-nonce + last-write-wins on `writers_nonce`; #2233 replaces that with DAG-causal verification.
+
+When two current writers issue rotations *concurrently* (siblings in the DAG, neither in the other's causal history, both signed by valid pre-rotation writers), the merge has to pick a deterministic outcome. v2 picks LWW by `writers_nonce`; that loses information. Before P2 designs the rotation-history schema, we need to know what merge rule we're storing for, because the rule constrains the schema.
+
+This ADR captures the rule and the rejected alternatives.
+
+### Concurrent vs. causal: definitions used in this ADR
+
+For two rotation actions `R₁` and `R₂` on the same entity, contained in causal deltas `D₁` and `D₂`:
+
+- **`R₁ happens-before R₂`** iff `D₁.id` is in the transitive `parents` set of `D₂` (the DAG-causal "knows about" relation).
+- **Concurrent** iff neither `R₁ happens-before R₂` nor `R₂ happens-before R₁`.
+
+These are the standard CRDT terms; we use them in the strict DAG-structural sense, not wall-clock time.
+
+## Decision
+
+**Causal-first LWW, with HLC tiebreak, with signer-pubkey tiebreak.**
+
+Given two rotations `R₁` (in delta `D₁`) and `R₂` (in delta `D₂`) on the same entity:
+
+1. **Causal precedence wins, unconditionally.** If `R₁ happens-before R₂`, then `R₂` wins. The author of `R₂` saw `R₁`'s reality and chose to rotate from that state — overriding `R₂` would discard a writer's informed decision.
+2. **For truly concurrent rotations**, the rotation with the **larger `D.hlc`** wins. `HybridTimestamp` is `Ord` and embeds both NTP64 wall-time and a node `ID`, giving a deterministic total order across nodes.
+3. **HLC tiebreak (vanishingly rare)** by lexicographic comparison of the signing writer's pubkey bytes — smaller bytes win. Spelled out for spec completeness; practically unreachable because HLC's embedded node ID already disambiguates same-instant events from different nodes.
+
+The same rule resolves writes (`insert`) by analogy: causal-first, then HLC, then signer-hash. Rotations and value writes use the same merge ordering.
+
+### Worked examples
+
+> Notation: `Wₐ`, `W_b` are writers. `(setₓ)` is the post-rotation writer set. Arrows `→` denote DAG edges (parent → child). Times in brackets are HLCs.
+
+**Example A — sequential, no race.**
+```
+[t=10] D₁ by Wₐ: rotate → (Wₐ, W_b)
+   ↓
+[t=20] D₂ by W_b: rotate → (W_b, W_c)
+```
+`D₁ happens-before D₂`. Result: `(W_b, W_c)`. (No change vs. v2.)
+
+**Example B — concurrent siblings, different intent.**
+```
+        [t=10] D_root: writers = (Wₐ, W_b)
+              ↓             ↓
+[t=20, Wₐ] D₁: → (Wₐ)    [t=21, W_b] D₂: → (W_b)
+   (Wₐ rotates W_b out)    (W_b rotates Wₐ out)
+```
+Concurrent. HLC: `D₂` (21) > `D₁` (20). Result: `(W_b)`. `Wₐ` is rotated out; `Wₐ`'s rotation that removed `W_b` is discarded.
+
+This is the *expected information loss* of any non-union rule — and is why option 2 (union-with-re-election) exists. We accept the loss; see "Consequences" below.
+
+**Example C — concurrent siblings, same HLC (exotic).**
+```
+        D_root: writers = (Wₐ, W_b)
+              ↓             ↓
+[t=20, Wₐ] D₁: → (Wₐ, W_c)   [t=20, W_b] D₂: → (W_b, W_d)
+```
+HLC tie. Tiebreak by signer pubkey bytes: assume `bytes(Wₐ) < bytes(W_b)` lexicographically → `D₁` wins → result `(Wₐ, W_c)`.
+
+In practice, `HybridTimestamp` includes a node ID, so two distinct nodes producing identical HLCs at the same nanosecond requires the IDs to also collide — astronomically unlikely. The tiebreak is for spec completeness, not real-world frequency.
+
+**Example D — concurrent rotation vs. concurrent value write.**
+```
+        D_root: value = "hello", writers = (Wₐ, W_b)
+              ↓             ↓
+[t=20, Wₐ] D₁: rotate → (Wₐ)   [t=21, W_b] D₂: insert("world")
+```
+The value-write action (D₂'s insert) and the rotation action (D₁) target the same entity but are different action kinds. Resolved independently:
+- **Writer set**: only `D₁` rotates → `(Wₐ)`.
+- **Value**: `D₂` writes "world" with HLC 21; later HLC wins → "world".
+
+Result: writers `(Wₐ)`, value `"world"`. `W_b`'s write is *kept* even though `W_b` is no longer a writer post-merge — `W_b` was authoritatively a writer at the time `D₂` was authored (siblings of `D_root`), and the verifier validates against `writers_at(entity, D₂.parents)`, not against the post-merge writer set. (See [#2233 epic constraints](https://github.com/calimero-network/core/issues/2233).)
+
+This is the central guarantee that makes concurrent operation safe: a write signed by the writer-set-as-of-the-author's-causal-view never gets retroactively rejected by a later rotation.
+
+## Alternatives considered
+
+### A1 — LWW by `writers_nonce` *(what v2 ships)*
+
+| Pro | Con |
+|---|---|
+| Simple, already implemented | Loses one rotation's intent on every concurrent rotation |
+| No DAG infra needed | `writers_nonce` collisions on concurrent siblings — falls back to BTreeSet sort, fully arbitrary |
+| | Doesn't address the four #2197 partition scenarios |
+
+**Rejected** because it doesn't deliver the correctness improvement that motivates #2233. If the answer is "LWW is fine," the entire epic is unnecessary.
+
+### A2 — Writer-set union with re-election
+
+Apply both rotations, take the union, mark the entity as "needs re-election." A current writer must issue a signed re-election to reduce the set.
+
+| Pro | Con |
+|---|---|
+| No information loss — both rotations preserved | UX disaster: every concurrent rotation requires a follow-up coordination step |
+| Theoretically the most "CRDT-pure" choice | Forces every app to handle a "pending re-election" UI state |
+| | Storage cost: P2 must carry intermediate union state |
+| | If no re-election ever happens, the union persists indefinitely — *worse* than LWW because a malicious writer added by an attacker stays in until manually removed |
+| | Double-spend / safety windows: between rotation and re-election, the union has more writers than either author intended |
+
+**Rejected.** The intent-preservation upside doesn't justify the operational complexity. Apps that need this can implement it on top of the chosen rule (commit-then-re-elect via two `rotate_writers` calls) without the storage layer mandating it.
+
+### A3 — Signer-pubkey hash tiebreak (alone)
+
+| Pro | Con |
+|---|---|
+| Deterministic | Same intent loss as LWW |
+| | Doesn't use causal information at all |
+
+**Rejected as the primary rule.** Adopted as the *final* tiebreak in our chosen rule (after HLC) because it's a clean deterministic floor.
+
+### A4 — First-causal-parent-wins *(closest to chosen rule)*
+
+The original framing in the #2233 epic: "the rotation whose nearest common DAG ancestor is causally earliest wins."
+
+| Pro | Con |
+|---|---|
+| Uses DAG infra naturally | The "nearest common ancestor" is the same delta for any two siblings — degenerates to needing a separate tiebreak anyway |
+| | Underspecified for the sibling case (which is exactly the hard case) |
+
+**Refined into the chosen rule.** The chosen rule keeps the spirit ("causal first") and replaces the underspecified ancestor comparison with concrete HLC + pubkey tiebreaks for true siblings.
+
+### A5 — Reject concurrent rotations
+
+The entity refuses to apply a rotation if its current writer set has already moved past the rotation's claimed view. The losing writer must re-fetch state and re-issue.
+
+| Pro | Con |
+|---|---|
+| Strong intent preservation (winning rotation always reflects its author's full intent) | Breaks the "eventually converges without app intervention" CRDT guarantee |
+| | Two co-admins rotating at the same time → both rotations *could* fail in pathological reorderings, requiring app retry logic |
+| | Adversarial writers can DoS rotation by spamming concurrent attempts |
+| | Nodes processing the rejection have to surface "rotation rejected, please retry" to userland — every SharedStorage user has to handle this |
+
+**Rejected.** Calimero's model is "sync converges silently, no app retries needed for ordinary CRDT merges." Rotation should not be a special case where convergence requires application-level retry.
+
+## Consequences
+
+### What P2 needs to store
+
+The chosen rule is **stateless beyond a per-entity rotation log** sorted by causal order. No intermediate "pending re-election" state, no union accumulation. P2 schema (option a in the epic) is sufficient:
+
+```text
+RotationLogEntry {
+    delta_id:        [u8; 32],   // CausalDelta.id where the rotation lives
+    delta_hlc:       HybridTimestamp,  // for sibling tiebreak
+    signer:          PublicKey,        // for HLC-tie tiebreak
+    new_writers:     BTreeSet<PublicKey>,
+    writers_nonce:   u64,         // kept for v2 compat / debugging only
+}
+```
+
+`writers_at(entity_id, causal_parents)` walks the log filtered to entries whose `delta_id` is in `causal_parents`' transitive ancestor set, picks the *latest* by the rule above, and returns its `new_writers`.
+
+If `causal_parents` is empty (P1 codepath, snapshot leaf push, local apply), `writers_at` returns the most recently appended entry — matches v2 LWW behavior, preserves backward compatibility.
+
+### What P3 (verifier) does with it
+
+The verifier validates a Shared action's signature against `writers_at(action.entity_id, ctx.causal_parents)` — *not* against the currently stored writer set. This is what makes Example D safe.
+
+The v2 `signer: Option<PublicKey>` hint on `SignatureData` (already shipped, dormant) is validated against the same `writers_at(...)` set — not current. Spelled out in the #2233 epic; reaffirmed here.
+
+### What about pure value writes (insert)?
+
+The same rule extends without change: causal-first, HLC second, signer-hash third. P2 doesn't need a separate value-write history; the existing CRDT-merge layer (LWW per slot for `LwwRegister`, etc.) already handles this — only the *verifier* needs to know `writers_at(entity, causal_parents)` to validate signatures, not to merge values.
+
+### What we accept
+
+- **One rotation's intent can be lost** in the truly-concurrent case (Example B). This is unavoidable without union-with-re-election (A2), and we judged A2's complexity worse than the loss.
+- **Out-of-order delivery is fine.** Two nodes seeing `D₁` then `D₂` vs. `D₂` then `D₁` converge to the same result because the rule depends only on (causal relation, HLC, signer hash) — all immutable per-delta.
+- **HLC clock skew matters.** A writer with a fast clock can win all concurrent races. This is the standard LWW concern; mitigated by the existing HLC + drift-tolerance check (`DRIFT_TOLERANCE_NANOS`). If clock-skew abuse becomes a real threat, A2 (union-with-re-election) is the escape hatch — schema can be extended without a wire-format break since the rotation log is local-only.
+
+### What we explicitly do NOT decide here
+
+- **Compaction policy.** The epic specifies "1000-entry sliding window + snapshot." That number belongs in P6 measurements; the *shape* (sliding window with a snapshot of the writer set at the boundary) is locked in here so P2 can lay out the index schema.
+- **Re-election as an opt-in feature.** Apps that want union-with-re-election can build it: `rotate_writers(union)` followed by a coordinated `rotate_writers(reduced)`. The storage layer doesn't need to know.
+- **Bootstrap race.** Listed as item 4 in #2197 / #2233. Not addressed by this ADR — bootstrap concurrency happens *before* there's a shared causal ancestor, so causal-first doesn't apply. P5/P6 is the right place; tracked separately.
+
+## References
+
+- [#2197](https://github.com/calimero-network/core/issues/2197) — original SharedStorage spec, partition scenarios
+- [#2230](https://github.com/calimero-network/core/issues/2230) — v2 follow-ups (signer hint, rotate-self-out)
+- [#2233](https://github.com/calimero-network/core/issues/2233) — DAG-causal verification epic (this ADR is phase P4-design)
+- [#2249](https://github.com/calimero-network/core/pull/2249) — v2 PR (signer hint plumbing referenced above)


### PR DESCRIPTION
Closes the storage-layer scope of #2233 (DAG-causal Shared verification). Addresses the four partition scenarios from #2197 that motivated the epic.

## Summary

- Switches `Interface::apply_action`'s Shared verifier from "currently-stored writers" to `writers_at(causal_parents)` per **ADR 0001** (this PR adds the ADR). Concurrent rotations resolve via causal-precedence-first → larger HLC → smaller signer-pubkey bytes.
- Adds a per-entity `RotationLog` (new `Key::RotationLog(Id)` variant) capturing every signature-verified rotation, plus the `writers_at` reader.
- Plumbs an `ApplyContext { delta_id, delta_hlc, happens_before, ... }` through `apply_action` and ~100 call sites (no `Default` — every site forced to construct explicitly so future fields are a compile error everywhere).
- Falls back to v2 stored-writer behavior + nonce check whenever `ApplyContext` is empty, so the new path is dormant until the WASM ABI is wired.

## Reviewer guide (read commit-by-commit)

1. `35fee7fb` **P1** — `ApplyContext` plumbing. No behavior change. Mechanical.
2. `448ac541` **P4-design** — ADR 0001. Walks 4 worked examples; rejects 5 alternatives. Worth reading first to ground the rest.
3. `34444fdd` **P2** — `rotation_log` module + `writers_at`. Storage layer takes a DAG-ancestry closure so it stays decoupled from the DAG crate.
4. `6e0ff6b0` **P3** — Verifier swap + write hook in `apply_action`'s Shared arm. Logs `storage::p3_verifier` warnings on v2/v3 divergence (rollout telemetry per the epic exit criterion).
5. `9ad2106d` **P4-impl** — No-op for the chosen rule (causal-first LWW has no convergence reduction step) plus the missing ADR Example D test.
6. `1de5e799` **P5** — Cross-node partition scenario tests for all four #2197 motivating cases. Required moving the rotation-log write hook to fire right after sig verification (not gated by `save_internal`'s LWW-by-HLC drop) and making `rotation_log::append` idempotent on `delta_id`.
7. `1397bfbf` … `ea57faed` **Review passes** — clippy/test-code nits, helper extraction, doc clarifications on rotation-log semantics, DeleteRef test parity, and promotion of the `append` debug_assert into a real `StorageError::DuplicateRotationInDelta` so multi-rotation-per-delta misuse surfaces in release builds.

## Production status — dormant until WASM ABI follow-up

Production WASM-side sync paths still construct `ApplyContext` with `None`/empty values, so:
- The rotation log stays empty.
- The verifier falls back to v2 stored-writer behavior + nonce check.

Threading `CausalDelta.{id,hlc,parents}` through `__calimero_sync_next` is a separate follow-up — call sites are marked with `// P3 of #2233:` comments and the work is tracked in **#2266**. The epic exit criterion (4 weeks of zero-divergence telemetry before removing the v2 nonce check) gates the actual cutover and is tracked separately.

The bootstrap-race scenario from #2197 is deferred per ADR 0001 ("explicitly do NOT decide here") — bootstrap concurrency happens before there's a shared causal ancestor, so causal-first doesn't apply; that lives in P6 / a separate spec.

A `#[cfg(test)]` thread-local `disable_nonce_check_for_testing()` RAII guard lets P5 tests validate the v3 target behavior (the v2 nonce check rejects the very out-of-order delivery cases DAG-causal accepts). Production codepath unchanged — the const fn returns `false` outside `cfg(test)`.

## v2 baseline confirmation (review follow-up)

A reviewer asked whether the v2-fallback arm in `apply_action` (`(None, Some(stored)) => stored.clone()` for `authoritative_writers`) introduces a regression by signature-verifying against potentially stale stored writers when `ApplyContext` is empty. **It does not** — this matches v2's pre-PR behavior byte-for-byte:

- **`master:cc5c111d:crates/storage/src/interface.rs:207-215`** — v2 already chose `authoritative_writers` from the stored entity's `StorageType::Shared { writers: stored_w, .. }`, falling back to the action's claimed writers only when no stored entry existed. The `(None, Some(stored)) => stored.clone()` arm in this PR is the exact same arm, just expressed inside the new `match (ctx_writers, stored_writers)` shape so the DAG-causal path can take precedence when `ctx_writers` is `Some`.
- **`master:cc5c111d:crates/storage/src/index.rs:705-747`** — `Index::update_hash_for` only updates `own_hash`/`full_hash`/`updated_at`; it never touches `storage_type`. So the stored writer set stays frozen at bootstrap on master, and consequently a signature check against `stored_writers` after a rotation is *already* checking against stale data on master. This PR doesn't change that, it just routes around it when DAG context is supplied.

In short: the v2 arm in this PR is a faithful re-expression of the existing v2 behavior, and the staleness it inherits is a **pre-existing v2 limitation**, not a regression introduced here. The DAG-causal path (`writers_at(causal_parents)`) is the actual fix for that staleness, and it activates as soon as the WASM ABI is wired (tracked in **#2266**).

## Test plan

- [x] All 11 commits build clean on top of current master.
- [x] `cargo test -p calimero-storage` — **432 tests passing** (415 → 423 → 425 → 429 → 432 across P2/P3/P4-impl/P5 + review passes).
- [x] `cargo test -p calimero-node --lib` — 53 passing, no regressions.
- [x] `cargo test -p calimero-node --tests` — 303 integration passing, no regressions.
- [x] All four #2197 partition scenarios pass: update-vs-rotation race, self-removal mid-flight, concurrent conflicting rotations, long-partition reconciliation.
- [ ] WASM ABI follow-up PR (**#2266**) wires `CausalDelta.{id,hlc,parents}` through `__calimero_sync_next` so the new code path actually fires in production.
- [ ] Telemetry pass: monitor `storage::p3_verifier` divergence warnings for 4 weeks before removing v2 nonce check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes signature verification for `Shared` storage actions and adds new persisted rotation-log state used to resolve writers, which can affect authorization and sync convergence if misapplied or if call sites pass incomplete context.
> 
> **Overview**
> Implements DAG-causal verification for `Shared` storage actions by introducing an explicit `ApplyContext` and switching `Interface::apply_action` to validate signatures against the writer set resolved *at the delta’s causal frontier* (via `rotation_log::writers_at`) when DAG context is provided, while preserving the v2 stored-writer/nonce behavior when context is empty.
> 
> Adds a per-entity persisted `RotationLog` (new `Key::RotationLog`) with idempotent `append` and causal/HLC/signer ordering logic, plus a write hook in `apply_action` to record signature-verified writer-set rotations (and a new `DuplicateRotationInDelta` error for conflicting duplicate delta entries).
> 
> Plumbs the new `ApplyContext` through storage sync entry points (`Root::sync`, `compare_affective`) and updates node/runtime/macro call sites and tests accordingly; also adds test-only support to bypass the nonce check to exercise out-of-order DAG-causal scenarios and introduces new P3/P5-focused test suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea57faed79a3e0f2db894ae33c8ff0719133b130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

