### PR TITLE
chore: bump 0.10.1 rc.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.32"
+version = "0.10.1-rc.33"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
Cuts rc.33 off latest master (HEAD `b11520ed feat(node): wire DAG-causal Shared verifier through WASM ABI`).

Bumps `[workspace.metadata.workspaces].version` from `0.10.1-rc.32` to `0.10.1-rc.33` in `Cargo.toml`. No other changes.

## Test plan

- [ ] CI passes (build + tests + ABI verify all unchanged from master)
- [ ] On merge, the release workflow tags `0.10.1-rc.33` and publishes the usual artifacts (binaries, docker, homebrew formulas)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-metadata-only change; it just updates the workspace version string and should not affect build output beyond versioning/publishing.
> 
> **Overview**
> Bumps `[workspace.metadata.workspaces].version` in `Cargo.toml` from `0.10.1-rc.32` to `0.10.1-rc.33` to cut the next release candidate. No functional code changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad7f8d4ed9e1ed2ba9b44104005dfac8b4fe0c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->