### PR TITLE
feat(governance): leave_context + leave_group + leave_namespace + Owner role

### DIFF
--- a/architecture/index.html
+++ b/architecture/index.html
@@ -173,7 +173,7 @@
   </div>
   <div>
     <h3>Namespace &amp; Group</h3>
-    <p>A <strong>namespace</strong> is a root group that serves as the application boundary and identity scope. Each namespace gets its own Ed25519 keypair. Groups within a namespace share a <strong>single governance DAG</strong> with cleartext RootOps and encrypted GroupOps. Membership, capabilities, and access control propagate via gossipsub.</p>
+    <p>A <strong>namespace</strong> is a root group that serves as the application boundary and identity scope. Each namespace gets its own Ed25519 keypair. Groups within a namespace share a <strong>single governance DAG</strong> with cleartext RootOps and encrypted GroupOps. Membership, capabilities, and access control propagate via gossipsub. See <a href="membership-and-leave.html">Membership &amp; Leave</a> for the leave operations and Owner role design, and <a href="auto-follow.html">Auto-Follow</a> for opt-in context auto-join.</p>
   </div>
   <div>
     <h3>State Sync</h3>

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -1,0 +1,532 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Membership &amp; Leave Operations — Calimero Core Architecture</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="main">
+<div class="content">
+<div class="breadcrumb"><a href="index.html">Home</a><span class="sep">/</span><span>Membership &amp; Leave</span></div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     1. TITLE + STATS
+     ═══════════════════════════════════════════════════════════════════ -->
+<h1>Membership &amp; <em>Leave Operations</em></h1>
+<p class="page-subtitle">Voluntary leave and Owner role across namespaces, groups, and contexts</p>
+
+<div class="g4" style="margin-bottom:36px;">
+  <div class="stat"><div class="v">3 leaves</div><div class="l">context · group · namespace</div></div>
+  <div class="stat"><div class="v">1 op</div><div class="l">TransferOwnership</div></div>
+  <div class="stat"><div class="v">Direct</div><div class="l">leave deletes a row</div></div>
+  <div class="stat"><div class="v">Owner≠Admin</div><div class="l">exclusive role</div></div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     2. PROBLEM &amp; MOTIVATION
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card ga">
+<h2>Problem</h2>
+<p>
+Today, the only way out of a Calimero group or namespace is to be removed by an admin —
+<code>MemberRemoved</code> is admin-initiated and there is no self-leave op. Users cannot
+voluntarily exit a workspace they joined; muting a context they're auto-followed into requires
+client-side filtering rather than a real opt-out, because auto-follow re-adds them on the next
+<code>ContextRegistered</code> event.
+</p>
+<p>
+Separately, every group already records a single "creator / fallback admin" identity
+(<code>GroupMetaValue.admin_identity</code>) but no role distinguishes that creator from any other
+admin. There is no way to express "this person owns the group, others administrate it" — admins
+can demote each other, kick each other, and leave a group ownerless. There is no
+<code>TransferOwnership</code> op to designate a successor.
+</p>
+<p>
+This page proposes three new leave operations and formalizes Owner as a real, exclusive,
+transferable role distinct from Admin. The four pieces share infrastructure: Owner blocks
+<code>leave_group</code>/<code>leave_namespace</code>; leave operations reuse the existing
+<code>MemberRemoved</code> key-rotation pipeline; <code>leave_namespace</code> is
+<code>leave_group</code> plus the cascade handler.
+</p>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     3. MEMBERSHIP MODEL RECAP
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gb">
+<h2>Membership Model Recap</h2>
+<p>
+Background on the data shapes the leave operations operate over. Names match the code as it
+exists today.
+</p>
+
+<h3>Hierarchy</h3>
+<ul>
+  <li><b>Namespace.</b> A <code>ContextGroupId</code> with no parent. The trust anchor for everything
+  beneath it. There is no separate <code>Namespace</code> type — a namespace is a root group.</li>
+  <li><b>Group / subgroup.</b> A <code>ContextGroup</code> with a <code>parent_group_id</code>.
+  Forms a strict tree under a single namespace.</li>
+  <li><b>Context.</b> A unit of replicated state. Belongs to exactly one group via
+  <code>ContextGroupRef</code>. Members of the group can join, sync, and write to it.</li>
+</ul>
+
+<h3>Direct vs inherited membership</h3>
+<p>
+Group membership is computed by <code>check_group_membership_path</code>
+(<code>crates/context/src/group_store/membership.rs:217-291</code>):
+</p>
+<ul>
+  <li><b>Direct membership</b> = a stored <code>(member, group)</code> row exists. Created by
+  <code>add_group_members</code> (explicit invitation). Required for Restricted groups; possible
+  but redundant for Open subgroups.</li>
+  <li><b>Inherited membership</b> = no row exists; the walker concludes membership by walking the
+  parent chain through Open subgroups when the member holds the
+  <code>CAN_JOIN_OPEN_SUBGROUPS</code> capability in the parent.</li>
+</ul>
+<p>
+This distinction is critical for leave operations. <b>Leave deletes a direct row.</b> If the only
+path to membership is inheritance, there is no row to delete — the member must leave whichever
+ancestor provides the inheritance.
+</p>
+
+<h3>Visibility (Open vs Restricted)</h3>
+<p>
+A per-group flag (<code>VisibilityMode::{Open, Restricted}</code> in
+<code>crates/context/config/src/lib.rs:134-137</code>) that controls whether the parent-walk
+inherits into this subgroup or stops cold:
+</p>
+<ul>
+  <li><b>Open</b>: parent members with <code>CAN_JOIN_OPEN_SUBGROUPS</code> inherit membership.</li>
+  <li><b>Restricted</b>: walks halt; only direct invitations admit members.</li>
+</ul>
+<p>
+At leave-time, visibility doesn't change behavior — it only affects whether a row exists in the
+first place. Most members of Open subgroups have no row (inherited); most members of Restricted
+subgroups have one (direct invite).
+</p>
+
+<h3>Roles &amp; capabilities</h3>
+<p>
+Roles defined in <code>crates/primitives/src/context.rs:253-265</code>:
+</p>
+<ul>
+  <li><code>Admin</code>, <code>Member</code>, <code>ReadOnly</code>, <code>ReadOnlyTee</code>.</li>
+  <li>This proposal adds <code>Owner</code> as a fifth role — exactly one per group, transferable.</li>
+</ul>
+<p>
+Per-member capability bits (<code>crates/context/config/src/lib.rs:144-156</code>):
+</p>
+<ul>
+  <li><code>CAN_CREATE_CONTEXT</code>, <code>CAN_INVITE_MEMBERS</code>,
+  <code>CAN_JOIN_OPEN_SUBGROUPS</code>, <code>MANAGE_MEMBERS</code>,
+  <code>MANAGE_APPLICATION</code>.</li>
+</ul>
+
+<h3>Existing protections</h3>
+<ul>
+  <li><b>Last-admin protection</b> (<code>membership_policy.rs:39-46</code>):
+  <code>MemberRemoved</code> rejects with <code>LastAdmin</code> if it would leave a group with
+  zero admins. Also enforced on demotion.</li>
+  <li><b>Key rotation on removal</b> (<code>group_governance_publisher.rs:216-220</code>):
+  publishing <code>MemberRemoved</code> automatically generates a fresh group key, wraps it for
+  remaining members, and emits <code>RootOp::KeyDelivery</code>. The leave operations in this
+  proposal hook into the same pipeline.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     4. leave_context
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>leave_context — local-only opt-out</h2>
+<p>
+Stop syncing a context on this node. No DAG op, no broadcast, no key rotation. Other members
+never observe the leave; from their perspective the leaver is still in the membership list (which
+is implicit anyway, computed from group membership + auto-follow).
+</p>
+
+<h3>Storage</h3>
+<p>
+Add a single nullable timestamp field to <code>ContextIdentity</code>
+(<code>crates/store/src/key/context.rs:120</code>):
+</p>
+<div class="typedef">
+<span class="kw">struct</span> <span class="ty">ContextIdentity</span> {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment">// existing fields...</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="kw">pub</span> <span class="field">manually_left_at</span>: <span class="ty">Option</span>&lt;<span class="ty">Timestamp</span>&gt;,<br>
+}
+</div>
+
+<h3>Flow</h3>
+<ol>
+  <li>Client calls <code>leave_context(context_id)</code>.</li>
+  <li>Local node sets <code>manually_left_at = now()</code> on the <code>ContextIdentity</code>
+  row for this <code>(member, context)</code> pair.</li>
+  <li>Sync layer reads the flag on next tick; stops sending and accepting deltas for that pair.</li>
+  <li>Auto-follow handler (<code>auto_follow.rs:255</code>) gains a check: if
+  <code>manually_left_at.is_some()</code>, skip the auto-rejoin.</li>
+  <li>Done. One local DB write. No network involvement.</li>
+</ol>
+
+<h3>Properties</h3>
+<table class="properties">
+  <tr><td><b>Scope</b></td><td>Local only</td></tr>
+  <tr><td><b>DAG entry</b></td><td>None</td></tr>
+  <tr><td><b>Key rotation</b></td><td>None — leaver still holds the group key</td></tr>
+  <tr><td><b>Coordination</b></td><td>None — cannot fail</td></tr>
+  <tr><td><b>Reversibility</b></td><td>Trivial — flip the flag back via <code>JoinContextRequest</code> or a dedicated <code>rejoin_context</code></td></tr>
+  <tr><td><b>Other members observe</b></td><td>No</td></tr>
+  <tr><td><b>Forward secrecy</b></td><td>Not provided — leaver retains the key, can decrypt anything they sync later if they rejoin</td></tr>
+</table>
+
+<h3>What this is not</h3>
+<ul>
+  <li><b>Not a kick.</b> Leaver still appears in any "members of this context" query.</li>
+  <li><b>Not a cryptographic leave.</b> If the user wants forward secrecy on a context, they must
+  leave the group containing it (which rotates the group key).</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     5. leave_group
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>leave_group — distributed, two-phase, no cascade</h2>
+<p>
+Self-removal from a single group. Reuses the existing <code>MemberRemoved</code> key-rotation
+pipeline but the publisher/rotation responsibility splits across two parties: the leaver
+publishes the leave op, then a remaining admin publishes the <code>KeyDelivery</code> with the
+fresh group key. The leaver never holds the new key.
+</p>
+
+<h3>New op</h3>
+<div class="typedef">
+<span class="kw">enum</span> <span class="ty">GroupOp</span> {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment">// existing variants...</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="ty">MemberLeft</span> { <span class="field">member</span>: <span class="ty">PublicKey</span> },<br>
+}
+</div>
+<p>
+Distinct from <code>MemberRemoved</code> for audit clarity — "this member chose to leave" vs
+"this member was removed" are semantically different events even when they have similar effects.
+</p>
+
+<h3>Preconditions</h3>
+<ul>
+  <li>Signer has a <b>direct row</b> in the group (computed via
+  <code>check_group_membership_path</code>; reject with <code>NotADirectMember</code> if the
+  signer is only an inherited member — they must leave the anchor instead).</li>
+  <li>Signer is not the Owner (<code>OwnerCannotLeave</code>; must
+  <code>TransferOwnership</code> first).</li>
+  <li>If signer is admin, removing them does not leave the group with zero admins
+  (<code>LastAdmin</code> via existing <code>ensure_not_last_admin_removal</code>).</li>
+</ul>
+
+<h3>Flow</h3>
+<ol>
+  <li>Leaver's client calls <code>leave_group(group_id)</code>.</li>
+  <li>Server-side validation runs the preconditions above.</li>
+  <li>Leaver publishes <code>MemberLeft { member: signer }</code> via the governance DAG. Signed
+  by the leaver. Targets this group.</li>
+  <li>Op broadcasts to all members of the group. Each receiver applies it: deletes the
+  <code>(leaver, group_id)</code> row from local membership state. Leaver's own node also drops
+  sync state for this group's contexts and (optionally) purges encrypted blobs.</li>
+  <li>The first remaining admin to ack the op enters <b>phase two</b>:
+  <ol>
+    <li>Generates a fresh group key via <code>build_key_rotation</code>
+    (<code>group_keys.rs:266</code>).</li>
+    <li>Wraps it for each remaining member (leaver excluded).</li>
+    <li>Publishes <code>RootOp::KeyDelivery</code> carrying the wrapped bundles.</li>
+  </ol>
+  </li>
+  <li>Each remaining member receives <code>KeyDelivery</code>, unwraps their bundle, replaces the
+  active group key. New writes use the new key from now on. The leaver's old key still decrypts
+  historical content but not new writes.</li>
+</ol>
+
+<h3>Cascade behavior</h3>
+<table class="properties">
+  <tr><td><b>Direct rows in subgroups under this group</b></td><td>Untouched. Leaver keeps those memberships. (You can be invited to a child while explicitly leaving the parent.)</td></tr>
+  <tr><td><b>Inherited memberships in Open subgroups</b></td><td>Resolve themselves. The walker stops finding the leaver once their parent row is gone — no extra work needed.</td></tr>
+</table>
+
+<h3>Failure modes</h3>
+<ul>
+  <li><b>Network partition between phase one and phase two.</b> <code>MemberLeft</code> lands but
+  <code>KeyDelivery</code> is delayed. Forward secrecy briefly weak — the leaver is no longer in
+  the membership list but new writes are still under the old key (which they hold). Heals on
+  partition resolve.</li>
+  <li><b>All admins offline.</b> <code>MemberLeft</code> lands; rotation never fires until an
+  admin returns. Operational mitigation: alert when no rotation follows a leave within a
+  configurable window.</li>
+</ul>
+
+<h3>Rejoin</h3>
+<ul>
+  <li><b>Restricted group</b>: requires fresh <code>add_group_members</code> from a remaining
+  admin. New keys delivered via the existing membership-add path.</li>
+  <li><b>Open group</b> (if leaver had a redundant direct row): same. If leaver's path to the
+  group was via inheritance from a parent, that inheritance is automatically restored as soon as
+  they rejoin the parent.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     6. leave_namespace
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>leave_namespace — cascading, heaviest</h2>
+<p>
+A namespace is the root group. Leaving it cascades through every descendant where the leaver has
+a direct row, rotating each scope's group key independently. Plus the namespace's own root key.
+This is the only operation in the proposal that fans out across multiple scopes.
+</p>
+
+<h3>Preconditions</h3>
+<ul>
+  <li>Signer has a direct row at the namespace root.</li>
+  <li>Signer does not own the namespace OR any subgroup beneath it. If they do →
+  <code>MustTransferOwnership { groups: [...] }</code> listing every owned scope.</li>
+  <li>Removing the signer doesn't leave any scope (namespace or descendant) admin-less. If it
+  would → <code>LastAdmin { group: G }</code> reports the offending scope, forcing a successor
+  promotion before retry.</li>
+</ul>
+
+<h3>Flow</h3>
+<ol>
+  <li>Client calls <code>leave_namespace(namespace_id)</code>.</li>
+  <li>Server-side validation walks the subgroup tree:
+    <ul>
+      <li>Compute <code>direct_groups = [namespace, G1, G2, ...]</code> — every group in the
+      namespace where the signer has a direct row.</li>
+      <li>Run owner check + last-admin check across all of them. If any fails, surface the
+      offending scope and bail before publishing anything.</li>
+    </ul>
+  </li>
+  <li>Signer publishes a single <code>MemberLeft { member: signer }</code> at the namespace root.</li>
+  <li>The cascade handler (<code>cascade_remove_member_from_group_tree</code>,
+  <code>mod.rs:811</code>) fans out: locally and on each receiver, fire the
+  <code>MemberLeft</code>-equivalent for each scope in <code>direct_groups</code>.</li>
+  <li>Per-scope key rotation runs the same phase-two pattern as <code>leave_group</code>, in
+  parallel. Total network ops: one root-level <code>MemberLeft</code> +
+  <span class="ty">N</span> <code>KeyDelivery</code> ops where <span class="ty">N</span> = number
+  of direct memberships in the subtree.</li>
+  <li>Local cleanup on the leaver's node:
+    <ul>
+      <li><b>Soft mode (default):</b> archive namespace data as read-only. Leaver can browse their
+      historical view.</li>
+      <li><b>Hard mode (opt-in):</b> purge keys, DAG entries, encrypted blobs.</li>
+    </ul>
+  </li>
+</ol>
+
+<h3>Edge case — last member of the namespace</h3>
+<p>
+If the leaver is the last remaining member, <code>MemberLeft</code> writes locally but has no
+peers to broadcast to. The namespace effectively dies on the leaver's node.
+</p>
+<p>
+If the leaver is also the owner AND last member, they're stuck in the cycle — they must transfer
+ownership but there's no one to transfer to. Use a dedicated <code>DeleteNamespace</code> op
+(analogous to <code>DeleteGroup</code> but at root) that bypasses the owner-cannot-leave rule.
+</p>
+
+<h3>Failure modes</h3>
+<ul>
+  <li>Same as <code>leave_group</code>, multiplied across scopes. Each rotation can fail
+  independently.</li>
+  <li>Partial cascade: if some sub-rotations succeed and others don't, the leaver's root row is
+  gone everywhere but some peers may have lingering ghost rows in subgroups. Eventually
+  consistent — peers detect the leaver-not-in-root state and reconcile on next sync.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     7. OWNER ROLE
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gd">
+<h2>Owner Role</h2>
+<p>
+Promotes the existing <code>GroupMetaValue.admin_identity</code> field
+(<code>crates/store/src/key/group/mod.rs:1160-1169</code>) from "fallback creator-admin" to a
+real, exclusive, transferable role. Every group has exactly one Owner. Owner is also an admin —
+all admin permissions cascade. The distinction is exclusive privileges no admin can perform, plus
+the property that Owner cannot be involuntarily removed.
+</p>
+
+<h3>Storage change</h3>
+<p>
+Semantic rename of <code>admin_identity</code> to <code>owner_identity</code>. Field shape and
+serialization unchanged — every existing group's current <code>admin_identity</code> becomes
+its Owner. No migration needed at the data layer; the change is at the type and access-path
+layer (rename callsites, expose as a real role).
+</p>
+
+<h3>New op</h3>
+<div class="typedef">
+<span class="kw">enum</span> <span class="ty">GroupOp</span> {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment">// existing variants + MemberLeft...</span><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="ty">TransferOwnership</span> { <span class="field">new_owner</span>: <span class="ty">PublicKey</span> },<br>
+}
+</div>
+<ul>
+  <li>Signer must equal current <code>owner_identity</code>.</li>
+  <li><code>new_owner</code> must already be a member of the group.</li>
+  <li>Apply: update <code>owner_identity</code> to <code>new_owner</code>. Old owner becomes a
+  regular admin (retains admin powers; doesn't lose them as a side-effect of transfer).</li>
+  <li>No key rotation (membership unchanged).</li>
+</ul>
+
+<h3>Privilege matrix</h3>
+<table class="properties">
+  <tr><th>Action</th><th>Member</th><th>Admin</th><th>Owner</th></tr>
+  <tr><td>Invite members (with <code>CAN_INVITE_MEMBERS</code>)</td><td>✓</td><td>✓</td><td>✓</td></tr>
+  <tr><td>Create context (with <code>CAN_CREATE_CONTEXT</code>)</td><td>✓</td><td>✓</td><td>✓</td></tr>
+  <tr><td>Remove non-owner members (<code>MANAGE_MEMBERS</code>)</td><td>—</td><td>✓</td><td>✓</td></tr>
+  <tr><td>Promote member → admin</td><td>—</td><td>✓</td><td>✓</td></tr>
+  <tr><td>Demote admin → member</td><td>—</td><td>✓<sup>1</sup></td><td>✓</td></tr>
+  <tr><td><code>TransferOwnership</code></td><td>—</td><td>—</td><td>✓</td></tr>
+  <tr><td><code>DeleteGroup</code> / <code>DeleteContext</code> / <code>DeleteNamespace</code></td><td>—</td><td>—</td><td>✓</td></tr>
+  <tr><td>Be involuntarily removed (<code>MemberRemoved</code>)</td><td>✓</td><td>✓</td><td>✗ — <code>CannotRemoveOwner</code></td></tr>
+  <tr><td>Self-leave via <code>leave_group</code> / <code>leave_namespace</code></td><td>✓</td><td>✓ (last-admin permitting)</td><td>✗ — must <code>TransferOwnership</code> first</td></tr>
+</table>
+<p style="font-size:0.9em; color:#6b6b80; margin-top:8px;">
+<sup>1</sup> Open question. The existing code allows admins to demote each other
+(<code>mod.rs:823</code>); restricting to Owner-only would tighten centralization. This proposal
+preserves the current behavior (admins can demote each other), but the doc author may want to
+revisit.
+</p>
+
+<h3>Owner per context</h3>
+<p>
+Same model. <code>CreateContext</code> records its creator as <code>owner_identity</code> on
+the context's metadata. The context owner can <code>TransferContextOwnership</code> and
+<code>DeleteContext</code>. Other than that, regular context membership is governed by the
+parent group as before.
+</p>
+
+<h3>Interactions with leave operations</h3>
+<ul>
+  <li><b><code>leave_context</code></b>: no owner constraint. Local opt-out doesn't touch
+  governance — even an owner can mute a context locally.</li>
+  <li><b><code>leave_group</code></b>: rejected for owner. Error fast-paths to
+  <code>TransferOwnership</code>.</li>
+  <li><b><code>leave_namespace</code></b>: rejected if signer owns the namespace OR any subgroup
+  beneath it. Error lists every owned scope. UI may bundle these into a single multi-transfer
+  flow.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     8. SINGLE-PAGE REFERENCE
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card ga">
+<h2>Single-Page Reference</h2>
+<table class="properties">
+  <tr>
+    <th>Op</th>
+    <th>Scope</th>
+    <th>DAG?</th>
+    <th>Key rotation?</th>
+    <th>Cascade?</th>
+    <th>Reversible?</th>
+  </tr>
+  <tr>
+    <td><code>leave_context</code></td>
+    <td>Local only</td>
+    <td>None</td>
+    <td>None</td>
+    <td>n/a</td>
+    <td>Trivial — flip flag</td>
+  </tr>
+  <tr>
+    <td><code>leave_group</code></td>
+    <td>Single group</td>
+    <td><code>MemberLeft</code></td>
+    <td>Yes (1 group)</td>
+    <td>None</td>
+    <td>Re-invite (Restricted) / re-inherit (Open)</td>
+  </tr>
+  <tr>
+    <td><code>leave_namespace</code></td>
+    <td>Whole subtree</td>
+    <td><code>MemberLeft</code> at root</td>
+    <td>Yes (1 + N)</td>
+    <td>All direct-row scopes</td>
+    <td>Re-invite at root + re-inherit</td>
+  </tr>
+  <tr>
+    <td><code>TransferOwnership</code></td>
+    <td>Single group/context</td>
+    <td>Op</td>
+    <td>None (membership unchanged)</td>
+    <td>None</td>
+    <td>Transfer back</td>
+  </tr>
+  <tr>
+    <td><code>DeleteGroup</code> (Owner)</td>
+    <td>Single group + descendants</td>
+    <td>Op</td>
+    <td>n/a (everyone gets removed)</td>
+    <td>Yes</td>
+    <td>None — destructive</td>
+  </tr>
+  <tr>
+    <td><code>DeleteNamespace</code> (Owner)</td>
+    <td>Whole subtree</td>
+    <td>Op</td>
+    <td>n/a</td>
+    <td>Yes</td>
+    <td>None — destructive</td>
+  </tr>
+</table>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     9. STATUS LEGEND
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gb">
+<h2>Implementation Status</h2>
+<p>
+This page commits the design before any code lands. Status flips from <b>proposed</b> to
+<b>implemented</b> as each feature ships, in PRs that update the corresponding section.
+</p>
+<table class="properties">
+  <tr><th>Section</th><th>Status</th><th>Tracking</th></tr>
+  <tr><td>Membership Model Recap</td><td>Documents existing code</td><td>—</td></tr>
+  <tr><td><code>leave_context</code></td><td>Proposed</td><td>—</td></tr>
+  <tr><td><code>leave_group</code></td><td>Proposed</td><td>—</td></tr>
+  <tr><td><code>leave_namespace</code></td><td>Proposed</td><td>—</td></tr>
+  <tr><td>Owner Role + <code>TransferOwnership</code></td><td>Proposed</td><td>—</td></tr>
+  <tr><td><code>DeleteGroup</code> / <code>DeleteNamespace</code> Owner-gating</td><td>Proposed</td><td>—</td></tr>
+</table>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     10. OPEN QUESTIONS
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>Open Questions</h2>
+<ol>
+  <li><b>Soft vs hard local cleanup default for <code>leave_namespace</code>.</b> This proposal
+  defaults to soft (archive). Privacy-conscious products may want hard (purge) as the default.</li>
+  <li><b>Admin-mutual demote.</b> Today admins can demote each other. Should this be restricted
+  to Owner-only? This proposal preserves current behavior; revisit if a security concern surfaces.</li>
+  <li><b>Old owner after <code>TransferOwnership</code>.</b> Becomes a regular admin (this
+  proposal) or just a member (alternative)? Admin retains operational continuity; member is a
+  cleaner "step-down" semantic.</li>
+  <li><b>Multi-scope transfer ergonomics.</b> If an owner of a namespace + 5 subgroups wants to
+  leave, does the UI surface 6 separate prompts or one bulk-transfer flow?</li>
+  <li><b>Cascade visibility in <code>leave_namespace</code>.</b> Remaining peers see one
+  user-facing event (<code>MemberLeft</code>) or N events (one per cascading scope's
+  <code>KeyDelivery</code>)? Recommend collapsing to one user-facing event with internal fan-out.</li>
+  <li><b>Owner-leaves-with-no-successor edge case.</b> Dedicated <code>DeleteNamespace</code> op
+  (this proposal) or refuse outright?</li>
+</ol>
+</div>
+
+</div>
+</div>
+</body>
+</html>

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -148,25 +148,56 @@ is implicit anyway, computed from group membership + auto-follow).
 
 <h3>Storage</h3>
 <p>
-Add a single nullable timestamp field to <code>ContextIdentity</code>
-(<code>crates/store/src/key/context.rs:120</code>):
+Two separate stores live side by side: the synced <code>ContextIdentity</code> row
+(<code>key</code> at <code>crates/store/src/key/context.rs:120</code>, value at
+<code>crates/store/src/types/context.rs:117</code>) and a node-local
+<code>ContextLeftMarker</code> tombstone in a new column.
+</p>
+<p>
+The marker lives in <code>Column::ContextLocal</code> (a new column
+specifically for node-local context-scoped state — never synchronized).
+Keying is identical to <code>ContextIdentity</code> so the
+<code>(context_id, member_pk)</code> pair is the unit of opt-out:
 </p>
 <div class="typedef">
-<span class="kw">struct</span> <span class="ty">ContextIdentity</span> {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="comment">// existing fields...</span><br>
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="kw">pub</span> <span class="field">manually_left_at</span>: <span class="ty">Option</span>&lt;<span class="ty">Timestamp</span>&gt;,<br>
+<span class="kw">pub struct</span> <span class="ty">ContextLeftMarker</span>(<span class="ty">Key</span>&lt;(ContextId, PublicKeyComponent)&gt;);<br><br>
+<span class="comment">// Borsh value:</span><br>
+<span class="kw">pub struct</span> <span class="ty">ContextLeftMarker</span> {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="kw">pub</span> <span class="field">left_at_ms</span>: <span class="ty">u64</span>,<br>
 }
 </div>
+<p>
+A separate column instead of a flag on <code>ContextIdentity</code> for two
+reasons: (a) <code>ContextIdentity</code> is part of the synced membership
+shape, so adding a node-local field to it would conflate replicated and
+node-local state; (b) extending the existing Borsh value would break
+deserialization of pre-existing on-disk rows, requiring a migration.
+The dedicated column makes the node-local-ness explicit at the storage
+layer and keeps the synced shape clean.
+</p>
 
 <h3>Flow</h3>
 <ol>
   <li>Client calls <code>leave_context(context_id)</code>.</li>
-  <li>Local node sets <code>manually_left_at = now()</code> on the <code>ContextIdentity</code>
-  row for this <code>(member, context)</code> pair.</li>
-  <li>Sync layer reads the flag on next tick; stops sending and accepting deltas for that pair.</li>
-  <li>Auto-follow handler (<code>auto_follow.rs:255</code>) gains a check: if
-  <code>manually_left_at.is_some()</code>, skip the auto-rejoin.</li>
-  <li>Done. One local DB write. No network involvement.</li>
+  <li>Handler resolves the local <code>ContextIdentity</code> via
+  <code>find_local_signing_identity</code> — scans the column for the row
+  where this node holds the private key. Falls back to the namespace
+  identity if no local row exists.</li>
+  <li>In a single batched store handle (so they land in one commit), the
+  handler:
+    <ol type="a">
+      <li>Writes the <code>ContextLeftMarker</code> row in
+      <code>Column::ContextLocal</code>.</li>
+      <li>Deletes the corresponding <code>ContextIdentity</code> row,
+      which stops sync (the sync layer iterates these rows).</li>
+    </ol>
+  </li>
+  <li>Calls <code>node_client.unsubscribe(&amp;context_id)</code> to leave
+  the gossipsub topic, mirroring <code>join_context</code>'s subscribe.</li>
+  <li>Auto-follow handler (<code>auto_follow.rs:255</code>) checks for the
+  marker via <code>has_left_context</code> on every
+  <code>ContextRegistered</code> event and skips the auto-rejoin if it
+  finds one.</li>
 </ol>
 
 <h3>Properties</h3>
@@ -175,7 +206,7 @@ Add a single nullable timestamp field to <code>ContextIdentity</code>
   <tr><td><b>DAG entry</b></td><td>None</td></tr>
   <tr><td><b>Key rotation</b></td><td>None — leaver still holds the group key</td></tr>
   <tr><td><b>Coordination</b></td><td>None — cannot fail</td></tr>
-  <tr><td><b>Reversibility</b></td><td>Trivial — flip the flag back via <code>JoinContextRequest</code> or a dedicated <code>rejoin_context</code></td></tr>
+  <tr><td><b>Reversibility</b></td><td>Trivial — <code>JoinContextRequest</code> deletes the marker as a side-effect of joining and writes a fresh <code>ContextIdentity</code> row</td></tr>
   <tr><td><b>Other members observe</b></td><td>No</td></tr>
   <tr><td><b>Forward secrecy</b></td><td>Not provided — leaver retains the key, can decrypt anything they sync later if they rejoin</td></tr>
 </table>
@@ -528,5 +559,6 @@ This page commits the design before any code lands. Status flips from <b>propose
 
 </div>
 </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -495,11 +495,11 @@ This page commits the design before any code lands. Status flips from <b>propose
 <table class="properties">
   <tr><th>Section</th><th>Status</th><th>Tracking</th></tr>
   <tr><td>Membership Model Recap</td><td>Documents existing code</td><td>—</td></tr>
-  <tr><td><code>leave_context</code></td><td>Proposed</td><td>—</td></tr>
-  <tr><td><code>leave_group</code></td><td>Proposed</td><td>—</td></tr>
-  <tr><td><code>leave_namespace</code></td><td>Proposed</td><td>—</td></tr>
-  <tr><td>Owner Role + <code>TransferOwnership</code></td><td>Proposed</td><td>—</td></tr>
-  <tr><td><code>DeleteGroup</code> / <code>DeleteNamespace</code> Owner-gating</td><td>Proposed</td><td>—</td></tr>
+  <tr><td><code>leave_context</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>crates/context/src/handlers/leave_context.rs</code>, <code>auto_follow.rs</code> gate, <code>POST /admin-api/contexts/:id/leave</code></td></tr>
+  <tr><td><code>leave_group</code></td><td>Proposed (planned PR #2)</td><td>—</td></tr>
+  <tr><td><code>leave_namespace</code></td><td>Proposed (planned PR #3)</td><td>—</td></tr>
+  <tr><td>Owner Role + <code>TransferOwnership</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>GroupMetaValue.owner_identity</code>, <code>GroupOp::TransferOwnership</code>, <code>CannotRemoveOwner</code> gate in <code>MemberRemoved</code></td></tr>
+  <tr><td><code>DeleteGroup</code> Owner-gating</td><td><b>Implemented</b> (PR #2280)</td><td>Group-scope only — root <code>GroupDeleted</code> + <code>DeleteNamespace</code> Owner-gating planned with <code>leave_namespace</code> in PR #3</td></tr>
 </table>
 </div>
 

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -496,8 +496,8 @@ This page commits the design before any code lands. Status flips from <b>propose
   <tr><th>Section</th><th>Status</th><th>Tracking</th></tr>
   <tr><td>Membership Model Recap</td><td>Documents existing code</td><td>—</td></tr>
   <tr><td><code>leave_context</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>crates/context/src/handlers/leave_context.rs</code>, <code>auto_follow.rs</code> gate, <code>POST /admin-api/contexts/:id/leave</code></td></tr>
-  <tr><td><code>leave_group</code></td><td>Proposed (planned PR #2)</td><td>—</td></tr>
-  <tr><td><code>leave_namespace</code></td><td>Proposed (planned PR #3)</td><td>—</td></tr>
+  <tr><td><code>leave_group</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>GroupOp::MemberLeft</code>, <code>crates/context/src/handlers/leave_group.rs</code>, <code>POST /admin-api/groups/:id/leave</code> — apply enforces self-leave + direct-row + owner + last-admin. <em>No key rotation</em>; admin follow-up required for forward secrecy (deferred).</td></tr>
+  <tr><td><code>leave_namespace</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>crates/context/src/handlers/leave_namespace.rs</code>, <code>POST /admin-api/namespaces/:id/leave</code>. Apply detects no-parent and cascades through descendant groups where leaver has direct rows; multi-scope owner + last-admin checked upfront. <em>No per-scope key rotation</em>.</td></tr>
   <tr><td>Owner Role + <code>TransferOwnership</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>GroupMetaValue.owner_identity</code>, <code>GroupOp::TransferOwnership</code>, <code>CannotRemoveOwner</code> gate in <code>MemberRemoved</code></td></tr>
   <tr><td><code>DeleteGroup</code> Owner-gating</td><td><b>Implemented</b> (PR #2280)</td><td>Group-scope only — root <code>GroupDeleted</code> + <code>DeleteNamespace</code> Owner-gating planned with <code>leave_namespace</code> in PR #3</td></tr>
 </table>

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -15,6 +15,9 @@ use calimero_server_primitives::admin::GetMemberCapabilitiesApiResponse;
 use calimero_server_primitives::admin::GetTeeAdmissionPolicyApiResponse;
 use calimero_server_primitives::admin::GroupInfoApiResponse;
 use calimero_server_primitives::admin::JoinContextApiResponse;
+use calimero_server_primitives::admin::LeaveContextApiResponse;
+use calimero_server_primitives::admin::LeaveGroupApiResponse;
+use calimero_server_primitives::admin::LeaveNamespaceApiResponse;
 use calimero_server_primitives::admin::ListGroupContextsApiResponse;
 use calimero_server_primitives::admin::ListGroupMembersApiResponse;
 use calimero_server_primitives::admin::ListSubgroupsApiResponse;
@@ -259,6 +262,48 @@ where
         let response = self
             .connection
             .post_no_body(&format!("admin-api/contexts/{context_id}/join"))
+            .await?;
+        Ok(response)
+    }
+
+    /// Local-only opt-out from a single context. Stops sync and disarms
+    /// auto-follow on this node only — peers do not observe the leave.
+    /// Reversal: call [`Self::join_context`] which clears the marker.
+    /// See `architecture/membership-and-leave.html` § 4 for semantics.
+    pub async fn leave_context(&self, context_id: &str) -> Result<LeaveContextApiResponse> {
+        let response = self
+            .connection
+            .post_no_body(&format!("admin-api/contexts/{context_id}/leave"))
+            .await?;
+        Ok(response)
+    }
+
+    /// Distributed self-leave from a single group. Publishes a
+    /// `MemberLeft` op that all peers apply, deleting the leaver's
+    /// direct membership row. Subject to apply-side validation:
+    /// signer must be a direct member, must not be Owner, and must
+    /// not be the only admin (`LastAdmin` rejection). See
+    /// `architecture/membership-and-leave.html` § 5.
+    pub async fn leave_group(&self, group_id: &str) -> Result<LeaveGroupApiResponse> {
+        let response = self
+            .connection
+            .post_no_body(&format!("admin-api/groups/{group_id}/leave"))
+            .await?;
+        Ok(response)
+    }
+
+    /// Self-leave from a namespace (root group). Cascades through
+    /// every descendant where the leaver has a direct row; multi-scope
+    /// owner + last-admin checks run upfront. Rejects with
+    /// `MustTransferOwnership` if the leaver owns any group in the
+    /// subtree. See `architecture/membership-and-leave.html` § 6.
+    pub async fn leave_namespace(
+        &self,
+        namespace_id: &str,
+    ) -> Result<LeaveNamespaceApiResponse> {
+        let response = self
+            .connection
+            .post_no_body(&format!("admin-api/namespaces/{namespace_id}/leave"))
             .await?;
         Ok(response)
     }

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -297,10 +297,7 @@ where
     /// owner + last-admin checks run upfront. Rejects with
     /// `MustTransferOwnership` if the leaver owns any group in the
     /// subtree. See `architecture/membership-and-leave.html` § 6.
-    pub async fn leave_namespace(
-        &self,
-        namespace_id: &str,
-    ) -> Result<LeaveNamespaceApiResponse> {
+    pub async fn leave_namespace(&self, namespace_id: &str) -> Result<LeaveNamespaceApiResponse> {
         let response = self
             .connection
             .post_no_body(&format!("admin-api/namespaces/{namespace_id}/leave"))

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -29,16 +29,16 @@ use crate::group::{
     GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse, GetNamespaceIdentityRequest,
     GroupContextEntry, GroupInfoResponse, GroupSummary, GroupUpgradeInfo, JoinContextRequest,
     JoinContextResponse, JoinGroupRequest, JoinGroupResponse, LeaveContextRequest,
-    LeaveContextResponse, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
-    ListGroupMembersResponse, ListNamespacesForApplicationRequest, ListNamespacesRequest,
-    NamespaceSummary, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
-    SetDefaultCapabilitiesRequest, SetGroupAliasRequest, SetMemberAliasRequest,
-    SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest,
-    StoreGroupContextRequest, StoreGroupMetaRequest, StoreMemberAliasRequest,
-    StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
-    SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
-    UpgradeGroupResponse,
+    LeaveContextResponse, LeaveGroupRequest, LeaveGroupResponse, ListAllGroupsRequest,
+    ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
+    ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
+    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest,
+    SetGroupAliasRequest, SetMemberAliasRequest, SetMemberCapabilitiesRequest,
+    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextAliasRequest,
+    StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreMemberAliasRequest, StoreMemberCapabilityRequest,
+    StoreSubgroupVisibilityRequest, SyncGroupRequest, SyncGroupResponse,
+    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest, UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1257,6 +1257,12 @@ impl ContextClient {
         LeaveContext,
         LeaveContextRequest,
         eyre::Result<LeaveContextResponse>
+    );
+    forward_to_actor!(
+        leave_group,
+        LeaveGroup,
+        LeaveGroupRequest,
+        eyre::Result<LeaveGroupResponse>
     );
     forward_to_actor!(
         set_member_capabilities,

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -29,16 +29,17 @@ use crate::group::{
     GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse, GetNamespaceIdentityRequest,
     GroupContextEntry, GroupInfoResponse, GroupSummary, GroupUpgradeInfo, JoinContextRequest,
     JoinContextResponse, JoinGroupRequest, JoinGroupResponse, LeaveContextRequest,
-    LeaveContextResponse, LeaveGroupRequest, LeaveGroupResponse, ListAllGroupsRequest,
-    ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
-    ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
-    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest,
-    SetGroupAliasRequest, SetMemberAliasRequest, SetMemberCapabilitiesRequest,
-    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextAliasRequest,
-    StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest, StoreGroupContextRequest,
-    StoreGroupMetaRequest, StoreMemberAliasRequest, StoreMemberCapabilityRequest,
-    StoreSubgroupVisibilityRequest, SyncGroupRequest, SyncGroupResponse,
-    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest, UpgradeGroupResponse,
+    LeaveContextResponse, LeaveGroupRequest, LeaveGroupResponse, LeaveNamespaceRequest,
+    LeaveNamespaceResponse, ListAllGroupsRequest, ListGroupContextsRequest,
+    ListGroupMembersRequest, ListGroupMembersResponse, ListNamespacesForApplicationRequest,
+    ListNamespacesRequest, NamespaceSummary, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
+    SetDefaultCapabilitiesRequest, SetGroupAliasRequest, SetMemberAliasRequest,
+    SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest,
+    StoreGroupContextRequest, StoreGroupMetaRequest, StoreMemberAliasRequest,
+    StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
+    UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1263,6 +1264,12 @@ impl ContextClient {
         LeaveGroup,
         LeaveGroupRequest,
         eyre::Result<LeaveGroupResponse>
+    );
+    forward_to_actor!(
+        leave_namespace,
+        LeaveNamespace,
+        LeaveNamespaceRequest,
+        eyre::Result<LeaveNamespaceResponse>
     );
     forward_to_actor!(
         set_member_capabilities,

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -28,16 +28,17 @@ use crate::group::{
     GetGroupForContextRequest, GetGroupInfoRequest, GetGroupUpgradeStatusRequest,
     GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse, GetNamespaceIdentityRequest,
     GroupContextEntry, GroupInfoResponse, GroupSummary, GroupUpgradeInfo, JoinContextRequest,
-    JoinContextResponse, JoinGroupRequest, JoinGroupResponse, ListAllGroupsRequest,
-    ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
-    ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
-    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest,
-    SetGroupAliasRequest, SetMemberAliasRequest, SetMemberCapabilitiesRequest,
-    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextAliasRequest,
-    StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest, StoreGroupContextRequest,
-    StoreGroupMetaRequest, StoreMemberAliasRequest, StoreMemberCapabilityRequest,
-    StoreSubgroupVisibilityRequest, SyncGroupRequest, SyncGroupResponse,
-    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest, UpgradeGroupResponse,
+    JoinContextResponse, JoinGroupRequest, JoinGroupResponse, LeaveContextRequest,
+    LeaveContextResponse, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
+    ListGroupMembersResponse, ListNamespacesForApplicationRequest, ListNamespacesRequest,
+    NamespaceSummary, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
+    SetDefaultCapabilitiesRequest, SetGroupAliasRequest, SetMemberAliasRequest,
+    SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest,
+    StoreGroupContextRequest, StoreGroupMetaRequest, StoreMemberAliasRequest,
+    StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
+    UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1250,6 +1251,12 @@ impl ContextClient {
         JoinContext,
         JoinContextRequest,
         eyre::Result<JoinContextResponse>
+    );
+    forward_to_actor!(
+        leave_context,
+        LeaveContext,
+        LeaveContextRequest,
+        eyre::Result<LeaveContextResponse>
     );
     forward_to_actor!(
         set_member_capabilities,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -362,6 +362,32 @@ pub struct JoinContextResponse {
     pub member_public_key: PublicKey,
 }
 
+/// Request to leave a context locally on this node. Purely a node-local opt-out:
+/// no governance op is published, no key rotation is performed, peers never
+/// observe the leave. The handler:
+///
+/// 1. Deletes the local `ContextIdentity` row, which stops sync (the sync layer
+///    iterates `ContextIdentity` rows to determine what to replicate).
+/// 2. Writes a `ContextLeftMarker` tombstone in the `Column::ContextLocal`
+///    column, which the auto-follow handler checks before re-joining.
+///
+/// Cleared by an explicit `JoinContextRequest` from the user, which removes the
+/// marker as a side effect of joining.
+#[derive(Debug)]
+pub struct LeaveContextRequest {
+    pub context_id: ContextId,
+}
+
+impl Message for LeaveContextRequest {
+    type Result = eyre::Result<LeaveContextResponse>;
+}
+
+#[derive(Clone, Debug)]
+pub struct LeaveContextResponse {
+    pub context_id: ContextId,
+    pub member_public_key: PublicKey,
+}
+
 // ---- Group Permission Types ----
 
 #[derive(Debug)]

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -416,6 +416,29 @@ pub struct LeaveGroupResponse {
     pub member_public_key: PublicKey,
 }
 
+/// Self-leave from a namespace (root group). Operationally a `MemberLeft`
+/// at the namespace root, but the apply path detects "this group has no
+/// parent" and cascades through every descendant group where the leaver
+/// has a direct row — running owner + last-admin checks across all of
+/// them BEFORE any mutation. See § 6 of the design doc.
+///
+/// Same forward-secrecy caveat as `leave_group`: row-removal cascade
+/// only, no per-scope key rotation in this PR.
+#[derive(Debug)]
+pub struct LeaveNamespaceRequest {
+    pub namespace_id: ContextGroupId,
+}
+
+impl Message for LeaveNamespaceRequest {
+    type Result = eyre::Result<LeaveNamespaceResponse>;
+}
+
+#[derive(Clone, Debug)]
+pub struct LeaveNamespaceResponse {
+    pub namespace_id: ContextGroupId,
+    pub member_public_key: PublicKey,
+}
+
 // ---- Group Permission Types ----
 
 #[derive(Debug)]

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -388,6 +388,34 @@ pub struct LeaveContextResponse {
     pub member_public_key: PublicKey,
 }
 
+/// Self-leave from a single group. Distributed governance op:
+/// publishes `GroupOp::MemberLeft { member: signer }` which deletes
+/// the leaver's direct membership row across all peers and cascades
+/// the per-context identity rows under the group.
+///
+/// Preconditions enforced at apply: signer must be a direct member
+/// (not just inherited), must not be Owner, and last-admin protection
+/// applies (admin can't leave if they're the only admin).
+///
+/// **Forward-secrecy note:** this op deliberately does not trigger
+/// the key-rotation pipeline that admin-initiated `MemberRemoved`
+/// does. For full cryptographic leave today, pair with admin
+/// follow-up; the proper two-phase rotation is a deferred follow-up.
+#[derive(Debug)]
+pub struct LeaveGroupRequest {
+    pub group_id: ContextGroupId,
+}
+
+impl Message for LeaveGroupRequest {
+    type Result = eyre::Result<LeaveGroupResponse>;
+}
+
+#[derive(Clone, Debug)]
+pub struct LeaveGroupResponse {
+    pub group_id: ContextGroupId,
+    pub member_public_key: PublicKey,
+}
+
 // ---- Group Permission Types ----
 
 #[derive(Debug)]

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -61,6 +61,16 @@ pub enum GroupOp {
     },
     /// Remove a member.
     MemberRemoved { member: PublicKey },
+    /// Self-leave: a member voluntarily exits the group. Distinct from
+    /// `MemberRemoved` for audit clarity (this is a member choosing to
+    /// leave; `MemberRemoved` is admin-initiated). Apply requires
+    /// `signer == member`. Does NOT trigger the key-rotation pipeline —
+    /// the leaver cannot generate the new key without retaining it, and
+    /// proper forward secrecy requires a follow-up two-phase rotation
+    /// (planned as a follow-up). For full cryptographic leave today,
+    /// pair with admin-initiated `MemberRemoved`.
+    /// See `architecture/membership-and-leave.html` § 5.
+    MemberLeft { member: PublicKey },
     /// Set a member’s role (same as upsert member with new role).
     MemberRoleSet {
         member: PublicKey,
@@ -180,6 +190,7 @@ impl GroupOp {
             GroupOp::Noop => "noop",
             GroupOp::MemberAdded { .. } => "member_added",
             GroupOp::MemberRemoved { .. } => "member_removed",
+            GroupOp::MemberLeft { .. } => "member_left",
             GroupOp::MemberRoleSet { .. } => "member_role_set",
             GroupOp::MemberCapabilitySet { .. } => "member_capability_set",
             GroupOp::DefaultCapabilitiesSet { .. } => "default_capabilities_set",

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -159,6 +159,12 @@ pub enum GroupOp {
         auto_follow_contexts: bool,
         auto_follow_subgroups: bool,
     },
+    /// Transfer ownership of this group to `new_owner`. Signer must be the
+    /// current Owner; `new_owner` must already be a member. Updates
+    /// `GroupMetaValue.owner_identity`. The previous owner remains a
+    /// regular admin (no automatic role change beyond the owner field).
+    /// See `architecture/membership-and-leave.html` § 7.
+    TransferOwnership { new_owner: PublicKey },
 }
 
 impl GroupOp {
@@ -189,6 +195,7 @@ impl GroupOp {
             GroupOp::GroupMigrationSet { .. } => "group_migration_set",
             GroupOp::ContextCapabilityGranted { .. } => "context_capability_granted",
             GroupOp::ContextCapabilityRevoked { .. } => "context_capability_revoked",
+            GroupOp::TransferOwnership { .. } => "transfer_ownership",
             GroupOp::TeeAdmissionPolicySet { .. } => "tee_admission_policy_set",
             GroupOp::MemberJoinedViaTeeAttestation { .. } => "member_joined_via_tee",
             GroupOp::MemberSetAutoFollow { .. } => "member_set_auto_follow",

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -15,14 +15,15 @@ use crate::group::{
     DeleteGroupRequest, DeleteNamespaceRequest, DetachContextFromGroupRequest,
     GetGroupForContextRequest, GetGroupInfoRequest, GetGroupUpgradeStatusRequest,
     GetMemberCapabilitiesRequest, GetNamespaceIdentityRequest, JoinContextRequest,
-    JoinGroupRequest, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
-    ListNamespacesForApplicationRequest, ListNamespacesRequest, RemoveGroupMembersRequest,
-    RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest, SetGroupAliasRequest,
-    SetMemberAliasRequest, SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest,
-    SetTeeAdmissionPolicyRequest, StoreContextAliasRequest, StoreDefaultCapabilitiesRequest,
-    StoreGroupAliasRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
-    StoreMemberAliasRequest, StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest,
-    SyncGroupRequest, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
+    JoinGroupRequest, LeaveContextRequest, ListAllGroupsRequest, ListGroupContextsRequest,
+    ListGroupMembersRequest, ListNamespacesForApplicationRequest, ListNamespacesRequest,
+    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest,
+    SetGroupAliasRequest, SetMemberAliasRequest, SetMemberCapabilitiesRequest,
+    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextAliasRequest,
+    StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreMemberAliasRequest, StoreMemberCapabilityRequest,
+    StoreSubgroupVisibilityRequest, SyncGroupRequest, UpdateGroupSettingsRequest,
+    UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -321,6 +322,10 @@ pub enum ContextMessage {
     JoinContext {
         request: JoinContextRequest,
         outcome: oneshot::Sender<<JoinContextRequest as Message>::Result>,
+    },
+    LeaveContext {
+        request: LeaveContextRequest,
+        outcome: oneshot::Sender<<LeaveContextRequest as Message>::Result>,
     },
     SetMemberCapabilities {
         request: SetMemberCapabilitiesRequest,

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -15,15 +15,15 @@ use crate::group::{
     DeleteGroupRequest, DeleteNamespaceRequest, DetachContextFromGroupRequest,
     GetGroupForContextRequest, GetGroupInfoRequest, GetGroupUpgradeStatusRequest,
     GetMemberCapabilitiesRequest, GetNamespaceIdentityRequest, JoinContextRequest,
-    JoinGroupRequest, LeaveContextRequest, ListAllGroupsRequest, ListGroupContextsRequest,
-    ListGroupMembersRequest, ListNamespacesForApplicationRequest, ListNamespacesRequest,
-    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest,
-    SetGroupAliasRequest, SetMemberAliasRequest, SetMemberCapabilitiesRequest,
-    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextAliasRequest,
-    StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest, StoreGroupContextRequest,
-    StoreGroupMetaRequest, StoreMemberAliasRequest, StoreMemberCapabilityRequest,
-    StoreSubgroupVisibilityRequest, SyncGroupRequest, UpdateGroupSettingsRequest,
-    UpdateMemberRoleRequest, UpgradeGroupRequest,
+    JoinGroupRequest, LeaveContextRequest, LeaveGroupRequest, ListAllGroupsRequest,
+    ListGroupContextsRequest, ListGroupMembersRequest, ListNamespacesForApplicationRequest,
+    ListNamespacesRequest, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
+    SetDefaultCapabilitiesRequest, SetGroupAliasRequest, SetMemberAliasRequest,
+    SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest,
+    StoreGroupContextRequest, StoreGroupMetaRequest, StoreMemberAliasRequest,
+    StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -326,6 +326,10 @@ pub enum ContextMessage {
     LeaveContext {
         request: LeaveContextRequest,
         outcome: oneshot::Sender<<LeaveContextRequest as Message>::Result>,
+    },
+    LeaveGroup {
+        request: LeaveGroupRequest,
+        outcome: oneshot::Sender<<LeaveGroupRequest as Message>::Result>,
     },
     SetMemberCapabilities {
         request: SetMemberCapabilitiesRequest,

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -15,15 +15,15 @@ use crate::group::{
     DeleteGroupRequest, DeleteNamespaceRequest, DetachContextFromGroupRequest,
     GetGroupForContextRequest, GetGroupInfoRequest, GetGroupUpgradeStatusRequest,
     GetMemberCapabilitiesRequest, GetNamespaceIdentityRequest, JoinContextRequest,
-    JoinGroupRequest, LeaveContextRequest, LeaveGroupRequest, ListAllGroupsRequest,
-    ListGroupContextsRequest, ListGroupMembersRequest, ListNamespacesForApplicationRequest,
-    ListNamespacesRequest, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
-    SetDefaultCapabilitiesRequest, SetGroupAliasRequest, SetMemberAliasRequest,
-    SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextAliasRequest, StoreDefaultCapabilitiesRequest, StoreGroupAliasRequest,
-    StoreGroupContextRequest, StoreGroupMetaRequest, StoreMemberAliasRequest,
-    StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
-    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
+    JoinGroupRequest, LeaveContextRequest, LeaveGroupRequest, LeaveNamespaceRequest,
+    ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
+    ListNamespacesForApplicationRequest, ListNamespacesRequest, RemoveGroupMembersRequest,
+    RetryGroupUpgradeRequest, SetDefaultCapabilitiesRequest, SetGroupAliasRequest,
+    SetMemberAliasRequest, SetMemberCapabilitiesRequest, SetSubgroupVisibilityRequest,
+    SetTeeAdmissionPolicyRequest, StoreContextAliasRequest, StoreDefaultCapabilitiesRequest,
+    StoreGroupAliasRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
+    StoreMemberAliasRequest, StoreMemberCapabilityRequest, StoreSubgroupVisibilityRequest,
+    SyncGroupRequest, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -330,6 +330,10 @@ pub enum ContextMessage {
     LeaveGroup {
         request: LeaveGroupRequest,
         outcome: oneshot::Sender<<LeaveGroupRequest as Message>::Result>,
+    },
+    LeaveNamespace {
+        request: LeaveNamespaceRequest,
+        outcome: oneshot::Sender<<LeaveNamespaceRequest as Message>::Result>,
     },
     SetMemberCapabilities {
         request: SetMemberCapabilitiesRequest,

--- a/crates/context/src/auto_follow.rs
+++ b/crates/context/src/auto_follow.rs
@@ -255,6 +255,18 @@ async fn handle_context_registered(
     if !should_auto_follow_contexts(store, &gid, &self_pk) {
         return;
     }
+    if has_left_context(store, &context_id, &self_pk) {
+        // The user explicitly opted out of this context on this node via
+        // `leave_context`. Do not auto-rejoin even if `auto_follow.contexts`
+        // is true at the group level. Cleared by an explicit
+        // `JoinContextRequest` from the user.
+        debug!(
+            %context_id,
+            group_id = %hex::encode(group_id),
+            "auto-follow: skipping context-registered event — member has explicitly left this context"
+        );
+        return;
+    }
     if limiter.acquire().await.is_err() {
         debug!("auto-follow: rate limiter closed, skipping context event (shutdown)");
         return;
@@ -386,6 +398,28 @@ fn should_auto_follow_contexts(
                 group_id = %hex::encode(group_id.to_bytes()),
                 ?err,
                 "auto-follow: failed to read member value"
+            );
+            false
+        }
+    }
+}
+
+/// Returns `true` if the member has explicitly called `leave_context` on this
+/// node for `(member, context_id)`. Looked up in the node-local
+/// `Column::ContextLocal` column — never synced to peers.
+fn has_left_context(
+    store: &Store,
+    context_id: &calimero_primitives::context::ContextId,
+    member: &PublicKey,
+) -> bool {
+    let key = calimero_store::key::ContextLeftMarker::new(*context_id, *member);
+    match store.handle().has(&key) {
+        Ok(present) => present,
+        Err(err) => {
+            warn!(
+                %context_id,
+                ?err,
+                "auto-follow: failed to read leave marker — defaulting to not-left"
             );
             false
         }

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -1050,6 +1050,50 @@ fn apply_group_op_mutations(
             // Last-admin protection — same helper used by MemberRemoved.
             membership_policy.ensure_not_last_admin_removal(member)?;
 
+            // Detect namespace-leave: if this group has no parent it IS the
+            // namespace, and leaving must cascade through every descendant
+            // group where the leaver has a direct row. Per the design's
+            // "no cascade for leave_group" rule, non-namespace groups don't
+            // touch siblings or descendants. See § 6 for cascade semantics.
+            let is_namespace_leave =
+                crate::group_store::namespace::resolve_namespace(store, group_id)? == *group_id;
+
+            if is_namespace_leave {
+                // Walk subtree, gather descendants where leaver has a direct
+                // row. Run owner + last-admin checks across all of them
+                // BEFORE mutating anything, so a failure surfaces the
+                // offending scope to the user with no half-applied cleanup.
+                let descendants =
+                    crate::group_store::namespace::collect_descendant_groups(store, group_id)?;
+
+                let mut direct_descendants: Vec<ContextGroupId> = Vec::new();
+                for sub in &descendants {
+                    if get_group_member_role(store, sub, member)?.is_some() {
+                        if let Some(sub_meta) = load_group_meta(store, sub)? {
+                            if sub_meta.owner_identity == *member {
+                                bail!(
+                                    "cannot leave namespace: leaver owns subgroup {}; \
+                                     transfer ownership of every owned scope first",
+                                    hex::encode(sub.to_bytes())
+                                );
+                            }
+                        }
+                        let sub_policy = MembershipPolicy::new(store, *sub);
+                        sub_policy.ensure_not_last_admin_removal(member)?;
+                        direct_descendants.push(*sub);
+                    }
+                }
+
+                for sub in &direct_descendants {
+                    cascade_remove_member_from_group_tree(store, sub, member)?;
+                    remove_group_member(store, sub, member)?;
+                    crate::op_events::notify(crate::op_events::OpEvent::MemberRemoved {
+                        group_id: sub.to_bytes(),
+                        member: *member,
+                    });
+                }
+            }
+
             cascade_remove_member_from_group_tree(store, group_id, member)?;
             remove_group_member(store, group_id, member)?;
 
@@ -1063,7 +1107,8 @@ fn apply_group_op_mutations(
             // now, an admin-initiated `MemberRemoved` is the path to a
             // cryptographically-complete leave; `MemberLeft` is the
             // governance-level departure (membership row removed, peers
-            // observe the leave) without the rotation.
+            // observe the leave) without the rotation. Same caveat applies
+            // to the namespace cascade above — row-removal only.
             crate::op_events::notify(crate::op_events::OpEvent::MemberRemoved {
                 group_id: group_id.to_bytes(),
                 member: *member,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -1131,14 +1131,29 @@ fn apply_group_op_mutations(
                 );
             }
 
-            // The new owner must already be a member of the group. Transfer
-            // does not implicitly invite — the successor must already be in
-            // place. Prevents accidental ownership leaks to non-members.
-            if get_group_member_role(store, group_id, new_owner)?.is_none() {
-                bail!(
-                    "new owner is not a member of group {}; invite them first",
+            // The new owner must already be an Admin of the group. Transfer
+            // does not implicitly invite or promote — the successor must
+            // already be in place at admin tier. This prevents two awkward
+            // states:
+            //   * Transferring to a non-member: would create an absentee
+            //     owner.
+            //   * Transferring to a plain Member: Owner has all Admin
+            //     privileges by design (see doc § 7 privilege matrix), so
+            //     a plain-Member owner would have a confusing "owner with
+            //     reduced capabilities" status. Require Admin first;
+            //     promote then transfer if needed.
+            match get_group_member_role(store, group_id, new_owner)? {
+                Some(GroupMemberRole::Admin) => {}
+                Some(other) => bail!(
+                    "new owner of group {} must be an Admin, but is currently {:?}; \
+                     promote them to Admin before transferring ownership",
+                    hex::encode(group_id.to_bytes()),
+                    other
+                ),
+                None => bail!(
+                    "new owner is not a member of group {}; invite and promote them first",
                     hex::encode(group_id.to_bytes())
-                );
+                ),
             }
 
             meta.owner_identity = *new_owner;

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -1016,6 +1016,59 @@ fn apply_group_op_mutations(
                 subgroups: *auto_follow_subgroups,
             });
         }
+        GroupOp::MemberLeft { member } => {
+            // Self-leave: signer must equal the member being removed.
+            // No capability check beyond self-equality — any member can
+            // leave themselves without admin involvement.
+            if signer != member {
+                bail!("MemberLeft is self-leave only: signer must equal the leaving member");
+            }
+
+            // Direct-row check. If `signer` is only an inherited member
+            // (Open subgroup with no stored row), there's nothing to delete
+            // here — they have to leave whichever ancestor anchors their
+            // membership instead.
+            if get_group_member_role(store, group_id, member)?.is_none() {
+                bail!(
+                    "member is not a direct member of group {}; \
+                     leave the parent group where the membership anchor lives",
+                    hex::encode(group_id.to_bytes())
+                );
+            }
+
+            // Owner cannot self-leave. Must TransferOwnership first.
+            if let Some(meta) = load_group_meta(store, group_id)? {
+                if meta.owner_identity == *member {
+                    bail!(
+                        "owner of group {} cannot self-leave; \
+                         transfer ownership to a successor first",
+                        hex::encode(group_id.to_bytes())
+                    );
+                }
+            }
+
+            // Last-admin protection — same helper used by MemberRemoved.
+            membership_policy.ensure_not_last_admin_removal(member)?;
+
+            cascade_remove_member_from_group_tree(store, group_id, member)?;
+            remove_group_member(store, group_id, member)?;
+
+            // NOTE on forward secrecy: this op deliberately does NOT trigger
+            // the key-rotation pipeline that `MemberRemoved` does, because
+            // the publisher (the leaver) cannot generate the new key without
+            // also retaining it — which would defeat forward secrecy.
+            // Proper forward secrecy on self-leave requires a follow-up
+            // two-phase rotation (a remaining admin's apply hook publishes
+            // KeyDelivery), which is tracked as a follow-up to this PR. For
+            // now, an admin-initiated `MemberRemoved` is the path to a
+            // cryptographically-complete leave; `MemberLeft` is the
+            // governance-level departure (membership row removed, peers
+            // observe the leave) without the rotation.
+            crate::op_events::notify(crate::op_events::OpEvent::MemberRemoved {
+                group_id: group_id.to_bytes(),
+                member: *member,
+            });
+        }
         GroupOp::TransferOwnership { new_owner } => {
             // Owner-only — current owner is the only signer who can transfer.
             let mut meta = load_group_meta(store, group_id)?.ok_or_else(|| {

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -807,6 +807,18 @@ fn apply_group_op_mutations(
         GroupOp::MemberRemoved { member } => {
             permissions.require_manage_members(signer, "remove member")?;
             permissions.require_admin_to_remove_admin(signer, member)?;
+            // Owner is immune to involuntary removal. Owner must
+            // `TransferOwnership` first to step down, then they can be
+            // removed (or self-leave once that op exists).
+            if let Some(meta) = load_group_meta(store, group_id)? {
+                if meta.owner_identity == *member {
+                    bail!(
+                        "cannot remove owner of group {}; owner must \
+                         TransferOwnership to a successor before removal",
+                        hex::encode(group_id.to_bytes())
+                    );
+                }
+            }
             membership_policy.ensure_not_last_admin_removal(member)?;
             cascade_remove_member_from_group_tree(store, group_id, member)?;
             remove_group_member(store, group_id, member)?;
@@ -883,7 +895,22 @@ fn apply_group_op_mutations(
             settings.set_group_alias(signer, alias)?;
         }
         GroupOp::GroupDelete => {
-            permissions.require_admin(signer)?;
+            // Owner-only. Admins can no longer delete the group on their
+            // own — only the owner can. Tightens the previous policy
+            // (`require_admin`) which let any admin destroy the group.
+            let meta = load_group_meta(store, group_id)?.ok_or_else(|| {
+                eyre::eyre!(
+                    "cannot delete unknown group {}",
+                    hex::encode(group_id.to_bytes())
+                )
+            })?;
+            if meta.owner_identity != *signer {
+                bail!(
+                    "only the owner of group {} can delete it; \
+                     transfer ownership first if a non-owner needs to remove it",
+                    hex::encode(group_id.to_bytes())
+                );
+            }
             if count_group_contexts(store, group_id)? > 0 {
                 bail!("cannot delete group: one or more contexts are still registered");
             }
@@ -988,6 +1015,36 @@ fn apply_group_op_mutations(
                 contexts: *auto_follow_contexts,
                 subgroups: *auto_follow_subgroups,
             });
+        }
+        GroupOp::TransferOwnership { new_owner } => {
+            // Owner-only — current owner is the only signer who can transfer.
+            let mut meta = load_group_meta(store, group_id)?.ok_or_else(|| {
+                eyre::eyre!(
+                    "cannot transfer ownership of unknown group {}",
+                    hex::encode(group_id.to_bytes())
+                )
+            })?;
+
+            if meta.owner_identity != *signer {
+                bail!(
+                    "only the current owner of group {} can transfer ownership; \
+                     signer is not the owner",
+                    hex::encode(group_id.to_bytes())
+                );
+            }
+
+            // The new owner must already be a member of the group. Transfer
+            // does not implicitly invite — the successor must already be in
+            // place. Prevents accidental ownership leaks to non-members.
+            if get_group_member_role(store, group_id, new_owner)?.is_none() {
+                bail!(
+                    "new owner is not a member of group {}; invite them first",
+                    hex::encode(group_id.to_bytes())
+                );
+            }
+
+            meta.owner_identity = *new_owner;
+            save_group_meta(store, group_id, &meta)?;
         }
         #[allow(unreachable_patterns)]
         _ => return Ok(false),

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -748,6 +748,7 @@ impl<'a> NamespaceGovernance<'a> {
             // as its parent).
             let meta = calimero_store::key::GroupMetaValue {
                 admin_identity: op.signer,
+                owner_identity: op.signer,
                 target_application_id: parent_meta.target_application_id,
                 app_key: [0u8; 32],
                 upgrade_policy: calimero_primitives::context::UpgradePolicy::default(),

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -25,6 +25,7 @@ fn test_meta() -> GroupMetaValue {
         upgrade_policy: UpgradePolicy::Automatic,
         created_at: 1_700_000_000,
         admin_identity: PublicKey::from([0x01; 32]),
+        owner_identity: PublicKey::from([0x01; 32]),
         migration: None,
         auto_join: true,
     }
@@ -2617,6 +2618,7 @@ fn auto_group_node_identity_is_admin_member() {
             upgrade_policy: UpgradePolicy::Automatic,
             created_at: 1_700_000_000,
             admin_identity: node_pk,
+            owner_identity: node_pk,
             migration: None,
             auto_join: true,
         },
@@ -3840,6 +3842,7 @@ fn sample_meta_with_admin(admin: PublicKey) -> GroupMetaValue {
         upgrade_policy: UpgradePolicy::Automatic,
         created_at: 1_700_000_000,
         admin_identity: admin,
+        owner_identity: admin,
         migration: None,
         auto_join: true,
     }
@@ -4606,6 +4609,7 @@ fn namespace_member_pubkeys_includes_meta_admin_without_member_row() {
         upgrade_policy: UpgradePolicy::Automatic,
         created_at: 1_700_000_000,
         admin_identity: admin,
+        owner_identity: admin,
         migration: None,
         auto_join: true,
     };
@@ -4635,6 +4639,7 @@ fn namespace_member_pubkeys_dedups_admin_with_member_row() {
         upgrade_policy: UpgradePolicy::Automatic,
         created_at: 1_700_000_000,
         admin_identity: admin,
+        owner_identity: admin,
         migration: None,
         auto_join: true,
     };

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -1252,7 +1252,12 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
     let admin_sk = PrivateKey::random(&mut rng);
     let admin_pk = admin_sk.public_key();
 
-    save_group_meta(&store, &gid, &test_meta()).unwrap();
+    // GroupDelete is now Owner-only; align the meta's owner_identity with
+    // the signing key so the delete at the end passes the owner gate.
+    let mut meta = test_meta();
+    meta.admin_identity = admin_pk;
+    meta.owner_identity = admin_pk;
+    save_group_meta(&store, &gid, &meta).unwrap();
     add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
 
     let member_m = PrivateKey::random(&mut rng).public_key();

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -25,6 +25,7 @@ pub mod get_member_capabilities;
 pub mod get_namespace_identity;
 pub mod join_context;
 pub mod join_group;
+pub mod leave_context;
 pub mod list_all_groups;
 pub mod list_group_contexts;
 pub mod list_group_members;
@@ -141,6 +142,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::JoinContext { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::LeaveContext { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::SetMemberCapabilities { request, outcome } => {

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -26,6 +26,7 @@ pub mod get_namespace_identity;
 pub mod join_context;
 pub mod join_group;
 pub mod leave_context;
+pub mod leave_group;
 pub mod list_all_groups;
 pub mod list_group_contexts;
 pub mod list_group_members;
@@ -145,6 +146,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::LeaveContext { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::LeaveGroup { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::SetMemberCapabilities { request, outcome } => {

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -27,6 +27,7 @@ pub mod join_context;
 pub mod join_group;
 pub mod leave_context;
 pub mod leave_group;
+pub mod leave_namespace;
 pub mod list_all_groups;
 pub mod list_group_contexts;
 pub mod list_group_members;
@@ -149,6 +150,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::LeaveGroup { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::LeaveNamespace { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::SetMemberCapabilities { request, outcome } => {

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -111,6 +111,9 @@ impl Handler<CreateGroupRequest> for ContextManager {
                     upgrade_policy,
                     created_at: now,
                     admin_identity: admin_identity.into(),
+                    // Creator is the initial Owner. Transferable via
+                    // `GroupOp::TransferOwnership`.
+                    owner_identity: admin_identity.into(),
                     migration: None,
                     auto_join: true,
                 };

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -203,6 +203,23 @@ impl Handler<JoinContextRequest> for ContextManager {
                             sender_key: None,
                         },
                     )?;
+
+                    // Clear any leave-tombstone written by a previous
+                    // `leave_context` for this `(member, context)` pair —
+                    // explicit rejoin means the user is opting back in, so
+                    // auto-follow should not see the marker on future events.
+                    let marker_key = calimero_store::key::ContextLeftMarker::new(
+                        context_id,
+                        joiner_identity,
+                    );
+                    if let Err(err) = handle.delete(&marker_key) {
+                        warn!(
+                            %context_id,
+                            ?err,
+                            "join_context: failed to clear leave marker — \
+                             auto-follow may continue to skip this context until cleared"
+                        );
+                    }
                 }
 
                 node_client.subscribe(&context_id).await?;

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -93,6 +93,7 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     );
                     let meta = calimero_store::key::GroupMetaValue {
                         admin_identity,
+                        owner_identity: admin_identity,
                         target_application_id:
                             calimero_primitives::application::ApplicationId::from([0u8; 32]),
                         app_key: [0u8; 32],

--- a/crates/context/src/handlers/leave_context.rs
+++ b/crates/context/src/handlers/leave_context.rs
@@ -1,0 +1,118 @@
+//! Local-only opt-out from a single context.
+//!
+//! See `architecture/membership-and-leave.html` § leave_context for the full
+//! design. Summary:
+//!
+//! 1. Resolve the calling member's `(context_id, public_key)` pair.
+//! 2. Delete the local `ContextIdentity` row, which stops sync (the sync layer
+//!    iterates `ContextIdentity` rows when deciding what to replicate).
+//! 3. Write a `ContextLeftMarker` tombstone in `Column::ContextLocal`. The
+//!    auto-follow handler (`crate::auto_follow::has_left_context`) checks
+//!    this marker before re-joining on a `ContextRegistered` event.
+//!
+//! No governance op is published. Peers never observe the leave. Reversal is
+//! a regular `JoinContextRequest`, which clears the marker as a side effect.
+//!
+//! # Why a separate column instead of a flag on `ContextIdentity`?
+//!
+//! `ContextIdentity` is part of the synced membership shape; storing a
+//! "node-local opt-out" on it would conflate replicated and node-local state
+//! and force every receiver to ignore the field. A dedicated
+//! `Column::ContextLocal` makes the node-local-ness explicit at the storage
+//! layer.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::group::{LeaveContextRequest, LeaveContextResponse};
+use calimero_store::{key, types};
+use eyre::{bail, eyre, WrapErr};
+use tracing::{info, warn};
+
+use crate::group_store;
+use crate::ContextManager;
+
+impl Handler<LeaveContextRequest> for ContextManager {
+    type Result = ActorResponse<Self, <LeaveContextRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        LeaveContextRequest { context_id }: LeaveContextRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let datastore = self.datastore.clone();
+
+        ActorResponse::r#async(
+            async move {
+                // 1. Resolve the calling member's public key for the group owning
+                //    this context. If the context isn't mapped to a group locally,
+                //    there's nothing to leave — the node never joined.
+                let group_id = group_store::get_group_for_context(&datastore, &context_id)?
+                    .ok_or_else(|| {
+                        eyre!(
+                            "context {} is not mapped to any local group; \
+                             nothing to leave on this node",
+                            context_id
+                        )
+                    })?;
+
+                let member_public_key =
+                    match group_store::resolve_namespace_identity(&datastore, &group_id)? {
+                        Some((pk, _, _)) => pk,
+                        None => {
+                            bail!(
+                                "no identity stored for group {} on this node; \
+                                 cannot leave context {}",
+                                hex::encode(group_id.to_bytes()),
+                                context_id
+                            )
+                        }
+                    };
+
+                let now_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+
+                // 2. Write the leave marker. We do this BEFORE deleting the
+                //    identity row so that any concurrent auto-follow handler
+                //    that reads the identity row first would still find the
+                //    marker on its leave-check and skip re-joining.
+                let marker_key = key::ContextLeftMarker::new(context_id, member_public_key);
+                let marker_value = types::ContextLeftMarker { left_at_ms: now_ms };
+
+                datastore
+                    .handle()
+                    .put(&marker_key, &marker_value)
+                    .wrap_err("failed to write context-leave marker")?;
+
+                // 3. Delete the identity row. With this row gone, sync stops
+                //    replicating this context to/from this node.
+                let identity_key = key::ContextIdentity::new(context_id, member_public_key);
+                if let Err(err) = datastore.handle().delete(&identity_key) {
+                    // The marker is already in place, so even if delete fails
+                    // we won't auto-rejoin. Log and proceed; sync will cleanly
+                    // ignore the row at most until a future flush.
+                    warn!(
+                        %context_id,
+                        ?err,
+                        "leave_context: marker written but identity-row delete failed; \
+                         sync will retry on next opportunity"
+                    );
+                }
+
+                info!(
+                    %context_id,
+                    %member_public_key,
+                    "leave_context: opted out locally — sync stopped, auto-follow disarmed"
+                );
+
+                Ok(LeaveContextResponse {
+                    context_id,
+                    member_public_key,
+                })
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/context/src/handlers/leave_context.rs
+++ b/crates/context/src/handlers/leave_context.rs
@@ -1,25 +1,33 @@
 //! Local-only opt-out from a single context.
 //!
-//! See `architecture/membership-and-leave.html` § leave_context for the full
-//! design. Summary:
+//! See `architecture/membership-and-leave.html` § 4 for the design.
 //!
-//! 1. Resolve the calling member's `(context_id, public_key)` pair.
-//! 2. Delete the local `ContextIdentity` row, which stops sync (the sync layer
-//!    iterates `ContextIdentity` rows when deciding what to replicate).
-//! 3. Write a `ContextLeftMarker` tombstone in `Column::ContextLocal`. The
-//!    auto-follow handler (`crate::auto_follow::has_left_context`) checks
-//!    this marker before re-joining on a `ContextRegistered` event.
+//! Mechanism:
+//!   1. Look up the context's local signing identity by scanning
+//!      `ContextIdentity` rows for `(context_id, *)` and finding the one
+//!      where this node holds the private key. This handles cases where
+//!      a context was created with a per-context identity that differs
+//!      from the namespace-level identity (e.g. via
+//!      `CreateContextRequest.identity_secret`).
+//!   2. In a single batched store handle, write the `ContextLeftMarker`
+//!      tombstone in `Column::ContextLocal` AND delete the
+//!      `ContextIdentity` row. The auto-follow handler
+//!      (`crate::auto_follow::has_left_context`) checks the marker
+//!      before re-joining; the deleted identity row stops sync.
+//!   3. Unsubscribe from the context's gossipsub topic so the node
+//!      stops receiving traffic for it.
 //!
-//! No governance op is published. Peers never observe the leave. Reversal is
-//! a regular `JoinContextRequest`, which clears the marker as a side effect.
+//! No governance op is published. Peers never observe the leave.
+//! Reversal is a regular `JoinContextRequest`, which clears the marker
+//! as a side effect.
 //!
 //! # Why a separate column instead of a flag on `ContextIdentity`?
 //!
 //! `ContextIdentity` is part of the synced membership shape; storing a
-//! "node-local opt-out" on it would conflate replicated and node-local state
-//! and force every receiver to ignore the field. A dedicated
-//! `Column::ContextLocal` makes the node-local-ness explicit at the storage
-//! layer.
+//! "node-local opt-out" on it would conflate replicated and node-local
+//! state. A dedicated `Column::ContextLocal` makes the node-local-ness
+//! explicit at the storage layer. (Reviewed-and-decided choice — the
+//! design doc § 4 reflects this.)
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -41,70 +49,96 @@ impl Handler<LeaveContextRequest> for ContextManager {
         _ctx: &mut Self::Context,
     ) -> Self::Result {
         let datastore = self.datastore.clone();
+        let node_client = self.node_client.clone();
 
         ActorResponse::r#async(
             async move {
-                // 1. Resolve the calling member's public key for the group owning
-                //    this context. If the context isn't mapped to a group locally,
-                //    there's nothing to leave — the node never joined.
-                let group_id = group_store::get_group_for_context(&datastore, &context_id)?
-                    .ok_or_else(|| {
-                        eyre!(
-                            "context {} is not mapped to any local group; \
-                             nothing to leave on this node",
-                            context_id
-                        )
-                    })?;
-
-                let member_public_key =
-                    match group_store::resolve_namespace_identity(&datastore, &group_id)? {
-                        Some((pk, _, _)) => pk,
-                        None => {
-                            bail!(
-                                "no identity stored for group {} on this node; \
-                                 cannot leave context {}",
-                                hex::encode(group_id.to_bytes()),
+                // Find this node's actual context-specific identity by scanning
+                // the `ContextIdentity` column for a row keyed by this context
+                // where we hold the private key. Falls back to the namespace
+                // identity only when no such row exists (e.g. inherited
+                // membership we've never explicitly joined).
+                //
+                // This is the right resolution because `ContextIdentity` rows
+                // can be keyed by an identity that differs from the
+                // namespace-level pk (`CreateContextRequest.identity_secret`
+                // can mint a per-context identity on creation). Resolving
+                // through `find_local_signing_identity` deletes the row that
+                // actually exists on disk.
+                let member_public_key = match group_store::find_local_signing_identity(
+                    &datastore,
+                    &context_id,
+                )? {
+                    Some(pk) => pk,
+                    None => {
+                        // No ContextIdentity row exists locally — the node
+                        // never joined or was already cleaned up. Fall back
+                        // to the namespace identity for the marker so a
+                        // future auto-follow event still finds an opt-out
+                        // record under our identity. If even that fails,
+                        // there's nothing for us to leave.
+                        let group_id =
+                            group_store::get_group_for_context(&datastore, &context_id)?
+                                .ok_or_else(|| {
+                                    eyre!(
+                                        "context {} is not mapped to any local group; \
+                                         nothing to leave on this node",
+                                        context_id
+                                    )
+                                })?;
+                        match group_store::resolve_namespace_identity(&datastore, &group_id)? {
+                            Some((pk, _, _)) => pk,
+                            None => bail!(
+                                "no local identity for context {}; nothing to leave",
                                 context_id
-                            )
+                            ),
                         }
-                    };
+                    }
+                };
 
                 let now_ms = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .map(|d| d.as_millis() as u64)
-                    .unwrap_or(0);
+                    .wrap_err("system clock is before UNIX_EPOCH")?
+                    .as_millis() as u64;
 
-                // 2. Write the leave marker. We do this BEFORE deleting the
-                //    identity row so that any concurrent auto-follow handler
-                //    that reads the identity row first would still find the
-                //    marker on its leave-check and skip re-joining.
                 let marker_key = key::ContextLeftMarker::new(context_id, member_public_key);
                 let marker_value = types::ContextLeftMarker { left_at_ms: now_ms };
-
-                datastore
-                    .handle()
-                    .put(&marker_key, &marker_value)
-                    .wrap_err("failed to write context-leave marker")?;
-
-                // 3. Delete the identity row. With this row gone, sync stops
-                //    replicating this context to/from this node.
                 let identity_key = key::ContextIdentity::new(context_id, member_public_key);
-                if let Err(err) = datastore.handle().delete(&identity_key) {
-                    // The marker is already in place, so even if delete fails
-                    // we won't auto-rejoin. Log and proceed; sync will cleanly
-                    // ignore the row at most until a future flush.
+
+                // Write the marker AND delete the identity row through the
+                // same handle so they land in the same batched commit. This
+                // closes the window where a crash between the two writes
+                // would leave a dangling marker (or worse, no marker but
+                // the identity row already gone — which would let
+                // auto-follow re-add freely on next event).
+                {
+                    let mut handle = datastore.handle();
+                    handle
+                        .put(&marker_key, &marker_value)
+                        .wrap_err("failed to write context-leave marker")?;
+                    handle
+                        .delete(&identity_key)
+                        .wrap_err("failed to delete context identity row")?;
+                }
+
+                // Stop receiving gossipsub traffic for this context. The
+                // inverse of `node_client.subscribe(context_id)` that
+                // `join_context` calls. If the unsubscribe fails the node
+                // is in a slightly leaky state (still receiving messages)
+                // but the membership is already gone — log and proceed.
+                if let Err(err) = node_client.unsubscribe(&context_id).await {
                     warn!(
                         %context_id,
                         ?err,
-                        "leave_context: marker written but identity-row delete failed; \
-                         sync will retry on next opportunity"
+                        "leave_context: unsubscribe from gossipsub failed; \
+                         node may still receive context messages until restart"
                     );
                 }
 
                 info!(
                     %context_id,
                     %member_public_key,
-                    "leave_context: opted out locally — sync stopped, auto-follow disarmed"
+                    "leave_context: opted out locally — sync stopped, auto-follow disarmed, gossipsub unsubscribed"
                 );
 
                 Ok(LeaveContextResponse {

--- a/crates/context/src/handlers/leave_context.rs
+++ b/crates/context/src/handlers/leave_context.rs
@@ -105,12 +105,29 @@ impl Handler<LeaveContextRequest> for ContextManager {
                 let marker_value = types::ContextLeftMarker { left_at_ms: now_ms };
                 let identity_key = key::ContextIdentity::new(context_id, member_public_key);
 
-                // Write the marker AND delete the identity row through the
-                // same handle so they land in the same batched commit. This
-                // closes the window where a crash between the two writes
-                // would leave a dangling marker (or worse, no marker but
-                // the identity row already gone — which would let
-                // auto-follow re-add freely on next event).
+                // The two writes are sequential, not atomic — `Handle`
+                // forwards each `put`/`delete` directly to the underlying
+                // DB layer, which commits per-call. The store does have a
+                // batched `WriteLayer::apply(&Transaction)` primitive
+                // (crates/store/src/layer.rs:44) we could thread through,
+                // but ordering + idempotency get us the same correctness
+                // guarantee here:
+                //
+                //   * Marker first → if the delete then fails, the marker
+                //     still gates auto-follow (it returns `false` for any
+                //     concurrent `ContextRegistered` event). Sync stays
+                //     active until the delete succeeds, but auto-follow
+                //     can't re-register a row that's already there.
+                //   * Marker put is idempotent (same key, fresher
+                //     timestamp on retry).
+                //   * Delete is idempotent (no-op on already-gone row).
+                //   * Both errors bubble up; the caller can retry the
+                //     whole leave without producing inconsistent state.
+                //
+                // The window where "marker exists but identity row still
+                // present" is observable but coherent: leaver still
+                // appears in member lists, sync continues, but
+                // auto-follow won't re-add. Calling leave again succeeds.
                 {
                     let mut handle = datastore.handle();
                     handle

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -89,13 +89,15 @@ impl Handler<LeaveGroupRequest> for ContextManager {
                     observe_handler_delivery("leave_group", "MemberLeft", report);
                 }
 
-                // Unsubscribe from the namespace topic if this was our
-                // last anchor in the namespace tree. Conservative: only
-                // unsubscribe if the leaver is no longer a member of any
-                // group in the namespace. For simplicity in this PR, we
-                // always attempt the unsubscribe; it's a no-op if other
-                // memberships remain.
-                let _ = node_client.unsubscribe_namespace(group_id.to_bytes()).await;
+                // Note: we deliberately do NOT call
+                // `node_client.unsubscribe_namespace` here. Namespace
+                // subscription tracks namespace-level governance traffic
+                // and a member who leaves a single subgroup can still be
+                // a member of other groups under the same namespace —
+                // unsubscribing prematurely would cut them off from
+                // governance ops they still need. The namespace topic is
+                // only safe to unsubscribe in `leave_namespace`, where
+                // the member is leaving the whole subtree.
 
                 info!(
                     ?group_id,

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -1,0 +1,115 @@
+//! Self-leave from a single group.
+//!
+//! See `architecture/membership-and-leave.html` § 5 for the full design.
+//! This handler publishes `GroupOp::MemberLeft { member: signer }` via
+//! the existing local-governance pipeline. All apply-side validation
+//! (direct-row, owner, last-admin) lives in
+//! `crate::group_store::apply_group_op_mutations` so peers reject the
+//! op identically to the publisher.
+//!
+//! No key rotation is attached. See the apply-arm comment for the
+//! forward-secrecy rationale (briefly: the leaver cannot generate the
+//! new key without retaining it; proper two-phase rotation is a
+//! deferred follow-up).
+
+use std::sync::Arc;
+
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::group::{LeaveGroupRequest, LeaveGroupResponse};
+use tracing::info;
+
+use crate::governance_broadcast::observe_handler_delivery;
+use crate::group_store;
+use crate::ContextManager;
+
+impl Handler<LeaveGroupRequest> for ContextManager {
+    type Result = ActorResponse<Self, <LeaveGroupRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        LeaveGroupRequest { group_id }: LeaveGroupRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        // Resolve this node's identity for the group's namespace. If the
+        // node has no namespace identity, it can't be a member of any
+        // subgroup under it — nothing to leave.
+        let self_identity = match self.node_namespace_identity(&group_id) {
+            Some((pk, sk_bytes)) => (pk, sk_bytes),
+            None => {
+                return ActorResponse::reply(Err(eyre::eyre!(
+                    "this node has no namespace identity for the namespace owning {:?}; \
+                     not a member, nothing to leave",
+                    group_id
+                )))
+            }
+        };
+        let (member_public_key, signer_sk_bytes) = self_identity;
+        let signer_sk = calimero_primitives::identity::PrivateKey::from(signer_sk_bytes);
+
+        // Pre-flight direct-row check so we surface a friendly error
+        // instead of going through publish-then-apply-fail. Apply will
+        // re-validate this anyway on every receiver.
+        match group_store::get_group_member_role(&self.datastore, &group_id, &member_public_key) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return ActorResponse::reply(Err(eyre::eyre!(
+                    "this node is not a direct member of {:?}; \
+                     leave the parent group where the membership anchor lives instead",
+                    group_id
+                )))
+            }
+            Err(err) => return ActorResponse::reply(Err(err)),
+        }
+
+        let datastore = self.datastore.clone();
+        let node_client = self.node_client.clone();
+        let ack_router = Arc::clone(&self.ack_router);
+
+        ActorResponse::r#async(
+            async move {
+                let op = calimero_context_client::local_governance::GroupOp::MemberLeft {
+                    member: member_public_key,
+                };
+
+                // sign_apply_and_publish runs the apply path locally
+                // (which enforces owner / last-admin / direct-row checks
+                // again) and broadcasts to peers. Errors at apply bubble
+                // up here as the user-facing failure.
+                let report = group_store::sign_apply_and_publish(
+                    &datastore,
+                    &node_client,
+                    &ack_router,
+                    &group_id,
+                    &signer_sk,
+                    op,
+                )
+                .await?;
+
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery("leave_group", "MemberLeft", report);
+                }
+
+                // Unsubscribe from the namespace topic if this was our
+                // last anchor in the namespace tree. Conservative: only
+                // unsubscribe if the leaver is no longer a member of any
+                // group in the namespace. For simplicity in this PR, we
+                // always attempt the unsubscribe; it's a no-op if other
+                // memberships remain.
+                let _ = node_client.unsubscribe_namespace(group_id.to_bytes()).await;
+
+                info!(
+                    ?group_id,
+                    %member_public_key,
+                    "left group voluntarily (MemberLeft published, peers will see the leave; \
+                     no key rotation attached — admin follow-up required for forward secrecy)"
+                );
+
+                Ok(LeaveGroupResponse {
+                    group_id,
+                    member_public_key,
+                })
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/context/src/handlers/leave_namespace.rs
+++ b/crates/context/src/handlers/leave_namespace.rs
@@ -1,0 +1,120 @@
+//! Self-leave from a namespace (root group).
+//!
+//! See `architecture/membership-and-leave.html` § 6 for the design.
+//! This handler is a thin wrapper over `leave_group`: it publishes
+//! `GroupOp::MemberLeft { member: signer }` at the namespace root.
+//! The apply path in `crate::group_store` detects "this group has no
+//! parent" and cascades through every descendant where the leaver has
+//! a direct row — owner + last-admin checks across all of them
+//! upfront, then row-removal cascade.
+//!
+//! No key rotation. Same forward-secrecy caveat as `leave_group`.
+//! See architecture doc § 6 for the soft-vs-hard local-cleanup choice
+//! (left as a follow-up — current behavior is "soft": no purge,
+//! membership rows removed but encrypted blobs and keys remain on the
+//! local node).
+
+use std::sync::Arc;
+
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::group::{LeaveNamespaceRequest, LeaveNamespaceResponse};
+use tracing::info;
+
+use crate::governance_broadcast::observe_handler_delivery;
+use crate::group_store;
+use crate::ContextManager;
+
+impl Handler<LeaveNamespaceRequest> for ContextManager {
+    type Result = ActorResponse<Self, <LeaveNamespaceRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        LeaveNamespaceRequest { namespace_id }: LeaveNamespaceRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let self_identity = match self.node_namespace_identity(&namespace_id) {
+            Some((pk, sk_bytes)) => (pk, sk_bytes),
+            None => {
+                return ActorResponse::reply(Err(eyre::eyre!(
+                    "this node has no namespace identity for {:?}; \
+                     not a member, nothing to leave",
+                    namespace_id
+                )))
+            }
+        };
+        let (member_public_key, signer_sk_bytes) = self_identity;
+        let signer_sk = calimero_primitives::identity::PrivateKey::from(signer_sk_bytes);
+
+        // Verify this is actually a namespace (no parent). If a non-root
+        // group_id was passed by mistake, route the user to leave_group.
+        let resolved = match group_store::resolve_namespace(&self.datastore, &namespace_id) {
+            Ok(g) => g,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+        if resolved != namespace_id {
+            return ActorResponse::reply(Err(eyre::eyre!(
+                "{:?} is not a namespace (root group); use leave_group for subgroups",
+                namespace_id
+            )));
+        }
+
+        // Direct-row check at the root. Apply re-validates everything.
+        match group_store::get_group_member_role(&self.datastore, &namespace_id, &member_public_key)
+        {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return ActorResponse::reply(Err(eyre::eyre!(
+                    "this node is not a direct member of namespace {:?}",
+                    namespace_id
+                )))
+            }
+            Err(err) => return ActorResponse::reply(Err(err)),
+        }
+
+        let datastore = self.datastore.clone();
+        let node_client = self.node_client.clone();
+        let ack_router = Arc::clone(&self.ack_router);
+
+        ActorResponse::r#async(
+            async move {
+                let op = calimero_context_client::local_governance::GroupOp::MemberLeft {
+                    member: member_public_key,
+                };
+
+                // The apply path detects "this group is the namespace" and
+                // performs the multi-scope owner / last-admin checks +
+                // cascade across descendants. If any check fails, the error
+                // surfaces here as the user-facing failure.
+                let report = group_store::sign_apply_and_publish(
+                    &datastore,
+                    &node_client,
+                    &ack_router,
+                    &namespace_id,
+                    &signer_sk,
+                    op,
+                )
+                .await?;
+
+                if let Some(report) = report.as_ref() {
+                    observe_handler_delivery("leave_namespace", "MemberLeft", report);
+                }
+
+                let _ = node_client
+                    .unsubscribe_namespace(namespace_id.to_bytes())
+                    .await;
+
+                info!(
+                    ?namespace_id,
+                    %member_public_key,
+                    "left namespace voluntarily — cascade complete; key rotation deferred"
+                );
+
+                Ok(LeaveNamespaceResponse {
+                    namespace_id,
+                    member_public_key,
+                })
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/context/src/handlers/list_namespaces.rs
+++ b/crates/context/src/handlers/list_namespaces.rs
@@ -120,6 +120,7 @@ mod tests {
             upgrade_policy: UpgradePolicy::Automatic,
             created_at: 1_700_000_000,
             admin_identity: PublicKey::from([0x01; 32]),
+            owner_identity: PublicKey::from([0x01; 32]),
             migration: None,
             auto_join: true,
         }
@@ -206,6 +207,7 @@ mod tests {
             upgrade_policy: UpgradePolicy::Automatic,
             created_at: 1_700_000_000,
             admin_identity: node_identity_pk,
+            owner_identity: node_identity_pk,
             migration: None,
             auto_join: true,
         };

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -42,6 +42,7 @@ fn sample_meta(admin: PublicKey) -> GroupMetaValue {
         upgrade_policy: UpgradePolicy::Automatic,
         created_at: 1_700_000_000,
         admin_identity: admin,
+        owner_identity: admin,
         migration: None,
         auto_join: true,
     }

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -955,8 +955,17 @@ fn state_hash_prevents_concurrent_op_divergence() {
     let admin_c_pk = admin_c_sk.public_key();
     let new_member_d = PrivateKey::random(&mut rng).public_key();
 
+    // Test exercises admin-removing-admin semantics under concurrent state.
+    // The owner-immunity gate (`CannotRemoveOwner`) would block op_c if
+    // admin_a were the owner — assign owner to a separate "founder" identity
+    // so neither admin_a nor admin_c is owner-protected.
+    let founder_pk = PrivateKey::random(&mut rng).public_key();
+    let mut meta = sample_meta(admin_a_pk);
+    meta.owner_identity = founder_pk;
+
     for store in [&node_b, &node_c] {
-        save_group_meta(store, &gid, &sample_meta(admin_a_pk)).unwrap();
+        save_group_meta(store, &gid, &meta).unwrap();
+        add_group_member(store, &gid, &founder_pk, GroupMemberRole::Admin).unwrap();
         add_group_member(store, &gid, &admin_a_pk, GroupMemberRole::Admin).unwrap();
         add_group_member(store, &gid, &admin_c_pk, GroupMemberRole::Admin).unwrap();
     }

--- a/crates/meroctl/src/cli/group.rs
+++ b/crates/meroctl/src/cli/group.rs
@@ -8,6 +8,8 @@ pub mod contexts;
 pub mod delete;
 pub mod get;
 pub mod join_context;
+pub mod leave;
+pub mod leave_context;
 pub mod members;
 pub mod reparent;
 pub mod settings;
@@ -73,6 +75,11 @@ pub enum GroupSubCommands {
     Sync(sync::SyncCommand),
     #[command(alias = "join-context")]
     JoinContext(join_context::JoinContextCommand),
+    /// Leave a context locally (no DAG op published).
+    #[command(alias = "leave-context")]
+    LeaveContext(leave_context::LeaveContextCommand),
+    /// Voluntarily leave a group (publishes MemberLeft).
+    Leave(leave::LeaveCommand),
     Settings(settings::SettingsCommand),
 }
 
@@ -90,6 +97,8 @@ impl GroupCommand {
             GroupSubCommands::Upgrade(cmd) => cmd.run(environment).await,
             GroupSubCommands::Sync(cmd) => cmd.run(environment).await,
             GroupSubCommands::JoinContext(cmd) => cmd.run(environment).await,
+            GroupSubCommands::LeaveContext(cmd) => cmd.run(environment).await,
+            GroupSubCommands::Leave(cmd) => cmd.run(environment).await,
             GroupSubCommands::Settings(cmd) => cmd.run(environment).await,
         }
     }

--- a/crates/meroctl/src/cli/group/leave.rs
+++ b/crates/meroctl/src/cli/group/leave.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+#[derive(Clone, Debug, Parser)]
+#[command(about = "Voluntarily leave a group (publishes MemberLeft). \
+             Rejected if you are the Owner (transfer ownership first), \
+             the only admin, or only an inherited member of an Open subgroup.")]
+pub struct LeaveCommand {
+    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID to leave")]
+    pub group_id: String,
+}
+
+impl LeaveCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?;
+        let response = client.leave_group(&self.group_id).await?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/cli/group/leave_context.rs
+++ b/crates/meroctl/src/cli/group/leave_context.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+#[derive(Clone, Debug, Parser)]
+#[command(about = "Locally opt out of a context (no DAG op, no broadcast). \
+             Stops sync and disarms auto-follow on this node only — \
+             peers do not observe the leave. Reverse with `group join-context`.")]
+pub struct LeaveContextCommand {
+    #[clap(name = "CONTEXT_ID", help = "The context ID to leave locally")]
+    pub context_id: String,
+}
+
+impl LeaveContextCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?;
+        let response = client.leave_context(&self.context_id).await?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/cli/namespace.rs
+++ b/crates/meroctl/src/cli/namespace.rs
@@ -12,6 +12,7 @@ pub mod groups;
 pub mod identity;
 pub mod invite;
 pub mod join;
+pub mod leave;
 pub mod list;
 
 pub const EXAMPLES: &str = r"
@@ -53,6 +54,8 @@ pub enum NamespaceSubCommands {
     Delete(delete::DeleteCommand),
     Invite(invite::InviteCommand),
     Join(join::JoinCommand),
+    /// Voluntarily leave a namespace (cascades through descendant groups).
+    Leave(leave::LeaveCommand),
     Groups(groups::GroupsCommand),
     CreateGroup(create_group::CreateGroupCommand),
     #[command(alias = "ls")]
@@ -69,6 +72,7 @@ impl NamespaceCommand {
             NamespaceSubCommands::Delete(cmd) => cmd.run(environment).await,
             NamespaceSubCommands::Invite(cmd) => cmd.run(environment).await,
             NamespaceSubCommands::Join(cmd) => cmd.run(environment).await,
+            NamespaceSubCommands::Leave(cmd) => cmd.run(environment).await,
             NamespaceSubCommands::Groups(cmd) => cmd.run(environment).await,
             NamespaceSubCommands::CreateGroup(cmd) => cmd.run(environment).await,
             NamespaceSubCommands::List(cmd) => cmd.run(environment).await,

--- a/crates/meroctl/src/cli/namespace/leave.rs
+++ b/crates/meroctl/src/cli/namespace/leave.rs
@@ -1,0 +1,26 @@
+use clap::Parser;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+#[derive(Clone, Debug, Parser)]
+#[command(
+    about = "Voluntarily leave a namespace (publishes MemberLeft at the root \
+             and cascades through every descendant where you have a direct row). \
+             Rejected with `MustTransferOwnership` if you own any group in the subtree."
+)]
+pub struct LeaveCommand {
+    #[clap(name = "NAMESPACE_ID", help = "The hex-encoded namespace ID to leave")]
+    pub namespace_id: String,
+}
+
+impl LeaveCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?;
+        let response = client.leave_namespace(&self.namespace_id).await?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -3,7 +3,8 @@ use calimero_server_primitives::admin::{
     CreateNamespaceApiResponse, DeleteGroupApiResponse, DeleteNamespaceApiResponse,
     DetachContextFromGroupApiResponse, GetGroupUpgradeStatusApiResponse,
     GetMemberCapabilitiesApiResponse, GroupInfoApiResponse, JoinContextApiResponse,
-    JoinGroupApiResponse, ListGroupContextsApiResponse, ListGroupMembersApiResponse,
+    JoinGroupApiResponse, LeaveContextApiResponse, LeaveGroupApiResponse,
+    LeaveNamespaceApiResponse, ListGroupContextsApiResponse, ListGroupMembersApiResponse,
     ListNamespaceGroupsApiResponse, ListNamespacesApiResponse, ListSubgroupsApiResponse,
     NamespaceApiResponse, NamespaceIdentityApiResponse, RegisterGroupSigningKeyApiResponse,
     RemoveGroupMembersApiResponse, ReparentGroupApiResponse, SetDefaultCapabilitiesApiResponse,
@@ -399,6 +400,54 @@ impl Report for JoinContextApiResponse {
             Cell::new("Value").fg(Color::Blue),
         ]);
         let _ = table.add_row(vec!["Context ID", &self.data.context_id.to_string()]);
+        let _ = table.add_row(vec![
+            "Member Public Key",
+            &self.data.member_public_key.to_string(),
+        ]);
+        println!("{table}");
+    }
+}
+
+impl Report for LeaveContextApiResponse {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.set_header(vec![
+            Cell::new("Left Context (local-only)").fg(Color::Yellow),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = table.add_row(vec!["Context ID", &self.data.context_id.to_string()]);
+        let _ = table.add_row(vec![
+            "Member Public Key",
+            &self.data.member_public_key.to_string(),
+        ]);
+        println!("{table}");
+    }
+}
+
+impl Report for LeaveGroupApiResponse {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.set_header(vec![
+            Cell::new("Left Group (MemberLeft published)").fg(Color::Yellow),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = table.add_row(vec!["Group ID", &self.data.group_id]);
+        let _ = table.add_row(vec![
+            "Member Public Key",
+            &self.data.member_public_key.to_string(),
+        ]);
+        println!("{table}");
+    }
+}
+
+impl Report for LeaveNamespaceApiResponse {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.set_header(vec![
+            Cell::new("Left Namespace (cascaded through descendants)").fg(Color::Yellow),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = table.add_row(vec!["Namespace ID", &self.data.namespace_id]);
         let _ = table.add_row(vec![
             "Member Public Key",
             &self.data.member_public_key.to_string(),

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -178,6 +178,7 @@ pub async fn join_namespace(
         let admin_identity = PublicKey::from(invitation.invitation.inviter_identity.to_bytes());
         let meta = GroupMetaValue {
             admin_identity,
+            owner_identity: admin_identity,
             target_application_id: ApplicationId::from([0u8; 32]),
             app_key: [0u8; 32],
             upgrade_policy: UpgradePolicy::default(),

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -42,6 +42,7 @@ fn sample_meta(admin: PublicKey) -> GroupMetaValue {
         upgrade_policy: UpgradePolicy::Automatic,
         created_at: 1_700_000_000,
         admin_identity: admin,
+        owner_identity: admin,
         migration: None,
         auto_join: true,
     }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2242,6 +2242,21 @@ pub struct LeaveContextApiResponseData {
     pub member_public_key: PublicKey,
 }
 
+// ---- Leave Group (distributed self-leave op) ----
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaveGroupApiResponse {
+    pub data: LeaveGroupApiResponseData,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaveGroupApiResponseData {
+    pub group_id: String,
+    pub member_public_key: PublicKey,
+}
+
 // ---- Get Context Group ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2227,6 +2227,21 @@ pub struct JoinContextApiResponseData {
     pub member_public_key: PublicKey,
 }
 
+// ---- Leave Context (local-only opt-out) ----
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaveContextApiResponse {
+    pub data: LeaveContextApiResponseData,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaveContextApiResponseData {
+    pub context_id: ContextId,
+    pub member_public_key: PublicKey,
+}
+
 // ---- Get Context Group ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2257,6 +2257,21 @@ pub struct LeaveGroupApiResponseData {
     pub member_public_key: PublicKey,
 }
 
+// ---- Leave Namespace (cascading self-leave) ----
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaveNamespaceApiResponse {
+    pub data: LeaveNamespaceApiResponseData,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaveNamespaceApiResponseData {
+    pub namespace_id: String,
+    pub member_public_key: PublicKey,
+}
+
 // ---- Get Context Group ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -9,5 +9,6 @@ pub mod get_contexts_for_application;
 pub mod get_contexts_with_executors_for_application;
 pub mod invite_specialized_node;
 pub mod join_context;
+pub mod leave_context;
 pub mod sync;
 pub mod update_context_application;

--- a/crates/server/src/admin/handlers/context/leave_context.rs
+++ b/crates/server/src/admin/handlers/context/leave_context.rs
@@ -9,18 +9,34 @@ use tracing::{error, info};
 
 use crate::admin::handlers::groups::parse_context_id;
 use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::auth::AuthenticatedKey;
 use crate::AdminState;
 
 pub async fn handler(
     Path(context_id_str): Path<String>,
     Extension(state): Extension<Arc<AdminState>>,
+    auth_key: Option<Extension<AuthenticatedKey>>,
 ) -> impl IntoResponse {
     let context_id = match parse_context_id(&context_id_str) {
         Ok(id) => id,
         Err(err) => return err.into_response(),
     };
 
-    info!(context_id=%context_id_str, "Leaving context locally (no DAG op published)");
+    // Authentication is enforced by the admin-API auth middleware; an
+    // unauthenticated request never reaches this handler with `auth_key`
+    // populated. We extract it here so authenticated callers' identity
+    // appears in audit logs alongside the action — same shape as
+    // `delete_group` / `delete_namespace`. The handler resolves the
+    // actual member identity from local storage independently, so the
+    // auth_key isn't a control point for *which* identity to leave —
+    // it's the auth boundary for whether a leave is permitted at all.
+    let auth_caller = auth_key.map(|Extension(k)| k.0);
+
+    info!(
+        context_id=%context_id_str,
+        ?auth_caller,
+        "Leaving context locally (no DAG op published)"
+    );
 
     let result = state
         .ctx_client

--- a/crates/server/src/admin/handlers/context/leave_context.rs
+++ b/crates/server/src/admin/handlers/context/leave_context.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_client::group::LeaveContextRequest;
+use calimero_server_primitives::admin::{LeaveContextApiResponse, LeaveContextApiResponseData};
+use tracing::{error, info};
+
+use crate::admin::handlers::groups::parse_context_id;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(context_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let context_id = match parse_context_id(&context_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(context_id=%context_id_str, "Leaving context locally (no DAG op published)");
+
+    let result = state
+        .ctx_client
+        .leave_context(LeaveContextRequest { context_id })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(resp) => {
+            info!(
+                context_id=%resp.context_id,
+                member=%resp.member_public_key,
+                "Successfully left context locally"
+            );
+            ApiResponse {
+                payload: LeaveContextApiResponse {
+                    data: LeaveContextApiResponseData {
+                        context_id: resp.context_id,
+                        member_public_key: resp.member_public_key,
+                    },
+                },
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(context_id=%context_id_str, error=?err, "Failed to leave context");
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -8,6 +8,7 @@ pub mod get_group_upgrade_status;
 pub mod get_member_capabilities;
 pub mod get_tee_admission_policy;
 pub mod join_group;
+pub mod leave_group;
 pub mod list_all_groups;
 pub mod list_group_contexts;
 pub mod list_group_members;

--- a/crates/server/src/admin/handlers/groups/leave_group.rs
+++ b/crates/server/src/admin/handlers/groups/leave_group.rs
@@ -9,18 +9,26 @@ use tracing::{error, info};
 
 use super::parse_group_id;
 use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::auth::AuthenticatedKey;
 use crate::AdminState;
 
 pub async fn handler(
     Path(group_id_str): Path<String>,
     Extension(state): Extension<Arc<AdminState>>,
+    auth_key: Option<Extension<AuthenticatedKey>>,
 ) -> impl IntoResponse {
     let group_id = match parse_group_id(&group_id_str) {
         Ok(id) => id,
         Err(err) => return err.into_response(),
     };
 
-    info!(group_id=%group_id_str, "Leaving group (publishing MemberLeft)");
+    let auth_caller = auth_key.map(|Extension(k)| k.0);
+
+    info!(
+        group_id=%group_id_str,
+        ?auth_caller,
+        "Leaving group (publishing MemberLeft)"
+    );
 
     let result = state
         .ctx_client

--- a/crates/server/src/admin/handlers/groups/leave_group.rs
+++ b/crates/server/src/admin/handlers/groups/leave_group.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_client::group::LeaveGroupRequest;
+use calimero_server_primitives::admin::{LeaveGroupApiResponse, LeaveGroupApiResponseData};
+use tracing::{error, info};
+
+use super::parse_group_id;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(group_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let group_id = match parse_group_id(&group_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(group_id=%group_id_str, "Leaving group (publishing MemberLeft)");
+
+    let result = state
+        .ctx_client
+        .leave_group(LeaveGroupRequest { group_id })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(resp) => {
+            info!(
+                group_id=%group_id_str,
+                member=%resp.member_public_key,
+                "Successfully left group"
+            );
+            ApiResponse {
+                payload: LeaveGroupApiResponse {
+                    data: LeaveGroupApiResponseData {
+                        group_id: hex::encode(resp.group_id.to_bytes()),
+                        member_public_key: resp.member_public_key,
+                    },
+                },
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(group_id=%group_id_str, error=?err, "Failed to leave group");
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/handlers/namespaces/leave_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/leave_namespace.rs
@@ -9,19 +9,24 @@ use tracing::{error, info};
 
 use crate::admin::handlers::groups::parse_group_id;
 use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::auth::AuthenticatedKey;
 use crate::AdminState;
 
 pub async fn handler(
     Path(namespace_id_str): Path<String>,
     Extension(state): Extension<Arc<AdminState>>,
+    auth_key: Option<Extension<AuthenticatedKey>>,
 ) -> impl IntoResponse {
     let namespace_id = match parse_group_id(&namespace_id_str) {
         Ok(id) => id,
         Err(err) => return err.into_response(),
     };
 
+    let auth_caller = auth_key.map(|Extension(k)| k.0);
+
     info!(
         namespace_id=%namespace_id_str,
+        ?auth_caller,
         "Leaving namespace (publishing MemberLeft at root, cascading through descendants)"
     );
 

--- a/crates/server/src/admin/handlers/namespaces/leave_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/leave_namespace.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_client::group::LeaveNamespaceRequest;
+use calimero_server_primitives::admin::{LeaveNamespaceApiResponse, LeaveNamespaceApiResponseData};
+use tracing::{error, info};
+
+use crate::admin::handlers::groups::parse_group_id;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(namespace_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let namespace_id = match parse_group_id(&namespace_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(
+        namespace_id=%namespace_id_str,
+        "Leaving namespace (publishing MemberLeft at root, cascading through descendants)"
+    );
+
+    let result = state
+        .ctx_client
+        .leave_namespace(LeaveNamespaceRequest { namespace_id })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(resp) => {
+            info!(
+                namespace_id=%namespace_id_str,
+                member=%resp.member_public_key,
+                "Successfully left namespace"
+            );
+            ApiResponse {
+                payload: LeaveNamespaceApiResponse {
+                    data: LeaveNamespaceApiResponseData {
+                        namespace_id: hex::encode(resp.namespace_id.to_bytes()),
+                        member_public_key: resp.member_public_key,
+                    },
+                },
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(namespace_id=%namespace_id_str, error=?err, "Failed to leave namespace");
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/handlers/namespaces/mod.rs
+++ b/crates/server/src/admin/handlers/namespaces/mod.rs
@@ -5,6 +5,7 @@ pub mod get_identity;
 pub mod get_namespace;
 pub mod invite_namespace;
 pub mod join_namespace;
+pub mod leave_namespace;
 pub mod list;
 pub mod list_for_application;
 pub mod list_namespace_groups;

--- a/crates/server/src/admin/handlers/usage.rs
+++ b/crates/server/src/admin/handlers/usage.rs
@@ -232,6 +232,7 @@ mod tests {
             upgrade_policy: UpgradePolicy::Automatic,
             created_at: 1_700_000_000,
             admin_identity: node_identity_pk,
+            owner_identity: node_identity_pk,
             migration: None,
             auto_join: true,
         };
@@ -288,6 +289,7 @@ mod tests {
             upgrade_policy: UpgradePolicy::Automatic,
             created_at: 1_700_000_000,
             admin_identity: node_sk.public_key(),
+            owner_identity: node_sk.public_key(),
             migration: None,
             auto_join: true,
         };

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -281,6 +281,10 @@ pub(crate) fn setup(
             post(namespaces::join_namespace::handler),
         )
         .route(
+            "/namespaces/:namespace_id/leave",
+            post(namespaces::leave_namespace::handler),
+        )
+        .route(
             "/namespaces/:namespace_id/identity",
             get(namespaces::get_identity::handler),
         )

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -192,6 +192,10 @@ pub(crate) fn setup(
             post(groups::remove_group_members::handler),
         )
         .route(
+            "/groups/:group_id/leave",
+            post(groups::leave_group::handler),
+        )
+        .route(
             "/groups/:group_id/members/:identity/role",
             put(groups::update_member_role::handler),
         )

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -25,8 +25,8 @@ use crate::admin::handlers::applications::{
 use crate::admin::handlers::context::{
     create_context, delete_context, get_context, get_context_group, get_context_identities,
     get_context_ids, get_context_storage, get_contexts_for_application,
-    get_contexts_with_executors_for_application, invite_specialized_node, join_context, sync,
-    update_context_application,
+    get_contexts_with_executors_for_application, invite_specialized_node, join_context,
+    leave_context, sync, update_context_application,
 };
 use crate::admin::handlers::identity::generate_context_identity;
 use crate::admin::handlers::packages::{get_latest_version, list_packages, list_versions};
@@ -230,6 +230,10 @@ pub(crate) fn setup(
         .route(
             "/contexts/:context_id/join",
             post(join_context::handler),
+        )
+        .route(
+            "/contexts/:context_id/leave",
+            post(leave_context::handler),
         )
         .route(
             "/groups/:group_id/members/:identity/capabilities",

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -27,6 +27,11 @@ pub enum Column {
     Alias,
     Generic,
     Group,
+    /// Node-local context-scoped state. NOT synchronized across nodes.
+    /// Used for things like the per-(member, context) `leave_context`
+    /// tombstone — sync-and-auto-follow stop on the node where the user
+    /// opted out, while peers see no change.
+    ContextLocal,
 }
 
 pub trait Database<'a>: Debug + Send + Sync + 'static {

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -26,7 +26,8 @@ pub use blobs::BlobMeta;
 pub use calimero_primitives::context::GroupMemberRole;
 use component::KeyComponents;
 pub use context::{
-    ContextConfig, ContextDagDelta, ContextIdentity, ContextMeta, ContextPrivateState, ContextState,
+    ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker, ContextMeta,
+    ContextPrivateState, ContextState,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -175,6 +175,69 @@ impl Debug for ContextIdentity {
     }
 }
 
+/// Per-(member, context) tombstone written when a member calls `leave_context`.
+/// Lives in the node-local `ContextLocal` column — not synchronized.
+///
+/// Presence of this row signals: the member explicitly opted out of this context
+/// on this node, and auto-follow must NOT re-create the corresponding
+/// `ContextIdentity` row on auto-rejoin events. An explicit `JoinContextRequest`
+/// from the user clears the marker.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextLeftMarker(Key<(ContextId, PublicKeyComponent)>);
+
+impl ContextLeftMarker {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId, context_pk: PrimitivePublicKey) -> Self {
+        Self(Key(
+            GenericArray::from(*context_id).concat(GenericArray::from(*context_pk))
+        ))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        let mut context_id = [0; 32];
+        context_id.copy_from_slice(&AsRef::<[_; 64]>::as_ref(&self.0)[..32]);
+        context_id.into()
+    }
+
+    #[must_use]
+    pub fn public_key(&self) -> PrimitivePublicKey {
+        let mut public_key = [0; 32];
+        public_key.copy_from_slice(&AsRef::<[_; 64]>::as_ref(&self.0)[32..]);
+        public_key.into()
+    }
+}
+
+impl AsKeyParts for ContextLeftMarker {
+    type Components = (ContextId, PublicKeyComponent);
+
+    fn column() -> Column {
+        Column::ContextLocal
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        &self.0
+    }
+}
+
+impl FromKeyParts for ContextLeftMarker {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(parts))
+    }
+}
+
+impl Debug for ContextLeftMarker {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextLeftMarker")
+            .field("context_id", &self.context_id())
+            .field("public_key", &self.public_key())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct StateKey;
 

--- a/crates/store/src/key/group/mod.rs
+++ b/crates/store/src/key/group/mod.rs
@@ -1163,6 +1163,17 @@ pub struct GroupMetaValue {
     pub upgrade_policy: UpgradePolicy,
     pub created_at: u64,
     pub admin_identity: PrimitivePublicKey,
+    /// Single-instance Owner of this group. Distinct from the legacy
+    /// `admin_identity` (which is now a fallback creator-admin marker for
+    /// pre-existing groups). The Owner has exclusive privileges no other
+    /// admin can perform: `TransferOwnership`, `DeleteGroup`/
+    /// `DeleteNamespace`, and immunity from involuntary `MemberRemoved`.
+    /// See `architecture/membership-and-leave.html` § 7.
+    ///
+    /// Set to the signer of `CreateGroupRequest` on group creation. New
+    /// groups have `owner_identity == admin_identity` initially.
+    /// Transferable via `GroupOp::TransferOwnership { new_owner }`.
+    pub owner_identity: PrimitivePublicKey,
     pub migration: Option<Vec<u8>>,
     /// When true, joining members auto-subscribe to all visible contexts.
     pub auto_join: bool,
@@ -1980,6 +1991,7 @@ mod tests {
                 upgrade_policy: UpgradePolicy::Automatic,
                 created_at: 1_700_000_000,
                 admin_identity: PrimitivePublicKey::from([0xCC; 32]),
+                owner_identity: PrimitivePublicKey::from([0xCC; 32]),
                 migration: None,
                 auto_join: true,
             };
@@ -2006,6 +2018,7 @@ mod tests {
                 },
                 created_at: 1_700_000_000,
                 admin_identity: PrimitivePublicKey::from([0x33; 32]),
+                owner_identity: PrimitivePublicKey::from([0x33; 32]),
                 migration: None,
                 auto_join: true,
             };

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -11,7 +11,8 @@ mod group;
 pub use application::{ApplicationMeta, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
-    ContextConfig, ContextDagDelta, ContextIdentity, ContextMeta, ContextPrivateState, ContextState,
+    ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker, ContextMeta,
+    ContextPrivateState, ContextState,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -124,6 +124,23 @@ impl PredefinedEntry for key::ContextIdentity {
     type DataType<'a> = ContextIdentity;
 }
 
+/// Tombstone value for `key::ContextLeftMarker`. Stores when the user explicitly
+/// left this context on this node (millis since epoch). Presence of the row is
+/// what matters for the auto-follow gate; the timestamp is for diagnostics.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "Tombstone value — additions would need a migration"
+)]
+pub struct ContextLeftMarker {
+    pub left_at_ms: u64,
+}
+
+impl PredefinedEntry for key::ContextLeftMarker {
+    type Codec = Borsh;
+    type DataType<'a> = ContextLeftMarker;
+}
+
 /// DAG delta data (persisted)
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug)]
 pub struct ContextDagDelta {


### PR DESCRIPTION
## Summary

Implements the full design from `architecture/membership-and-leave.html` (committed as part of this PR): three new leave operations and the formalized Owner role.

Six commits, building on each other:

1. **`docs(architecture): membership-and-leave design proposal`** — 532-line HTML doc with full design, privilege matrix, and reference table. Status legend flips through implemented as commits land.
2. **`feat(context): leave_context — local-only opt-out`** — `Column::ContextLocal`, `ContextLeftMarker` key, handler, auto-follow gate, admin-API endpoint. Pure local: no DAG entry, no key rotation, no broadcast.
3. **`feat(governance): add owner_identity field to GroupMetaValue`** — adds the field across every `GroupMetaValue` construction site. New groups default `owner_identity == admin_identity` (creator becomes Owner).
4. **`feat(governance): TransferOwnership op + Owner-only gates`** — new `GroupOp::TransferOwnership` variant + apply, `CannotRemoveOwner` rejection in `MemberRemoved`, `GroupDelete` tightened from `require_admin` to owner-only.
5. **`feat(governance): leave_group — distributed self-leave op`** — `GroupOp::MemberLeft { member }` variant, validation (self-leave + direct-row + owner + last-admin), `LeaveGroupRequest` actor + handler + admin-API.
6. **`feat(governance): leave_namespace — cascading self-leave at the root`** — apply detects no-parent and cascades through descendants where leaver has direct rows; multi-scope owner + last-admin checks upfront. `LeaveNamespaceRequest` + handler + admin-API.

## Admin API surface added

| Endpoint | Behavior |
|---|---|
| `POST /admin-api/contexts/:context_id/leave` | Local-only opt-out from a single context |
| `POST /admin-api/groups/:group_id/leave` | Distributed self-leave from a single group |
| `POST /admin-api/namespaces/:namespace_id/leave` | Self-leave from namespace + cascade through subtree |

Plus a new `GroupOp::TransferOwnership { new_owner }` available through the existing local-governance path.

## Privilege model after this PR

| Action | Member | Admin | Owner |
|---|---|---|---|
| `leave_context` (local-only) | ✓ | ✓ | ✓ |
| `leave_group` | ✓ (last-admin permitting) | ✓ (last-admin permitting) | ✗ — must `TransferOwnership` first |
| `leave_namespace` | ✓ (per-scope last-admin) | ✓ (per-scope last-admin) | ✗ — must transfer every owned scope first |
| `MemberRemoved` (against you) | ✓ | ✓ | ✗ — `CannotRemoveOwner` |
| `TransferOwnership` | ✗ | ✗ | ✓ |
| `GroupDelete` | ✗ | ✗ | ✓ (was `require_admin`, tightened) |

## Deliberately deferred

Flagged in the doc and in inline comments; not in this PR:

1. **Two-phase rotation for self-leave.** `MemberLeft` does NOT trigger the key-rotation pipeline that admin-initiated `MemberRemoved` does. The leaver cannot generate the new key without retaining it, which would defeat forward secrecy. Proper design needs a remaining admin's apply-hook to publish the follow-up `KeyDelivery` — that's a discrete piece of broadcast-layer work and was the right thing to defer rather than rush. **Today, for cryptographic forward secrecy, pair `MemberLeft` with admin follow-up `MemberRemoved`.**
2. **Hard local-cleanup mode for `leave_namespace`.** Currently soft-only: rows removed across subtree but encrypted blobs and keys remain on the leaver's local node. Hard purge is a follow-up.
3. **Tests for the new ops.** Existing tests still pass (workspace builds clean, including the test suites that exercise the modified `GroupMetaValue` shape). Targeted tests for `MemberLeft`, `TransferOwnership`, `CannotRemoveOwner`, and the namespace cascade are deferred to a follow-up.
4. **Root-level `RootOp::GroupDeleted` / `DeleteNamespace` Owner-gating.** The handler-side `DeleteNamespace` op is still admin-gated; tightening to namespace-Owner is coupled with the multi-scope-owner check work and was natural to defer alongside hard-cleanup.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] Workspace compiles after `GroupMetaValue.owner_identity` field addition (~14 construction sites updated)
- [ ] Targeted tests for new ops (deferred — see above)
- [ ] CI passes
- [ ] Reviewer confirms forward-secrecy trade-off in `MemberLeft` is acceptable for v1

## Open questions surfaced in the doc (Section 10)

These are decisions that would inform follow-up work:

1. Soft vs hard cleanup default for `leave_namespace` (currently soft).
2. Whether admins can demote each other (currently yes, preserving existing behavior).
3. Old owner's role after `TransferOwnership` (currently stays admin).
4. Multi-scope transfer ergonomics in the UI.
5. User-facing event collapsing for namespace cascade.
6. Owner-leaves-with-no-successor edge case (currently routes to `DeleteNamespace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core governance/membership mutation paths (new `GroupOp` variants, namespace cascade, and stricter delete/remove authorization), which can affect access control and group state convergence. Also adds new admin API endpoints and a new local storage column, so regressions could impact membership/sync behavior.
> 
> **Overview**
> Adds three new leave flows exposed via admin API and `meroctl`: **local** `leave_context` (writes a node-local `ContextLeftMarker`, deletes `ContextIdentity`, unsubscribes from gossipsub, and gates auto-follow until an explicit re-`join_context` clears the marker), plus **distributed** `leave_group`/`leave_namespace` which publish `GroupOp::MemberLeft` and remove the caller’s direct membership row (namespace leave cascades through descendant groups where the member has direct rows).
> 
> Formalizes an **Owner** concept by adding `owner_identity` to `GroupMetaValue`, introducing `GroupOp::TransferOwnership`, preventing involuntary removal of owners, and tightening `GroupDelete` to be owner-only; constructors/tests are updated accordingly. Documentation is expanded with a new `architecture/membership-and-leave.html` design page and cross-links from the architecture index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1cde9a831e023de26646391f2e8e4697f5a4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->