### PR TITLE
feat(sdk): forbid std collections in #[app::state] + add #[derive(Mer…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "calimero-prelude",
  "calimero-primitives",
  "calimero-sdk-macros",
+ "calimero-storage",
  "calimero-sys",
  "calimero-wasm-abi",
  "serde",

--- a/apps/abi_conformance/abi.expected.json
+++ b/apps/abi_conformance/abi.expected.json
@@ -12,8 +12,14 @@
               "kind": "string"
             },
             "value": {
-              "kind": "u32"
-            }
+              "kind": "record",
+              "fields": [],
+              "crdt_type": "lww_register",
+              "inner_type": {
+                "kind": "u32"
+              }
+            },
+            "crdt_type": "unordered_map"
           }
         },
         {
@@ -21,8 +27,14 @@
           "type": {
             "kind": "list",
             "items": {
-              "$ref": "UserId32"
-            }
+              "kind": "record",
+              "fields": [],
+              "crdt_type": "lww_register",
+              "inner_type": {
+                "$ref": "UserId32"
+              }
+            },
+            "crdt_type": "vector"
           }
         }
       ]

--- a/apps/abi_conformance/src/lib.rs
+++ b/apps/abi_conformance/src/lib.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::{Deserialize, Serialize};
+use calimero_storage::collections::{LwwRegister, UnorderedMap, Vector};
 use thiserror::Error;
 
 // Test multi-file ABI generation
@@ -104,13 +105,20 @@ pub enum Event {
     StructEvent { id: u32, name: String }, // Struct variant with multiple named fields
 }
 
-// State
+// State.
+//
+// Uses CRDT analogues of the previously-bare std types: `UnorderedMap` for the
+// map field and `Vector` for the list, with primitive values wrapped in
+// `LwwRegister` to satisfy the `V: Mergeable` bound. The full std-type matrix
+// is still exercised through the method signatures below — that's where ABI
+// generation actually has to handle them. State schemas are covered separately
+// by the `state-schema-conformance` app.
 #[app::state(emits = Event)]
-#[derive(Debug, PartialEq, Eq, PartialOrd, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct AbiState {
-    counters: BTreeMap<String, u32>, // map<string,u32>
-    users: Vec<UserId32>,            // list<UserId32>
+    counters: UnorderedMap<String, LwwRegister<u32>>,
+    users: Vector<LwwRegister<UserId32>>,
 }
 
 // Implementation
@@ -118,10 +126,10 @@ pub struct AbiState {
 impl AbiState {
     #[app::init]
     #[must_use]
-    pub const fn init() -> Self {
+    pub fn init() -> Self {
         Self {
-            counters: BTreeMap::new(),
-            users: Vec::new(),
+            counters: UnorderedMap::new_with_field_name("counters"),
+            users: Vector::new_with_field_name("users"),
         }
     }
 

--- a/apps/blobs/src/lib.rs
+++ b/apps/blobs/src/lib.rs
@@ -9,7 +9,7 @@
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::{app, env};
-use calimero_storage::collections::UnorderedMap;
+use calimero_storage::collections::{Counter, LwwRegister, UnorderedMap};
 
 // === CONSTANTS ===
 
@@ -101,37 +101,19 @@ pub struct FileRecord {
     pub uploaded_at: u64,
 }
 
-// Implement Mergeable for FileRecord
+// Manual `Mergeable` impl for `FileRecord` — opaque LWW per file ID.
 //
-// **Why is this needed?**
-// The auto-generated merge for FileShareState includes:
-//   self.files.merge(&other.files)?;
-//
-// UnorderedMap::merge() requires V: Mergeable, so FileRecord must implement it.
-//
-// **When is this actually called?**
-// - NOT on different files (DAG handles via element IDs)
-// - NOT on sequential updates (HLC provides ordering)
-// - ONLY on concurrent updates to the SAME file key (rare!)
-//
-// **What does it do?**
-// Simple LWW based on uploaded_at timestamp. For file uploads, this is correct
-// since uploads are atomic (you upload the whole file, not partial updates).
-//
-// **Could we avoid this?**
-// Yes! If FileShareState used proper CRDT types for root fields:
-//   owner: LwwRegister<String> instead of String
-//   file_counter: Counter instead of u64
-// Then this Mergeable impl wouldn't be needed at all - DAG would handle everything!
-//
-// See: crates/storage/DAG_VS_MERGE.md for full explanation
+// Why manual instead of `#[derive(Mergeable)]`? `FileRecord` is treated
+// atomically (one full record per file_id). Deriving would require every
+// inner field (`String`, `u64`, ...) to be Mergeable, forcing each to be
+// wrapped in `LwwRegister` / `Counter` — overkill for an immutable upload
+// record. The hand-rolled impl uses `uploaded_at` as the LWW tiebreaker,
+// which is correct for atomic uploads.
 impl calimero_storage::collections::Mergeable for FileRecord {
     fn merge(
         &mut self,
         other: &Self,
     ) -> Result<(), calimero_storage::collections::crdt_meta::MergeError> {
-        // Simple LWW: take the version with later uploaded_at timestamp
-        // This is correct for file uploads (atomic operations)
         if other.uploaded_at > self.uploaded_at {
             *self = other.clone();
         }
@@ -139,22 +121,21 @@ impl calimero_storage::collections::Mergeable for FileRecord {
     }
 }
 
-/// Application state for the file sharing system
+/// Application state for the file sharing system.
 #[app::state(emits = FileShareEvent)]
 #[derive(BorshDeserialize, BorshSerialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct FileShareState {
-    /// Context owner's identity as base58-encoded public key
-    /// Set during initialization from `env::executor_id()`
-    pub owner: String,
+    /// Context owner's identity as base58-encoded public key.
+    /// Set during initialization from `env::executor_id()`.
+    pub owner: LwwRegister<String>,
 
-    /// Map of file ID to file metadata records
-    /// Key: file ID (e.g., "file_0"), Value: FileRecord
+    /// Map of file ID to file metadata records.
+    /// Key: file ID (e.g., "file_0"), Value: FileRecord.
     pub files: UnorderedMap<String, FileRecord>,
 
-    /// Counter for generating unique file IDs
-    /// Incremented on each file upload
-    pub file_counter: u64,
+    /// Monotonic counter used to generate unique file IDs.
+    pub file_counter: Counter,
 }
 
 /// Events emitted by the application
@@ -195,9 +176,9 @@ impl FileShareState {
         app::log!("Initializing file sharing app for owner: {}", owner);
 
         FileShareState {
-            owner,
-            files: UnorderedMap::new(),
-            file_counter: 0,
+            owner: LwwRegister::new(owner),
+            files: UnorderedMap::new_with_field_name("files"),
+            file_counter: Counter::new_with_field_name("file_counter"),
         }
     }
 
@@ -225,8 +206,18 @@ impl FileShareState {
     ) -> Result<String, String> {
         let blob_id = parse_blob_id_base58(&blob_id_str)?;
 
-        let file_id = format!("file_{}", self.file_counter);
-        self.file_counter += 1;
+        // Counter is a monotonic CRDT — it converges across replicas (taking
+        // the per-source max on merge). Using its current value as the file ID
+        // means concurrent uploads on different nodes can still pick the same
+        // ID; that limitation existed with the previous bare `u64` too.
+        let next_id = self
+            .file_counter
+            .value()
+            .map_err(|e| format!("Failed to read file counter: {e:?}"))?;
+        let file_id = format!("file_{next_id}");
+        self.file_counter
+            .increment()
+            .map_err(|e| format!("Failed to increment file counter: {e:?}"))?;
 
         let uploader_id = env::executor_id();
         let uploader = encode_blob_id_base58(&uploader_id);
@@ -436,7 +427,10 @@ impl FileShareState {
              - Total files: {}\n\
              - Total storage: {:.2} MB ({} bytes)\n\
              - Owner: {}",
-            file_count, total_mb, total_size, self.owner
+            file_count,
+            total_mb,
+            total_size,
+            self.owner.get()
         ))
     }
 }

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -2,13 +2,14 @@
 
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::Counter;
 
 #[app::state(emits = Event)]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct XCallExample {
-    /// Counter for tracking pongs received
-    counter: u64,
+    /// Counter for tracking pongs received.
+    counter: Counter,
 }
 
 #[app::event]
@@ -26,7 +27,9 @@ pub enum Event {
 impl XCallExample {
     #[app::init]
     pub fn init() -> XCallExample {
-        XCallExample { counter: 0 }
+        XCallExample {
+            counter: Counter::new_with_field_name("counter"),
+        }
     }
 
     /// Send a ping to another context via cross-context call
@@ -84,8 +87,8 @@ impl XCallExample {
 
     /// Receive a pong from another context
     ///
-    /// This function is called via xcall from other contexts
-    /// It increments the counter when a pong is received
+    /// This function is called via xcall from other contexts.
+    /// It increments the counter when a pong is received.
     ///
     /// # Arguments
     /// * `from_context` - The 32-byte ID of the context sending the pong
@@ -98,30 +101,23 @@ impl XCallExample {
             from_context
         );
 
-        // Increment the counter
-        self.counter += 1;
+        self.counter.increment()?;
+        let counter = self.counter.value()?;
 
-        // Emit an event to notify that a pong was received
         app::emit!(Event::PongReceived {
             from_context,
-            counter: self.counter,
+            counter,
         });
 
-        app::log!("Pong received! Counter is now: {}", self.counter);
+        app::log!("Pong received! Counter is now: {}", counter);
 
         Ok(())
     }
 
     /// Get the current counter value
     pub fn get_counter(&self) -> app::Result<u64> {
-        app::log!("Getting counter value: {}", self.counter);
-        Ok(self.counter)
-    }
-
-    /// Reset the counter to zero
-    pub fn reset_counter(&mut self) -> app::Result<()> {
-        app::log!("Resetting counter");
-        self.counter = 0;
-        Ok(())
+        let value = self.counter.value()?;
+        app::log!("Getting counter value: {}", value);
+        Ok(value)
     }
 }

--- a/architecture/crates/sdk.html
+++ b/architecture/crates/sdk.html
@@ -364,7 +364,66 @@ app::emit!((Event::ItemSet { key: <span class="comment">"foo"</span>, value: <sp
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════
-     5. SAMPLE APPS
+     5. MERGEABLE STATE LINT
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>Mergeable State Lint</h2>
+<p style="margin-bottom:18px;">A compile-time check, applied by <span class="code">#[app::state]</span> and <span class="code">#[derive(Mergeable)]</span>, that rejects field types which cannot participate in CRDT merging. Without it, those fields silently fail to converge across replicas — the worst class of distributed-systems bug, because there is no error and no log line, just data that quietly disagrees.</p>
+
+<div class="cb" style="margin-bottom:18px;">
+  <h4 style="color:#ef4444;">The problem</h4>
+  <p style="margin-top:8px;">In Calimero, two nodes can independently update the same logical state and later sync. Convergence requires every persistent field to know how to merge with another copy of itself — that's the contract <span class="code">Mergeable</span> encodes. Std collections (<span class="code">HashMap</span>, <span class="code">BTreeMap</span>, <span class="code">Vec</span>, ...) and bare primitives (<span class="code">String</span>, <span class="code">u64</span>, ...) have no such contract; before this lint, they would compile fine, get persisted as opaque blobs, and silently diverge.</p>
+  <p style="margin-top:10px;">A particularly subtle variant: <span class="code">LwwRegister&lt;HashMap&lt;K, V&gt;&gt;</span>. The wrapper makes the whole field <span class="code">Mergeable</span>, so the type system accepts it — but merging happens at the <em>register</em> level (last-write-wins on the entire map), not at the <em>map entry</em> level. Two nodes inserting different keys concurrently will see one set of inserts win and the other vanish.</p>
+</div>
+
+<div class="cb" style="margin-bottom:18px;">
+  <h4 style="color:#10b981;">What the lint rejects</h4>
+  <p style="margin-top:8px;">Walking the AST of every field in a <span class="code">#[app::state]</span> struct (and every field of every <span class="code">#[derive(Mergeable)]</span> struct), recursing into generic arguments:</p>
+  <ul style="margin-top:10px; padding-left:20px;">
+    <li><strong>Forbidden anywhere in the type tree:</strong> <span class="code">HashMap</span>, <span class="code">BTreeMap</span>, <span class="code">HashSet</span>, <span class="code">BTreeSet</span>, <span class="code">LinkedList</span>, <span class="code">VecDeque</span>. These have no merge semantics at any depth — including inside <span class="code">LwwRegister&lt;_&gt;</span>.</li>
+    <li><strong>Forbidden at the field root only:</strong> bare <span class="code">Vec</span>, bare <span class="code">String</span>, bare primitives (<span class="code">u8..u128</span>, <span class="code">i8..i128</span>, <span class="code">f32</span>/<span class="code">f64</span>, <span class="code">bool</span>, <span class="code">char</span>). Inside CRDT collections their use is fine — e.g. <span class="code">UnorderedMap&lt;String, _&gt;</span> uses <span class="code">String</span> as a key, which is just bytes; only the value side has to be <span class="code">Mergeable</span>.</li>
+    <li><strong>Allowed transparently:</strong> <span class="code">Option&lt;T&gt;</span> and <span class="code">Box&lt;T&gt;</span> pass through to their inner type; the lint applies as if the wrapper weren't there.</li>
+  </ul>
+</div>
+
+<div class="cb" style="margin-bottom:18px;">
+  <h4 style="color:#f59e0b;">Example diagnostic</h4>
+  <div class="typedef" style="margin-top:10px; white-space:pre-wrap;">error: (calimero)&gt; `HashMap` is not allowed here — std collections are not CRDTs and would silently diverge across replicas. Use `UnorderedMap&lt;K, V&gt;` from `calimero_storage::collections` instead.
+
+       If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas.
+  --&gt; tests/compile_fail/state_hashmap_in_lww.rs:12:24
+   |
+12 |     items: LwwRegister&lt;HashMap&lt;String, String&gt;&gt;,
+   |                        ^^^^^^^</div>
+</div>
+
+<div class="cb" style="margin-bottom:18px;">
+  <h4 style="color:#6366f1;">#[derive(Mergeable)]</h4>
+  <p style="margin-top:8px;">Companion proc-macro for user-defined structs that need to live inside CRDT collections (<span class="code">UnorderedMap&lt;_, V&gt;</span>, <span class="code">Vector&lt;V&gt;</span>, ...). Runs the same field-level lint and generates a field-by-field <span class="code">Mergeable</span> impl that delegates to each field's own <span class="code">merge()</span>. Re-exported as <span class="code">calimero_sdk::app::Mergeable</span>.</p>
+  <div class="typedef" style="margin-top:10px;">
+<span class="kw">use</span> calimero_sdk::app::<span class="ty">Mergeable</span>;<br>
+<span class="kw">use</span> calimero_storage::collections::{<span class="ty">Counter</span>, <span class="ty">LwwRegister</span>};<br><br>
+<span class="kw">#[derive(Mergeable)]</span><br>
+<span class="kw">pub struct</span> <span class="ty">UserStats</span> {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">visits</span>: Counter,<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="field">name</span>: LwwRegister&lt;String&gt;,<br>
+}
+  </div>
+  <p style="margin-top:10px;">Enums are rejected by the derive — there is no canonical merge rule for "left side is <span class="code">VariantA</span>, right side is <span class="code">VariantB</span>". Wrap in <span class="code">LwwRegister&lt;MyEnum&gt;</span> for last-write-wins, or implement <span class="code">Mergeable</span> by hand.</p>
+</div>
+
+<div class="cb" style="margin-bottom:0;">
+  <h4 style="color:#ec4899;">Escape hatch</h4>
+  <p style="margin-top:8px;">There is no attribute opt-out. The only way to put a non-CRDT field in persistent state is to <em>not</em> use <span class="code">#[app::state]</span> / <span class="code">#[derive(Mergeable)]</span> and implement <span class="code">Mergeable</span> by hand. This is intentional: any non-CRDT field will not converge, and we want that decision to require explicit code, not a flag. The hand-rolled impl on <span class="code">FileRecord</span> in <span class="code">apps/blobs</span> is a worked example — atomic LWW on an <span class="code">uploaded_at</span> timestamp, justified inline.</p>
+</div>
+
+<div style="margin-top:14px; font-size:0.85em; color:#6b6b80;">
+  Implementation: <span class="code">crates/sdk/macros/src/forbidden_types.rs</span>. Negative tests: <span class="code">crates/sdk/tests/compile_fail/</span>. Originally landed in <a href="https://github.com/calimero-network/core/pull/2276" target="_blank" rel="noopener">PR #2276</a>.
+</div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     6. SAMPLE APPS
      ═══════════════════════════════════════════════════════════════════ -->
 <div class="card gd">
 <h2>Sample Apps</h2>

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -21,3 +21,4 @@ calimero-wasm-abi.workspace = true
 
 [dev-dependencies]
 trybuild.workspace = true
+calimero-storage.workspace = true

--- a/crates/sdk/macros/src/errors.rs
+++ b/crates/sdk/macros/src/errors.rs
@@ -86,6 +86,26 @@ pub enum ParseError<'a> {
     InitMethodWithoutInitAttribute,
     #[error("method annotated with `#[app::init]` must be named `init`")]
     AppInitMethodNotNamedInit,
+    #[error(
+        "`{type_name}` is not allowed here — std collections are not CRDTs and would silently \
+         diverge across replicas. Use `{suggestion}` from `calimero_storage::collections` instead.\n\n\
+         If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` \
+         and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas."
+    )]
+    ForbiddenStdCollection {
+        type_name: &'static str,
+        suggestion: &'static str,
+    },
+    #[error(
+        "bare `{type_name}` is not allowed as a mergeable field — it has no merge semantics and \
+         would silently diverge across replicas. Wrap it: `{suggestion}`.\n\n\
+         If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` \
+         and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas."
+    )]
+    ForbiddenBarePrimitive {
+        type_name: &'static str,
+        suggestion: &'static str,
+    },
 }
 
 impl AsRef<Self> for ParseError<'_> {

--- a/crates/sdk/macros/src/forbidden_types.rs
+++ b/crates/sdk/macros/src/forbidden_types.rs
@@ -237,4 +237,15 @@ mod tests {
         assert!(check(parse_quote!(MyCustomStruct)).is_none());
         assert!(check(parse_quote!(LwwRegister<MyCustomStruct>)).is_none());
     }
+
+    #[test]
+    fn box_is_pass_through() {
+        // `Box<T>` is in the lint's pass_through list — the inner type is what
+        // matters for merge semantics. The corresponding `Mergeable for Box<T>`
+        // impl in crates/storage/src/collections/crdt_impls.rs makes this honest.
+        assert!(check(parse_quote!(Box<Counter>)).is_none());
+        // Inner type is checked at the top level via pass-through.
+        assert!(check(parse_quote!(Box<String>)).is_some());
+        assert!(check(parse_quote!(Box<HashMap<String, String>>)).is_some());
+    }
 }

--- a/crates/sdk/macros/src/forbidden_types.rs
+++ b/crates/sdk/macros/src/forbidden_types.rs
@@ -1,0 +1,237 @@
+//! Shared compile-time check that rejects non-mergeable types in persistent state.
+//!
+//! Used by `#[app::state]` and `#[derive(Mergeable)]` to make sure every field
+//! either is a Calimero CRDT collection (or a `LwwRegister<T>` / `Option<T>` /
+//! user-derived `Mergeable` struct) — never a `std::collections::HashMap`, a
+//! bare `Vec`, a bare `String`, or a primitive. Without this check, those fields
+//! silently fail to merge and replicas drift apart.
+
+use syn::spanned::Spanned;
+use syn::{Fields, GenericArgument, PathArguments, Type};
+
+use crate::errors::{Errors, ParseError};
+
+/// Recursively validates the type of a single field. The `is_top_level` flag is
+/// true for the field's own type, false for anything reached via a generic
+/// argument or tuple element — the rules differ at the root vs. nested.
+pub fn validate_field_type<T>(ty: &Type, errors: &Errors<'_, T>, is_top_level: bool) {
+    match ty {
+        Type::Path(tp) => {
+            let Some(last) = tp.path.segments.last() else {
+                return;
+            };
+            let ident_str = last.ident.to_string();
+
+            if let Some(suggestion) = forbidden_std_collection(&ident_str) {
+                errors.subsume(syn::Error::new(
+                    last.ident.span(),
+                    ParseError::ForbiddenStdCollection {
+                        type_name: leak_str(ident_str.clone()),
+                        suggestion,
+                    },
+                ));
+            } else if is_top_level {
+                if let Some(suggestion) = forbidden_top_level_bare(&ident_str) {
+                    errors.subsume(syn::Error::new(
+                        last.ident.span(),
+                        ParseError::ForbiddenBarePrimitive {
+                            type_name: leak_str(ident_str.clone()),
+                            suggestion,
+                        },
+                    ));
+                }
+            }
+
+            // Wrappers that pass through to their inner type for top-level checks.
+            // `Option<T>` and `Box<T>` don't change merge semantics; the inner
+            // type is what carries them.
+            let pass_through = matches!(ident_str.as_str(), "Option" | "Box");
+
+            if let PathArguments::AngleBracketed(args) = &last.arguments {
+                for arg in &args.args {
+                    if let GenericArgument::Type(inner) = arg {
+                        validate_field_type(inner, errors, is_top_level && pass_through);
+                    }
+                }
+            }
+        }
+        Type::Tuple(t) => {
+            for elem in &t.elems {
+                validate_field_type(elem, errors, false);
+            }
+        }
+        Type::Array(t) => validate_field_type(&t.elem, errors, false),
+        Type::Group(g) => validate_field_type(&g.elem, errors, is_top_level),
+        Type::Paren(p) => validate_field_type(&p.elem, errors, is_top_level),
+        Type::Reference(r) => validate_field_type(&r.elem, errors, false),
+        _ => {}
+    }
+}
+
+/// Validate every field in a `Fields` block (struct or enum variant).
+pub fn validate_fields<T>(fields: &Fields, errors: &Errors<'_, T>) {
+    for field in fields.iter() {
+        validate_field_type(&field.ty, errors, true);
+    }
+}
+
+/// Std-collection types whose presence anywhere in a field's type is wrong:
+/// they would be persisted as opaque blobs with no merge semantics, even when
+/// nested inside an SDK wrapper like `LwwRegister<HashMap<...>>`.
+fn forbidden_std_collection(ident: &str) -> Option<&'static str> {
+    match ident {
+        "HashMap" => Some("UnorderedMap<K, V>"),
+        "BTreeMap" => Some("UnorderedMap<K, V>"),
+        "HashSet" => Some("UnorderedSet<T>"),
+        "BTreeSet" => Some("UnorderedSet<T>"),
+        "LinkedList" => Some("Vector<T>"),
+        "VecDeque" => Some("Vector<T>"),
+        _ => None,
+    }
+}
+
+/// Types that are illegal as the *root* of a field but may appear nested inside
+/// SDK wrappers (e.g. `UnorderedMap<String, _>` keeps `String` at depth 1, which
+/// is fine because the trait bound `V: Mergeable` constrains the value side).
+fn forbidden_top_level_bare(ident: &str) -> Option<&'static str> {
+    match ident {
+        "Vec" => Some("Vector<T>"),
+        "String" => Some("LwwRegister<String>"),
+        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64" | "i128"
+        | "isize" => Some("LwwRegister<T> for last-write-wins, or Counter for monotonic counters"),
+        "f32" | "f64" => Some("LwwRegister<T>"),
+        "bool" | "char" => Some("LwwRegister<T>"),
+        _ => None,
+    }
+}
+
+/// `ParseError` variants take `&'static str` (a thiserror constraint we share
+/// with the rest of the codebase). Field idents are owned `String`s, so we leak
+/// them — proc-macros are short-lived processes, the leak is bounded by the
+/// number of forbidden fields the user wrote. That's fine.
+fn leak_str(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
+/// Helper used by `Span::call_site()` callers when no concrete span is available.
+#[allow(dead_code)]
+pub fn span_for(ty: &Type) -> proc_macro2::Span {
+    ty.span()
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::*;
+    use crate::errors::Errors;
+
+    fn check(ty: Type) -> Option<String> {
+        let errors: Errors<'_> = Errors::default();
+        validate_field_type(&ty, &errors, true);
+        errors.take().map(|e| e.to_string())
+    }
+
+    #[test]
+    fn allowed_unordered_map() {
+        assert!(check(parse_quote!(UnorderedMap<String, LwwRegister<String>>)).is_none());
+    }
+
+    #[test]
+    fn allowed_vector_of_lww() {
+        assert!(check(parse_quote!(Vector<LwwRegister<u64>>)).is_none());
+    }
+
+    #[test]
+    fn allowed_counter() {
+        assert!(check(parse_quote!(Counter)).is_none());
+    }
+
+    #[test]
+    fn allowed_option_of_crdt() {
+        assert!(check(parse_quote!(Option<UnorderedMap<String, LwwRegister<String>>>)).is_none());
+    }
+
+    #[test]
+    fn rejects_top_level_string() {
+        let err = check(parse_quote!(String)).expect("should error");
+        assert!(err.contains("`String`"), "{err}");
+        assert!(err.contains("LwwRegister<String>"), "{err}");
+    }
+
+    #[test]
+    fn rejects_top_level_u64() {
+        let err = check(parse_quote!(u64)).expect("should error");
+        assert!(err.contains("`u64`"), "{err}");
+        assert!(err.contains("Counter"), "{err}");
+    }
+
+    #[test]
+    fn rejects_top_level_vec() {
+        let err = check(parse_quote!(Vec<u8>)).expect("should error");
+        assert!(err.contains("`Vec`"), "{err}");
+        assert!(err.contains("Vector<T>"), "{err}");
+    }
+
+    #[test]
+    fn rejects_hashmap_at_top_level() {
+        let err = check(parse_quote!(HashMap<String, String>)).expect("should error");
+        assert!(err.contains("`HashMap`"), "{err}");
+        assert!(err.contains("UnorderedMap"), "{err}");
+    }
+
+    #[test]
+    fn rejects_hashmap_via_full_path() {
+        let err =
+            check(parse_quote!(std::collections::HashMap<String, String>)).expect("should error");
+        assert!(err.contains("`HashMap`"), "{err}");
+    }
+
+    #[test]
+    fn rejects_btree_set_anywhere() {
+        let err = check(parse_quote!(LwwRegister<BTreeSet<u64>>)).expect("should error");
+        assert!(err.contains("`BTreeSet`"), "{err}");
+    }
+
+    #[test]
+    fn rejects_hashmap_inside_lww_register() {
+        // The blob-via-LwwRegister escape hatch is exactly the bug we're trying
+        // to catch: `LwwRegister<T>` makes the inner type Mergeable as a whole,
+        // so a HashMap inside would silently compile but never CRDT-merge.
+        let err = check(parse_quote!(LwwRegister<HashMap<String, u64>>)).expect("should error");
+        assert!(err.contains("`HashMap`"), "{err}");
+    }
+
+    #[test]
+    fn rejects_hashmap_inside_unordered_map_value() {
+        let err = check(parse_quote!(UnorderedMap<String, HashMap<String, u64>>))
+            .expect("should error");
+        assert!(err.contains("`HashMap`"), "{err}");
+    }
+
+    #[test]
+    fn rejects_vec_deque_and_linked_list() {
+        assert!(check(parse_quote!(VecDeque<u8>)).is_some());
+        assert!(check(parse_quote!(LinkedList<u8>)).is_some());
+    }
+
+    #[test]
+    fn allows_string_as_unordered_map_key() {
+        // Keys aren't mergeable — they're stored as bytes — so `String` at depth
+        // 1 inside `UnorderedMap` is fine. Only top-level bare `String` is wrong.
+        assert!(check(parse_quote!(UnorderedMap<String, LwwRegister<String>>)).is_none());
+    }
+
+    #[test]
+    fn rejects_bare_bool() {
+        assert!(check(parse_quote!(bool)).is_some());
+    }
+
+    #[test]
+    fn allows_user_struct_at_top_level() {
+        // Unknown idents are presumed to be user types; the trait bound on the
+        // collection ensures they implement Mergeable at the use site.
+        assert!(check(parse_quote!(MyCustomStruct)).is_none());
+        assert!(check(parse_quote!(LwwRegister<MyCustomStruct>)).is_none());
+    }
+}

--- a/crates/sdk/macros/src/forbidden_types.rs
+++ b/crates/sdk/macros/src/forbidden_types.rs
@@ -149,7 +149,10 @@ mod tests {
 
     #[test]
     fn allowed_option_of_crdt() {
-        assert!(check(parse_quote!(Option<UnorderedMap<String, LwwRegister<String>>>)).is_none());
+        assert!(check(parse_quote!(
+            Option<UnorderedMap<String, LwwRegister<String>>>
+        ))
+        .is_none());
     }
 
     #[test]
@@ -204,8 +207,8 @@ mod tests {
 
     #[test]
     fn rejects_hashmap_inside_unordered_map_value() {
-        let err = check(parse_quote!(UnorderedMap<String, HashMap<String, u64>>))
-            .expect("should error");
+        let err =
+            check(parse_quote!(UnorderedMap<String, HashMap<String, u64>>)).expect("should error");
         assert!(err.contains("`HashMap`"), "{err}");
     }
 

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -33,7 +33,7 @@ use macros::parse_macro_input;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
-use syn::{Expr, ItemImpl};
+use syn::{DeriveInput, Expr, ItemImpl};
 
 use crate::event::{EventImpl, EventImplInput};
 use crate::items::{Empty, StructOrEnumItem};
@@ -43,9 +43,11 @@ use crate::state::{StateArgs, StateImpl, StateImplInput};
 
 mod errors;
 mod event;
+mod forbidden_types;
 mod items;
 mod logic;
 mod macros;
+mod mergeable;
 mod migration;
 mod private;
 mod reserved;
@@ -312,6 +314,32 @@ pub fn bail(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as TokenStream2);
 
     quote!(::calimero_sdk::__bail__!(#input)).into()
+}
+
+/// Derives `Mergeable` for a user-defined struct so it can be used as a value
+/// inside Calimero CRDT collections (`UnorderedMap<_, V>`, `Vector<V>`, ...).
+///
+/// The derive applies the same forbidden-type lint as `#[app::state]` to every
+/// field — `std::collections::*`, bare `Vec`, bare `String`, and bare
+/// primitives are rejected because they have no merge semantics and would
+/// silently diverge across replicas. Use SDK CRDT types or `LwwRegister<T>`
+/// instead.
+///
+/// # Generated impl
+///
+/// `merge()` calls each field's own `Mergeable::merge()` in declaration order.
+/// Every field must therefore implement `Mergeable`. If you really need a
+/// non-CRDT field, skip the derive and implement `Mergeable` by hand.
+///
+/// # Limitations
+///
+/// Enums are rejected — there's no canonical way to merge values from
+/// different variants. Wrap in `LwwRegister<MyEnum>` for last-write-wins, or
+/// implement `Mergeable` by hand.
+#[proc_macro_derive(Mergeable)]
+pub fn derive_mergeable(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    mergeable::derive(input).into()
 }
 
 /// Logs a message to the runtime's logging system.

--- a/crates/sdk/macros/src/mergeable.rs
+++ b/crates/sdk/macros/src/mergeable.rs
@@ -1,0 +1,101 @@
+//! `#[derive(Mergeable)]` — opt-in derive for user-defined structs that need to
+//! participate in CRDT merging.
+//!
+//! Why a derive at all? `UnorderedMap<K, V>`, `Vector<V>` etc. require
+//! `V: Mergeable`. Without this derive, users would have to hand-roll the impl
+//! for every struct they want to put inside a Calimero collection — easy to get
+//! wrong, easy to silently merge incorrectly. The derive applies the same
+//! forbidden-type lint as `#[app::state]` recursively to each field, then
+//! generates a field-by-field `merge()` that delegates to each field's own
+//! `Mergeable` impl.
+
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{Data, DeriveInput, Fields};
+
+use crate::errors::Errors;
+use crate::forbidden_types::validate_fields;
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+    let errors = Errors::default();
+
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let merge_body: TokenStream = match &input.data {
+        Data::Struct(s) => {
+            validate_fields(&s.fields, &errors);
+            generate_struct_merge(&s.fields)
+        }
+        Data::Enum(_) => {
+            // Enum merge is ambiguous (different variants on each side — which
+            // wins?). Reject; users that need it can `impl Mergeable` by hand
+            // or wrap the enum in `LwwRegister<MyEnum>` for LWW semantics.
+            return quote_spanned! {input.ident.span()=>
+                ::core::compile_error!(
+                    "(calimero)> #[derive(Mergeable)] on enums is not supported — \
+                     enum variants have no canonical merge rule. Implement Mergeable manually \
+                     or wrap the enum in `LwwRegister<MyEnum>` for last-write-wins semantics."
+                );
+            };
+        }
+        Data::Union(_) => {
+            return quote_spanned! {input.ident.span()=>
+                ::core::compile_error!(
+                    "(calimero)> #[derive(Mergeable)] is not supported on unions"
+                );
+            };
+        }
+    };
+
+    if let Err(errs) = errors.check() {
+        return errs.to_compile_error();
+    }
+
+    quote! {
+        impl #impl_generics ::calimero_storage::collections::Mergeable
+            for #ident #ty_generics #where_clause
+        {
+            fn merge(
+                &mut self,
+                other: &Self,
+            ) -> ::core::result::Result<
+                (),
+                ::calimero_storage::collections::crdt_meta::MergeError,
+            > {
+                #merge_body
+                ::core::result::Result::Ok(())
+            }
+        }
+    }
+}
+
+fn generate_struct_merge(fields: &Fields) -> TokenStream {
+    match fields {
+        Fields::Named(named) => {
+            let calls = named.named.iter().map(|f| {
+                let name = f.ident.as_ref().expect("named field has ident");
+                quote! {
+                    ::calimero_storage::collections::Mergeable::merge(
+                        &mut self.#name,
+                        &other.#name,
+                    )?;
+                }
+            });
+            quote! { #(#calls)* }
+        }
+        Fields::Unnamed(unnamed) => {
+            let calls = unnamed.unnamed.iter().enumerate().map(|(i, _)| {
+                let idx = syn::Index::from(i);
+                quote! {
+                    ::calimero_storage::collections::Mergeable::merge(
+                        &mut self.#idx,
+                        &other.#idx,
+                    )?;
+                }
+            });
+            quote! { #(#calls)* }
+        }
+        Fields::Unit => quote! {},
+    }
+}

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -345,68 +345,47 @@ fn generate_mergeable_impl(
         }
     };
 
-    // Generate merge calls for each field
-    // Only merge fields that are known CRDT types
+    // Call merge on every field. The forbidden-type lint above guarantees
+    // each field is either an SDK CRDT, an `Option<T>` / `Box<T>` of one, or a
+    // user struct that derives / implements Mergeable. If a user manages to
+    // smuggle in a non-Mergeable type, the trait bound below produces a clean
+    // compile error pointing at that field — much better than the silent skip
+    // this code used to do (which lost concurrent updates with no diagnostic).
     let merge_calls: Vec<_> = fields
         .iter()
         .enumerate()
-        .filter_map(|(idx, field)| {
-            let field_type = &field.ty;
-
-            // Check if this is a known CRDT type by examining the type path
-            let type_str = quote! { #field_type }.to_string();
-
-            // Only generate merge for CRDT collections
-            // Non-CRDT fields (String, u64, etc.) are handled by storage layer's LWW
-            let is_crdt = type_str.contains("UnorderedMap")
-                || type_str.contains("Vector")
-                || type_str.contains("UnorderedSet")
-                || type_str.contains("Counter")
-                || type_str.contains("ReplicatedGrowableArray")
-                || type_str.contains("LwwRegister")
-                || type_str.contains("UserStorage")
-                || type_str.contains("FrozenStorage")
-                || type_str.contains("SharedStorage");
-
-            if !is_crdt {
-                // Skip non-CRDT fields
-                return None;
-            }
-
-            // Handle both named fields and tuple struct fields
+        .map(|(idx, field)| {
             if let Some(field_name) = &field.ident {
-                // Named field
-                Some(quote! {
+                quote! {
                     ::calimero_storage::collections::Mergeable::merge(
                         &mut self.#field_name,
-                        &other.#field_name
+                        &other.#field_name,
                     ).map_err(|e| {
                         ::calimero_storage::collections::crdt_meta::MergeError::StorageError(
-                            format!(
+                            ::std::format!(
                                 "Failed to merge field '{}': {:?}",
-                                stringify!(#field_name),
+                                ::core::stringify!(#field_name),
                                 e
                             )
                         )
                     })?;
-                })
+                }
             } else {
-                // Tuple struct field
                 let field_index = syn::Index::from(idx);
-                Some(quote! {
+                quote! {
                     ::calimero_storage::collections::Mergeable::merge(
                         &mut self.#field_index,
-                        &other.#field_index
+                        &other.#field_index,
                     ).map_err(|e| {
                         ::calimero_storage::collections::crdt_meta::MergeError::StorageError(
-                            format!(
+                            ::std::format!(
                                 "Failed to merge field {}: {:?}",
                                 #idx,
                                 e
                             )
                         )
                     })?;
-                })
+                }
             }
         })
         .collect();
@@ -425,14 +404,13 @@ fn generate_mergeable_impl(
         //
         // Performance:
         // - Local ops: O(1) - this is NOT called
-        // - Remote sync: O(N) where N = number of CRDT fields (typically 3-10)
-        // - Happens during network sync (already slow), so overhead is negligible
+        // - Remote sync: O(N) where N = number of state fields
         //
         // What it does:
-        // - Merges each CRDT field (Map, Counter, RGA, etc.)
-        // - Skips non-CRDT fields (String, u64, etc.) - handled by storage LWW
-        // - Recursive merging for nested CRDTs
-        // - Guarantees no divergence!
+        // - Calls Mergeable::merge on every field. The forbidden-type lint
+        //   guarantees every field implements Mergeable (CRDT collection,
+        //   LwwRegister, Option/Box of same, or user struct deriving Mergeable).
+        // - Recursive: each field's merge handles its own subtree.
         //
         impl #impl_generics ::calimero_storage::collections::Mergeable for #ident #ty_generics #where_clause {
             fn merge(&mut self, other: &Self)
@@ -557,6 +535,71 @@ fn generate_assign_deterministic_ids_impl(
             pub fn __assign_deterministic_ids(&mut self) {
                 #(#reassign_calls)*
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::*;
+
+    /// Helper: render the merge body for a given struct definition.
+    fn render_merge(item: syn::ItemStruct) -> String {
+        let ident = item.ident.clone();
+        let generics = item.generics.clone();
+        let orig = StructOrEnumItem::Struct(item);
+        generate_mergeable_impl(&ident, &generics, &orig).to_string()
+    }
+
+    /// Regression: the generator used to skip any field whose type string
+    /// didn't contain a hardcoded CRDT name (UnorderedMap, Counter, ...). User
+    /// types with their own `Mergeable` impl — including those produced by
+    /// `#[derive(Mergeable)]` — would silently fall through, dropping all
+    /// concurrent updates to those fields with no diagnostic. Today every
+    /// field gets a merge call; the trait bound enforces correctness.
+    #[test]
+    fn merge_impl_calls_every_field_including_user_types() {
+        let item: syn::ItemStruct = parse_quote! {
+            pub struct AppRoot {
+                pub counter: Counter,
+                pub user: UserDerivedStruct,
+                pub items: UnorderedMap<String, LwwRegister<String>>,
+            }
+        };
+
+        let rendered = render_merge(item);
+
+        for field in ["counter", "user", "items"] {
+            let needle = format!("self . {field}");
+            assert!(
+                rendered.contains(&needle),
+                "expected merge call referencing `self.{field}` in:\n{rendered}",
+            );
+        }
+        assert_eq!(
+            rendered
+                .matches(":: calimero_storage :: collections :: Mergeable :: merge")
+                .count(),
+            3,
+            "expected exactly one merge call per field in:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn merge_impl_handles_tuple_struct_fields() {
+        let item: syn::ItemStruct = parse_quote! {
+            pub struct Wrap(pub Counter, pub UserDerivedStruct);
+        };
+
+        let rendered = render_merge(item);
+
+        for index in ["self . 0", "self . 1"] {
+            assert!(
+                rendered.contains(index),
+                "expected merge call referencing `{index}` in:\n{rendered}",
+            );
         }
     }
 }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -7,6 +7,7 @@ use syn::{
 };
 
 use crate::errors::{Errors, ParseError, Pretty};
+use crate::forbidden_types::validate_fields;
 use crate::items::StructOrEnumItem;
 use crate::macros::infallible;
 use crate::reserved::idents;
@@ -300,6 +301,17 @@ impl<'a> TryFrom<StateImplInput<'a>> for StateImpl<'a> {
                     }
                 }
                 GenericParam::Const(_) => {}
+            }
+        }
+
+        match input.item {
+            StructOrEnumItem::Struct(item) => {
+                validate_fields(&item.fields, &errors);
+            }
+            StructOrEnumItem::Enum(item) => {
+                for variant in &item.variants {
+                    validate_fields(&variant.fields, &errors);
+                }
             }
         }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -32,7 +32,7 @@ pub mod app {
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
     pub use calimero_sdk_macros::{
-        bail, destroy, emit, err, event, init, log, logic, migrate, private, state,
+        bail, destroy, emit, err, event, init, log, logic, migrate, private, state, Mergeable,
     };
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -41,7 +41,3 @@ pub mod __private {
     pub use crate::returns::{IntoResult, WrappedReturn};
 }
 
-#[cfg(test)]
-mod integration_tests_package_usage {
-    use trybuild as _;
-}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -40,4 +40,3 @@ pub mod app {
 pub mod __private {
     pub use crate::returns::{IntoResult, WrappedReturn};
 }
-

--- a/crates/sdk/tests/compile_fail.rs
+++ b/crates/sdk/tests/compile_fail.rs
@@ -1,0 +1,18 @@
+//! Negative tests for the `#[app::state]` and `#[derive(Mergeable)]` lints.
+//!
+//! Each `tests/compile_fail/*.rs` is a tiny crate that *should fail* to
+//! compile because it triggers the forbidden-type lint. The matching
+//! `*.stderr` file captures the expected error output. To regenerate after
+//! intentional message changes, run:
+//!
+//!     TRYBUILD=overwrite cargo test --test compile_fail
+//!
+//! Coverage is intentionally narrow: one rejection path per file. If you add
+//! a new lint case, add a focused test here so the failure mode stays
+//! discoverable in review.
+
+#[test]
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/crates/sdk/tests/compile_fail/derive_mergeable_enum.rs
+++ b/crates/sdk/tests/compile_fail/derive_mergeable_enum.rs
@@ -1,0 +1,13 @@
+// Rejection: `#[derive(Mergeable)]` on an enum. Variants have no canonical
+// merge rule; users should wrap in `LwwRegister<MyEnum>` or impl manually.
+
+use calimero_sdk::app::Mergeable;
+use calimero_storage::collections::Counter;
+
+#[derive(Mergeable)]
+pub enum BadEnum {
+    Empty,
+    Counted(Counter),
+}
+
+fn main() {}

--- a/crates/sdk/tests/compile_fail/derive_mergeable_enum.stderr
+++ b/crates/sdk/tests/compile_fail/derive_mergeable_enum.stderr
@@ -1,0 +1,5 @@
+error: (calimero)> #[derive(Mergeable)] on enums is not supported — enum variants have no canonical merge rule. Implement Mergeable manually or wrap the enum in `LwwRegister<MyEnum>` for last-write-wins semantics.
+ --> tests/compile_fail/derive_mergeable_enum.rs:8:10
+  |
+8 | pub enum BadEnum {
+  |          ^^^^^^^

--- a/crates/sdk/tests/compile_fail/derive_mergeable_hashmap.rs
+++ b/crates/sdk/tests/compile_fail/derive_mergeable_hashmap.rs
@@ -1,0 +1,13 @@
+// Rejection: `#[derive(Mergeable)]` on a struct with a `HashMap` field. The
+// derive applies the same lint as `#[app::state]`.
+
+use std::collections::HashMap;
+
+use calimero_sdk::app::Mergeable;
+
+#[derive(Mergeable)]
+pub struct BadStruct {
+    items: HashMap<String, String>,
+}
+
+fn main() {}

--- a/crates/sdk/tests/compile_fail/derive_mergeable_hashmap.stderr
+++ b/crates/sdk/tests/compile_fail/derive_mergeable_hashmap.stderr
@@ -1,0 +1,7 @@
+error: (calimero)> `HashMap` is not allowed here — std collections are not CRDTs and would silently diverge across replicas. Use `UnorderedMap<K, V>` from `calimero_storage::collections` instead.
+
+       If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas.
+  --> tests/compile_fail/derive_mergeable_hashmap.rs:10:12
+   |
+10 |     items: HashMap<String, String>,
+   |            ^^^^^^^

--- a/crates/sdk/tests/compile_fail/state_bare_primitive.rs
+++ b/crates/sdk/tests/compile_fail/state_bare_primitive.rs
@@ -1,0 +1,11 @@
+// Rejection: bare `u64` as a state field — primitives aren't Mergeable.
+// Suggestion should point at `Counter` (or `LwwRegister<T>`).
+
+use calimero_sdk::app;
+
+#[app::state]
+pub struct BadState {
+    count: u64,
+}
+
+fn main() {}

--- a/crates/sdk/tests/compile_fail/state_bare_primitive.stderr
+++ b/crates/sdk/tests/compile_fail/state_bare_primitive.stderr
@@ -1,0 +1,7 @@
+error: (calimero)> bare `u64` is not allowed as a mergeable field — it has no merge semantics and would silently diverge across replicas. Wrap it: `LwwRegister<T> for last-write-wins, or Counter for monotonic counters`.
+
+       If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas.
+ --> tests/compile_fail/state_bare_primitive.rs:8:12
+  |
+8 |     count: u64,
+  |            ^^^

--- a/crates/sdk/tests/compile_fail/state_bare_string.rs
+++ b/crates/sdk/tests/compile_fail/state_bare_string.rs
@@ -1,0 +1,10 @@
+// Rejection: bare `String` as a state field — has no merge semantics.
+
+use calimero_sdk::app;
+
+#[app::state]
+pub struct BadState {
+    name: String,
+}
+
+fn main() {}

--- a/crates/sdk/tests/compile_fail/state_bare_string.stderr
+++ b/crates/sdk/tests/compile_fail/state_bare_string.stderr
@@ -1,0 +1,7 @@
+error: (calimero)> bare `String` is not allowed as a mergeable field — it has no merge semantics and would silently diverge across replicas. Wrap it: `LwwRegister<String>`.
+
+       If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas.
+ --> tests/compile_fail/state_bare_string.rs:7:11
+  |
+7 |     name: String,
+  |           ^^^^^^

--- a/crates/sdk/tests/compile_fail/state_hashmap_field.rs
+++ b/crates/sdk/tests/compile_fail/state_hashmap_field.rs
@@ -1,0 +1,12 @@
+// Rejection: `HashMap` as a state field — std collections aren't CRDTs.
+
+use std::collections::HashMap;
+
+use calimero_sdk::app;
+
+#[app::state]
+pub struct BadState {
+    items: HashMap<String, String>,
+}
+
+fn main() {}

--- a/crates/sdk/tests/compile_fail/state_hashmap_field.stderr
+++ b/crates/sdk/tests/compile_fail/state_hashmap_field.stderr
@@ -1,0 +1,7 @@
+error: (calimero)> `HashMap` is not allowed here — std collections are not CRDTs and would silently diverge across replicas. Use `UnorderedMap<K, V>` from `calimero_storage::collections` instead.
+
+       If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas.
+ --> tests/compile_fail/state_hashmap_field.rs:9:12
+  |
+9 |     items: HashMap<String, String>,
+  |            ^^^^^^^

--- a/crates/sdk/tests/compile_fail/state_hashmap_in_lww.rs
+++ b/crates/sdk/tests/compile_fail/state_hashmap_in_lww.rs
@@ -1,0 +1,15 @@
+// Rejection: `HashMap` smuggled inside `LwwRegister` — would compile-and-blob
+// without the lint, defeating CRDT merge semantics. This is the exact bug
+// pattern the lint is designed to catch.
+
+use std::collections::HashMap;
+
+use calimero_sdk::app;
+use calimero_storage::collections::LwwRegister;
+
+#[app::state]
+pub struct BadState {
+    items: LwwRegister<HashMap<String, String>>,
+}
+
+fn main() {}

--- a/crates/sdk/tests/compile_fail/state_hashmap_in_lww.stderr
+++ b/crates/sdk/tests/compile_fail/state_hashmap_in_lww.stderr
@@ -1,0 +1,7 @@
+error: (calimero)> `HashMap` is not allowed here — std collections are not CRDTs and would silently diverge across replicas. Use `UnorderedMap<K, V>` from `calimero_storage::collections` instead.
+
+       If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` and implement `Mergeable` by hand — but understand that any non-CRDT field will not converge across replicas.
+  --> tests/compile_fail/state_hashmap_in_lww.rs:12:24
+   |
+12 |     items: LwwRegister<HashMap<String, String>>,
+   |                        ^^^^^^^

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -77,6 +77,17 @@ impl<T: Mergeable + Clone> Mergeable for Option<T> {
     }
 }
 
+// `Box<T>` is just heap indirection — merge semantics are unchanged from `T`.
+// Without this impl, the `#[app::state]` lint would let `Box<Counter>` fields
+// through (`Box` is in the lint's pass-through list) only for the trait bound
+// to fail later with an unhelpful diagnostic. Trivial delegation makes the
+// claim honest.
+impl<T: Mergeable> Mergeable for Box<T> {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        (**self).merge(&**other)
+    }
+}
+
 // ============================================================================
 // LwwRegister
 // ============================================================================

--- a/crates/storage/tests/derive_mergeable.rs
+++ b/crates/storage/tests/derive_mergeable.rs
@@ -68,3 +68,26 @@ fn derive_supports_unit_structs() {
 // Regression coverage for the silent-skip bug in `#[app::state]`'s generated
 // merge lives in `crates/sdk/macros/src/state.rs::tests` (the generator is a
 // private function and easier to inspect directly via TokenStream).
+
+#[derive(Mergeable)]
+struct BoxedField {
+    boxed_counter: Box<Counter>,
+}
+
+#[test]
+fn box_delegates_merge_to_inner() {
+    // Sanity check that `Mergeable for Box<T>` actually composes with the
+    // derive — the lint's `pass_through` list claims Box is OK at the type
+    // level, this confirms the impl exists and merges field-by-field.
+    let mut a = BoxedField {
+        boxed_counter: Box::new(Counter::new()),
+    };
+    let mut b = BoxedField {
+        boxed_counter: Box::new(Counter::new()),
+    };
+    b.boxed_counter.increment().unwrap();
+
+    a.merge(&b).unwrap();
+
+    assert!(a.boxed_counter.value().unwrap() >= 1);
+}

--- a/crates/storage/tests/derive_mergeable.rs
+++ b/crates/storage/tests/derive_mergeable.rs
@@ -1,0 +1,66 @@
+//! End-to-end coverage for the `#[derive(Mergeable)]` proc-macro.
+//!
+//! Lives under `tests/` because the derive lands in `calimero-sdk-macros`
+//! (re-exported via `calimero-sdk::app::Mergeable`) but emits paths into
+//! `calimero-storage`. The integration test binary links both crates and
+//! verifies the generated impl actually merges field-by-field.
+
+use calimero_sdk::app::Mergeable;
+use calimero_storage::collections::{Counter, LwwRegister, Mergeable as _};
+
+#[derive(Mergeable)]
+struct UserStats {
+    visits: Counter,
+    name: LwwRegister<String>,
+}
+
+#[test]
+fn derive_emits_field_by_field_merge() {
+    let mut a = UserStats {
+        visits: Counter::new(),
+        name: LwwRegister::new("alice".to_owned()),
+    };
+    a.visits.increment().unwrap();
+
+    let mut b = UserStats {
+        visits: Counter::new(),
+        name: LwwRegister::new("bob".to_owned()),
+    };
+    b.visits.increment().unwrap();
+    b.visits.increment().unwrap();
+
+    a.merge(&b).unwrap();
+
+    // Counter takes max-per-executor, so after merge the visible total covers
+    // each replica's local count.
+    let total = a.visits.value().unwrap();
+    assert!(
+        total >= 2,
+        "merged counter should reflect at least b's contribution, got {total}"
+    );
+}
+
+#[derive(Mergeable)]
+struct TupleWrapper(LwwRegister<u64>, Counter);
+
+#[test]
+fn derive_supports_tuple_structs() {
+    let mut a = TupleWrapper(LwwRegister::new(1), Counter::new());
+    let mut b = TupleWrapper(LwwRegister::new(2), Counter::new());
+    b.1.increment().unwrap();
+    b.1.increment().unwrap();
+
+    a.merge(&b).unwrap();
+
+    assert!(a.1.value().unwrap() >= 2);
+}
+
+#[derive(Mergeable)]
+struct EmptyMarker;
+
+#[test]
+fn derive_supports_unit_structs() {
+    let mut a = EmptyMarker;
+    let b = EmptyMarker;
+    a.merge(&b).unwrap();
+}

--- a/crates/storage/tests/derive_mergeable.rs
+++ b/crates/storage/tests/derive_mergeable.rs
@@ -64,3 +64,7 @@ fn derive_supports_unit_structs() {
     let b = EmptyMarker;
     a.merge(&b).unwrap();
 }
+
+// Regression coverage for the silent-skip bug in `#[app::state]`'s generated
+// merge lives in `crates/sdk/macros/src/state.rs::tests` (the generator is a
+// private function and easier to inspect directly via TokenStream).

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -85,6 +85,19 @@
         }
       }
     },
+    "CrdtType": {
+      "type": "string",
+      "enum": [
+        "lww_register",
+        "counter",
+        "vector",
+        "unordered_map",
+        "authored_map",
+        "unordered_set",
+        "replicated_growable_array",
+        "authored_vector"
+      ]
+    },
     "CollectionType": {
       "oneOf": [
         {
@@ -97,6 +110,9 @@
             },
             "items": {
               "$ref": "#/definitions/TypeRef"
+            },
+            "crdt_type": {
+              "$ref": "#/definitions/CrdtType"
             }
           }
         },
@@ -113,6 +129,9 @@
             },
             "value": {
               "$ref": "#/definitions/TypeRef"
+            },
+            "crdt_type": {
+              "$ref": "#/definitions/CrdtType"
             }
           }
         },
@@ -129,6 +148,12 @@
               "items": {
                 "$ref": "#/definitions/Field"
               }
+            },
+            "crdt_type": {
+              "$ref": "#/definitions/CrdtType"
+            },
+            "inner_type": {
+              "$ref": "#/definitions/TypeRef"
             }
           }
         }


### PR DESCRIPTION
…geable)]

Std collections, bare `Vec`, bare `String`, and bare primitives in app state have no merge semantics — when two replicas update them concurrently, the auto-generated `Mergeable` impl skips the field, replicas silently diverge, and the bug is invisible until users notice missing data.

This change makes that bug a compile error.

* `#[app::state]`: fields are validated against a forbidden-type list (HashMap, BTreeMap, HashSet, BTreeSet, LinkedList, VecDeque anywhere in the type tree; bare Vec/String/primitives at the field root). Suggests the SDK replacement (`UnorderedMap`, `LwwRegister<T>`, `Counter`, ...). No `allow_std` opt-out — the lint is absolute.

* `#[derive(Mergeable)]`: new proc-macro on `calimero_sdk::app::Mergeable` for user-defined structs that need to live inside CRDT collections. Runs the same lint and generates a field-by-field `Mergeable` impl. Enums are rejected (no canonical merge rule); users wrap in `LwwRegister<MyEnum>` or hand-roll the impl.

* Existing example apps that relied on bare std types are migrated to proper CRDT types: `xcall-example` uses `Counter`, `blobs` uses `LwwRegister<String>` + `Counter`, `abi_conformance` uses `UnorderedMap<_, LwwRegister<_>>` + `Vector<LwwRegister<_>>`. The full std-type ABI matrix is still exercised through method signatures.

Tests: 16 new unit tests in `forbidden_types::tests` covering allow/reject across nested generics; 3 integration tests in
`crates/storage/tests/derive_mergeable.rs` proving the generated impl merges field-by-field on named, tuple, and unit structs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core `#[app::state]` macro behavior (now rejecting previously-valid field types and changing generated merge logic to merge all fields), which is a breaking change that can surface across many downstream apps at compile time and alter sync convergence behavior.
> 
> **Overview**
> **SDK macros now enforce mergeable persistent state.** `#[app::state]` adds a recursive forbidden-type lint that rejects std collections anywhere in the type tree and rejects bare `Vec`/`String`/primitives at the field root, emitting actionable diagnostics; the generated state `Mergeable` impl is updated to *merge every field* (no more silent skipping).
> 
> **New `#[derive(Mergeable)]` proc-macro** is added and re-exported via `calimero_sdk::app::Mergeable`, generating field-by-field `Mergeable` impls for user structs (enums/unions rejected) and sharing the same lint rules.
> 
> **Example apps and ABI/schema updated** to use CRDT types in state (`UnorderedMap`/`Vector` + `LwwRegister`, `Counter`), `calimero-sdk` adds `calimero-storage` dev-dependency plus `trybuild` compile-fail tests, storage adds `Mergeable for Box<T>`, and the WASM ABI schema/expected ABI is extended with `crdt_type` metadata for collection/register types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit defdbd2f72f580a553394e86cb066db7cea3b0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->