### PR TITLE
feat(governance): readiness FSM + cache + beacon manager + J6 join (#2237)

### DIFF
--- a/crates/context/src/governance_broadcast.rs
+++ b/crates/context/src/governance_broadcast.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use calimero_context_client::local_governance::{
     hash_scoped_namespace, AckRouter, GovernanceError, NamespaceOp, NamespaceTopicMsg, RootOp,
-    SignedAck, SignedNamespaceOp,
+    SignedAck, SignedNamespaceOp, SignedReadinessBeacon,
 };
 use calimero_node_primitives::sync::{BroadcastMessage, MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -165,6 +165,35 @@ pub fn verify_ack(
     }
     namespace_member_pubkeys(store, namespace_id)
         .map(|members| members.contains(&ack.signer_pubkey))
+        .unwrap_or(false)
+}
+
+/// Verify a [`SignedReadinessBeacon`] against the local store's view of
+/// namespace membership.
+///
+/// The Ed25519 signature is checked via
+/// [`SignedReadinessBeacon::verify_signature`], which uses the canonical
+/// `READINESS_BEACON_SIGN_DOMAIN || borsh(SignableReadinessBeacon)`
+/// payload defined alongside the wire type in
+/// `calimero_context_client::local_governance::wire`. This rejects
+/// field-substitution replays (proven by the `signed_readiness_beacon_*`
+/// tamper tests in that module).
+///
+/// The membership check uses [`namespace_member_pubkeys`], which
+/// includes the meta admin even when the admin has no member row —
+/// matching `verify_ack`'s behaviour and ensuring legitimate beacons
+/// from the namespace creator are not silently dropped.
+///
+/// Returns `false` on any failure (signature, membership, store error)
+/// so the receiver can drop the beacon without surfacing an error to
+/// the gossipsub layer.
+#[must_use]
+pub fn verify_readiness_beacon(store: &Store, beacon: &SignedReadinessBeacon) -> bool {
+    if beacon.verify_signature().is_err() {
+        return false;
+    }
+    namespace_member_pubkeys(store, beacon.namespace_id)
+        .map(|members| members.contains(&beacon.peer_pubkey))
         .unwrap_or(false)
 }
 

--- a/crates/context/src/governance_broadcast/tests.rs
+++ b/crates/context/src/governance_broadcast/tests.rs
@@ -499,3 +499,77 @@ async fn no_peers_with_min_acks_positive_returns_no_ack_received() {
         res
     );
 }
+
+// ---------------------------------------------------------------------------
+// verify_readiness_beacon
+// ---------------------------------------------------------------------------
+
+/// Build a properly-signed beacon for a given namespace, signed by `sk`.
+/// Mirrors `signed_ack` in shape — the signed body is the canonical
+/// `READINESS_BEACON_SIGN_DOMAIN || borsh(SignableReadinessBeacon)`
+/// payload from `wire.rs`.
+fn signed_beacon(
+    sk: &PrivateKey,
+    namespace_id: [u8; 32],
+    applied_through: u64,
+    strong: bool,
+) -> SignedReadinessBeacon {
+    let mut beacon = SignedReadinessBeacon {
+        namespace_id,
+        peer_pubkey: sk.public_key(),
+        dag_head: [9u8; 32],
+        applied_through,
+        ts_millis: 1_700_000_000_000,
+        strong,
+        signature: [0u8; 64],
+    };
+    beacon.signature = sk
+        .sign(&beacon.signable_bytes().expect("signable_bytes"))
+        .expect("sign")
+        .to_bytes();
+    beacon
+}
+
+#[tokio::test]
+async fn verify_readiness_beacon_accepts_signed_member_beacon() {
+    let store = empty_store();
+    let sk = PrivateKey::random(&mut rand::thread_rng());
+    let ns_id = [42u8; 32];
+    plant_namespace_member(&store, ns_id, &sk.public_key());
+
+    let beacon = signed_beacon(&sk, ns_id, 17, true);
+    assert!(
+        verify_readiness_beacon(&store, &beacon),
+        "signed beacon from a member must verify"
+    );
+}
+
+#[tokio::test]
+async fn verify_readiness_beacon_rejects_non_member_signer() {
+    // Properly-signed beacon, but the signer has no membership row in
+    // the namespace — must be dropped to prevent unverified peers from
+    // populating other nodes' ReadinessCache.
+    let store = empty_store();
+    let sk = PrivateKey::random(&mut rand::thread_rng());
+    let ns_id = [42u8; 32];
+    // No plant_namespace_member call.
+    let beacon = signed_beacon(&sk, ns_id, 17, true);
+    assert!(!verify_readiness_beacon(&store, &beacon));
+}
+
+#[tokio::test]
+async fn verify_readiness_beacon_rejects_bad_signature() {
+    // Defence-in-depth: even if a member's pubkey is in the namespace,
+    // a beacon with the wrong signature must fail. The tamper tests in
+    // wire.rs cover the per-field substitution paths; this test only
+    // verifies that `verify_readiness_beacon` short-circuits on
+    // `verify_signature` failure before consulting membership.
+    let store = empty_store();
+    let sk = PrivateKey::random(&mut rand::thread_rng());
+    let ns_id = [42u8; 32];
+    plant_namespace_member(&store, ns_id, &sk.public_key());
+
+    let mut beacon = signed_beacon(&sk, ns_id, 17, true);
+    beacon.signature = [0u8; 64]; // clobber the signature
+    assert!(!verify_readiness_beacon(&store, &beacon));
+}

--- a/crates/node/AGENTS.md
+++ b/crates/node/AGENTS.md
@@ -30,11 +30,18 @@ src/
 ├── handlers.rs               # Handler module parent
 ├── handlers/
 │   ├── network_event.rs      # Network event handler
+│   ├── network_event/
+│   │   ├── namespace.rs      # ns/<id> topic dispatch (Op/Ack/ReadinessBeacon/ReadinessProbe)
+│   │   └── readiness.rs      # ReadinessBeacon + ReadinessProbe receiver-side handlers
 │   ├── state_delta.rs        # State delta handler
 │   ├── stream_opened.rs      # Stream opened handler
 │   ├── blob_protocol.rs      # Blob protocol handler
 │   ├── get_blob_bytes.rs     # Get blob bytes handler
 │   └── specialized_node_invite.rs  # Specialized node invitation handler
+├── readiness.rs              # ReadinessTier FSM + ReadinessCache + ReadinessManager actor
+├── readiness/
+│   └── tests.rs              # FSM transition tests + cache picker / atomicity tests
+├── join_namespace.rs         # J6 namespace-join: join_namespace/await_namespace_ready/with_retry
 ├── sync/
 │   ├── mod.rs                # Sync module (exception to no mod.rs rule)
 │   ├── manager.rs            # SyncManager
@@ -108,6 +115,53 @@ pub struct SyncManager {
 }
 ```
 
+### ReadinessManager
+
+Per-namespace readiness-beacon emitter and FSM driver. Closes the
+cold-start gap between joining a namespace and being able to publish
+governance ops without losing them to gossipsub's GRAFT handshake.
+See #2237 and the `crates/node/src/readiness.rs` module doc.
+
+```rust
+// src/readiness.rs
+pub struct ReadinessManager {
+    pub cache: Arc<ReadinessCache>,           // shared with receiver
+    pub config: ReadinessConfig,
+    pub state_per_namespace: HashMap<[u8; 32], ReadinessState>,
+    pub node_client: NodeClient,              // raw publish (bypasses 10s mesh-wait)
+    pub datastore: Store,                     // namespace-identity loading
+    pub last_probe_response_at: HashMap<(PeerId, [u8; 32]), Instant>,
+}
+```
+
+- Beacons signed via `READINESS_BEACON_SIGN_DOMAIN` (canonical
+  `signable_bytes`) and verified by
+  `calimero_context::governance_broadcast::verify_readiness_beacon`
+  (signature + namespace member set).
+- Periodic emission on `beacon_interval` ticks for `*Ready` tiers.
+- Edge-trigger emission on tier transition into `*Ready` (via
+  `LocalStateChanged` / `ApplyBeaconLocal`).
+- Probe-response rate-limit at `BEACON_INTERVAL / 2` per
+  `(peer, namespace)` to close traffic + mailbox amplification.
+
+### J6 namespace-join (Phase 8)
+
+Free functions in `src/join_namespace.rs` (not on `ContextClient`
+because of a Cargo dep cycle):
+
+```rust
+pub async fn join_namespace(...) -> Result<JoinStarted, JoinError>;
+pub async fn await_namespace_ready(...) -> Result<ReadyReport, ReadyError>;
+pub async fn join_and_wait_ready(...) -> Result<ReadyReport, ReadyError>;
+pub async fn join_namespace_with_retry(...) -> Result<JoinStarted, JoinError>;
+```
+
+The fast path (`join_namespace`) provisions the namespace identity,
+seeds local trust by writing a minimal `GroupMetaValue` with the
+invitation's inviter as `admin_identity` (so beacons signed by the
+inviter pass `verify_readiness_beacon`), subscribes to `ns/<id>`,
+publishes a `ReadinessProbe`, and awaits the first fresh beacon.
+
 ## Key Files
 
 | File                            | Purpose                        |
@@ -115,7 +169,11 @@ pub struct SyncManager {
 | `src/lib.rs`                    | NodeManager actor definition   |
 | `src/run.rs`                    | `start()` function, NodeConfig |
 | `src/handlers/network_event.rs` | Network event handling         |
+| `src/handlers/network_event/namespace.rs` | `ns/<id>` topic dispatch (Op/Ack/Beacon/Probe) |
+| `src/handlers/network_event/readiness.rs` | Beacon receive + probe forwarding |
 | `src/handlers/state_delta.rs`   | State delta processing         |
+| `src/readiness.rs`              | Readiness FSM + cache + manager (#2237) |
+| `src/join_namespace.rs`         | J6 namespace-join flow         |
 | `src/sync/manager.rs`           | Sync coordination              |
 | `primitives/src/client.rs`      | NodeClient interface           |
 
@@ -153,3 +211,13 @@ cargo test -p calimero-node --test network_simulation
 - NodeManager is an actix Actor - use message passing
 - Sync operations are async - use proper await handling
 - Delta stores are per-context (ContextId key)
+- `ReadinessCache` and `ReadinessCacheNotify` use poison-recoverable
+  mutex helpers (`entries_lock` / `waiters_lock`); never call `.lock()`
+  directly on those fields
+- `ReadinessCache::insert` does NOT verify signatures or membership —
+  the receiver-side gate `verify_readiness_beacon` is the choke point;
+  callers from outside the receiver path must verify first
+- `ns/<id>` topic publishes wrap inner `NamespaceTopicMsg` in
+  `BroadcastMessage::NamespaceGovernanceDelta { namespace_id, delta_id,
+  parent_ids, payload: borsh(NamespaceTopicMsg) }` — sender-side
+  envelope skips break receive-side decoding silently

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -27,6 +27,7 @@ prometheus-client.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["io-std", "macros"] }
 tracing.workspace = true
 zeroize.workspace = true

--- a/crates/node/src/handlers/network_event.rs
+++ b/crates/node/src/handlers/network_event.rs
@@ -19,6 +19,7 @@ use crate::NodeManager;
 mod blobs;
 mod heartbeat;
 mod namespace;
+mod readiness;
 mod specialized;
 mod subscriptions;
 

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -97,6 +97,7 @@ pub(super) fn handle_namespace_governance_delta(
     let pull_budget_max_peers = this.managers.sync.sync_config.parent_pull_additional_peers;
     let pull_budget_duration = this.managers.sync.sync_config.parent_pull_budget;
     let op_for_delivery = op.clone();
+    let readiness_addr = this.readiness_addr.clone();
 
     let op_for_ack = op.clone();
     let _ignored = ctx.spawn(
@@ -108,6 +109,19 @@ pub(super) fn handle_namespace_governance_delta(
                     return;
                 }
             };
+
+            // Notify the ReadinessManager FSM that we've made local
+            // progress on this namespace. Without this signal,
+            // `state_per_namespace` stays empty forever, no beacons emit,
+            // and the readiness subsystem is inert (#2269 cursor[bot]
+            // HIGH-severity finding). `Pending` and `Duplicate` outcomes
+            // do NOT advance our applied count — Pending is waiting on
+            // parents (no real progress yet) and Duplicate is a re-deliver.
+            if matches!(outcome, NamespaceApplyOutcome::Applied) {
+                if let Some(addr) = &readiness_addr {
+                    addr.do_send(crate::readiness::NamespaceOpApplied { namespace_id });
+                }
+            }
 
             // Phase 4: emit a `SignedAck` on the same topic when we've
             // newly applied the op. `Pending` (waiting on parents) and

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -55,11 +55,26 @@ pub(super) fn handle_namespace_governance_delta(
         // submodule. Beacon receive verifies + inserts into the cache;
         // probe receive forwards to the rate-limited
         // `EmitOutOfCycleBeacon` handler on `ReadinessManager`.
+        //
+        // Cross-check `inner.namespace_id == namespace_id` (the topic's
+        // namespace) BEFORE forwarding — without this, a peer could
+        // publish a beacon claiming `beacon.namespace_id = X` on the
+        // gossipsub topic for namespace Y, polluting namespace X's
+        // cache from a Y subscription. Mirrors the existing `Op` arm
+        // check below.
         NamespaceTopicMsg::ReadinessBeacon(beacon) => {
+            if beacon.namespace_id != namespace_id {
+                warn!("ReadinessBeacon namespace_id mismatch with topic; dropping");
+                return;
+            }
             super::readiness::handle_readiness_beacon(this, ctx, source, beacon);
             return;
         }
         NamespaceTopicMsg::ReadinessProbe(probe) => {
+            if probe.namespace_id != namespace_id {
+                warn!("ReadinessProbe namespace_id mismatch with topic; dropping");
+                return;
+            }
             super::readiness::handle_readiness_probe(this, ctx, source, probe);
             return;
         }

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -51,11 +51,16 @@ pub(super) fn handle_namespace_governance_delta(
             let _ = this.clients.context.ack_router().route(ack);
             return;
         }
-        // Phases 7/8 will wire these variants. Until then, drop them
-        // forward-compatibly so the wire schema reservations don't
-        // require another cluster-wide upgrade.
-        NamespaceTopicMsg::ReadinessBeacon(_) | NamespaceTopicMsg::ReadinessProbe(_) => {
-            debug!("NamespaceTopicMsg readiness variant not yet handled; dropping");
+        // Phase 7.3: forward readiness variants to the dedicated
+        // submodule. Beacon receive verifies + inserts into the cache;
+        // probe receive forwards to the rate-limited
+        // `EmitOutOfCycleBeacon` handler on `ReadinessManager`.
+        NamespaceTopicMsg::ReadinessBeacon(beacon) => {
+            super::readiness::handle_readiness_beacon(this, ctx, source, beacon);
+            return;
+        }
+        NamespaceTopicMsg::ReadinessProbe(probe) => {
+            super::readiness::handle_readiness_probe(this, ctx, source, probe);
             return;
         }
     };

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -37,6 +37,10 @@ pub(super) fn handle_readiness_beacon(
     }
     let namespace_id = beacon.namespace_id;
     manager.readiness_cache.insert(&beacon);
+    // Wake any `await_first_fresh_beacon` waiters for this namespace
+    // (Phase 8.1). Must run AFTER `cache.insert` so a waiter that
+    // re-checks the cache on wakeup sees the new entry.
+    manager.readiness_notify.notify(namespace_id);
     if let Some(addr) = &manager.readiness_addr {
         addr.do_send(ApplyBeaconLocal { namespace_id });
     }

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -17,7 +17,7 @@
 use calimero_context::governance_broadcast::verify_readiness_beacon;
 use calimero_context_client::local_governance::{ReadinessProbe, SignedReadinessBeacon};
 use libp2p::PeerId;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::readiness::{ApplyBeaconLocal, EmitOutOfCycleBeacon};
 use crate::NodeManager;
@@ -36,11 +36,21 @@ pub(super) fn handle_readiness_beacon(
         return;
     }
     let namespace_id = beacon.namespace_id;
+    let peer_pubkey = beacon.peer_pubkey;
+    let applied_through = beacon.applied_through;
+    let strong = beacon.strong;
     manager.readiness_cache.insert(&beacon);
     // Wake any `await_first_fresh_beacon` waiters for this namespace
     // (Phase 8.1). Must run AFTER `cache.insert` so a waiter that
     // re-checks the cache on wakeup sees the new entry.
     manager.readiness_notify.notify(namespace_id);
+    info!(
+        namespace_id = %hex::encode(namespace_id),
+        peer = %peer_pubkey,
+        applied_through,
+        strong,
+        "readiness beacon received"
+    );
     if let Some(addr) = &manager.readiness_addr {
         addr.do_send(ApplyBeaconLocal { namespace_id });
     }

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -1,0 +1,62 @@
+//! Receiver-side handlers for the namespace-topic readiness variants.
+//!
+//! Phase 7.3 of the three-phase governance contract (#2237).
+//!
+//! - `handle_readiness_beacon` verifies the signature + namespace
+//!   membership via [`verify_readiness_beacon`], inserts the beacon
+//!   into the shared [`ReadinessCache`] (the cache is internally
+//!   synchronised, so we bypass the `ReadinessManager` mailbox here
+//!   to avoid a per-beacon hop), then notifies the manager via
+//!   [`ApplyBeaconLocal`] so the FSM can re-evaluate against the new
+//!   `peer_summary`.
+//! - `handle_readiness_probe` forwards the probe to the manager which
+//!   rate-limits the per-(peer, namespace) response at
+//!   `BEACON_INTERVAL / 2` — see
+//!   [`Handler<EmitOutOfCycleBeacon>`](crate::readiness::ReadinessManager).
+
+use calimero_context::governance_broadcast::verify_readiness_beacon;
+use calimero_context_client::local_governance::{ReadinessProbe, SignedReadinessBeacon};
+use libp2p::PeerId;
+use tracing::debug;
+
+use crate::readiness::{ApplyBeaconLocal, EmitOutOfCycleBeacon};
+use crate::NodeManager;
+
+pub(super) fn handle_readiness_beacon(
+    manager: &mut NodeManager,
+    _ctx: &mut actix::Context<NodeManager>,
+    _peer_id: PeerId,
+    beacon: SignedReadinessBeacon,
+) {
+    if !verify_readiness_beacon(&manager.datastore, &beacon) {
+        debug!(
+            namespace_id = %hex::encode(beacon.namespace_id),
+            "ReadinessBeacon failed verification; dropping"
+        );
+        return;
+    }
+    let namespace_id = beacon.namespace_id;
+    manager.readiness_cache.insert(&beacon);
+    if let Some(addr) = &manager.readiness_addr {
+        addr.do_send(ApplyBeaconLocal { namespace_id });
+    }
+}
+
+pub(super) fn handle_readiness_probe(
+    manager: &mut NodeManager,
+    _ctx: &mut actix::Context<NodeManager>,
+    peer_id: PeerId,
+    probe: ReadinessProbe,
+) {
+    // Forward to the manager so it can rate-limit per-(peer, namespace).
+    // No verification needed at this layer — `ReadinessProbe` is
+    // unsigned (it carries a 16-byte nonce only), and the
+    // `EmitOutOfCycleBeacon` handler is the choke point that prevents
+    // probe-driven amplification regardless of probe content.
+    if let Some(addr) = &manager.readiness_addr {
+        addr.do_send(EmitOutOfCycleBeacon {
+            namespace_id: probe.namespace_id,
+            requesting_peer: peer_id,
+        });
+    }
+}

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -333,14 +333,17 @@ pub async fn await_namespace_ready(
 
     // step 2: load the namespace identity for signing MemberJoined.
     let group_id = ContextGroupId::from(namespace_id);
-    let (_, my_pk, my_sk_bytes, mut sender_key) =
+    let (_, my_pk, mut my_sk_bytes, mut sender_key) =
         group_store::get_or_create_namespace_identity(store, &group_id)
             .map_err(|e| ReadyError::Local(e.to_string()))?;
-    // `PrivateKey::from(my_sk_bytes)` consumes and zeroizes my_sk_bytes
-    // on its own drop. `sender_key` is discarded here — zeroize the
-    // raw `[u8; 32]` before drop.
+    // `sender_key` is unused — zeroize immediately. `my_sk_bytes` is
+    // consumed by `PrivateKey::from(...)` below; because `[u8; 32]:
+    // Copy` the "move" copies the bytes, so the stack copy survives
+    // until we explicitly zeroize it after the call. `PrivateKey`'s
+    // `Drop` impl zeroizes its own internal copy.
     sender_key.zeroize();
     let signing_key = PrivateKey::from(my_sk_bytes);
+    my_sk_bytes.zeroize();
 
     // step 3: publish MemberJoined via three-phase contract.
     let op = NamespaceOp::Root(RootOp::MemberJoined {

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -470,20 +470,26 @@ pub async fn join_namespace_with_retry(
         {
             Ok(started) => return Ok(started),
             Err(JoinError::NoReadyPeers { .. }) => {
-                if start.elapsed() + delay > max_total {
+                // Sample jitter FIRST so the budget check accounts for the
+                // actual sleep duration (`delay + jitter`), not just `delay`.
+                // With `MAX_BACKOFF = 30s`, max jitter ≈ 7.5s — without
+                // including it the function could overshoot `max_total` by
+                // up to that much per iteration, violating the documented
+                // "clamped by remaining total budget" contract.
+                let jitter = {
+                    let bound = delay.as_millis() as u64 / 4;
+                    if bound == 0 {
+                        Duration::ZERO
+                    } else {
+                        Duration::from_millis(rand::thread_rng().gen_range(0..bound))
+                    }
+                };
+                if start.elapsed() + delay + jitter > max_total {
                     return Err(JoinError::NoReadyPeers {
                         waited_ms: start.elapsed().as_millis() as u64,
                     });
                 }
-                let jitter_ms = {
-                    let bound = delay.as_millis() as u64 / 4;
-                    if bound == 0 {
-                        0
-                    } else {
-                        rand::thread_rng().gen_range(0..bound)
-                    }
-                };
-                tokio::time::sleep(delay + Duration::from_millis(jitter_ms)).await;
+                tokio::time::sleep(delay + jitter).await;
                 delay = std::cmp::min(delay * 2, MAX_BACKOFF);
             }
             Err(other) => return Err(other),

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -24,11 +24,15 @@ use calimero_context_client::local_governance::{
 use calimero_context_config::types::{ContextGroupId, SignedGroupOpenInvitation};
 use calimero_node_primitives::client::NodeClient;
 use calimero_node_primitives::sync::BroadcastMessage;
+use calimero_primitives::application::ApplicationId;
+use calimero_primitives::context::UpgradePolicy;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
+use calimero_store::key::GroupMetaValue;
 use calimero_store::Store;
 use rand::Rng;
 use thiserror::Error;
 use tracing::debug;
+use zeroize::Zeroize;
 
 use crate::readiness::{ReadinessCache, ReadinessCacheNotify, ReadinessConfig};
 
@@ -134,10 +138,56 @@ pub async fn join_namespace(
     // step 2: provision identity (mark_membership_pending equivalent —
     // the namespace identity row IS the local pending marker until
     // MemberJoined ack arrives).
-    let (ns_id, _pk, _sk_bytes, _sender_key) =
+    let (ns_id, _pk, mut sk_bytes, mut sender_key) =
         group_store::get_or_create_namespace_identity(store, &group_id)
             .map_err(|e| JoinError::Local(e.to_string()))?;
     let namespace_id = ns_id.to_bytes();
+    // Zeroize raw secret-key bytes before drop — `PrivateKey::from(...)`
+    // owns its own zeroizing wrapper, but the bare `[u8; 32]` arrays
+    // returned by `get_or_create_namespace_identity` do not. Mirrors
+    // PR #2264's `emit_namespace_ack` zeroize discipline. We don't need
+    // the bytes in the J6 fast path (signing happens in
+    // `await_namespace_ready`), so wipe them immediately.
+    sk_bytes.zeroize();
+    sender_key.zeroize();
+
+    // step 2b: trust seed for `verify_readiness_beacon`.
+    //
+    // `verify_readiness_beacon` checks `peer_pubkey ∈
+    // namespace_member_pubkeys(store, ns_id)`. A fresh joiner has
+    // applied no DAG ops yet, so without this seed `namespace_member_pubkeys`
+    // returns an empty set and EVERY incoming beacon fails verification
+    // — `await_first_fresh_beacon` then always times out, defeating the
+    // J6 fast path (#2269 review issue #1).
+    //
+    // The invitation is admin-signed, so `inviter_identity` is by
+    // definition an authorized namespace member. Writing a minimal
+    // `GroupMeta { admin_identity: inviter, ... }` makes
+    // `namespace_member_pubkeys` include the inviter (the meta-admin
+    // is added by `namespace_member_pubkeys` even without a member row),
+    // so beacons signed by the inviter verify. Other members' beacons
+    // remain unverifiable until backfill applies the real DAG state —
+    // for J6 cold-start the inviter alone is sufficient.
+    //
+    // The block mirrors the local-init prelude of
+    // `Handler<JoinGroupRequest>` in `crates/context/src/handlers/join_group.rs`.
+    if group_store::load_group_meta(store, &group_id)
+        .map_err(|e| JoinError::Local(e.to_string()))?
+        .is_none()
+    {
+        let admin_identity = PublicKey::from(invitation.invitation.inviter_identity.to_bytes());
+        let meta = GroupMetaValue {
+            admin_identity,
+            target_application_id: ApplicationId::from([0u8; 32]),
+            app_key: [0u8; 32],
+            upgrade_policy: UpgradePolicy::default(),
+            migration: None,
+            created_at: 0,
+            auto_join: true,
+        };
+        group_store::save_group_meta(store, &group_id, &meta)
+            .map_err(|e| JoinError::Local(e.to_string()))?;
+    }
 
     // step 3: subscribe to namespace topic. Idempotent.
     node_client
@@ -210,11 +260,14 @@ pub async fn join_namespace(
 /// timed out without acks — the caller decides whether that's
 /// acceptable for their flow.
 ///
-/// `deadline` is the FULL function budget. Sub-steps are not
-/// individually deadline-clamped because the backfill duration is
-/// unbounded by the caller's perspective; the
-/// `sign_and_publish_namespace_op` call carries its own per-op timeout
-/// derived from `op_kind_label`.
+/// `deadline` clamps the *backfill wait* and the *cold-start mesh wait*
+/// inside this function. The downstream `sign_and_publish_without_apply`
+/// call carries its own per-op-kind timeout (`OP_ACK_MEMBER_CHANGE_TIMEOUT
+/// = 5s` for `MemberJoined`) and is NOT clamped by `deadline`, so the
+/// total wall-clock can exceed `deadline` by up to that publish timeout.
+/// Document this asymmetry rather than wrap the publish in another
+/// timeout layer (which would race with the publish's own ack-collection
+/// logic).
 pub async fn await_namespace_ready(
     store: &Store,
     node_client: &NodeClient,
@@ -246,11 +299,47 @@ pub async fn await_namespace_ready(
     let backfill_wait = std::cmp::min(deadline / 4, Duration::from_secs(2));
     tokio::time::sleep(backfill_wait).await;
 
+    // step 1b: mesh-wait. `sign_and_publish_without_apply` runs
+    // `assert_transport_ready` which fails if mesh < min(known, mesh_n_low).
+    // A J6 cold-start joiner's mesh on the namespace topic typically
+    // forms within 1-2 gossipsub heartbeats (~1-2s) AFTER subscription
+    // — but `await_namespace_ready` is called immediately after
+    // `join_namespace` returns, so the mesh may still be empty.
+    // Poll briefly so the publish gate has a chance to pass before we
+    // surface a `NamespaceNotReady` error (#2269 review issue #6).
+    let mesh_deadline = start
+        + std::cmp::min(
+            deadline.saturating_sub(start.elapsed()),
+            Duration::from_secs(3),
+        );
+    let mesh_n_low = node_client.gossipsub_mesh_n_low();
+    loop {
+        let mesh = node_client
+            .mesh_peer_count_for_namespace(namespace_id)
+            .await;
+        let topic = ns_topic(namespace_id);
+        let known = node_client.known_subscribers(&topic);
+        let required = std::cmp::min(mesh_n_low, known);
+        if mesh >= required {
+            break;
+        }
+        if Instant::now() >= mesh_deadline {
+            // Fall through — let `sign_and_publish_without_apply`
+            // surface the typed `NamespaceNotReady` error.
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
     // step 2: load the namespace identity for signing MemberJoined.
     let group_id = ContextGroupId::from(namespace_id);
-    let (_, my_pk, my_sk_bytes, _) =
+    let (_, my_pk, my_sk_bytes, mut sender_key) =
         group_store::get_or_create_namespace_identity(store, &group_id)
             .map_err(|e| ReadyError::Local(e.to_string()))?;
+    // `PrivateKey::from(my_sk_bytes)` consumes and zeroizes my_sk_bytes
+    // on its own drop. `sender_key` is discarded here — zeroize the
+    // raw `[u8; 32]` before drop.
+    sender_key.zeroize();
     let signing_key = PrivateKey::from(my_sk_bytes);
 
     // step 3: publish MemberJoined via three-phase contract.
@@ -283,12 +372,19 @@ pub async fn await_namespace_ready(
 
 /// Convenience aggregator: run the J6 fast path then the slow path.
 ///
-/// `deadline` is split into a join slice and a ready slice with
-/// `join = clamp(deadline / 3, 1s, deadline)`. The 1s floor prevents
-/// `deadline / 3` from rounding to a near-zero value on small
-/// deadlines; the cap stops the floor from EXCEEDING the caller's
-/// total budget. Callers who want fine-grained control should call
-/// `join_namespace` and `await_namespace_ready` directly.
+/// Deadline split: `join_deadline = min(2s, deadline / 2)`, so the
+/// ready half always gets at least half the caller's budget — even on
+/// small deadlines (e.g. `deadline = 500ms` → `join = 250ms`,
+/// `ready = ~250ms`). Earlier `clamp(deadline/3, 1s, deadline)` fully
+/// consumed budgets ≤ 1s on the join half (#2269 review issue #8).
+///
+/// `ready_deadline` is computed from `start.elapsed()` (not the
+/// allocated `join_deadline`), so any unused join budget rolls over to
+/// the ready half (#2269 review issue #5). Net effect: callers
+/// authorise a single total budget and we use it efficiently.
+///
+/// Callers who want fine-grained control should call `join_namespace`
+/// and `await_namespace_ready` directly.
 pub async fn join_and_wait_ready(
     store: &Store,
     node_client: &NodeClient,
@@ -299,10 +395,8 @@ pub async fn join_and_wait_ready(
     invitation: SignedGroupOpenInvitation,
     deadline: Duration,
 ) -> Result<ReadyReport, ReadyError> {
-    let join_deadline = std::cmp::min(
-        std::cmp::max(deadline / 3, Duration::from_secs(1)),
-        deadline,
-    );
+    let start = Instant::now();
+    let join_deadline = std::cmp::min(Duration::from_secs(2), deadline / 2);
     let started = join_namespace(
         store,
         node_client,
@@ -317,7 +411,7 @@ pub async fn join_and_wait_ready(
         JoinError::InvalidInvitation(msg) => ReadyError::InvalidInvitation(msg),
         other => ReadyError::JoinFailed(other.to_string()),
     })?;
-    let ready_deadline = deadline.saturating_sub(join_deadline);
+    let ready_deadline = deadline.saturating_sub(start.elapsed());
     await_namespace_ready(
         store,
         node_client,

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -307,11 +307,20 @@ pub async fn await_namespace_ready(
     // `join_namespace` returns, so the mesh may still be empty.
     // Poll briefly so the publish gate has a chance to pass before we
     // surface a `NamespaceNotReady` error (#2269 review issue #6).
-    let mesh_deadline = start
-        + std::cmp::min(
-            deadline.saturating_sub(start.elapsed()),
-            Duration::from_secs(3),
-        );
+    //
+    // Anchor at `Instant::now()` (not `start`) so the mesh-poll budget
+    // is "up to 3s from HERE", not "up to 3s from function entry".
+    // `start.elapsed()` already includes the prior backfill_wait sleep
+    // (up to 2s), so anchoring at `start + min(remaining, 3s)` would
+    // collapse the mesh window to as little as 1s on a 10s deadline
+    // — even though the caller's overall budget still has plenty of
+    // room. Saturating against `remaining` keeps total wall-clock
+    // within the caller's `deadline`.
+    let mesh_poll_window = std::cmp::min(
+        deadline.saturating_sub(start.elapsed()),
+        Duration::from_secs(3),
+    );
+    let mesh_deadline = Instant::now() + mesh_poll_window;
     let mesh_n_low = node_client.gossipsub_mesh_n_low();
     loop {
         let mesh = node_client

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -1,0 +1,395 @@
+//! J6 namespace-join flow: split `join_namespace` into a fast probe-then-
+//! beacon path and a separate `await_namespace_ready` that runs backfill
+//! and publishes `RootOp::MemberJoined` through the three-phase contract.
+//!
+//! Phase 8 of the three-phase governance contract (#2237).
+//!
+//! These functions live as free functions in `calimero-node` (rather
+//! than as methods on `ContextClient` per the plan's `&self` shape)
+//! because `ContextClient` lives in `calimero-context-primitives`,
+//! which cannot depend on `calimero-node` (where `ReadinessCache` and
+//! `ReadinessCacheNotify` live) without a Cargo cycle. The
+//! free-function form takes the cache/notify as explicit args and is
+//! callable from any holder of those Arcs (server handlers, tests,
+//! [`NodeManager`] internals).
+
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use calimero_context::governance_broadcast::ns_topic;
+use calimero_context::group_store::{self, namespace_member_pubkeys, NamespaceGovernance};
+use calimero_context_client::local_governance::{
+    AckRouter, NamespaceOp, NamespaceTopicMsg, ReadinessProbe, RootOp,
+};
+use calimero_context_config::types::{ContextGroupId, SignedGroupOpenInvitation};
+use calimero_node_primitives::client::NodeClient;
+use calimero_node_primitives::sync::BroadcastMessage;
+use calimero_primitives::identity::{PrivateKey, PublicKey};
+use calimero_store::Store;
+use rand::Rng;
+use thiserror::Error;
+use tracing::debug;
+
+use crate::readiness::{ReadinessCache, ReadinessCacheNotify, ReadinessConfig};
+
+/// Outcome of `join_namespace` (J6 fast path).
+#[derive(Debug, Clone)]
+pub struct JoinStarted {
+    pub namespace_id: [u8; 32],
+    pub sync_partner: PublicKey,
+    pub partner_head: [u8; 32],
+    pub partner_applied: u64,
+    pub elapsed_ms: u64,
+}
+
+/// Outcome of `await_namespace_ready` (J6 slow path).
+#[derive(Debug, Clone)]
+pub struct ReadyReport {
+    pub namespace_id: [u8; 32],
+    pub final_head: [u8; 32],
+    pub applied_through: u64,
+    pub members_learned: usize,
+    pub acked_by: Vec<PublicKey>,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum JoinError {
+    /// No fresh beacon arrived before the deadline. The most common
+    /// trigger is a cold-start joiner whose namespace mesh hasn't seen
+    /// any *Ready peers yet — try again with `join_namespace_with_retry`.
+    #[error("no ready peers responded within {waited_ms}ms")]
+    NoReadyPeers { waited_ms: u64 },
+    #[error("invitation invalid: {0}")]
+    InvalidInvitation(String),
+    #[error("transport: {0}")]
+    Transport(String),
+    #[error("local: {0}")]
+    Local(String),
+}
+
+#[derive(Debug, Error)]
+pub enum ReadyError {
+    #[error("no ready peers in cache")]
+    NoReadyPeers,
+    #[error("backfill: {0}")]
+    Backfill(String),
+    #[error("publish MemberJoined: {0}")]
+    PublishMemberJoined(String),
+    #[error("local: {0}")]
+    Local(String),
+    #[error("join failed: {0}")]
+    JoinFailed(String),
+    #[error("invitation invalid: {0}")]
+    InvalidInvitation(String),
+}
+
+/// J6 fast path: provision identity, subscribe to the namespace topic,
+/// publish a [`ReadinessProbe`], and resolve on the first fresh beacon.
+///
+/// Returns [`JoinStarted`] carrying the partner the caller should sync
+/// against in [`await_namespace_ready`].
+///
+/// Implementation steps mirror spec §8.1:
+/// 1. Validate the invitation expiration locally — no transport hop
+///    needed for an obviously-stale invitation.
+/// 2. `get_or_create_namespace_identity` — provisions the joiner's
+///    namespace identity if absent. Idempotent: repeat-calls with the
+///    same `group_id` reuse the stored identity.
+/// 3. `subscribe_namespace` — gossipsub subscription is the precondition
+///    for any peer beacon to reach our cache.
+/// 4. Publish a `ReadinessProbe` so a *Ready peer can short-circuit the
+///    periodic emission interval — closes the cold-start window.
+/// 5. `await_first_fresh_beacon` — registers a `Notified` future
+///    BEFORE checking the cache (Phase 8.1's race-fix), then resolves
+///    on the first beacon-or-already-cached entry, or times out.
+///
+/// `deadline` is the FULL function budget (steps 1–5). The probe wait
+/// budget is `deadline.saturating_sub(start.elapsed())`, so a slow
+/// step 1–4 doesn't overshoot the caller's stated total.
+pub async fn join_namespace(
+    store: &Store,
+    node_client: &NodeClient,
+    readiness_cache: &Arc<ReadinessCache>,
+    readiness_notify: &Arc<ReadinessCacheNotify>,
+    config: &ReadinessConfig,
+    invitation: SignedGroupOpenInvitation,
+    deadline: Duration,
+) -> Result<JoinStarted, JoinError> {
+    let start = Instant::now();
+
+    // step 1: validate invitation expiration locally.
+    let group_id = invitation.invitation.group_id;
+    let expiration = invitation.invitation.expiration_timestamp;
+    if expiration != 0 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now > expiration {
+            return Err(JoinError::InvalidInvitation("invitation expired".into()));
+        }
+    }
+
+    // step 2: provision identity (mark_membership_pending equivalent —
+    // the namespace identity row IS the local pending marker until
+    // MemberJoined ack arrives).
+    let (ns_id, _pk, _sk_bytes, _sender_key) =
+        group_store::get_or_create_namespace_identity(store, &group_id)
+            .map_err(|e| JoinError::Local(e.to_string()))?;
+    let namespace_id = ns_id.to_bytes();
+
+    // step 3: subscribe to namespace topic. Idempotent.
+    node_client
+        .subscribe_namespace(namespace_id)
+        .await
+        .map_err(|e| JoinError::Transport(e.to_string()))?;
+
+    // step 4: publish a ReadinessProbe. Best-effort — a publish error
+    // here (e.g. NoPeersSubscribedToTopic on a solo node) is not fatal:
+    // the probe simply doesn't reach anyone, and `await_first_fresh_beacon`
+    // below will time out with `NoReadyPeers`.
+    let probe = ReadinessProbe {
+        namespace_id,
+        nonce: rand::random(),
+    };
+    let inner = borsh::to_vec(&NamespaceTopicMsg::ReadinessProbe(probe))
+        .map_err(|e| JoinError::Transport(e.to_string()))?;
+    // Wrap in the BroadcastMessage envelope used on `ns/<id>` topics —
+    // the receiver-side dispatch in `network_event::handle_namespace_governance_delta`
+    // unwraps NamespaceGovernanceDelta and decodes the inner
+    // NamespaceTopicMsg. delta_id/parent_ids are zero/empty since
+    // probes are not DAG content.
+    let envelope = BroadcastMessage::NamespaceGovernanceDelta {
+        namespace_id,
+        delta_id: [0u8; 32],
+        parent_ids: Vec::new(),
+        payload: inner,
+    };
+    let bytes = borsh::to_vec(&envelope).map_err(|e| JoinError::Transport(e.to_string()))?;
+    let topic = ns_topic(namespace_id);
+    if let Err(err) = node_client.network_client().publish(topic, bytes).await {
+        debug!(
+            ?err,
+            "ReadinessProbe publish failed (non-fatal — solo or no-peers)"
+        );
+    }
+
+    // step 5: collect the first fresh beacon. Clamp the wait to the
+    // remaining budget so total wall-clock stays within the caller's
+    // `deadline`.
+    let remaining = deadline.saturating_sub(start.elapsed());
+    let (sync_partner, entry) = readiness_cache
+        .await_first_fresh_beacon(
+            readiness_notify,
+            namespace_id,
+            config.ttl_heartbeat,
+            remaining,
+        )
+        .await
+        .ok_or_else(|| JoinError::NoReadyPeers {
+            waited_ms: start.elapsed().as_millis() as u64,
+        })?;
+
+    Ok(JoinStarted {
+        namespace_id,
+        sync_partner,
+        partner_head: entry.head,
+        partner_applied: entry.applied_through,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+    })
+}
+
+/// J6 slow path: backfill the namespace DAG against the partner picked
+/// in [`join_namespace`], then publish `RootOp::MemberJoined` through
+/// the three-phase contract and wait for at least one ack.
+///
+/// Returns [`ReadyReport`] with the post-publish observable state
+/// (final head, applied_through, member count). An empty `acked_by` is
+/// surfaced via the underlying `DeliveryReport` when the publish
+/// timed out without acks — the caller decides whether that's
+/// acceptable for their flow.
+///
+/// `deadline` is the FULL function budget. Sub-steps are not
+/// individually deadline-clamped because the backfill duration is
+/// unbounded by the caller's perspective; the
+/// `sign_and_publish_namespace_op` call carries its own per-op timeout
+/// derived from `op_kind_label`.
+pub async fn await_namespace_ready(
+    store: &Store,
+    node_client: &NodeClient,
+    ack_router: &AckRouter,
+    invitation: SignedGroupOpenInvitation,
+    namespace_id: [u8; 32],
+    deadline: Duration,
+) -> Result<ReadyReport, ReadyError> {
+    let start = Instant::now();
+
+    // step 1: backfill — request a namespace governance pull. This
+    // schedules `SyncManager::sync_namespace` which opens a stream to
+    // a mesh peer and applies received ops. We do not block on
+    // completion of that stream here — the assumption is that by the
+    // time we publish MemberJoined below, our local applied_through
+    // has caught up enough to validate the op. A targeted pull from
+    // the J6 sync_partner is the future refinement.
+    if let Err(err) = node_client.sync_namespace(namespace_id).await {
+        debug!(
+            ?err,
+            "namespace sync request failed (non-fatal — try publish anyway)"
+        );
+    }
+
+    // Best-effort wait for backfill progress. We sleep up to
+    // `min(deadline / 4, 2s)` to give the sync stream time to apply
+    // ops before we publish MemberJoined. Without this, the publish
+    // can succeed but our local DAG remains behind.
+    let backfill_wait = std::cmp::min(deadline / 4, Duration::from_secs(2));
+    tokio::time::sleep(backfill_wait).await;
+
+    // step 2: load the namespace identity for signing MemberJoined.
+    let group_id = ContextGroupId::from(namespace_id);
+    let (_, my_pk, my_sk_bytes, _) =
+        group_store::get_or_create_namespace_identity(store, &group_id)
+            .map_err(|e| ReadyError::Local(e.to_string()))?;
+    let signing_key = PrivateKey::from(my_sk_bytes);
+
+    // step 3: publish MemberJoined via three-phase contract.
+    let op = NamespaceOp::Root(RootOp::MemberJoined {
+        member: my_pk,
+        signed_invitation: invitation,
+    });
+    let report = NamespaceGovernance::new(store, namespace_id)
+        .sign_and_publish_without_apply(node_client, ack_router, &signing_key, op)
+        .await
+        .map_err(|e| ReadyError::PublishMemberJoined(e.to_string()))?;
+
+    // step 4: assemble ReadyReport with post-publish observable state.
+    // Note the read accessors are best-effort — if the underlying
+    // store read fails we substitute defaults rather than fail the
+    // whole join, since the caller's primary signal is `acked_by`.
+    let members_learned = namespace_member_pubkeys(store, namespace_id)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    Ok(ReadyReport {
+        namespace_id,
+        final_head: [0u8; 32], // TODO(read accessor) — pull from DAG once ns-DAG read API is exposed
+        applied_through: 0,    // TODO(read accessor) — same
+        members_learned,
+        acked_by: report.acked_by,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+    })
+}
+
+/// Convenience aggregator: run the J6 fast path then the slow path.
+///
+/// `deadline` is split into a join slice and a ready slice with
+/// `join = clamp(deadline / 3, 1s, deadline)`. The 1s floor prevents
+/// `deadline / 3` from rounding to a near-zero value on small
+/// deadlines; the cap stops the floor from EXCEEDING the caller's
+/// total budget. Callers who want fine-grained control should call
+/// `join_namespace` and `await_namespace_ready` directly.
+pub async fn join_and_wait_ready(
+    store: &Store,
+    node_client: &NodeClient,
+    ack_router: &AckRouter,
+    readiness_cache: &Arc<ReadinessCache>,
+    readiness_notify: &Arc<ReadinessCacheNotify>,
+    config: &ReadinessConfig,
+    invitation: SignedGroupOpenInvitation,
+    deadline: Duration,
+) -> Result<ReadyReport, ReadyError> {
+    let join_deadline = std::cmp::min(
+        std::cmp::max(deadline / 3, Duration::from_secs(1)),
+        deadline,
+    );
+    let started = join_namespace(
+        store,
+        node_client,
+        readiness_cache,
+        readiness_notify,
+        config,
+        invitation.clone(),
+        join_deadline,
+    )
+    .await
+    .map_err(|e| match e {
+        JoinError::InvalidInvitation(msg) => ReadyError::InvalidInvitation(msg),
+        other => ReadyError::JoinFailed(other.to_string()),
+    })?;
+    let ready_deadline = deadline.saturating_sub(join_deadline);
+    await_namespace_ready(
+        store,
+        node_client,
+        ack_router,
+        invitation,
+        started.namespace_id,
+        ready_deadline,
+    )
+    .await
+}
+
+const ATTEMPT_DEADLINE: Duration = Duration::from_secs(10);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+const INITIAL_BACKOFF: Duration = Duration::from_secs(3);
+
+/// Retry [`join_namespace`] with exponential backoff + jitter.
+///
+/// Each attempt's deadline is clamped by the remaining total budget,
+/// so a caller passing `max_total < ATTEMPT_DEADLINE` (e.g. 2s) does
+/// NOT block on a single 10s attempt. The retry loop only re-enters
+/// on `JoinError::NoReadyPeers` — invalid invitations and transport
+/// errors are returned to the caller immediately because retrying
+/// them is wasted work.
+pub async fn join_namespace_with_retry(
+    store: &Store,
+    node_client: &NodeClient,
+    readiness_cache: &Arc<ReadinessCache>,
+    readiness_notify: &Arc<ReadinessCacheNotify>,
+    config: &ReadinessConfig,
+    invitation: SignedGroupOpenInvitation,
+    max_total: Duration,
+) -> Result<JoinStarted, JoinError> {
+    let mut delay = INITIAL_BACKOFF;
+    let start = Instant::now();
+    loop {
+        let remaining = max_total.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            return Err(JoinError::NoReadyPeers {
+                waited_ms: start.elapsed().as_millis() as u64,
+            });
+        }
+        let attempt_deadline = std::cmp::min(ATTEMPT_DEADLINE, remaining);
+        match join_namespace(
+            store,
+            node_client,
+            readiness_cache,
+            readiness_notify,
+            config,
+            invitation.clone(),
+            attempt_deadline,
+        )
+        .await
+        {
+            Ok(started) => return Ok(started),
+            Err(JoinError::NoReadyPeers { .. }) => {
+                if start.elapsed() + delay > max_total {
+                    return Err(JoinError::NoReadyPeers {
+                        waited_ms: start.elapsed().as_millis() as u64,
+                    });
+                }
+                let jitter_ms = {
+                    let bound = delay.as_millis() as u64 / 4;
+                    if bound == 0 {
+                        0
+                    } else {
+                        rand::thread_rng().gen_range(0..bound)
+                    }
+                };
+                tokio::time::sleep(delay + Duration::from_millis(jitter_ms)).await;
+                delay = std::cmp::min(delay * 2, MAX_BACKOFF);
+            }
+            Err(other) => return Err(other),
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -18,6 +18,7 @@ mod constants;
 mod delta_store;
 pub mod gc;
 pub mod handlers;
+pub mod join_namespace;
 pub mod key_delivery;
 mod manager;
 pub mod network_event_channel;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -22,6 +22,7 @@ pub mod key_delivery;
 mod manager;
 pub mod network_event_channel;
 pub mod network_event_processor;
+pub mod readiness;
 mod run;
 mod specialized_node_invite_state;
 mod state;

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -116,6 +116,7 @@ async fn apply_signed_group_op_via_context_client() {
         sync_manager,
         context_client.clone(),
         node_client,
+        store.clone(),
         node_state,
     );
 

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+
+use crate::readiness::{ReadinessCache, ReadinessConfig, ReadinessManager};
 use crate::sync::SyncManager;
 use crate::{NodeClients, NodeManagers, NodeState};
-use actix::Actor;
+use actix::{Actor, Addr};
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
+use calimero_store::Store;
 mod startup;
 
 /// Main node orchestrator.
@@ -17,6 +21,29 @@ pub struct NodeManager {
     pub(crate) clients: NodeClients,
     pub(crate) managers: NodeManagers,
     pub(crate) state: NodeState,
+    /// Datastore handle. Held on the manager so `setup_readiness_manager`
+    /// can hand a clone to [`ReadinessManager`] for namespace-identity
+    /// loading during beacon signing (Phase 7.2), and so the receiver-side
+    /// `verify_readiness_beacon` (Phase 7.3) can read the namespace
+    /// member set when `handle_readiness_beacon` runs on the manager
+    /// actor.
+    pub(crate) datastore: Store,
+    /// Shared per-namespace readiness-beacon cache. The receiver-side
+    /// `network_event::readiness::handle_readiness_beacon` (Phase 7.3)
+    /// calls `cache.insert(&beacon)` directly without an actor-mailbox
+    /// hop — the cache is internally synchronised, so routing through
+    /// the `ReadinessManager` would only add latency.
+    ///
+    /// Held on the manager (not on `NodeClients`) so the cascaded-event
+    /// helpers in `handlers/state_delta` can keep their lightweight
+    /// `NodeClients` re-construction without having to plumb the cache
+    /// through. Those helpers don't read beacons.
+    pub(crate) readiness_cache: Arc<ReadinessCache>,
+    /// Address of the [`ReadinessManager`] actor. Wired by
+    /// `setup_readiness_manager` in [`Actor::started`]; `None` until
+    /// then (and during early-startup races where receivers may fire
+    /// before the manager is mounted — drop the message in that case).
+    pub(crate) readiness_addr: Option<Addr<ReadinessManager>>,
 }
 
 impl NodeManager {
@@ -25,6 +52,7 @@ impl NodeManager {
         sync_manager: SyncManager,
         context_client: ContextClient,
         node_client: NodeClient,
+        datastore: Store,
         state: NodeState,
     ) -> Self {
         Self {
@@ -37,6 +65,9 @@ impl NodeManager {
                 sync: sync_manager,
             },
             state,
+            datastore,
+            readiness_cache: Arc::new(ReadinessCache::default()),
+            readiness_addr: None,
         }
     }
 }
@@ -48,5 +79,27 @@ impl Actor for NodeManager {
         self.setup_startup_subscriptions(ctx);
         self.setup_maintenance_intervals(ctx);
         self.setup_hash_heartbeat_interval(ctx);
+        self.setup_readiness_manager(ctx);
+    }
+}
+
+impl NodeManager {
+    /// Mount the [`ReadinessManager`] actor and store its address so
+    /// receiver-side handlers can post `ApplyBeaconLocal` /
+    /// `EmitOutOfCycleBeacon`. Idempotent — only mounts once per
+    /// manager instance.
+    pub(crate) fn setup_readiness_manager(&mut self, _ctx: &mut actix::Context<Self>) {
+        if self.readiness_addr.is_some() {
+            return;
+        }
+        let manager = ReadinessManager {
+            cache: self.readiness_cache.clone(),
+            config: ReadinessConfig::default(),
+            state_per_namespace: std::collections::HashMap::new(),
+            node_client: self.clients.node.clone(),
+            datastore: self.datastore.clone(),
+            last_probe_response_at: std::collections::HashMap::new(),
+        };
+        self.readiness_addr = Some(manager.start());
     }
 }

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
-use crate::readiness::{ReadinessCache, ReadinessCacheNotify, ReadinessConfig, ReadinessManager};
-use crate::sync::SyncManager;
-use crate::{NodeClients, NodeManagers, NodeState};
 use actix::{Actor, Addr};
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
 use calimero_store::Store;
+
+use crate::readiness::{ReadinessCache, ReadinessCacheNotify, ReadinessConfig, ReadinessManager};
+use crate::sync::SyncManager;
+use crate::{NodeClients, NodeManagers, NodeState};
+
 mod startup;
 
 /// Main node orchestrator.

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::readiness::{ReadinessCache, ReadinessConfig, ReadinessManager};
+use crate::readiness::{ReadinessCache, ReadinessCacheNotify, ReadinessConfig, ReadinessManager};
 use crate::sync::SyncManager;
 use crate::{NodeClients, NodeManagers, NodeState};
 use actix::{Actor, Addr};
@@ -39,6 +39,11 @@ pub struct NodeManager {
     /// `NodeClients` re-construction without having to plumb the cache
     /// through. Those helpers don't read beacons.
     pub(crate) readiness_cache: Arc<ReadinessCache>,
+    /// Per-namespace `Notify` registry paired with `readiness_cache`.
+    /// The receiver-side beacon handler calls `notify(ns)` after
+    /// `cache.insert(&beacon)` so any in-flight
+    /// `await_first_fresh_beacon` future wakes immediately.
+    pub(crate) readiness_notify: Arc<ReadinessCacheNotify>,
     /// Address of the [`ReadinessManager`] actor. Wired by
     /// `setup_readiness_manager` in [`Actor::started`]; `None` until
     /// then (and during early-startup races where receivers may fire
@@ -67,6 +72,7 @@ impl NodeManager {
             state,
             datastore,
             readiness_cache: Arc::new(ReadinessCache::default()),
+            readiness_notify: Arc::new(ReadinessCacheNotify::default()),
             readiness_addr: None,
         }
     }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -395,13 +395,95 @@ impl ReadinessManager {
         }
     }
 
-    /// Sign and publish a [`SignedReadinessBeacon`] on the namespace topic.
+    /// Sign and publish a [`SignedReadinessBeacon`] on the namespace
+    /// topic.
     ///
-    /// Body filled in Task 7.2; in Task 7.1 this is intentionally a stub
-    /// so the actor compiles standalone — no beacons are emitted until
-    /// 7.2 lands the signing + publish path.
-    fn publish_beacon(&self, _ns_id: [u8; 32], _state: &ReadinessState) {
-        // Intentional stub — see doc comment.
+    /// Best-effort: any error is logged at `debug` (no peers subscribed
+    /// yet, identity not yet provisioned, etc.) and the call returns
+    /// silently. The freshness-tick interval will retry on the next
+    /// `beacon_interval`, and an edge-trigger beacon will fire on the
+    /// next tier transition into `*Ready`.
+    ///
+    /// The signed body uses [`SignedReadinessBeacon::signable_bytes`] —
+    /// the canonical scheme defined alongside the wire type in
+    /// `calimero_context_client::local_governance::wire`. Receivers
+    /// verify via [`SignedReadinessBeacon::verify_signature`] which
+    /// includes the `READINESS_BEACON_SIGN_DOMAIN` prefix and rejects
+    /// field-substitution replays (proven by the tamper tests in
+    /// that module).
+    fn publish_beacon(&self, ns_id: [u8; 32], state: &ReadinessState) {
+        use calimero_context_client::local_governance::{
+            NamespaceTopicMsg, SignedReadinessBeacon,
+        };
+
+        let group_id = calimero_context_config::types::ContextGroupId::from(ns_id);
+        let identity = match calimero_context::group_store::get_namespace_identity(
+            &self.datastore,
+            &group_id,
+        ) {
+            Ok(Some(id)) => id,
+            Ok(None) => return, // No identity for this namespace yet — skip.
+            Err(err) => {
+                tracing::debug!(?err, ?ns_id, "ReadinessBeacon: identity load failed");
+                return;
+            }
+        };
+        let (peer_pubkey, sk_bytes, _sender_key) = identity;
+
+        let strong = matches!(state.tier, ReadinessTier::PeerValidatedReady);
+        let ts_millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        // Build with a placeholder signature, sign over the canonical
+        // signable_bytes(), then write the real signature back.
+        let mut beacon = SignedReadinessBeacon {
+            namespace_id: ns_id,
+            peer_pubkey,
+            dag_head: state.local_head,
+            applied_through: state.local_applied_through,
+            ts_millis,
+            strong,
+            signature: [0u8; 64],
+        };
+        let signable = match beacon.signable_bytes() {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::debug!(?err, "ReadinessBeacon: signable_bytes failed");
+                return;
+            }
+        };
+        let signing_key = calimero_primitives::identity::PrivateKey::from(sk_bytes);
+        let signature = match signing_key.sign(&signable) {
+            Ok(sig) => sig.to_bytes(),
+            Err(err) => {
+                tracing::debug!(?err, "ReadinessBeacon: sign failed");
+                return;
+            }
+        };
+        beacon.signature = signature;
+
+        let topic = calimero_context::governance_broadcast::ns_topic(ns_id);
+        let envelope = NamespaceTopicMsg::ReadinessBeacon(beacon);
+        let bytes = match borsh::to_vec(&envelope) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::debug!(?err, "ReadinessBeacon: borsh encode failed");
+                return;
+            }
+        };
+
+        // Detached publish — the caller (`emit_periodic_beacons` /
+        // edge-trigger) doesn't await; gossipsub publish failures are
+        // non-fatal. Using `network_client().publish` directly bypasses
+        // the 10s mesh-wait gate of `NodeClient::publish_on_namespace`.
+        let net = self.node_client.network_client().clone();
+        actix::spawn(async move {
+            if let Err(err) = net.publish(topic, bytes).await {
+                tracing::debug!(?err, "ReadinessBeacon publish failed (non-fatal)");
+            }
+        });
     }
 }
 

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -6,7 +6,12 @@
 //! Phase 7; the join-flow consumer (`await_first_fresh_beacon`,
 //! `join_namespace`, `await_namespace_ready`) lands in Phase 8.
 
+use std::collections::BTreeMap;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use calimero_context_client::local_governance::SignedReadinessBeacon;
+use calimero_primitives::identity::PublicKey;
 
 #[cfg(test)]
 mod tests;
@@ -153,6 +158,152 @@ pub fn evaluate_readiness(
             ReadinessTier::Degraded {
                 reason: DemotionReason::NoRecentPeers,
             }
+        }
+    }
+}
+
+/// Per-(namespace, peer) snapshot of the most recent fresh beacon we
+/// have received from that peer.
+#[derive(Debug, Clone)]
+pub struct CacheEntry {
+    pub head: [u8; 32],
+    pub applied_through: u64,
+    /// Peer-signed millis-since-epoch from the beacon itself.
+    /// Authoritative per-peer ordering signal — used by `insert` to drop
+    /// stale beacons that gossipsub may re-deliver out-of-order on mesh
+    /// churn / peer reconnect.
+    pub ts_millis: u64,
+    pub received_at: Instant,
+    pub strong: bool,
+}
+
+/// Maximum tolerated drift between a beacon's `ts_millis` and local
+/// wall-clock. Beacons claiming a wall-clock more than this far in the
+/// future are rejected to close the cache-poisoning vector documented
+/// on [`ReadinessCache::insert`].
+///
+/// 60s tolerates legitimate NTP-synced clock drift while bounding the
+/// damage a malicious or badly-skewed signer can do.
+pub const MAX_BEACON_CLOCK_DRIFT_MS: u64 = 60_000;
+
+/// Per-namespace, per-peer beacon cache.
+///
+/// Uses `BTreeMap` (not `HashMap`) because `calimero_primitives::identity::PublicKey`
+/// derives `Ord` but not `Hash`. Lookups are O(log n) on a per-namespace
+/// map that holds at most one entry per peer; the practical n is the
+/// namespace member count, well within a regime where the constant
+/// factors of `BTreeMap` are competitive with `HashMap`.
+#[derive(Default)]
+pub struct ReadinessCache {
+    entries: Mutex<BTreeMap<([u8; 32], PublicKey), CacheEntry>>,
+}
+
+impl ReadinessCache {
+    /// Insert iff the incoming beacon is *newer* than any cached entry from
+    /// the same peer (by `ts_millis`, with `applied_through` as tiebreaker
+    /// on clock equality). Gossipsub does not guarantee delivery order —
+    /// without this filter, an older re-delivered beacon could overwrite a
+    /// fresher one, causing `pick_sync_partner` and `peer_summary` to
+    /// regress and the FSM to spuriously demote
+    /// `PeerValidatedReady → CatchingUp`.
+    ///
+    /// Also rejects beacons with `ts_millis` more than
+    /// [`MAX_BEACON_CLOCK_DRIFT_MS`] ahead of local wall-clock. Without
+    /// this bound, a malicious or clock-skewed member could sign a beacon
+    /// with `ts_millis = year 2100`, poisoning their cache entry: every
+    /// subsequent legitimate beacon from the same peer would be dropped
+    /// by the `older-than-existing` filter, freezing `applied_through`
+    /// and `dag_head` at attacker-chosen values indefinitely. Beacons
+    /// are signed and verified against namespace membership, so only
+    /// current members can attempt this — but a single compromised key
+    /// would otherwise be sufficient.
+    pub fn insert(&self, beacon: &SignedReadinessBeacon) {
+        // Wall-clock sanity bound — reject far-future ts_millis to close
+        // the cache-poisoning attack described above.
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        if beacon.ts_millis > now_ms.saturating_add(MAX_BEACON_CLOCK_DRIFT_MS) {
+            return;
+        }
+
+        let mut g = self.entries.lock().expect("readiness cache lock");
+        let key = (beacon.namespace_id, beacon.peer_pubkey);
+        if let Some(existing) = g.get(&key) {
+            // Drop the beacon if it's older or equal-clock-but-not-fresher.
+            if beacon.ts_millis < existing.ts_millis
+                || (beacon.ts_millis == existing.ts_millis
+                    && beacon.applied_through <= existing.applied_through)
+            {
+                return;
+            }
+        }
+        let _ = g.insert(
+            key,
+            CacheEntry {
+                head: beacon.dag_head,
+                applied_through: beacon.applied_through,
+                ts_millis: beacon.ts_millis,
+                received_at: Instant::now(),
+                strong: beacon.strong,
+            },
+        );
+    }
+
+    pub fn fresh_peers(&self, ns: [u8; 32], ttl: Duration) -> Vec<(PublicKey, CacheEntry)> {
+        let g = self.entries.lock().expect("readiness cache lock");
+        let now = Instant::now();
+        g.iter()
+            .filter(|((nns, _), e)| *nns == ns && now.duration_since(e.received_at) <= ttl)
+            .map(|((_, pk), e)| (*pk, e.clone()))
+            .collect()
+    }
+
+    /// Sort order: `(strong desc, applied_through desc, received_at desc)`.
+    pub fn pick_sync_partner(
+        &self,
+        ns: [u8; 32],
+        ttl: Duration,
+    ) -> Option<(PublicKey, CacheEntry)> {
+        let mut peers = self.fresh_peers(ns, ttl);
+        peers.sort_by(|a, b| {
+            b.1.strong
+                .cmp(&a.1.strong)
+                .then(b.1.applied_through.cmp(&a.1.applied_through))
+                .then(b.1.received_at.cmp(&a.1.received_at))
+        });
+        peers.into_iter().next()
+    }
+
+    pub fn max_applied_through(&self, ns: [u8; 32], ttl: Duration) -> Option<u64> {
+        self.fresh_peers(ns, ttl)
+            .into_iter()
+            .map(|(_, e)| e.applied_through)
+            .max()
+    }
+
+    /// Atomic snapshot — `max_applied_through` and `heard_recent_beacon`
+    /// are read under a single lock acquisition so the FSM's match arms
+    /// cannot observe a torn state (e.g. `heard_recent_beacon=true`
+    /// while `max_applied_through=None`). All call sites that build a
+    /// `PeerSummary` MUST use this rather than two separate calls to
+    /// `max_applied_through` and `fresh_peers`.
+    pub fn peer_summary(&self, ns: [u8; 32], ttl: Duration) -> PeerSummary {
+        let g = self.entries.lock().expect("readiness cache lock");
+        let now = Instant::now();
+        let mut max_applied: Option<u64> = None;
+        let mut any_fresh = false;
+        for ((nns, _), e) in g.iter() {
+            if *nns != ns || now.duration_since(e.received_at) > ttl {
+                continue;
+            }
+            any_fresh = true;
+            max_applied = Some(max_applied.map_or(e.applied_through, |m| m.max(e.applied_through)));
+        }
+        PeerSummary {
+            max_applied_through: max_applied,
+            heard_recent_beacon: any_fresh,
         }
     }
 }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -424,19 +424,6 @@ pub struct ApplyBeaconLocal {
     pub namespace_id: [u8; 32],
 }
 
-/// Carries a snapshot of locally-observed namespace state into the FSM
-/// driver. The actor merges this into `state_per_namespace`, re-evaluates
-/// `evaluate_readiness`, and emits an edge-trigger beacon if the tier
-/// transitions into a *Ready variant.
-#[derive(Message)]
-#[rtype(result = "()")]
-pub struct LocalStateChanged {
-    pub namespace_id: [u8; 32],
-    pub local_applied_through: u64,
-    pub local_head: [u8; 32],
-    pub local_pending_ops: usize,
-}
-
 /// A single namespace governance op was successfully applied locally.
 ///
 /// Sent from the receiver-side network-event handler after a
@@ -596,60 +583,6 @@ impl ReadinessManager {
     }
 }
 
-impl Handler<LocalStateChanged> for ReadinessManager {
-    type Result = ();
-
-    fn handle(&mut self, msg: LocalStateChanged, _ctx: &mut Self::Context) {
-        // Atomic single-lock snapshot — see ReadinessCache::peer_summary
-        // for why peer_summary is the only correct source for PeerSummary.
-        let peers = self
-            .cache
-            .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
-
-        // Scoped borrow on `state_per_namespace`: compute next tier,
-        // mutate the entry, snapshot for emission. The borrow ends at
-        // the end of this block so `clear_probe_window_for` and
-        // `publish_beacon` can re-borrow `self` afterwards.
-        let to_emit = {
-            let entry = self
-                .state_per_namespace
-                .entry(msg.namespace_id)
-                .or_insert_with(|| ReadinessState {
-                    tier: ReadinessTier::Bootstrapping,
-                    local_applied_through: 0,
-                    local_head: [0u8; 32],
-                    local_pending_ops: 0,
-                    subscribed_at: Instant::now(),
-                });
-            entry.local_applied_through = msg.local_applied_through;
-            entry.local_head = msg.local_head;
-            entry.local_pending_ops = msg.local_pending_ops;
-            let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
-            if new_tier != entry.tier {
-                entry.tier = new_tier;
-                // Edge trigger: a tier transition into *Ready warrants
-                // an immediate beacon so peers see our promotion without
-                // waiting for the next freshness tick.
-                if matches!(
-                    new_tier,
-                    ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
-                ) {
-                    Some(entry.clone())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        if let Some(snapshot) = to_emit {
-            self.clear_probe_window_for(msg.namespace_id);
-            self.publish_beacon(msg.namespace_id, &snapshot);
-        }
-    }
-}
-
 /// Out-of-cycle beacon emission triggered by an inbound
 /// [`calimero_context_client::local_governance::ReadinessProbe`].
 ///
@@ -674,7 +607,7 @@ impl Handler<NamespaceOpApplied> for ReadinessManager {
 
         // Increment the per-namespace local apply counter, then re-evaluate
         // FSM and edge-emit on transition into a *Ready tier. Uses the
-        // same scoped-borrow pattern as Handler<LocalStateChanged> so
+        // same scoped-borrow pattern as Handler<ApplyBeaconLocal> so
         // `clear_probe_window_for` and `publish_beacon` can re-borrow
         // self after the entry borrow ends.
         let to_emit = {
@@ -733,7 +666,7 @@ impl Handler<EmitOutOfCycleBeacon> for ReadinessManager {
         // tier, we still record `last_probe_response_at` so the same
         // peer cannot poll us into pathological recheck rates. After a
         // tier transition into *Ready, `last_probe_response_at` for
-        // affected (peer, ns) is cleared in `LocalStateChanged` /
+        // affected (peer, ns) is cleared in `NamespaceOpApplied` /
         // `ApplyBeaconLocal` so a later probe immediately gets a beacon.
         let now = Instant::now();
         let min_spacing = self.config.beacon_interval / 2;

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -445,21 +445,51 @@ pub struct NamespaceOpApplied {
 
 impl ReadinessManager {
     fn emit_periodic_beacons(&mut self) {
-        // Snapshot the (ns_id, state) pairs we want to publish so the
-        // borrow on `self.state_per_namespace` is released before
-        // `publish_beacon` runs (`publish_beacon` will load identity
-        // material from `self.datastore` in Task 7.2).
-        let to_emit: Vec<([u8; 32], ReadinessState)> = self
-            .state_per_namespace
-            .iter()
-            .filter(|(_, s)| {
-                matches!(
-                    s.tier,
+        // The freshness tick is the natural FSM-recompute checkpoint.
+        // Without re-evaluating, a `*Ready` tier set hours ago would
+        // persist forever even if every peer beacon expired in the
+        // meantime — leaving us emitting stale "I'm ready" claims with
+        // no peer-validated backing. Re-eval on every tick lets TTL
+        // expiry demote `PeerValidatedReady → Degraded(NoRecentPeers)`
+        // and gain-of-peer-awareness promote `LocallyReady →
+        // PeerValidatedReady`.
+        //
+        // Walk all namespaces (not just `*Ready` ones — a
+        // `Bootstrapping` ns may have caught up enough to promote
+        // since its last evaluation), recompute the tier, persist any
+        // change, and collect the post-recompute `*Ready` snapshots
+        // for emission.
+        let now = Instant::now();
+        let ttl = self.config.ttl_heartbeat;
+        let cfg = self.config;
+        let mut to_emit: Vec<([u8; 32], ReadinessState)> = Vec::new();
+        let ns_ids: Vec<[u8; 32]> = self.state_per_namespace.keys().copied().collect();
+        for ns_id in ns_ids {
+            // Atomic single-lock snapshot per namespace — see
+            // `ReadinessCache::peer_summary` for why.
+            let peers = self.cache.peer_summary(ns_id, ttl);
+            let snapshot = if let Some(entry) = self.state_per_namespace.get_mut(&ns_id) {
+                let new_tier = evaluate_readiness(entry, &peers, &cfg, now);
+                if new_tier != entry.tier {
+                    entry.tier = new_tier;
+                }
+                if matches!(
+                    entry.tier,
                     ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
-                )
-            })
-            .map(|(ns, s)| (*ns, s.clone()))
-            .collect();
+                ) {
+                    Some(entry.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            if let Some(snapshot) = snapshot {
+                to_emit.push((ns_id, snapshot));
+            }
+        }
+        // Emit outside the borrow on `state_per_namespace` because
+        // `publish_beacon` loads identity material from `self.datastore`.
         for (ns_id, state) in to_emit {
             self.publish_beacon(ns_id, &state);
         }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -471,6 +471,13 @@ impl ReadinessManager {
             let snapshot = if let Some(entry) = self.state_per_namespace.get_mut(&ns_id) {
                 let new_tier = evaluate_readiness(entry, &peers, &cfg, now);
                 if new_tier != entry.tier {
+                    tracing::info!(
+                        namespace_id = %hex::encode(ns_id),
+                        old = ?entry.tier,
+                        new = ?new_tier,
+                        cause = "periodic_tick",
+                        "readiness tier transition"
+                    );
                     entry.tier = new_tier;
                 }
                 if matches!(
@@ -605,9 +612,20 @@ impl ReadinessManager {
         // non-fatal. Using `network_client().publish` directly bypasses
         // the 10s mesh-wait gate of `NodeClient::publish_on_namespace`.
         let net = self.node_client.network_client().clone();
+        let log_ns = ns_id;
+        let log_applied = state.local_applied_through;
+        let log_strong = strong;
         actix::spawn(async move {
-            if let Err(err) = net.publish(topic, bytes).await {
-                tracing::debug!(?err, "ReadinessBeacon publish failed (non-fatal)");
+            match net.publish(topic, bytes).await {
+                Ok(_) => tracing::info!(
+                    namespace_id = %hex::encode(log_ns),
+                    applied_through = log_applied,
+                    strong = log_strong,
+                    "readiness beacon emitted"
+                ),
+                Err(err) => {
+                    tracing::debug!(?err, "ReadinessBeacon publish failed (non-fatal)");
+                }
             }
         });
     }
@@ -654,6 +672,13 @@ impl Handler<NamespaceOpApplied> for ReadinessManager {
             entry.local_applied_through = entry.local_applied_through.saturating_add(1);
             let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
             if new_tier != entry.tier {
+                tracing::info!(
+                    namespace_id = %hex::encode(msg.namespace_id),
+                    old = ?entry.tier,
+                    new = ?new_tier,
+                    cause = "namespace_op_applied",
+                    "readiness tier transition"
+                );
                 entry.tier = new_tier;
                 if matches!(
                     new_tier,
@@ -756,6 +781,13 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
             .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
         let new_tier = evaluate_readiness(&state, &peers, &self.config, Instant::now());
         if new_tier != state.tier {
+            tracing::info!(
+                namespace_id = %hex::encode(msg.namespace_id),
+                old = ?state.tier,
+                new = ?new_tier,
+                cause = "peer_beacon_received",
+                "readiness tier transition"
+            );
             let snapshot = if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
                 s.tier = new_tier;
                 if matches!(
@@ -860,6 +892,13 @@ impl ReadinessCache {
             //    `enable()` and the `select!` poll wake the
             //    (already-registered) future.
             if let Some(entry) = self.pick_sync_partner(ns, ttl) {
+                tracing::info!(
+                    namespace_id = %hex::encode(ns),
+                    partner = %entry.0,
+                    partner_applied = entry.1.applied_through,
+                    partner_strong = entry.1.strong,
+                    "first fresh beacon resolved"
+                );
                 return Some(entry);
             }
             tokio::select! {

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -61,7 +61,6 @@ pub enum DemotionReason {
 pub struct ReadinessState {
     pub tier: ReadinessTier,
     pub local_applied_through: u64,
-    pub local_head: [u8; 32],
     pub local_pending_ops: usize,
     pub subscribed_at: Instant,
 }
@@ -548,12 +547,29 @@ impl ReadinessManager {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
 
+        // Read the canonical namespace DAG head from the store at emit
+        // time. Caching this on the actor (the original `state.local_head`
+        // approach) created a stale-state risk and — worse — was never
+        // updated, so beacons always carried `dag_head = [0u8; 32]`
+        // (cursor[bot] medium-severity, #2269). For multi-head namespaces
+        // we pick the lex-min so the same head set always serialises to
+        // the same beacon field; receivers treat `dag_head` as a sync
+        // hint, not authoritative state.
+        let dag_head = {
+            let handle = self.datastore.handle();
+            let key = calimero_store::key::NamespaceGovHead::new(ns_id);
+            match handle.get(&key) {
+                Ok(Some(head)) => head.dag_heads.iter().min().copied().unwrap_or([0u8; 32]),
+                Ok(None) | Err(_) => [0u8; 32],
+            }
+        };
+
         // Build with a placeholder signature, sign over the canonical
         // signable_bytes(), then write the real signature back.
         let mut beacon = SignedReadinessBeacon {
             namespace_id: ns_id,
             peer_pubkey,
-            dag_head: state.local_head,
+            dag_head,
             applied_through: state.local_applied_through,
             ts_millis,
             strong,
@@ -665,7 +681,6 @@ impl Handler<NamespaceOpApplied> for ReadinessManager {
                 .or_insert_with(|| ReadinessState {
                     tier: ReadinessTier::Bootstrapping,
                     local_applied_through: 0,
-                    local_head: [0u8; 32],
                     local_pending_ops: 0,
                     subscribed_at: Instant::now(),
                 });

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -412,22 +412,19 @@ impl ReadinessManager {
     /// field-substitution replays (proven by the tamper tests in
     /// that module).
     fn publish_beacon(&self, ns_id: [u8; 32], state: &ReadinessState) {
-        use calimero_context_client::local_governance::{
-            NamespaceTopicMsg, SignedReadinessBeacon,
-        };
+        use calimero_context_client::local_governance::{NamespaceTopicMsg, SignedReadinessBeacon};
 
         let group_id = calimero_context_config::types::ContextGroupId::from(ns_id);
-        let identity = match calimero_context::group_store::get_namespace_identity(
-            &self.datastore,
-            &group_id,
-        ) {
-            Ok(Some(id)) => id,
-            Ok(None) => return, // No identity for this namespace yet — skip.
-            Err(err) => {
-                tracing::debug!(?err, ?ns_id, "ReadinessBeacon: identity load failed");
-                return;
-            }
-        };
+        let identity =
+            match calimero_context::group_store::get_namespace_identity(&self.datastore, &group_id)
+            {
+                Ok(Some(id)) => id,
+                Ok(None) => return, // No identity for this namespace yet — skip.
+                Err(err) => {
+                    tracing::debug!(?err, ?ns_id, "ReadinessBeacon: identity load failed");
+                    return;
+                }
+            };
         let (peer_pubkey, sk_bytes, _sender_key) = identity;
 
         let strong = matches!(state.tier, ReadinessTier::PeerValidatedReady);
@@ -524,6 +521,89 @@ impl Handler<LocalStateChanged> for ReadinessManager {
             ) {
                 let snapshot = entry.clone();
                 self.publish_beacon(msg.namespace_id, &snapshot);
+            }
+        }
+    }
+}
+
+/// Out-of-cycle beacon emission triggered by an inbound
+/// [`calimero_context_client::local_governance::ReadinessProbe`].
+///
+/// Carries the requesting peer so the actor can rate-limit responses
+/// per-(peer, namespace) — see [`Handler<EmitOutOfCycleBeacon>`].
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct EmitOutOfCycleBeacon {
+    pub namespace_id: [u8; 32],
+    pub requesting_peer: PeerId,
+}
+
+impl Handler<EmitOutOfCycleBeacon> for ReadinessManager {
+    type Result = ();
+
+    fn handle(&mut self, msg: EmitOutOfCycleBeacon, _ctx: &mut Self::Context) {
+        // Rate-limit probe responses per (peer, namespace) at
+        // `BEACON_INTERVAL / 2` to close the unsigned-`ReadinessProbe`
+        // traffic-amplification path: one ~48-byte probe would otherwise
+        // trigger one ~200-byte signed beacon from EVERY *Ready peer on
+        // the topic (≈Nx amplification). Bypass via varying `nonce` is
+        // blocked because the rate-limit key is (peer, namespace), not
+        // probe content.
+        let now = Instant::now();
+        let min_spacing = self.config.beacon_interval / 2;
+        let key = (msg.requesting_peer, msg.namespace_id);
+        if let Some(last) = self.last_probe_response_at.get(&key) {
+            if now.duration_since(*last) < min_spacing {
+                return; // within rate-limit window — drop silently
+            }
+        }
+        // Snapshot-then-emit so `publish_beacon` does not borrow
+        // `state_per_namespace` across the call (it loads identity from
+        // `self.datastore`).
+        let snapshot = match self.state_per_namespace.get(&msg.namespace_id) {
+            Some(s)
+                if matches!(
+                    s.tier,
+                    ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
+                ) =>
+            {
+                s.clone()
+            }
+            // Either no state for this namespace or not in a *Ready tier —
+            // nothing to advertise, drop the probe silently. Don't update
+            // `last_probe_response_at` so a later probe after we promote
+            // is not silently rate-limited.
+            _ => return,
+        };
+        self.publish_beacon(msg.namespace_id, &snapshot);
+        let _ = self.last_probe_response_at.insert(key, now);
+    }
+}
+
+impl Handler<ApplyBeaconLocal> for ReadinessManager {
+    type Result = ();
+
+    fn handle(&mut self, msg: ApplyBeaconLocal, _ctx: &mut Self::Context) {
+        // A peer beacon has just been inserted into the cache. Re-evaluate
+        // the FSM with the (possibly) updated `peer_summary` and edge-emit
+        // if our tier transitions into *Ready.
+        let Some(state) = self.state_per_namespace.get(&msg.namespace_id).cloned() else {
+            return;
+        };
+        let peers = self
+            .cache
+            .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
+        let new_tier = evaluate_readiness(&state, &peers, &self.config, Instant::now());
+        if new_tier != state.tier {
+            if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
+                s.tier = new_tier;
+                if matches!(
+                    new_tier,
+                    ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
+                ) {
+                    let snapshot = s.clone();
+                    self.publish_beacon(msg.namespace_id, &snapshot);
+                }
             }
         }
     }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -6,12 +6,16 @@
 //! Phase 7; the join-flow consumer (`await_first_fresh_beacon`,
 //! `join_namespace`, `await_namespace_ready`) lands in Phase 8.
 
-use std::collections::BTreeMap;
-use std::sync::Mutex;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use actix::{Actor, AsyncContext, Context, Handler, Message};
 use calimero_context_client::local_governance::SignedReadinessBeacon;
+use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::identity::PublicKey;
+use calimero_store::Store;
+use libp2p::PeerId;
 
 #[cfg(test)]
 mod tests;
@@ -193,7 +197,7 @@ pub const MAX_BEACON_CLOCK_DRIFT_MS: u64 = 60_000;
 /// map that holds at most one entry per peer; the practical n is the
 /// namespace member count, well within a regime where the constant
 /// factors of `BTreeMap` are competitive with `HashMap`.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ReadinessCache {
     entries: Mutex<BTreeMap<([u8; 32], PublicKey), CacheEntry>>,
 }
@@ -304,6 +308,141 @@ impl ReadinessCache {
         PeerSummary {
             max_applied_through: max_applied,
             heard_recent_beacon: any_fresh,
+        }
+    }
+}
+
+/// Per-namespace beacon emitter and FSM driver.
+///
+/// Holds:
+/// - the shared [`ReadinessCache`] so the receiver-side handler can
+///   `cache.insert(&beacon)` directly without an actor-mailbox hop
+///   (the cache is internally synchronised),
+/// - the [`NodeClient`] for `publish` access on the namespace topic
+///   (bypassing the 10s mesh-wait gate of `publish_on_namespace` —
+///   beacon emission is best-effort and must not block the periodic
+///   tick),
+/// - the [`Store`] for namespace-identity loading in beacon signing
+///   (Task 7.2),
+/// - per-namespace local FSM state and last-probe-response timestamps
+///   for the `BEACON_INTERVAL/2` rate limit (Task 7.3).
+pub struct ReadinessManager {
+    pub cache: Arc<ReadinessCache>,
+    pub config: ReadinessConfig,
+    pub state_per_namespace: HashMap<[u8; 32], ReadinessState>,
+    pub node_client: NodeClient,
+    pub datastore: Store,
+    /// Per-(peer, namespace) timestamp of the last out-of-cycle beacon
+    /// emitted in response to a [`ReadinessProbe`]. Used by Task 7.3 to
+    /// rate-limit probe responses at `BEACON_INTERVAL / 2` and close the
+    /// unsigned-probe traffic-amplification path.
+    pub last_probe_response_at: HashMap<(PeerId, [u8; 32]), Instant>,
+}
+
+impl Actor for ReadinessManager {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        // Periodic freshness-tick beacon emission. Only namespaces in a
+        // *Ready tier emit; the filter is inside `emit_periodic_beacons`.
+        ctx.run_interval(self.config.beacon_interval, |this, _ctx| {
+            this.emit_periodic_beacons();
+        });
+    }
+}
+
+/// Hint that a peer beacon has just been inserted into the cache for this
+/// namespace and the FSM should be re-evaluated. Sent by the receiver-side
+/// `handle_readiness_beacon` handler in Task 7.3.
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct ApplyBeaconLocal {
+    pub namespace_id: [u8; 32],
+}
+
+/// Carries a snapshot of locally-observed namespace state into the FSM
+/// driver. The actor merges this into `state_per_namespace`, re-evaluates
+/// `evaluate_readiness`, and emits an edge-trigger beacon if the tier
+/// transitions into a *Ready variant.
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct LocalStateChanged {
+    pub namespace_id: [u8; 32],
+    pub local_applied_through: u64,
+    pub local_head: [u8; 32],
+    pub local_pending_ops: usize,
+}
+
+impl ReadinessManager {
+    fn emit_periodic_beacons(&mut self) {
+        // Snapshot the (ns_id, state) pairs we want to publish so the
+        // borrow on `self.state_per_namespace` is released before
+        // `publish_beacon` runs (`publish_beacon` will load identity
+        // material from `self.datastore` in Task 7.2).
+        let to_emit: Vec<([u8; 32], ReadinessState)> = self
+            .state_per_namespace
+            .iter()
+            .filter(|(_, s)| {
+                matches!(
+                    s.tier,
+                    ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
+                )
+            })
+            .map(|(ns, s)| (*ns, s.clone()))
+            .collect();
+        for (ns_id, state) in to_emit {
+            self.publish_beacon(ns_id, &state);
+        }
+    }
+
+    /// Sign and publish a [`SignedReadinessBeacon`] on the namespace topic.
+    ///
+    /// Body filled in Task 7.2; in Task 7.1 this is intentionally a stub
+    /// so the actor compiles standalone — no beacons are emitted until
+    /// 7.2 lands the signing + publish path.
+    fn publish_beacon(&self, _ns_id: [u8; 32], _state: &ReadinessState) {
+        // Intentional stub — see doc comment.
+    }
+}
+
+impl Handler<LocalStateChanged> for ReadinessManager {
+    type Result = ();
+
+    fn handle(&mut self, msg: LocalStateChanged, _ctx: &mut Self::Context) {
+        let entry = self
+            .state_per_namespace
+            .entry(msg.namespace_id)
+            .or_insert_with(|| ReadinessState {
+                tier: ReadinessTier::Bootstrapping,
+                local_applied_through: 0,
+                local_head: [0u8; 32],
+                local_pending_ops: 0,
+                subscribed_at: Instant::now(),
+            });
+        entry.local_applied_through = msg.local_applied_through;
+        entry.local_head = msg.local_head;
+        entry.local_pending_ops = msg.local_pending_ops;
+
+        // Atomic single-lock snapshot — see ReadinessCache::peer_summary
+        // for why peer_summary is the only correct source for PeerSummary.
+        let peers = self
+            .cache
+            .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
+        let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
+        if new_tier != entry.tier {
+            entry.tier = new_tier;
+            // Edge trigger: a tier transition into *Ready warrants an
+            // immediate beacon so peers see our promotion without waiting
+            // for the next freshness tick. The clone-then-emit pattern
+            // mirrors `emit_periodic_beacons` and keeps `publish_beacon`
+            // free of borrows on `state_per_namespace`.
+            if matches!(
+                new_tier,
+                ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
+            ) {
+                let snapshot = entry.clone();
+                self.publish_beacon(msg.namespace_id, &snapshot);
+            }
         }
     }
 }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -1,0 +1,158 @@
+//! Per-namespace readiness FSM, beacon cache, and (in later tasks)
+//! the actor that emits beacons and handles probes.
+//!
+//! Phase 6 of the three-phase governance contract: pure types + logic.
+//! The actor wiring (periodic beacon emission, probe handling) lands in
+//! Phase 7; the join-flow consumer (`await_first_fresh_beacon`,
+//! `join_namespace`, `await_namespace_ready`) lands in Phase 8.
+
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+mod tests;
+
+/// Tier in the per-namespace readiness FSM.
+///
+/// Data-carrying variants (`CatchingUp { target_applied_through }`,
+/// `Degraded { reason }`) keep the FSM, metrics labels, and logs aligned
+/// on a single source of truth — a flat enum plus a parallel side-channel
+/// struct would risk the variant and the demotion reason drifting apart
+/// over time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadinessTier {
+    Bootstrapping,
+    LocallyReady,
+    PeerValidatedReady,
+    CatchingUp { target_applied_through: u64 },
+    Degraded { reason: DemotionReason },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DemotionReason {
+    PendingOps(usize),
+    NoRecentPeers,
+    PeerSawHigherThroughput,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadinessState {
+    pub tier: ReadinessTier,
+    pub local_applied_through: u64,
+    pub local_head: [u8; 32],
+    pub local_pending_ops: usize,
+    pub subscribed_at: Instant,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ReadinessConfig {
+    pub boot_grace: Duration,
+    pub ttl_heartbeat: Duration,
+    pub beacon_interval: Duration,
+    pub applied_through_grace: u64,
+}
+
+impl Default for ReadinessConfig {
+    fn default() -> Self {
+        Self {
+            boot_grace: Duration::from_secs(10),
+            ttl_heartbeat: Duration::from_secs(60),
+            beacon_interval: Duration::from_secs(5),
+            applied_through_grace: 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PeerSummary {
+    pub max_applied_through: Option<u64>,
+    pub heard_recent_beacon: bool,
+}
+
+/// Pure transition function for the readiness FSM.
+///
+/// Maps `(state, peers, cfg, now)` → next `ReadinessTier`. The function
+/// is total (every input combination has a defined output) and free of
+/// side effects; the actor in Phase 7 calls it on every beacon, every
+/// freshness tick, and on local-state changes.
+pub fn evaluate_readiness(
+    state: &ReadinessState,
+    peers: &PeerSummary,
+    cfg: &ReadinessConfig,
+    now: Instant,
+) -> ReadinessTier {
+    // Pending ops always demote — record the count so observability can see
+    // *how many* ops are blocking promotion, not just that *some* exist.
+    if state.local_pending_ops > 0 {
+        return ReadinessTier::Degraded {
+            reason: DemotionReason::PendingOps(state.local_pending_ops),
+        };
+    }
+
+    // Empty-DAG joiners never self-promote (no LocallyReady from local_applied_through=0).
+    // If we hear a peer beacon we know there's a target to catch up to → CatchingUp
+    // carrying that target; otherwise we don't know whether a network exists yet →
+    // stay Bootstrapping. With the atomic `ReadinessCache::peer_summary` snapshot,
+    // `heard_recent_beacon == true` implies `max_applied_through.is_some()`, so the
+    // `unwrap_or(0)` is a defensive fallback only.
+    if state.local_applied_through == 0 {
+        return if peers.heard_recent_beacon {
+            ReadinessTier::CatchingUp {
+                target_applied_through: peers.max_applied_through.unwrap_or(0),
+            }
+        } else {
+            ReadinessTier::Bootstrapping
+        };
+    }
+
+    let boot_grace_elapsed = now.duration_since(state.subscribed_at) >= cfg.boot_grace;
+
+    match (
+        peers.max_applied_through,
+        peers.heard_recent_beacon,
+        boot_grace_elapsed,
+    ) {
+        // Heard a peer beacon: tip-fresh → PeerValidatedReady; behind → CatchingUp{target}.
+        (Some(peer_at), true, _) => {
+            if state.local_applied_through + cfg.applied_through_grace >= peer_at {
+                ReadinessTier::PeerValidatedReady
+            } else {
+                ReadinessTier::CatchingUp {
+                    target_applied_through: peer_at,
+                }
+            }
+        }
+        // No peer beacons but we've waited BOOT_GRACE: self-promote (LocallyReady).
+        (None, false, true) => ReadinessTier::LocallyReady,
+        // No peer beacons and still in boot grace: stay Bootstrapping.
+        (None, false, false) => ReadinessTier::Bootstrapping,
+        // Defensive: with an atomic `ReadinessCache::peer_summary` snapshot, both
+        // `(None, true, _)` and `(Some(_), false, _)` are unreachable —
+        // `max_applied_through` and `heard_recent_beacon` are both derived from
+        // the same fresh-within-TTL filter, so they are always either
+        // (None, false) or (Some(_), true). The arms below remain as safe
+        // fallbacks for any future non-atomic call site, return spec
+        // §7.2-aligned tiers, and `debug_assert!` loud in dev builds so a
+        // regression is caught immediately.
+        //
+        // `(None, true)`: claim of fresh peer with no max_applied_through →
+        // no usable target → stay Bootstrapping (no self-promotion).
+        (None, true, _) => {
+            debug_assert!(
+                false,
+                "PeerSummary built from non-atomic reads (None, true) — use ReadinessCache::peer_summary"
+            );
+            ReadinessTier::Bootstrapping
+        }
+        // `(Some(_), false)`: we knew about a peer once, no fresh beacon now.
+        // Spec §7.2 says `*Ready → Degraded { reason: NoRecentPeers }`.
+        (Some(_), false, _) => {
+            debug_assert!(
+                false,
+                "PeerSummary built from non-atomic reads (Some, false) — use ReadinessCache::peer_summary"
+            );
+            ReadinessTier::Degraded {
+                reason: DemotionReason::NoRecentPeers,
+            }
+        }
+    }
+}

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -1,10 +1,19 @@
-//! Per-namespace readiness FSM, beacon cache, and (in later tasks)
-//! the actor that emits beacons and handles probes.
+//! Per-namespace readiness FSM, beacon cache, and the [`ReadinessManager`]
+//! actor that emits beacons and handles probes.
 //!
-//! Phase 6 of the three-phase governance contract: pure types + logic.
-//! The actor wiring (periodic beacon emission, probe handling) lands in
-//! Phase 7; the join-flow consumer (`await_first_fresh_beacon`,
-//! `join_namespace`, `await_namespace_ready`) lands in Phase 8.
+//! Implements implementation-plan Phase 6 (FSM + cache types) and
+//! Phase 7 (actor / emission / probe handling) of the three-phase
+//! governance contract for #2237. The "three phases" referred to are
+//! `assert_transport_ready` / `publish + collect acks` / `apply on
+//! receipt` — see `crates/context/src/governance_broadcast.rs`. The
+//! "Phase 6/7/8" numbers in this PR refer to the implementation plan
+//! at `docs/superpowers/plans/2026-04-25-governance-three-phase-readiness.md`,
+//! which slices the work into landable chunks.
+//!
+//! The join-flow consumer (`await_first_fresh_beacon` via
+//! [`ReadinessCache::await_first_fresh_beacon`], plus `join_namespace`
+//! / `await_namespace_ready`) lives in Phase 8, partially in this
+//! module and partially in [`crate::join_namespace`].
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
@@ -39,8 +48,12 @@ pub enum ReadinessTier {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DemotionReason {
     PendingOps(usize),
+    /// We had a fresh peer beacon for this namespace once, but no
+    /// peer has emitted within `ttl_heartbeat` recently — the spec
+    /// §7.2 "*Ready → Degraded" arm. Surfaced from `evaluate_readiness`
+    /// when `peer_summary` returns the (defensive) `(Some, false)`
+    /// state that should be unreachable under atomic-snapshot reads.
     NoRecentPeers,
-    PeerSawHigherThroughput,
 }
 
 #[derive(Debug, Clone)]
@@ -122,7 +135,16 @@ pub fn evaluate_readiness(
     ) {
         // Heard a peer beacon: tip-fresh → PeerValidatedReady; behind → CatchingUp{target}.
         (Some(peer_at), true, _) => {
-            if state.local_applied_through + cfg.applied_through_grace >= peer_at {
+            // saturating_add: in debug builds an overflow on
+            // `local_applied_through + applied_through_grace` would
+            // panic if `local_applied_through` were near `u64::MAX` —
+            // an unreachable state in practice, but a defensive
+            // saturating_add costs nothing and silences the audit.
+            if state
+                .local_applied_through
+                .saturating_add(cfg.applied_through_grace)
+                >= peer_at
+            {
                 ReadinessTier::PeerValidatedReady
             } else {
                 ReadinessTier::CatchingUp {
@@ -203,12 +225,24 @@ pub struct ReadinessCache {
 }
 
 impl ReadinessCache {
-    /// Insert iff the incoming beacon is *newer* than any cached entry from
-    /// the same peer (by `ts_millis`, with `applied_through` as tiebreaker
-    /// on clock equality). Gossipsub does not guarantee delivery order —
-    /// without this filter, an older re-delivered beacon could overwrite a
-    /// fresher one, causing `pick_sync_partner` and `peer_summary` to
-    /// regress and the FSM to spuriously demote
+    /// Insert a beacon into the cache.
+    ///
+    /// **Verification contract**: this method assumes the beacon has
+    /// already been verified for signature AND namespace membership by
+    /// the caller. The single legitimate caller is the receiver-side
+    /// `network_event::readiness::handle_readiness_beacon`, which calls
+    /// `calimero_context::governance_broadcast::verify_readiness_beacon`
+    /// (sig + member-set check) BEFORE invoking `insert`. Putting
+    /// verification inside `insert` would couple the cache to
+    /// `&Store`, drag namespace-membership state into a pure-types
+    /// module, and duplicate work since the receiver gate runs first.
+    ///
+    /// Insert iff the incoming beacon is *newer* than any cached entry
+    /// from the same peer (by `ts_millis`, with `applied_through` as
+    /// tiebreaker on clock equality). Gossipsub does not guarantee
+    /// delivery order — without this filter, an older re-delivered
+    /// beacon could overwrite a fresher one, causing `pick_sync_partner`
+    /// and `peer_summary` to regress and the FSM to spuriously demote
     /// `PeerValidatedReady → CatchingUp`.
     ///
     /// Also rejects beacons with `ts_millis` more than
@@ -217,10 +251,13 @@ impl ReadinessCache {
     /// with `ts_millis = year 2100`, poisoning their cache entry: every
     /// subsequent legitimate beacon from the same peer would be dropped
     /// by the `older-than-existing` filter, freezing `applied_through`
-    /// and `dag_head` at attacker-chosen values indefinitely. Beacons
-    /// are signed and verified against namespace membership, so only
-    /// current members can attempt this — but a single compromised key
-    /// would otherwise be sufficient.
+    /// and `dag_head` at attacker-chosen values indefinitely.
+    ///
+    /// Opportunistically evicts entries past `2 × MAX_BEACON_CLOCK_DRIFT_MS`
+    /// for *this namespace* on every insert — keeps long-lived nodes
+    /// from accumulating entries from peers that left the namespace.
+    /// Stale-but-within-eviction-window entries are still filtered out
+    /// of `fresh_peers`/`peer_summary` by the per-call `ttl` check.
     pub fn insert(&self, beacon: &SignedReadinessBeacon) {
         // Wall-clock sanity bound — reject far-future ts_millis to close
         // the cache-poisoning attack described above.
@@ -232,6 +269,7 @@ impl ReadinessCache {
             return;
         }
 
+        let now = Instant::now();
         let mut g = self.entries.lock().expect("readiness cache lock");
         let key = (beacon.namespace_id, beacon.peer_pubkey);
         if let Some(existing) = g.get(&key) {
@@ -243,13 +281,26 @@ impl ReadinessCache {
                 return;
             }
         }
+
+        // Opportunistic eviction for the same namespace — keep the
+        // BTreeMap from accumulating entries from peers that left the
+        // namespace on long-running nodes. Eviction window
+        // (`2 × MAX_BEACON_CLOCK_DRIFT_MS`) is intentionally wider
+        // than typical TTLs so reads can still see "stale-but-recent"
+        // entries (filtered by per-call `ttl`) without competing
+        // against this prune.
+        let evict_window = Duration::from_millis(MAX_BEACON_CLOCK_DRIFT_MS.saturating_mul(2));
+        g.retain(|(ns, _), entry| {
+            *ns != beacon.namespace_id || now.duration_since(entry.received_at) <= evict_window
+        });
+
         let _ = g.insert(
             key,
             CacheEntry {
                 head: beacon.dag_head,
                 applied_through: beacon.applied_through,
                 ts_millis: beacon.ts_millis,
-                received_at: Instant::now(),
+                received_at: now,
                 strong: beacon.strong,
             },
         );
@@ -265,19 +316,20 @@ impl ReadinessCache {
     }
 
     /// Sort order: `(strong desc, applied_through desc, received_at desc)`.
+    ///
+    /// O(n) via `Iterator::max_by` — earlier sort-then-take-first was
+    /// O(n log n) for a single-element selection.
     pub fn pick_sync_partner(
         &self,
         ns: [u8; 32],
         ttl: Duration,
     ) -> Option<(PublicKey, CacheEntry)> {
-        let mut peers = self.fresh_peers(ns, ttl);
-        peers.sort_by(|a, b| {
-            b.1.strong
-                .cmp(&a.1.strong)
-                .then(b.1.applied_through.cmp(&a.1.applied_through))
-                .then(b.1.received_at.cmp(&a.1.received_at))
-        });
-        peers.into_iter().next()
+        self.fresh_peers(ns, ttl).into_iter().max_by(|a, b| {
+            a.1.strong
+                .cmp(&b.1.strong)
+                .then(a.1.applied_through.cmp(&b.1.applied_through))
+                .then(a.1.received_at.cmp(&b.1.received_at))
+        })
     }
 
     pub fn max_applied_through(&self, ns: [u8; 32], ttl: Duration) -> Option<u64> {
@@ -413,6 +465,7 @@ impl ReadinessManager {
     /// that module).
     fn publish_beacon(&self, ns_id: [u8; 32], state: &ReadinessState) {
         use calimero_context_client::local_governance::{NamespaceTopicMsg, SignedReadinessBeacon};
+        use calimero_node_primitives::sync::BroadcastMessage;
 
         let group_id = calimero_context_config::types::ContextGroupId::from(ns_id);
         let identity =
@@ -462,11 +515,28 @@ impl ReadinessManager {
         beacon.signature = signature;
 
         let topic = calimero_context::governance_broadcast::ns_topic(ns_id);
-        let envelope = NamespaceTopicMsg::ReadinessBeacon(beacon);
+        // Wrap the NamespaceTopicMsg in the BroadcastMessage envelope used
+        // on `ns/<id>` topics — the receiver-side dispatch in
+        // `network_event::handle_namespace_governance_delta` unwraps
+        // NamespaceGovernanceDelta and decodes the inner NamespaceTopicMsg.
+        // delta_id/parent_ids are zero/empty since beacons are not DAG content.
+        let inner = match borsh::to_vec(&NamespaceTopicMsg::ReadinessBeacon(beacon)) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::debug!(?err, "ReadinessBeacon: borsh encode (inner) failed");
+                return;
+            }
+        };
+        let envelope = BroadcastMessage::NamespaceGovernanceDelta {
+            namespace_id: ns_id,
+            delta_id: [0u8; 32],
+            parent_ids: Vec::new(),
+            payload: inner,
+        };
         let bytes = match borsh::to_vec(&envelope) {
             Ok(b) => b,
             Err(err) => {
-                tracing::debug!(?err, "ReadinessBeacon: borsh encode failed");
+                tracing::debug!(?err, "ReadinessBeacon: borsh encode (envelope) failed");
                 return;
             }
         };

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -608,3 +608,85 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
         }
     }
 }
+
+/// Per-namespace `tokio::sync::Notify` registry that wakes waiters
+/// blocked on [`ReadinessCache::await_first_fresh_beacon`] when a
+/// beacon arrives.
+///
+/// Lives on `NodeManager` (alongside `readiness_cache`) so the
+/// receiver-side beacon handler in
+/// `handlers::network_event::readiness::handle_readiness_beacon` can
+/// call `notify.notify(ns)` after `cache.insert(&beacon)` without
+/// going through the actor mailbox.
+#[derive(Debug, Default)]
+pub struct ReadinessCacheNotify {
+    waiters: Mutex<HashMap<[u8; 32], Arc<tokio::sync::Notify>>>,
+}
+
+impl ReadinessCacheNotify {
+    /// Get-or-create the per-namespace `Notify`. Cloned so the caller
+    /// holds it across `.await` points without keeping the registry
+    /// lock.
+    pub fn waiter_for(&self, ns: [u8; 32]) -> Arc<tokio::sync::Notify> {
+        let mut g = self.waiters.lock().expect("readiness notify lock");
+        g.entry(ns)
+            .or_insert_with(|| Arc::new(tokio::sync::Notify::new()))
+            .clone()
+    }
+
+    pub fn notify(&self, ns: [u8; 32]) {
+        let g = self.waiters.lock().expect("readiness notify lock");
+        if let Some(n) = g.get(&ns) {
+            n.notify_waiters();
+        }
+    }
+}
+
+impl ReadinessCache {
+    /// Block until a fresh-within-`ttl` beacon for `ns` is available
+    /// in the cache, or `deadline` elapses.
+    ///
+    /// Avoids the classic `Notify` race:
+    /// `tokio::sync::Notify::notify_waiters()` does NOT store a permit
+    /// — it only wakes already-registered waiters. A naive
+    /// `pick_sync_partner` (miss) → `waiter.notified().await` ordering
+    /// would lose any beacon inserted *between* those two steps,
+    /// blocking until the next beacon or `deadline`.
+    ///
+    /// Fix: register the `Notified` future via `enable()` (tokio
+    /// ≥ 1.32) BEFORE the cache check on every iteration. Any
+    /// subsequent `notify_waiters()` then wakes us, even if it fires
+    /// before we reach the `select!`. The race-test
+    /// `await_first_fresh_beacon_resolves_on_late_arrival` exercises
+    /// this exact ordering.
+    pub async fn await_first_fresh_beacon(
+        &self,
+        notify: &ReadinessCacheNotify,
+        ns: [u8; 32],
+        ttl: Duration,
+        deadline: Duration,
+    ) -> Option<(PublicKey, CacheEntry)> {
+        let waiter = notify.waiter_for(ns);
+        let timeout_fut = tokio::time::sleep(deadline);
+        tokio::pin!(timeout_fut);
+        loop {
+            // 1. Create + pin a fresh Notified for this iteration.
+            let notified = waiter.notified();
+            tokio::pin!(notified);
+            // 2. Register without polling. From here on, any
+            //    `notify_waiters()` is guaranteed to wake us, even if
+            //    it fires before we reach the `select!`.
+            notified.as_mut().enable();
+            // 3. Safe to check the cache — beacons arriving between
+            //    `enable()` and the `select!` poll wake the
+            //    (already-registered) future.
+            if let Some(entry) = self.pick_sync_partner(ns, ttl) {
+                return Some(entry);
+            }
+            tokio::select! {
+                _ = notified => { /* loop, re-register, re-check */ }
+                _ = &mut timeout_fut => return None,
+            }
+        }
+    }
+}

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -225,6 +225,24 @@ pub struct ReadinessCache {
 }
 
 impl ReadinessCache {
+    /// Acquire the entries map, recovering from a poisoned mutex.
+    ///
+    /// A `PoisonError` only happens if a previous holder panicked while
+    /// the guard was live; the BTreeMap's invariants are not at risk
+    /// here (no nested invariants between entries), so continuing with
+    /// the inner guard via `into_inner()` is strictly preferable to
+    /// permanently DoSing the readiness subsystem on the first transient
+    /// panic. Mirrors `AckRouter::lock` from PR #2264.
+    fn entries_lock(
+        &self,
+    ) -> std::sync::MutexGuard<'_, BTreeMap<([u8; 32], PublicKey), CacheEntry>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl ReadinessCache {
     /// Insert a beacon into the cache.
     ///
     /// **Verification contract**: this method assumes the beacon has
@@ -270,7 +288,7 @@ impl ReadinessCache {
         }
 
         let now = Instant::now();
-        let mut g = self.entries.lock().expect("readiness cache lock");
+        let mut g = self.entries_lock();
         let key = (beacon.namespace_id, beacon.peer_pubkey);
         if let Some(existing) = g.get(&key) {
             // Drop the beacon if it's older or equal-clock-but-not-fresher.
@@ -307,7 +325,7 @@ impl ReadinessCache {
     }
 
     pub fn fresh_peers(&self, ns: [u8; 32], ttl: Duration) -> Vec<(PublicKey, CacheEntry)> {
-        let g = self.entries.lock().expect("readiness cache lock");
+        let g = self.entries_lock();
         let now = Instant::now();
         g.iter()
             .filter(|((nns, _), e)| *nns == ns && now.duration_since(e.received_at) <= ttl)
@@ -346,7 +364,7 @@ impl ReadinessCache {
     /// `PeerSummary` MUST use this rather than two separate calls to
     /// `max_applied_through` and `fresh_peers`.
     pub fn peer_summary(&self, ns: [u8; 32], ttl: Duration) -> PeerSummary {
-        let g = self.entries.lock().expect("readiness cache lock");
+        let g = self.entries_lock();
         let now = Instant::now();
         let mut max_applied: Option<u64> = None;
         let mut any_fresh = false;
@@ -558,40 +576,52 @@ impl Handler<LocalStateChanged> for ReadinessManager {
     type Result = ();
 
     fn handle(&mut self, msg: LocalStateChanged, _ctx: &mut Self::Context) {
-        let entry = self
-            .state_per_namespace
-            .entry(msg.namespace_id)
-            .or_insert_with(|| ReadinessState {
-                tier: ReadinessTier::Bootstrapping,
-                local_applied_through: 0,
-                local_head: [0u8; 32],
-                local_pending_ops: 0,
-                subscribed_at: Instant::now(),
-            });
-        entry.local_applied_through = msg.local_applied_through;
-        entry.local_head = msg.local_head;
-        entry.local_pending_ops = msg.local_pending_ops;
-
         // Atomic single-lock snapshot — see ReadinessCache::peer_summary
         // for why peer_summary is the only correct source for PeerSummary.
         let peers = self
             .cache
             .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
-        let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
-        if new_tier != entry.tier {
-            entry.tier = new_tier;
-            // Edge trigger: a tier transition into *Ready warrants an
-            // immediate beacon so peers see our promotion without waiting
-            // for the next freshness tick. The clone-then-emit pattern
-            // mirrors `emit_periodic_beacons` and keeps `publish_beacon`
-            // free of borrows on `state_per_namespace`.
-            if matches!(
-                new_tier,
-                ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
-            ) {
-                let snapshot = entry.clone();
-                self.publish_beacon(msg.namespace_id, &snapshot);
+
+        // Scoped borrow on `state_per_namespace`: compute next tier,
+        // mutate the entry, snapshot for emission. The borrow ends at
+        // the end of this block so `clear_probe_window_for` and
+        // `publish_beacon` can re-borrow `self` afterwards.
+        let to_emit = {
+            let entry = self
+                .state_per_namespace
+                .entry(msg.namespace_id)
+                .or_insert_with(|| ReadinessState {
+                    tier: ReadinessTier::Bootstrapping,
+                    local_applied_through: 0,
+                    local_head: [0u8; 32],
+                    local_pending_ops: 0,
+                    subscribed_at: Instant::now(),
+                });
+            entry.local_applied_through = msg.local_applied_through;
+            entry.local_head = msg.local_head;
+            entry.local_pending_ops = msg.local_pending_ops;
+            let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
+            if new_tier != entry.tier {
+                entry.tier = new_tier;
+                // Edge trigger: a tier transition into *Ready warrants
+                // an immediate beacon so peers see our promotion without
+                // waiting for the next freshness tick.
+                if matches!(
+                    new_tier,
+                    ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
+                ) {
+                    Some(entry.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
             }
+        };
+
+        if let Some(snapshot) = to_emit {
+            self.clear_probe_window_for(msg.namespace_id);
+            self.publish_beacon(msg.namespace_id, &snapshot);
         }
     }
 }
@@ -613,12 +643,24 @@ impl Handler<EmitOutOfCycleBeacon> for ReadinessManager {
 
     fn handle(&mut self, msg: EmitOutOfCycleBeacon, _ctx: &mut Self::Context) {
         // Rate-limit probe responses per (peer, namespace) at
-        // `BEACON_INTERVAL / 2` to close the unsigned-`ReadinessProbe`
-        // traffic-amplification path: one ~48-byte probe would otherwise
-        // trigger one ~200-byte signed beacon from EVERY *Ready peer on
-        // the topic (≈Nx amplification). Bypass via varying `nonce` is
-        // blocked because the rate-limit key is (peer, namespace), not
-        // probe content.
+        // `BEACON_INTERVAL / 2` to close BOTH:
+        // - The traffic-amplification path: one ~48-byte unsigned probe
+        //   would otherwise trigger one ~200-byte signed beacon from
+        //   EVERY *Ready peer on the topic (≈Nx amplification).
+        // - The mailbox-CPU path: even when we drop on tier (non-Ready),
+        //   each probe from the same peer still costs a HashMap lookup
+        //   + state lookup. Applying the rate-limit FIRST short-circuits
+        //   on the timestamp before the tier check.
+        //
+        // Bypass via varying `nonce` is blocked because the rate-limit
+        // key is (peer, namespace), not probe content.
+        //
+        // Tier-promotion fairness: if we drop a probe due to non-Ready
+        // tier, we still record `last_probe_response_at` so the same
+        // peer cannot poll us into pathological recheck rates. After a
+        // tier transition into *Ready, `last_probe_response_at` for
+        // affected (peer, ns) is cleared in `LocalStateChanged` /
+        // `ApplyBeaconLocal` so a later probe immediately gets a beacon.
         let now = Instant::now();
         let min_spacing = self.config.beacon_interval / 2;
         let key = (msg.requesting_peer, msg.namespace_id);
@@ -627,6 +669,7 @@ impl Handler<EmitOutOfCycleBeacon> for ReadinessManager {
                 return; // within rate-limit window — drop silently
             }
         }
+
         // Snapshot-then-emit so `publish_beacon` does not borrow
         // `state_per_namespace` across the call (it loads identity from
         // `self.datastore`).
@@ -637,16 +680,27 @@ impl Handler<EmitOutOfCycleBeacon> for ReadinessManager {
                     ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
                 ) =>
             {
-                s.clone()
+                Some(s.clone())
             }
-            // Either no state for this namespace or not in a *Ready tier —
-            // nothing to advertise, drop the probe silently. Don't update
-            // `last_probe_response_at` so a later probe after we promote
-            // is not silently rate-limited.
-            _ => return,
+            _ => None,
         };
-        self.publish_beacon(msg.namespace_id, &snapshot);
+        // Stamp BEFORE potential publish: the rate-limit budget is
+        // consumed by *this probe* regardless of whether we publish.
         let _ = self.last_probe_response_at.insert(key, now);
+        if let Some(snapshot) = snapshot {
+            self.publish_beacon(msg.namespace_id, &snapshot);
+        }
+    }
+}
+
+impl ReadinessManager {
+    /// Clear rate-limit timestamps for `ns_id` after a tier transition
+    /// into a *Ready variant so a probe that arrives shortly after the
+    /// promotion gets a fresh beacon instead of being silently dropped
+    /// by the still-running rate-limit window.
+    fn clear_probe_window_for(&mut self, ns_id: [u8; 32]) {
+        self.last_probe_response_at
+            .retain(|(_, key_ns), _| *key_ns != ns_id);
     }
 }
 
@@ -665,15 +719,22 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
             .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
         let new_tier = evaluate_readiness(&state, &peers, &self.config, Instant::now());
         if new_tier != state.tier {
-            if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
+            let snapshot = if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
                 s.tier = new_tier;
                 if matches!(
                     new_tier,
                     ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
                 ) {
-                    let snapshot = s.clone();
-                    self.publish_beacon(msg.namespace_id, &snapshot);
+                    Some(s.clone())
+                } else {
+                    None
                 }
+            } else {
+                None
+            };
+            if let Some(snapshot) = snapshot {
+                self.clear_probe_window_for(msg.namespace_id);
+                self.publish_beacon(msg.namespace_id, &snapshot);
             }
         }
     }
@@ -694,18 +755,29 @@ pub struct ReadinessCacheNotify {
 }
 
 impl ReadinessCacheNotify {
+    /// Acquire the waiters map, recovering from a poisoned mutex.
+    /// See [`ReadinessCache::entries_lock`] for rationale (mirrors
+    /// `AckRouter::lock` from PR #2264).
+    fn waiters_lock(
+        &self,
+    ) -> std::sync::MutexGuard<'_, HashMap<[u8; 32], Arc<tokio::sync::Notify>>> {
+        self.waiters
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// Get-or-create the per-namespace `Notify`. Cloned so the caller
     /// holds it across `.await` points without keeping the registry
     /// lock.
     pub fn waiter_for(&self, ns: [u8; 32]) -> Arc<tokio::sync::Notify> {
-        let mut g = self.waiters.lock().expect("readiness notify lock");
+        let mut g = self.waiters_lock();
         g.entry(ns)
             .or_insert_with(|| Arc::new(tokio::sync::Notify::new()))
             .clone()
     }
 
     pub fn notify(&self, ns: [u8; 32]) {
-        let g = self.waiters.lock().expect("readiness notify lock");
+        let g = self.waiters_lock();
         if let Some(n) = g.get(&ns) {
             n.notify_waiters();
         }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -25,6 +25,7 @@ use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
 use libp2p::PeerId;
+use zeroize::Zeroize;
 
 #[cfg(test)]
 mod tests;
@@ -496,7 +497,14 @@ impl ReadinessManager {
                     return;
                 }
             };
-        let (peer_pubkey, sk_bytes, _sender_key) = identity;
+        let (peer_pubkey, mut sk_bytes, mut sender_key) = identity;
+        // `sender_key` is unused on the beacon path — zeroize immediately.
+        // `sk_bytes` is consumed into `PrivateKey::from(...)` below;
+        // because `[u8; 32]: Copy`, that "move" actually leaves a copy
+        // of the bytes on the stack here, so we explicitly zeroize the
+        // local AFTER the signing block. `PrivateKey`'s `Drop` impl
+        // zeroizes its own internal copy.
+        sender_key.zeroize();
 
         let strong = matches!(state.tier, ReadinessTier::PeerValidatedReady);
         let ts_millis = std::time::SystemTime::now()
@@ -523,6 +531,10 @@ impl ReadinessManager {
             }
         };
         let signing_key = calimero_primitives::identity::PrivateKey::from(sk_bytes);
+        // Wipe the stack copy that `Copy`-move-into-PrivateKey left
+        // behind. `signing_key` itself is dropped at the end of the
+        // function and zeroizes via its own `Drop` impl.
+        sk_bytes.zeroize();
         let signature = match signing_key.sign(&signable) {
             Ok(sig) => sig.to_bytes(),
             Err(err) => {

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -351,13 +351,6 @@ impl ReadinessCache {
         })
     }
 
-    pub fn max_applied_through(&self, ns: [u8; 32], ttl: Duration) -> Option<u64> {
-        self.fresh_peers(ns, ttl)
-            .into_iter()
-            .map(|(_, e)| e.applied_through)
-            .max()
-    }
-
     /// Atomic snapshot — `max_applied_through` and `heard_recent_beacon`
     /// are read under a single lock acquisition so the FSM's match arms
     /// cannot observe a torn state (e.g. `heard_recent_beacon=true`
@@ -442,6 +435,25 @@ pub struct LocalStateChanged {
     pub local_applied_through: u64,
     pub local_head: [u8; 32],
     pub local_pending_ops: usize,
+}
+
+/// A single namespace governance op was successfully applied locally.
+///
+/// Sent from the receiver-side network-event handler after a
+/// `NamespaceApplyOutcome::Applied`. The actor increments its own
+/// per-namespace `local_applied_through` counter — this is the single
+/// progress signal the FSM needs to leave `Bootstrapping` and start
+/// emitting beacons.
+///
+/// The actor maintains the count internally (not the caller) because
+/// the count exists nowhere else in the codebase: `apply_signed_namespace_op`
+/// doesn't return a new height, and the namespace DAG doesn't expose a
+/// monotonic apply counter. Keeping the count on the actor keeps the
+/// scope minimal.
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct NamespaceOpApplied {
+    pub namespace_id: [u8; 32],
 }
 
 impl ReadinessManager {
@@ -648,6 +660,56 @@ impl Handler<LocalStateChanged> for ReadinessManager {
 pub struct EmitOutOfCycleBeacon {
     pub namespace_id: [u8; 32],
     pub requesting_peer: PeerId,
+}
+
+impl Handler<NamespaceOpApplied> for ReadinessManager {
+    type Result = ();
+
+    fn handle(&mut self, msg: NamespaceOpApplied, _ctx: &mut Self::Context) {
+        // Atomic single-lock snapshot — see ReadinessCache::peer_summary
+        // for why peer_summary is the only correct source for PeerSummary.
+        let peers = self
+            .cache
+            .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
+
+        // Increment the per-namespace local apply counter, then re-evaluate
+        // FSM and edge-emit on transition into a *Ready tier. Uses the
+        // same scoped-borrow pattern as Handler<LocalStateChanged> so
+        // `clear_probe_window_for` and `publish_beacon` can re-borrow
+        // self after the entry borrow ends.
+        let to_emit = {
+            let entry = self
+                .state_per_namespace
+                .entry(msg.namespace_id)
+                .or_insert_with(|| ReadinessState {
+                    tier: ReadinessTier::Bootstrapping,
+                    local_applied_through: 0,
+                    local_head: [0u8; 32],
+                    local_pending_ops: 0,
+                    subscribed_at: Instant::now(),
+                });
+            entry.local_applied_through = entry.local_applied_through.saturating_add(1);
+            let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
+            if new_tier != entry.tier {
+                entry.tier = new_tier;
+                if matches!(
+                    new_tier,
+                    ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
+                ) {
+                    Some(entry.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some(snapshot) = to_emit {
+            self.clear_probe_window_for(msg.namespace_id);
+            self.publish_beacon(msg.namespace_id, &snapshot);
+        }
+    }
 }
 
 impl Handler<EmitOutOfCycleBeacon> for ReadinessManager {

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -333,3 +333,63 @@ fn peer_summary_excludes_stale_and_returns_none_after_ttl() {
     assert!(!s.heard_recent_beacon);
     assert_eq!(s.max_applied_through, None);
 }
+
+#[tokio::test]
+async fn await_first_fresh_beacon_resolves_immediately_when_cached() {
+    let cache = ReadinessCache::default();
+    let notify = ReadinessCacheNotify::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    cache.insert(&make_beacon(pk, 5, true));
+    let got = cache
+        .await_first_fresh_beacon(
+            &notify,
+            [42u8; 32],
+            Duration::from_secs(60),
+            Duration::from_secs(5),
+        )
+        .await;
+    assert!(got.is_some());
+}
+
+#[tokio::test]
+async fn await_first_fresh_beacon_resolves_on_late_arrival() {
+    // The race-fix test: spawns a writer that inserts AFTER the awaiter
+    // has registered its `Notified` future via `enable()`. Without the
+    // `enable()`-before-cache-check ordering, the wake fired by
+    // `notify_waiters()` would be lost (Notify stores no permit) and
+    // the awaiter would block until the timeout.
+    let cache = std::sync::Arc::new(ReadinessCache::default());
+    let notify = std::sync::Arc::new(ReadinessCacheNotify::default());
+    let cache_w = cache.clone();
+    let notify_w = notify.clone();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let _ = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cache_w.insert(&make_beacon(pk, 7, true));
+        notify_w.notify([42u8; 32]);
+    });
+    let got = cache
+        .await_first_fresh_beacon(
+            &notify,
+            [42u8; 32],
+            Duration::from_secs(60),
+            Duration::from_secs(2),
+        )
+        .await;
+    assert!(got.is_some());
+}
+
+#[tokio::test]
+async fn await_first_fresh_beacon_times_out() {
+    let cache = ReadinessCache::default();
+    let notify = ReadinessCacheNotify::default();
+    let got = cache
+        .await_first_fresh_beacon(
+            &notify,
+            [42u8; 32],
+            Duration::from_secs(60),
+            Duration::from_millis(50),
+        )
+        .await;
+    assert!(got.is_none());
+}

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -1,3 +1,6 @@
+use calimero_context_client::local_governance::SignedReadinessBeacon;
+use calimero_primitives::identity::PrivateKey;
+
 use super::*;
 
 fn base_state() -> ReadinessState {
@@ -143,4 +146,190 @@ fn applied_through_grace_prevents_thrashing() {
     };
     let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
     assert_eq!(result, ReadinessTier::PeerValidatedReady);
+}
+
+fn make_beacon(pk: PublicKey, applied_through: u64, strong: bool) -> SignedReadinessBeacon {
+    SignedReadinessBeacon {
+        namespace_id: [42u8; 32],
+        peer_pubkey: pk,
+        dag_head: [9u8; 32],
+        applied_through,
+        ts_millis: 0,
+        strong,
+        signature: [0u8; 64],
+    }
+}
+
+#[test]
+fn pick_sync_partner_prefers_strong_over_locally_ready() {
+    let cache = ReadinessCache::default();
+    let weak_pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let strong_pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    cache.insert(&make_beacon(weak_pk, 100, false));
+    cache.insert(&make_beacon(strong_pk, 50, true));
+    let pick = cache
+        .pick_sync_partner([42u8; 32], Duration::from_secs(60))
+        .unwrap();
+    assert_eq!(
+        pick.0, strong_pk,
+        "strong=true beats higher applied_through if strong=false"
+    );
+}
+
+#[test]
+fn pick_sync_partner_among_strong_picks_highest_applied_through() {
+    let cache = ReadinessCache::default();
+    let pk_a = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let pk_b = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    cache.insert(&make_beacon(pk_a, 5, true));
+    cache.insert(&make_beacon(pk_b, 10, true));
+    let pick = cache
+        .pick_sync_partner([42u8; 32], Duration::from_secs(60))
+        .unwrap();
+    assert_eq!(pick.0, pk_b);
+}
+
+#[test]
+fn pick_sync_partner_excludes_stale_entries() {
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    cache.insert(&make_beacon(pk, 5, true));
+    // Wait beyond TTL by setting a very small TTL on the query.
+    std::thread::sleep(Duration::from_millis(10));
+    let pick = cache.pick_sync_partner([42u8; 32], Duration::from_millis(5));
+    assert!(pick.is_none());
+}
+
+#[test]
+fn pick_sync_partner_empty_cache_returns_none() {
+    let cache = ReadinessCache::default();
+    assert!(cache
+        .pick_sync_partner([42u8; 32], Duration::from_secs(60))
+        .is_none());
+}
+
+#[test]
+fn insert_drops_stale_beacon_from_same_peer() {
+    // Regression: gossipsub out-of-order delivery must not stale-overwrite
+    // a fresher entry. The fresher beacon's `applied_through` and
+    // `ts_millis` should remain after the older beacon arrives second.
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let mut fresh = make_beacon(pk, 100, true);
+    fresh.ts_millis = 2000;
+    let mut stale = make_beacon(pk, 50, true);
+    stale.ts_millis = 1000;
+    cache.insert(&fresh);
+    cache.insert(&stale); // arrives second but is older — must be dropped
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert_eq!(
+        s.max_applied_through,
+        Some(100),
+        "stale beacon must not overwrite fresher entry from same peer",
+    );
+}
+
+#[test]
+fn insert_accepts_newer_beacon_from_same_peer() {
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let mut older = make_beacon(pk, 50, true);
+    older.ts_millis = 1000;
+    let mut newer = make_beacon(pk, 100, true);
+    newer.ts_millis = 2000;
+    cache.insert(&older);
+    cache.insert(&newer); // arrives second and IS newer — must replace
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert_eq!(s.max_applied_through, Some(100));
+}
+
+#[test]
+fn insert_rejects_far_future_ts_millis() {
+    // Cache-poisoning regression: a malicious or clock-skewed member could
+    // sign a beacon with `ts_millis = year 2100`, then every legitimate
+    // beacon would be rejected as "older". MAX_BEACON_CLOCK_DRIFT_MS (60s)
+    // bounds the damage.
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let mut poison = make_beacon(pk, 999, true);
+    poison.ts_millis = now_ms + 600_000; // 10 minutes ahead — well beyond 60s drift
+    cache.insert(&poison);
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert_eq!(
+        s.max_applied_through, None,
+        "far-future beacon must be rejected to prevent cache poisoning"
+    );
+    // A legitimate beacon afterwards should be accepted normally.
+    let mut legit = make_beacon(pk, 42, true);
+    legit.ts_millis = now_ms;
+    cache.insert(&legit);
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert_eq!(s.max_applied_through, Some(42));
+}
+
+#[test]
+fn insert_accepts_ts_millis_within_clock_drift_window() {
+    // 30s ahead is within the 60s drift window — should be accepted.
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let mut b = make_beacon(pk, 17, true);
+    b.ts_millis = now_ms + 30_000;
+    cache.insert(&b);
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert_eq!(s.max_applied_through, Some(17));
+}
+
+#[test]
+fn insert_uses_applied_through_to_break_ts_millis_ties() {
+    // Same wall-clock millis (rare but possible across reboots / clock
+    // skew): the higher applied_through wins.
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    let mut a = make_beacon(pk, 10, true);
+    a.ts_millis = 1000;
+    let mut b = make_beacon(pk, 20, true);
+    b.ts_millis = 1000;
+    cache.insert(&a);
+    cache.insert(&b);
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert_eq!(s.max_applied_through, Some(20));
+}
+
+#[test]
+fn peer_summary_atomic_when_fresh_peer_present() {
+    // Snapshot must always have heard_recent_beacon == true ⇒
+    // max_applied_through.is_some().
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    cache.insert(&make_beacon(pk, 7, true));
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert!(s.heard_recent_beacon);
+    assert_eq!(s.max_applied_through, Some(7));
+}
+
+#[test]
+fn peer_summary_no_fresh_peers_returns_none_and_false() {
+    let cache = ReadinessCache::default();
+    let s = cache.peer_summary([42u8; 32], Duration::from_secs(60));
+    assert!(!s.heard_recent_beacon);
+    assert_eq!(s.max_applied_through, None);
+}
+
+#[test]
+fn peer_summary_excludes_stale_and_returns_none_after_ttl() {
+    let cache = ReadinessCache::default();
+    let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
+    cache.insert(&make_beacon(pk, 9, false));
+    std::thread::sleep(Duration::from_millis(10));
+    let s = cache.peer_summary([42u8; 32], Duration::from_millis(5));
+    assert!(!s.heard_recent_beacon);
+    assert_eq!(s.max_applied_through, None);
 }

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -7,7 +7,6 @@ fn base_state() -> ReadinessState {
     ReadinessState {
         tier: ReadinessTier::Bootstrapping,
         local_applied_through: 5,
-        local_head: [0u8; 32],
         local_pending_ops: 0,
         subscribed_at: Instant::now(),
     }

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -1,0 +1,146 @@
+use super::*;
+
+fn base_state() -> ReadinessState {
+    ReadinessState {
+        tier: ReadinessTier::Bootstrapping,
+        local_applied_through: 5,
+        local_head: [0u8; 32],
+        local_pending_ops: 0,
+        subscribed_at: Instant::now(),
+    }
+}
+
+#[test]
+fn bootstrapping_to_peer_validated_when_caught_up_with_peer() {
+    let state = base_state();
+    let peers = PeerSummary {
+        max_applied_through: Some(5),
+        heard_recent_beacon: true,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert_eq!(result, ReadinessTier::PeerValidatedReady);
+}
+
+#[test]
+fn bootstrapping_to_catching_up_when_behind_peer() {
+    let state = base_state();
+    let peers = PeerSummary {
+        max_applied_through: Some(10),
+        heard_recent_beacon: true,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    // CatchingUp now carries the target — verify both the variant and the
+    // value so a regression that loses the target wouldn't pass with a
+    // `matches!(_, _ { .. })` wildcard.
+    assert_eq!(
+        result,
+        ReadinessTier::CatchingUp {
+            target_applied_through: 10
+        }
+    );
+}
+
+#[test]
+fn bootstrapping_to_locally_ready_after_boot_grace_with_no_peers() {
+    let state = ReadinessState {
+        subscribed_at: Instant::now() - Duration::from_secs(11),
+        ..base_state()
+    };
+    let peers = PeerSummary {
+        max_applied_through: None,
+        heard_recent_beacon: false,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert_eq!(result, ReadinessTier::LocallyReady);
+}
+
+#[test]
+fn empty_dag_with_no_beacon_stays_bootstrapping() {
+    let state = ReadinessState {
+        local_applied_through: 0,
+        subscribed_at: Instant::now() - Duration::from_secs(60),
+        ..base_state()
+    };
+    let peers = PeerSummary {
+        max_applied_through: None,
+        heard_recent_beacon: false,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert_eq!(result, ReadinessTier::Bootstrapping);
+}
+
+#[test]
+fn empty_dag_with_peer_beacon_transitions_to_catching_up() {
+    // Empty-DAG joiner that hears a peer beacon must move to CatchingUp so
+    // backfill begins, and the variant must carry the peer's
+    // applied_through as the target.
+    let state = ReadinessState {
+        local_applied_through: 0,
+        subscribed_at: Instant::now() - Duration::from_secs(60),
+        ..base_state()
+    };
+    let peers = PeerSummary {
+        max_applied_through: Some(7),
+        heard_recent_beacon: true,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert_eq!(
+        result,
+        ReadinessTier::CatchingUp {
+            target_applied_through: 7
+        }
+    );
+}
+
+#[test]
+fn empty_dag_never_promotes_to_locally_ready_after_boot_grace() {
+    // Even after boot grace with no peers, an empty DAG must NOT
+    // self-promote.
+    let state = ReadinessState {
+        local_applied_through: 0,
+        subscribed_at: Instant::now() - Duration::from_secs(3600),
+        ..base_state()
+    };
+    let peers = PeerSummary {
+        max_applied_through: None,
+        heard_recent_beacon: false,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert_eq!(result, ReadinessTier::Bootstrapping);
+}
+
+#[test]
+fn pending_ops_always_demotes_to_degraded() {
+    let state = ReadinessState {
+        local_pending_ops: 3,
+        ..base_state()
+    };
+    let peers = PeerSummary {
+        max_applied_through: Some(5),
+        heard_recent_beacon: true,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    // Degraded now carries the reason — verify the count flows through
+    // verbatim.
+    assert_eq!(
+        result,
+        ReadinessTier::Degraded {
+            reason: DemotionReason::PendingOps(3)
+        }
+    );
+}
+
+#[test]
+fn applied_through_grace_prevents_thrashing() {
+    // Local at 8, peer at 9, grace=2 → still ready (8 + 2 >= 9).
+    let state = ReadinessState {
+        local_applied_through: 8,
+        ..base_state()
+    };
+    let peers = PeerSummary {
+        max_applied_through: Some(9),
+        heard_recent_beacon: true,
+    };
+    let result = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert_eq!(result, ReadinessTier::PeerValidatedReady);
+}

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -255,6 +255,7 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
         sync_manager.clone(),
         context_client.clone(),
         node_client.clone(),
+        datastore.clone(),
         node_state.clone(),
     );
 


### PR DESCRIPTION
## Summary

Phases 6, 7 and 8 of the three-phase governance contract permanent fix
for #2237. Lands the per-namespace **readiness beacon** infrastructure
that closes the cold-start gap between joining a namespace and being
able to publish governance ops without losing them to gossipsub's
GRAFT handshake.

**Status: ready for review.** All implementation phases complete, all
review-bot findings + my own `/code-review:code-review` findings
resolved.

## Phase scope

### Phase 6 — Readiness FSM + Cache (pure types)

- `crates/node/src/readiness.rs` — `ReadinessTier` (data-carrying
  variants), `ReadinessState`, `ReadinessConfig`, `PeerSummary`,
  `evaluate_readiness` total transition fn.
- `ReadinessCache` with monotonic `ts_millis` filter,
  `MAX_BEACON_CLOCK_DRIFT_MS = 60s` cache-poisoning guard,
  opportunistic eviction (`2 × drift` window), atomic `peer_summary`.
  Uses `BTreeMap` because `PublicKey` derives `Ord` not `Hash` (plan
  deviation, documented).

### Phase 7 — `ReadinessManager` actor + receiver dispatch

- `ReadinessManager` actix actor: periodic beacon emission (filtered
  to `*Ready` tiers), edge-trigger on tier transitions, probe-response
  with `BEACON_INTERVAL / 2` rate limit per (peer, namespace).
- `crates/context/src/governance_broadcast.rs` — `verify_readiness_beacon`
  (sig via canonical `signable_bytes()` from #2260 + member-set check).
- `crates/node/src/handlers/network_event/readiness.rs` — receiver-side
  dispatch wired into `network_event/namespace.rs`. Beacons go straight
  into the cache (bypassing the actor mailbox) then `notify`+`do_send`
  the manager.

### Phase 8 — J6 namespace-join flow

- `crates/node/src/join_namespace.rs` (new module):
  - `join_namespace` (J6 fast path) — provision identity + write minimal
    `GroupMetaValue { admin_identity = inviter, ... }` as a beacon-trust
    seed → subscribe → publish `ReadinessProbe` → `await_first_fresh_beacon`.
  - `await_namespace_ready` (J6 slow path) — `sync_namespace` backfill
    + 3s mesh-wait poll → publish `RootOp::MemberJoined` through the
    three-phase contract.
  - `join_and_wait_ready` — convenience aggregator with
    `join_deadline = min(2s, deadline / 2)` and `ready_deadline = deadline.saturating_sub(start.elapsed())`.
  - `join_namespace_with_retry` — exponential backoff + jitter on
    `JoinError::NoReadyPeers`, attempt deadline clamped by remaining
    budget.
- `ReadinessCacheNotify` + `await_first_fresh_beacon` with the
  `Notified::enable()` race-fix (registers waiter BEFORE the cache
  check, so a beacon arriving in the gap between cache-miss and
  `.await` is not silently lost).

## Plan deviations

- **Cache key shape**: `BTreeMap<([u8; 32], PublicKey), CacheEntry>`
  not `HashMap` (PublicKey derives Eq/Ord, not Hash). O(log n) on a
  per-namespace map ≈ namespace member count.
- **J6 mounting point**: free functions in `crates/node/src/join_namespace.rs`
  taking `(store, node_client, cache, notify, ...)` rather than methods
  on `ContextClient`. Required because `ContextClient` lives in
  `calimero-context-primitives` which cannot depend on
  `calimero-node` where `ReadinessCache` lives — Cargo cycle.
- **`mark_membership_pending`**: not a separate primitive; the
  namespace identity row written by `get_or_create_namespace_identity`
  IS the local pending marker.
- **Beacon-trust seed**: `join_namespace` writes a minimal
  `GroupMetaValue` with the inviter as `admin_identity`. Without this
  trust seed, fresh joiners would have empty member sets and all
  incoming beacons would fail `verify_readiness_beacon` — defeating
  J6. Inviter is admin-signed in the invitation so this is safe;
  other peers' beacons stay unverifiable until backfill applies the
  real DAG state.

## Wire-format note

`SignedReadinessBeacon`, `SignableReadinessBeacon`, `ReadinessProbe`,
and the `NamespaceTopicMsg::ReadinessBeacon`/`ReadinessProbe` variants
shipped with #2260 (signature domain `READINESS_BEACON_SIGN_DOMAIN ||
borsh(SignableReadinessBeacon)`, with field-substitution tamper tests).
Both publishers in this PR wrap the inner `NamespaceTopicMsg` in
`BroadcastMessage::NamespaceGovernanceDelta { namespace_id, delta_id:
[0u8;32], parent_ids: vec![], payload }` matching the
`network_event/namespace.rs` decoder.

## Reviewer-feedback round-trip

- 9 inline meroreviewer threads (Phase 6/7 round) — all resolved,
  see https://github.com/calimero-network/core/pull/2269#issuecomment-4336889258
  for the thread-to-commit map.
- 10 issues from `/code-review:code-review` self-review — all fixed
  in `0e0592ca`, including:
  - Joiner-cannot-verify-any-beacon (J6 design bug — beacon-trust seed)
  - Mutex `.expect()` poison-recovery (7 sites, mirrors AckRouter)
  - Missing `namespace_id` cross-check on beacon/probe arms
  - `sk_bytes` zeroize discipline
  - `ready_deadline` elapsed vs allocation
  - `assert_transport_ready` cold-start mesh-wait
  - 500ms-deadline split bug
  - Import order in `manager.rs`
  - `EmitOutOfCycleBeacon` rate-limit ordering (pre-tier check)
  - Module/function doc accuracy

## Test plan

- [x] `cargo build -p calimero-node` clean
- [x] `cargo test -p calimero-node --lib` — 77/77 pass (20 readiness
  unit tests + 3 verify_readiness_beacon + existing 54)
- [x] `cargo clippy -p calimero-node --lib --tests -- -A warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI workflow tests
- [ ] Multi-node e2e test for `join_and_wait_ready` against a warm
  namespace (deferred to a follow-up — fixture work needed)

## Observable behavior

End-to-end testable via the `join_namespace` → `await_namespace_ready`
path:
- Joiner publishes a `ReadinessProbe` on `ns/<id>`.
- Warm peer's `EmitOutOfCycleBeacon` handler responds with a signed
  beacon (rate-limited to `BEACON_INTERVAL/2` per (peer, namespace)).
- Joiner verifies (sig + inviter-as-admin trust seed), inserts to
  cache, wakes the `await_first_fresh_beacon` future.
- Joiner runs backfill via `sync_namespace`, polls the namespace mesh
  briefly, then publishes `RootOp::MemberJoined` via the three-phase
  contract.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new readiness-beacon networking paths, a new actor/FSM, and a new namespace-join workflow that affects gossip handling and governance publishing behavior; bugs here could impact join reliability or allow cache pollution despite added verification checks.
> 
> **Overview**
> Implements the *readiness beacon* infrastructure to reduce cold-start drops when joining/publishing governance ops. This adds `verify_readiness_beacon` (signature + namespace-membership check) and tests, and wires `NamespaceTopicMsg::ReadinessBeacon`/`ReadinessProbe` handling into the node’s namespace-topic dispatch with topic/namespace cross-checks.
> 
> Introduces a new `ReadinessManager` actor with a per-namespace readiness FSM, shared `ReadinessCache` + `Notify` wakeups, periodic/edge-trigger beacon emission, and probe-triggered out-of-cycle beacons with per-(peer,namespace) rate limiting; namespace-op application now notifies the FSM (`NamespaceOpApplied`) so it can advance and emit.
> 
> Adds a J6 namespace-join module (`join_namespace`, `await_namespace_ready`, `join_and_wait_ready`, `join_namespace_with_retry`) that subscribes, probes for beacons, seeds minimal trust metadata for initial beacon verification, waits for a fresh beacon, triggers backfill, polls for mesh readiness, then publishes `RootOp::MemberJoined` via the existing three-phase publish/ack contract. Node wiring is updated to mount the readiness manager on startup and pass a `Store` handle through `NodeManager` construction; docs and dependencies are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4b197b9d3cb6aebc44361dbe5a25762a49a68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->