### PR TITLE
feat(governance): KeyDelivery + handler observability + cleanup — Phases 9-12 (#2237)

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -111,29 +111,22 @@ jobs:
       - name: Run e2e-kv-store Workflow
         id: run_e2e_kv_store
         run: |
+          # Phase 11.3 (#2237): single attempt, fail loud. The retry loop +
+          # `merobox nuke --force` between attempts existed to mask
+          # cold-start governance flakes (#2198, #2225). With the
+          # three-phase contract in place (publish_and_await_ack +
+          # readiness FSM + parent_pull single-peer fallback), a flake
+          # here is a real bug worth surfacing rather than retrying past.
           mkdir -p docker-logs
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-              
-              if merobox bootstrap run \
-                  "workflows/e2e.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/e2e.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           # Collect logs
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
@@ -145,37 +138,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run e2e-kv-store Groups Workflow
         id: run_groups
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/groups.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/groups.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           # Collect logs
           echo "Collecting Docker logs for groups workflow"
@@ -188,37 +164,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run group-3node Workflow
         id: run_group_3node
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/group-3node.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/group-3node.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
               if [ -n "$container" ]; then
@@ -229,37 +188,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run group-context-isolation Workflow
         id: run_group_context_isolation
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/group-context-isolation.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/group-context-isolation.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
               if [ -n "$container" ]; then
@@ -270,37 +212,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run group-late-joiner Workflow
         id: run_group_late_joiner
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/group-late-joiner.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/group-late-joiner.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
               if [ -n "$container" ]; then
@@ -311,37 +236,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run group-subgroup Workflow
         id: run_group_subgroup
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/group-subgroup.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/group-subgroup.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
               if [ -n "$container" ]; then
@@ -352,37 +260,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run group-multi-service Workflow
         id: run_group_multi_service
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/group-multi-service.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/group-multi-service.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
               if [ -n "$container" ]; then
@@ -393,37 +284,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run handler-test Workflow
         id: run_handler_test
         run: |
           cd apps/e2e-kv-store
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/handler-test.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/handler-test.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
               if [ -n "$container" ]; then
@@ -434,37 +308,20 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
-          else
-              echo "failed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Run xcall-example Workflow
         id: run_xcall
         run: |
           cd apps/xcall-example
-          max_attempts=2
-          attempt=1
-          success=false
-
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-
-              if merobox bootstrap run \
-                  "workflows/xcall.yml" \
-                  --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
-                  --e2e-mode; then
-                  success=true
-                  break
-              else
-                  attempt=$((attempt + 1))
-              fi
-          done
+          if merobox bootstrap run \
+              "workflows/xcall.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
+          else
+              failed=true
+          fi
 
           # Collect logs
           for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
@@ -476,11 +333,36 @@ jobs:
           merobox stop --all || true
           merobox nuke --force || true
 
-          if [ "$success" = false ]; then
-              echo "failed=true" >> $GITHUB_OUTPUT
+          echo "failed=$failed" >> $GITHUB_OUTPUT
+
+      - name: Run kv-store-joiner-cold Workflow
+        id: run_joiner_cold
+        run: |
+          # Phase 12.2 (#2237): regression guard for the cold-join →
+          # first-execute window. Verifies that join_context returns with
+          # the group key locally stored, so the joiner's first call to
+          # `set` does not hit the strict "group key not yet delivered"
+          # error path in execute/mod.rs.
+          cd apps/e2e-kv-store
+          if merobox bootstrap run \
+              "workflows/kv-store-joiner-cold.yml" \
+              --image ghcr.io/calimero-network/merod:${{ steps.image-tag.outputs.tag }} \
+              --e2e-mode; then
+              failed=false
           else
-              echo "failed=false" >> $GITHUB_OUTPUT
+              failed=true
           fi
+
+          for container in $(docker ps -a --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null || true); do
+              if [ -n "$container" ]; then
+                  docker logs "$container" > "$GITHUB_WORKSPACE/docker-logs/joiner-cold-${container}.log" 2>&1 || true
+              fi
+          done
+
+          merobox stop --all || true
+          merobox nuke --force || true
+
+          echo "failed=$failed" >> $GITHUB_OUTPUT
 
       - name: Upload Workflow Data Artifacts
         if: ${{ !cancelled() }}
@@ -517,7 +399,8 @@ jobs:
           steps.run_group_subgroup.outputs.failed == 'true' ||
           steps.run_group_multi_service.outputs.failed == 'true' ||
           steps.run_handler_test.outputs.failed == 'true' ||
-          steps.run_xcall.outputs.failed == 'true'
+          steps.run_xcall.outputs.failed == 'true' ||
+          steps.run_joiner_cold.outputs.failed == 'true'
         run: |
           echo "Workflow failures detected:"
           if [ "${{ steps.run_e2e_kv_store.outputs.failed }}" == "true" ]; then
@@ -546,5 +429,8 @@ jobs:
           fi
           if [ "${{ steps.run_xcall.outputs.failed }}" == "true" ]; then
             echo "  - xcall-example workflow failed"
+          fi
+          if [ "${{ steps.run_joiner_cold.outputs.failed }}" == "true" ]; then
+            echo "  - kv-store-joiner-cold workflow failed"
           fi
           exit 1

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -191,6 +191,9 @@ jobs:
           - workflow: shared-storage
             file: workflows/test_shared_storage.yml
             app: kv-store-with-shared-storage
+          - workflow: kv-store-joiner-cold
+            file: workflows/kv-store-joiner-cold.yml
+            app: e2e-kv-store
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -217,11 +220,14 @@ jobs:
 
       - name: Run ${{ matrix.workflow }}
         run: |
+          # Phase 11.3 (#2237): single attempt, fail loud. The retry loop
+          # + `merobox nuke --force` between attempts existed to mask
+          # cold-start governance flakes (#2198, #2225). With the
+          # three-phase contract (publish_and_await_ack + readiness FSM
+          # + parent_pull single-peer fallback) in place, a flake here
+          # is a real bug worth surfacing.
           mkdir -p docker-logs
           cd apps/${{ matrix.app }}
-          max_attempts=2
-          attempt=1
-          success=false
 
           # Start a background watcher that streams `docker logs -f` from
           # each node container to an artifact file as soon as it appears.
@@ -237,22 +243,16 @@ jobs:
           # persists logs natively we'll remove this block (calimero/core#2179).
           LOGDIR="$GITHUB_WORKSPACE/docker-logs"
           WATCHER_STATE_DIR="$(mktemp -d)"
-          # The watcher reads the current attempt from this file each poll so
-          # that (a) retry containers, which are nuked and recreated with the
-          # same names as attempt 1's, get picked up as new followers, and
-          # (b) attempt 1's logs aren't clobbered by attempt 2's output.
-          echo "1" > "$WATCHER_STATE_DIR/attempt"
           (
               while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-                  cur_attempt=$(cat "$WATCHER_STATE_DIR/attempt" 2>/dev/null || echo 1)
                   # Follow containers labeled by merobox, excluding the
                   # short-lived init containers (`*-init`).
                   for c in $(docker ps --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null | grep -v -- '-init$' || true); do
-                      mark="$WATCHER_STATE_DIR/attempt${cur_attempt}-${c}"
+                      mark="$WATCHER_STATE_DIR/${c}"
                       if [ ! -f "$mark" ]; then
                           touch "$mark"
-                          echo "[log-watcher] following $c (attempt $cur_attempt)"
-                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-attempt${cur_attempt}-${c}.log" 2>&1 &
+                          echo "[log-watcher] following $c"
+                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-${c}.log" 2>&1 &
                       fi
                   done
                   sleep 1
@@ -260,26 +260,14 @@ jobs:
           ) &
           WATCHER_PID=$!
 
-          while [ $attempt -le $max_attempts ]; do
-              if [ $attempt -gt 1 ]; then
-                  merobox stop --all || true
-                  merobox nuke --force || true
-                  sleep 2
-              fi
-              # Tell the watcher which attempt we're on; it namespaces its
-              # mark files + log filenames by this so each retry captures
-              # cleanly without clobbering prior-attempt logs.
-              echo "$attempt" > "$WATCHER_STATE_DIR/attempt"
-
-              if merobox bootstrap run \
-                  "${{ matrix.file }}" \
-                  --image merod:local \
-                  --e2e-mode; then
-                  success=true
-                  break
-              fi
-              attempt=$((attempt + 1))
-          done
+          if merobox bootstrap run \
+              "${{ matrix.file }}" \
+              --image merod:local \
+              --e2e-mode; then
+              success=true
+          else
+              success=false
+          fi
 
           # Signal the watcher to stop and give `docker logs -f` followers
           # a moment to flush their final output.
@@ -293,7 +281,7 @@ jobs:
           merobox nuke --force || true
 
           if [ "$success" = false ]; then
-              echo "::error::${{ matrix.workflow }} workflow failed after $max_attempts attempts"
+              echo "::error::${{ matrix.workflow }} workflow failed"
               exit 1
           fi
 
@@ -332,7 +320,7 @@ jobs:
         run: |
           message="## E2E Rust Apps Failed
 
-          One or more E2E workflows (e2e-kv-store, xcall-example) failed after retries.
+          One or more E2E workflows (e2e-kv-store, xcall-example) failed.
 
           Please check the workflow logs for more details."
 

--- a/apps/e2e-kv-store/workflows/kv-store-joiner-cold.yml
+++ b/apps/e2e-kv-store/workflows/kv-store-joiner-cold.yml
@@ -1,0 +1,135 @@
+name: E2E KV Store - Cold Joiner First Execute (#2237)
+description: >
+  Exercises the cold-join → first-execute window that the Phase 9 KeyDelivery
+  wait closes. Node-1 creates a namespace+context and writes data. Node-2 joins
+  the namespace and the context, then IMMEDIATELY calls `set` without an
+  intervening `wait_for_sync`. With the three-phase governance contract in
+  place (publish_and_await_ack + KeyDelivery `required_signers` + the joiner-
+  side `KEY_DELIVERY_FALLBACK_WAIT` in `join_group`), the joiner must hold the
+  group key by the time `join_context` returns, so the immediate `set`
+  succeeds. Without the contract, the call would hit the new strict-error
+  branch in `execute/mod.rs` ("group key not yet delivered") and fail.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: node-1 alone creates namespace and context ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/e2e_kv_store.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create context in namespace on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Node-1 seeds initial state
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "seed"
+      value: "from_node_1"
+
+  # --- Cold join: node-2 joins WITHOUT a settle window ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+
+  - name: Node-2 joins context (KeyDelivery wait must complete inside this call)
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+
+  # --- The critical step: write IMMEDIATELY, no intervening wait_for_sync ---
+  #
+  # This is the regression guard for #2237. Phase 9.2's KEY_DELIVERY_FALLBACK_WAIT
+  # in `join_group` blocks until the group key is locally stored, so the
+  # `execute` call below has the key it needs. Phase 9.3 means a missing key
+  # surfaces as a hard `InternalError` rather than silently mis-encrypting,
+  # so any regression here surfaces as a workflow failure rather than as
+  # silent state divergence detected only by later read-back.
+
+  - name: Node-2 writes immediately after join (cold path)
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "cold_write"
+      value: "node2_first_op"
+
+  # --- Verify cluster convergence (sanity check that crypto wasn't mis-keyed) ---
+
+  - name: Wait for cluster convergence
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 30
+    trigger_sync: true
+
+  - name: Node-1 reads node-2's cold write
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "cold_write"
+    outputs:
+      cold_write_node1: result
+
+  - name: Assert node-2's cold write decrypts correctly on node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{cold_write_node1}}, {"output": "node2_first_op"})'
+
+  - name: Node-2 reads node-1's seed key
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "seed"
+    outputs:
+      seed_node2: result
+
+  - name: Assert node-2 sees node-1's seed
+    type: json_assert
+    statements:
+      - 'json_equal({{seed_node2}}, {"output": "from_node_1"})'
+
+stop_all_nodes: false

--- a/crates/context/src/governance_broadcast.rs
+++ b/crates/context/src/governance_broadcast.rs
@@ -253,6 +253,59 @@ pub struct DeliveryReport {
     pub elapsed_ms: u64,
 }
 
+/// Per-handler delivery observability log.
+///
+/// The publish-boundary helpers
+/// (`NamespaceGovernance::sign_apply_and_publish` and friends) already
+/// log a `tracing::debug!` line carrying op_kind / acks / elapsed_ms —
+/// good enough for protocol-level diagnostics but invisible at the
+/// default `info` log level. Handlers in `crates/context/src/handlers/*`
+/// own the user-facing API surface, so promoting an `info!` line here
+/// gives operators a per-endpoint signal: which API call flaked, on
+/// which namespace, and whether the ack collection landed within the
+/// op timeout. Centralising the log shape keeps every handler emit
+/// identical so log-aggregation queries don't have to special-case the
+/// per-endpoint format.
+///
+/// `acked_by.is_empty()` is logged at `warn!` to highlight cold-start
+/// or GRAFT-window publishes that landed on the wire but didn't gather
+/// confirmation in time. The local DAG advance is durable in either
+/// case — the warn is a hint that downstream peers may need
+/// reconciliation, not a failure indication.
+pub fn observe_handler_delivery(handler: &str, op_kind: &str, report: &DeliveryReport) {
+    let outcome = if report.acked_by.is_empty() {
+        "empty"
+    } else {
+        "acked"
+    };
+    crate::metrics::record_governance_handler_delivery(
+        handler,
+        op_kind,
+        outcome,
+        report.elapsed_ms,
+    );
+    if report.acked_by.is_empty() {
+        tracing::warn!(
+            handler,
+            op_kind,
+            elapsed_ms = report.elapsed_ms,
+            op_hash = %hex::encode(report.op_hash),
+            "governance op published but no acks collected before deadline \
+             (publisher boundary deemed delivery best-effort; receivers will \
+             reconcile via heartbeat)"
+        );
+    } else {
+        tracing::info!(
+            handler,
+            op_kind,
+            acks = report.acked_by.len(),
+            elapsed_ms = report.elapsed_ms,
+            op_hash = %hex::encode(report.op_hash),
+            "governance op delivered"
+        );
+    }
+}
+
 /// Abstraction over the gossipsub transport used by
 /// [`publish_and_await_ack_namespace`]. The blanket impl on
 /// `NetworkClient` covers production callers; unit tests substitute a

--- a/crates/context/src/group_store/governance_signer.rs
+++ b/crates/context/src/group_store/governance_signer.rs
@@ -69,9 +69,16 @@ impl<'a> GovernanceSigner<'a> {
         namespace_id: [u8; 32],
         signer_sk: &PrivateKey,
         op: NamespaceOp,
+        required_signers: Option<Vec<PublicKey>>,
     ) -> EyreResult<DeliveryReport> {
         super::NamespaceGovernance::new(self.store, namespace_id)
-            .sign_and_publish_without_apply(self.node_client, self.ack_router, signer_sk, op)
+            .sign_and_publish_without_apply(
+                self.node_client,
+                self.ack_router,
+                signer_sk,
+                op,
+                required_signers,
+            )
             .await
     }
 }

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -159,6 +159,21 @@ impl<'a> NamespaceGovernance<'a> {
                                                 key_id = %hex::encode(key_id),
                                                 "received group key via KeyDelivery"
                                             );
+                                            // Wake any `join_group` future
+                                            // waiting on the gossip-fallback
+                                            // path. The apply path already
+                                            // filtered by
+                                            // `envelope.recipient ==
+                                            // recipient_sk.public_key()`, so
+                                            // this only fires for our own
+                                            // identity. Emit *before*
+                                            // `retry_encrypted_ops_for_group`
+                                            // so the wake-up isn't blocked
+                                            // by a slow retry pass.
+                                            notify_op_event(OpEvent::GroupKeyDelivered {
+                                                group_id: *group_id,
+                                                recipient: recipient_sk.public_key(),
+                                            });
                                             self.retry_encrypted_ops_for_group(*group_id).map_err(
                                                 |e| {
                                                     eyre::eyre!(
@@ -365,6 +380,7 @@ impl<'a> NamespaceGovernance<'a> {
         ack_router: &AckRouter,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
+        required_signers: Option<Vec<PublicKey>>,
     ) -> EyreResult<DeliveryReport> {
         let topic = ns_topic(self.namespace_id);
         let mesh = node_client
@@ -374,8 +390,17 @@ impl<'a> NamespaceGovernance<'a> {
         assert_transport_ready(mesh, known, node_client.gossipsub_mesh_n_low())
             .map_err(|e| eyre::eyre!(e))?;
 
-        self.publish_post_gate(node_client, ack_router, signer_sk, op, topic, mesh, known)
-            .await
+        self.publish_post_gate(
+            node_client,
+            ack_router,
+            signer_sk,
+            op,
+            topic,
+            mesh,
+            known,
+            required_signers,
+        )
+        .await
     }
 
     /// Caller-gated variant of [`sign_and_publish_without_apply`]: assumes
@@ -396,8 +421,17 @@ impl<'a> NamespaceGovernance<'a> {
         known: usize,
     ) -> EyreResult<DeliveryReport> {
         let topic = ns_topic(self.namespace_id);
-        self.publish_post_gate(node_client, ack_router, signer_sk, op, topic, mesh, known)
-            .await
+        self.publish_post_gate(
+            node_client,
+            ack_router,
+            signer_sk,
+            op,
+            topic,
+            mesh,
+            known,
+            None,
+        )
+        .await
     }
 
     /// Shared body of [`sign_and_publish_without_apply`] and
@@ -416,6 +450,7 @@ impl<'a> NamespaceGovernance<'a> {
         topic: TopicHash,
         mesh: usize,
         known_at_gate: usize,
+        required_signers: Option<Vec<PublicKey>>,
     ) -> EyreResult<DeliveryReport> {
         let head = self.read_head_record()?;
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
@@ -467,7 +502,7 @@ impl<'a> NamespaceGovernance<'a> {
             signed,
             op_timeout,
             min_acks,
-            None,
+            required_signers,
         )
         .await
         .map_err(|e| eyre::eyre!(e))?;
@@ -938,9 +973,10 @@ pub async fn sign_and_publish_namespace_op(
     namespace_id: [u8; 32],
     signer_sk: &PrivateKey,
     op: NamespaceOp,
+    required_signers: Option<Vec<PublicKey>>,
 ) -> EyreResult<DeliveryReport> {
     NamespaceGovernance::new(store, namespace_id)
-        .sign_and_publish_without_apply(node_client, ack_router, signer_sk, op)
+        .sign_and_publish_without_apply(node_client, ack_router, signer_sk, op, required_signers)
         .await
 }
 

--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -5,6 +5,7 @@ use calimero_context_client::group::AddGroupMembersRequest;
 use calimero_context_client::local_governance::{GroupOp, NamespaceOp, RootOp};
 use tracing::{info, warn};
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -35,7 +36,7 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
         ActorResponse::r#async(
             async move {
                 for (identity, role) in &members {
-                    let _report = group_store::sign_apply_and_publish(
+                    let report = group_store::sign_apply_and_publish(
                         &datastore,
                         &node_client,
                         &ack_router,
@@ -47,6 +48,9 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                         },
                     )
                     .await?;
+                    if let Some(report) = report.as_ref() {
+                        observe_handler_delivery("add_group_members", "MemberAdded", report);
+                    }
 
                     if let Some((_key_id, group_key)) =
                         group_store::load_current_group_key(&datastore, &group_id)?
@@ -58,6 +62,14 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                                     group_id: group_id.to_bytes(),
                                     envelope,
                                 });
+                                // KeyDelivery is recipient-specific: the
+                                // only ack that proves successful delivery
+                                // is from the added member themselves.
+                                // Pass `required_signers = Some([identity])`
+                                // so non-recipient acks are filtered out
+                                // and the report's `acked_by` cleanly
+                                // signals whether the recipient applied
+                                // and acked.
                                 if let Err(e) = group_store::sign_and_publish_namespace_op(
                                     &datastore,
                                     &node_client,
@@ -65,6 +77,7 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                                     ns_id.to_bytes(),
                                     &sk,
                                     delivery_op,
+                                    Some(vec![*identity]),
                                 )
                                 .await
                                 {

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -7,6 +7,7 @@ use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PrivateKey;
 use tracing::info;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -127,7 +128,7 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
                     PrivateKey::from(effective_signing_key.ok_or_else(|| {
                         eyre::eyre!("no signing key available for TEE admission")
                     })?);
-                let _report = group_store::sign_apply_and_publish(
+                let report = group_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -146,6 +147,13 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
                     },
                 )
                 .await?;
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery(
+                        "admit_tee_node",
+                        "MemberJoinedViaTeeAttestation",
+                        report,
+                    );
+                }
 
                 info!(%member, ?group_id, "TEE node admitted via attestation");
                 // Auto-follow flags for the admitted TEE member are

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -24,6 +24,7 @@ use tracing::{debug, warn};
 
 use super::execute::execute;
 use super::execute::storage::{ContextPrivateStorage, ContextStorage};
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::{group_store, ContextManager, ContextMeta};
 
 impl Handler<CreateContextRequest> for ContextManager {
@@ -450,7 +451,7 @@ async fn create_context(
     // worst case is a single context associated with a since-removed member.
     {
         let sk = PrivateKey::from(*identity_secret);
-        let _report = group_store::sign_apply_and_publish(
+        let report = group_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,
@@ -465,6 +466,9 @@ async fn create_context(
             },
         )
         .await?;
+        if let Some(report) = report.as_ref() {
+            observe_handler_delivery("create_context", "ContextRegistered", report);
+        }
     }
 
     // Write ContextIdentity so the sync key-share can find keys for this context.
@@ -484,7 +488,7 @@ async fn create_context(
 
     if let Some(ref alias_str) = alias {
         let sk = PrivateKey::from(*identity_secret);
-        let _report = group_store::sign_apply_and_publish(
+        let report = group_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,
@@ -496,6 +500,9 @@ async fn create_context(
             },
         )
         .await?;
+        if let Some(report) = report.as_ref() {
+            observe_handler_delivery("create_context", "ContextAliasSet", report);
+        }
     }
 
     Ok(context.root_hash)

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -11,6 +11,7 @@ use calimero_store::Store;
 use rand::Rng;
 use tracing::{info, warn};
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -181,7 +182,9 @@ impl Handler<CreateGroupRequest> for ContextManager {
                     )
                     .await
                     {
-                        Ok(_report) => {}
+                        Ok(report) => {
+                            observe_handler_delivery("create_group", "GroupCreated", &report);
+                        }
                         Err(e) => {
                             tracing::warn!(?e, "failed to publish GroupCreated on namespace DAG");
                         }

--- a/crates/context/src/handlers/delete_context.rs
+++ b/crates/context/src/handlers/delete_context.rs
@@ -15,6 +15,7 @@ use eyre::bail;
 
 use calimero_primitives::identity::PrivateKey;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::{group_store, ContextManager};
 
 impl Handler<DeleteContextRequest> for ContextManager {
@@ -133,7 +134,7 @@ async fn delete_context(
                      cannot publish local detach op"
                 )
             })?;
-        let _report = group_store::sign_apply_and_publish(
+        let report = group_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,
@@ -142,6 +143,9 @@ async fn delete_context(
             calimero_context_client::local_governance::GroupOp::ContextDetached { context_id },
         )
         .await?;
+        if let Some(report) = report.as_ref() {
+            observe_handler_delivery("delete_context", "ContextDetached", report);
+        }
     }
 
     Ok(())

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -7,6 +7,7 @@ use calimero_primitives::identity::PrivateKey;
 use eyre::bail;
 use tracing::info;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -106,7 +107,7 @@ impl Handler<DeleteGroupRequest> for ContextManager {
                     cascade_context_ids,
                 });
 
-                let _report = group_store::sign_apply_and_publish_namespace_op(
+                let report = group_store::sign_apply_and_publish_namespace_op(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -115,6 +116,7 @@ impl Handler<DeleteGroupRequest> for ContextManager {
                     op,
                 )
                 .await?;
+                observe_handler_delivery("delete_group", "GroupDeleted", &report);
 
                 // Best-effort unsubscribe — the group is gone now, no point
                 // staying on its topic. Subscriptions for descendants likewise.

--- a/crates/context/src/handlers/detach_context_from_group.rs
+++ b/crates/context/src/handlers/detach_context_from_group.rs
@@ -5,6 +5,7 @@ use calimero_context_client::group::DetachContextFromGroupRequest;
 use calimero_context_client::local_governance::GroupOp;
 use eyre::bail;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -42,7 +43,7 @@ impl Handler<DetachContextFromGroupRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let _report = group_store::sign_apply_and_publish(
+                let report = group_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -51,6 +52,13 @@ impl Handler<DetachContextFromGroupRequest> for ContextManager {
                     GroupOp::ContextDetached { context_id },
                 )
                 .await?;
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery(
+                        "detach_context_from_group",
+                        "ContextDetached",
+                        report,
+                    );
+                }
 
                 Ok(())
             }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -225,15 +225,40 @@ impl Handler<ExecuteRequest> for ContextManager {
                             return ActorResponse::reply(Err(ExecuteError::InternalError));
                         }
                     };
+                    // Group-context branch: the group/namespace key is the
+                    // *authoritative* encryption key. Falling back to
+                    // `identity.sender_key` here would produce ciphertext
+                    // that other group members cannot decrypt — silent
+                    // state divergence across the cluster. With the
+                    // Phase 9 join-time KeyDelivery wait in place, the
+                    // joiner should already hold this key by the time
+                    // they call `execute`. If we get here with no key,
+                    // it's a real "key not yet delivered" condition and
+                    // the caller needs to know — surface it loudly
+                    // rather than silently mis-encrypting.
                     match crate::group_store::load_current_group_key(&self.datastore, &key_group_id)
                     {
                         Ok(Some((kid, gk))) => (PrivateKey::from(gk), kid),
-                        _ => {
-                            if let Some(sk) = identity.sender_key {
-                                (sk, [0u8; 32])
-                            } else {
-                                return ActorResponse::reply(Err(ExecuteError::InternalError));
-                            }
+                        Ok(None) => {
+                            error!(
+                                group_id = ?gid,
+                                key_group_id = ?key_group_id,
+                                ?context_id,
+                                "state-delta encryption: group key not yet delivered \
+                                 (KeyDelivery pending or failed) — refusing sender_key fallback \
+                                 to avoid mis-encrypting for inheritance-eligible receivers"
+                            );
+                            return ActorResponse::reply(Err(ExecuteError::InternalError));
+                        }
+                        Err(err) => {
+                            error!(
+                                group_id = ?gid,
+                                key_group_id = ?key_group_id,
+                                ?context_id,
+                                %err,
+                                "state-delta encryption: load_current_group_key failed",
+                            );
+                            return ActorResponse::reply(Err(ExecuteError::InternalError));
                         }
                     }
                 }

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::{JoinGroupRequest, JoinGroupResponse};
@@ -7,11 +8,23 @@ use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNames
 use calimero_primitives::context::{ContextConfigParams, GroupMemberRole};
 use calimero_primitives::identity::PrivateKey;
 use calimero_store::key;
+use tokio::sync::broadcast::error::RecvError;
 use tracing::{info, warn};
 
+use crate::op_events::subscribe as subscribe_op_events;
+use crate::op_events::OpEvent;
 use crate::{group_store, ContextManager};
 
 const NAMESPACE_MESH_GRACE: Duration = Duration::from_secs(2);
+
+/// Maximum time `join_group` waits on the gossip-fallback path for a
+/// `KeyDelivery` op addressed to the joiner. Reached only when the
+/// direct join response did not carry a key (served peer didn't hold
+/// it, or the direct stream request timed out). The wait fires
+/// after MemberJoined is on the wire, so the bound is "round-trip to
+/// any admin + their `publish_and_await_ack` budget", not the full
+/// gossipsub heartbeat reconciliation window.
+const KEY_DELIVERY_FALLBACK_WAIT: Duration = Duration::from_secs(5);
 
 impl Handler<JoinGroupRequest> for ContextManager {
     type Result = ActorResponse<Self, <JoinGroupRequest as Message>::Result>;
@@ -201,8 +214,36 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     );
                 }
 
+                // The joiner needs the group key to decrypt subsequent
+                // group ops. Two delivery paths converge here:
+                //
+                //   1. Direct stream (`request_namespace_join` above).
+                //      Authoritative when the served peer holds the key.
+                //   2. Gossip `KeyDelivery` from any admin who applies our
+                //      `MemberJoined` op below — Phase 9.1 already targets
+                //      the recipient via `required_signers` so the admin
+                //      knows whether *we* acked.
+                //
+                // If path 1 didn't deliver a key, we fall through to path 2
+                // here and block `join_group` until either a `KeyDelivery`
+                // for our identity arrives or `KEY_DELIVERY_FALLBACK_WAIT`
+                // elapses. Subscribing BEFORE publishing MemberJoined
+                // closes the race where an admin could see our op,
+                // immediately publish KeyDelivery, and have us miss it
+                // before subscribing.
+                let needs_key_wait =
+                    group_store::load_current_group_key(&datastore, &group_id)?.is_none();
+                let mut op_event_rx = if needs_key_wait {
+                    Some(subscribe_op_events())
+                } else {
+                    None
+                };
+
                 // Publish MemberJoined so other namespace members learn
-                // about us (fire-and-forget, the joiner doesn't depend on it).
+                // about us. Joiner can't ack their own op (they're not yet
+                // a recognised member from the receiver's view until the
+                // op applies), so `required_signers = None` here — any
+                // ack from any current member is fine.
                 let member_joined_op = NamespaceOp::Root(RootOp::MemberJoined {
                     member: joiner_identity,
                     signed_invitation: invitation.clone(),
@@ -214,11 +255,76 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     namespace_id,
                     &sk,
                     member_joined_op,
+                    None,
                 )
                 .await
                 {
                     Ok(_report) => {}
                     Err(e) => warn!(?e, "failed to publish MemberJoined (non-fatal)"),
+                }
+
+                if let Some(rx) = op_event_rx.as_mut() {
+                    let deadline = Instant::now() + KEY_DELIVERY_FALLBACK_WAIT;
+                    loop {
+                        // Re-check the store on every iteration: the apply
+                        // path emits the event AFTER `store_group_key`, so
+                        // any successful unwrap is observable as an
+                        // already-stored key by the time we get woken.
+                        // This also catches races where an event was
+                        // dropped via `RecvError::Lagged` before we got to
+                        // it (broadcast channel is process-wide and other
+                        // tasks may flood it).
+                        if group_store::load_current_group_key(&datastore, &group_id)?.is_some() {
+                            info!(
+                                ?group_id,
+                                "group key acquired via gossip KeyDelivery fallback"
+                            );
+                            break;
+                        }
+                        let now = Instant::now();
+                        if now >= deadline {
+                            warn!(
+                                ?group_id,
+                                "timed out waiting for KeyDelivery via gossip fallback; \
+                                 group state will reconcile via heartbeat"
+                            );
+                            break;
+                        }
+                        let remaining = deadline - now;
+                        match tokio::time::timeout(remaining, rx.recv()).await {
+                            Ok(Ok(OpEvent::GroupKeyDelivered {
+                                group_id: g,
+                                recipient,
+                            })) if g == group_id.to_bytes() && recipient == joiner_identity => {
+                                // Loop back to re-read the store — the
+                                // emitter publishes AFTER store_group_key
+                                // succeeded, so the next iteration's
+                                // `load_current_group_key` will hit and
+                                // break cleanly.
+                                continue;
+                            }
+                            Ok(Ok(_)) => continue, // unrelated event
+                            Ok(Err(RecvError::Lagged(_))) => {
+                                // Broadcast capacity exceeded — relevant
+                                // events may have been dropped. Re-check
+                                // store; if the key arrived during the
+                                // overflow window we'll observe it on the
+                                // next iteration and break cleanly.
+                                continue;
+                            }
+                            Ok(Err(RecvError::Closed)) => {
+                                // The static `op_events::NOTIFIER` cannot
+                                // be dropped at runtime today, so this
+                                // branch is functionally unreachable. If
+                                // a future refactor changes that, fall
+                                // through to the deadline check rather
+                                // than spinning on a permanently-closed
+                                // channel.
+                                break;
+                            }
+                            Err(_) => continue, // timeout slice — outer deadline check handles exit
+                        }
+                    }
                 }
 
                 // -------------------------------------------------------

--- a/crates/context/src/handlers/remove_group_members.rs
+++ b/crates/context/src/handlers/remove_group_members.rs
@@ -8,6 +8,7 @@ use calimero_primitives::identity::PublicKey;
 use eyre::bail;
 use tracing::info;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -58,7 +59,7 @@ impl Handler<RemoveGroupMembersRequest> for ContextManager {
         ActorResponse::r#async(
             async move {
                 for identity in &members {
-                    let _report = group_store::sign_apply_and_publish_removal(
+                    let report = group_store::sign_apply_and_publish_removal(
                         &datastore,
                         &node_client,
                         &ack_router,
@@ -67,6 +68,9 @@ impl Handler<RemoveGroupMembersRequest> for ContextManager {
                         identity,
                     )
                     .await?;
+                    if let Some(report) = report.as_ref() {
+                        observe_handler_delivery("remove_group_members", "MemberRemoved", report);
+                    }
                 }
                 info!(
                     ?group_id,

--- a/crates/context/src/handlers/set_member_capabilities.rs
+++ b/crates/context/src/handlers/set_member_capabilities.rs
@@ -4,6 +4,7 @@ use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::SetMemberCapabilitiesRequest;
 use calimero_context_client::local_governance::GroupOp;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::{group_store, ContextManager};
 
 impl Handler<SetMemberCapabilitiesRequest> for ContextManager {
@@ -42,7 +43,7 @@ impl Handler<SetMemberCapabilitiesRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let _report = group_store::sign_apply_and_publish(
+                let report = group_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -54,6 +55,13 @@ impl Handler<SetMemberCapabilitiesRequest> for ContextManager {
                     },
                 )
                 .await?;
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery(
+                        "set_member_capabilities",
+                        "MemberCapabilitySet",
+                        report,
+                    );
+                }
                 tracing::info!(?group_id, %member, capabilities, "member capabilities updated");
                 Ok(())
             }

--- a/crates/context/src/handlers/set_tee_admission_policy.rs
+++ b/crates/context/src/handlers/set_tee_admission_policy.rs
@@ -7,6 +7,7 @@ use calimero_primitives::identity::PrivateKey;
 use eyre::bail;
 use tracing::info;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::group_store;
 use crate::ContextManager;
 
@@ -95,7 +96,7 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
                 let sk = PrivateKey::from(effective_signing_key.ok_or_else(|| {
                     eyre::eyre!("local group governance requires a signing key for the requester")
                 })?);
-                let _report = group_store::sign_apply_and_publish(
+                let report = group_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -112,6 +113,13 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
                     },
                 )
                 .await?;
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery(
+                        "set_tee_admission_policy",
+                        "TeeAdmissionPolicySet",
+                        report,
+                    );
+                }
 
                 info!(?group_id, accept_mock, "TEE admission policy updated");
 

--- a/crates/context/src/handlers/update_member_role.rs
+++ b/crates/context/src/handlers/update_member_role.rs
@@ -5,6 +5,7 @@ use calimero_context_client::group::UpdateMemberRoleRequest;
 use calimero_context_client::local_governance::GroupOp;
 use calimero_primitives::context::GroupMemberRole;
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::{group_store, ContextManager};
 
 impl Handler<UpdateMemberRoleRequest> for ContextManager {
@@ -69,7 +70,7 @@ impl Handler<UpdateMemberRoleRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let _report = group_store::sign_apply_and_publish(
+                let report = group_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -81,6 +82,9 @@ impl Handler<UpdateMemberRoleRequest> for ContextManager {
                     },
                 )
                 .await?;
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery("update_member_role", "MemberRoleSet", report);
+                }
                 tracing::info!(?group_id, ?identity, "member role updated");
                 Ok(())
             }

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -13,6 +13,7 @@ use calimero_store::key::{self, GroupUpgradeStatus, GroupUpgradeValue};
 use eyre::bail;
 use tracing::{debug, error, info, warn};
 
+use crate::governance_broadcast::observe_handler_delivery;
 use crate::{group_store, ContextManager};
 
 impl Handler<UpgradeGroupRequest> for ContextManager {
@@ -130,7 +131,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                             .as_ref()
                             .ok_or_else(|| eyre::eyre!("target application not found"))?;
                         let app_key = *app_meta.bytecode.blob_id().as_ref();
-                        let _report = group_store::sign_apply_and_publish(
+                        let report = group_store::sign_apply_and_publish(
                             &datastore,
                             &node_client,
                             &ack_router_for_lazy,
@@ -142,8 +143,15 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                             },
                         )
                         .await?;
+                        if let Some(report) = report.as_ref() {
+                            observe_handler_delivery(
+                                "upgrade_group",
+                                "TargetApplicationSet",
+                                report,
+                            );
+                        }
                         if migration_bytes.is_some() {
-                            let _report = group_store::sign_apply_and_publish(
+                            let report = group_store::sign_apply_and_publish(
                                 &datastore,
                                 &node_client,
                                 &ack_router_for_lazy,
@@ -154,6 +162,13 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                                 },
                             )
                             .await?;
+                            if let Some(report) = report.as_ref() {
+                                observe_handler_delivery(
+                                    "upgrade_group",
+                                    "GroupMigrationSet",
+                                    report,
+                                );
+                            }
                         }
                     }
 
@@ -268,7 +283,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("target application not found"))?;
                 let app_key = *app_meta.bytecode.blob_id().as_ref();
-                let _report = group_store::sign_apply_and_publish(
+                let report = group_store::sign_apply_and_publish(
                     &datastore_for_canary,
                     &node_client,
                     &ack_router_for_canary,
@@ -280,8 +295,11 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     },
                 )
                 .await?;
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery("upgrade_group", "TargetApplicationSet", report);
+                }
                 if migration_bytes.is_some() {
-                    let _report = group_store::sign_apply_and_publish(
+                    let report = group_store::sign_apply_and_publish(
                         &datastore_for_canary,
                         &node_client,
                         &ack_router_for_canary,
@@ -292,6 +310,9 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         },
                     )
                     .await?;
+                    if let Some(report) = report.as_ref() {
+                        observe_handler_delivery("upgrade_group", "GroupMigrationSet", report);
+                    }
                 }
             }
 

--- a/crates/context/src/metrics.rs
+++ b/crates/context/src/metrics.rs
@@ -41,12 +41,29 @@ pub(crate) struct GovernancePublishLabels {
     pub(crate) op_kind: String,
 }
 
+/// Labels for handler-level governance op delivery outcomes.
+///
+/// `outcome` is one of:
+///   - `"acked"`: at least one valid ack was collected within `op_timeout`.
+///   - `"empty"`: the op was published but no ack arrived in time. The
+///     local DAG advance is durable; downstream peers will reconcile via
+///     parent_pull / readiness beacons. Useful as a leading indicator of
+///     mesh fragility (cold-start, partition, GRAFT delay).
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct GovernanceHandlerDeliveryLabels {
+    pub(crate) handler: String,
+    pub(crate) op_kind: String,
+    pub(crate) outcome: String,
+}
+
 #[derive(Clone, Debug)]
 struct GroupStoreMetricSink {
     namespace_retry_events: Family<NamespaceRetryLabels, Counter>,
     namespace_decode_events: Family<NamespaceDecodeLabels, Counter>,
     membership_policy_rejections: Family<MembershipPolicyLabels, Counter>,
     governance_publish_mesh_peers: Family<GovernancePublishLabels, Histogram>,
+    governance_handler_delivery_total: Family<GovernanceHandlerDeliveryLabels, Counter>,
+    governance_handler_delivery_seconds: Family<GovernanceHandlerDeliveryLabels, Histogram>,
 }
 
 static GROUP_STORE_METRICS: OnceLock<GroupStoreMetricSink> = OnceLock::new();
@@ -108,11 +125,42 @@ impl Metrics {
             governance_publish_mesh_peers.clone(),
         );
 
+        // Phase 12.1 (#2237): handler-level delivery outcomes. Counters
+        // and a wait-time histogram sliced by handler / op_kind / outcome.
+        // Operators use `outcome="empty"` rate as the leading indicator of
+        // cold-start mesh fragility — under a healthy mesh it should be
+        // approximately zero in steady state.
+        let governance_handler_delivery_total =
+            Family::<GovernanceHandlerDeliveryLabels, Counter>::default();
+        group_store_registry.register(
+            "governance_handler_delivery_total",
+            "Governance op publish outcomes, sliced by handler / op_kind / outcome",
+            governance_handler_delivery_total.clone(),
+        );
+
+        // Buckets cover the realistic ack-wait range: 1ms → 30s. Cheap
+        // ops (alias / capability) settle ≤100ms; membership ops 100ms–2s;
+        // heavy ops (create_context / upgrade) up to ~10s; the 30s tail
+        // catches op_timeout-bound publishes.
+        let governance_handler_delivery_seconds =
+            Family::<GovernanceHandlerDeliveryLabels, Histogram>::new_with_constructor(|| {
+                Histogram::new([
+                    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0,
+                ])
+            });
+        group_store_registry.register(
+            "governance_handler_delivery_seconds",
+            "Governance op ack-collection wait time at the handler boundary",
+            governance_handler_delivery_seconds.clone(),
+        );
+
         let _ = GROUP_STORE_METRICS.set(GroupStoreMetricSink {
             namespace_retry_events: namespace_retry_events.clone(),
             namespace_decode_events: namespace_decode_events.clone(),
             membership_policy_rejections: membership_policy_rejections.clone(),
             governance_publish_mesh_peers: governance_publish_mesh_peers.clone(),
+            governance_handler_delivery_total: governance_handler_delivery_total.clone(),
+            governance_handler_delivery_seconds: governance_handler_delivery_seconds.clone(),
         });
 
         Self {
@@ -182,4 +230,35 @@ pub(crate) fn record_governance_publish_mesh_peers(op_kind: &str, mesh_count: us
             op_kind: op_kind.to_owned(),
         })
         .observe(mesh_count as f64);
+}
+
+/// Record a handler-level governance op delivery outcome.
+///
+/// Called from [`crate::governance_broadcast::observe_handler_delivery`] so
+/// every API endpoint that publishes a governance op contributes to the
+/// `governance_handler_delivery_total` and `governance_handler_delivery_seconds`
+/// series with consistent labels. `outcome` is `"acked"` when at least one
+/// valid ack arrived within `op_timeout`, `"empty"` otherwise.
+pub fn record_governance_handler_delivery(
+    handler: &str,
+    op_kind: &str,
+    outcome: &str,
+    elapsed_ms: u64,
+) {
+    let Some(metrics) = GROUP_STORE_METRICS.get() else {
+        return;
+    };
+    let labels = GovernanceHandlerDeliveryLabels {
+        handler: handler.to_owned(),
+        op_kind: op_kind.to_owned(),
+        outcome: outcome.to_owned(),
+    };
+    metrics
+        .governance_handler_delivery_total
+        .get_or_create(&labels)
+        .inc();
+    metrics
+        .governance_handler_delivery_seconds
+        .get_or_create(&labels)
+        .observe(elapsed_ms as f64 / 1000.0);
 }

--- a/crates/context/src/op_events.rs
+++ b/crates/context/src/op_events.rs
@@ -83,6 +83,18 @@ pub enum OpEvent {
         contexts: bool,
         subgroups: bool,
     },
+    /// `RootOp::KeyDelivery` — the local node successfully unwrapped and
+    /// stored a group key from a `KeyDelivery` op addressed to it.
+    /// Subscribers (notably `join_group`) use this as the wake-up signal
+    /// for the gossip-fallback path when the direct join response did
+    /// not deliver a key. Only fires for *our* identity (the apply path
+    /// already filters by `envelope.recipient == our_pk`); subscribers
+    /// must still match on `group_id` because the broadcast channel is
+    /// process-wide.
+    GroupKeyDelivered {
+        group_id: [u8; 32],
+        recipient: PublicKey,
+    },
 }
 
 /// The process-wide broadcast channel. Tests share this channel, so
@@ -172,6 +184,34 @@ mod tests {
             group_id: [0xCC; 32],
             member: PublicKey::from([0xDD; 32]),
         });
+    }
+
+    #[tokio::test]
+    async fn notify_delivers_groupkeydelivered_to_subscriber() {
+        let mut rx = subscribe();
+        // Tag the group_id uniquely so the parallel-test broadcast channel
+        // doesn't bleed into unrelated assertions in other test cases.
+        let group_id = [0xA1; 32];
+        let recipient = PublicKey::from([0xB2; 32]);
+        notify(OpEvent::GroupKeyDelivered {
+            group_id,
+            recipient,
+        });
+        let event = recv_matching(&mut rx, |e| {
+            matches!(
+                e,
+                OpEvent::GroupKeyDelivered { group_id: g, .. } if *g == group_id,
+            )
+        })
+        .await
+        .expect("GroupKeyDelivered event delivered");
+        match event {
+            OpEvent::GroupKeyDelivered {
+                recipient: got_recipient,
+                ..
+            } => assert_eq!(got_recipient, recipient),
+            _ => unreachable!(),
+        }
     }
 
     #[tokio::test]

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -207,11 +207,32 @@ pub(super) fn handle_namespace_state_heartbeat(
         return;
     }
 
+    // Phase 11.2 (#2237): the heartbeat is now liveness-only. The
+    // active catch-up arms (republishing ops the peer is missing,
+    // backfilling ops we are missing, and the cross-peer
+    // `resolve_namespace_pending` fan-out) are gone. With the
+    // three-phase contract in place (Phase 5+6+7+8):
+    //
+    //   * `publish_and_await_ack_namespace` blocks the publisher until
+    //     at least one mesh peer applies + acks, so a freshly-applied
+    //     op is already known to be on at least one receiver before the
+    //     publisher returns.
+    //   * `parent_pull` runs on every gossip op whose parents are
+    //     missing locally — that's the on-receive recovery path.
+    //   * `ReadinessBeacon` carries `applied_through` and `dag_head`,
+    //     so peers detect divergence and pick a sync partner via
+    //     `pick_sync_partner` without needing the heartbeat to
+    //     advertise heads.
+    //
+    // The heartbeat-driven catch-up was the fallback before any of
+    // those existed. Keeping it now duplicates work the new path
+    // already performs, and makes the system noisier without making it
+    // more correct (a genuinely stuck DAG is recovered by the join /
+    // probe / beacon flow, not by the heartbeat). We still log the
+    // divergence detection at debug for observability — operators
+    // chasing a wedged namespace can grep for the `peer_heads` count
+    // mismatch — but no remediation runs from here.
     let context_client = this.clients.context.clone();
-    let network_client = this.managers.sync.network_client.clone();
-    let sync_timeout = this.managers.sync.sync_config.timeout;
-    let pull_budget_max_peers = this.managers.sync.sync_config.parent_pull_additional_peers;
-    let pull_budget_duration = this.managers.sync.sync_config.parent_pull_budget;
 
     let _ignored = ctx.spawn(
         async move {
@@ -224,89 +245,27 @@ pub(super) fn handle_namespace_state_heartbeat(
             };
             drop(handle);
 
-            let we_need: Vec<[u8; 32]> = peer_heads
+            let we_missing = peer_heads
                 .iter()
                 .filter(|h| !local_heads.contains(*h))
-                .copied()
-                .collect();
-
+                .count();
             let peer_head_set: HashSet<[u8; 32]> = peer_heads.iter().copied().collect();
-            let peer_needs: Vec<[u8; 32]> = local_heads
+            let peer_missing = local_heads
                 .iter()
                 .filter(|h| !peer_head_set.contains(*h))
-                .copied()
-                .collect();
+                .count();
 
-            if !peer_needs.is_empty() {
-                let store_inner = context_client.datastore_handle().into_inner();
-                let handle_inner = store_inner.handle();
-                for delta_id in &peer_needs {
-                    let key = calimero_store::key::NamespaceGovOp::new(namespace_id, *delta_id);
-                    if let Ok(Some(value)) = handle_inner.get(&key) {
-                        // Decode straight to the typed op so we can wrap it in
-                        // `NamespaceTopicMsg::Op` and serialize once. Going via
-                        // `extract_signed_op_bytes` would force a redundant
-                        // serialize/deserialize round-trip on every republish.
-                        let Some(signed_op) =
-                            crate::sync::helpers::extract_signed_op(&value.skeleton_bytes)
-                        else {
-                            continue;
-                        };
-                        let Ok(wrapped) = borsh::to_vec(&NamespaceTopicMsg::Op(signed_op)) else {
-                            continue;
-                        };
-                        let payload = BroadcastMessage::NamespaceGovernanceDelta {
-                            namespace_id,
-                            delta_id: *delta_id,
-                            parent_ids: vec![],
-                            payload: wrapped,
-                        };
-                        if let Ok(bytes) = borsh::to_vec(&payload) {
-                            let topic = libp2p::gossipsub::TopicHash::from_raw(format!(
-                                "ns/{}",
-                                hex::encode(namespace_id)
-                            ));
-                            let _ = network_client.publish(topic, bytes).await;
-                        }
-                    }
-                }
-            }
-
-            if we_need.is_empty() {
+            if we_missing == 0 && peer_missing == 0 {
                 return;
             }
-
-            info!(
+            tracing::debug!(
                 namespace_id = %hex::encode(namespace_id),
-                missing = we_need.len(),
                 %source,
-                "namespace heartbeat divergence: requesting missing deltas"
+                we_missing,
+                peer_missing,
+                "namespace heartbeat: divergence detected (liveness-only — recovery via \
+                 publish_and_await_ack / parent_pull / readiness beacon)"
             );
-
-            // First attempt: the peer that advertised its heads.
-            fetch_and_apply_namespace_backfill(
-                &context_client,
-                &network_client,
-                source,
-                namespace_id,
-                we_need,
-                sync_timeout,
-            )
-            .await;
-
-            // Cross-peer fallback (#2198): if the first peer did not fully
-            // resolve our pending chain, iterate other namespace-mesh peers
-            // until the DAG drains or the budget is exhausted.
-            resolve_namespace_pending(
-                &context_client,
-                &network_client,
-                source,
-                namespace_id,
-                sync_timeout,
-                pull_budget_max_peers,
-                pull_budget_duration,
-            )
-            .await;
         }
         .into_actor(this),
     );

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -360,7 +360,7 @@ pub async fn await_namespace_ready(
         signed_invitation: invitation,
     });
     let report = NamespaceGovernance::new(store, namespace_id)
-        .sign_and_publish_without_apply(node_client, ack_router, &signing_key, op)
+        .sign_and_publish_without_apply(node_client, ack_router, &signing_key, op, None)
         .await
         .map_err(|e| ReadyError::PublishMemberJoined(e.to_string()))?;
 

--- a/crates/node/src/key_delivery.rs
+++ b/crates/node/src/key_delivery.rs
@@ -56,23 +56,34 @@ pub async fn maybe_publish_key_delivery(
         envelope,
     });
 
-    if let Err(e) = calimero_context::group_store::sign_and_publish_namespace_op(
+    // Pass `required_signers = Some([member])` so only the joiner's ack
+    // counts toward delivery confirmation. The publisher boundary will
+    // reflect the joiner's ack (or its absence) in the returned
+    // `DeliveryReport.acked_by`; Phase 9.2 will gate `join_group` on
+    // observing that ack before returning to the API caller.
+    let report = match calimero_context::group_store::sign_and_publish_namespace_op(
         &store,
         node_client,
         context_client.ack_router(),
         namespace_id,
         &sender_sk,
         delivery_op,
+        Some(vec![member]),
     )
     .await
     {
-        warn!(?e, "failed to publish KeyDelivery");
-        return;
-    }
+        Ok(r) => r,
+        Err(e) => {
+            warn!(?e, "failed to publish KeyDelivery");
+            return;
+        }
+    };
 
     info!(
         group_id = %hex::encode(group_id.to_bytes()),
         %member,
+        acked = report.acked_by.len(),
+        elapsed_ms = report.elapsed_ms,
         "published KeyDelivery for new joiner"
     );
 }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -838,17 +838,28 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
             .cache
             .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
         let new_tier = evaluate_readiness(&state, &peers, &self.config, Instant::now());
-        if new_tier != state.tier {
-            tracing::info!(
-                namespace_id = %hex::encode(msg.namespace_id),
-                old = ?state.tier,
-                new = ?new_tier,
-                cause = "peer_beacon_received",
-                "readiness tier transition"
-            );
-            let snapshot = if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
+        let tier_changed = new_tier != state.tier;
+
+        // Always persist `local_applied_through` back to the map,
+        // independent of whether the tier transitioned this tick.
+        // The previous structure scoped the write inside the
+        // `tier_changed` branch, which silently dropped the refreshed
+        // value on the steady-state path and left the map drifting
+        // until the next periodic-tick refresh in `emit_periodic_beacons`.
+        // Other FSM eval sites (`Handler<NamespaceOpApplied>`,
+        // `emit_periodic_beacons`) already persist unconditionally, so
+        // this also keeps the three eval entry points symmetric.
+        let snapshot = if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
+            s.local_applied_through = state.local_applied_through;
+            if tier_changed {
+                tracing::info!(
+                    namespace_id = %hex::encode(msg.namespace_id),
+                    old = ?state.tier,
+                    new = ?new_tier,
+                    cause = "peer_beacon_received",
+                    "readiness tier transition"
+                );
                 s.tier = new_tier;
-                s.local_applied_through = state.local_applied_through;
                 if matches!(
                     new_tier,
                     ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady
@@ -859,11 +870,13 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
                 }
             } else {
                 None
-            };
-            if let Some(snapshot) = snapshot {
-                self.clear_probe_window_for(msg.namespace_id);
-                self.publish_beacon(msg.namespace_id, &snapshot);
             }
+        } else {
+            None
+        };
+        if let Some(snapshot) = snapshot {
+            self.clear_probe_window_for(msg.namespace_id);
+            self.publish_beacon(msg.namespace_id, &snapshot);
         }
     }
 }

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -453,46 +453,6 @@ pub(crate) fn read_local_applied_through(store: &Store, ns_id: [u8; 32]) -> u64 
     }
 }
 
-/// Enumerate every namespace that has a stored governance DAG head.
-///
-/// The previous design populated `state_per_namespace` only via
-/// `Handler<NamespaceOpApplied>`, which only fires from the gossipsub
-/// receive path (`network_event/namespace.rs::handle_namespace_governance_delta`).
-/// That left two important cases without an FSM entry — and therefore
-/// without a beacon emission:
-///
-///   1. **Publisher-only namespaces** — a node that creates a namespace
-///      and signs ops via `sign_apply_and_publish` never receives its
-///      own publish back through gossipsub, so `NamespaceOpApplied`
-///      never fires and no beacon is ever emitted on its behalf.
-///   2. **Direct-stream joiners** — a node that joins via
-///      `request_namespace_join` applies the bundled ops via
-///      `apply_signed_namespace_op` directly, bypassing the gossipsub
-///      receive path. Subsequent gossip ops do fire `NamespaceOpApplied`,
-///      but in short-lived sessions the beacon may never get a tick.
-///
-/// Reading the canonical `NamespaceGovHead` key set on every periodic
-/// tick closes both gaps without adding cross-crate plumbing for a new
-/// "publisher applied" message: the store is already the source of
-/// truth for what namespaces this node participates in. The cost is
-/// one prefix iteration per `beacon_interval` (5s default), which is
-/// negligible against the same store's per-op writes.
-fn scan_namespaces_with_state(store: &Store) -> Vec<[u8; 32]> {
-    let handle = store.handle();
-    let mut iter = match handle.iter::<calimero_store::key::NamespaceGovHead>() {
-        Ok(it) => it,
-        Err(_) => return Vec::new(),
-    };
-    let mut ns_ids = Vec::new();
-    for key_result in iter.keys() {
-        match key_result {
-            Ok(key) => ns_ids.push(key.namespace_id()),
-            Err(_) => break,
-        }
-    }
-    ns_ids
-}
-
 impl ReadinessManager {
     fn emit_periodic_beacons(&mut self) {
         // The freshness tick is the natural FSM-recompute checkpoint.
@@ -513,25 +473,6 @@ impl ReadinessManager {
         let ttl = self.config.ttl_heartbeat;
         let cfg = self.config;
         let mut to_emit: Vec<([u8; 32], ReadinessState)> = Vec::new();
-
-        // Reconcile the in-memory FSM with canonical store state on
-        // every tick: any namespace that has a stored governance head
-        // record but no FSM entry yet (publisher-only or direct-join
-        // path — see `scan_namespaces_with_state` doc) gets a fresh
-        // `Bootstrapping` entry. Re-running the scan on every tick
-        // also captures namespaces created at runtime after the
-        // actor mounted, without a separate event hookup.
-        for stored_ns in scan_namespaces_with_state(&self.datastore) {
-            self.state_per_namespace
-                .entry(stored_ns)
-                .or_insert_with(|| ReadinessState {
-                    tier: ReadinessTier::Bootstrapping,
-                    local_applied_through: 0,
-                    local_pending_ops: 0,
-                    subscribed_at: Instant::now(),
-                });
-        }
-
         let ns_ids: Vec<[u8; 32]> = self.state_per_namespace.keys().copied().collect();
         for ns_id in ns_ids {
             // Atomic single-lock snapshot per namespace — see

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -425,21 +425,32 @@ pub struct ApplyBeaconLocal {
 
 /// A single namespace governance op was successfully applied locally.
 ///
-/// Sent from the receiver-side network-event handler after a
-/// `NamespaceApplyOutcome::Applied`. The actor increments its own
-/// per-namespace `local_applied_through` counter — this is the single
-/// progress signal the FSM needs to leave `Bootstrapping` and start
-/// emitting beacons.
+/// Sent from BOTH the receiver-side network-event handler (after a
+/// `NamespaceApplyOutcome::Applied`) and the publisher-side apply path,
+/// so the FSM observes every monotonic advance regardless of origin.
 ///
-/// The actor maintains the count internally (not the caller) because
-/// the count exists nowhere else in the codebase: `apply_signed_namespace_op`
-/// doesn't return a new height, and the namespace DAG doesn't expose a
-/// monotonic apply counter. Keeping the count on the actor keeps the
-/// scope minimal.
+/// The actor no longer maintains its own counter — it now refreshes
+/// `local_applied_through` from `NamespaceGovHeadValue.sequence` in the
+/// store on every FSM evaluation. This closes the publisher-side miss
+/// the previous actor-local counter exhibited (it was incremented only
+/// from the receive path) without changing the message contract.
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct NamespaceOpApplied {
     pub namespace_id: [u8; 32],
+}
+
+/// Read the canonical local-applied sequence for a namespace from the
+/// store. Returns 0 if the head record is missing or the read fails;
+/// neither is fatal for FSM evaluation (a brand-new namespace with no
+/// applied ops legitimately has no head record).
+pub(crate) fn read_local_applied_through(store: &Store, ns_id: [u8; 32]) -> u64 {
+    let handle = store.handle();
+    let key = calimero_store::key::NamespaceGovHead::new(ns_id);
+    match handle.get(&key) {
+        Ok(Some(head)) => head.sequence,
+        Ok(None) | Err(_) => 0,
+    }
 }
 
 impl ReadinessManager {
@@ -467,7 +478,12 @@ impl ReadinessManager {
             // Atomic single-lock snapshot per namespace — see
             // `ReadinessCache::peer_summary` for why.
             let peers = self.cache.peer_summary(ns_id, ttl);
+            // Refresh canonical sequence from the store before each
+            // evaluation so the periodic tick observes publisher-side
+            // applies that don't fire `NamespaceOpApplied`.
+            let applied_through = read_local_applied_through(&self.datastore, ns_id);
             let snapshot = if let Some(entry) = self.state_per_namespace.get_mut(&ns_id) {
+                entry.local_applied_through = applied_through;
                 let new_tier = evaluate_readiness(entry, &peers, &cfg, now);
                 if new_tier != entry.tier {
                     tracing::info!(
@@ -669,11 +685,15 @@ impl Handler<NamespaceOpApplied> for ReadinessManager {
             .cache
             .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
 
-        // Increment the per-namespace local apply counter, then re-evaluate
-        // FSM and edge-emit on transition into a *Ready tier. Uses the
-        // same scoped-borrow pattern as Handler<ApplyBeaconLocal> so
+        // Refresh `local_applied_through` from the canonical store
+        // record (`NamespaceGovHeadValue.sequence`) before evaluating the
+        // FSM. This is the single source of truth for both publisher
+        // and receiver applies, so the FSM observes every monotonic
+        // advance regardless of where it originated. Uses the same
+        // scoped-borrow pattern as `Handler<ApplyBeaconLocal>` so
         // `clear_probe_window_for` and `publish_beacon` can re-borrow
         // self after the entry borrow ends.
+        let applied_through = read_local_applied_through(&self.datastore, msg.namespace_id);
         let to_emit = {
             let entry = self
                 .state_per_namespace
@@ -684,7 +704,7 @@ impl Handler<NamespaceOpApplied> for ReadinessManager {
                     local_pending_ops: 0,
                     subscribed_at: Instant::now(),
                 });
-            entry.local_applied_through = entry.local_applied_through.saturating_add(1);
+            entry.local_applied_through = applied_through;
             let new_tier = evaluate_readiness(entry, &peers, &self.config, Instant::now());
             if new_tier != entry.tier {
                 tracing::info!(
@@ -788,9 +808,12 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
         // A peer beacon has just been inserted into the cache. Re-evaluate
         // the FSM with the (possibly) updated `peer_summary` and edge-emit
         // if our tier transitions into *Ready.
-        let Some(state) = self.state_per_namespace.get(&msg.namespace_id).cloned() else {
+        let Some(mut state) = self.state_per_namespace.get(&msg.namespace_id).cloned() else {
             return;
         };
+        // Refresh from the store before evaluating — see
+        // `Handler<NamespaceOpApplied>` for rationale.
+        state.local_applied_through = read_local_applied_through(&self.datastore, msg.namespace_id);
         let peers = self
             .cache
             .peer_summary(msg.namespace_id, self.config.ttl_heartbeat);
@@ -805,6 +828,7 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
             );
             let snapshot = if let Some(s) = self.state_per_namespace.get_mut(&msg.namespace_id) {
                 s.tier = new_tier;
+                s.local_applied_through = state.local_applied_through;
                 if matches!(
                     new_tier,
                     ReadinessTier::PeerValidatedReady | ReadinessTier::LocallyReady

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -453,6 +453,46 @@ pub(crate) fn read_local_applied_through(store: &Store, ns_id: [u8; 32]) -> u64 
     }
 }
 
+/// Enumerate every namespace that has a stored governance DAG head.
+///
+/// The previous design populated `state_per_namespace` only via
+/// `Handler<NamespaceOpApplied>`, which only fires from the gossipsub
+/// receive path (`network_event/namespace.rs::handle_namespace_governance_delta`).
+/// That left two important cases without an FSM entry — and therefore
+/// without a beacon emission:
+///
+///   1. **Publisher-only namespaces** — a node that creates a namespace
+///      and signs ops via `sign_apply_and_publish` never receives its
+///      own publish back through gossipsub, so `NamespaceOpApplied`
+///      never fires and no beacon is ever emitted on its behalf.
+///   2. **Direct-stream joiners** — a node that joins via
+///      `request_namespace_join` applies the bundled ops via
+///      `apply_signed_namespace_op` directly, bypassing the gossipsub
+///      receive path. Subsequent gossip ops do fire `NamespaceOpApplied`,
+///      but in short-lived sessions the beacon may never get a tick.
+///
+/// Reading the canonical `NamespaceGovHead` key set on every periodic
+/// tick closes both gaps without adding cross-crate plumbing for a new
+/// "publisher applied" message: the store is already the source of
+/// truth for what namespaces this node participates in. The cost is
+/// one prefix iteration per `beacon_interval` (5s default), which is
+/// negligible against the same store's per-op writes.
+fn scan_namespaces_with_state(store: &Store) -> Vec<[u8; 32]> {
+    let handle = store.handle();
+    let mut iter = match handle.iter::<calimero_store::key::NamespaceGovHead>() {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+    let mut ns_ids = Vec::new();
+    for key_result in iter.keys() {
+        match key_result {
+            Ok(key) => ns_ids.push(key.namespace_id()),
+            Err(_) => break,
+        }
+    }
+    ns_ids
+}
+
 impl ReadinessManager {
     fn emit_periodic_beacons(&mut self) {
         // The freshness tick is the natural FSM-recompute checkpoint.
@@ -473,6 +513,25 @@ impl ReadinessManager {
         let ttl = self.config.ttl_heartbeat;
         let cfg = self.config;
         let mut to_emit: Vec<([u8; 32], ReadinessState)> = Vec::new();
+
+        // Reconcile the in-memory FSM with canonical store state on
+        // every tick: any namespace that has a stored governance head
+        // record but no FSM entry yet (publisher-only or direct-join
+        // path — see `scan_namespaces_with_state` doc) gets a fresh
+        // `Bootstrapping` entry. Re-running the scan on every tick
+        // also captures namespaces created at runtime after the
+        // actor mounted, without a separate event hookup.
+        for stored_ns in scan_namespaces_with_state(&self.datastore) {
+            self.state_per_namespace
+                .entry(stored_ns)
+                .or_insert_with(|| ReadinessState {
+                    tier: ReadinessTier::Bootstrapping,
+                    local_applied_through: 0,
+                    local_pending_ops: 0,
+                    subscribed_at: Instant::now(),
+                });
+        }
+
         let ns_ids: Vec<[u8; 32]> = self.state_per_namespace.keys().copied().collect();
         for ns_id in ns_ids {
             // Atomic single-lock snapshot per namespace — see

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -441,15 +441,35 @@ pub struct NamespaceOpApplied {
 }
 
 /// Read the canonical local-applied sequence for a namespace from the
-/// store. Returns 0 if the head record is missing or the read fails;
-/// neither is fatal for FSM evaluation (a brand-new namespace with no
-/// applied ops legitimately has no head record).
+/// store. Returns 0 if the head record is missing (legitimate for a
+/// brand-new namespace with no applied ops) or if the read fails
+/// transiently. The two cases are distinguished in the log:
+///
+///   - `Ok(None)` is silent — empty-DAG is the well-defined start state.
+///   - `Err(_)` emits a `warn!` so a transiently broken store layer
+///     does not silently regress the FSM. With this log present, an
+///     operator chasing a `*Ready → Bootstrapping` regression has a
+///     clear breadcrumb instead of guessing at a fail-soft `0`.
+///
+/// Returning `0` on the error path (rather than propagating) keeps
+/// the FSM evaluation total — `evaluate_readiness` is a pure
+/// transition fn and should not have to handle store I/O errors.
+/// On the next successful read the FSM recovers naturally.
 pub(crate) fn read_local_applied_through(store: &Store, ns_id: [u8; 32]) -> u64 {
     let handle = store.handle();
     let key = calimero_store::key::NamespaceGovHead::new(ns_id);
     match handle.get(&key) {
         Ok(Some(head)) => head.sequence,
-        Ok(None) | Err(_) => 0,
+        Ok(None) => 0,
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                namespace_id = %hex::encode(ns_id),
+                "read_local_applied_through: store read failed; treating as 0 — \
+                 FSM may regress until the next successful read"
+            );
+            0
+        }
     }
 }
 

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -71,13 +71,28 @@ pub const DEFAULT_PEER_STATE_PROBE_CONCURRENCY: usize = 4;
 ///
 /// Applies to both data-delta parent pulls (cold-start join_context, #2198)
 /// and governance-op parent pulls (subgroup MemberAdded propagation, #2209).
-pub const DEFAULT_PARENT_PULL_ADDITIONAL_PEERS: usize = 3;
+///
+/// Phase 11.1 (#2237) reduced this from 3 → 1 once `publish_and_await_ack`
+/// took over delivery confirmation: the publisher boundary now blocks until
+/// at least one mesh peer acks the op, so a "no peer has the parent" outcome
+/// is far rarer than under fire-and-forget gossipsub. A single fallback peer
+/// covers the residual transient (the acker just left the mesh, or our local
+/// pending-op record points to a peer that has since rotated their identity);
+/// fan-out beyond that is redundant work the heartbeat path already handles
+/// for genuinely-stuck divergence.
+pub const DEFAULT_PARENT_PULL_ADDITIONAL_PEERS: usize = 1;
 
 /// Total wall-clock budget (milliseconds) for the cross-peer
 /// missing-parent fetch loop, including the initial peer attempt.
 /// When exhausted, the sync session returns an error rather than
 /// reporting silent success on a partially-applied DAG.
-pub const DEFAULT_PARENT_PULL_BUDGET_MS: u64 = 10_000;
+///
+/// Phase 11.1 (#2237) reduced this from 10s → 5s in tandem with
+/// `DEFAULT_PARENT_PULL_ADDITIONAL_PEERS` 3 → 1: with at most two peer
+/// attempts (initial + one fallback), the prior 10s window was mostly
+/// idle wall-clock time. 5s is two `BACKFILL_REQUEST_TIMEOUT` cycles
+/// (default 2s) plus margin for the mesh-snapshot refetch.
+pub const DEFAULT_PARENT_PULL_BUDGET_MS: u64 = 5_000;
 
 /// Synchronization configuration.
 ///

--- a/crates/server/src/admin/handlers/groups/reparent_group.rs
+++ b/crates/server/src/admin/handlers/groups/reparent_group.rs
@@ -92,12 +92,19 @@ pub async fn handler(
     )
     .await
     {
-        Ok(_report) => ApiResponse {
-            payload: ReparentGroupApiResponse {
-                reparented: !was_already_there,
-            },
+        Ok(report) => {
+            calimero_context::governance_broadcast::observe_handler_delivery(
+                "reparent_group",
+                "GroupReparented",
+                &report,
+            );
+            ApiResponse {
+                payload: ReparentGroupApiResponse {
+                    reparented: !was_already_there,
+                },
+            }
+            .into_response()
         }
-        .into_response(),
         Err(err) => {
             error!(child=%group_id_str, new_parent=%req.new_parent_id, error=?err, "Failed to reparent subgroup");
             parse_api_error(err).into_response()

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -104,7 +104,12 @@ pub async fn handler(
     )
     .await
     {
-        Ok(_report) => {
+        Ok(report) => {
+            calimero_context::governance_broadcast::observe_handler_delivery(
+                "create_group_in_namespace",
+                "GroupCreated",
+                &report,
+            );
             let group_id = calimero_context_config::types::ContextGroupId::from(group_id);
 
             // Store the creator's signing key for the new subgroup. Without

--- a/crates/server/src/admin/handlers/tee/fleet_join.rs
+++ b/crates/server/src/admin/handlers/tee/fleet_join.rs
@@ -217,7 +217,14 @@ pub async fn handler(
                 )
                 .await
                 {
-                    Ok(_report) => {
+                    Ok(report) => {
+                        if let Some(report) = report.as_ref() {
+                            calimero_context::governance_broadcast::observe_handler_delivery(
+                                "fleet_join",
+                                "MemberSetAutoFollow",
+                                report,
+                            );
+                        }
                         info!(
                             group_id = %req.group_id,
                             "fleet-join: auto-follow enabled for self"


### PR DESCRIPTION
## Summary

Final batch for the three-phase governance contract (#2237). Builds on PR #2269 (Phase 6+7+8: readiness FSM + J6 join). Combines Phases 9, 10, 11, 12 into one PR.

## Phase 9 — KeyDelivery integration

- **9.1** Plumbed `required_signers: Option<Vec<PublicKey>>` through `sign_and_publish_namespace_op` → `sign_and_publish_without_apply` → `publish_post_gate` → `publish_and_await_ack_namespace`. KeyDelivery emits in `key_delivery.rs` and `add_group_members.rs` now pass `Some(vec![member])` so only the recipient's ack counts toward delivery confirmation.
- **9.2** New `OpEvent::GroupKeyDelivered { group_id, recipient }` emitted from the apply path after `store_group_key` succeeds. `join_group` subscribes BEFORE publishing `MemberJoined` when the local store has no group key, then waits up to 5s (`KEY_DELIVERY_FALLBACK_WAIT`). Closes the cold-join race where the served peer didn't carry the key in the direct join response.
- **9.3** Removed silent fallback to `identity.sender_key` for group-context state-delta encryption in `execute/mod.rs`. Now hard-fails with `error!` log when `load_current_group_key` returns None for a group context — silent fallback there mis-encrypted for inheritance-eligible receivers.
- **9 follow-up** `local_applied_through` now reads from `NamespaceGovHeadValue.sequence` in the store on every FSM evaluation. Replaces actor-local counter that missed publisher-side applies.

## Phase 10 — Handler delivery observability

New `governance_broadcast::observe_handler_delivery(handler, op_kind, &report)` helper. `info!` when at least one ack arrived, `warn!` on `acked_by.is_empty()`. Wired into 14 handlers across `crates/context/src/handlers/*` and three server admin endpoints (`reparent_group`, `create_group_in_namespace`, `fleet_join`).

## Phase 11 — Cleanup of pre-contract scaffolding

- **11.1** `DEFAULT_PARENT_PULL_ADDITIONAL_PEERS` 3 → 1, `DEFAULT_PARENT_PULL_BUDGET_MS` 10s → 5s. Multi-peer fan-out is redundant once `publish_and_await_ack` blocks on at least one acker.
- **11.2** `handle_namespace_state_heartbeat` is now liveness-only. Removed the `peer_needs` republish loop, the `we_need` backfill, and the `resolve_namespace_pending` fan-out. Recovery flows through `publish_and_await_ack` / `parent_pull` / readiness beacons.
- **11.3** Dropped `max_attempts=2` retry + `merobox nuke --force` between attempts from all 9 jobs in `e2e-rust-apps-release.yml`. Single attempt, fail loud.

## Phase 12 — Metrics + e2e regression guard

- **12.1** Two new metrics:
  - `governance_handler_delivery_total{handler, op_kind, outcome}` — counter, sliced by `acked|empty` outcome.
  - `governance_handler_delivery_seconds{handler, op_kind, outcome}` — ack-collection wait time histogram (1ms–30s buckets).
- **12.2** New `kv-store-joiner-cold.yml` exercises the join → first-execute window. Wired into `e2e-rust-apps-release.yml` as `run_joiner_cold`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p calimero-context -p calimero-node -p calimero-server -- -A warnings` clean
- [x] `cargo test -p calimero-context --lib` — 173/173 passed (added `OpEvent::GroupKeyDelivered` regression test)
- [x] `cargo test -p calimero-node --lib` — 77/77 passed
- [ ] `merobox bootstrap run apps/e2e-kv-store/workflows/kv-store-joiner-cold.yml` (CI)
- [ ] Existing e2e suite green on single attempt (CI — Phase 11.3 dropped retries)

## Local code review

3-agent review (bug scan + CLAUDE.md compliance + design) before pushing. Two actionable items addressed inline:
- Import order CLAUDE.md violation (split grouped `use`, imported `std::time::Instant`).
- Hardened wait loop's `RecvError::Closed` arm to `break` rather than `continue` (defensive — `op_events::NOTIFIER` is `OnceLock`-static and cannot close at runtime).

Deferred (out of scope, pre-existing): detached-context `Ok(None)` fallback in `execute/mod.rs` (Phase 9.3 only tightened the group-context branch; non-group fallback is untouched and pre-existing); `KeyDelivery` ack-timeout retry strategy (deliberate — joiner-side `KEY_DELIVERY_FALLBACK_WAIT` + heartbeat reconcile is the recovery path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes governance propagation/ack semantics, join-time key delivery behavior, and state-delta encryption error handling, plus removes heartbeat-based catch-up; regressions could impact cluster convergence and data availability.
> 
> **Overview**
> Strengthens the three-phase governance contract by plumbing `required_signers` through namespace publish paths so **KeyDelivery can require the recipient’s ack**, and by adding a join-time **gossip fallback wait** (new `OpEvent::GroupKeyDelivered`) so `join_group` blocks briefly until the group key is stored.
> 
> Hardens execution correctness by **removing sender-key fallback** for group-context state-delta encryption when the group key is missing (now fails loudly), and improves operability with a shared `observe_handler_delivery` helper plus new metrics (`governance_handler_delivery_*`) wired into multiple context and admin handlers.
> 
> Simplifies sync/CI scaffolding: namespace heartbeat handling becomes **liveness-only** (catch-up logic removed), parent-pull retry budgets are reduced, and E2E workflows drop retry loops and add a new `kv-store-joiner-cold` regression workflow to guard the cold-join→first-execute window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd10d7d91f27bdbdd00ab8187dba5bf991bff4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->