### PR TITLE
feat(admin-api): add group_state_hash; rename context root_hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.34"
+version = "0.10.1-rc.35"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -130,6 +130,11 @@ pub struct GroupInfoResponse {
     pub default_capabilities: u32,
     pub subgroup_visibility: String,
     pub alias: Option<String>,
+    /// SHA-256 hash of the group's authorization-relevant state
+    /// (members + roles + admin + owner + target app), produced by
+    /// `compute_group_state_hash`. Used by clients to detect governance
+    /// convergence across nodes.
+    pub state_hash: [u8; 32],
 }
 
 #[derive(Debug)]

--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -44,6 +44,8 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
 
             let alias = group_store::get_group_alias(&self.datastore, &group_id)?;
 
+            let state_hash = group_store::compute_group_state_hash(&self.datastore, &group_id)?;
+
             Ok(GroupInfoResponse {
                 group_id,
                 app_key: meta.app_key.into(),
@@ -55,6 +57,7 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
                 default_capabilities,
                 subgroup_visibility,
                 alias,
+                state_hash,
             })
         })();
 

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -109,6 +109,7 @@ pub struct Context {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub service_name: Option<String>,
     /// The root hash of the context's state Merkle tree.
+    #[serde(rename = "contextStateHash")]
     pub root_hash: Hash,
     /// Current DAG heads (delta IDs with no children yet)
     /// Used to track causal dependencies when creating new deltas

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -109,6 +109,10 @@ pub struct Context {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub service_name: Option<String>,
     /// The root hash of the context's state Merkle tree.
+    // Explicit rename (overrides struct-level rename_all = "camelCase")
+    // pins the public JSON name to `contextStateHash` independent of the
+    // Rust field name. Part of the cross-DAG auth roadmap's three-level
+    // naming pattern: contextStateHash / groupStateHash / namespaceStateHash.
     #[serde(rename = "contextStateHash")]
     pub root_hash: Hash,
     /// Current DAG heads (delta IDs with no children yet)

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1692,6 +1692,9 @@ pub struct GroupInfoApiResponseData {
     /// Hex-encoded SHA-256 hash of the group's authorization-relevant
     /// state. Mirrors `contextStateHash` on context responses; lets
     /// clients poll for governance convergence across nodes.
+    // Explicit rename pins the JSON name even if the Rust field is
+    // refactored, matching the same pattern as `contextStateHash`.
+    #[serde(rename = "groupStateHash")]
     pub group_state_hash: String,
 }
 

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1689,6 +1689,10 @@ pub struct GroupInfoApiResponseData {
     pub subgroup_visibility: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    /// Hex-encoded SHA-256 hash of the group's authorization-relevant
+    /// state. Mirrors `contextStateHash` on context responses; lets
+    /// clients poll for governance convergence across nodes.
+    pub group_state_hash: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/context/get_contexts_with_executors_for_application.rs
+++ b/crates/server/src/admin/handlers/context/get_contexts_with_executors_for_application.rs
@@ -17,6 +17,7 @@ use crate::AdminState;
 pub struct ContextWithExecutors {
     pub id: String,
     pub application_id: String,
+    #[serde(rename = "contextStateHash")]
     pub root_hash: String,
     pub executors: Vec<String>,
 }

--- a/crates/server/src/admin/handlers/groups/get_group_info.rs
+++ b/crates/server/src/admin/handlers/groups/get_group_info.rs
@@ -46,6 +46,7 @@ pub async fn handler(
                         default_capabilities: info.default_capabilities,
                         subgroup_visibility: info.subgroup_visibility,
                         alias: info.alias,
+                        group_state_hash: hex::encode(info.state_hash),
                     },
                 },
             }


### PR DESCRIPTION
## Summary

Implements **A1** of the [cross-DAG authorization roadmap](https://github.com/calimero-network/core/pull/2286) (`docs/rfc/cross-dag-authorization.md`).

Exposes a per-group governance state hash alongside the existing per-context storage state hash, with a consistent naming pattern across the admin API.

- New: `groupStateHash` field on group info responses (computed via `compute_group_state_hash` — SHA-256 over members + roles + admin + owner + target app)
- Renamed (JSON-only via serde): `rootHash` → `contextStateHash` on context info responses

Lets clients poll for governance convergence across nodes — unblocks **A2** (`wait_for_governance_sync` merobox step).

## Changes

- Add `group_state_hash` field to `GroupInfoApiResponseData` (camelCase JSON: `groupStateHash`)
- Pipe the hash through `GroupInfoResponse` (internal) → context handler → HTTP handler (hex-encoded)
- Rename `Context.root_hash` → `contextStateHash` at the JSON layer via serde annotation. **Internal Rust field stays `root_hash`** — touching the field name would cascade across ~50 usage sites in `crates/context`, `crates/runtime`, etc. The rename is API-only by design.
- Same serde rename on `ContextWithExecutors.root_hash`
- `Snapshot::root_hash` (storage primitive) unchanged — it is the right name in storage terminology

## Naming pattern across exposed state hashes

| Level | Rust field | JSON field | Status |
|---|---|---|---|
| Context (storage Merkle) | `root_hash` (Rust internal) | `contextStateHash` | this PR |
| Group (governance flat) | `group_state_hash` | `groupStateHash` | this PR |
| Namespace (hierarchical Merkle) | `namespace_state_hash` | `namespaceStateHash` | deferred to A3, Phase 4 |

## Coordinated changes

Paired update needed in [merobox](https://github.com/calimero-network/merobox) — `wait_for_sync.py` and `context.py` need to read `contextStateHash` (currently fall back to `rootHash`/`root_hash`). Separate PR coming.

## Test plan

- [x] cargo check passes for affected crates
- [x] cargo test -p calimero-context --lib (173 tests pass)
- [x] cargo test -p calimero-server --lib
- [x] cargo test -p calimero-server-primitives --lib
- [x] cargo test -p calimero-primitives --lib
- [ ] e2e: confirm two converged nodes return identical groupStateHash; two divergent nodes return different values (validate after merobox PR is paired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public Admin API response schemas (adds `groupStateHash` and renames `rootHash` to `contextStateHash`), which can break existing clients if not updated; underlying state computation is reused and low-risk.
> 
> **Overview**
> Adds a governance convergence signal to the Admin API by exposing a per-group SHA-256 state hash. `GetGroupInfo` now computes `compute_group_state_hash` and returns it through the internal `GroupInfoResponse` and the HTTP admin endpoint as hex-encoded `groupStateHash`.
> 
> Renames the JSON field for a context’s storage hash from `rootHash` to `contextStateHash` (serde rename only; Rust field remains `root_hash`), including on the “contexts with executors” admin response. Also bumps the workspace version to `0.10.1-rc.35`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bdce74e46bc0f24d647de5fc8f840ab0d053ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->