### PR TITLE
fix(client/test): add groupStateHash to get_group_info mock response

### DIFF
--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -121,7 +121,8 @@ async fn get_group_info() {
                 "contextCount": 0,
                 "activeUpgrade": null,
                 "defaultCapabilities": 0,
-                "subgroupVisibility": "open"
+                "subgroupVisibility": "open",
+                "groupStateHash": "0000000000000000000000000000000000000000000000000000000000000000"
             }
         })))
         .expect(1)


### PR DESCRIPTION
A1 (#2289) added `pub group_state_hash: String` to GroupInfoApiResponseData. The unit test mock in
crates/client/src/tests.rs::get_group_info wasn't updated, so deserialization fails on the missing field after the merge.

Adds a zero-hex placeholder to the mock JSON body — purely a test fixture concern; the field's real value comes from compute_group_state_hash in the actual handler path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only fixture update to match a new response field; no production logic changes.
> 
> **Overview**
> Fixes the `get_group_info` client unit test by updating the mocked JSON response to include the newly-required `groupStateHash` field, preventing deserialization failures after the API response schema change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a72ec32300e6e26ff3173e4296dbbb8a31beb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->