### PR TITLE
fix(governance): owner_identity in state hash + reject leave_group on namespace root

### DIFF
--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -62,9 +62,16 @@ pub fn enumerate_all_groups(
 
 /// Compute a deterministic SHA-256 hash of the group's authorization-relevant state.
 ///
-/// Covers members (sorted by public key) + roles + admin identity + target application.
-/// This hash is embedded in each SignedGroupOp to ensure ops can only apply against
-/// the exact state they were signed against, preventing divergence from concurrent ops.
+/// Covers members (sorted by public key) + roles + admin identity + owner identity +
+/// target application. This hash is embedded in each SignedGroupOp to ensure ops can
+/// only apply against the exact state they were signed against, preventing divergence
+/// from concurrent ops.
+///
+/// `owner_identity` is part of the hash because it gates a real authorization decision:
+/// `TransferOwnership`, `GroupDelete`, and the `CannotRemoveOwner` check on
+/// `MemberRemoved` all branch on the current owner. Without including it, two ops
+/// signed before and after a `TransferOwnership` would compute the same state hash and
+/// the divergence-prevention check would fail to detect that ownership changed.
 pub fn compute_group_state_hash(store: &Store, group_id: &ContextGroupId) -> EyreResult<[u8; 32]> {
     let meta = load_group_meta(store, group_id)?
         .ok_or_else(|| eyre::eyre!("group not found for state hash computation"))?;
@@ -75,6 +82,7 @@ pub fn compute_group_state_hash(store: &Store, group_id: &ContextGroupId) -> Eyr
     let mut hasher = Sha256::new();
     hasher.update(group_id.to_bytes());
     hasher.update(AsRef::<[u8]>::as_ref(&meta.admin_identity));
+    hasher.update(AsRef::<[u8]>::as_ref(&meta.owner_identity));
     hasher.update(meta.target_application_id.as_ref());
     for (pk, role) in &members {
         hasher.update(AsRef::<[u8]>::as_ref(pk));

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -33,6 +33,25 @@ impl Handler<LeaveGroupRequest> for ContextManager {
         // Resolve this node's identity for the group's namespace. If the
         // node has no namespace identity, it can't be a member of any
         // subgroup under it — nothing to leave.
+        // Reject if the caller passed a namespace (root group) here.
+        // Although the apply path's `MemberLeft` arm correctly cascades
+        // for root-group leaves, this handler does NOT call
+        // `unsubscribe_namespace` (it can't, because the leaver may still
+        // be in other groups under the same namespace). For a namespace
+        // leave, the proper handler is `leave_namespace`, which both
+        // applies the cascade AND unsubscribes from gossipsub.
+        match group_store::resolve_namespace(&self.datastore, &group_id) {
+            Ok(ns) if ns == group_id => {
+                return ActorResponse::reply(Err(eyre::eyre!(
+                    "{:?} is a namespace (root group); use leave_namespace, \
+                     which also unsubscribes from the namespace gossipsub topic",
+                    group_id
+                )))
+            }
+            Ok(_) => {}
+            Err(err) => return ActorResponse::reply(Err(err)),
+        }
+
         let self_identity = match self.node_namespace_identity(&group_id) {
             Some((pk, sk_bytes)) => (pk, sk_bytes),
             None => {


### PR DESCRIPTION
## Summary

Two bugs surfaced by Cursor BugBot post-merge of #2280 — one **high-severity correctness bug** in concurrent-op handling and one **medium-severity** UX/state-leak issue.

### High: `compute_group_state_hash` omits `owner_identity`

`compute_group_state_hash` (`crates/context/src/group_store/meta.rs`) hashes `admin_identity` but missed the new `owner_identity` field added in #2280. The state hash is embedded in every `SignedGroupOp` to prevent ops from applying against state they weren't signed against — without `owner_identity` in the hash, two ops signed before and after a `TransferOwnership` produce identical state hashes. The divergence-prevention check can't detect that ownership changed, breaking the consistency contract for every owner-gated op:

- `TransferOwnership` itself — concurrent transfers can't be ordered.
- `GroupDelete` — owner-only gate sees stale owner.
- `MemberRemoved` with `CannotRemoveOwner` — immunity check sees stale owner; concurrent transfer + remove could remove the new owner.

**Fix**: add `owner_identity` to the hash inputs, alongside `admin_identity`. Function comment explains why.

### Medium: `leave_group` on namespace root skips gossipsub unsubscribe

If `leave_group` is invoked with a namespace ID, the apply path correctly cascades through descendants (because `MemberLeft` at root detects the no-parent case and walks the subtree). But the handler itself does NOT call `unsubscribe_namespace` — that's intentional for subgroup leaves (leaver may still be in other groups under the namespace), but it's wrong for a namespace leave because all membership rows are gone yet the node remains subscribed to namespace governance traffic.

**Fix**: reject `leave_group` calls where the target group is a namespace (no parent), with a clear error pointing the caller at `leave_namespace`. The user-facing API is now strict about which op to use; gossipsub unsubscribe stays in the namespace handler where the precondition is unambiguous.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p calimero-context --lib` — 173/173
- [ ] CI passes
- [ ] (Optional, post-merge) regression tests covering: concurrent `TransferOwnership` rejection by state-hash divergence; `leave_group(namespace_id)` returns `is a namespace; use leave_namespace`

## Why this is a follow-up rather than amending #2280

#2280 already merged at 09:58Z. These fixes need to land separately on master.

## References

- High: [Cursor BugBot finding on c5e147568](https://github.com/calimero-network/core/pull/2280#issuecomment-bot)
- Medium: same review — both flagged after the original merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the governance state-hash inputs used to sign/validate ops, which could cause previously-signed operations to be rejected if any clients still compute the old hash. The `leave_group` behavior change is localized but may break callers that incorrectly used it for namespace/root leaves.
> 
> **Overview**
> Fixes a concurrency/correctness gap in governance by including `meta.owner_identity` in `compute_group_state_hash`, so owner-gated ops (`TransferOwnership`, `GroupDelete`, owner-removal checks) cannot be applied against a state different from what was signed.
> 
> Tightens the `leave_group` API by rejecting requests targeting a namespace/root group (detected via `resolve_namespace`), directing callers to `leave_namespace` so the namespace gossipsub unsubscribe is handled correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0c9f679ab8f9a3c61639f1c92a7b7cf71ab632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->