### PR TITLE
feat(node): wire DAG-causal Shared verifier through WASM ABI (#2266)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "hex",
+ "indexmap 2.13.0",
  "libp2p",
  "lz4_flex",
  "prometheus-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,6 +1412,7 @@ dependencies = [
  "sha2 0.10.9",
  "tar",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "zeroize",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -39,6 +39,7 @@ calimero-crypto.workspace = true
 calimero-blobstore.workspace = true
 calimero-network.workspace = true
 dashmap.workspace = true
+indexmap.workspace = true
 calimero-network-primitives.workspace = true
 calimero-node-primitives.workspace = true
 calimero-primitives = { workspace = true, features = ["borsh", "rand"] }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -53,5 +53,7 @@ calimero-utils-actix.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 calimero-dag = { workspace = true, features = ["testing"] }
+calimero-storage = { workspace = true, features = ["testing"] }
+ed25519-dalek.workspace = true
 rand_chacha = "0.3"
 tempfile.workspace = true

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -211,12 +211,7 @@ mod tests {
                     ancestors: vec![],
                     metadata: Metadata::default(),
                 },
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
+                &ApplyContext::empty(),
             )
         });
         assert!(write_result.is_ok(), "apply_action should succeed");

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -620,9 +620,19 @@ impl ContextStorageApplier {
     /// restoration completes.
     async fn restore_topology(&self, deltas: impl IntoIterator<Item = ([u8; 32], Vec<[u8; 32]>)>) {
         let mut topology = self.topology.write().await;
-        for (delta_id, parents) in deltas {
-            let _previous = topology.insert(delta_id, parents);
-        }
+        seed_topology(&mut topology, deltas);
+    }
+}
+
+/// Pure seed of a topology mirror. Extracted so the seeding semantics
+/// (later entries overwrite earlier ones with the same delta id) can be
+/// unit-tested without standing up a `ContextStorageApplier`.
+fn seed_topology(
+    topology: &mut HashMap<[u8; 32], Vec<[u8; 32]>>,
+    deltas: impl IntoIterator<Item = ([u8; 32], Vec<[u8; 32]>)>,
+) {
+    for (delta_id, parents) in deltas {
+        let _previous = topology.insert(delta_id, parents);
     }
 }
 
@@ -2130,5 +2140,149 @@ impl DeltaStore {
         );
 
         added_count
+    }
+}
+
+#[cfg(test)]
+mod happens_before_tests {
+    //! Direct unit tests for the topology-snapshot reachability primitive
+    //! that drives Shared writer-set resolution at apply time. Covered
+    //! cases mirror the ADR 0001 examples and the bounded-cache reasoning
+    //! in `apply()`.
+
+    use super::*;
+
+    fn id(b: u8) -> [u8; 32] {
+        [b; 32]
+    }
+
+    fn topology(edges: &[(u8, &[u8])]) -> HashMap<[u8; 32], Vec<[u8; 32]>> {
+        edges
+            .iter()
+            .map(|(child, parents)| (id(*child), parents.iter().copied().map(id).collect()))
+            .collect()
+    }
+
+    #[test]
+    fn self_is_not_strict_ancestor() {
+        let t = topology(&[(2, &[1])]);
+        assert!(!happens_before_in_topology(&t, &id(1), &id(1)));
+        assert!(!happens_before_in_topology(&t, &id(2), &id(2)));
+    }
+
+    #[test]
+    fn single_hop_ancestry() {
+        // 1 → 2
+        let t = topology(&[(2, &[1])]);
+        assert!(happens_before_in_topology(&t, &id(1), &id(2)));
+        assert!(!happens_before_in_topology(&t, &id(2), &id(1)));
+    }
+
+    #[test]
+    fn transitive_ancestry() {
+        // 1 → 2 → 3 → 4
+        let t = topology(&[(2, &[1]), (3, &[2]), (4, &[3])]);
+        assert!(happens_before_in_topology(&t, &id(1), &id(4)));
+        assert!(happens_before_in_topology(&t, &id(2), &id(4)));
+        assert!(!happens_before_in_topology(&t, &id(4), &id(1)));
+    }
+
+    #[test]
+    fn diamond_merge() {
+        //   1
+        //  / \
+        // 2   3
+        //  \ /
+        //   4
+        let t = topology(&[(2, &[1]), (3, &[1]), (4, &[2, 3])]);
+        assert!(happens_before_in_topology(&t, &id(1), &id(4)));
+        assert!(happens_before_in_topology(&t, &id(2), &id(4)));
+        assert!(happens_before_in_topology(&t, &id(3), &id(4)));
+        // Siblings 2 and 3 are concurrent — neither precedes the other.
+        assert!(!happens_before_in_topology(&t, &id(2), &id(3)));
+        assert!(!happens_before_in_topology(&t, &id(3), &id(2)));
+    }
+
+    #[test]
+    fn unknown_node_returns_false() {
+        // Querying a node the topology has never seen must be a clean
+        // false, not a panic — happens during sync when peers reference
+        // deltas we haven't received yet.
+        let t = topology(&[(2, &[1])]);
+        assert!(!happens_before_in_topology(&t, &id(1), &id(99)));
+        assert!(!happens_before_in_topology(&t, &id(99), &id(2)));
+    }
+
+    #[test]
+    fn missing_parent_terminates() {
+        // Topology references a parent it doesn't list (42 has no own
+        // entry). BFS must terminate cleanly at that leaf — and report
+        // 42 as a direct ancestor of 2, since 2's parent list contains
+        // it. Anything *behind* 42 is unknown and reports false.
+        let t = topology(&[(2, &[42])]);
+        assert!(happens_before_in_topology(&t, &id(42), &id(2)));
+        assert!(!happens_before_in_topology(&t, &id(1), &id(2)));
+        assert!(!happens_before_in_topology(&t, &id(99), &id(42)));
+    }
+
+    #[test]
+    fn cycle_is_resilient() {
+        // Causal DAGs cannot have cycles, but the BFS must still
+        // terminate if a malformed mirror ever produced one — the
+        // `seen` set is the load-bearing guard.
+        let t = topology(&[(1, &[2]), (2, &[1])]);
+        // The query terminates rather than spinning; ancestry result
+        // for cyclic input is best-effort.
+        let _ = happens_before_in_topology(&t, &id(1), &id(2));
+        let _ = happens_before_in_topology(&t, &id(2), &id(1));
+    }
+}
+
+#[cfg(test)]
+mod seed_topology_tests {
+    //! `seed_topology` is the cross-restart correctness hinge: without
+    //! the seeding step in `load_persisted_deltas`, the topology mirror
+    //! is empty after restart and `happens_before` returns false for all
+    //! ancestry that pre-dates the restart.
+
+    use super::*;
+
+    fn id(b: u8) -> [u8; 32] {
+        [b; 32]
+    }
+
+    #[test]
+    fn seeded_chain_is_visible_to_happens_before() {
+        // Pretend we restored a 1 → 2 → 3 chain from disk.
+        let mut topology = HashMap::new();
+        seed_topology(
+            &mut topology,
+            vec![(id(2), vec![id(1)]), (id(3), vec![id(2)])],
+        );
+
+        assert!(happens_before_in_topology(&topology, &id(1), &id(3)));
+        assert!(happens_before_in_topology(&topology, &id(2), &id(3)));
+        assert!(!happens_before_in_topology(&topology, &id(3), &id(1)));
+    }
+
+    #[test]
+    fn seed_overwrites_existing_entries() {
+        // If the same id appears twice (shouldn't, but defensive), the
+        // later one wins — same semantic as the `apply()` path's
+        // `topology.insert(...)`.
+        let mut topology = HashMap::new();
+        seed_topology(&mut topology, vec![(id(2), vec![id(1)])]);
+        seed_topology(&mut topology, vec![(id(2), vec![id(7)])]);
+
+        assert_eq!(topology.get(&id(2)), Some(&vec![id(7)]));
+    }
+
+    #[test]
+    fn seed_with_empty_iter_is_noop() {
+        let mut topology = HashMap::new();
+        let _ = topology.insert(id(2), vec![id(1)]);
+        seed_topology(&mut topology, std::iter::empty());
+        assert_eq!(topology.len(), 1);
+        assert_eq!(topology.get(&id(2)), Some(&vec![id(1)]));
     }
 }

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -25,7 +25,8 @@ use calimero_storage::action::Action;
 use calimero_storage::address::Id;
 use calimero_storage::delta::StorageDelta;
 use calimero_storage::entities::StorageType;
-use calimero_storage::store::MainStorage;
+use calimero_storage::rotation_log::RotationLog;
+use calimero_storage::store::Key as StorageKey;
 use eyre::Result;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
@@ -574,15 +575,25 @@ impl ContextStorageApplier {
                 continue;
             }
 
-            let log = match calimero_storage::rotation_log::load::<MainStorage>(entity_id) {
-                Ok(Some(log)) => log,
-                Ok(None) => continue, // No log → verifier falls back to v2 stored-writers.
-                Err(e) => {
-                    return Err(eyre::eyre!(
-                        "rotation_log::load for entity {entity_id:?} failed: {e}"
-                    ))
-                }
-            };
+            // #2266 / #2272-review: read the rotation log directly from
+            // the datastore rather than via `MainStorage::storage_read`.
+            // `MainStorage` routes through the `RUNTIME_ENV` thread-local
+            // which is only installed inside `context_client.execute()` —
+            // i.e. *after* this function runs. Without this direct read
+            // the load fell through to an empty in-process mock in
+            // production, silently disabling the entire DAG-causal
+            // verifier path. See PR #2272 review thread "rotation_log::load
+            // called outside RuntimeEnv scope".
+            let log =
+                match load_rotation_log_direct(&self.context_client, self.context_id, entity_id) {
+                    Ok(Some(log)) => log,
+                    Ok(None) => continue, // No log → verifier falls back to v2 stored-writers.
+                    Err(e) => {
+                        return Err(eyre::eyre!(
+                            "rotation_log direct read for entity {entity_id:?} failed: {e}"
+                        ))
+                    }
+                };
 
             let resolved = rotation_log_reader::writers_at(&log, &delta.parents, |a, b| {
                 happens_before_in_topology(&topology_snapshot, a, b)
@@ -634,6 +645,44 @@ fn seed_topology(
     for (delta_id, parents) in deltas {
         let _previous = topology.insert(delta_id, parents);
     }
+}
+
+/// Read a `RotationLog` directly from the datastore for a given context
+/// + entity, bypassing `calimero_storage::rotation_log::load` (which
+/// goes through the `RUNTIME_ENV` thread-local that's only installed
+/// inside `context_client.execute()`).
+///
+/// The on-disk shape mirrors what
+/// `calimero_node_primitives::sync::storage_bridge::create_runtime_env`
+/// writes inside the WASM execute scope: `Key::RotationLog(entity_id)`
+/// is hashed to a 32-byte state key, and the value lives under
+/// `ContextState::new(context_id, state_key)`. Decoded via Borsh.
+///
+/// Returns `Ok(None)` for entities with no rotation log yet (every
+/// pre-rotation Shared entity), which is fine — the receiver verifier
+/// then falls back to v2 stored-writers, matching pre-#2266 behavior.
+fn load_rotation_log_direct(
+    context_client: &ContextClient,
+    context_id: ContextId,
+    entity_id: Id,
+) -> Result<Option<RotationLog>> {
+    let storage_key = StorageKey::RotationLog(entity_id).to_bytes();
+    let state_key = calimero_store::key::ContextState::new(context_id, storage_key);
+    let handle = context_client.datastore_handle();
+    // Copy the bytes out before `handle` is dropped — `state.value` is a
+    // `Slice<'_>` borrowed from the handle's read snapshot.
+    let bytes: Option<Vec<u8>> = match handle.get(&state_key) {
+        Ok(Some(state)) => Some(state.value.into_boxed().into_vec()),
+        Ok(None) => None,
+        Err(e) => return Err(eyre::eyre!("rotation_log datastore read failed: {e:?}")),
+    };
+    drop(handle);
+    let Some(bytes) = bytes else {
+        return Ok(None);
+    };
+    let log = borsh::from_slice::<RotationLog>(&bytes)
+        .map_err(|e| eyre::eyre!("rotation_log decode failed: {e}"))?;
+    Ok(Some(log))
 }
 
 /// Reverse-BFS reachability over a `delta_id → parents` mirror of the

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -305,10 +305,10 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
             let mut topology = self.topology.write().await;
             let _previous = topology.insert(delta.id, delta.parents.clone());
 
-            // `IndexMap::shift_remove_index(0)` evicts oldest-first
-            // (insertion order), preserving recently-applied deltas
-            // whose ancestry links are still needed by buffered
-            // children. Cf. #2272 review on non-deterministic eviction.
+            // Evict oldest-first (insertion order) so recently-applied
+            // deltas — whose ancestry links are still needed by buffered
+            // children — survive the cap. Cf. #2272 review on
+            // non-deterministic eviction.
             cap_topology(&mut topology);
         }
 
@@ -644,14 +644,21 @@ fn seed_topology(
 /// oldest-inserted entries first (the `IndexMap` insertion-order
 /// invariant is what makes this deterministic). Targets 90% of the cap
 /// after eviction so we don't thrash on every insert near the boundary.
+///
+/// Uses `IndexMap::drain(0..excess)` for an O(n) eviction in a single
+/// memmove pass. A naive `shift_remove_index(0)` loop would be O(excess
+/// × n) — at 100K persisted deltas during `restore_topology`, that's
+/// ~9 billion shifts and a multi-second startup stall under the
+/// topology write lock. Cf. PR #2272 review on quadratic eviction cost.
 fn cap_topology(topology: &mut IndexMap<[u8; 32], Vec<[u8; 32]>>) {
     if topology.len() <= MAX_TOPOLOGY_ENTRIES {
         return;
     }
     let excess = topology.len() - (MAX_TOPOLOGY_ENTRIES * 9 / 10);
-    for _ in 0..excess {
-        let _removed = topology.shift_remove_index(0);
-    }
+    // The `Drain` iterator's destructor removes the front-range entries
+    // and shifts the tail left by `excess` in a single memmove. Letting
+    // it drop at end of statement is sufficient.
+    drop(topology.drain(0..excess));
 }
 
 /// Read a `RotationLog` directly from the datastore for a given context
@@ -2385,6 +2392,42 @@ mod seed_topology_tests {
                 "expected recent entry {i} to survive"
             );
         }
+    }
+
+    /// Stress test for the eviction's asymptotic cost.
+    ///
+    /// `restore_topology` may seed up to N entries from disk in one shot.
+    /// A naive `loop { shift_remove_index(0) }` would be O(excess × n)
+    /// — at the values exercised here (n=10× cap, excess=91% of n) that
+    /// reduces to ~9 billion shifts and a multi-second startup stall
+    /// under the topology write lock. The `drain(0..excess)` form is
+    /// O(n). This test runs in well under a second; if a future change
+    /// reverts to per-element eviction, the timeout makes it loud.
+    /// Cf. PR #2272 review on quadratic eviction cost.
+    #[test]
+    fn cap_topology_evicts_in_linear_time() {
+        let mut topology: IndexMap<[u8; 32], Vec<[u8; 32]>> = IndexMap::new();
+        let total = MAX_TOPOLOGY_ENTRIES * 10;
+        for i in 0..total {
+            let mut k32 = [0_u8; 32];
+            k32[..8].copy_from_slice(&u64::try_from(i).unwrap().to_le_bytes());
+            let _ = topology.insert(k32, vec![]);
+        }
+
+        let start = std::time::Instant::now();
+        cap_topology(&mut topology);
+        let elapsed = start.elapsed();
+
+        let target = MAX_TOPOLOGY_ENTRIES * 9 / 10;
+        assert_eq!(topology.len(), target);
+        // Generous bound — this should take milliseconds, not seconds.
+        // A regression to O(excess × n) at this size would take many
+        // seconds and trip this assertion.
+        assert!(
+            elapsed.as_secs() < 2,
+            "cap_topology({total} entries) took {elapsed:?} — likely a \
+             regression to O(excess × n) eviction"
+        );
     }
 
     #[test]

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -28,10 +28,19 @@ use calimero_storage::entities::StorageType;
 use calimero_storage::rotation_log::RotationLog;
 use calimero_storage::store::Key as StorageKey;
 use eyre::Result;
+use indexmap::IndexMap;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
 use crate::sync::rotation_log_reader;
+
+/// Maximum entries in the applier-local topology mirror. Exceeding this
+/// triggers oldest-first eviction (insertion-ordered via `IndexMap`)
+/// down to 90% of the cap. Applied both inside `apply()` (steady state)
+/// and at the end of `restore_topology` (startup seed) so a long-lived
+/// node persisting >10K deltas doesn't carry the full set in memory
+/// across restarts. Per #2272 review.
+const MAX_TOPOLOGY_ENTRIES: usize = 10_000;
 
 /// Result of adding a delta with cascaded event information
 #[derive(Debug)]
@@ -120,14 +129,16 @@ struct ContextStorageApplier {
     /// [`rotation_log_reader::writers_at`] needs — kept separate from
     /// the `Arc<RwLock<CoreDagStore>>` so reads here don't deadlock
     /// against the dag write lock the caller holds during `add_delta`.
-    /// (#2266)
-    topology: Arc<RwLock<HashMap<[u8; 32], Vec<[u8; 32]>>>>,
-    /// Cache for resolved writer sets keyed on `(entity_id, delta_id)`.
-    /// Each entry is the answer to "what was the writer set for this
-    /// Shared entity as of this delta's causal frontier?" Cache hits
-    /// dominate when chains of deltas all reference the same entity
-    /// against the same parent set. (#2266)
-    effective_writers_cache: Arc<RwLock<HashMap<(Id, [u8; 32]), BTreeSet<PublicKey>>>>,
+    ///
+    /// Stored as `IndexMap` so eviction at the `MAX_TOPOLOGY_ENTRIES`
+    /// cap iterates insertion order (oldest-first) — `HashMap`'s
+    /// iteration order is non-deterministic and could evict recent
+    /// ancestry links still needed by buffered children, which is
+    /// security-adjacent: a missing link makes `happens_before` return
+    /// false, `writers_at` returns `None`, and the verifier falls back
+    /// to v2 stored-writers, potentially admitting a revoked writer.
+    /// (#2266 + #2272 review)
+    topology: Arc<RwLock<IndexMap<[u8; 32], Vec<[u8; 32]>>>>,
 }
 
 #[async_trait::async_trait]
@@ -294,14 +305,11 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
             let mut topology = self.topology.write().await;
             let _previous = topology.insert(delta.id, delta.parents.clone());
 
-            const MAX_TOPOLOGY_ENTRIES: usize = 10_000;
-            if topology.len() > MAX_TOPOLOGY_ENTRIES {
-                let excess = topology.len() - (MAX_TOPOLOGY_ENTRIES * 9 / 10);
-                let keys_to_remove: Vec<_> = topology.keys().take(excess).copied().collect();
-                for key in keys_to_remove {
-                    let _removed = topology.remove(&key);
-                }
-            }
+            // `IndexMap::shift_remove_index(0)` evicts oldest-first
+            // (insertion order), preserving recently-applied deltas
+            // whose ancestry links are still needed by buffered
+            // children. Cf. #2272 review on non-deterministic eviction.
+            cap_topology(&mut topology);
         }
 
         // Store the ACTUAL computed hash after applying this delta for future merge detection
@@ -536,11 +544,15 @@ impl ContextStorageApplier {
     /// Iterates the action payload, picks out Shared `Add`/`Update`/
     /// `DeleteRef`s, dedups by entity, and resolves each via
     /// [`rotation_log_reader::writers_at`] against this applier's
-    /// `topology` view of the DAG. Cache-keyed on `(entity_id, delta_id)`.
+    /// `topology` view of the DAG.
     ///
     /// Returns a map keyed by entity id; non-Shared entities are absent.
     /// An empty result is normal — a delta with only User/Frozen/Public
     /// actions has nothing to resolve.
+    ///
+    /// No caching: each delta is applied at most once (the DAG dedups
+    /// by content-addressed `delta.id`), so a per-`(entity, delta_id)`
+    /// cache could never hit. Removed per #2272 review.
     async fn resolve_effective_writers_for_delta(
         &self,
         delta: &CausalDelta<Vec<Action>>,
@@ -569,21 +581,11 @@ impl ContextStorageApplier {
         let topology_snapshot = self.topology.read().await.clone();
 
         for entity_id in shared_entities {
-            let cache_key = (entity_id, delta.id);
-            if let Some(cached) = self.effective_writers_cache.read().await.get(&cache_key) {
-                let _replaced = out.insert(entity_id, cached.clone());
-                continue;
-            }
-
-            // #2266 / #2272-review: read the rotation log directly from
-            // the datastore rather than via `MainStorage::storage_read`.
-            // `MainStorage` routes through the `RUNTIME_ENV` thread-local
-            // which is only installed inside `context_client.execute()` —
-            // i.e. *after* this function runs. Without this direct read
-            // the load fell through to an empty in-process mock in
-            // production, silently disabling the entire DAG-causal
-            // verifier path. See PR #2272 review thread "rotation_log::load
-            // called outside RuntimeEnv scope".
+            // Read the rotation log directly from the datastore rather
+            // than via `MainStorage::storage_read`. `MainStorage` routes
+            // through the `RUNTIME_ENV` thread-local which is only
+            // installed inside `context_client.execute()` — i.e. *after*
+            // this function runs. See `load_rotation_log_direct` doc.
             let log =
                 match load_rotation_log_direct(&self.context_client, self.context_id, entity_id) {
                     Ok(Some(log)) => log,
@@ -600,21 +602,7 @@ impl ContextStorageApplier {
             });
 
             if let Some(set) = resolved {
-                let _replaced = out.insert(entity_id, set.clone());
-
-                let mut cache = self.effective_writers_cache.write().await;
-                let _previous = cache.insert(cache_key, set);
-
-                // Bound the cache the same way as parent_hashes/topology
-                // to keep long-lived nodes from growing unboundedly.
-                const MAX_EFFECTIVE_WRITERS_ENTRIES: usize = 10_000;
-                if cache.len() > MAX_EFFECTIVE_WRITERS_ENTRIES {
-                    let excess = cache.len() - (MAX_EFFECTIVE_WRITERS_ENTRIES * 9 / 10);
-                    let keys_to_remove: Vec<_> = cache.keys().take(excess).copied().collect();
-                    for key in keys_to_remove {
-                        let _removed = cache.remove(&key);
-                    }
-                }
+                let _replaced = out.insert(entity_id, set);
             }
         }
 
@@ -632,6 +620,11 @@ impl ContextStorageApplier {
     async fn restore_topology(&self, deltas: impl IntoIterator<Item = ([u8; 32], Vec<[u8; 32]>)>) {
         let mut topology = self.topology.write().await;
         seed_topology(&mut topology, deltas);
+        // #2272 review: enforce the same `MAX_TOPOLOGY_ENTRIES` cap that
+        // `apply()` uses. Without this, a context with 100K persisted
+        // deltas would seed all of them at startup and consume ~10MB+
+        // until enough new deltas triggered the steady-state cap.
+        cap_topology(&mut topology);
     }
 }
 
@@ -639,11 +632,25 @@ impl ContextStorageApplier {
 /// (later entries overwrite earlier ones with the same delta id) can be
 /// unit-tested without standing up a `ContextStorageApplier`.
 fn seed_topology(
-    topology: &mut HashMap<[u8; 32], Vec<[u8; 32]>>,
+    topology: &mut IndexMap<[u8; 32], Vec<[u8; 32]>>,
     deltas: impl IntoIterator<Item = ([u8; 32], Vec<[u8; 32]>)>,
 ) {
     for (delta_id, parents) in deltas {
         let _previous = topology.insert(delta_id, parents);
+    }
+}
+
+/// Trim a topology mirror to `MAX_TOPOLOGY_ENTRIES` by evicting the
+/// oldest-inserted entries first (the `IndexMap` insertion-order
+/// invariant is what makes this deterministic). Targets 90% of the cap
+/// after eviction so we don't thrash on every insert near the boundary.
+fn cap_topology(topology: &mut IndexMap<[u8; 32], Vec<[u8; 32]>>) {
+    if topology.len() <= MAX_TOPOLOGY_ENTRIES {
+        return;
+    }
+    let excess = topology.len() - (MAX_TOPOLOGY_ENTRIES * 9 / 10);
+    for _ in 0..excess {
+        let _removed = topology.shift_remove_index(0);
     }
 }
 
@@ -688,8 +695,12 @@ fn load_rotation_log_direct(
 /// Reverse-BFS reachability over a `delta_id → parents` mirror of the
 /// DAG: returns true iff `a` is in the transitive ancestry of `b`. Pure
 /// over the snapshot — `happens_before(x, x) == false` (strict ancestry).
-fn happens_before_in_topology(
-    topology: &HashMap<[u8; 32], Vec<[u8; 32]>>,
+///
+/// Re-exported under `calimero_node::sync::happens_before_in_topology`
+/// for integration tests so they can mirror the production resolve
+/// flow without copying the function (#2272 review).
+pub fn happens_before_in_topology(
+    topology: &IndexMap<[u8; 32], Vec<[u8; 32]>>,
     a: &[u8; 32],
     b: &[u8; 32],
 ) -> bool {
@@ -745,12 +756,13 @@ impl DeltaStore {
             our_identity,
             parent_hashes: Arc::clone(&parent_hashes),
             merged_deltas: Arc::clone(&merged_deltas),
-            // #2266: applier-local DAG topology + per-(entity,delta) cache
-            // for the rotation-log-driven writer-set resolution. Populated
-            // by `apply()` and seeded by `load_persisted_deltas` →
+            // #2266: applier-local DAG topology mirror for the
+            // rotation-log-driven writer-set resolution. Populated by
+            // `apply()` and seeded by `load_persisted_deltas` →
             // `restore_topology` so cross-restart ancestry is preserved.
-            topology: Arc::new(RwLock::new(HashMap::new())),
-            effective_writers_cache: Arc::new(RwLock::new(HashMap::new())),
+            // Insertion-ordered (IndexMap) so the eviction at the
+            // `MAX_TOPOLOGY_ENTRIES` cap is deterministic (oldest-first).
+            topology: Arc::new(RwLock::new(IndexMap::new())),
         });
 
         Self {
@@ -2205,7 +2217,7 @@ mod happens_before_tests {
         [b; 32]
     }
 
-    fn topology(edges: &[(u8, &[u8])]) -> HashMap<[u8; 32], Vec<[u8; 32]>> {
+    fn topology(edges: &[(u8, &[u8])]) -> IndexMap<[u8; 32], Vec<[u8; 32]>> {
         edges
             .iter()
             .map(|(child, parents)| (id(*child), parents.iter().copied().map(id).collect()))
@@ -2303,7 +2315,7 @@ mod seed_topology_tests {
     #[test]
     fn seeded_chain_is_visible_to_happens_before() {
         // Pretend we restored a 1 → 2 → 3 chain from disk.
-        let mut topology = HashMap::new();
+        let mut topology = IndexMap::new();
         seed_topology(
             &mut topology,
             vec![(id(2), vec![id(1)]), (id(3), vec![id(2)])],
@@ -2319,7 +2331,7 @@ mod seed_topology_tests {
         // If the same id appears twice (shouldn't, but defensive), the
         // later one wins — same semantic as the `apply()` path's
         // `topology.insert(...)`.
-        let mut topology = HashMap::new();
+        let mut topology = IndexMap::new();
         seed_topology(&mut topology, vec![(id(2), vec![id(1)])]);
         seed_topology(&mut topology, vec![(id(2), vec![id(7)])]);
 
@@ -2328,10 +2340,60 @@ mod seed_topology_tests {
 
     #[test]
     fn seed_with_empty_iter_is_noop() {
-        let mut topology = HashMap::new();
+        let mut topology = IndexMap::new();
         let _ = topology.insert(id(2), vec![id(1)]);
         seed_topology(&mut topology, std::iter::empty());
         assert_eq!(topology.len(), 1);
         assert_eq!(topology.get(&id(2)), Some(&vec![id(1)]));
+    }
+
+    #[test]
+    fn cap_topology_evicts_oldest_first() {
+        // Insert MAX + extra entries; cap to 90% of MAX. The oldest
+        // inserts must be the ones evicted; the most recent must
+        // survive — that's the load-bearing security property
+        // (see comment on `topology` field).
+        let mut topology: IndexMap<[u8; 32], Vec<[u8; 32]>> = IndexMap::new();
+        let total = MAX_TOPOLOGY_ENTRIES + 50;
+        for i in 0..total {
+            let key = u32::try_from(i).unwrap().to_le_bytes();
+            let mut k32 = [0_u8; 32];
+            k32[..4].copy_from_slice(&key);
+            let _ = topology.insert(k32, vec![]);
+        }
+        cap_topology(&mut topology);
+
+        let target = MAX_TOPOLOGY_ENTRIES * 9 / 10;
+        assert_eq!(topology.len(), target);
+
+        // The first `total - target` inserts must be gone; the rest
+        // must be present (insertion order, deterministic).
+        let evicted_count = total - target;
+        for i in 0..evicted_count {
+            let mut k32 = [0_u8; 32];
+            k32[..4].copy_from_slice(&u32::try_from(i).unwrap().to_le_bytes());
+            assert!(
+                !topology.contains_key(&k32),
+                "expected oldest entry {i} to be evicted"
+            );
+        }
+        for i in evicted_count..total {
+            let mut k32 = [0_u8; 32];
+            k32[..4].copy_from_slice(&u32::try_from(i).unwrap().to_le_bytes());
+            assert!(
+                topology.contains_key(&k32),
+                "expected recent entry {i} to survive"
+            );
+        }
+    }
+
+    #[test]
+    fn cap_topology_under_cap_is_noop() {
+        let mut topology: IndexMap<[u8; 32], Vec<[u8; 32]>> = IndexMap::new();
+        for i in 0..100_u8 {
+            let _ = topology.insert([i; 32], vec![]);
+        }
+        cap_topology(&mut topology);
+        assert_eq!(topology.len(), 100);
     }
 }

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -9,7 +9,7 @@
 //! This ensures that all nodes converge to the same state regardless of the
 //! order in which they receive concurrent deltas.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -22,10 +22,15 @@ use calimero_primitives::context::ContextId;
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
+use calimero_storage::address::Id;
 use calimero_storage::delta::StorageDelta;
+use calimero_storage::entities::StorageType;
+use calimero_storage::store::MainStorage;
 use eyre::Result;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+
+use crate::sync::rotation_log_reader;
 
 /// Result of adding a delta with cascaded event information
 #[derive(Debug)]
@@ -107,6 +112,21 @@ struct ContextStorageApplier {
     /// while Node-B applies X sequentially → hash H2. When Node-B's child delta
     /// arrives, we must recognize that our parent hash differs from the author's.
     merged_deltas: Arc<RwLock<HashSet<[u8; 32]>>>,
+    /// `delta_id → parents` for every applied delta this node has seen.
+    /// Maintained inside `apply()` (after WASM success) and seeded by
+    /// `restore_topology` from `load_persisted_deltas`. Read-only inside
+    /// `apply()` to derive the `happens_before` predicate that
+    /// [`rotation_log_reader::writers_at`] needs — kept separate from
+    /// the `Arc<RwLock<CoreDagStore>>` so reads here don't deadlock
+    /// against the dag write lock the caller holds during `add_delta`.
+    /// (#2266)
+    topology: Arc<RwLock<HashMap<[u8; 32], Vec<[u8; 32]>>>>,
+    /// Cache for resolved writer sets keyed on `(entity_id, delta_id)`.
+    /// Each entry is the answer to "what was the writer set for this
+    /// Shared entity as of this delta's causal frontier?" Cache hits
+    /// dominate when chains of deltas all reference the same entity
+    /// against the same parent set. (#2266)
+    effective_writers_cache: Arc<RwLock<HashMap<(Id, [u8; 32]), BTreeSet<PublicKey>>>>,
 }
 
 #[async_trait::async_trait]
@@ -159,9 +179,28 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
             );
         }
 
-        // Serialize actions to StorageDelta
-        let artifact = borsh::to_vec(&StorageDelta::Actions(delta.payload.clone()))
-            .map_err(|e| ApplyError::Application(format!("Failed to serialize delta: {e}")))?;
+        // #2266: resolve `effective_writers` for every Shared entity
+        // touched by this delta, then ship the artifact as
+        // `StorageDelta::CausalActions` so the receiver's verifier
+        // validates Shared signatures against the pre-resolved set
+        // (per ADR 0001 / writers_at(delta.parents)) instead of
+        // falling back to v2 stored writers. Resolution reads `topology`
+        // (this applier's local copy of the DAG parent links) so it
+        // doesn't contend with the dag write lock held by our caller.
+        let effective_writers = self
+            .resolve_effective_writers_for_delta(delta)
+            .await
+            .map_err(|e| {
+                ApplyError::Application(format!("Failed to resolve effective writers: {e}"))
+            })?;
+
+        let artifact = borsh::to_vec(&StorageDelta::CausalActions {
+            actions: delta.payload.clone(),
+            delta_id: delta.id,
+            delta_hlc: delta.hlc,
+            effective_writers,
+        })
+        .map_err(|e| ApplyError::Application(format!("Failed to serialize delta: {e}")))?;
 
         let wasm_start = std::time::Instant::now();
 
@@ -241,6 +280,26 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
                     expected_hash = %Hash::from(delta.expected_root_hash),
                     "Hash mismatch (concurrent state) - CRDT merge ensures consistency"
                 );
+            }
+        }
+
+        // #2266: record this delta's parent links into the applier's
+        // topology mirror so cascaded children's `apply()` can resolve
+        // happens_before against an up-to-date view. Done after WASM
+        // success so a failed apply doesn't pollute the topology with
+        // an unapplied delta. Bounded the same way as `parent_hashes`
+        // below so it can't grow without limit on long-lived nodes.
+        {
+            let mut topology = self.topology.write().await;
+            let _previous = topology.insert(delta.id, delta.parents.clone());
+
+            const MAX_TOPOLOGY_ENTRIES: usize = 10_000;
+            if topology.len() > MAX_TOPOLOGY_ENTRIES {
+                let excess = topology.len() - (MAX_TOPOLOGY_ENTRIES * 9 / 10);
+                let keys_to_remove: Vec<_> = topology.keys().take(excess).copied().collect();
+                for key in keys_to_remove {
+                    let _removed = topology.remove(&key);
+                }
             }
         }
 
@@ -470,6 +529,128 @@ impl ContextStorageApplier {
         );
         true
     }
+
+    /// Resolve the writer set for every Shared entity touched by `delta`.
+    ///
+    /// Iterates the action payload, picks out Shared `Add`/`Update`/
+    /// `DeleteRef`s, dedups by entity, and resolves each via
+    /// [`rotation_log_reader::writers_at`] against this applier's
+    /// `topology` view of the DAG. Cache-keyed on `(entity_id, delta_id)`.
+    ///
+    /// Returns a map keyed by entity id; non-Shared entities are absent.
+    /// An empty result is normal — a delta with only User/Frozen/Public
+    /// actions has nothing to resolve.
+    async fn resolve_effective_writers_for_delta(
+        &self,
+        delta: &CausalDelta<Vec<Action>>,
+    ) -> Result<BTreeMap<Id, BTreeSet<PublicKey>>> {
+        let mut shared_entities: BTreeSet<Id> = BTreeSet::new();
+        for action in &delta.payload {
+            let metadata = match action {
+                Action::Add { metadata, .. }
+                | Action::Update { metadata, .. }
+                | Action::DeleteRef { metadata, .. } => metadata,
+                Action::Compare { .. } => continue,
+            };
+            if matches!(metadata.storage_type, StorageType::Shared { .. }) {
+                let _inserted = shared_entities.insert(action.id());
+            }
+        }
+
+        let mut out: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
+        if shared_entities.is_empty() {
+            return Ok(out);
+        }
+
+        // Snapshot topology once per delta apply. The `happens_before`
+        // closure consults this snapshot for every reachability test
+        // inside `writers_at`, avoiding repeated lock acquisitions.
+        let topology_snapshot = self.topology.read().await.clone();
+
+        for entity_id in shared_entities {
+            let cache_key = (entity_id, delta.id);
+            if let Some(cached) = self.effective_writers_cache.read().await.get(&cache_key) {
+                let _replaced = out.insert(entity_id, cached.clone());
+                continue;
+            }
+
+            let log = match calimero_storage::rotation_log::load::<MainStorage>(entity_id) {
+                Ok(Some(log)) => log,
+                Ok(None) => continue, // No log → verifier falls back to v2 stored-writers.
+                Err(e) => {
+                    return Err(eyre::eyre!(
+                        "rotation_log::load for entity {entity_id:?} failed: {e}"
+                    ))
+                }
+            };
+
+            let resolved = rotation_log_reader::writers_at(&log, &delta.parents, |a, b| {
+                happens_before_in_topology(&topology_snapshot, a, b)
+            });
+
+            if let Some(set) = resolved {
+                let _replaced = out.insert(entity_id, set.clone());
+
+                let mut cache = self.effective_writers_cache.write().await;
+                let _previous = cache.insert(cache_key, set);
+
+                // Bound the cache the same way as parent_hashes/topology
+                // to keep long-lived nodes from growing unboundedly.
+                const MAX_EFFECTIVE_WRITERS_ENTRIES: usize = 10_000;
+                if cache.len() > MAX_EFFECTIVE_WRITERS_ENTRIES {
+                    let excess = cache.len() - (MAX_EFFECTIVE_WRITERS_ENTRIES * 9 / 10);
+                    let keys_to_remove: Vec<_> = cache.keys().take(excess).copied().collect();
+                    for key in keys_to_remove {
+                        let _removed = cache.remove(&key);
+                    }
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Seed `topology` with deltas restored by `load_persisted_deltas`.
+    ///
+    /// Persisted deltas are restored into the dag via
+    /// `restore_applied_delta` without going through `apply()`, so the
+    /// topology mirror would otherwise miss them and `happens_before`
+    /// would incorrectly return false for ancestry that crosses the
+    /// pre-restart boundary. Call this once after persisted-delta
+    /// restoration completes.
+    async fn restore_topology(&self, deltas: impl IntoIterator<Item = ([u8; 32], Vec<[u8; 32]>)>) {
+        let mut topology = self.topology.write().await;
+        for (delta_id, parents) in deltas {
+            let _previous = topology.insert(delta_id, parents);
+        }
+    }
+}
+
+/// Reverse-BFS reachability over a `delta_id → parents` mirror of the
+/// DAG: returns true iff `a` is in the transitive ancestry of `b`. Pure
+/// over the snapshot — `happens_before(x, x) == false` (strict ancestry).
+fn happens_before_in_topology(
+    topology: &HashMap<[u8; 32], Vec<[u8; 32]>>,
+    a: &[u8; 32],
+    b: &[u8; 32],
+) -> bool {
+    if a == b {
+        return false;
+    }
+    let mut frontier: Vec<[u8; 32]> = topology.get(b).cloned().unwrap_or_default();
+    let mut seen: HashSet<[u8; 32]> = HashSet::new();
+    while let Some(node) = frontier.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        if &node == a {
+            return true;
+        }
+        if let Some(parents) = topology.get(&node) {
+            frontier.extend(parents.iter().copied());
+        }
+    }
+    false
 }
 
 /// Node-level delta store that wraps calimero-dag
@@ -505,6 +686,12 @@ impl DeltaStore {
             our_identity,
             parent_hashes: Arc::clone(&parent_hashes),
             merged_deltas: Arc::clone(&merged_deltas),
+            // #2266: applier-local DAG topology + per-(entity,delta) cache
+            // for the rotation-log-driven writer-set resolution. Populated
+            // by `apply()` and seeded by `load_persisted_deltas` →
+            // `restore_topology` so cross-restart ancestry is preserved.
+            topology: Arc::new(RwLock::new(HashMap::new())),
+            effective_writers_cache: Arc::new(RwLock::new(HashMap::new())),
         });
 
         Self {
@@ -679,6 +866,12 @@ impl DeltaStore {
         let mut loaded_count = 0;
         let mut remaining = all_deltas;
         let mut progress_made = true;
+        // #2266: collect (delta_id, parents) for the applier-local
+        // topology mirror. Persisted deltas bypass `apply()` (they're
+        // restored as already-applied), so without this seed the mirror
+        // would be empty after restart and `happens_before` would
+        // incorrectly return false for any cross-restart ancestry.
+        let mut topology_seed: Vec<([u8; 32], Vec<[u8; 32]>)> = Vec::new();
 
         while progress_made && !remaining.is_empty() {
             progress_made = false;
@@ -698,6 +891,7 @@ impl DeltaStore {
                     if dag.restore_applied_delta(dag_delta.clone()) {
                         loaded_count += 1;
                         to_remove.push(*delta_id);
+                        topology_seed.push((*delta_id, dag_delta.parents.clone()));
                         progress_made = true;
                     }
                 }
@@ -706,6 +900,11 @@ impl DeltaStore {
             for delta_id in to_remove {
                 drop(remaining.remove(&delta_id));
             }
+        }
+
+        // Seed the applier topology with everything we just restored.
+        if !topology_seed.is_empty() {
+            self.applier.restore_topology(topology_seed).await;
         }
 
         // Count + small bs58 sample rather than full-list Debug —

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -88,16 +88,11 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
                 ancestors: vec![],
                 metadata: Metadata::default(),
             };
-            // P1 of #2233: snapshot leaf push has no DAG-causal context.
-            Interface::<MainStorage>::apply_action(
-                root_action,
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            )?;
+            // #2266: snapshot leaf push has no `CausalDelta` in scope —
+            // these bytes come from a peer who already verified them.
+            // Empty ctx → verifier falls back to v2 stored-writers, which
+            // is the safe semantic for already-verified replicated state.
+            Interface::<MainStorage>::apply_action(root_action, &ApplyContext::empty())?;
         }
 
         // Get root info for ancestor chain
@@ -122,16 +117,11 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
         }
     };
 
-    // P1 of #2233: snapshot leaf push has no DAG-causal context.
-    Interface::<MainStorage>::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )?;
+    // #2266: snapshot leaf push has no `CausalDelta` in scope — these
+    // bytes come from a peer who already verified them. Empty ctx →
+    // verifier falls back to v2 stored-writers, which is the safe
+    // semantic for already-verified replicated state.
+    Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())?;
     Ok(())
 }
 

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -43,6 +43,7 @@ mod manager;
 pub mod metrics;
 pub(crate) mod parent_pull;
 pub mod prometheus_metrics;
+pub(crate) mod rotation_log_reader;
 mod snapshot;
 pub(crate) mod stream;
 mod tracking;

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -58,6 +58,9 @@ mod p3_dag_causal_tests;
 mod p5_partition_scenarios_tests;
 
 pub use config::SyncConfig;
+// Re-export for integration tests so they can mirror the production
+// resolve flow without copying the BFS body (#2272 review).
+pub use crate::delta_store::happens_before_in_topology;
 pub use hash_comparison_protocol::{
     HashComparisonConfig, HashComparisonFirstRequest, HashComparisonProtocol, HashComparisonStats,
 };

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -43,7 +43,7 @@ mod manager;
 pub mod metrics;
 pub(crate) mod parent_pull;
 pub mod prometheus_metrics;
-pub(crate) mod rotation_log_reader;
+pub mod rotation_log_reader;
 mod snapshot;
 pub(crate) mod stream;
 mod tracking;

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -48,6 +48,15 @@ mod snapshot;
 pub(crate) mod stream;
 mod tracking;
 
+// Cross-node integration tests for the four motivating partition scenarios
+// of #2197 / ADR 0001. Migrated from `calimero_storage::tests` per #2266
+// step 5 — they exercise the production sync-layer flow: load rotation log,
+// resolve `effective_writers` via `rotation_log_reader::writers_at`, apply.
+#[cfg(test)]
+mod p3_dag_causal_tests;
+#[cfg(test)]
+mod p5_partition_scenarios_tests;
+
 pub use config::SyncConfig;
 pub use hash_comparison_protocol::{
     HashComparisonConfig, HashComparisonFirstRequest, HashComparisonProtocol, HashComparisonStats,

--- a/crates/node/src/sync/p3_dag_causal_tests.rs
+++ b/crates/node/src/sync/p3_dag_causal_tests.rs
@@ -1,37 +1,89 @@
 //! Tests for phase **P3** of [#2233](https://github.com/calimero-network/core/issues/2233):
 //!
-//! - **Verifier swap.** When `ApplyContext` carries DAG-causal information,
-//!   `Interface::apply_action` validates `Shared` signatures against
-//!   `writers_at(causal_parents)` (per ADR 0001) instead of stored writers.
+//! - **Verifier swap.** When `ApplyContext` carries DAG-causal information
+//!   (resolved `effective_writers`), `Interface::apply_action` validates
+//!   `Shared` signatures against that set instead of stored writers.
 //!   When the context is empty, behavior matches v2 exactly.
 //! - **Write hook.** Successful applies of `Shared` rotations append a
 //!   [`RotationLogEntry`]. Value-writes (writers unchanged) and ctx without
 //!   `delta_id`/`delta_hlc` are no-ops.
+//!
+//! Migrated from `calimero_storage::tests::p3_dag_causal` per #2266 step 5.
+//! The closure-typed `happens_before` ApplyContext field is gone; resolution
+//! happens in this crate's `rotation_log_reader::writers_at` against a DAG
+//! the test owns. The single storage-layer write-hook stale-writers
+//! regression stays in `calimero_storage::tests::write_hook` (it asserts
+//! a storage-internal invariant; no DAG needed).
 
 use core::num::NonZeroU128;
+use std::collections::{BTreeSet, HashMap, HashSet};
 
-use ed25519_dalek::SigningKey;
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::action::Action;
+use calimero_storage::address::Id;
+use calimero_storage::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use calimero_storage::index::Index;
+use calimero_storage::interface::{ApplyContext, Interface, StorageError};
+use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use calimero_storage::rotation_log::{self, RotationLogEntry};
+use calimero_storage::store::{MockedStorage, StorageAdaptor};
+use ed25519_dalek::{Signer, SigningKey};
 
-use crate::address::Id;
-use crate::entities::{ChildInfo, Metadata};
-use crate::env;
-use crate::index::Index;
-use crate::interface::{ApplyContext, Interface};
-use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
-use crate::rotation_log::{self, RotationLogEntry};
-use crate::store::{MockedStorage, StorageAdaptor};
-use crate::tests::common::{build_signed_shared_action, pubkey_of};
+use crate::sync::rotation_log_reader;
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+/// Minimal DAG mirror used by tests to provide a `happens_before` predicate
+/// over delta ids — same shape as P5's `Dag`, scoped here so each test
+/// builds the DAG it needs.
+struct Dag {
+    parents: HashMap<[u8; 32], Vec<[u8; 32]>>,
+}
+
+impl Dag {
+    fn new() -> Self {
+        Self {
+            parents: HashMap::new(),
+        }
+    }
+
+    fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {
+        self.parents.insert(delta_id, parents);
+    }
+
+    fn happens_before(&self, ancestor: &[u8; 32], descendant: &[u8; 32]) -> bool {
+        if ancestor == descendant {
+            return false;
+        }
+        let mut frontier: Vec<[u8; 32]> = self.parents.get(descendant).cloned().unwrap_or_default();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        while let Some(node) = frontier.pop() {
+            if !seen.insert(node) {
+                continue;
+            }
+            if node == *ancestor {
+                return true;
+            }
+            if let Some(ps) = self.parents.get(&node) {
+                frontier.extend(ps.iter().copied());
+            }
+        }
+        false
+    }
+}
 
 // Each test uses a unique mocked-storage scope so they don't bleed into each
 // other (the mock store is a thread-local BTreeMap keyed on (scope, key)).
 type S<const SCOPE: usize> = MockedStorage<SCOPE>;
 
-// =============================================================================
-// Helpers
-// =============================================================================
-
 fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
+}
+
+fn pubkey_of(sk: &SigningKey) -> PublicKey {
+    PublicKey::from(*sk.verifying_key().as_bytes())
 }
 
 fn hlc(ns: u64) -> HybridTimestamp {
@@ -39,16 +91,17 @@ fn hlc(ns: u64) -> HybridTimestamp {
     HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
 }
 
-/// Returns an HLC nanosecond value rooted at "now" plus `step` seconds.
-/// Use this so sequential actions in a test always have strictly-increasing
-/// nonces without depending on wall-clock advancement between calls.
+/// Returns a HLC nanosecond value rooted at "now" plus `step` seconds.
 fn hlc_at(step: u64) -> u64 {
-    env::time_now().saturating_add(step.saturating_mul(1_000_000_000))
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    now.saturating_add(step.saturating_mul(1_000_000_000))
 }
 
 /// Pre-create the root index entry so non-root child entities can be
 /// added/updated by `apply_action` without tripping `IndexNotFound`.
-/// Returns the root `ChildInfo` ready to embed in an action's `ancestors`.
 fn setup_root<S: StorageAdaptor>() -> ChildInfo {
     let root_id = Id::root();
     let root_meta = Metadata::default();
@@ -56,34 +109,81 @@ fn setup_root<S: StorageAdaptor>() -> ChildInfo {
     ChildInfo::new(root_id, [0; 32], root_meta)
 }
 
-fn empty_ctx<'a>() -> ApplyContext<'a> {
-    ApplyContext {
-        causal_parents: &[],
-        delta_id: None,
-        delta_hlc: None,
-        happens_before: None,
-    }
-}
-
-fn dag_ctx<'a>(
-    parents: &'a [[u8; 32]],
-    delta_id: [u8; 32],
-    delta_hlc_ns: u64,
-    happens_before: &'a dyn Fn(&[u8; 32], &[u8; 32]) -> bool,
-) -> ApplyContext<'a> {
-    ApplyContext {
-        causal_parents: parents,
-        delta_id: Some(delta_id),
-        delta_hlc: Some(hlc(delta_hlc_ns)),
-        happens_before: Some(happens_before),
-    }
-}
-
-// Convenient per-test entity id derived from the scope so each test gets a
-// distinct, deterministic id (avoids any cross-test interference even if
-// scopes were reused).
 fn entity_id(seed: u8) -> Id {
     Id::new([seed; 32])
+}
+
+/// Build a signed `Shared` action — see notes on the storage-side helper
+/// (`tests::common::build_signed_shared_action`) for invariants.
+fn build_signed_shared_action(
+    add: bool,
+    id: Id,
+    data: Vec<u8>,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let mut metadata = Metadata::new(hlc_ns, hlc_ns);
+    metadata.storage_type = StorageType::Shared {
+        writers,
+        signature_data: Some(SignatureData {
+            signature: [0; 64],
+            nonce: hlc_ns,
+            signer: Some(pubkey_of(signer_sk)),
+        }),
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::Shared {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
+    action
+}
+
+/// Build an `ApplyContext` for `apply_action` by resolving `effective_writers`
+/// against the rotation log + DAG, mirroring the production sync-layer flow.
+fn ctx_for<S: StorageAdaptor>(
+    entity: Id,
+    parents: &[[u8; 32]],
+    delta_id: [u8; 32],
+    delta_hlc_ns: u64,
+    dag: &Dag,
+) -> ApplyContext {
+    let effective_writers = match rotation_log::load::<S>(entity).unwrap() {
+        Some(log) => {
+            rotation_log_reader::writers_at(&log, parents, |a, b| dag.happens_before(a, b))
+        }
+        None => None,
+    };
+    ApplyContext {
+        effective_writers,
+        delta_id: Some(delta_id),
+        delta_hlc: Some(hlc(delta_hlc_ns)),
+    }
 }
 
 // =============================================================================
@@ -95,8 +195,7 @@ fn entity_id(seed: u8) -> Id {
 /// claim when the entity doesn't exist yet (bootstrap).
 #[test]
 fn verifier_without_dag_context_uses_stored_writers() {
-    env::reset_for_testing();
-    let root = setup_root::<S<400>>();
+    let root = setup_root::<S<6400>>();
 
     let alice_sk = make_signing_key(0xA1);
     let alice = pubkey_of(&alice_sk);
@@ -111,7 +210,7 @@ fn verifier_without_dag_context_uses_stored_writers() {
         &alice_sk,
         vec![root.clone()],
     );
-    Interface::<S<400>>::apply_action(bootstrap, empty_ctx())
+    Interface::<S<6400>>::apply_action(bootstrap, &ApplyContext::empty())
         .expect("bootstrap accepted with v2 fallback");
 
     let update = build_signed_shared_action(
@@ -123,14 +222,14 @@ fn verifier_without_dag_context_uses_stored_writers() {
         &alice_sk,
         vec![],
     );
-    Interface::<S<400>>::apply_action(update, empty_ctx()).expect("update by writer accepted");
+    Interface::<S<6400>>::apply_action(update, &ApplyContext::empty())
+        .expect("update by writer accepted");
 }
 
 /// Action signed by a non-writer is rejected by the v2 path.
 #[test]
 fn verifier_without_dag_context_rejects_non_writer() {
-    env::reset_for_testing();
-    let root = setup_root::<S<401>>();
+    let root = setup_root::<S<6401>>();
 
     let alice_sk = make_signing_key(0xA2);
     let bob_sk = make_signing_key(0xB2);
@@ -146,7 +245,7 @@ fn verifier_without_dag_context_rejects_non_writer() {
         &alice_sk,
         vec![root.clone()],
     );
-    Interface::<S<401>>::apply_action(bootstrap, empty_ctx()).unwrap();
+    Interface::<S<6401>>::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
 
     // Bob is not in the stored writer set — must reject.
     let forged = build_signed_shared_action(
@@ -158,22 +257,18 @@ fn verifier_without_dag_context_rejects_non_writer() {
         &bob_sk,
         vec![],
     );
-    let result = Interface::<S<401>>::apply_action(forged, empty_ctx());
-    assert!(matches!(
-        result,
-        Err(crate::interface::StorageError::InvalidSignature)
-    ));
+    let result = Interface::<S<6401>>::apply_action(forged, &ApplyContext::empty());
+    assert!(matches!(result, Err(StorageError::InvalidSignature)));
 }
 
 /// **The partition-correctness fix.** A pre-populated rotation log says the
 /// writer set as-of `D1` is `{Alice}`. The stored entity (simulating
 /// divergent state from a partition) has `{Bob}`. An action signed by Alice
 /// with `causal_parents = [D1]` must be accepted: per ADR 0001 the verifier
-/// consults the rotation log, not stored.
+/// consults the rotation log resolution, not stored.
 #[test]
 fn verifier_with_dag_context_uses_rotation_log() {
-    env::reset_for_testing();
-    let root = setup_root::<S<402>>();
+    let root = setup_root::<S<6402>>();
 
     let alice_sk = make_signing_key(0xA3);
     let bob_sk = make_signing_key(0xB3);
@@ -191,11 +286,11 @@ fn verifier_with_dag_context_uses_rotation_log() {
         &bob_sk,
         vec![root.clone()],
     );
-    Interface::<S<402>>::apply_action(bootstrap, empty_ctx()).unwrap();
+    Interface::<S<6402>>::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
 
     // Pre-populate the rotation log: as-of delta D1, the writer set was {Alice}.
     let d1 = [0xD1; 32];
-    rotation_log::append::<S<402>>(
+    rotation_log::append::<S<6402>>(
         id,
         RotationLogEntry {
             delta_id: d1,
@@ -217,14 +312,13 @@ fn verifier_with_dag_context_uses_rotation_log() {
         &alice_sk,
         vec![],
     );
-    let parents = [d1];
-    // Direct parent-match in writers_at handles `delta_id == d1`; no DAG ancestry needed here.
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
-    let ctx = dag_ctx(&parents, [0xD2; 32], hlc_at(2), happens_before);
+    let mut dag = Dag::new();
+    dag.record(d1, vec![]);
+    let ctx = ctx_for::<S<6402>>(id, &[d1], [0xD2; 32], hlc_at(2), &dag);
 
-    // Without P3 this would be rejected (sig vs stored {Bob} fails).
-    // With P3 it's accepted because writers_at returns {Alice}.
-    Interface::<S<402>>::apply_action(action, ctx)
+    // Without DAG-causal this would be rejected (sig vs stored {Bob} fails).
+    // With DAG-causal it's accepted because writers_at returns {Alice}.
+    Interface::<S<6402>>::apply_action(action, &ctx)
         .expect("DAG-causal verifier accepts Alice — she's the writer as-of D1");
 }
 
@@ -232,8 +326,7 @@ fn verifier_with_dag_context_uses_rotation_log() {
 /// writer set is rejected.
 #[test]
 fn verifier_with_dag_context_rejects_non_causal_writer() {
-    env::reset_for_testing();
-    let root = setup_root::<S<403>>();
+    let root = setup_root::<S<6403>>();
 
     let alice_sk = make_signing_key(0xA4);
     let bob_sk = make_signing_key(0xB4);
@@ -251,10 +344,10 @@ fn verifier_with_dag_context_rejects_non_causal_writer() {
         &bob_sk,
         vec![root.clone()],
     );
-    Interface::<S<403>>::apply_action(bootstrap, empty_ctx()).unwrap();
+    Interface::<S<6403>>::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
 
     let d1 = [0xD1; 32];
-    rotation_log::append::<S<403>>(
+    rotation_log::append::<S<6403>>(
         id,
         RotationLogEntry {
             delta_id: d1,
@@ -276,16 +369,12 @@ fn verifier_with_dag_context_rejects_non_causal_writer() {
         &mallory_sk,
         vec![],
     );
-    let parents = [d1];
-    // Direct parent-match in writers_at handles `delta_id == d1`; no DAG ancestry needed here.
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
-    let ctx = dag_ctx(&parents, [0xD2; 32], hlc_at(2), happens_before);
+    let mut dag = Dag::new();
+    dag.record(d1, vec![]);
+    let ctx = ctx_for::<S<6403>>(id, &[d1], [0xD2; 32], hlc_at(2), &dag);
 
-    let result = Interface::<S<403>>::apply_action(forged, ctx);
-    assert!(matches!(
-        result,
-        Err(crate::interface::StorageError::InvalidSignature)
-    ));
+    let result = Interface::<S<6403>>::apply_action(forged, &ctx);
+    assert!(matches!(result, Err(StorageError::InvalidSignature)));
 }
 
 // =============================================================================
@@ -295,8 +384,7 @@ fn verifier_with_dag_context_rejects_non_causal_writer() {
 /// Bootstrap with full DAG context appends one rotation log entry.
 #[test]
 fn write_hook_appends_on_bootstrap_with_ctx() {
-    env::reset_for_testing();
-    let root = setup_root::<S<404>>();
+    let root = setup_root::<S<6404>>();
 
     let alice_sk = make_signing_key(0xA5);
     let alice = pubkey_of(&alice_sk);
@@ -311,11 +399,11 @@ fn write_hook_appends_on_bootstrap_with_ctx() {
         &alice_sk,
         vec![root.clone()],
     );
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
-    let ctx = dag_ctx(&[], [0xAA; 32], hlc_at(0), happens_before);
-    Interface::<S<404>>::apply_action(bootstrap, ctx).unwrap();
+    let dag = Dag::new();
+    let ctx = ctx_for::<S<6404>>(id, &[], [0xAA; 32], hlc_at(0), &dag);
+    Interface::<S<6404>>::apply_action(bootstrap, &ctx).unwrap();
 
-    let log = rotation_log::load::<S<404>>(id)
+    let log = rotation_log::load::<S<6404>>(id)
         .unwrap()
         .expect("rotation log exists after Shared apply with delta ctx");
     assert_eq!(log.entries.len(), 1);
@@ -325,11 +413,10 @@ fn write_hook_appends_on_bootstrap_with_ctx() {
 }
 
 /// Same bootstrap but with empty ctx (no delta_id) — the log stays empty.
-/// Production sync paths behave like this until the WASM ABI extension lands.
+/// Local-apply / snapshot-leaf paths behave like this.
 #[test]
 fn write_hook_skips_when_ctx_lacks_delta_id() {
-    env::reset_for_testing();
-    let root = setup_root::<S<405>>();
+    let root = setup_root::<S<6405>>();
 
     let alice_sk = make_signing_key(0xA6);
     let alice = pubkey_of(&alice_sk);
@@ -344,22 +431,21 @@ fn write_hook_skips_when_ctx_lacks_delta_id() {
         &alice_sk,
         vec![root.clone()],
     );
-    Interface::<S<405>>::apply_action(bootstrap, empty_ctx()).unwrap();
+    Interface::<S<6405>>::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
 
-    assert_eq!(rotation_log::load::<S<405>>(id).unwrap(), None);
+    assert_eq!(rotation_log::load::<S<6405>>(id).unwrap(), None);
 }
 
 /// Value-write (writer set unchanged) does not append an entry.
 #[test]
 fn write_hook_skips_when_writers_unchanged() {
-    env::reset_for_testing();
-    let root = setup_root::<S<406>>();
+    let root = setup_root::<S<6406>>();
 
     let alice_sk = make_signing_key(0xA7);
     let alice = pubkey_of(&alice_sk);
     let id = entity_id(0x46);
 
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+    let mut dag = Dag::new();
 
     let bootstrap = build_signed_shared_action(
         true,
@@ -370,13 +456,15 @@ fn write_hook_skips_when_writers_unchanged() {
         &alice_sk,
         vec![root.clone()],
     );
-    Interface::<S<406>>::apply_action(
+    let bootstrap_id = [0xBB; 32];
+    dag.record(bootstrap_id, vec![]);
+    Interface::<S<6406>>::apply_action(
         bootstrap,
-        dag_ctx(&[], [0xBB; 32], hlc_at(0), happens_before),
+        &ctx_for::<S<6406>>(id, &[], bootstrap_id, hlc_at(0), &dag),
     )
     .unwrap();
     assert_eq!(
-        rotation_log::load::<S<406>>(id)
+        rotation_log::load::<S<6406>>(id)
             .unwrap()
             .unwrap()
             .entries
@@ -394,21 +482,22 @@ fn write_hook_skips_when_writers_unchanged() {
         &alice_sk,
         vec![],
     );
-    Interface::<S<406>>::apply_action(
+    let vw_id = [0xCC; 32];
+    dag.record(vw_id, vec![bootstrap_id]);
+    Interface::<S<6406>>::apply_action(
         value_write,
-        dag_ctx(&[], [0xCC; 32], hlc_at(1), happens_before),
+        &ctx_for::<S<6406>>(id, &[bootstrap_id], vw_id, hlc_at(1), &dag),
     )
     .unwrap();
 
-    let log = rotation_log::load::<S<406>>(id).unwrap().unwrap();
+    let log = rotation_log::load::<S<6406>>(id).unwrap().unwrap();
     assert_eq!(log.entries.len(), 1, "value-write did not append");
 }
 
 /// Genuine rotation (writer set changes) appends a second entry.
 #[test]
 fn write_hook_appends_on_writer_set_change() {
-    env::reset_for_testing();
-    let root = setup_root::<S<407>>();
+    let root = setup_root::<S<6407>>();
 
     let alice_sk = make_signing_key(0xA8);
     let bob_sk = make_signing_key(0xB8);
@@ -416,7 +505,7 @@ fn write_hook_appends_on_writer_set_change() {
     let bob = pubkey_of(&bob_sk);
     let id = entity_id(0x47);
 
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
+    let mut dag = Dag::new();
 
     let bootstrap = build_signed_shared_action(
         true,
@@ -427,9 +516,11 @@ fn write_hook_appends_on_writer_set_change() {
         &alice_sk,
         vec![root.clone()],
     );
-    Interface::<S<407>>::apply_action(
+    let d0 = [0xD0; 32];
+    dag.record(d0, vec![]);
+    Interface::<S<6407>>::apply_action(
         bootstrap,
-        dag_ctx(&[], [0xD0; 32], hlc_at(0), happens_before),
+        &ctx_for::<S<6407>>(id, &[], d0, hlc_at(0), &dag),
     )
     .unwrap();
 
@@ -443,148 +534,33 @@ fn write_hook_appends_on_writer_set_change() {
         &alice_sk,
         vec![],
     );
-    Interface::<S<407>>::apply_action(
+    let d1 = [0xD1; 32];
+    dag.record(d1, vec![d0]);
+    Interface::<S<6407>>::apply_action(
         rotation,
-        dag_ctx(&[[0xD0; 32]], [0xD1; 32], hlc_at(1), happens_before),
+        &ctx_for::<S<6407>>(id, &[d0], d1, hlc_at(1), &dag),
     )
     .unwrap();
 
-    let log = rotation_log::load::<S<407>>(id).unwrap().unwrap();
+    let log = rotation_log::load::<S<6407>>(id).unwrap().unwrap();
     assert_eq!(log.entries.len(), 2);
-    assert_eq!(log.entries[1].delta_id, [0xD1; 32]);
+    assert_eq!(log.entries[1].delta_id, d1);
     assert_eq!(
         log.entries[1].new_writers,
         [alice, bob].into_iter().collect()
     );
 }
 
-/// Documents a known design fragility flagged in PR #2265 review.
-///
-/// `maybe_append_rotation_log` decides whether to append by comparing the
-/// action's claimed `writers` against the currently-stored writers. But
-/// `Index::update_hash_for` only touches `own_hash`/`full_hash`/`updated_at`
-/// — it never updates `metadata.storage_type`, so the stored writers stay
-/// frozen at the bootstrap set forever.
-///
-/// As a result, a value-write that *happens* to claim the bootstrap writers
-/// (e.g., authored by a peer with stale view) is correctly NOT logged as a
-/// rotation, even after a real rotation has updated the writer set logically.
-/// The rotation-detection logic depends on this stale-stored-writers behavior
-/// to avoid false positives.
-///
-/// If `update_hash_for` is ever changed to also update `storage_type`, the
-/// rotation-detection logic must switch to comparing against
-/// `writers_at(causal_parents)` instead, or stale value-writes will be
-/// falsely flagged as rotations. Same root cause underlies the v2 fallback
-/// verifier's reliance on stored writers for signature checks; both are
-/// tracked as #2233 P3 follow-up.
-#[test]
-fn write_hook_relies_on_stale_stored_writers_for_rotation_detection() {
-    env::reset_for_testing();
-    let root = setup_root::<S<408>>();
-
-    let alice_sk = make_signing_key(0xAB);
-    let bob_sk = make_signing_key(0xBB);
-    let alice = pubkey_of(&alice_sk);
-    let bob = pubkey_of(&bob_sk);
-    let id = entity_id(0x48);
-
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
-
-    // Bootstrap with {Alice, Bob}.
-    let bootstrap = build_signed_shared_action(
-        true,
-        id,
-        b"v0".to_vec(),
-        [alice, bob].into_iter().collect(),
-        hlc_at(0),
-        &alice_sk,
-        vec![root.clone()],
-    );
-    Interface::<S<408>>::apply_action(
-        bootstrap,
-        dag_ctx(&[], [0xE0; 32], hlc_at(0), happens_before),
-    )
-    .unwrap();
-
-    // D1: Alice rotates Bob out → writers = {Alice}. Logged as a rotation.
-    let rotation = build_signed_shared_action(
-        false,
-        id,
-        b"v1".to_vec(),
-        [alice].into_iter().collect(),
-        hlc_at(1),
-        &alice_sk,
-        vec![],
-    );
-    Interface::<S<408>>::apply_action(
-        rotation,
-        dag_ctx(&[[0xE0; 32]], [0xE1; 32], hlc_at(1), happens_before),
-    )
-    .unwrap();
-    assert_eq!(
-        rotation_log::load::<S<408>>(id)
-            .unwrap()
-            .unwrap()
-            .entries
-            .len(),
-        2,
-        "post-D1 baseline: bootstrap + rotation"
-    );
-
-    // D2: Alice value-write claiming the BOOTSTRAP writers {Alice, Bob}.
-    // She's authorized (signature verifies against the authoritative set),
-    // so the write itself is accepted. The rotation-detection compares
-    // action.writers `{Alice, Bob}` against `pre_apply_writers` — which is
-    // STILL `{Alice, Bob}` because `Index::update_hash_for` never updated
-    // `storage_type` after D1. So `is_rotation = false` and no log entry
-    // is appended.
-    //
-    // If the index had updated to `{Alice}` after D1, this comparison would
-    // be `{Alice, Bob} != {Alice}` → IS rotation → falsely append. This
-    // assertion catches that future regression.
-    let value_write_with_stale_writers = build_signed_shared_action(
-        false,
-        id,
-        b"v2".to_vec(),
-        [alice, bob].into_iter().collect(), // claims bootstrap writers
-        hlc_at(2),
-        &alice_sk,
-        vec![],
-    );
-    Interface::<S<408>>::apply_action(
-        value_write_with_stale_writers,
-        dag_ctx(&[[0xE1; 32]], [0xE2; 32], hlc_at(2), happens_before),
-    )
-    .unwrap();
-
-    let log = rotation_log::load::<S<408>>(id).unwrap().unwrap();
-    assert_eq!(
-        log.entries.len(),
-        2,
-        "value-write with stale writer claim must NOT append \
-         (relies on stored writers staying frozen at bootstrap)"
-    );
-}
-
 // =============================================================================
-// P4-impl coverage: ADR Example D (write vs rotate on the same entity)
+// ADR Example D coverage (write vs rotate on the same entity)
 // =============================================================================
-//
-// The other ADR examples (A sequential, B concurrent siblings HLC, C HLC tie)
-// are exercised in `rotation_log::tests`. Example D — a value-write signed by
-// a pre-rotation writer must still verify after the rotation lands locally —
-// is the central guarantee that makes concurrent operation safe, and it
-// involves the full apply_action verifier swap, so it lives here next to
-// the rest of the P3 verifier coverage.
 
 /// ADR Example D: pre-rotation value-write is accepted even after the
 /// rotation that removes the signer is applied locally. The verifier must
 /// consult `writers_at(value_write.parents)`, NOT the post-merge writer set.
 #[test]
 fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
-    env::reset_for_testing();
-    let root = setup_root::<S<420>>();
+    let root = setup_root::<S<6420>>();
 
     let alice_sk = make_signing_key(0xA9);
     let bob_sk = make_signing_key(0xB9);
@@ -592,8 +568,11 @@ fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
     let bob = pubkey_of(&bob_sk);
     let id = entity_id(0x60);
 
+    let mut dag = Dag::new();
+
     // D_root: writers = {Alice, Bob}. Bootstrap so the entity exists locally.
     let d_root = [0xD0; 32];
+    dag.record(d_root, vec![]);
     let bootstrap = build_signed_shared_action(
         true,
         id,
@@ -603,16 +582,16 @@ fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
         &alice_sk,
         vec![root.clone()],
     );
-    let happens_before_simple: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
-    Interface::<S<420>>::apply_action(
+    Interface::<S<6420>>::apply_action(
         bootstrap,
-        dag_ctx(&[], d_root, hlc_at(0), happens_before_simple),
+        &ctx_for::<S<6420>>(id, &[], d_root, hlc_at(0), &dag),
     )
     .unwrap();
 
     // D1 (concurrent sibling of D_root from D2's perspective): Alice rotates
     // Bob out → writers = {Alice}. Apply this first.
     let d1 = [0xD1; 32];
+    dag.record(d1, vec![d_root]);
     let rotation = build_signed_shared_action(
         false,
         id,
@@ -622,21 +601,22 @@ fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
         &alice_sk,
         vec![],
     );
-    Interface::<S<420>>::apply_action(
+    Interface::<S<6420>>::apply_action(
         rotation,
-        dag_ctx(&[d_root], d1, hlc_at(1), happens_before_simple),
+        &ctx_for::<S<6420>>(id, &[d_root], d1, hlc_at(1), &dag),
     )
     .unwrap();
 
     // Sanity: the local stored writer set is now {Alice} and the rotation log
     // has two entries (bootstrap + rotation).
-    let log = rotation_log::load::<S<420>>(id).unwrap().unwrap();
+    let log = rotation_log::load::<S<6420>>(id).unwrap().unwrap();
     assert_eq!(log.entries.len(), 2);
 
     // D2 (concurrent sibling of D1): Bob writes "world" against the writer
     // set he saw — {Alice, Bob}. From Bob's local view this is valid; D2's
-    // parent is D_root, NOT D1. Carry that into ctx.causal_parents.
+    // parent is D_root, NOT D1.
     let d2 = [0xD2; 32];
+    dag.record(d2, vec![d_root]);
     let bob_write = build_signed_shared_action(
         false,
         id,
@@ -646,24 +626,13 @@ fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
         &bob_sk,
         vec![],
     );
-
-    // happens_before: D_root precedes everything; D1 and D2 are siblings so
-    // neither precedes the other.
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| {
-        // D_root happens-before D1 and D2.
-        if *a == d_root && (*b == d1 || *b == d2) {
-            return true;
-        }
-        false
-    };
-    let parents = [d_root];
-    let ctx = dag_ctx(&parents, d2, hlc_at(2), happens_before);
+    let ctx = ctx_for::<S<6420>>(id, &[d_root], d2, hlc_at(2), &dag);
 
     // Crucial: even though stored writers (post-D1) is {Alice}, D2 is causally
     // a sibling of D1 — it never saw the rotation. writers_at(D2.parents=[D_root])
     // returns the bootstrap writer set {Alice, Bob}, so Bob's signature
-    // verifies. Without P3 this would fail (sig vs stored {Alice}).
-    Interface::<S<420>>::apply_action(bob_write, ctx).expect(
+    // verifies. Without DAG-causal this would fail (sig vs stored {Alice}).
+    Interface::<S<6420>>::apply_action(bob_write, &ctx).expect(
         "ADR Example D: pre-rotation write by Bob accepted because writers_at \
          (causal parents of D2) includes Bob, even though stored writers no longer do",
     );
@@ -674,8 +643,7 @@ fn adr_example_d_pre_rotation_write_accepted_after_rotation() {
 /// rejected if the signer is no longer in the writer set as-of those parents.
 #[test]
 fn write_post_rotation_by_removed_writer_rejected() {
-    env::reset_for_testing();
-    let root = setup_root::<S<421>>();
+    let root = setup_root::<S<6421>>();
 
     let alice_sk = make_signing_key(0xAA);
     let bob_sk = make_signing_key(0xBA);
@@ -683,7 +651,10 @@ fn write_post_rotation_by_removed_writer_rejected() {
     let bob = pubkey_of(&bob_sk);
     let id = entity_id(0x61);
 
+    let mut dag = Dag::new();
+
     let d_root = [0xD0; 32];
+    dag.record(d_root, vec![]);
     let bootstrap = build_signed_shared_action(
         true,
         id,
@@ -693,15 +664,15 @@ fn write_post_rotation_by_removed_writer_rejected() {
         &alice_sk,
         vec![root.clone()],
     );
-    let happens_before_simple: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|_, _| false;
-    Interface::<S<421>>::apply_action(
+    Interface::<S<6421>>::apply_action(
         bootstrap,
-        dag_ctx(&[], d_root, hlc_at(0), happens_before_simple),
+        &ctx_for::<S<6421>>(id, &[], d_root, hlc_at(0), &dag),
     )
     .unwrap();
 
     // D1: Alice rotates Bob out.
     let d1 = [0xD1; 32];
+    dag.record(d1, vec![d_root]);
     let rotation = build_signed_shared_action(
         false,
         id,
@@ -711,14 +682,15 @@ fn write_post_rotation_by_removed_writer_rejected() {
         &alice_sk,
         vec![],
     );
-    Interface::<S<421>>::apply_action(
+    Interface::<S<6421>>::apply_action(
         rotation,
-        dag_ctx(&[d_root], d1, hlc_at(1), happens_before_simple),
+        &ctx_for::<S<6421>>(id, &[d_root], d1, hlc_at(1), &dag),
     )
     .unwrap();
 
     // D2 has D1 as a parent — Bob saw the rotation and tries to write anyway.
     let d2 = [0xD2; 32];
+    dag.record(d2, vec![d1]);
     let bob_write_post = build_signed_shared_action(
         false,
         id,
@@ -728,26 +700,13 @@ fn write_post_rotation_by_removed_writer_rejected() {
         &bob_sk,
         vec![],
     );
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| {
-        // D_root → D1 → D2. (D_root → D2 transitively.)
-        matches!(
-            (*a, *b),
-            (x, y) if x == d_root && (y == d1 || y == d2)
-                || (x == d1 && y == d2)
-        )
-    };
-    let parents = [d1];
-    let ctx = dag_ctx(&parents, d2, hlc_at(2), happens_before);
+    let ctx = ctx_for::<S<6421>>(id, &[d1], d2, hlc_at(2), &dag);
 
     // writers_at(D2.parents=[D1]) returns {Alice} — Bob is no longer a writer
     // and his signature must fail.
-    let result = Interface::<S<421>>::apply_action(bob_write_post, ctx);
+    let result = Interface::<S<6421>>::apply_action(bob_write_post, &ctx);
     assert!(
-        matches!(
-            result,
-            Err(crate::interface::StorageError::InvalidSignature)
-        ),
-        "post-rotation write by removed writer must be rejected; got {:?}",
-        result
+        matches!(result, Err(StorageError::InvalidSignature)),
+        "post-rotation write by removed writer must be rejected; got {result:?}",
     );
 }

--- a/crates/node/src/sync/p5_partition_scenarios_tests.rs
+++ b/crates/node/src/sync/p5_partition_scenarios_tests.rs
@@ -1,45 +1,30 @@
 //! Phase **P5** of [#2233](https://github.com/calimero-network/core/issues/2233):
 //! cross-node integration tests for the four motivating partition scenarios.
 //!
-//! Each test simulates 2–3 "nodes" — each backed by its own
-//! [`MockedStorage`] scope — and feeds them the same [`CausalDelta`]s in
-//! different orders. With the P3 verifier swap and rotation-log write hook
-//! in place, the four #2197 scenarios should resolve correctly:
-//!
-//! - **Update-vs-rotation race** (Bob writes pre-rotation under partition;
-//!   rotation lands first on Carol; Bob's write must be accepted).
-//! - **Self-removal mid-flight** (writer rotates self out, in-flight updates
-//!   causally-before the rotation are accepted, after rejected).
-//! - **Concurrent conflicting rotations** (two writers issue rotations
-//!   concurrently — deterministic convergence per ADR 0001).
-//! - **Long-partition reconciliation** (many rotations + writes on each side,
-//!   then merge — both sides converge to the same final state).
-//!
-//! The fifth listed motivator (bootstrap race) is deferred per ADR 0001 —
-//! see "What we explicitly do NOT decide here".
-//!
-//! These tests run at the storage layer rather than via the WASM/sync
-//! harnesses because the production WASM ABI doesn't yet thread
-//! `CausalDelta.{id,hlc,parents}` through to `apply_action` — that's a
-//! separate follow-up. The storage-layer simulation gives us full control
-//! over delivery order and DAG ancestry, which is what the scenarios
-//! actually exercise.
+//! Migrated from `calimero_storage::tests::p5_partition_scenarios` per #2266
+//! step 5 — the storage crate no longer carries DAG-ancestry knowledge, so
+//! these scenarios live where the DAG does. The `deliver` helper now
+//! mirrors the production sync-layer flow: load the rotation log, resolve
+//! `effective_writers` via [`crate::sync::rotation_log_reader::writers_at`],
+//! and apply with the resolved set in `ApplyContext`. See ADR 0001.
 
 use core::num::NonZeroU128;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
-use ed25519_dalek::SigningKey;
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::action::Action;
+use calimero_storage::address::Id;
+use calimero_storage::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use calimero_storage::index::Index;
+use calimero_storage::interface::{
+    disable_nonce_check_for_testing, ApplyContext, Interface, StorageError,
+};
+use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use calimero_storage::rotation_log;
+use calimero_storage::store::{MockedStorage, StorageAdaptor};
+use ed25519_dalek::{Signer, SigningKey};
 
-use crate::action::Action;
-use crate::address::Id;
-use crate::entities::{ChildInfo, Metadata};
-use crate::env;
-use crate::index::Index;
-use crate::interface::{disable_nonce_check_for_testing, ApplyContext, Interface, StorageError};
-use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
-use crate::rotation_log;
-use crate::store::{MockedStorage, StorageAdaptor};
-use crate::tests::common::{build_signed_shared_action, pubkey_of};
+use crate::sync::rotation_log_reader;
 
 // =============================================================================
 // Harness
@@ -59,13 +44,10 @@ impl Dag {
         }
     }
 
-    /// Record a delta and its parents.
     fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {
         self.parents.insert(delta_id, parents);
     }
 
-    /// `true` iff `ancestor` is in the transitive ancestry of `descendant`.
-    /// Same delta returns `false` (not strictly happens-before).
     fn happens_before(&self, ancestor: &[u8; 32], descendant: &[u8; 32]) -> bool {
         if ancestor == descendant {
             return false;
@@ -100,22 +82,84 @@ fn hlc(ns: u64) -> HybridTimestamp {
     HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
 }
 
-/// Apply `delta` to a node identified by const-generic `SCOPE`. The DAG
-/// closure is taken by reference so the caller controls its lifetime; the
-/// rotation-log write hook and verifier both consult it.
+/// Apply `delta` to a node identified by const-generic `SCOPE`. Mirrors the
+/// production sync-layer flow from `delta_store::ContextStorageApplier::apply`:
+/// resolve `effective_writers` against the rotation log + DAG, build an
+/// `ApplyContext`, then `Interface::apply_action`.
 fn deliver<S: StorageAdaptor>(delta: &Delta, dag: &Dag) -> Result<(), StorageError> {
-    let happens_before: &dyn Fn(&[u8; 32], &[u8; 32]) -> bool = &|a, b| dag.happens_before(a, b);
+    let entity_id = delta.action.id();
+    let effective_writers: Option<BTreeSet<PublicKey>> = match rotation_log::load::<S>(entity_id)? {
+        Some(log) => {
+            rotation_log_reader::writers_at(&log, &delta.parents, |a, b| dag.happens_before(a, b))
+        }
+        None => None,
+    };
     let ctx = ApplyContext {
-        causal_parents: &delta.parents,
+        effective_writers,
         delta_id: Some(delta.id),
         delta_hlc: Some(hlc(delta.hlc_ns)),
-        happens_before: Some(happens_before),
     };
-    Interface::<S>::apply_action(delta.action.clone(), ctx)
+    Interface::<S>::apply_action(delta.action.clone(), &ctx)
 }
 
 fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
+}
+
+fn pubkey_of(sk: &SigningKey) -> PublicKey {
+    PublicKey::from(*sk.verifying_key().as_bytes())
+}
+
+/// Build a signed `Shared` storage action (Add or Update). Inlined from
+/// `calimero_storage::tests::common::build_signed_shared_action` because
+/// that module is `#[cfg(test)]` inside storage and not visible across crates.
+fn build_signed_shared_action(
+    add: bool,
+    id: Id,
+    data: Vec<u8>,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let mut metadata = Metadata::new(hlc_ns, hlc_ns);
+    metadata.storage_type = StorageType::Shared {
+        writers,
+        signature_data: Some(SignatureData {
+            signature: [0; 64],
+            nonce: hlc_ns,
+            signer: Some(pubkey_of(signer_sk)),
+        }),
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::Shared {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
+    action
 }
 
 fn setup_root<S: StorageAdaptor>() -> ChildInfo {
@@ -129,6 +173,21 @@ fn one_sec(n: u64) -> u64 {
     n.saturating_mul(1_000_000_000)
 }
 
+/// Resolve the writer set as-of a causal frontier by loading the log and
+/// running the node-side reader. Used by tests that assert convergence on
+/// rotated writer sets across nodes.
+fn writers_at_frontier<S: StorageAdaptor, F>(
+    id: Id,
+    frontier: &[[u8; 32]],
+    happens_before: F,
+) -> Option<BTreeSet<PublicKey>>
+where
+    F: Fn(&[u8; 32], &[u8; 32]) -> bool,
+{
+    let log = rotation_log::load::<S>(id).unwrap()?;
+    rotation_log_reader::writers_at(&log, frontier, happens_before)
+}
+
 // =============================================================================
 // Scenario 1: Update-vs-rotation race (#2197 motivator 1)
 // =============================================================================
@@ -140,14 +199,13 @@ fn one_sec(n: u64) -> u64 {
 /// rotation; from Bob's view he was authoritatively a writer when he
 /// authored the action.
 ///
-/// Without P3 this is the failure mode #2197 calls out: Carol's stored
-/// writer set after applying the rotation is {Alice}, so she'd reject
-/// Bob's signature against the stored set.
+/// Without the DAG-causal verifier this is the failure mode #2197 calls out:
+/// Carol's stored writer set after applying the rotation is {Alice}, so
+/// she'd reject Bob's signature against the stored set.
 #[test]
 fn update_vs_rotation_race_pre_rotation_write_accepted() {
-    env::reset_for_testing();
     let _nonce_off = disable_nonce_check_for_testing();
-    type Carol = MockedStorage<500>;
+    type Carol = MockedStorage<5500>;
     let root = setup_root::<Carol>();
 
     let alice_sk = make_signing_key(0xA1);
@@ -224,19 +282,6 @@ fn update_vs_rotation_race_pre_rotation_write_accepted() {
     // The rotation log on Carol should have entries from D_root and D1; D2
     // was a value-write whose claimed `{Alice, Bob}` matches the bootstrap
     // set, so it doesn't trigger the rotation hook.
-    //
-    // KNOWN FRAGILITY (PR #2265 review): D2 is correctly skipped here only
-    // because the index's `storage_type.writers` is *frozen at bootstrap* —
-    // `Index::update_hash_for` updates `own_hash`/`full_hash`/`updated_at`
-    // but never touches `storage_type`. So `pre_apply_writers` returned to
-    // `maybe_append_rotation_log` is `{Alice, Bob}` (bootstrap), not the
-    // post-D1 `{Alice}`. The comparison `pre_apply_writers != action.writers`
-    // is thus `{A,B} != {A,B}` → not a rotation. If `update_hash_for` is
-    // ever changed to keep `storage_type` in sync, the rotation-detection
-    // logic must move to comparing against `writers_at(causal_parents)`
-    // instead of stored, or stale value-writes will be falsely logged.
-    // See `write_hook_relies_on_stale_stored_writers_for_rotation_detection`
-    // in p3_dag_causal.rs for the explicit demonstration. Tracked in #2233 P3.
     let log = rotation_log::load::<Carol>(id).unwrap().unwrap();
     assert_eq!(log.entries.len(), 2, "log has D_root and D1");
     assert_eq!(log.entries[0].delta_id, d_root_id);
@@ -254,9 +299,8 @@ fn update_vs_rotation_race_pre_rotation_write_accepted() {
 /// and tried to write anyway) should be rejected.
 #[test]
 fn self_removal_mid_flight_pre_accepted_post_rejected() {
-    env::reset_for_testing();
     let _nonce_off = disable_nonce_check_for_testing();
-    type Carol = MockedStorage<510>;
+    type Carol = MockedStorage<5510>;
     let root = setup_root::<Carol>();
 
     let alice_sk = make_signing_key(0xA2);
@@ -323,7 +367,6 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
     dag.record(d1.id, d1.parents.clone());
 
     // D3: Alice tries to write AFTER her own rotation — has D1 as parent.
-    // Per ADR she's no longer a writer at this causal point and must be rejected.
     let d3_id = [0xE3; 32];
     let d3 = Delta {
         id: d3_id,
@@ -350,8 +393,7 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
     let post_result = deliver::<Carol>(&d3, &dag);
     assert!(
         matches!(post_result, Err(StorageError::InvalidSignature)),
-        "post-rotation write by removed writer must be rejected; got {:?}",
-        post_result
+        "post-rotation write by removed writer must be rejected; got {post_result:?}",
     );
 }
 
@@ -366,10 +408,9 @@ fn self_removal_mid_flight_pre_accepted_post_rejected() {
 /// the same final writer set.
 #[test]
 fn concurrent_conflicting_rotations_deterministic_convergence() {
-    env::reset_for_testing();
     let _nonce_off = disable_nonce_check_for_testing();
-    type Carol = MockedStorage<520>;
-    type Dave = MockedStorage<521>;
+    type Carol = MockedStorage<5520>;
+    type Dave = MockedStorage<5521>;
     let carol_root = setup_root::<Carol>();
     let dave_root = setup_root::<Dave>();
 
@@ -471,12 +512,10 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
     let causal_frontier = [d1_id, d2_id];
     let happens_before = |a: &[u8; 32], b: &[u8; 32]| dag.happens_before(a, b);
 
-    let carol_writers = rotation_log::writers_at::<Carol, _>(id, &causal_frontier, &happens_before)
-        .unwrap()
-        .unwrap();
-    let dave_writers = rotation_log::writers_at::<Dave, _>(id, &causal_frontier, &happens_before)
-        .unwrap()
-        .unwrap();
+    let carol_writers =
+        writers_at_frontier::<Carol, _>(id, &causal_frontier, &happens_before).unwrap();
+    let dave_writers =
+        writers_at_frontier::<Dave, _>(id, &causal_frontier, &happens_before).unwrap();
 
     assert_eq!(carol_writers, dave_writers, "deterministic convergence");
     assert_eq!(
@@ -494,16 +533,11 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
 /// writes and rotations. After the partition heals, both nodes deliver each
 /// other's deltas. Both should agree on the same final answer for
 /// `writers_at` queried over the merged causal frontier.
-///
-/// The chains here are small (3 deltas per side) but the structure exercises
-/// the same logic at any depth: a long chain of causally-ordered rotations
-/// reduces to "the latest in causal order wins" per ADR 0001.
 #[test]
 fn long_partition_reconciliation_converges() {
-    env::reset_for_testing();
     let _nonce_off = disable_nonce_check_for_testing();
-    type Left = MockedStorage<530>;
-    type Right = MockedStorage<531>;
+    type Left = MockedStorage<5530>;
+    type Right = MockedStorage<5531>;
     let left_root = setup_root::<Left>();
     let right_root = setup_root::<Right>();
 
@@ -637,12 +671,8 @@ fn long_partition_reconciliation_converges() {
     let frontier = [l2, r2];
     let hb = |a: &[u8; 32], b: &[u8; 32]| dag.happens_before(a, b);
 
-    let left_writers = rotation_log::writers_at::<Left, _>(id, &frontier, &hb)
-        .unwrap()
-        .unwrap();
-    let right_writers = rotation_log::writers_at::<Right, _>(id, &frontier, &hb)
-        .unwrap()
-        .unwrap();
+    let left_writers = writers_at_frontier::<Left, _>(id, &frontier, &hb).unwrap();
+    let right_writers = writers_at_frontier::<Right, _>(id, &frontier, &hb).unwrap();
 
     assert_eq!(
         left_writers, right_writers,

--- a/crates/node/src/sync/rotation_log_reader.rs
+++ b/crates/node/src/sync/rotation_log_reader.rs
@@ -1,0 +1,297 @@
+//! DAG-causal rotation-log resolution for the node sync layer.
+//!
+//! Per #2266 (Option B from #2267), the storage crate no longer carries
+//! DAG-ancestry knowledge. Storage owns the rotation log's on-disk shape
+//! ([`calimero_storage::rotation_log`]) and the `append` write hook;
+//! resolution — "given a delta's parents and a DAG-ancestry predicate,
+//! what was the writer set as of that causal point?" — lives here, where
+//! the DAG itself does.
+//!
+//! The functions in this module are **pure** (no I/O). Callers load the
+//! rotation log via [`calimero_storage::rotation_log::load`] and pass
+//! `&RotationLog` in. The DAG-ancestry closure is supplied by the caller
+//! (typically wrapping the node's `CoreDagStore::happens_before`).
+
+use std::collections::BTreeSet;
+
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::rotation_log::{RotationLog, RotationLogEntry};
+
+/// Returns the writer set from the most recently *appended* entry in
+/// `log`.
+///
+/// "Most recently appended" is **insertion order on this node**, not
+/// causal order — concurrent rotations applied in different orders
+/// across nodes can produce different answers. Use it only when no
+/// causal context is available (snapshot leaf push, local apply).
+///
+/// Returns `None` if the log has no entries and no snapshot.
+#[must_use]
+#[allow(
+    dead_code,
+    reason = "wired in Step 3 of #2266 (delta_store apply path)"
+)]
+pub fn latest_writers(log: &RotationLog) -> Option<BTreeSet<PublicKey>> {
+    if let Some(entry) = log.entries.last() {
+        return Some(entry.new_writers.clone());
+    }
+    log.snapshot.as_ref().map(|s| s.writers.clone())
+}
+
+/// Returns the writer set as-of a causal point in the DAG.
+///
+/// Implements ADR 0001's merge rule end-to-end:
+/// 1. Filter entries to those reachable from `causal_parents`.
+/// 2. Among reachable entries, pick the causally latest.
+/// 3. Truly-concurrent tie → larger `delta_hlc` wins.
+/// 4. HLC tie → smaller `signer` pubkey bytes win (`None` treated as larger).
+///
+/// `happens_before(a, b)` returns true iff delta `a` is in the
+/// transitive ancestry of delta `b`. The caller closes over its DAG
+/// view (typically `CoreDagStore`) to provide the predicate.
+///
+/// `causal_parents` is the parent set of the apply context's delta —
+/// i.e. `CausalDelta.parents` of the delta being applied.
+///
+/// # Reachability
+///
+/// An entry `e` is reachable iff
+/// `causal_parents.iter().any(|p| e.delta_id == *p || happens_before(&e.delta_id, p))`.
+/// In words: the rotation's delta is one of the apply-context's parents,
+/// or in the transitive ancestry of one.
+///
+/// # When `causal_parents` is empty
+///
+/// Returns the same answer as [`latest_writers`] — the v2-compatible
+/// fallback for paths without DAG context.
+#[must_use]
+#[allow(
+    dead_code,
+    reason = "wired in Step 3 of #2266 (delta_store apply path)"
+)]
+pub fn writers_at<F>(
+    log: &RotationLog,
+    causal_parents: &[[u8; 32]],
+    happens_before: F,
+) -> Option<BTreeSet<PublicKey>>
+where
+    F: Fn(&[u8; 32], &[u8; 32]) -> bool,
+{
+    if causal_parents.is_empty() {
+        return latest_writers(log);
+    }
+
+    let reachable: Vec<&RotationLogEntry> = log
+        .entries
+        .iter()
+        .filter(|e| {
+            causal_parents
+                .iter()
+                .any(|p| e.delta_id == *p || happens_before(&e.delta_id, p))
+        })
+        .collect();
+
+    let latest = reachable.into_iter().max_by(|a, b| {
+        // 1. Causal precedence wins.
+        if happens_before(&a.delta_id, &b.delta_id) {
+            return std::cmp::Ordering::Less;
+        }
+        if happens_before(&b.delta_id, &a.delta_id) {
+            return std::cmp::Ordering::Greater;
+        }
+        // 2. Truly concurrent → larger HLC wins.
+        match a.delta_hlc.cmp(&b.delta_hlc) {
+            std::cmp::Ordering::Equal => {}
+            non_eq => return non_eq,
+        }
+        // 3. HLC tie → smaller signer bytes win. We're picking max, so
+        //    return Greater for the entry whose signer is smaller. None
+        //    signers are treated as larger than any Some — unsigned
+        //    legacy entries lose ties to signed ones.
+        match (&a.signer, &b.signer) {
+            (Some(sa), Some(sb)) => sb.digest().cmp(sa.digest()),
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    });
+
+    if let Some(entry) = latest {
+        return Some(entry.new_writers.clone());
+    }
+
+    // Nothing in `entries` was reachable. If the log was compacted (P6),
+    // the snapshot's writer set is the answer for any apply context whose
+    // history pre-dates the cutoff.
+    log.snapshot.as_ref().map(|s| s.writers.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use core::num::NonZeroU128;
+
+    use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+    use calimero_storage::rotation_log::{RotationLog, RotationLogEntry, RotationSnapshot};
+
+    use super::*;
+
+    fn pk(b: u8) -> PublicKey {
+        PublicKey::from([b; 32])
+    }
+
+    fn entry(
+        delta_id: u8,
+        hlc_time: u64,
+        signer: u8,
+        writers: &[u8],
+        nonce: u64,
+    ) -> RotationLogEntry {
+        // Distinct non-zero ID per signer keeps HLCs ordered by `hlc_time`
+        // first; the ID component only kicks in on `time` collisions, which
+        // is the tiebreak case we test independently via `signer`.
+        let id_u128 = NonZeroU128::new(u128::from(signer) + 1).unwrap();
+        let ts = Timestamp::new(NTP64(hlc_time), ID::from(id_u128));
+        RotationLogEntry {
+            delta_id: [delta_id; 32],
+            delta_hlc: HybridTimestamp::new(ts),
+            signer: Some(pk(signer)),
+            new_writers: writers.iter().copied().map(pk).collect(),
+            writers_nonce: nonce,
+        }
+    }
+
+    fn log_of(entries: Vec<RotationLogEntry>) -> RotationLog {
+        RotationLog {
+            snapshot: None,
+            entries,
+        }
+    }
+
+    #[test]
+    fn empty_log_returns_none() {
+        let log = RotationLog::empty();
+        assert_eq!(latest_writers(&log), None);
+        assert_eq!(writers_at(&log, &[[0; 32]], |_, _| false), None);
+    }
+
+    #[test]
+    fn latest_writers_returns_last_appended() {
+        let log = log_of(vec![
+            entry(1, 100, 0xAA, &[0xAA], 1),
+            entry(2, 200, 0xBB, &[0xBB], 2),
+        ]);
+        assert_eq!(
+            latest_writers(&log),
+            Some([0xBB].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn writers_at_with_empty_parents_falls_back_to_latest() {
+        // ADR: empty causal_parents → match latest_writers (v2 LWW compat).
+        let log = log_of(vec![
+            entry(1, 100, 0xAA, &[0xAA], 1),
+            entry(2, 200, 0xBB, &[0xBB], 2),
+        ]);
+        assert_eq!(
+            writers_at(&log, &[], |_, _| false),
+            Some([0xBB].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn writers_at_returns_only_reachable_entries() {
+        // ADR Example A: sequential rotations. R1 is the parent, R2 builds
+        // on it. Querying with causal_parents = [R1.delta_id] should pick
+        // R1, NOT R2 — R2 hasn't happened yet from R1's frontier.
+        let log = log_of(vec![
+            entry(1, 100, 0xAA, &[0xAA, 0xBB], 1),
+            entry(2, 200, 0xBB, &[0xBB, 0xCC], 2),
+        ]);
+
+        let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
+
+        let writers = writers_at(&log, &[[1; 32]], happens_before);
+        assert_eq!(writers, Some([0xAA, 0xBB].into_iter().map(pk).collect()));
+
+        let writers = writers_at(&log, &[[2; 32]], happens_before);
+        assert_eq!(writers, Some([0xBB, 0xCC].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_concurrent_siblings_resolved_by_hlc() {
+        // ADR Example B: two concurrent siblings with different HLCs.
+        // Larger HLC wins.
+        let log = log_of(vec![
+            entry(1, 20, 0xAA, &[0xAA], 10),
+            entry(2, 21, 0xBB, &[0xBB], 10),
+        ]);
+
+        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
+        let writers = writers_at(&log, &[[1; 32], [2; 32]], none_precede);
+        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_hlc_tie_resolved_by_signer_bytes() {
+        // ADR Example C: HLC tie (same time AND same node ID).
+        // Smaller signer pubkey bytes win.
+        let identical_ts = HybridTimestamp::new(Timestamp::new(
+            NTP64(50),
+            ID::from(NonZeroU128::new(1).unwrap()),
+        ));
+        let mk = |delta_id: u8, signer: u8, writers: &[u8]| RotationLogEntry {
+            delta_id: [delta_id; 32],
+            delta_hlc: identical_ts,
+            signer: Some(pk(signer)),
+            new_writers: writers.iter().copied().map(pk).collect(),
+            writers_nonce: 10,
+        };
+        let log = log_of(vec![mk(1, 0xAA, &[0xAA, 0xCC]), mk(2, 0xBB, &[0xBB, 0xDD])]);
+
+        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
+        let writers = writers_at(&log, &[[1; 32], [2; 32]], none_precede);
+        // 0xAA is smaller → wins.
+        assert_eq!(writers, Some([0xAA, 0xCC].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_causal_precedence_overrides_hlc() {
+        // R1 happens-before R2, but R1.hlc > R2.hlc (clock skew). Causal
+        // wins: R2's author saw R1's reality and chose to rotate from there.
+        let log = log_of(vec![
+            entry(1, 999, 0xAA, &[0xAA], 1), // huge HLC
+            entry(2, 100, 0xBB, &[0xBB], 2), // smaller HLC
+        ]);
+
+        let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
+        let writers = writers_at(&log, &[[2; 32]], happens_before);
+        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
+    }
+
+    #[test]
+    fn writers_at_unreachable_entries_ignored() {
+        // Entry exists but isn't reachable from the queried parents.
+        // Returns None — verifier falls back as it sees fit.
+        let log = log_of(vec![entry(1, 100, 0xAA, &[0xAA], 1)]);
+        let writers = writers_at(&log, &[[42; 32]], |_, _| false);
+        assert_eq!(writers, None);
+    }
+
+    #[test]
+    fn writers_at_falls_back_to_snapshot_when_entries_unreachable() {
+        // P6 compaction wrote a snapshot but no live entries reach the query.
+        let snap_writers: BTreeSet<PublicKey> = [0xEE].into_iter().map(pk).collect();
+        let log = RotationLog {
+            snapshot: Some(RotationSnapshot {
+                writers: snap_writers.clone(),
+                cutoff_index: 5,
+            }),
+            entries: vec![entry(99, 100, 0xFF, &[0xFF], 99)],
+        };
+
+        // happens_before never matches: live entry at delta 99 is unreachable.
+        let writers = writers_at(&log, &[[1; 32]], |_, _| false);
+        assert_eq!(writers, Some(snap_writers));
+    }
+}

--- a/crates/node/src/sync/rotation_log_reader.rs
+++ b/crates/node/src/sync/rotation_log_reader.rs
@@ -27,10 +27,6 @@ use calimero_storage::rotation_log::{RotationLog, RotationLogEntry};
 ///
 /// Returns `None` if the log has no entries and no snapshot.
 #[must_use]
-#[allow(
-    dead_code,
-    reason = "wired in Step 3 of #2266 (delta_store apply path)"
-)]
 pub fn latest_writers(log: &RotationLog) -> Option<BTreeSet<PublicKey>> {
     if let Some(entry) = log.entries.last() {
         return Some(entry.new_writers.clone());
@@ -65,10 +61,6 @@ pub fn latest_writers(log: &RotationLog) -> Option<BTreeSet<PublicKey>> {
 /// Returns the same answer as [`latest_writers`] — the v2-compatible
 /// fallback for paths without DAG context.
 #[must_use]
-#[allow(
-    dead_code,
-    reason = "wired in Step 3 of #2266 (delta_store apply path)"
-)]
 pub fn writers_at<F>(
     log: &RotationLog,
     causal_parents: &[[u8; 32]],

--- a/crates/node/tests/dag_causal_runtime_env_probe.rs
+++ b/crates/node/tests/dag_causal_runtime_env_probe.rs
@@ -1,0 +1,145 @@
+//! Regression probe for #2272 review 🔴: confirms the seam between
+//! `MainStorage`'s `RUNTIME_ENV` thread-local route and direct datastore
+//! reads behaves the way the production fix in `delta_store.rs` assumes.
+//!
+//! The bug this guards against: `resolve_effective_writers_for_delta`
+//! runs **before** `context_client.execute()`, so the `RUNTIME_ENV`
+//! thread-local that `MainStorage::storage_read` consults is not yet
+//! installed. Reads via `MainStorage` fall through to an in-process
+//! empty mock and return `None` — silently disabling the entire
+//! DAG-causal verifier in production.
+//!
+//! What this probe pins:
+//!
+//! 1. **Inside** a `with_runtime_env` scope, `MainStorage::storage_read`
+//!    *does* see writes that went through the same env. (Sanity check —
+//!    if this ever fails, the bridge itself is broken.)
+//!
+//! 2. **Outside** that scope, `MainStorage::storage_read` returns
+//!    `None` even when the bytes are present in the underlying store.
+//!    This is the regression: it's what made the silent-disable
+//!    possible.
+//!
+//! 3. A direct `Handle<Store>::get` against the same state key
+//!    returns the bytes regardless of whether `RUNTIME_ENV` is set.
+//!    This is what the production fix uses.
+//!
+//! If any of these pin assumptions changes (e.g. someone wires
+//! `MainStorage` to fall through to the datastore handle), this probe
+//! fails loudly and the production path needs re-evaluation.
+
+use std::sync::Arc;
+
+use borsh::{from_slice, to_vec};
+use calimero_node_primitives::sync::storage_bridge::create_runtime_env;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::address::Id;
+use calimero_storage::env::{storage_write, with_runtime_env};
+use calimero_storage::rotation_log::{self, RotationLog, RotationLogEntry};
+use calimero_storage::store::{Key as StorageKey, MainStorage, StorageAdaptor};
+use calimero_store::db::InMemoryDB;
+use calimero_store::{key, Store};
+
+fn pk(b: u8) -> PublicKey {
+    PublicKey::from([b; 32])
+}
+
+fn dummy_entry() -> RotationLogEntry {
+    use core::num::NonZeroU128;
+
+    use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+
+    let ts = Timestamp::new(NTP64(100), ID::from(NonZeroU128::new(1).unwrap()));
+    RotationLogEntry {
+        delta_id: [0xAB; 32],
+        delta_hlc: HybridTimestamp::new(ts),
+        signer: Some(pk(0xAA)),
+        new_writers: [pk(0xAA), pk(0xBB)].into_iter().collect(),
+        writers_nonce: 1,
+    }
+}
+
+#[tokio::test]
+async fn rotation_log_route_seam() {
+    // Production-shaped backend: real `Store` over an in-memory DB.
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+    let context_id = ContextId::from([0xCA; 32]);
+    let executor = pk(0xEE);
+    let entity_id = Id::from([0xEF; 32]);
+
+    let env = create_runtime_env(&store, context_id, executor);
+
+    // ---- Phase 1: write through the env (mimics WASM-side rotation log
+    //               persistence — what `Interface::apply_action`'s write
+    //               hook does inside `context_client.execute()`).
+    let log = RotationLog {
+        snapshot: None,
+        entries: vec![dummy_entry()],
+    };
+    let log_bytes = to_vec(&log).expect("encode rotation log");
+    with_runtime_env(env.clone(), || {
+        // Bypass `rotation_log::save` to avoid coupling this probe to its
+        // internal layout — write the raw bytes under the same key the
+        // bridge expects.
+        let written = storage_write(StorageKey::RotationLog(entity_id), &log_bytes);
+        // First write returns false (no prior value); idempotent re-runs
+        // would return true. We only assert the operation completed.
+        let _ = written;
+    });
+
+    // ---- Phase 2 (sanity): inside the env, `MainStorage` sees the write.
+    let inside_env_read = with_runtime_env(env.clone(), || {
+        MainStorage::storage_read(StorageKey::RotationLog(entity_id))
+    });
+    assert!(
+        inside_env_read.is_some(),
+        "regression: MainStorage::storage_read returned None *inside* the \
+         RuntimeEnv scope — the bridge itself is broken"
+    );
+
+    // ---- Phase 3 (the bug): outside the env, `MainStorage` falls
+    //               through to an empty in-process mock and returns None
+    //               — even though the bytes are still in the store.
+    //               This is what made #2272's silent-disable possible.
+    let outside_env_main = MainStorage::storage_read(StorageKey::RotationLog(entity_id));
+    assert!(
+        outside_env_main.is_none(),
+        "PIN INVALIDATED: MainStorage::storage_read returned Some *outside* \
+         RuntimeEnv. If this fires, MainStorage now falls through to a \
+         real backend, which means the production `load_rotation_log_direct` \
+         workaround in delta_store.rs may no longer be needed — re-evaluate."
+    );
+
+    // Also confirm: through `rotation_log::load::<MainStorage>` (the
+    // path #2272 originally took), the answer is None outside the env.
+    let outside_env_load = rotation_log::load::<MainStorage>(entity_id)
+        .expect("rotation_log::load should not error on missing key");
+    assert!(
+        outside_env_load.is_none(),
+        "regression: rotation_log::load::<MainStorage> returned Some \
+         outside RuntimeEnv — see PIN INVALIDATED note above."
+    );
+
+    // ---- Phase 4 (the fix): a direct `Handle<Store>::get` against the
+    //               state key returns the bytes regardless of env.
+    //               This is what `load_rotation_log_direct` uses.
+    let storage_key = StorageKey::RotationLog(entity_id).to_bytes();
+    let state_key = key::ContextState::new(context_id, storage_key);
+    let handle = store.handle();
+    let direct_bytes: Vec<u8> = handle
+        .get(&state_key)
+        .expect("datastore read")
+        .expect("rotation log present in store")
+        .value
+        .into_boxed()
+        .into_vec();
+    drop(handle);
+
+    let decoded = from_slice::<RotationLog>(&direct_bytes).expect("decode rotation log");
+    assert_eq!(
+        decoded.entries.len(),
+        1,
+        "direct read decoded a different number of entries than written"
+    );
+}

--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -48,12 +48,14 @@
 //! buffering → resolve → cache → Borsh artifact → verifier swap) for the
 //! partition / late-delivery cases #2266 was opened to fix.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
+
+use indexmap::IndexMap;
 use std::sync::Arc;
 
 use borsh::{from_slice, to_vec};
 use calimero_dag::{ApplyError, CausalDelta, DagStore, DeltaApplier, DeltaKind};
-use calimero_node::sync::rotation_log_reader;
+use calimero_node::sync::{happens_before_in_topology, rotation_log_reader};
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
@@ -149,34 +151,6 @@ fn build_signed_shared_action(
     action
 }
 
-/// Reverse-BFS reachability over a `delta_id → parents` mirror: returns
-/// true iff `a` is in the transitive ancestry of `b`. Mirrors the
-/// production `delta_store::happens_before_in_topology` so this probe
-/// resolves writer sets the same way the live sync layer does.
-fn happens_before_in_topology(
-    topology: &HashMap<[u8; 32], Vec<[u8; 32]>>,
-    a: &[u8; 32],
-    b: &[u8; 32],
-) -> bool {
-    if a == b {
-        return false;
-    }
-    let mut frontier: Vec<[u8; 32]> = topology.get(b).cloned().unwrap_or_default();
-    let mut seen: HashSet<[u8; 32]> = HashSet::new();
-    while let Some(node) = frontier.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        if &node == a {
-            return true;
-        }
-        if let Some(parents) = topology.get(&node) {
-            frontier.extend(parents.iter().copied());
-        }
-    }
-    false
-}
-
 // =============================================================================
 // SharedRotationApplier — production-flow mirror minus the WASM hop
 // =============================================================================
@@ -188,18 +162,15 @@ fn happens_before_in_topology(
 ///
 /// - the per-Shared-entity resolution loop (`writers_at`),
 /// - the topology mirror that `happens_before_in_topology` consults,
-/// - the `(entity_id, delta_id)` cache,
 /// - Borsh roundtrip of [`StorageDelta::CausalActions`],
 /// - the receiver-side variant branching that builds a per-action
 ///   [`ApplyContext`] from the resolved map.
 struct SharedRotationApplier {
     /// `delta_id → parents` for every applied delta. Updated after a
     /// successful apply. Used as the snapshot the `happens_before`
-    /// closure runs against during resolution.
-    topology: Arc<RwLock<HashMap<[u8; 32], Vec<[u8; 32]>>>>,
-    /// Resolved writer-set cache. Same key/shape as
-    /// `ContextStorageApplier::effective_writers_cache`.
-    effective_writers_cache: Arc<RwLock<HashMap<(Id, [u8; 32]), BTreeSet<PublicKey>>>>,
+    /// closure runs against during resolution. `IndexMap` to mirror
+    /// production's deterministic insertion-order iteration.
+    topology: Arc<RwLock<IndexMap<[u8; 32], Vec<[u8; 32]>>>>,
     /// Successful-apply log (id + action count + serialized artifact
     /// size) for assertions.
     applied: Arc<RwLock<Vec<AppliedDelta>>>,
@@ -216,8 +187,7 @@ struct AppliedDelta {
 impl SharedRotationApplier {
     fn new() -> Self {
         Self {
-            topology: Arc::new(RwLock::new(HashMap::new())),
-            effective_writers_cache: Arc::new(RwLock::new(HashMap::new())),
+            topology: Arc::new(RwLock::new(IndexMap::new())),
             applied: Arc::new(RwLock::new(Vec::new())),
         }
     }
@@ -254,12 +224,6 @@ impl SharedRotationApplier {
         let topology_snapshot = self.topology.read().await.clone();
 
         for entity_id in shared_entities {
-            let cache_key = (entity_id, delta.id);
-            if let Some(cached) = self.effective_writers_cache.read().await.get(&cache_key) {
-                let _replaced = out.insert(entity_id, cached.clone());
-                continue;
-            }
-
             let log = match rotation_log::load::<MainStorage>(entity_id) {
                 Ok(Some(log)) => log,
                 Ok(None) => continue, // No log → verifier falls back to v2 stored-writers.
@@ -271,9 +235,7 @@ impl SharedRotationApplier {
             });
 
             if let Some(set) = resolved {
-                let _replaced = out.insert(entity_id, set.clone());
-                let mut cache = self.effective_writers_cache.write().await;
-                let _previous = cache.insert(cache_key, set);
+                let _replaced = out.insert(entity_id, set);
             }
         }
 

--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -1,0 +1,662 @@
+//! End-to-end probe for the DAG-causal Shared verifier wiring (#2266).
+//!
+//! Drives `CausalDelta`s through `calimero_dag::DagStore` with a custom
+//! [`DeltaApplier`] that mirrors the production `ContextStorageApplier::apply`
+//! flow minus the WASM hop:
+//!
+//!   1. Resolve `effective_writers` per Shared entity via
+//!      `rotation_log_reader::writers_at(&log, &delta.parents,
+//!      |a,b| happens_before_in_topology(...))`.
+//!   2. Serialize a [`StorageDelta::CausalActions`] artifact with that map
+//!      (Borsh roundtrip — mirrors what `__calimero_sync_next` would receive).
+//!   3. On the receive side, deserialize and dispatch each action through
+//!      [`Interface::apply_action`] with a per-action `ApplyContext`
+//!      whose `effective_writers` is keyed on `action.id()` — exactly what
+//!      `Root::sync`'s `CausalActions` branch does in WASM.
+//!   4. After success, record the delta's parent links into the local
+//!      topology mirror and the resolved writer sets into the cache, so
+//!      cascaded children's `apply()` sees an up-to-date view.
+//!
+//! Tests in this file:
+//!
+//! - **`update_vs_rotation_race_pre_rotation_write_accepted_through_full_sync_path`**
+//!   — regression check that a writer's pre-rotation write is accepted even
+//!   when delivered AFTER the rotation that revokes them. NOTE: this case
+//!   currently also passes under v2 by accident (the index's
+//!   `metadata.storage_type.writers` is frozen at bootstrap due to a known
+//!   `Index::update_hash_for` fragility, so v2's stored-writers fallback
+//!   happens to return the same set as `writers_at([D_root])`). See the
+//!   storage-side `write_hook_relies_on_stale_stored_writers_for_rotation_detection`.
+//!   Kept here because v3 must continue to accept it.
+//!
+//! - **`post_rotation_forgery_by_revoked_writer_rejected`** — the strong probe
+//!   for #2266. Bob's signed write whose parents include the rotation must be
+//!   rejected because `writers_at([D1]) = {Alice}`. Under v2 the verifier
+//!   would consult stored writers (still `{Alice, Bob}` due to the same
+//!   index fragility) and accept the forgery. Toggling the resolve step off
+//!   in `SharedRotationApplier::apply` makes this test fail with `Ok(true)`
+//!   — confirms it would have caught the v2 bug.
+//!
+//! - **`buffered_pre_rotation_write_resolves_correctly_after_parents_arrive`**
+//!   — the regression check above + adversarial DAG delivery order that
+//!   forces `DagStore` to buffer the pre-rotation write until its parent
+//!   arrives. Catches a topology-mirror update-ordering bug class (if the
+//!   topology were updated before WASM apply, buffered deltas would resolve
+//!   against the wrong snapshot).
+//!
+//! Together these exercise the production sync-layer path end-to-end (DAG
+//! buffering → resolve → cache → Borsh artifact → verifier swap) for the
+//! partition / late-delivery cases #2266 was opened to fix.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
+
+use borsh::{from_slice, to_vec};
+use calimero_dag::{ApplyError, CausalDelta, DagStore, DeltaApplier, DeltaKind};
+use calimero_node::sync::rotation_log_reader;
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::action::Action;
+use calimero_storage::address::Id;
+use calimero_storage::delta::StorageDelta;
+use calimero_storage::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use calimero_storage::index::Index;
+use calimero_storage::interface::{
+    disable_nonce_check_for_testing, ApplyContext, Interface, StorageError,
+};
+use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use calimero_storage::rotation_log;
+use calimero_storage::store::MainStorage;
+use core::num::NonZeroU128;
+use ed25519_dalek::{Signer, SigningKey};
+use tokio::sync::RwLock;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn pubkey_of(sk: &SigningKey) -> PublicKey {
+    PublicKey::from(*sk.verifying_key().as_bytes())
+}
+
+fn one_sec(n: u64) -> u64 {
+    n.saturating_mul(1_000_000_000)
+}
+
+fn hlc(ns: u64) -> HybridTimestamp {
+    let node_id = ID::from(NonZeroU128::new(1).unwrap());
+    HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
+}
+
+fn setup_root() -> ChildInfo {
+    let root_id = Id::root();
+    let root_meta = Metadata::default();
+    Index::<MainStorage>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
+    ChildInfo::new(root_id, [0; 32], root_meta)
+}
+
+/// Build a signed `Shared` action (Add or Update). The signature is over
+/// `payload_for_signing()`, just like production.
+fn build_signed_shared_action(
+    add: bool,
+    id: Id,
+    data: Vec<u8>,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let mut metadata = Metadata::new(hlc_ns, hlc_ns);
+    metadata.storage_type = StorageType::Shared {
+        writers,
+        signature_data: Some(SignatureData {
+            signature: [0; 64],
+            nonce: hlc_ns,
+            signer: Some(pubkey_of(signer_sk)),
+        }),
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::Shared {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
+    action
+}
+
+/// Reverse-BFS reachability over a `delta_id → parents` mirror: returns
+/// true iff `a` is in the transitive ancestry of `b`. Mirrors the
+/// production `delta_store::happens_before_in_topology` so this probe
+/// resolves writer sets the same way the live sync layer does.
+fn happens_before_in_topology(
+    topology: &HashMap<[u8; 32], Vec<[u8; 32]>>,
+    a: &[u8; 32],
+    b: &[u8; 32],
+) -> bool {
+    if a == b {
+        return false;
+    }
+    let mut frontier: Vec<[u8; 32]> = topology.get(b).cloned().unwrap_or_default();
+    let mut seen: HashSet<[u8; 32]> = HashSet::new();
+    while let Some(node) = frontier.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        if &node == a {
+            return true;
+        }
+        if let Some(parents) = topology.get(&node) {
+            frontier.extend(parents.iter().copied());
+        }
+    }
+    false
+}
+
+// =============================================================================
+// SharedRotationApplier — production-flow mirror minus the WASM hop
+// =============================================================================
+
+/// `DeltaApplier` that mirrors `ContextStorageApplier::apply` from
+/// `crates/node/src/delta_store.rs:134`, with the WASM execute call
+/// replaced by direct dispatch into [`Interface::apply_action`]. This
+/// keeps the test fast and dependency-free while still exercising:
+///
+/// - the per-Shared-entity resolution loop (`writers_at`),
+/// - the topology mirror that `happens_before_in_topology` consults,
+/// - the `(entity_id, delta_id)` cache,
+/// - Borsh roundtrip of [`StorageDelta::CausalActions`],
+/// - the receiver-side variant branching that builds a per-action
+///   [`ApplyContext`] from the resolved map.
+struct SharedRotationApplier {
+    /// `delta_id → parents` for every applied delta. Updated after a
+    /// successful apply. Used as the snapshot the `happens_before`
+    /// closure runs against during resolution.
+    topology: Arc<RwLock<HashMap<[u8; 32], Vec<[u8; 32]>>>>,
+    /// Resolved writer-set cache. Same key/shape as
+    /// `ContextStorageApplier::effective_writers_cache`.
+    effective_writers_cache: Arc<RwLock<HashMap<(Id, [u8; 32]), BTreeSet<PublicKey>>>>,
+    /// Successful-apply log (id + action count + serialized artifact
+    /// size) for assertions.
+    applied: Arc<RwLock<Vec<AppliedDelta>>>,
+}
+
+#[derive(Debug, Clone)]
+struct AppliedDelta {
+    delta_id: [u8; 32],
+    /// Size of the serialized `StorageDelta::CausalActions` artifact.
+    /// Asserts the wire format went through Borsh on both sides.
+    artifact_bytes: usize,
+}
+
+impl SharedRotationApplier {
+    fn new() -> Self {
+        Self {
+            topology: Arc::new(RwLock::new(HashMap::new())),
+            effective_writers_cache: Arc::new(RwLock::new(HashMap::new())),
+            applied: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    async fn applied(&self) -> Vec<AppliedDelta> {
+        self.applied.read().await.clone()
+    }
+
+    /// Resolve `effective_writers` for every Shared entity in `delta`.
+    /// Mirrors `ContextStorageApplier::resolve_effective_writers_for_delta`.
+    async fn resolve_effective_writers(
+        &self,
+        delta: &CausalDelta<Vec<Action>>,
+    ) -> BTreeMap<Id, BTreeSet<PublicKey>> {
+        // Collect Shared-entity ids touched by this delta.
+        let mut shared_entities: BTreeSet<Id> = BTreeSet::new();
+        for action in &delta.payload {
+            let metadata = match action {
+                Action::Add { metadata, .. }
+                | Action::Update { metadata, .. }
+                | Action::DeleteRef { metadata, .. } => metadata,
+                Action::Compare { .. } => continue,
+            };
+            if matches!(metadata.storage_type, StorageType::Shared { .. }) {
+                let _inserted = shared_entities.insert(action.id());
+            }
+        }
+
+        let mut out: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
+        if shared_entities.is_empty() {
+            return out;
+        }
+
+        let topology_snapshot = self.topology.read().await.clone();
+
+        for entity_id in shared_entities {
+            let cache_key = (entity_id, delta.id);
+            if let Some(cached) = self.effective_writers_cache.read().await.get(&cache_key) {
+                let _replaced = out.insert(entity_id, cached.clone());
+                continue;
+            }
+
+            let log = match rotation_log::load::<MainStorage>(entity_id) {
+                Ok(Some(log)) => log,
+                Ok(None) => continue, // No log → verifier falls back to v2 stored-writers.
+                Err(e) => panic!("rotation_log::load for {entity_id:?} failed: {e}"),
+            };
+
+            let resolved = rotation_log_reader::writers_at(&log, &delta.parents, |a, b| {
+                happens_before_in_topology(&topology_snapshot, a, b)
+            });
+
+            if let Some(set) = resolved {
+                let _replaced = out.insert(entity_id, set.clone());
+                let mut cache = self.effective_writers_cache.write().await;
+                let _previous = cache.insert(cache_key, set);
+            }
+        }
+
+        out
+    }
+}
+
+#[async_trait::async_trait]
+impl DeltaApplier<Vec<Action>> for SharedRotationApplier {
+    async fn apply(&self, delta: &CausalDelta<Vec<Action>>) -> Result<(), ApplyError> {
+        // Step 1 — resolve.
+        let effective_writers = self.resolve_effective_writers(delta).await;
+
+        // Step 2 — serialize the CausalActions artifact, mirroring what the
+        // sender ships across the wire to `__calimero_sync_next`.
+        let artifact = to_vec(&StorageDelta::CausalActions {
+            actions: delta.payload.clone(),
+            delta_id: delta.id,
+            delta_hlc: delta.hlc,
+            effective_writers,
+        })
+        .map_err(|e| ApplyError::Application(format!("serialize artifact: {e}")))?;
+        let artifact_size = artifact.len();
+
+        // Step 3 — receiver side: deserialize and dispatch. Mirrors
+        // `Root::sync`'s `CausalActions` branch.
+        let storage_delta: StorageDelta = from_slice(&artifact)
+            .map_err(|e| ApplyError::Application(format!("deserialize artifact: {e}")))?;
+        let (actions, recv_delta_id, recv_hlc, recv_writers) = match storage_delta {
+            StorageDelta::CausalActions {
+                actions,
+                delta_id,
+                delta_hlc,
+                effective_writers,
+            } => (actions, delta_id, delta_hlc, effective_writers),
+            other => {
+                return Err(ApplyError::Application(format!(
+                    "unexpected variant on receive: {other:?}"
+                )))
+            }
+        };
+
+        for action in &actions {
+            let ctx = ApplyContext {
+                effective_writers: recv_writers.get(&action.id()).cloned(),
+                delta_id: Some(recv_delta_id),
+                delta_hlc: Some(recv_hlc),
+            };
+            Interface::<MainStorage>::apply_action(action.clone(), &ctx)
+                .map_err(|e: StorageError| ApplyError::Application(e.to_string()))?;
+        }
+
+        // Step 4 — record topology + tally.
+        {
+            let mut topology = self.topology.write().await;
+            let _previous = topology.insert(delta.id, delta.parents.clone());
+        }
+        self.applied.write().await.push(AppliedDelta {
+            delta_id: delta.id,
+            artifact_bytes: artifact_size,
+        });
+        Ok(())
+    }
+}
+
+/// Build a `CausalDelta` with explicit HLC. `CausalDelta::new_test` defaults
+/// the HLC, but our scenarios depend on HLC ordering for sibling tiebreak.
+fn delta_with_hlc(
+    id: [u8; 32],
+    parents: Vec<[u8; 32]>,
+    hlc_ns: u64,
+    payload: Vec<Action>,
+) -> CausalDelta<Vec<Action>> {
+    CausalDelta {
+        id,
+        parents,
+        payload,
+        hlc: hlc(hlc_ns),
+        expected_root_hash: [0; 32],
+        kind: DeltaKind::Regular,
+    }
+}
+
+// =============================================================================
+// Scenario 1: update-vs-rotation race (#2197 motivator 1)
+// =============================================================================
+
+/// Bob writes "world" against the writer set he sees ({Alice, Bob}) under
+/// a partition. Concurrently, Alice rotates Bob out. Carol receives both
+/// in adversarial order. Carol must accept Bob's pre-rotation write — per
+/// ADR 0001 the verifier consults `writers_at(D2.parents=[D_root])`, which
+/// includes Bob, even though stored writers post-D1 is `{Alice}`.
+///
+/// Without #2266, this test would fail: the verifier would fall back to
+/// stored writers `{Alice}` and reject Bob's signature.
+#[tokio::test]
+async fn update_vs_rotation_race_pre_rotation_write_accepted_through_full_sync_path() {
+    let _nonce_off = disable_nonce_check_for_testing();
+    let root = setup_root();
+
+    let alice_sk = make_signing_key(0xA1);
+    let bob_sk = make_signing_key(0xB1);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let entity_id = Id::new([0x70; 32]);
+
+    let applier = SharedRotationApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    // D_root: Alice bootstraps with writers = {Alice, Bob}.
+    let d_root_id = [0xD0; 32];
+    let d_root = delta_with_hlc(
+        d_root_id,
+        vec![[0; 32]],
+        one_sec(10),
+        vec![build_signed_shared_action(
+            true,
+            entity_id,
+            b"hello".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![root.clone()],
+        )],
+    );
+    dag.add_delta(d_root, &applier)
+        .await
+        .expect("D_root applied");
+
+    // D1: Alice rotates Bob out. Parent = D_root.
+    let d1_id = [0xD1; 32];
+    let d1 = delta_with_hlc(
+        d1_id,
+        vec![d_root_id],
+        one_sec(20),
+        vec![build_signed_shared_action(
+            false,
+            entity_id,
+            b"hello".to_vec(),
+            [alice].into_iter().collect(), // Bob removed
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        )],
+    );
+
+    // D2: Bob's pre-rotation write — parent = D_root (concurrent with D1).
+    let d2_id = [0xD2; 32];
+    let d2 = delta_with_hlc(
+        d2_id,
+        vec![d_root_id],
+        one_sec(21),
+        vec![build_signed_shared_action(
+            false,
+            entity_id,
+            b"world".to_vec(),
+            [alice, bob].into_iter().collect(), // Bob's view
+            one_sec(21),
+            &bob_sk,
+            vec![],
+        )],
+    );
+
+    // Adversarial delivery: rotation first, then Bob's pre-rotation write.
+    dag.add_delta(d1, &applier).await.expect("rotation applied");
+    dag.add_delta(d2, &applier)
+        .await
+        .expect("pre-rotation write must be accepted via writers_at(D2.parents)");
+
+    // Three deltas applied (D_root, D1, D2). The artifact size on each
+    // apply is non-zero, proving the StorageDelta::CausalActions wire
+    // format went through Borsh on both sides.
+    let applied = applier.applied().await;
+    assert_eq!(applied.len(), 3);
+    assert!(applied.iter().all(|a| a.artifact_bytes > 0));
+    assert_eq!(applied[0].delta_id, d_root_id);
+    assert_eq!(applied[1].delta_id, d1_id);
+    assert_eq!(applied[2].delta_id, d2_id);
+
+    // Rotation log has D_root + D1; D2 is a value-write whose claimed
+    // {Alice, Bob} matches the bootstrap set, so the rotation hook
+    // correctly skips it.
+    let log = rotation_log::load::<MainStorage>(entity_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(log.entries.len(), 2);
+    assert_eq!(log.entries[0].delta_id, d_root_id);
+    assert_eq!(log.entries[1].delta_id, d1_id);
+}
+
+// =============================================================================
+// Post-rotation forgery rejected
+// =============================================================================
+
+/// Inverse of scenario 1: a write whose causal parents *include* the
+/// rotation must be rejected if the signer was revoked at that causal
+/// point. With #2266 the verifier looks up `writers_at([D1])` = {Alice}
+/// and rejects Bob's signature.
+#[tokio::test]
+async fn post_rotation_forgery_by_revoked_writer_rejected() {
+    let _nonce_off = disable_nonce_check_for_testing();
+    let root = setup_root();
+
+    let alice_sk = make_signing_key(0xA2);
+    let bob_sk = make_signing_key(0xB2);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let entity_id = Id::new([0x71; 32]);
+
+    let applier = SharedRotationApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    // D_root: bootstrap with {Alice, Bob}.
+    let d_root_id = [0xE0; 32];
+    let d_root = delta_with_hlc(
+        d_root_id,
+        vec![[0; 32]],
+        one_sec(10),
+        vec![build_signed_shared_action(
+            true,
+            entity_id,
+            b"v0".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![root.clone()],
+        )],
+    );
+    dag.add_delta(d_root, &applier).await.unwrap();
+
+    // D1: Alice rotates Bob out.
+    let d1_id = [0xE1; 32];
+    let d1 = delta_with_hlc(
+        d1_id,
+        vec![d_root_id],
+        one_sec(20),
+        vec![build_signed_shared_action(
+            false,
+            entity_id,
+            b"v0".to_vec(),
+            [alice].into_iter().collect(),
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        )],
+    );
+    dag.add_delta(d1, &applier).await.unwrap();
+
+    // D3: Bob saw the rotation and tries to write anyway. Parent = D1.
+    // Per ADR 0001, writers_at([D1]) = {Alice} — Bob is no longer a writer.
+    let d3_id = [0xE3; 32];
+    let d3 = delta_with_hlc(
+        d3_id,
+        vec![d1_id],
+        one_sec(30),
+        vec![build_signed_shared_action(
+            false,
+            entity_id,
+            b"forgery".to_vec(),
+            [alice].into_iter().collect(),
+            one_sec(30),
+            &bob_sk, // Bob signs even though revoked
+            vec![],
+        )],
+    );
+
+    let result = dag.add_delta(d3, &applier).await;
+    // `StorageError::InvalidSignature` displays as "Invalid signature for
+    // user-owned data" — match on the rejection, not the exact prose, so
+    // doc-string changes don't break this probe.
+    assert!(
+        matches!(&result, Err(calimero_dag::DagError::ApplyFailed(ApplyError::Application(msg))) if msg.contains("Invalid signature")),
+        "post-rotation forgery by revoked writer must be rejected with InvalidSignature; got {result:?}"
+    );
+
+    // Only D_root and D1 made it through; D3 was rejected before the
+    // applier could record it.
+    let applied = applier.applied().await;
+    assert_eq!(applied.len(), 2);
+    assert_eq!(applied[0].delta_id, d_root_id);
+    assert_eq!(applied[1].delta_id, d1_id);
+}
+
+// =============================================================================
+// Out-of-order buffering: same scenario, adversarial DAG ordering
+// =============================================================================
+
+/// Same correctness invariant as scenario 1, but the DAG receives D2
+/// (Bob's pre-rotation write) BEFORE its parent D_root has arrived. The
+/// `DagStore` must buffer D2 in pending, then once D_root + D1 land,
+/// apply them in topological order with each of their resolved
+/// `effective_writers` correctly computed against the topology that
+/// existed AT APPLY TIME. This catches a subtle bug class: if the
+/// topology mirror were updated *before* WASM apply (or if the cache
+/// keyed wrong), buffered deltas would resolve against an empty
+/// topology and silently fall back to v2 stored-writers, and Bob's
+/// write would be rejected.
+#[tokio::test]
+async fn buffered_pre_rotation_write_resolves_correctly_after_parents_arrive() {
+    let _nonce_off = disable_nonce_check_for_testing();
+    let root = setup_root();
+
+    let alice_sk = make_signing_key(0xA3);
+    let bob_sk = make_signing_key(0xB3);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let entity_id = Id::new([0x72; 32]);
+
+    let applier = SharedRotationApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    let d_root_id = [0xF0; 32];
+    let d_root = delta_with_hlc(
+        d_root_id,
+        vec![[0; 32]],
+        one_sec(10),
+        vec![build_signed_shared_action(
+            true,
+            entity_id,
+            b"hello".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(10),
+            &alice_sk,
+            vec![root.clone()],
+        )],
+    );
+
+    let d1_id = [0xF1; 32];
+    let d1 = delta_with_hlc(
+        d1_id,
+        vec![d_root_id],
+        one_sec(20),
+        vec![build_signed_shared_action(
+            false,
+            entity_id,
+            b"hello".to_vec(),
+            [alice].into_iter().collect(),
+            one_sec(20),
+            &alice_sk,
+            vec![],
+        )],
+    );
+
+    let d2_id = [0xF2; 32];
+    let d2 = delta_with_hlc(
+        d2_id,
+        vec![d_root_id],
+        one_sec(21),
+        vec![build_signed_shared_action(
+            false,
+            entity_id,
+            b"world".to_vec(),
+            [alice, bob].into_iter().collect(),
+            one_sec(21),
+            &bob_sk,
+            vec![],
+        )],
+    );
+
+    // Adversarial: D2 arrives FIRST, then D1, then D_root. D2 and D1
+    // both buffer until D_root lands; then they cascade in topo order.
+    let applied_d2 = dag.add_delta(d2, &applier).await.unwrap();
+    assert!(!applied_d2, "D2 must buffer (D_root missing)");
+    let applied_d1 = dag.add_delta(d1, &applier).await.unwrap();
+    assert!(!applied_d1, "D1 must buffer (D_root missing)");
+    assert_eq!(applier.applied().await.len(), 0, "nothing applied yet");
+
+    let applied_root = dag.add_delta(d_root, &applier).await.unwrap();
+    assert!(applied_root, "D_root applies; cascade flushes pending");
+
+    // All three should now be applied; the rotation log has D_root + D1.
+    let applied = applier.applied().await;
+    assert_eq!(applied.len(), 3, "D_root, D1, D2 all applied after cascade");
+    let applied_ids: Vec<_> = applied.iter().map(|a| a.delta_id).collect();
+    assert!(applied_ids.contains(&d_root_id));
+    assert!(applied_ids.contains(&d1_id));
+    assert!(
+        applied_ids.contains(&d2_id),
+        "Bob's pre-rotation write resolved correctly even after buffering"
+    );
+
+    let log = rotation_log::load::<MainStorage>(entity_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(log.entries.len(), 2);
+}

--- a/crates/node/tests/dag_storage_integration.rs
+++ b/crates/node/tests/dag_storage_integration.rs
@@ -61,16 +61,8 @@ impl DeltaApplier<Vec<Action>> for StorageApplier {
 
         // Actually apply each action to storage
         for action in &delta.payload {
-            Interface::<MainStorage>::apply_action(
-                action.clone(),
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            )
-            .map_err(|e| ApplyError::Application(e.to_string()))?;
+            Interface::<MainStorage>::apply_action(action.clone(), &ApplyContext::empty())
+                .map_err(|e| ApplyError::Application(e.to_string()))?;
         }
 
         // Track that this delta was applied

--- a/crates/node/tests/sync_protocols.rs
+++ b/crates/node/tests/sync_protocols.rs
@@ -47,16 +47,8 @@ impl DeltaApplier<Vec<Action>> for TestApplier {
     async fn apply(&self, delta: &CausalDelta<Vec<Action>>) -> Result<(), ApplyError> {
         // Apply actions to storage
         for action in &delta.payload {
-            Interface::<MainStorage>::apply_action(
-                action.clone(),
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            )
-            .map_err(|e| ApplyError::Application(e.to_string()))?;
+            Interface::<MainStorage>::apply_action(action.clone(), &ApplyContext::empty())
+                .map_err(|e| ApplyError::Application(e.to_string()))?;
         }
 
         self.applied.write().await.push(delta.id);

--- a/crates/node/tests/sync_sim/storage.rs
+++ b/crates/node/tests/sync_sim/storage.rs
@@ -336,15 +336,7 @@ impl SimStorage {
                 ancestors: vec![],
                 metadata: Metadata::default(),
             };
-            let _ = Interface::<MainStorage>::apply_action(
-                action,
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            );
+            let _ = Interface::<MainStorage>::apply_action(action, &ApplyContext::empty());
         });
     }
 
@@ -375,15 +367,7 @@ impl SimStorage {
                 ancestors: vec![ancestor],
                 metadata,
             };
-            let _ = Interface::<MainStorage>::apply_action(
-                action,
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            );
+            let _ = Interface::<MainStorage>::apply_action(action, &ApplyContext::empty());
         });
     }
 
@@ -423,15 +407,7 @@ impl SimStorage {
                     ancestors: vec![],
                     metadata: Metadata::default(),
                 };
-                let _ = Interface::<MainStorage>::apply_action(
-                    action,
-                    ApplyContext {
-                        causal_parents: &[],
-                        delta_id: None,
-                        delta_hlc: None,
-                        happens_before: None,
-                    },
-                );
+                let _ = Interface::<MainStorage>::apply_action(action, &ApplyContext::empty());
             } else {
                 // Create new entity as child of root
                 // First ensure root exists
@@ -447,15 +423,8 @@ impl SimStorage {
                         ancestors: vec![],
                         metadata: Metadata::default(),
                     };
-                    let _ = Interface::<MainStorage>::apply_action(
-                        root_action,
-                        ApplyContext {
-                            causal_parents: &[],
-                            delta_id: None,
-                            delta_hlc: None,
-                            happens_before: None,
-                        },
-                    );
+                    let _ =
+                        Interface::<MainStorage>::apply_action(root_action, &ApplyContext::empty());
                 }
 
                 // Add new entity under root
@@ -465,15 +434,7 @@ impl SimStorage {
                     ancestors: vec![ChildInfo::new(root_id, [0; 32], Metadata::default())],
                     metadata: Metadata::default(),
                 };
-                let _ = Interface::<MainStorage>::apply_action(
-                    action,
-                    ApplyContext {
-                        causal_parents: &[],
-                        delta_id: None,
-                        delta_hlc: None,
-                        happens_before: None,
-                    },
-                );
+                let _ = Interface::<MainStorage>::apply_action(action, &ApplyContext::empty());
             }
         });
     }
@@ -487,15 +448,7 @@ impl SimStorage {
                     deleted_at: calimero_storage::env::time_now(),
                     metadata: index.metadata.clone(),
                 };
-                let _ = Interface::<MainStorage>::apply_action(
-                    action,
-                    ApplyContext {
-                        causal_parents: &[],
-                        delta_id: None,
-                        delta_hlc: None,
-                        happens_before: None,
-                    },
-                );
+                let _ = Interface::<MainStorage>::apply_action(action, &ApplyContext::empty());
             }
         });
     }

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -937,7 +937,7 @@ impl VMHostFunctions<'_> {
                 // the verifier falls back to v2 stored-writers, which is
                 // safe for replicated state from a peer.
                 let sync_ctx = calimero_storage::interface::ApplyContext::empty();
-                calimero_storage::collections::Root::<Vec<u8>>::sync(&payload, sync_ctx)
+                calimero_storage::collections::Root::<Vec<u8>>::sync(&payload, &sync_ctx)
             })
             .map_err(|err| {
                 VMLogicError::from(HostError::Panic {

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -928,13 +928,14 @@ impl VMHostFunctions<'_> {
             );
 
             with_runtime_env(env.clone(), || {
-                // #2266: empty ctx for now. Step 3 of the WASM-ABI wiring
-                // routes deltas with `CausalDelta` metadata through the
-                // sync layer, which pre-resolves `effective_writers` and
-                // populates ctx before calling `Root::sync`. Until that
-                // path lands, this entry-point keeps the v2 stored-writers
-                // fallback (safe: this is host-side replay of an artifact
-                // already verified at apply-time).
+                // #2266: empty ctx is the TEMPLATE here. `payload` is a
+                // pre-built `StorageDelta` artifact — when its variant is
+                // `CausalActions`, `Root::sync` builds per-action ctxs
+                // from the embedded `effective_writers` map and ignores
+                // this template. For `Actions` (host-side replay of
+                // already-verified state) the template is used as-is and
+                // the verifier falls back to v2 stored-writers, which is
+                // safe for replicated state from a peer.
                 let sync_ctx = calimero_storage::interface::ApplyContext::empty();
                 calimero_storage::collections::Root::<Vec<u8>>::sync(&payload, sync_ctx)
             })

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -928,14 +928,14 @@ impl VMHostFunctions<'_> {
             );
 
             with_runtime_env(env.clone(), || {
-                // P1 of #2233: causal_parents is empty here. P3 will extend
-                // the ABI to pass CausalDelta.parents through to apply_action.
-                let sync_ctx = calimero_storage::interface::ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                };
+                // #2266: empty ctx for now. Step 3 of the WASM-ABI wiring
+                // routes deltas with `CausalDelta` metadata through the
+                // sync layer, which pre-resolves `effective_writers` and
+                // populates ctx before calling `Root::sync`. Until that
+                // path lands, this entry-point keeps the v2 stored-writers
+                // fallback (safe: this is host-side replay of an artifact
+                // already verified at apply-time).
+                let sync_ctx = calimero_storage::interface::ApplyContext::empty();
                 calimero_storage::collections::Root::<Vec<u8>>::sync(&payload, sync_ctx)
             })
             .map_err(|err| {

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -178,12 +178,13 @@ impl ToTokens for PublicLogicMethod<'_> {
                         ::calimero_sdk::env::panic_str("Expected payload to sync method.")
                     };
 
-                    // #2266: empty ctx today. Step 4 of the WASM-ABI wiring
-                    // extends the artifact (`StorageDelta`) with a
-                    // CausalActions variant that carries pre-resolved
-                    // `effective_writers`; `Root::sync` will branch on it
-                    // and populate ctx before applying. Until then this
-                    // path keeps v2 stored-writers fallback semantics.
+                    // #2266: ctx is empty here as a TEMPLATE — used as-is for
+                    // `StorageDelta::Actions` (SDK-driven local apply, v2
+                    // stored-writers fallback). For network-sync deltas the
+                    // node sync layer ships a `StorageDelta::CausalActions`
+                    // artifact carrying pre-resolved `effective_writers`;
+                    // `Root::sync` branches on the variant and builds a
+                    // per-action ctx from the map, ignoring this template.
                     let __sync_ctx = ::calimero_storage::interface::ApplyContext::empty();
                     ::calimero_storage::collections::Root::<#self_>::sync(&args, __sync_ctx).expect("fatal: sync failed");
                 }

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -186,7 +186,7 @@ impl ToTokens for PublicLogicMethod<'_> {
                     // `Root::sync` branches on the variant and builds a
                     // per-action ctx from the map, ignoring this template.
                     let __sync_ctx = ::calimero_storage::interface::ApplyContext::empty();
-                    ::calimero_storage::collections::Root::<#self_>::sync(&args, __sync_ctx).expect("fatal: sync failed");
+                    ::calimero_storage::collections::Root::<#self_>::sync(&args, &__sync_ctx).expect("fatal: sync failed");
                 }
 
                 impl ::calimero_sdk::state::AppStateInit for #self_ {

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -178,14 +178,13 @@ impl ToTokens for PublicLogicMethod<'_> {
                         ::calimero_sdk::env::panic_str("Expected payload to sync method.")
                     };
 
-                    // P1 of #2233: causal_parents is empty here. Wiring the
-                    // CausalDelta.parents through the WASM ABI is part of P3.
-                    let __sync_ctx = ::calimero_storage::interface::ApplyContext {
-                        causal_parents: &[],
-                        delta_id: None,
-                        delta_hlc: None,
-                        happens_before: None,
-                    };
+                    // #2266: empty ctx today. Step 4 of the WASM-ABI wiring
+                    // extends the artifact (`StorageDelta`) with a
+                    // CausalActions variant that carries pre-resolved
+                    // `effective_writers`; `Root::sync` will branch on it
+                    // and populate ctx before applying. Until then this
+                    // path keeps v2 stored-writers fallback semantics.
+                    let __sync_ctx = ::calimero_storage::interface::ApplyContext::empty();
                     ::calimero_storage::collections::Root::<#self_>::sync(&args, __sync_ctx).expect("fatal: sync failed");
                 }
 

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -125,10 +125,12 @@ where
     /// Syncs the root collection.
     ///
     /// `ctx` is the apply-time context for the inner [`Interface::apply_action`]
-    /// calls. Per #2266, when the artifact carries DAG-causal information
-    /// the sync layer pre-resolves `effective_writers` and populates ctx
-    /// before calling here; storage then validates Shared signatures
-    /// against the resolved set.
+    /// calls. Per #2266, the [`StorageDelta::CausalActions`] variant
+    /// carries pre-resolved `effective_writers` per Shared entity from
+    /// the sync layer; this function builds a per-action `ApplyContext`
+    /// from that map and ignores the passed `ctx` for that variant. For
+    /// [`StorageDelta::Actions`] the passed `ctx` is used as-is (typically
+    /// empty — verifier falls back to v2 stored-writers).
     #[expect(clippy::missing_errors_doc, reason = "NO")]
     pub fn sync(args: &[u8], ctx: crate::interface::ApplyContext) -> Result<(), StorageError> {
         let artifact =
@@ -136,122 +138,19 @@ where
 
         match artifact {
             StorageDelta::Actions(actions) => {
-                let mut root_snapshot: Option<(Vec<u8>, crate::entities::Metadata)> = None;
-
-                // #2238: defer ancestor-hash recomputation until the end of
-                // the action loop. Many deltas in a single merge often touch
-                // the same parent; without batching, each `add_child_to`
-                // walks from that parent to the root redoing the same O(K)
-                // hash work. The scope dedupes starting ids and flushes via
-                // `finish()?` after the loop so storage errors during flush
-                // propagate back to the caller (an error here means the
-                // merkle tree is left inconsistent).
-                let defer_scope = DeferredAncestorScope::<S>::new();
-
-                for action in actions {
-                    match &action {
-                        Action::Add {
-                            id, data, metadata, ..
-                        }
-                        | Action::Update {
-                            id, data, metadata, ..
-                        } if id.is_root() => {
-                            info!(
-                                target: "storage::root",
-                                payload_len = data.len(),
-                                created_at = metadata.created_at,
-                                updated_at = metadata.updated_at(),
-                                "captured root snapshot from delta replay"
-                            );
-                            root_snapshot = Some((data.clone(), metadata.clone()));
-                        }
-                        _ => {}
-                    }
-
-                    match action {
-                        Action::Compare { id } => {
-                            push_comparison(Comparison {
-                                data: <Interface<S>>::find_by_id_raw(id),
-                                comparison_data: <Interface<S>>::generate_comparison_data(Some(
-                                    id,
-                                ))?,
-                            });
-                        }
-                        Action::Add {
-                            id,
-                            data,
-                            metadata,
-                            ancestors,
-                        } => {
-                            // Skip root - it will be processed after all children via root_snapshot
-                            // This ensures children are created before root merge happens
-                            if !id.is_root() {
-                                info!(
-                                    target: "storage::sync_child",
-                                    %id,
-                                    data_len = data.len(),
-                                    created_at = metadata.created_at,
-                                    updated_at = metadata.updated_at(),
-                                    "SYNC CHILD: Applying Action::Add for child entity"
-                                );
-                                <Interface<S>>::apply_action(
-                                    Action::Add {
-                                        id,
-                                        data,
-                                        metadata,
-                                        ancestors,
-                                    },
-                                    &ctx,
-                                )?;
-                            }
-                        }
-                        Action::Update {
-                            id,
-                            data,
-                            metadata,
-                            ancestors,
-                        } => {
-                            // Skip root - it will be processed after all children via root_snapshot
-                            // This ensures children are created before root merge happens
-                            if !id.is_root() {
-                                info!(
-                                    target: "storage::sync_child",
-                                    %id,
-                                    data_len = data.len(),
-                                    created_at = metadata.created_at,
-                                    updated_at = metadata.updated_at(),
-                                    "SYNC CHILD: Applying Action::Update for child entity"
-                                );
-                                <Interface<S>>::apply_action(
-                                    Action::Update {
-                                        id,
-                                        data,
-                                        metadata,
-                                        ancestors,
-                                    },
-                                    &ctx,
-                                )?;
-                            }
-                        }
-                        Action::DeleteRef { .. } => {
-                            <Interface<S>>::apply_action(action, &ctx)?;
-                        }
-                    };
-                }
-
-                // Flush deferred ancestor walks. Errors here indicate a
-                // partially-propagated merkle tree and must surface to the
-                // caller rather than being silently logged by Drop.
-                defer_scope.finish()?;
-
-                if let Some((payload, metadata)) = root_snapshot {
-                    if <Interface<S>>::save_raw(Id::root(), payload, metadata)?.is_some() {
-                        info!(
-                            target: "storage::root",
-                            "persisted root document from delta replay"
-                        );
-                    }
-                }
+                Self::apply_actions(actions, |_| ctx.clone())?;
+            }
+            StorageDelta::CausalActions {
+                actions,
+                delta_id,
+                delta_hlc,
+                effective_writers,
+            } => {
+                Self::apply_actions(actions, |action| crate::interface::ApplyContext {
+                    effective_writers: effective_writers.get(&action.id()).cloned(),
+                    delta_id: Some(delta_id),
+                    delta_hlc: Some(delta_hlc),
+                })?;
             }
             StorageDelta::Comparisons(comparisons) => {
                 if comparisons.is_empty() {
@@ -276,6 +175,130 @@ where
             "committing root after delta replay"
         );
         Self::commit_headless();
+
+        Ok(())
+    }
+
+    /// Apply a batch of actions, deriving the per-action [`ApplyContext`]
+    /// from `ctx_for_action`. Shared between the `Actions` (uniform ctx)
+    /// and `CausalActions` (per-action ctx via `effective_writers` lookup)
+    /// branches of [`Self::sync`].
+    fn apply_actions<F>(actions: Vec<Action>, ctx_for_action: F) -> Result<(), StorageError>
+    where
+        F: Fn(&Action) -> crate::interface::ApplyContext,
+    {
+        let mut root_snapshot: Option<(Vec<u8>, crate::entities::Metadata)> = None;
+
+        // #2238: defer ancestor-hash recomputation until the end of
+        // the action loop. Many deltas in a single merge often touch
+        // the same parent; without batching, each `add_child_to`
+        // walks from that parent to the root redoing the same O(K)
+        // hash work. The scope dedupes starting ids and flushes via
+        // `finish()?` after the loop so storage errors during flush
+        // propagate back to the caller (an error here means the
+        // merkle tree is left inconsistent).
+        let defer_scope = DeferredAncestorScope::<S>::new();
+
+        for action in actions {
+            match &action {
+                Action::Add {
+                    id, data, metadata, ..
+                }
+                | Action::Update {
+                    id, data, metadata, ..
+                } if id.is_root() => {
+                    info!(
+                        target: "storage::root",
+                        payload_len = data.len(),
+                        created_at = metadata.created_at,
+                        updated_at = metadata.updated_at(),
+                        "captured root snapshot from delta replay"
+                    );
+                    root_snapshot = Some((data.clone(), metadata.clone()));
+                }
+                _ => {}
+            }
+
+            let action_ctx = ctx_for_action(&action);
+
+            match action {
+                Action::Compare { id } => {
+                    push_comparison(Comparison {
+                        data: <Interface<S>>::find_by_id_raw(id),
+                        comparison_data: <Interface<S>>::generate_comparison_data(Some(id))?,
+                    });
+                }
+                Action::Add {
+                    id,
+                    data,
+                    metadata,
+                    ancestors,
+                } => {
+                    if !id.is_root() {
+                        info!(
+                            target: "storage::sync_child",
+                            %id,
+                            data_len = data.len(),
+                            created_at = metadata.created_at,
+                            updated_at = metadata.updated_at(),
+                            "SYNC CHILD: Applying Action::Add for child entity"
+                        );
+                        <Interface<S>>::apply_action(
+                            Action::Add {
+                                id,
+                                data,
+                                metadata,
+                                ancestors,
+                            },
+                            &action_ctx,
+                        )?;
+                    }
+                }
+                Action::Update {
+                    id,
+                    data,
+                    metadata,
+                    ancestors,
+                } => {
+                    if !id.is_root() {
+                        info!(
+                            target: "storage::sync_child",
+                            %id,
+                            data_len = data.len(),
+                            created_at = metadata.created_at,
+                            updated_at = metadata.updated_at(),
+                            "SYNC CHILD: Applying Action::Update for child entity"
+                        );
+                        <Interface<S>>::apply_action(
+                            Action::Update {
+                                id,
+                                data,
+                                metadata,
+                                ancestors,
+                            },
+                            &action_ctx,
+                        )?;
+                    }
+                }
+                Action::DeleteRef { .. } => {
+                    <Interface<S>>::apply_action(action, &action_ctx)?;
+                }
+            };
+        }
+
+        // Flush deferred ancestor walks. Errors here indicate a
+        // partially-propagated merkle tree and must surface to the
+        // caller rather than being silently logged by Drop.
+        defer_scope.finish()?;
+
+        if let Some((payload, metadata)) = root_snapshot {
+            if <Interface<S>>::save_raw(Id::root(), payload, metadata)?.is_some() {
+                info!(
+                    target: "storage::root",
+                    "persisted root document from delta replay"
+                );
+            }
+        }
 
         Ok(())
     }

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -131,8 +131,11 @@ where
     /// from that map and ignores the passed `ctx` for that variant. For
     /// [`StorageDelta::Actions`] the passed `ctx` is used as-is (typically
     /// empty — verifier falls back to v2 stored-writers).
+    ///
+    /// Takes `&ApplyContext` (not by-value) for parity with
+    /// [`Interface::apply_action`]; per #2272 review.
     #[expect(clippy::missing_errors_doc, reason = "NO")]
-    pub fn sync(args: &[u8], ctx: crate::interface::ApplyContext) -> Result<(), StorageError> {
+    pub fn sync(args: &[u8], ctx: &crate::interface::ApplyContext) -> Result<(), StorageError> {
         let artifact =
             from_slice::<StorageDelta>(args).map_err(StorageError::DeserializationError)?;
 
@@ -165,7 +168,7 @@ where
                     comparison_data,
                 } in comparisons
                 {
-                    <Interface<S>>::compare_affective(data, comparison_data, &ctx)?;
+                    <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
                 }
             }
         }

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -125,10 +125,12 @@ where
     /// Syncs the root collection.
     ///
     /// `ctx` is the apply-time context for the inner [`Interface::apply_action`]
-    /// calls (DAG-causal parents of the delta the artifact came from). In phase
-    /// P1 of #2233 it is plumbed through but not consulted.
+    /// calls. Per #2266, when the artifact carries DAG-causal information
+    /// the sync layer pre-resolves `effective_writers` and populates ctx
+    /// before calling here; storage then validates Shared signatures
+    /// against the resolved set.
     #[expect(clippy::missing_errors_doc, reason = "NO")]
-    pub fn sync(args: &[u8], ctx: crate::interface::ApplyContext<'_>) -> Result<(), StorageError> {
+    pub fn sync(args: &[u8], ctx: crate::interface::ApplyContext) -> Result<(), StorageError> {
         let artifact =
             from_slice::<StorageDelta>(args).map_err(StorageError::DeserializationError)?;
 
@@ -199,7 +201,7 @@ where
                                         metadata,
                                         ancestors,
                                     },
-                                    ctx,
+                                    &ctx,
                                 )?;
                             }
                         }
@@ -227,12 +229,12 @@ where
                                         metadata,
                                         ancestors,
                                     },
-                                    ctx,
+                                    &ctx,
                                 )?;
                             }
                         }
                         Action::DeleteRef { .. } => {
-                            <Interface<S>>::apply_action(action, ctx)?;
+                            <Interface<S>>::apply_action(action, &ctx)?;
                         }
                     };
                 }
@@ -264,7 +266,7 @@ where
                     comparison_data,
                 } in comparisons
                 {
-                    <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
+                    <Interface<S>>::compare_affective(data, comparison_data, &ctx)?;
                 }
             }
         }

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -133,6 +133,19 @@ where
         Ok(&self.value)
     }
 
+    /// Read the current writer set. Public so callers can present a
+    /// "members with edit rights" UI and compute incremental rotations
+    /// (current set + new mod) without mirroring the set elsewhere.
+    pub fn writers(&self) -> &BTreeSet<PublicKey> {
+        &self.writers
+    }
+
+    /// Whether the writer set has been frozen. Once frozen, `rotate_writers`
+    /// is permanently rejected.
+    pub fn is_frozen(&self) -> bool {
+        self.writers_frozen
+    }
+
     /// Returns the signature attached to the most recently applied state of
     /// this entity, if any. Reads from the wrapper field first; if unset
     /// (e.g., the wrapper was just deserialized and the field hasn't been
@@ -440,6 +453,49 @@ mod tests {
         // Storage is still functional — alice can still write.
         let _ = s.insert(TestVal(2)).expect("alice can still write");
         assert_eq!(s.get().unwrap(), &TestVal(2));
+    }
+
+    #[test]
+    #[serial]
+    fn writers_accessor_reflects_bootstrap_then_rotation() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+
+        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
+
+        // Bootstrap-time writer set is observable.
+        assert_eq!(s.writers(), &writers(&[ALICE, BOB]));
+        assert!(!s.is_frozen());
+
+        // After a rotation, the accessor sees the new set without the
+        // caller having to mirror it elsewhere.
+        s.rotate_writers(writers(&[ALICE, CAROL])).unwrap();
+        assert_eq!(s.writers(), &writers(&[ALICE, CAROL]));
+        assert!(!s.is_frozen());
+    }
+
+    #[test]
+    #[serial]
+    fn is_frozen_accessor_reflects_construction_and_blocks_rotation() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+
+        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), true));
+
+        assert!(s.is_frozen());
+        assert_eq!(s.writers(), &writers(&[ALICE]));
+
+        // A frozen instance must reject rotation regardless of caller.
+        let err = s
+            .rotate_writers(writers(&[ALICE, BOB]))
+            .expect_err("rotation on frozen instance must fail");
+        assert!(
+            err.to_string().to_lowercase().contains("frozen"),
+            "error should mention frozen, got: {err}"
+        );
+
+        // The set is unchanged after the rejected rotation.
+        assert_eq!(s.writers(), &writers(&[ALICE]));
     }
 
     #[test]

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -385,6 +385,153 @@ pub fn reset_delta_context() {
     });
 }
 
+#[cfg(test)]
+mod borsh_roundtrip_tests {
+    //! `StorageDelta` has a custom `BorshDeserialize` impl that branches
+    //! on a leading u8 tag (0=Actions, 1=Comparisons, 2=CausalActions).
+    //! These tests guard the wire format: a regression here silently
+    //! corrupts every delta sent over the network.
+
+    use core::num::NonZeroU128;
+
+    use borsh::{from_slice, to_vec};
+
+    use super::*;
+    use crate::logical_clock::{Timestamp, ID, NTP64};
+
+    fn make_action(byte: u8) -> Action {
+        Action::Add {
+            id: Id::from([byte; 32]),
+            data: vec![byte; 4],
+            ancestors: vec![],
+            metadata: Metadata::new(100, 200),
+        }
+    }
+
+    fn make_hlc(time: u64) -> HybridTimestamp {
+        let ts = Timestamp::new(NTP64(time), ID::from(NonZeroU128::new(1).unwrap()));
+        HybridTimestamp::new(ts)
+    }
+
+    fn assert_actions_equal(a: &[Action], b: &[Action]) {
+        assert_eq!(a.len(), b.len(), "action count mismatch");
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert_eq!(x, y, "action mismatch");
+        }
+    }
+
+    #[test]
+    fn actions_variant_roundtrips() {
+        let original = StorageDelta::Actions(vec![make_action(1), make_action(2)]);
+        let bytes = to_vec(&original).unwrap();
+        // Tag 0 prefix preserved.
+        assert_eq!(bytes[0], 0);
+
+        let decoded: StorageDelta = from_slice(&bytes).unwrap();
+        match decoded {
+            StorageDelta::Actions(actions) => {
+                assert_actions_equal(&actions, &[make_action(1), make_action(2)]);
+            }
+            other => panic!("expected Actions, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn comparisons_variant_roundtrips_and_empty_input_falls_back() {
+        let original = StorageDelta::Comparisons(vec![]);
+        let bytes = to_vec(&original).unwrap();
+        assert_eq!(bytes[0], 1);
+
+        let decoded: StorageDelta = from_slice(&bytes).unwrap();
+        assert!(
+            matches!(&decoded, StorageDelta::Comparisons(v) if v.is_empty()),
+            "expected empty Comparisons, got {decoded:?}"
+        );
+
+        // The custom deserializer falls back to `Comparisons(vec![])` on
+        // empty input — exercised by legacy senders that send no artifact.
+        let empty: StorageDelta = from_slice(&[]).unwrap();
+        assert!(
+            matches!(&empty, StorageDelta::Comparisons(v) if v.is_empty()),
+            "expected fallback Comparisons(vec![]), got {empty:?}"
+        );
+    }
+
+    #[test]
+    fn causal_actions_variant_roundtrips() {
+        // The #2266 wire format: actions + delta_id + delta_hlc +
+        // BTreeMap<Id, BTreeSet<PublicKey>>.
+        let entity_a = Id::from([0xA1_u8; 32]);
+        let entity_b = Id::from([0xB2_u8; 32]);
+        let writer1 = PublicKey::from([0xAA_u8; 32]);
+        let writer2 = PublicKey::from([0xBB_u8; 32]);
+
+        let mut effective_writers = BTreeMap::new();
+        let _ = effective_writers.insert(entity_a, BTreeSet::from([writer1, writer2]));
+        let _ = effective_writers.insert(entity_b, BTreeSet::from([writer1]));
+
+        let original = StorageDelta::CausalActions {
+            actions: vec![make_action(0xFE)],
+            delta_id: [0xCD; 32],
+            delta_hlc: make_hlc(12_345),
+            effective_writers: effective_writers.clone(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        assert_eq!(bytes[0], 2, "CausalActions must use tag 2");
+
+        let decoded: StorageDelta = from_slice(&bytes).unwrap();
+        match decoded {
+            StorageDelta::CausalActions {
+                actions,
+                delta_id,
+                delta_hlc,
+                effective_writers: ew,
+            } => {
+                assert_actions_equal(&actions, &[make_action(0xFE)]);
+                assert_eq!(delta_id, [0xCD; 32]);
+                assert_eq!(delta_hlc, make_hlc(12_345));
+                assert_eq!(ew, effective_writers);
+            }
+            other => panic!("expected CausalActions, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn causal_actions_with_empty_effective_writers_roundtrips() {
+        // Non-Shared-only deltas resolve nothing; the map is empty.
+        // Receiver verifier sees None for every entity → v2 fallback.
+        let original = StorageDelta::CausalActions {
+            actions: vec![make_action(7)],
+            delta_id: [0; 32],
+            delta_hlc: make_hlc(0),
+            effective_writers: BTreeMap::new(),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: StorageDelta = from_slice(&bytes).unwrap();
+        assert!(
+            matches!(
+                &decoded,
+                StorageDelta::CausalActions { effective_writers, .. }
+                    if effective_writers.is_empty()
+            ),
+            "expected CausalActions with empty effective_writers, got {decoded:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_tag_errors() {
+        // Forward-compat guard: a tag the receiver doesn't know must
+        // surface as an error, not silent misinterpretation.
+        let bytes = vec![99_u8];
+        let result: Result<StorageDelta, _> = from_slice(&bytes);
+        assert!(
+            result.is_err(),
+            "expected error for unknown tag, got {result:?}"
+        );
+    }
+}
+
 // Helper function to hash Metadata storage type
 fn hash_metadata_storage_type_for_id(hasher: &mut Sha256, metadata: &Metadata) {
     match &metadata.storage_type {

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -4,15 +4,20 @@
 //! across nodes using a DAG (Directed Acyclic Graph) structure.
 
 use core::cell::RefCell;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::io;
 
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use calimero_primitives::identity::PublicKey;
+use sha2::{Digest, Sha256};
+
 use crate::action::Action;
+use crate::address::Id;
 use crate::entities::{Metadata, SignatureData, StorageType};
 use crate::env;
 use crate::integration::Comparison;
 use crate::logical_clock::HybridTimestamp;
-use borsh::{to_vec, BorshDeserialize, BorshSerialize};
-use sha2::{Digest, Sha256};
 
 /// A causal delta in the DAG representing a set of CRDT actions.
 ///
@@ -128,14 +133,47 @@ impl CausalDelta {
 
 /// Delta produced by storage operations for synchronization.
 ///
-/// Contains either a list of actions (operation-based CRDT) or comparisons
-/// (state-based CRDT for Merkle tree reconciliation).
+/// Three variants:
+/// - [`StorageDelta::Actions`] — local apply, snapshot leaf push,
+///   SDK→host commits. The verifier falls back to v2 stored-writers
+///   semantics for `Shared` actions in this variant.
+/// - [`StorageDelta::Comparisons`] — state-based Merkle tree sync.
+/// - [`StorageDelta::CausalActions`] — DAG-causal sync (#2266). The
+///   sync layer pre-resolves the writer set per Shared entity using
+///   the rotation log + DAG ancestry; the receiver's verifier
+///   validates Shared signatures against that pre-resolved set
+///   instead of stored writers.
 #[derive(Debug, BorshSerialize)]
 pub enum StorageDelta {
     /// A list of actions from direct operations.
     Actions(Vec<Action>),
     /// A list of comparisons for Merkle tree sync.
     Comparisons(Vec<Comparison>),
+    /// Actions delivered with DAG-causal context (#2266).
+    ///
+    /// `effective_writers` carries the pre-resolved writer set for
+    /// every `Shared` entity touched by `actions`, computed by the
+    /// sender's sync layer via
+    /// `rotation_log_reader::writers_at(rotation_log, delta.parents, happens_before)`.
+    /// Entries for non-Shared entities are omitted (the verifier
+    /// doesn't consult them).
+    CausalActions {
+        /// Actions to apply.
+        actions: Vec<Action>,
+        /// Hash of the originating `CausalDelta`. Used by the
+        /// rotation-log write hook to record the delta on detected
+        /// writer-set changes.
+        delta_id: [u8; 32],
+        /// Hybrid timestamp of the originating `CausalDelta`. Used by
+        /// the rotation-log write hook for sibling tiebreak (ADR 0001).
+        delta_hlc: HybridTimestamp,
+        /// Pre-resolved writer set per Shared entity touched by
+        /// `actions`. The receiver's verifier validates Shared
+        /// signatures against the entry for the action's entity id;
+        /// non-Shared entities (User / Frozen / Public) are absent
+        /// from the map.
+        effective_writers: BTreeMap<Id, BTreeSet<PublicKey>>,
+    },
 }
 
 impl BorshDeserialize for StorageDelta {
@@ -147,6 +185,12 @@ impl BorshDeserialize for StorageDelta {
         match tag {
             0 => Ok(StorageDelta::Actions(Vec::deserialize_reader(reader)?)),
             1 => Ok(StorageDelta::Comparisons(Vec::deserialize_reader(reader)?)),
+            2 => Ok(StorageDelta::CausalActions {
+                actions: Vec::deserialize_reader(reader)?,
+                delta_id: <[u8; 32]>::deserialize_reader(reader)?,
+                delta_hlc: HybridTimestamp::deserialize_reader(reader)?,
+                effective_writers: BTreeMap::deserialize_reader(reader)?,
+            }),
             _ => Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid tag")),
         }
     }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -38,9 +38,10 @@ mod tests;
 
 use core::fmt::Debug;
 use core::marker::PhantomData;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use borsh::{from_slice, to_vec};
+use calimero_primitives::identity::PublicKey;
 use indexmap::IndexMap;
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
@@ -62,47 +63,32 @@ pub type MainInterface = Interface<MainStorage>;
 /// Apply-time context passed to [`Interface::apply_action`].
 ///
 /// Centralizes apply-time metadata so the call signature doesn't accumulate
-/// positional parameters. P1 of #2233 introduced the struct with
-/// `causal_parents`; **P3** extends it with `delta_id`, `delta_hlc`, and
-/// `happens_before` so the rotation-log write hook can capture entries and
-/// the verifier can resolve `writers_at(causal_point)` per ADR 0001.
-///
-/// Construct explicitly at every call site — no `Default` on purpose so a
-/// future new field is a compile error everywhere, not a silent semantic
-/// change. For paths that genuinely have no causal context (snapshot leaf
-/// push, local apply, tests, P1-era code), construct as:
-///
-/// ```ignore
-/// ApplyContext {
-///     causal_parents: &[],
-///     delta_id: None,
-///     delta_hlc: None,
-///     happens_before: None,
-/// }
-/// ```
-///
-/// Sync paths with a `CausalDelta` in scope should populate the matching
-/// fields. Wiring the WASM ABI to thread `CausalDelta.{id,hlc,parents}` and
-/// a DAG-ancestry closure through `__calimero_sync_next` to here is a
-/// separate follow-up — see the `// P3 of #2233:` markers at production
-/// call sites.
+/// positional parameters. Per #2266 (DAG-causal Shared verifier), the node
+/// sync layer pre-resolves the writer set for a delta via
+/// `rotation_log_reader::writers_at(parents, happens_before)` and passes
+/// it here as `effective_writers`; storage no longer needs DAG ancestry
+/// knowledge. The closure-typed `happens_before` and `causal_parents`
+/// fields the P1/P3 design carried have been removed.
 ///
 /// # Field semantics
 ///
-/// All new fields are `Option`. Convention:
-/// - `None` → "this caller doesn't have it"; the verifier and write hook
-///   degrade gracefully (skip writes, fall back to v2 stored writers).
-/// - `Some(_)` → "this caller has it"; verifier MUST consult the new
-///   path, write hook MAY append a rotation entry.
-///
-/// `happens_before` is a closure rather than a precomputed set because the
-/// DAG is owned by the node sync layer; storage shouldn't need to pull it
-/// in. Caller closes over its DAG view and passes the predicate.
-#[derive(Clone, Copy)]
-pub struct ApplyContext<'a> {
-    /// Hashes of the parent deltas in the DAG. Empty when no causal context
-    /// is available.
-    pub causal_parents: &'a [[u8; 32]],
+/// - `effective_writers: Some(set)` → caller pre-resolved the
+///   ADR-0001-compliant writer set as of the delta's causal point.
+///   The Shared verifier MUST validate against this set.
+/// - `effective_writers: None` → caller has no DAG context (snapshot
+///   leaf push, local apply, tests). The verifier falls back to the
+///   entity's currently-stored `metadata.storage_type.writers` (v2
+///   semantics, preserved for these known-safe paths).
+/// - `delta_id` / `delta_hlc` carry the originating `CausalDelta`'s
+///   identity. Both populated together: the rotation-log write hook
+///   appends an entry only when both are `Some`.
+#[derive(Clone, Debug)]
+pub struct ApplyContext {
+    /// Pre-resolved authoritative writer set for `Shared` actions. When
+    /// `Some`, the verifier validates the signature against this set and
+    /// skips the v2 stored-writers fallback. Resolved by the node sync
+    /// layer per #2266.
+    pub effective_writers: Option<BTreeSet<PublicKey>>,
 
     /// Hash of the `CausalDelta` containing the action being applied. Used
     /// by the rotation-log write hook to record the originating delta on
@@ -113,25 +99,20 @@ pub struct ApplyContext<'a> {
     /// rotation-log write hook (sibling tiebreak per ADR 0001). `None` for
     /// callers without a `CausalDelta` in scope.
     pub delta_hlc: Option<crate::logical_clock::HybridTimestamp>,
-
-    /// DAG-ancestry predicate: `happens_before(a, b)` returns `true` iff
-    /// delta `a` is in the transitive ancestry of delta `b`. Provided by
-    /// the caller (typically the node sync layer with DAG access). `None`
-    /// when no DAG is available — the verifier then falls back to
-    /// [`rotation_log::latest_writers`](crate::rotation_log::latest_writers).
-    pub happens_before: Option<&'a dyn Fn(&[u8; 32], &[u8; 32]) -> bool>,
 }
 
-impl core::fmt::Debug for ApplyContext<'_> {
-    // Manual impl: `&dyn Fn` doesn't implement Debug. Print the rest and
-    // mark `happens_before` by presence only.
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ApplyContext")
-            .field("causal_parents", &self.causal_parents)
-            .field("delta_id", &self.delta_id)
-            .field("delta_hlc", &self.delta_hlc)
-            .field("happens_before", &self.happens_before.map(|_| "<closure>"))
-            .finish()
+impl ApplyContext {
+    /// Construct an empty context (no DAG-causal resolution available).
+    /// Used by snapshot-leaf push, local apply, and tests that don't
+    /// exercise the verifier swap. Verifier behavior is identical to v2
+    /// (validate against stored writers).
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            effective_writers: None,
+            delta_id: None,
+            delta_hlc: None,
+        }
     }
 }
 
@@ -231,21 +212,21 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Handles Add/Update/Delete actions, creating missing ancestors if needed.
     /// Generates Compare action for hash verification after applying changes.
     ///
-    /// `ctx` carries DAG-causal apply-time context (parents of the delta
-    /// this action belongs to, plus the delta's id/HLC and a DAG-ancestry
-    /// closure). For `Shared`-storage actions, **P3** of #2233 swaps the
-    /// signature verifier from "stored writers" to
-    /// `writers_at(id, ctx.causal_parents)` per ADR 0001, and appends a
-    /// [`RotationLogEntry`](crate::rotation_log::RotationLogEntry) on
-    /// detected rotations. Both behaviors degrade gracefully when ctx
-    /// fields are `None` / empty (callers without DAG context behave
-    /// identically to v2).
+    /// `ctx` carries apply-time metadata. For `Shared`-storage actions
+    /// (#2266), if `ctx.effective_writers` is `Some`, the signature is
+    /// validated against that pre-resolved set (the node sync layer
+    /// resolves it via `writers_at(delta.parents)` per ADR 0001). When
+    /// `None`, the verifier falls back to the entity's currently-stored
+    /// writer set (v2 semantics). On a successful apply that changes the
+    /// writer set, the rotation-log write hook appends a
+    /// [`RotationLogEntry`](crate::rotation_log::RotationLogEntry) when
+    /// `ctx.delta_id`/`delta_hlc` are populated.
     ///
     /// # Errors
     /// - `DeserializationError` if action data is invalid
     /// - `ActionNotAllowed` if Compare action is passed directly
     ///
-    pub fn apply_action(action: Action, ctx: ApplyContext<'_>) -> Result<(), StorageError> {
+    pub fn apply_action(action: Action, ctx: &ApplyContext) -> Result<(), StorageError> {
         // Verify that the action timestamp is not too far in the future
         // to prevent LWW Time Drift attacks.
         verify_action_timestamp(&action)?;
@@ -352,64 +333,22 @@ impl<S: StorageAdaptor> Interface<S> {
                             _ => None,
                         };
 
-                        // P3 of #2233: resolve the *effective* writer set the
-                        // signature must verify against.
+                        // #2266: the node sync layer pre-resolves the
+                        // ADR-0001-compliant writer set via
+                        // writers_at(delta.parents) and passes it as
+                        // effective_writers. Storage no longer carries
+                        // DAG-ancestry knowledge.
                         //
-                        // ADR 0001 says the verifier consults `writers_at(causal
-                        // parents)` — the writer set as of the apply context's
-                        // causal point — instead of the currently-stored writers.
-                        // That's the partition-correctness fix.
-                        //
-                        // Graceful degradation: when ctx lacks the DAG-ancestry
-                        // closure or the rotation log has nothing reachable,
-                        // fall through to the v2 stored set. Callers without
-                        // DAG context (snapshot leaf push, local apply, P1-era
-                        // code) continue to behave exactly as v2.
-                        let dag_causal_writers = if let Some(hb) = ctx.happens_before {
-                            crate::rotation_log::writers_at::<S, _>(*id, ctx.causal_parents, hb)?
-                        } else {
-                            None
+                        // When effective_writers is None (snapshot leaf
+                        // push, local apply), fall back to the entity's
+                        // currently-stored writers, then to the action's
+                        // claim for bootstrap. These paths are
+                        // already-verified state from a peer, so
+                        // stored-writers semantics are safe for them.
+                        let authoritative_writers = match ctx.effective_writers.as_ref() {
+                            Some(effective) => effective.clone(),
+                            None => stored_writers.clone().unwrap_or_else(|| writers.clone()),
                         };
-
-                        let authoritative_writers =
-                            match (dag_causal_writers.as_ref(), stored_writers.as_ref()) {
-                                (Some(causal), Some(stored)) => {
-                                    // Both paths returned a set. Telemetry hook for
-                                    // rollout: warn on divergence so it's visible in
-                                    // production logs before we commit to dropping
-                                    // the v2 nonce check (epic exit criterion).
-                                    if causal != stored {
-                                        warn!(
-                                            target: "storage::p3_verifier",
-                                            %id,
-                                            stored_count = stored.len(),
-                                            causal_count = causal.len(),
-                                            "P3 verifier divergence: DAG-causal writer set \
-                                             differs from stored. Using DAG-causal per #2233."
-                                        );
-                                    }
-                                    causal.clone()
-                                }
-                                (Some(causal), None) => causal.clone(),
-                                // No DAG-causal answer → v2 fallback to stored, then
-                                // to the action's claim for bootstrap (preserves the
-                                // pre-P3 behavior exactly).
-                                //
-                                // Caveat: `stored` here is `metadata.storage_type.writers`
-                                // from the entity index, which `Index::update_hash_for`
-                                // never updates after a rotation (it only refreshes
-                                // own_hash/full_hash/updated_at). So this fallback
-                                // always returns the *bootstrap* writer set, regardless
-                                // of how many rotations have applied. Production WASM
-                                // paths land here today (until the ABI threads
-                                // CausalDelta.{id,hlc,parents} through), which means
-                                // post-rotation writers cannot bootstrap a signature
-                                // and pre-rotation writers can still sign forever.
-                                // Same root cause as the rotation-log write hook's
-                                // stale-stored-writers fragility (#2233 P3 follow-up).
-                                (None, Some(stored)) => stored.clone(),
-                                (None, None) => writers.clone(),
-                            };
 
                         // Replay protection (per-entity monotonic nonce). Done BEFORE
                         // signature verification so replays are O(1)-rejected without
@@ -486,7 +425,7 @@ impl<S: StorageAdaptor> Interface<S> {
                         Self::maybe_append_rotation_log(
                             *id,
                             metadata,
-                            &ctx,
+                            ctx,
                             stored_writers.clone(),
                         )?;
                     }
@@ -821,10 +760,8 @@ impl<S: StorageAdaptor> Interface<S> {
     fn maybe_append_rotation_log(
         id: Id,
         metadata: &Metadata,
-        ctx: &ApplyContext<'_>,
-        pre_apply_writers: Option<
-            std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
-        >,
+        ctx: &ApplyContext,
+        pre_apply_writers: Option<BTreeSet<PublicKey>>,
     ) -> Result<(), StorageError> {
         // Only Shared entities have a rotation log.
         let StorageType::Shared {
@@ -1116,7 +1053,7 @@ impl<S: StorageAdaptor> Interface<S> {
     pub fn compare_affective(
         data: Option<Vec<u8>>,
         comparison_data: ComparisonData,
-        ctx: ApplyContext<'_>,
+        ctx: &ApplyContext,
     ) -> Result<(), StorageError> {
         let (local, remote) = <Interface<S>>::compare_trees(data, comparison_data)?;
 

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -130,6 +130,27 @@ impl ApplyContext {
 // storage dev-dependency. Production builds (no `testing` feature, no
 // `cfg(test)`) compile out the toggle entirely so the nonce check stays
 // live — `nonce_check_disabled_for_testing` reduces to `const false`.
+//
+// SECURITY: the `testing` feature disables replay protection for Shared
+// storage actions. The compile-error below blocks any release build that
+// accidentally activates it — the typical path is a downstream crate
+// declaring `calimero-storage = { ..., features = ["testing"] }` as a
+// regular dependency rather than `[dev-dependencies]`. Cargo's feature
+// unification would then propagate it into the production binary. The
+// guard fires only in release-without-test, so dev builds and `cargo test`
+// (with or without `--release` on test profile) keep working. Per #2272
+// review.
+
+#[cfg(all(feature = "testing", not(test), not(debug_assertions)))]
+compile_error!(
+    "calimero-storage `testing` feature enables `disable_nonce_check_for_testing`, \
+     which turns off replay protection for Shared storage actions. \
+     This must NEVER be enabled in a release build. \
+     If you see this error: a dependency declared `features = [\"testing\"]` \
+     outside `[dev-dependencies]` and Cargo's feature unification leaked \
+     it into the release graph. Move it into `[dev-dependencies]` or drop \
+     the feature."
+);
 
 #[cfg(any(test, feature = "testing"))]
 thread_local! {
@@ -140,11 +161,17 @@ thread_local! {
 /// that re-enables on drop, so a single test can scope the bypass without
 /// leaking it to the next test on the same thread.
 ///
-/// Tests should use this only when validating the **v3 target behavior**
-/// — i.e., the cross-node convergence properties that DAG-causal
-/// verification provides once the nonce check is retired. Tests of the
-/// nonce check itself (or of behavior expected to hold under the v2
-/// regime) should NOT bypass.
+/// # Security
+///
+/// **This disables replay protection for Shared storage actions.** Use
+/// it **only** when validating the v3 target behavior (post-#2266
+/// telemetry-soak nonce-check removal). Never call this from production
+/// code paths — the `testing` feature it depends on is rejected at
+/// compile time in release builds, but a stray call from a non-test code
+/// path inside a debug build would still create a window.
+///
+/// Tests of the nonce check itself (or of behavior expected to hold
+/// under the v2 regime) should NOT bypass.
 #[cfg(any(test, feature = "testing"))]
 #[must_use]
 pub fn disable_nonce_check_for_testing() -> NonceCheckGuard {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -124,10 +124,14 @@ impl ApplyContext {
 // production telemetry confirming DAG-causal subsumes it. Tests that need
 // to exercise the v3 target behavior (post-removal) can opt out here.
 //
-// Production code uses `cfg(not(test))` and always returns `false` so the
-// nonce check stays live. Test code uses the thread-local toggle.
+// Gated on `cfg(any(test, feature = "testing"))` so dependent crates' tests
+// (notably `calimero-node`'s migrated P3/P5 partition scenarios — see
+// #2266 step 5) can opt into the bypass via the `testing` feature on the
+// storage dev-dependency. Production builds (no `testing` feature, no
+// `cfg(test)`) compile out the toggle entirely so the nonce check stays
+// live — `nonce_check_disabled_for_testing` reduces to `const false`.
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 thread_local! {
     static SKIP_NONCE_CHECK: core::cell::Cell<bool> = const { core::cell::Cell::new(false) };
 }
@@ -141,7 +145,7 @@ thread_local! {
 /// verification provides once the nonce check is retired. Tests of the
 /// nonce check itself (or of behavior expected to hold under the v2
 /// regime) should NOT bypass.
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 #[must_use]
 pub fn disable_nonce_check_for_testing() -> NonceCheckGuard {
     SKIP_NONCE_CHECK.with(|c| c.set(true));
@@ -149,22 +153,22 @@ pub fn disable_nonce_check_for_testing() -> NonceCheckGuard {
 }
 
 /// RAII guard returned by [`disable_nonce_check_for_testing`].
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub struct NonceCheckGuard;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 impl Drop for NonceCheckGuard {
     fn drop(&mut self) {
         SKIP_NONCE_CHECK.with(|c| c.set(false));
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 fn nonce_check_disabled_for_testing() -> bool {
     SKIP_NONCE_CHECK.with(core::cell::Cell::get)
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "testing")))]
 const fn nonce_check_disabled_for_testing() -> bool {
     false
 }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -720,20 +720,24 @@ impl<S: StorageAdaptor> Interface<S> {
     /// 1. Already deleted - update tombstone if newer
     /// Append to the rotation log when applying a Shared rotation.
     ///
-    /// P3 of #2233 write hook. Called from [`apply_action`] after
-    /// `save_internal` succeeds. No-op for non-Shared actions, for
-    /// value-writes (writers unchanged), or when ctx lacks the delta
-    /// id/hlc the entry needs.
+    /// Rotation-log write hook (#2233 phase 3). Called from
+    /// [`apply_action`] after `save_internal` succeeds. No-op for
+    /// non-Shared actions, for value-writes (writers unchanged), or
+    /// when ctx lacks the delta id/hlc the entry needs.
     ///
     /// `pre_apply_writers` is the writer set in the index *before* this
     /// action mutated it — `Some` for an existing Shared entity, `None`
     /// for bootstrap (first time we see this entity). Bootstrap counts as
     /// the first rotation.
     ///
-    /// Skips silently rather than erroring on missing context: P3-era
-    /// production paths don't yet thread `CausalDelta.{id,hlc}` through
-    /// the WASM ABI, so the hook is dormant in production until that
-    /// follow-up lands. Tests construct full ctx explicitly.
+    /// Skips silently rather than erroring on missing context.
+    /// Empty-ctx callers (snapshot leaf push, local apply, the
+    /// `StorageDelta::Actions` artifact path) are not network-received
+    /// causal deltas and don't have an originating `CausalDelta` to
+    /// record. Network-sync deltas arrive via
+    /// [`StorageDelta::CausalActions`](crate::delta::StorageDelta::CausalActions)
+    /// (per #2266) which populates `delta_id`/`delta_hlc`, lighting up
+    /// the hook in production.
     ///
     /// # Caller invariant
     ///
@@ -783,9 +787,10 @@ impl<S: StorageAdaptor> Interface<S> {
         }
 
         // Need the originating delta's identity to record an entry the
-        // verifier can later look up. P3-era callers without WASM ABI
-        // extensions pass None here; the hook then silently no-ops so the
-        // log stays empty and writers_at falls back to v2 stored writers.
+        // node-side reader can later look up. Empty-ctx callers (snapshot
+        // leaf push, local apply, `StorageDelta::Actions`) pass None here
+        // and the hook silently no-ops; only `StorageDelta::CausalActions`
+        // (#2266) populates these and lights up the hook.
         let (Some(delta_id), Some(delta_hlc)) = (ctx.delta_id, ctx.delta_hlc) else {
             return Ok(());
         };

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -111,10 +111,13 @@ pub mod tests {
     pub mod merge_integration;
     /// Merkle hash propagation tests.
     pub mod merkle;
-    /// P3 (DAG-causal) verifier swap + rotation-log write hook tests.
-    pub mod p3_dag_causal;
-    /// P5 (DAG-causal) cross-node partition scenario tests.
-    pub mod p5_partition_scenarios;
+    // P3/P5 DAG-causal tests temporarily disabled while #2266 (WASM ABI
+    // wiring) lands. The closure-typed `happens_before` they exercise no
+    // longer exists on `ApplyContext` after the Step 1 shrink; the tests
+    // are migrated to the node crate (where the DAG lives) and re-enabled
+    // in Step 5 of #2266 via the sync-layer entry point.
+    // pub mod p3_dag_causal;
+    // pub mod p5_partition_scenarios;
     /// RGA (Replicated Growable Array) CRDT tests.
     pub mod rga;
     // TODO: Re-enable once Clone is implemented for collections

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -111,15 +111,11 @@ pub mod tests {
     pub mod merge_integration;
     /// Merkle hash propagation tests.
     pub mod merkle;
-    // P3/P5 DAG-causal tests temporarily disabled while #2266 (WASM ABI
-    // wiring) lands. The closure-typed `happens_before` they exercise no
-    // longer exists on `ApplyContext` after the Step 1 shrink; the tests
-    // are migrated to the node crate (where the DAG lives) and re-enabled
-    // in Step 5 of #2266 via the sync-layer entry point.
-    // pub mod p3_dag_causal;
-    // pub mod p5_partition_scenarios;
     /// RGA (Replicated Growable Array) CRDT tests.
     pub mod rga;
+    /// Storage-internal regression: the rotation-write hook depends on the
+    /// stored-writers field staying frozen at bootstrap (see #2266 step 5).
+    pub mod write_hook_stale_writers;
     // TODO: Re-enable once Clone is implemented for collections
     // /// Nested CRDT merge behavior tests.
     // pub mod nested_crdt_merge;

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -66,10 +66,11 @@ pub struct RotationLogEntry {
 
     /// Public key that signed the rotation action.
     ///
-    /// `None` only for legacy / unsigned-bootstrap entries — see
-    /// [`writers_at`] for how those participate in ordering (they sort
-    /// after any `Some(...)` entry at equal HLC, mirroring the
-    /// "smaller bytes win" rule with `None` treated as "larger than any").
+    /// `None` only for legacy / unsigned-bootstrap entries — see the
+    /// node-side `rotation_log_reader::writers_at` for how those
+    /// participate in ordering (they sort after any `Some(...)` entry
+    /// at equal HLC, mirroring the "smaller bytes win" rule with `None`
+    /// treated as "larger than any").
     pub signer: Option<PublicKey>,
 
     /// Resolved writer set after this rotation. `BTreeSet` so the on-wire

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -1,30 +1,22 @@
 //! Per-entity writer-set rotation log for `SharedStorage<T>`.
 //!
-//! Phase **P2** of [#2233](https://github.com/calimero-network/core/issues/2233)
-//! (DAG-causal Shared verification). Provides the storage shape and read API
-//! that P3's verifier uses to resolve "what was the writer set as of this
-//! causal point in the DAG?" — answering the partition-race scenarios called
-//! out in #2197.
+//! Storage owns the log's on-disk shape and the persistence primitives
+//! ([`load`], [`save`], [`append`]). DAG-causal *resolution* — "given a
+//! delta's parents and a happens-before predicate, what was the writer
+//! set as of that causal point?" — lives in the node sync layer
+//! (`calimero_node::sync::rotation_log_reader`), where the DAG itself
+//! does. This split was made in #2266 (per #2267 Option B) so storage no
+//! longer carries DAG-ancestry knowledge.
 //!
 //! # Design
 //!
 //! Per [ADR 0001](../../../docs/adr/0001-shared-storage-concurrent-rotation.md):
-//! every accepted rotation appends an entry; reads compare entries by
-//! **causal-first → HLC → signer-pubkey** ordering.
+//! every accepted rotation appends an entry; the node-side reader compares
+//! entries by **causal-first → HLC → signer-pubkey** ordering.
 //!
 //! The log is stored separately from `EntityIndex` under a dedicated
 //! [`Key::RotationLog`] so reading the index doesn't pull in the full
 //! rotation history.
-//!
-//! # P2 scope (this module)
-//!
-//! - Schema: [`RotationLogEntry`], [`RotationSnapshot`], [`RotationLog`]
-//! - Persistence: [`load`], [`save`], [`append`]
-//! - Read APIs: [`latest_writers`], [`writers_at`]
-//!
-//! Wiring into [`Interface::apply_action`](crate::interface::Interface::apply_action)
-//! and the verifier is **P3**. In P2 the module is callable but not yet invoked
-//! by the apply pipeline; standalone unit tests cover the schema and ordering.
 //!
 //! # Compaction (shape locked in, not implemented)
 //!
@@ -55,8 +47,8 @@ use crate::store::{Key, StorageAdaptor};
 ///
 /// Fields chosen to be sufficient for the ADR ordering rule without needing
 /// to consult any other state:
-/// - `delta_id` identifies the `CausalDelta` so the caller's DAG-ancestry
-///   predicate can locate it.
+/// - `delta_id` identifies the `CausalDelta` so the node-side reader's
+///   DAG-ancestry predicate can locate it.
 /// - `delta_hlc` is the sibling tiebreak when two rotations are concurrent.
 /// - `signer` is the final tiebreak for HLC ties (vanishingly rare but
 ///   pinned for spec completeness).
@@ -112,9 +104,9 @@ pub struct RotationSnapshot {
 ///
 /// `entries` is append-only; new rotations push to the end. Order in the
 /// vector is **insertion order** (which is the order the receiver applied
-/// them), not causal order — `writers_at` is responsible for resolving
-/// causal precedence at read time, since insertion order differs across
-/// nodes when sync delivers concurrent rotations in different orders.
+/// them), not causal order — the node-side reader resolves causal
+/// precedence at read time, since insertion order differs across nodes
+/// when sync delivers concurrent rotations in different orders.
 #[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct RotationLog {
     /// Compacted prefix; `None` until P6 compaction runs.
@@ -213,150 +205,6 @@ pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), 
     save::<S>(id, &log)
 }
 
-/// Returns the writer set from the most recently *appended* entry.
-///
-/// "Most recently appended" is **insertion order on this node**, not causal
-/// order — concurrent rotations applied in different orders across nodes
-/// can produce different answers from this function. Use it only when no
-/// causal context is available:
-/// - snapshot leaf push (no `CausalDelta` in scope)
-/// - local apply paths
-/// - P1-era code that hasn't been wired through P3 yet
-///
-/// Matches v2's LWW-by-`writers_nonce` behavior in practice (the latest
-/// inserted entry tends to also be the highest nonce on the local node),
-/// preserving backward compatibility.
-///
-/// Returns `Ok(None)` if the log is empty or absent.
-///
-/// # Errors
-///
-/// Propagates [`load`] errors (deserialization on read).
-pub fn latest_writers<S: StorageAdaptor>(
-    id: Id,
-) -> Result<Option<BTreeSet<PublicKey>>, StorageError> {
-    let Some(log) = load::<S>(id)? else {
-        return Ok(None);
-    };
-    if let Some(entry) = log.entries.last() {
-        return Ok(Some(entry.new_writers.clone()));
-    }
-    if let Some(snap) = log.snapshot {
-        return Ok(Some(snap.writers));
-    }
-    Ok(None)
-}
-
-/// Returns the writer set as-of a causal point in the DAG.
-///
-/// Implements ADR 0001's merge rule end-to-end:
-/// 1. Filter entries to those reachable from `causal_parents`.
-/// 2. Among reachable entries, pick the causally latest.
-/// 3. Truly-concurrent tie → larger `delta_hlc` wins.
-/// 4. HLC tie → smaller `signer` pubkey bytes win (`None` treated as larger).
-///
-/// **P4-impl** of #2233 is a no-op for the chosen rule — there's no
-/// intermediate state to materialise, no convergence reduction step.
-/// The whole rule lives here, with the per-entity write hook in
-/// [`Interface::apply_action`](crate::interface::Interface::apply_action)
-/// (P3) keeping the log fed.
-///
-/// `happens_before(a, b)` is the caller-provided DAG-ancestry predicate:
-/// returns true iff delta `a` is in the transitive ancestry of delta `b`
-/// (i.e., `a` happens-before `b` in the DAG-causal sense). Storage cannot
-/// answer this on its own — it doesn't have the DAG — so the node sync
-/// layer (which does) provides the closure at the call site.
-///
-/// `causal_parents` is the parent set of the apply context's delta (i.e.,
-/// `CausalDelta.parents` of the delta whose action is being applied).
-///
-/// # Reachability
-///
-/// An entry `e` is reachable iff
-/// `causal_parents.iter().any(|p| e.delta_id == *p || happens_before(&e.delta_id, p))`.
-/// In words: the rotation's delta is one of the apply-context's parents, or
-/// is in the transitive ancestry of one of them.
-///
-/// # When `causal_parents` is empty
-///
-/// Returns the same answer as [`latest_writers`] — the v2-compatible
-/// fallback for paths without DAG context.
-///
-/// Returns `Ok(None)` if no log entry is reachable (or the log is absent).
-///
-/// # Errors
-///
-/// Propagates [`load`] errors (deserialization on read).
-pub fn writers_at<S: StorageAdaptor, F>(
-    id: Id,
-    causal_parents: &[[u8; 32]],
-    happens_before: F,
-) -> Result<Option<BTreeSet<PublicKey>>, StorageError>
-where
-    F: Fn(&[u8; 32], &[u8; 32]) -> bool,
-{
-    if causal_parents.is_empty() {
-        return latest_writers::<S>(id);
-    }
-
-    let Some(log) = load::<S>(id)? else {
-        return Ok(None);
-    };
-
-    // Filter to entries reachable from any of the apply context's parents.
-    let reachable: Vec<&RotationLogEntry> = log
-        .entries
-        .iter()
-        .filter(|e| {
-            causal_parents
-                .iter()
-                .any(|p| e.delta_id == *p || happens_before(&e.delta_id, p))
-        })
-        .collect();
-
-    // ADR 0001 ordering. We want the *latest* entry, so define cmp such that
-    // "later" is `Greater`, then take the max.
-    let latest = reachable.into_iter().max_by(|a, b| {
-        // 1. Causal precedence wins: if a happens-before b, b is later.
-        if happens_before(&a.delta_id, &b.delta_id) {
-            return std::cmp::Ordering::Less;
-        }
-        if happens_before(&b.delta_id, &a.delta_id) {
-            return std::cmp::Ordering::Greater;
-        }
-        // 2. Truly concurrent → larger HLC wins.
-        match a.delta_hlc.cmp(&b.delta_hlc) {
-            std::cmp::Ordering::Equal => {}
-            non_eq => return non_eq,
-        }
-        // 3. HLC tie → entry with the smaller signer bytes is the WINNER
-        //    (per ADR 0001). We're computing `max_by`, so the comparator
-        //    must return `Greater` for the entry whose signer is smaller —
-        //    that makes `max_by` pick it. `None` signers compare as
-        //    `Greater` than any `Some(_)`, so unsigned legacy entries lose
-        //    HLC ties to signed ones.
-        match (&a.signer, &b.signer) {
-            (Some(sa), Some(sb)) => sb.digest().cmp(sa.digest()),
-            (Some(_), None) => std::cmp::Ordering::Greater,
-            (None, Some(_)) => std::cmp::Ordering::Less,
-            (None, None) => std::cmp::Ordering::Equal,
-        }
-    });
-
-    if let Some(entry) = latest {
-        return Ok(Some(entry.new_writers.clone()));
-    }
-
-    // Nothing in `entries` was reachable. If the log has been compacted
-    // (P6), the snapshot's writer set is the answer for any apply context
-    // whose history pre-dates the cutoff. For now `snapshot` is always
-    // `None`, so this falls through to `Ok(None)`.
-    if let Some(snap) = log.snapshot {
-        return Ok(Some(snap.writers));
-    }
-    Ok(None)
-}
-
 // =============================================================================
 // Tests
 // =============================================================================
@@ -406,11 +254,6 @@ mod tests {
     fn empty_when_no_log_written() {
         let id = id(1);
         assert_eq!(load::<Store>(id).unwrap(), None);
-        assert_eq!(latest_writers::<Store>(id).unwrap(), None);
-        assert_eq!(
-            writers_at::<Store, _>(id, &[[0; 32]], |_, _| false).unwrap(),
-            None
-        );
     }
 
     #[test]
@@ -421,130 +264,6 @@ mod tests {
         let loaded = load::<Store>(id).unwrap().unwrap();
         assert_eq!(loaded.entries, vec![e]);
         assert_eq!(loaded.snapshot, None);
-    }
-
-    #[test]
-    fn latest_writers_returns_last_appended() {
-        let id = id(3);
-        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA], 1)).unwrap();
-        append::<Store>(id, entry(2, 200, 0xBB, &[0xBB], 2)).unwrap();
-        assert_eq!(
-            latest_writers::<Store>(id).unwrap(),
-            Some([0xBB].into_iter().map(pk).collect())
-        );
-    }
-
-    #[test]
-    fn writers_at_with_empty_parents_falls_back_to_latest() {
-        // ADR: empty causal_parents → match latest_writers (v2 LWW compat).
-        let id = id(4);
-        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA], 1)).unwrap();
-        append::<Store>(id, entry(2, 200, 0xBB, &[0xBB], 2)).unwrap();
-        assert_eq!(
-            writers_at::<Store, _>(id, &[], |_, _| false).unwrap(),
-            Some([0xBB].into_iter().map(pk).collect())
-        );
-    }
-
-    #[test]
-    fn writers_at_returns_only_reachable_entries() {
-        // ADR Example A: sequential rotations. R1 is the parent, R2 builds on it.
-        // Querying with causal_parents = [R1.delta_id] should pick R1, NOT R2,
-        // because R2 hasn't happened yet from the perspective of someone
-        // looking at R1's frontier.
-        let id = id(5);
-        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA, 0xBB], 1)).unwrap();
-        append::<Store>(id, entry(2, 200, 0xBB, &[0xBB, 0xCC], 2)).unwrap();
-
-        // happens_before(a, b): R1 (id=[1;32]) happens-before R2 (id=[2;32]).
-        let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
-
-        // Query as-of R1: only R1 is reachable.
-        let writers = writers_at::<Store, _>(id, &[[1; 32]], happens_before).unwrap();
-        assert_eq!(writers, Some([0xAA, 0xBB].into_iter().map(pk).collect()));
-
-        // Query as-of R2: both reachable, R2 is causally later → R2 wins.
-        let writers = writers_at::<Store, _>(id, &[[2; 32]], happens_before).unwrap();
-        assert_eq!(writers, Some([0xBB, 0xCC].into_iter().map(pk).collect()));
-    }
-
-    #[test]
-    fn writers_at_concurrent_siblings_resolved_by_hlc() {
-        // ADR Example B: two concurrent siblings with different HLCs.
-        // Larger HLC wins.
-        let id = id(6);
-        // R1 by Alice at HLC=20, removes Bob.
-        append::<Store>(id, entry(1, 20, 0xAA, &[0xAA], 10)).unwrap();
-        // R2 by Bob at HLC=21, removes Alice. Concurrent with R1.
-        append::<Store>(id, entry(2, 21, 0xBB, &[0xBB], 10)).unwrap();
-
-        // Apply context's parents reference both rotations as siblings of D_root.
-        // Our happens_before says neither precedes the other.
-        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
-
-        // Query reaching both: HLC=21 > HLC=20 → R2 (writers={Bob}) wins.
-        let writers = writers_at::<Store, _>(id, &[[1; 32], [2; 32]], none_precede).unwrap();
-        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
-    }
-
-    #[test]
-    fn writers_at_hlc_tie_resolved_by_signer_bytes() {
-        // ADR Example C: HLC tie (same time AND same node ID, which is
-        // vanishingly rare in production but pinned in the spec).
-        // Smaller signer pubkey bytes win.
-        use core::num::NonZeroU128;
-
-        use crate::logical_clock::{Timestamp, ID, NTP64};
-
-        let id = id(7);
-        // Build two entries with IDENTICAL HLCs (same time, same node ID).
-        let identical_ts = HybridTimestamp::new(Timestamp::new(
-            NTP64(50),
-            ID::from(NonZeroU128::new(1).unwrap()),
-        ));
-        let mk = |delta_id: u8, signer: u8, writers: &[u8]| RotationLogEntry {
-            delta_id: [delta_id; 32],
-            delta_hlc: identical_ts,
-            signer: Some(pk(signer)),
-            new_writers: writers.iter().copied().map(pk).collect(),
-            writers_nonce: 10,
-        };
-        // signer 0xAA < signer 0xBB byte-wise.
-        append::<Store>(id, mk(1, 0xAA, &[0xAA, 0xCC])).unwrap();
-        append::<Store>(id, mk(2, 0xBB, &[0xBB, 0xDD])).unwrap();
-
-        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
-        let writers = writers_at::<Store, _>(id, &[[1; 32], [2; 32]], none_precede).unwrap();
-        // 0xAA is smaller → wins.
-        assert_eq!(writers, Some([0xAA, 0xCC].into_iter().map(pk).collect()));
-    }
-
-    #[test]
-    fn writers_at_causal_precedence_overrides_hlc() {
-        // R1 happens-before R2, but R1.hlc > R2.hlc (clock skew). Causal
-        // wins: R2's author saw R1's reality and chose to rotate from there.
-        let id = id(8);
-        append::<Store>(id, entry(1, 999, 0xAA, &[0xAA], 1)).unwrap(); // huge HLC
-        append::<Store>(id, entry(2, 100, 0xBB, &[0xBB], 2)).unwrap(); // smaller HLC
-
-        // R1 happens-before R2 in the DAG.
-        let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
-
-        let writers = writers_at::<Store, _>(id, &[[2; 32]], happens_before).unwrap();
-        // R2 wins despite smaller HLC, because it's causally later.
-        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
-    }
-
-    #[test]
-    fn writers_at_unreachable_entries_ignored() {
-        // Entry exists but isn't reachable from the queried parents.
-        // Returns None (not the latest) — verifier can fall back as it sees fit.
-        let id = id(9);
-        append::<Store>(id, entry(1, 100, 0xAA, &[0xAA], 1)).unwrap();
-
-        // Different parent that doesn't reach delta 1.
-        let writers = writers_at::<Store, _>(id, &[[42; 32]], |_, _| false).unwrap();
-        assert_eq!(writers, None);
     }
 
     #[test]
@@ -576,24 +295,5 @@ mod tests {
         // The original entry stays put; nothing was overwritten.
         let log = load::<Store>(id).unwrap().unwrap();
         assert_eq!(log.entries, vec![e1]);
-    }
-
-    #[test]
-    fn writers_at_falls_back_to_snapshot_when_entries_unreachable() {
-        // P6 compaction wrote a snapshot but no live entries reach the query.
-        let id = id(10);
-        let snap_writers: BTreeSet<PublicKey> = [0xEE].into_iter().map(pk).collect();
-        let log = RotationLog {
-            snapshot: Some(RotationSnapshot {
-                writers: snap_writers.clone(),
-                cutoff_index: 5,
-            }),
-            entries: vec![entry(99, 100, 0xFF, &[0xFF], 99)],
-        };
-        save::<Store>(id, &log).unwrap();
-
-        // happens_before never matches: live entry at delta 99 is unreachable.
-        let writers = writers_at::<Store, _>(id, &[[1; 32]], |_, _| false).unwrap();
-        assert_eq!(writers, Some(snap_writers));
     }
 }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -147,11 +147,13 @@ impl StorageAdaptor for MainStorage {
 // }
 
 #[cfg(any(test, not(target_arch = "wasm32")))]
-pub(crate) use mocked::MockedStorage;
+pub use mocked::MockedStorage;
 
-/// The mocked storage system.
+/// The mocked storage system. Compiled into native builds (gated off
+/// `wasm32`) so dependent crates can drive the same in-memory backend
+/// from their own tests — see `calimero_node::sync::*_tests`.
 #[cfg(any(test, not(target_arch = "wasm32")))]
-pub(crate) mod mocked {
+pub mod mocked {
     use core::cell::RefCell;
     use std::collections::BTreeMap;
 
@@ -166,8 +168,7 @@ pub(crate) mod mocked {
     }
 
     /// The mocked storage system.
-    #[expect(clippy::redundant_pub_crate, reason = "Needed here")]
-    pub(crate) struct MockedStorage<const SCOPE: usize>;
+    pub struct MockedStorage<const SCOPE: usize>;
 
     impl<const SCOPE: usize> StorageAdaptor for MockedStorage<SCOPE> {
         fn storage_read(key: Key) -> Option<Vec<u8>> {

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -167,7 +167,27 @@ pub mod mocked {
         pub(crate) static STORAGE: RefCell<BTreeMap<(Scope, Key), Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
     }
 
-    /// The mocked storage system.
+    /// In-memory mocked storage backend, scoped by a const generic so
+    /// multiple instances can coexist in one test process without
+    /// stepping on each other's state.
+    ///
+    /// # Scope contract
+    ///
+    /// The `SCOPE` const generic is the **only** thing isolating one
+    /// `MockedStorage<N>` from another. Two binaries linking
+    /// `calimero-storage` (e.g. a test binary that depends on both
+    /// `calimero-storage`'s tests and `calimero-node`'s tests via the
+    /// `testing` feature) share the same thread-local `STORAGE`, so a
+    /// scope-integer collision silently merges their state.
+    ///
+    /// Reserved scope ranges, to keep cross-crate usage from colliding:
+    ///
+    /// - `0..1_000`              — reserved for `calimero-storage`'s own tests.
+    /// - `usize::MAX`            — reserved for `DefaultStore` fallback (see `env.rs`).
+    /// - everything else         — available to dependent crates.
+    ///
+    /// New crates pulling in `MockedStorage` should pick a band well
+    /// outside the above. Per #2272 review.
     pub struct MockedStorage<const SCOPE: usize>;
 
     impl<const SCOPE: usize> StorageAdaptor for MockedStorage<SCOPE> {

--- a/crates/storage/src/tests/authored_primitives.rs
+++ b/crates/storage/src/tests/authored_primitives.rs
@@ -164,15 +164,7 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(
-        forged,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    ) {
+    match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }
@@ -208,15 +200,7 @@ fn authored_map_delete_by_non_owner_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(
-        forged,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    ) {
+    match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }
@@ -248,15 +232,7 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(
-        forged,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    ) {
+    match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }
@@ -287,15 +263,7 @@ fn authored_vector_delete_by_non_owner_is_rejected() {
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
 
-    match MainInterface::apply_action(
-        forged,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    ) {
+    match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
         other => panic!("expected InvalidSignature, got {:?}", other),
     }

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -117,16 +117,7 @@ fn tombstone_marks_deleted() {
         metadata: Metadata::default(),
     };
 
-    TestInterface::apply_action(
-        delete_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(delete_action, &ApplyContext::empty()).unwrap();
 
     // Entity should be gone
     assert!(TestInterface::find_by_id::<Page>(id).unwrap().is_none());
@@ -155,16 +146,7 @@ fn tombstone_prevents_old_resurrection() {
         metadata: save_meta, // Old metadata from before deletion
     };
 
-    TestInterface::apply_action(
-        resurrect_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(resurrect_action, &ApplyContext::empty()).unwrap();
 
     // Should remain deleted (tombstone is newer)
     assert!(TestInterface::find_by_id::<Page>(id).unwrap().is_none());
@@ -197,16 +179,7 @@ fn tombstone_allows_newer_update() {
         metadata: new_page.element().metadata.clone(),
     };
 
-    TestInterface::apply_action(
-        update_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(update_action, &ApplyContext::empty()).unwrap();
 
     // Should be resurrected (if the add timestamp is newer than delete)
     let retrieved = TestInterface::find_by_id::<Page>(id).unwrap();
@@ -247,26 +220,8 @@ fn delete_vs_update_conflict() {
     };
 
     // Apply delete first, then update
-    TestInterface::apply_action(
-        delete_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        update_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(delete_action, &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(update_action, &ApplyContext::empty()).unwrap();
 
     // Behavior depends on implementation
     // Just verify no panic
@@ -303,26 +258,8 @@ fn update_vs_delete_conflict() {
     };
 
     // Apply update first, then delete
-    TestInterface::apply_action(
-        update_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        delete_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(update_action, &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(delete_action, &ApplyContext::empty()).unwrap();
 
     // Delete wins (newer timestamp)
     let retrieved = TestInterface::find_by_id::<Page>(id).unwrap();
@@ -400,26 +337,8 @@ fn concurrent_update_same_entity_different_fields() {
     };
 
     // Apply both
-    TestInterface::apply_action(
-        action1,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        action2,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(action1, &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(action2, &ApplyContext::empty()).unwrap();
 
     // Later timestamp wins
     let retrieved = TestInterface::find_by_id::<Page>(page.id())
@@ -445,36 +364,9 @@ fn actions_idempotent() {
     };
 
     // Apply multiple times
-    TestInterface::apply_action(
-        action.clone(),
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        action.clone(),
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(action.clone(), &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(action.clone(), &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(action, &ApplyContext::empty()).unwrap();
 
     // Should only exist once
     let retrieved = TestInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -493,16 +385,7 @@ fn update_before_add_creates_entity() {
         metadata: page.element().metadata.clone(),
     };
 
-    TestInterface::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(action, &ApplyContext::empty()).unwrap();
 
     // Should be created
     let retrieved = TestInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -523,16 +406,7 @@ fn delete_prevents_old_add() {
         deleted_at: time_now(),
         metadata: Metadata::default(),
     };
-    TestInterface::apply_action(
-        delete_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(delete_action, &ApplyContext::empty()).unwrap();
 
     // Try to add with older timestamp (from before deletion)
     let add_action = Action::Add {
@@ -542,16 +416,7 @@ fn delete_prevents_old_add() {
         metadata: old_meta,
     };
 
-    TestInterface::apply_action(
-        add_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(add_action, &ApplyContext::empty()).unwrap();
 
     // Should remain deleted (tombstone wins)
     assert!(TestInterface::find_by_id::<Page>(page.id())
@@ -596,26 +461,8 @@ fn same_timestamp_lww_behavior() {
     };
 
     // Apply both - later one wins
-    TestInterface::apply_action(
-        action1,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        action2,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(action1, &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(action2, &ApplyContext::empty()).unwrap();
 
     let result = TestInterface::find_by_id::<Page>(id).unwrap().unwrap();
     assert_eq!(result.title, "Update 2");
@@ -635,15 +482,7 @@ fn empty_entity_data() {
     };
 
     // Should handle gracefully - expect deserialization to fail
-    let result = TestInterface::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    );
+    let result = TestInterface::apply_action(action, &ApplyContext::empty());
     // Just verify it doesn't panic - result may vary
     drop(result);
 }
@@ -660,15 +499,7 @@ fn malformed_entity_data() {
     };
 
     // Should fail gracefully
-    let result = TestInterface::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    );
+    let result = TestInterface::apply_action(action, &ApplyContext::empty());
     assert!(result.is_err());
 }
 
@@ -684,36 +515,9 @@ fn multiple_deletes_idempotent() {
     };
 
     // Delete multiple times
-    TestInterface::apply_action(
-        delete_action.clone(),
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        delete_action.clone(),
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
-    TestInterface::apply_action(
-        delete_action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    TestInterface::apply_action(delete_action.clone(), &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(delete_action.clone(), &ApplyContext::empty()).unwrap();
+    TestInterface::apply_action(delete_action, &ApplyContext::empty()).unwrap();
 
     // Should still be deleted
     assert!(TestInterface::find_by_id::<Page>(page.id())
@@ -747,16 +551,7 @@ fn many_sequential_updates() {
             metadata: page.element().metadata.clone(),
         };
 
-        TestInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        )
-        .unwrap();
+        TestInterface::apply_action(action, &ApplyContext::empty()).unwrap();
     }
 
     // Latest version should win
@@ -786,16 +581,7 @@ fn rapid_add_delete_cycles() {
                 deleted_at: time_now(),
                 metadata: Metadata::default(),
             };
-            TestInterface::apply_action(
-                action,
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            )
-            .unwrap();
+            TestInterface::apply_action(action, &ApplyContext::empty()).unwrap();
         } else {
             // Update (resurrect if was deleted)
             page.title = format!("Version {}", i);
@@ -807,16 +593,7 @@ fn rapid_add_delete_cycles() {
                 ancestors: vec![],
                 metadata: page.element().metadata.clone(),
             };
-            TestInterface::apply_action(
-                action,
-                ApplyContext {
-                    causal_parents: &[],
-                    delta_id: None,
-                    delta_hlc: None,
-                    happens_before: None,
-                },
-            )
-            .unwrap();
+            TestInterface::apply_action(action, &ApplyContext::empty()).unwrap();
         }
     }
 
@@ -841,15 +618,7 @@ fn test_future_timestamp_rejected() {
         metadata: page.element().metadata.clone(),
     };
 
-    let result = TestInterface::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    );
+    let result = TestInterface::apply_action(action, &ApplyContext::empty());
 
     assert!(
         result.is_err(),
@@ -881,16 +650,7 @@ fn test_near_future_timestamp_accepted() {
     };
 
     assert!(
-        TestInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok(),
+        TestInterface::apply_action(action, &ApplyContext::empty()).is_ok(),
         "Should accept timestamp within drift tolerance"
     );
 }
@@ -914,16 +674,7 @@ fn test_past_timestamp_accepted() {
     };
 
     assert!(
-        TestInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok(),
+        TestInterface::apply_action(action, &ApplyContext::empty()).is_ok(),
         "Should accept valid past timestamps"
     );
 }
@@ -943,15 +694,7 @@ fn test_delete_future_timestamp_rejected() {
         metadata: Metadata::default(),
     };
 
-    let result = TestInterface::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    );
+    let result = TestInterface::apply_action(action, &ApplyContext::empty());
     assert!(
         result.is_err(),
         "Should reject delete timestamp too far in the future"
@@ -978,16 +721,7 @@ fn test_delete_near_future_accepted() {
     };
 
     assert!(
-        TestInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok(),
+        TestInterface::apply_action(action, &ApplyContext::empty()).is_ok(),
         "Should accept delete timestamp within tolerance"
     );
 }

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -51,16 +51,9 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying just the root, what do we find? just the root, simple
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<0>>>::apply_action(
-            a1.clone(),
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(
+            <Interface<MockedStorage<0>>>::apply_action(a1.clone(), &ApplyContext::empty()).is_ok()
+        );
 
         let e1 = <Index<MockedStorage<0>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<0>>>::get_index(p1_id).unwrap();
@@ -78,16 +71,9 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying just a2, what do we find? a2 + a1 (sparse)
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<1>>>::apply_action(
-            a2.clone(),
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(
+            <Interface<MockedStorage<1>>>::apply_action(a2.clone(), &ApplyContext::empty()).is_ok()
+        );
 
         let e1 = <Index<MockedStorage<1>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<1>>>::get_index(p1_id).unwrap();
@@ -112,26 +98,12 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying a1, and then a2, what do we find?
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<2>>>::apply_action(
-            a1.clone(),
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
-        assert!(<Interface<MockedStorage<2>>>::apply_action(
-            a2.clone(),
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(
+            <Interface<MockedStorage<2>>>::apply_action(a1.clone(), &ApplyContext::empty()).is_ok()
+        );
+        assert!(
+            <Interface<MockedStorage<2>>>::apply_action(a2.clone(), &ApplyContext::empty()).is_ok()
+        );
 
         let e1 = <Index<MockedStorage<2>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<2>>>::get_index(p1_id).unwrap();
@@ -156,26 +128,12 @@ mod index__public_methods {
         // --------------------------------------------------------------
         // applying a2, and then a1, what do we find?
         // --------------------------------------------------------------
-        assert!(<Interface<MockedStorage<3>>>::apply_action(
-            a2.clone(),
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
-        assert!(<Interface<MockedStorage<3>>>::apply_action(
-            a1.clone(),
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(
+            <Interface<MockedStorage<3>>>::apply_action(a2.clone(), &ApplyContext::empty()).is_ok()
+        );
+        assert!(
+            <Interface<MockedStorage<3>>>::apply_action(a1.clone(), &ApplyContext::empty()).is_ok()
+        );
 
         let e1 = <Index<MockedStorage<3>>>::get_index(root_id).unwrap();
         let e2 = <Index<MockedStorage<3>>>::get_index(p1_id).unwrap();

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -165,16 +165,7 @@ mod interface__apply_actions {
             metadata: page.element().metadata.clone(),
         };
 
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify the page was added
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -198,16 +189,7 @@ mod interface__apply_actions {
             metadata: page.element().metadata.clone(),
         };
 
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify the page was updated
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id())
@@ -227,16 +209,7 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify the page was deleted
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -256,16 +229,7 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify the page was deleted (tombstone)
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -295,16 +259,7 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(
-            old_delete,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(old_delete, &ApplyContext::empty()).is_ok());
 
         // Page should still exist (update wins)
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -318,16 +273,7 @@ mod interface__apply_actions {
             metadata: Metadata::default(),
         };
 
-        assert!(MainInterface::apply_action(
-            new_delete,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(new_delete, &ApplyContext::empty()).is_ok());
 
         // Page should be deleted (deletion wins)
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -340,16 +286,7 @@ mod interface__apply_actions {
         let action = Action::Compare { id: page.id() };
 
         // Compare should fail
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_err());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_err());
     }
 
     #[test]
@@ -364,16 +301,7 @@ mod interface__apply_actions {
         };
 
         // Updating a non-existent page should still succeed (it will be added)
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify the page was added
         let retrieved_page = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -798,16 +726,7 @@ mod user_storage_signature_verification {
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce);
 
         // Valid signature should succeed
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify the page was added
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -834,15 +753,7 @@ mod user_storage_signature_verification {
             create_signed_user_add_action(&wrong_signing_key, owner, page.id(), serialized, nonce);
 
         // Invalid signature should fail
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -881,15 +792,7 @@ mod user_storage_signature_verification {
         };
 
         // Missing signature should fail
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -936,15 +839,7 @@ mod user_storage_signature_verification {
         }
 
         // Corrupted signature should fail
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -968,16 +863,7 @@ mod user_storage_signature_verification {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         // Wait a bit to ensure different timestamp
         sleep(Duration::from_millis(2));
@@ -997,16 +883,7 @@ mod user_storage_signature_verification {
             page.element().created_at(),
         );
 
-        assert!(MainInterface::apply_action(
-            action2,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action2, &ApplyContext::empty()).is_ok());
 
         // Verify the update
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -1048,16 +925,7 @@ mod user_storage_replay_protection {
             serialized.clone(),
             nonce,
         );
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1071,15 +939,7 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(
-            action2,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -1107,16 +967,7 @@ mod user_storage_replay_protection {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1131,15 +982,7 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(
-            action2,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -1162,16 +1005,7 @@ mod user_storage_replay_protection {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         // Multiple updates with increasing nonces
         for i in 2..=5 {
@@ -1189,16 +1023,7 @@ mod user_storage_replay_protection {
                 page.element().created_at(),
             );
             assert!(
-                MainInterface::apply_action(
-                    action,
-                    ApplyContext {
-                        causal_parents: &[],
-                        delta_id: None,
-                        delta_hlc: None,
-                        happens_before: None,
-                    }
-                )
-                .is_ok(),
+                MainInterface::apply_action(action, &ApplyContext::empty()).is_ok(),
                 "Update {} should succeed",
                 i
             );
@@ -1230,16 +1055,7 @@ mod user_storage_replay_protection {
             serialized1.clone(),
             first_nonce,
         );
-        assert!(MainInterface::apply_action(
-            action_first,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action_first, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(10));
 
@@ -1255,15 +1071,7 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(
-            action_old,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action_old, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -1329,16 +1137,7 @@ mod frozen_storage_verification {
             },
         };
 
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
 
         // Verify it was stored
         let stored = MainInterface::get(id);
@@ -1368,15 +1167,7 @@ mod frozen_storage_verification {
             },
         };
 
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -1413,16 +1204,7 @@ mod frozen_storage_verification {
                 field_name: None,
             },
         };
-        assert!(MainInterface::apply_action(
-            add_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(add_action, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1444,15 +1226,7 @@ mod frozen_storage_verification {
             },
         };
 
-        let result = MainInterface::apply_action(
-            update_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(update_action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1489,16 +1263,7 @@ mod frozen_storage_verification {
                 field_name: None,
             },
         };
-        assert!(MainInterface::apply_action(
-            add_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(add_action, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1509,15 +1274,7 @@ mod frozen_storage_verification {
             metadata: Metadata::default(),
         };
 
-        let result = MainInterface::apply_action(
-            delete_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1555,15 +1312,7 @@ mod frozen_storage_verification {
             },
         };
 
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -1606,16 +1355,7 @@ mod frozen_storage_verification {
         };
 
         // This should succeed since the hash of empty [] matches
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
     }
 }
 
@@ -1652,15 +1392,7 @@ mod timestamp_drift_protection {
             },
         };
 
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidTimestamp(ts, local)) => {
@@ -1695,16 +1427,7 @@ mod timestamp_drift_protection {
         };
 
         // Should succeed since within tolerance
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
     }
 
     #[test]
@@ -1732,16 +1455,7 @@ mod timestamp_drift_protection {
         };
 
         // Past timestamps are fine
-        assert!(MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
     }
 
     #[test]
@@ -1761,15 +1475,7 @@ mod timestamp_drift_protection {
             metadata: Metadata::default(),
         };
 
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidTimestamp(_, _)) => {}
@@ -1869,16 +1575,7 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1893,15 +1590,7 @@ mod storage_type_edge_cases {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(
-            action2,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -1926,16 +1615,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1943,16 +1623,7 @@ mod storage_type_edge_cases {
         let nonce2 = env::time_now();
         let delete_action = create_signed_delete_action(&signing_key, owner, page.id(), nonce2);
 
-        assert!(MainInterface::apply_action(
-            delete_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(delete_action, &ApplyContext::empty()).is_ok());
 
         // Verify entity is deleted
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -1975,16 +1646,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key1, owner1, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1992,15 +1654,7 @@ mod storage_type_edge_cases {
         let nonce2 = env::time_now();
         let delete_action = create_signed_delete_action(&signing_key2, owner2, page.id(), nonce2);
 
-        let result = MainInterface::apply_action(
-            delete_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -2023,16 +1677,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2052,15 +1697,7 @@ mod storage_type_edge_cases {
             },
         };
 
-        let result = MainInterface::apply_action(
-            delete_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -2097,15 +1734,7 @@ mod storage_type_edge_cases {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(
-            action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -2139,16 +1768,7 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce,
         );
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2167,15 +1787,7 @@ mod storage_type_edge_cases {
             },
         };
 
-        let result = MainInterface::apply_action(
-            action2,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -2210,16 +1822,7 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(
-            action1,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2233,31 +1836,14 @@ mod storage_type_edge_cases {
             nonce2,
             page.element().created_at(),
         );
-        assert!(MainInterface::apply_action(
-            action2,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            }
-        )
-        .is_ok());
+        assert!(MainInterface::apply_action(action2, &ApplyContext::empty()).is_ok());
 
         sleep(Duration::from_millis(2));
 
         // Try to delete with old nonce (replay attack)
         let delete_action = create_signed_delete_action(&signing_key, owner, page.id(), nonce1);
 
-        let result = MainInterface::apply_action(
-            delete_action,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        );
+        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1149,7 +1149,7 @@ fn test_e2e_sync_flow_with_isolated_storage() {
         // Apply actions to Node-2's storage via sync
         let sync_artifact =
             borsh::to_vec(&crate::delta::StorageDelta::Actions(delta.actions)).unwrap();
-        Root::<LwwRegister<String>, NodeStorage>::sync(&sync_artifact, ApplyContext::empty())
+        Root::<LwwRegister<String>, NodeStorage>::sync(&sync_artifact, &ApplyContext::empty())
             .unwrap();
     }
 
@@ -1447,7 +1447,7 @@ fn test_e2e_counter_sync_with_isolated_storage() {
     // Apply delta via sync
     if let Some(delta) = update_delta {
         let sync_payload = borsh::to_vec(&StorageDelta::Actions(delta.actions)).unwrap();
-        Root::<Counter, NodeStorage>::sync(&sync_payload, ApplyContext::empty()).unwrap();
+        Root::<Counter, NodeStorage>::sync(&sync_payload, &ApplyContext::empty()).unwrap();
         println!("Update delta applied to Node-2");
     }
 

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1149,16 +1149,8 @@ fn test_e2e_sync_flow_with_isolated_storage() {
         // Apply actions to Node-2's storage via sync
         let sync_artifact =
             borsh::to_vec(&crate::delta::StorageDelta::Actions(delta.actions)).unwrap();
-        Root::<LwwRegister<String>, NodeStorage>::sync(
-            &sync_artifact,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        )
-        .unwrap();
+        Root::<LwwRegister<String>, NodeStorage>::sync(&sync_artifact, ApplyContext::empty())
+            .unwrap();
     }
 
     // Get Node-2's hash after sync
@@ -1455,16 +1447,7 @@ fn test_e2e_counter_sync_with_isolated_storage() {
     // Apply delta via sync
     if let Some(delta) = update_delta {
         let sync_payload = borsh::to_vec(&StorageDelta::Actions(delta.actions)).unwrap();
-        Root::<Counter, NodeStorage>::sync(
-            &sync_payload,
-            ApplyContext {
-                causal_parents: &[],
-                delta_id: None,
-                delta_hlc: None,
-                happens_before: None,
-            },
-        )
-        .unwrap();
+        Root::<Counter, NodeStorage>::sync(&sync_payload, ApplyContext::empty()).unwrap();
         println!("Update delta applied to Node-2");
     }
 

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -253,16 +253,7 @@ fn merkle_hash_convergence_after_sync() {
         metadata: page1.element().metadata.clone(),
     };
 
-    Interface::<Storage2>::apply_action(
-        action,
-        ApplyContext {
-            causal_parents: &[],
-            delta_id: None,
-            delta_hlc: None,
-            happens_before: None,
-        },
-    )
-    .unwrap();
+    Interface::<Storage2>::apply_action(action, &ApplyContext::empty()).unwrap();
 
     // After sync, hashes should match
     let page2 = Interface::<Storage2>::find_by_id::<Page>(page1.id())

--- a/crates/storage/src/tests/write_hook_stale_writers.rs
+++ b/crates/storage/src/tests/write_hook_stale_writers.rs
@@ -1,0 +1,161 @@
+//! Regression test for a storage-internal invariant flagged in #2265 review:
+//! `Index::update_hash_for` does NOT touch `metadata.storage_type.writers`,
+//! so the stored writer set stays frozen at bootstrap. The rotation-detection
+//! logic in `maybe_append_rotation_log` relies on this — comparing the
+//! action's claimed `writers` against the (frozen) stored writers — to avoid
+//! falsely flagging stale value-writes as rotations.
+//!
+//! If `Index::update_hash_for` ever starts updating `storage_type`, this
+//! detection logic must move to comparing against `writers_at(causal_parents)`
+//! instead. This test catches that future regression at the storage layer
+//! without needing a DAG harness — the apply contexts here only carry
+//! `delta_id`/`delta_hlc` (no `effective_writers`) so the verifier falls
+//! through to the v2 stored-writers path and the write hook still fires.
+//!
+//! This test was extracted from `p3_dag_causal.rs` per #2266 step 5 — the
+//! rest of P3 moved to the node crate (where the DAG lives), but this case
+//! is purely about a storage-internal invariant and stays here.
+
+use core::num::NonZeroU128;
+
+use ed25519_dalek::SigningKey;
+
+use crate::address::Id;
+use crate::entities::{ChildInfo, Metadata};
+use crate::index::Index;
+use crate::interface::{ApplyContext, Interface};
+use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use crate::rotation_log;
+use crate::store::{MockedStorage, StorageAdaptor};
+use crate::tests::common::{build_signed_shared_action, pubkey_of};
+
+type S<const SCOPE: usize> = MockedStorage<SCOPE>;
+
+fn make_signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn hlc(ns: u64) -> HybridTimestamp {
+    let node_id = ID::from(NonZeroU128::new(1).unwrap());
+    HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
+}
+
+fn hlc_at(step: u64) -> u64 {
+    crate::env::time_now().saturating_add(step.saturating_mul(1_000_000_000))
+}
+
+fn setup_root<S: StorageAdaptor>() -> ChildInfo {
+    let root_id = Id::root();
+    let root_meta = Metadata::default();
+    Index::<S>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
+    ChildInfo::new(root_id, [0; 32], root_meta)
+}
+
+fn entity_id(seed: u8) -> Id {
+    Id::new([seed; 32])
+}
+
+/// Apply context with delta_id/delta_hlc populated (so the write hook fires)
+/// but no `effective_writers` (verifier falls through to v2 stored-writers).
+fn ctx(delta_id: [u8; 32], delta_hlc_ns: u64) -> ApplyContext {
+    ApplyContext {
+        effective_writers: None,
+        delta_id: Some(delta_id),
+        delta_hlc: Some(hlc(delta_hlc_ns)),
+    }
+}
+
+/// Documents a known design fragility: `maybe_append_rotation_log` decides
+/// whether to append by comparing the action's claimed `writers` against the
+/// currently-stored writers. But `Index::update_hash_for` only touches
+/// `own_hash`/`full_hash`/`updated_at` — it never updates
+/// `metadata.storage_type`, so the stored writers stay frozen at the
+/// bootstrap set forever.
+///
+/// As a result, a value-write that *happens* to claim the bootstrap writers
+/// (e.g., authored by a peer with stale view) is correctly NOT logged as a
+/// rotation, even after a real rotation has updated the writer set logically.
+/// The rotation-detection logic depends on this stale-stored-writers behavior
+/// to avoid false positives.
+///
+/// If `update_hash_for` is ever changed to also update `storage_type`, the
+/// rotation-detection logic must switch to comparing against
+/// `writers_at(causal_parents)` instead, or stale value-writes will be
+/// falsely flagged as rotations.
+#[test]
+fn write_hook_relies_on_stale_stored_writers_for_rotation_detection() {
+    crate::env::reset_for_testing();
+    let root = setup_root::<S<408>>();
+
+    let alice_sk = make_signing_key(0xAB);
+    let bob_sk = make_signing_key(0xBB);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let id = entity_id(0x48);
+
+    // Bootstrap with {Alice, Bob}.
+    let bootstrap = build_signed_shared_action(
+        true,
+        id,
+        b"v0".to_vec(),
+        [alice, bob].into_iter().collect(),
+        hlc_at(0),
+        &alice_sk,
+        vec![root.clone()],
+    );
+    Interface::<S<408>>::apply_action(bootstrap, &ctx([0xE0; 32], hlc_at(0))).unwrap();
+
+    // D1: Alice rotates Bob out → writers = {Alice}. Logged as a rotation.
+    let rotation = build_signed_shared_action(
+        false,
+        id,
+        b"v1".to_vec(),
+        [alice].into_iter().collect(),
+        hlc_at(1),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<408>>::apply_action(rotation, &ctx([0xE1; 32], hlc_at(1))).unwrap();
+    assert_eq!(
+        rotation_log::load::<S<408>>(id)
+            .unwrap()
+            .unwrap()
+            .entries
+            .len(),
+        2,
+        "post-D1 baseline: bootstrap + rotation"
+    );
+
+    // D2: Alice value-write claiming the BOOTSTRAP writers {Alice, Bob}.
+    // She's authorized (signature verifies against the authoritative set
+    // — here that's {Alice} via the v2 fallback because the verifier
+    // falls through to stored writers, but since `Bob` would normally be
+    // rejected, we sign with Alice). The rotation-detection compares
+    // action.writers `{Alice, Bob}` against `pre_apply_writers` — which is
+    // STILL `{Alice, Bob}` because `Index::update_hash_for` never updated
+    // `storage_type` after D1. So `is_rotation = false` and no log entry
+    // is appended.
+    //
+    // If the index had updated to `{Alice}` after D1, this comparison would
+    // be `{Alice, Bob} != {Alice}` → IS rotation → falsely append. This
+    // assertion catches that future regression.
+    let value_write_with_stale_writers = build_signed_shared_action(
+        false,
+        id,
+        b"v2".to_vec(),
+        [alice, bob].into_iter().collect(), // claims bootstrap writers
+        hlc_at(2),
+        &alice_sk,
+        vec![],
+    );
+    Interface::<S<408>>::apply_action(value_write_with_stale_writers, &ctx([0xE2; 32], hlc_at(2)))
+        .unwrap();
+
+    let log = rotation_log::load::<S<408>>(id).unwrap().unwrap();
+    assert_eq!(
+        log.entries.len(),
+        2,
+        "value-write with stale writer claim must NOT append \
+         (relies on stored writers staying frozen at bootstrap)"
+    );
+}

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -201,9 +201,9 @@ fn normalize_generic_type(
             Ok(TypeRef::list(item_type))
         }
         // Collection types - normalize to semantic ABI types
-        "BTreeMap" | "HashMap" | "UnorderedMap" | "IndexMap" => {
+        "BTreeMap" | "HashMap" | "UnorderedMap" | "IndexMap" | "AuthoredMap" => {
             // All map types -> map<K, V> (normalize to semantic type)
-            // UnorderedMap preserves CRDT type metadata
+            // UnorderedMap and AuthoredMap preserve CRDT type metadata
             if args.args.len() != 2 {
                 return Err(NormalizeError::TypePathError(format!(
                     "invalid {ident_str} type - expected 2 type arguments"
@@ -229,11 +229,11 @@ fn normalize_generic_type(
             let _key_type = normalize_type(key_ty, wasm32, resolver)?;
             let value_type = normalize_type(value_ty, wasm32, resolver)?;
 
-            // Preserve CRDT type for UnorderedMap
-            let crdt_type = if ident_str == "UnorderedMap" {
-                Some(CrdtCollectionType::UnorderedMap)
-            } else {
-                None
+            // Preserve CRDT type for UnorderedMap / AuthoredMap
+            let crdt_type = match ident_str.as_str() {
+                "UnorderedMap" => Some(CrdtCollectionType::UnorderedMap),
+                "AuthoredMap" => Some(CrdtCollectionType::AuthoredMap),
+                _ => None,
             };
 
             Ok(TypeRef::Collection {
@@ -296,6 +296,7 @@ fn normalize_generic_type(
         | "Counter"
         | "ReplicatedGrowableArray"
         | "Vector"
+        | "AuthoredVector"
         | "UnorderedSet"
         | "FrozenValue" => {
             // These CRDT wrappers unwrap to their inner type for ABI purposes
@@ -363,6 +364,16 @@ fn normalize_generic_type(
                         },
                         crdt_type: Some(CrdtCollectionType::Vector),
                         inner_type: None, // Inner type is in List.items
+                    })
+                }
+                "AuthoredVector" => {
+                    // AuthoredVector<T> -> List<T> with per-element author metadata
+                    Ok(TypeRef::Collection {
+                        collection: CollectionType::List {
+                            items: Box::new(inner_type),
+                        },
+                        crdt_type: Some(CrdtCollectionType::AuthoredVector),
+                        inner_type: None,
                     })
                 }
                 "UnorderedSet" => {

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -177,6 +177,7 @@ pub enum ScalarType {
 /// (timestamps, node IDs, element IDs, etc.) and must be preserved for correct deserialization.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum CrdtCollectionType {
     /// Last-Write-Wins Register: `(value: T, timestamp, node_id)`
     LwwRegister,
@@ -186,10 +187,15 @@ pub enum CrdtCollectionType {
     Vector,
     /// UnorderedMap: Map with element IDs and CRDT metadata
     UnorderedMap,
+    /// AuthoredMap: Map with per-entry author identity (insert is open;
+    /// update/remove gated by stored owner == executor)
+    AuthoredMap,
     /// UnorderedSet: Set with CRDT metadata
     UnorderedSet,
     /// ReplicatedGrowableArray: String with character-level CRDT
     ReplicatedGrowableArray,
+    /// AuthoredVector: List with per-element author identity
+    AuthoredVector,
 }
 
 /// Collection types

--- a/crates/wasm-abi/tests/normalize.rs
+++ b/crates/wasm-abi/tests/normalize.rs
@@ -421,3 +421,51 @@ fn test_new_storage_types() {
         TypeRef::map(TypeRef::list(TypeRef::reference("Person"))) // [cite: 31, 290]
     );
 }
+
+#[test]
+fn test_authored_collections_preserve_crdt_type() {
+    use calimero_wasm_abi::schema::{CollectionType, CrdtCollectionType};
+
+    let mut resolver = MockResolver::new();
+    resolver.add_record("Person");
+
+    // `AuthoredMap<String, u64>` normalizes to a Map<string, u64> with
+    // `crdt_type = AuthoredMap`. Codegen consumers dispatch on this tag
+    // to emit the open-insert / owner-only-update API surface.
+    let normalized =
+        normalize_type(&parse_type("AuthoredMap<String, u64>"), true, &resolver).unwrap();
+    match normalized {
+        TypeRef::Collection {
+            collection,
+            crdt_type,
+            ..
+        } => {
+            assert_eq!(crdt_type, Some(CrdtCollectionType::AuthoredMap));
+            assert!(
+                matches!(collection, CollectionType::Map { .. }),
+                "AuthoredMap must surface as a Map collection"
+            );
+        }
+        other => panic!("expected Collection variant, got {other:?}"),
+    }
+
+    // `AuthoredVector<Person>` normalizes to a List<$ref:Person> with
+    // `crdt_type = AuthoredVector`. Mirrors the Vector arm except for
+    // the per-element author identity carried at the storage layer.
+    let normalized =
+        normalize_type(&parse_type("AuthoredVector<Person>"), true, &resolver).unwrap();
+    match normalized {
+        TypeRef::Collection {
+            collection,
+            crdt_type,
+            ..
+        } => {
+            assert_eq!(crdt_type, Some(CrdtCollectionType::AuthoredVector));
+            assert!(
+                matches!(collection, CollectionType::List { .. }),
+                "AuthoredVector must surface as a List collection"
+            );
+        }
+        other => panic!("expected Collection variant, got {other:?}"),
+    }
+}

--- a/tools/merodb/src/deserializer.rs
+++ b/tools/merodb/src/deserializer.rs
@@ -347,6 +347,72 @@ fn deserialize_collection_with_crdt(
                     }
                 }
             }
+            CrdtCollectionType::AuthoredMap => {
+                // AuthoredMap<K, V> wraps UnorderedMap<K, V> and the
+                // CRDT payload byte layout is identical. Per-entry
+                // authorship lives in the per-entity metadata
+                // (`StorageType::User { owner }`) consumed at a higher
+                // layer in merodb, not in this payload.
+                match collection {
+                    CollectionType::Map { key, value } => {
+                        let len = u32::deserialize_reader(cursor)
+                            .wrap_err("Failed to deserialize AuthoredMap length")?;
+                        let mut map = serde_json::Map::new();
+                        for _ in 0..len {
+                            let key_value = deserialize_type_ref(cursor, key, manifest)?;
+                            let val_value = deserialize_type_ref(cursor, value, manifest)?;
+
+                            let mut element_id = [0_u8; 32];
+                            cursor
+                                .read_exact(&mut element_id)
+                                .wrap_err("Failed to read AuthoredMap element_id")?;
+
+                            let key_str = match key_value {
+                                Value::String(s) => s,
+                                other => other.to_string(),
+                            };
+
+                            drop(map.insert(
+                                key_str,
+                                json!({
+                                    "value": val_value,
+                                    "element_id": hex::encode(element_id)
+                                }),
+                            ));
+                        }
+                        Ok(json!({
+                            "entries": map,
+                            "crdt_type": "AuthoredMap"
+                        }))
+                    }
+                    _ => {
+                        eyre::bail!("AuthoredMap CRDT type must be a Map collection");
+                    }
+                }
+            }
+            CrdtCollectionType::AuthoredVector => {
+                // AuthoredVector<T> wraps Vector<T>; CRDT payload byte
+                // layout is identical. See AuthoredMap arm above for
+                // where authorship metadata is surfaced.
+                match collection {
+                    CollectionType::List { items } => {
+                        let len = u32::deserialize_reader(cursor)
+                            .wrap_err("Failed to deserialize AuthoredVector length")?;
+                        let mut array = Vec::new();
+                        for _ in 0..len {
+                            let value = deserialize_type_ref(cursor, items, manifest)?;
+                            array.push(value);
+                        }
+                        Ok(json!({
+                            "items": array,
+                            "crdt_type": "AuthoredVector"
+                        }))
+                    }
+                    _ => {
+                        eyre::bail!("AuthoredVector CRDT type must be a List collection");
+                    }
+                }
+            }
             CrdtCollectionType::UnorderedSet => {
                 // UnorderedSet<T> serializes similarly to Vec<T> but with CRDT metadata
                 match collection {
@@ -447,6 +513,14 @@ fn deserialize_collection_with_crdt(
                     "crdt_type": "ReplicatedGrowableArray"
                 }))
             }
+            // `CrdtCollectionType` is `#[non_exhaustive]`. Bail on unknown
+            // variants rather than silently mis-decoding — the cursor
+            // position would be wrong for any subsequent field.
+            other => eyre::bail!(
+                "merodb does not yet know how to deserialize CRDT type {:?} \
+                 — extend the match in deserializer.rs",
+                other
+            ),
         };
     }
 

--- a/tools/merodb/src/deserializer.rs
+++ b/tools/merodb/src/deserializer.rs
@@ -1192,4 +1192,162 @@ mod tests {
 
         Ok(())
     }
+
+    /// AuthoredMap byte layout is identical to UnorderedMap: length (u32)
+    /// then per entry `(key, value, element_id [u8;32])`. The decoder
+    /// must consume the element_id and surface it hex-encoded under
+    /// each entry, with `crdt_type: "AuthoredMap"` on the wrapper.
+    #[test]
+    fn test_deserialize_authored_map() -> Result<()> {
+        let manifest = create_manifest_with_type(
+            "AuthoredStringToU32",
+            TypeDef::Alias {
+                target: TypeRef::Collection {
+                    collection: CollectionType::Map {
+                        key: Box::new(TypeRef::string()),
+                        value: Box::new(TypeRef::u32()),
+                    },
+                    crdt_type: Some(CrdtCollectionType::AuthoredMap),
+                    inner_type: Some(Box::new(TypeRef::u32())),
+                },
+            },
+        );
+
+        let element_id_a: [u8; 32] = [0x11; 32];
+        let element_id_b: [u8; 32] = [0x22; 32];
+
+        let mut data = Vec::new();
+        2_u32.serialize(&mut data)?; // length
+
+        // entry 1: ("a", 1, element_id_a)
+        "a".to_owned().serialize(&mut data)?;
+        1_u32.serialize(&mut data)?;
+        data.extend_from_slice(&element_id_a);
+
+        // entry 2: ("b", 2, element_id_b)
+        "b".to_owned().serialize(&mut data)?;
+        2_u32.serialize(&mut data)?;
+        data.extend_from_slice(&element_id_b);
+
+        let result = deserialize_with_abi(&data, &manifest, "AuthoredStringToU32")?;
+        assert_eq!(
+            result,
+            json!({
+                "entries": {
+                    "a": { "value": 1, "element_id": hex::encode(element_id_a) },
+                    "b": { "value": 2, "element_id": hex::encode(element_id_b) },
+                },
+                "crdt_type": "AuthoredMap"
+            })
+        );
+
+        Ok(())
+    }
+
+    /// Empty AuthoredMap must round-trip cleanly — verifies the length-0
+    /// short-circuit doesn't accidentally consume bytes.
+    #[test]
+    fn test_deserialize_authored_map_empty() -> Result<()> {
+        let manifest = create_manifest_with_type(
+            "EmptyAuthored",
+            TypeDef::Alias {
+                target: TypeRef::Collection {
+                    collection: CollectionType::Map {
+                        key: Box::new(TypeRef::string()),
+                        value: Box::new(TypeRef::u32()),
+                    },
+                    crdt_type: Some(CrdtCollectionType::AuthoredMap),
+                    inner_type: Some(Box::new(TypeRef::u32())),
+                },
+            },
+        );
+
+        let mut data = Vec::new();
+        0_u32.serialize(&mut data)?;
+
+        let result = deserialize_with_abi(&data, &manifest, "EmptyAuthored")?;
+        assert_eq!(result, json!({ "entries": {}, "crdt_type": "AuthoredMap" }));
+
+        Ok(())
+    }
+
+    /// AuthoredVector byte layout is identical to plain Vector — length
+    /// (u32) then values, no element_id per entry. The wrapper carries
+    /// `crdt_type: "AuthoredVector"` so a UI consumer can distinguish it.
+    #[test]
+    fn test_deserialize_authored_vector() -> Result<()> {
+        let manifest = create_manifest_with_type(
+            "AuthoredU32Vec",
+            TypeDef::Alias {
+                target: TypeRef::Collection {
+                    collection: CollectionType::List {
+                        items: Box::new(TypeRef::u32()),
+                    },
+                    crdt_type: Some(CrdtCollectionType::AuthoredVector),
+                    inner_type: Some(Box::new(TypeRef::u32())),
+                },
+            },
+        );
+
+        let items = vec![10_u32, 20_u32, 30_u32];
+        let data = borsh::to_vec(&items)?;
+
+        let result = deserialize_with_abi(&data, &manifest, "AuthoredU32Vec")?;
+        assert_eq!(
+            result,
+            json!({
+                "items": [10, 20, 30],
+                "crdt_type": "AuthoredVector"
+            })
+        );
+
+        Ok(())
+    }
+
+    /// AuthoredMap on a non-Map collection must bail rather than mis-decode.
+    #[test]
+    fn test_authored_map_on_list_collection_errors() {
+        let manifest = create_manifest_with_type(
+            "Wrong",
+            TypeDef::Alias {
+                target: TypeRef::Collection {
+                    collection: CollectionType::List {
+                        items: Box::new(TypeRef::u32()),
+                    },
+                    crdt_type: Some(CrdtCollectionType::AuthoredMap),
+                    inner_type: Some(Box::new(TypeRef::u32())),
+                },
+            },
+        );
+        let data = vec![0_u8; 4];
+        let result = deserialize_with_abi(&data, &manifest, "Wrong");
+        assert!(
+            result.is_err(),
+            "AuthoredMap with non-Map collection must error, got {result:?}"
+        );
+    }
+
+    /// AuthoredVector on a non-List collection must bail rather than mis-decode.
+    #[test]
+    fn test_authored_vector_on_map_collection_errors() {
+        let manifest = create_manifest_with_type(
+            "Wrong",
+            TypeDef::Alias {
+                target: TypeRef::Collection {
+                    collection: CollectionType::Map {
+                        key: Box::new(TypeRef::string()),
+                        value: Box::new(TypeRef::u32()),
+                    },
+                    crdt_type: Some(CrdtCollectionType::AuthoredVector),
+                    inner_type: Some(Box::new(TypeRef::u32())),
+                },
+            },
+        );
+        let data = vec![0_u8; 4];
+        let result = deserialize_with_abi(&data, &manifest, "Wrong");
+        assert!(
+            result.is_err(),
+            "AuthoredVector with non-List collection must error, got {result:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Wires the DAG-causal Shared verifier (shipped as storage-layer plumbing in #2265) through the WASM ABI so it actually runs in production. Without this PR the verifier is dormant — every WASM call site builds an empty `ApplyContext` and falls back to the v2 stored-writers path, preserving the bug DAG-causal exists to fix.

Per #2267 (Option B, accepted): resolution lives in the node sync layer, not in storage. The closure-typed `happens_before` and `causal_parents` fields on `ApplyContext` are gone. The applier resolves `writers_at(delta.parents)` against its local DAG topology and ships a plain-data `BTreeMap<Id, BTreeSet<PublicKey>>` to the WASM side via a new `StorageDelta::CausalActions` variant.

After this lands, the v2 stale-stored-writers behavior is gone for any delta arriving with causal context (i.e. all network-received deltas). Snapshot leaf push and local apply remain on the v2 fallback by design — they have no causal context.

Two small follow-ups landed in the same PR:
- `SharedStorage::writers()` / `is_frozen()` accessors so apps can render writer-set UI and detect frozen state without inferring from rejection paths.
- `AuthoredMap` / `AuthoredVector` now flow through the WASM ABI normalize, with `CrdtCollectionType` marked `#[non_exhaustive]` and `merodb`'s schema-driven deserializer extended to handle them.

Closes #2266. Closes #2267 on merge (per its description).

## Commit shape

1. `refactor(storage): shrink ApplyContext to plain-data effective_writers` — drop the closure + `causal_parents`; verifier now branches on `Some(set) | None`.
2. `refactor: move rotation-log readers from storage to node sync layer` — `writers_at` / `latest_writers` become pure functions over `&RotationLog` in `crates/node/src/sync/rotation_log_reader.rs`. Storage no longer carries DAG-ancestry knowledge.
3. `feat(node): wire DAG-causal Shared verifier through WASM ABI` — applier maintains topology mirror + per-delta cache, emits `StorageDelta::CausalActions` artifacts. `Root::sync` deserializer branches on the variant.
4. `refactor(tests): migrate P3/P5 DAG-causal tests to node sync layer` — 14 tests moved from storage to node crate (where the DAG lives). Storage retains the write-hook stale-writers regression test.
5. `test(node): e2e probe for DAG-causal Shared verifier wiring` — three integration tests through `DagStore` + `StorageDelta::CausalActions` Borsh roundtrip + verifier swap, including a strong-probe (toggling the resolve step off in the test applier makes the post-rotation forgery case fail with `Ok(true)` — confirms the test would have caught the v2 bug).
6. `feat(storage): SharedStorage::writers / is_frozen accessors`
7. `feat(wasm-abi): AuthoredMap + AuthoredVector ABI support, plus merodb arms`

## Test plan

- [x] `cargo test -p calimero-storage --lib` — 410 passed (including new SharedStorage accessor tests + write-hook regression)
- [x] `cargo test -p calimero-node --lib sync::p` — 24 passed (10 P3 + 4 P5 migrated tests + others)
- [x] `cargo test -p calimero-node --test dag_causal_shared_e2e` — 3 passed (incl. strong-probe)
- [x] `cargo test -p calimero-wasm-abi --test normalize` — including new AuthoredMap/AuthoredVector normalize test
- [x] `cargo test --workspace --no-fail-fast` — 2,111 tests pass clean
- [x] `cargo check --workspace` — clean, including `merodb`
- [x] **Live merobox 2-node workflow** against locally-built merod (\`./target/release/merod\`, commit on this branch): install kv-store-with-shared-storage → set value → sync → rotate writers → sync → set value from new writer → sync → assert other node sees post-rotation value. ✓

## Out of scope

- The stale \`Index::update_hash_for\` writers-not-refreshed bug — same root cause as the v2 verifier issue but separate ADR per #2266 "Same-root-cause follow-ups."
- v2 nonce-check removal — gated on the 4-week post-#2266 telemetry window per the #2233 epic exit criterion.
- Sync-layer divergence telemetry comparing \`effective_writers\` against stored. Optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the signature-verification path for `Shared` data and introduces a new sync wire format (`StorageDelta::CausalActions`), so bugs could admit unauthorized writes or break cross-node convergence. The new topology caching/eviction and direct-datastore reads add additional correctness and security-sensitive edge cases.
> 
> **Overview**
> Enables **DAG-causal signature verification for `Shared` entities during sync** by having the node resolve the authoritative writer set from rotation logs + DAG ancestry and ship it over the WASM boundary, instead of falling back to v2 “stored writers”. This introduces a new `StorageDelta::CausalActions` wire variant carrying `delta_id`, `delta_hlc`, and per-entity `effective_writers`, and updates `Root::sync` to apply actions with per-action `ApplyContext` derived from that map.
> 
> Refactors storage apply plumbing to a plain-data `ApplyContext` (now passed by reference) and adds a node-side `rotation_log_reader` module; the node applier maintains a bounded, insertion-ordered topology mirror (with deterministic eviction) to answer `happens_before` during writer resolution and seeds it from persisted deltas on startup.
> 
> Updates runtime/SDK sync entrypoints and numerous call sites to use `ApplyContext::empty()` when no causal context exists, migrates the P3/P5 partition tests from storage to node, and adds new integration probes to prevent regressions in runtime-env vs direct datastore reads and end-to-end causal verification behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a323b597281f0b0129e6bfd6a3cfeb6f5cff01ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->