### PR TITLE
fix: update fuzzy tests

### DIFF
--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -25,8 +25,9 @@ use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::{app, env, PublicKey};
 use calimero_storage::collections::{
-    AuthoredMap, Counter, FrozenStorage, GCounter, LwwRegister, Mergeable, PNCounter,
-    ReplicatedGrowableArray, SharedStorage, UnorderedMap, UnorderedSet, UserStorage, Vector,
+    AuthoredMap, AuthoredVector, Counter, FrozenStorage, GCounter, LwwRegister, Mergeable,
+    PNCounter, ReplicatedGrowableArray, SharedStorage, UnorderedMap, UnorderedSet, UserStorage,
+    Vector,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -162,6 +163,10 @@ pub struct E2eKvStore {
     /// Shared keyspace map with per-entry ownership
     authored_items: AuthoredMap<String, LwwRegister<String>>,
 
+    // --- Authored Vector ---
+    /// Append-only vector with per-slot ownership; only the pusher can update/tombstone their slot
+    authored_vec: AuthoredVector<LwwRegister<String>>,
+
     // --- Shared Storage ---
     /// Group-writable single value; writers rotate at runtime
     shared_data: SharedStorage<LwwRegister<String>>,
@@ -286,6 +291,20 @@ pub enum Event<'a> {
         key: String,
     },
 
+    // Authored Vector Events
+    AuthoredVecPushed {
+        index: usize,
+        value: String,
+        owner: String,
+    },
+    AuthoredVecUpdated {
+        index: usize,
+        value: String,
+    },
+    AuthoredVecRemoved {
+        index: usize,
+    },
+
     // Shared Storage Events
     SharedSet {
         value: String,
@@ -392,6 +411,8 @@ impl E2eKvStore {
             rga_metadata: UnorderedMap::new(),
             // Authored Map
             authored_items: AuthoredMap::new(),
+            // Authored Vector
+            authored_vec: AuthoredVector::<LwwRegister<String>>::new(),
             // Shared Storage — init caller becomes the sole initial writer
             shared_data: SharedStorage::new(
                 std::iter::once(env::executor_id().into()).collect(),
@@ -1303,5 +1324,68 @@ impl E2eKvStore {
 
     pub fn shared_is_frozen(&self) -> Result<bool, String> {
         Ok(self.shared_data.is_frozen())
+    }
+
+    // AUTHORED VECTOR
+
+    pub fn authored_vec_push(&mut self, value: String) -> Result<usize, String> {
+        let index = self
+            .authored_vec
+            .push(LwwRegister::new(value.clone()))
+            .map_err(|e| format!("authored_vec_push failed: {:?}", e))?;
+        let owner = bs58::encode(env::executor_id()).into_string();
+        app::emit!(Event::AuthoredVecPushed {
+            index,
+            value,
+            owner,
+        });
+        Ok(index)
+    }
+
+    pub fn authored_vec_get(&self, index: usize) -> Result<Option<String>, String> {
+        Ok(self
+            .authored_vec
+            .get(index)
+            .map_err(|e| format!("authored_vec_get failed: {:?}", e))?
+            .map(|r| r.get().clone()))
+    }
+
+    pub fn authored_vec_update(&mut self, index: usize, value: String) -> Result<(), String> {
+        self.authored_vec
+            .update(index, LwwRegister::new(value.clone()))
+            .map_err(|e| format!("authored_vec_update failed: {:?}", e))?;
+        app::emit!(Event::AuthoredVecUpdated { index, value });
+        Ok(())
+    }
+
+    pub fn authored_vec_remove(&mut self, index: usize) -> Result<(), String> {
+        self.authored_vec
+            .tombstone(index)
+            .map_err(|e| format!("authored_vec_remove failed: {:?}", e))?;
+        app::emit!(Event::AuthoredVecRemoved { index });
+        Ok(())
+    }
+
+    pub fn authored_vec_get_owner(&self, index: usize) -> Result<Option<String>, String> {
+        Ok(self
+            .authored_vec
+            .owner_of(index)
+            .map_err(|e| format!("authored_vec_get_owner failed: {:?}", e))?
+            .map(|pk| pk.to_string()))
+    }
+
+    pub fn authored_vec_entries(&self) -> Result<Vec<String>, String> {
+        Ok(self
+            .authored_vec
+            .iter()
+            .map_err(|e| format!("authored_vec_entries failed: {:?}", e))?
+            .map(|r| r.get().clone())
+            .collect())
+    }
+
+    pub fn authored_vec_len(&self) -> Result<usize, String> {
+        self.authored_vec
+            .len()
+            .map_err(|e| format!("authored_vec_len failed: {:?}", e))
     }
 }

--- a/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
@@ -531,7 +531,7 @@ steps:
             args:
               value: "frozen_{{uuid}}"
             outputs:
-              frozen_hash: result
+              frozen_hash: result.output
           - type: assert
             non_blocking: true
             statements:

--- a/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
@@ -636,6 +636,36 @@ steps:
             statements:
               - "is_set({{authored_upd_result}})"
 
+      # AuthoredVector push + read — 3% of traffic
+      # Any node pushes, becomes owner of the new slot; index propagates to all peers
+      - name: "authored_vec_push_get"
+        weight: 3
+        steps:
+          - type: call
+            node: "{{random_node}}"
+            context_id: "{{e2e_context_id}}"
+            method: authored_vec_push
+            args:
+              value: "vec_{{uuid}}_{{timestamp}}"
+            outputs:
+              vec_push_index: result.output
+          - type: assert
+            non_blocking: true
+            statements:
+              - "is_set({{vec_push_index}})"
+          - type: wait
+            seconds: 1
+          - type: call
+            node: "{{random_node}}"
+            context_id: "{{e2e_context_id}}"
+            method: authored_vec_len
+            outputs:
+              vec_len_result: result
+          - type: assert
+            non_blocking: true
+            statements:
+              - "is_set({{vec_len_result}})"
+
       # SharedStorage concurrent write + read — 4% of traffic
       # All 4 nodes are writers; benchmarks LWW merge under concurrent writes
       - name: "shared_write_read"

--- a/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
@@ -531,6 +531,8 @@ steps:
             args:
               value: "frozen_{{uuid}}"
             outputs:
+              # add_frozen returns its hex hash wrapped as {"output": "<hash>"};
+              # other ops in this file return plain values, hence the deviation.
               frozen_hash: result.output
           - type: assert
             non_blocking: true


### PR DESCRIPTION
# fix: update fuzzy tests

## Description
REF:
```
context_id=73waMGWEyU74UZ4GggRiCbsxn5XnQykeXzWNJdrJB7tr 
err=function call error: guest panicked: Failed to deserialize input
from JSON: Error("invalid type: map, expected a string", line: 1, column: 12) at
apps/scaffolding-e2e/src/lib.rs:623:12
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted `AuthoredVector` field and related methods/events to the e2e app state, which can impact state serialization/migrations and test stability. Fuzzy-test workflow changes adjust result parsing and add new operations, which may alter load-test behavior and failure modes.
> 
> **Overview**
> Extends the `scaffolding-e2e` app with a new **per-slot-owned** `AuthoredVector` data structure, including state initialization, new `Event` variants, and public methods to `push`, `get`, `update`, `tombstone`, list entries, query length, and fetch slot owner.
> 
> Updates the scaffolding fuzzy load test to fix `add_frozen` output extraction (now reading `result.output` to avoid JSON deserialization errors) and adds a new weighted operation to exercise `AuthoredVector` push + length checks during the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19dd42820bccb3076f793bd72d21a95ec0151b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->