### PR TITLE
ci(doc-update): inline upstream workflow, drop cache:pip to unbreak master

### DIFF
--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,5 +1,17 @@
 name: Doc Auto-Update
 
+# Inlined from calimero-network/ai-code-reviewer reusable workflow at
+# SHA 71b0895c1908504b18f07f2856adfc9c8c8d1e4e, with one fix:
+# `cache: pip` removed from `actions/setup-python@v5`. The upstream sets
+# it unconditionally, but setup-python's pip cache requires a
+# requirements.txt or pyproject.toml in the calling repo — neither
+# exists here (core is Rust), so every run failed with:
+#   No file in /home/runner/work/core/core matched to
+#   [**/requirements.txt or **/pyproject.toml]
+# Tracked for an upstream fix; once that lands and we bump the pinned
+# install SHA, this can revert to a thin caller invoking the reusable
+# workflow.
+
 on:
   push:
     branches: [main, master]
@@ -23,13 +35,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  doc-update:
-    # Pinned to a specific SHA on calimero-network/ai-code-reviewer (which
-    # uses `master`, not `main`) to prevent an upstream change from running
-    # with this repo's GH_PAT. Bump deliberately when adopting new features.
-    uses: calimero-network/ai-code-reviewer/.github/workflows/doc-update.yaml@71b0895c1908504b18f07f2856adfc9c8c8d1e4e
-    with:
-      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GH_PAT: ${{ secrets.GH_PAT }}
+  update-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # NOTE: `cache: pip` deliberately omitted — see file-level comment.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Pinned to the same SHA as ai-review.yaml so both workflows install
+      # the audited version of ai-code-reviewer. Bump deliberately.
+      - name: Install ai-code-reviewer
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@71b0895c1908504b18f07f2856adfc9c8c8d1e4e
+
+      - name: Get merged PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          # Prefer explicit input (workflow_dispatch), then commit message, then gh CLI
+          PR_NUM="${{ github.event.inputs.pr_number }}"
+
+          if [ -z "$PR_NUM" ]; then
+            MSG="${{ github.event.head_commit.message }}"
+            PR_NUM=$(echo "$MSG" | grep -oP '(?<=pull request #)\d+' | head -1 || true)
+          fi
+
+          if [ -z "$PR_NUM" ]; then
+            PR_NUM=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --state merged \
+              --base "${{ github.event.repository.default_branch }}" \
+              --limit 1 \
+              --json number \
+              -q '.[0].number' 2>/dev/null || true)
+          fi
+
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Generate and open doc update PR
+        if: steps.pr.outputs.number != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          ai-reviewer update-docs "${{ github.repository }}" "${{ steps.pr.outputs.number }}" $DRY_RUN_FLAG
+
+      - name: No PR detected
+        if: steps.pr.outputs.number == ''
+        run: echo "Could not detect a merged PR — skipping doc update."

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -85,9 +85,22 @@ jobs:
           fi
 
           # 2. Otherwise: which PR introduced this exact commit?
+          #    `// empty` in the jq filter prevents JSON `null` (the jq result
+          #    when the API returns []) from being printed as the literal
+          #    string "null". Without it, PR_NUM=null would pass the -z check
+          #    later and we'd hand "null" to ai-reviewer.
+          #    Errors are surfaced (no `2>/dev/null`); a real API failure
+          #    should be visible in logs rather than silently skipping.
           if [ -z "$PR_NUM" ]; then
-            PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" \
-              --jq '.[0].number' 2>/dev/null || true)
+            if ! PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty'); then
+              echo "::warning::gh api commits/{sha}/pulls failed; doc update will be skipped"
+              PR_NUM=""
+            fi
+          fi
+
+          # Final sanity check: only forward digit-only values.
+          if [[ ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+            PR_NUM=""
           fi
 
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -60,34 +60,34 @@ jobs:
 
       - name: Get merged PR number
         id: pr
-        # Untrusted values (commit message, dispatch inputs) flow through `env`
-        # so the shell only sees `"$VAR"` references — never string-interpolated
-        # via `${{ ... }}` directly into a script. Without this, a merged PR
-        # whose commit message contained backticks or `$(...)` could execute
-        # arbitrary commands with this job's `contents: write` /
-        # `pull-requests: write` permissions.
+        # All event-derived values flow through `env` so the shell only sees
+        # `"$VAR"` references; nothing is `${{ ... }}`-interpolated directly
+        # into a `run` block.
+        #
+        # PR detection uses the `commits/{sha}/pulls` API rather than grepping
+        # the commit message + falling back to `gh pr list --limit 1`. The
+        # API returns the PR that *introduced* this commit to the default
+        # branch, which is correct for both merge commits and squash/rebase
+        # merges — and unlike the time-ordered list, it doesn't race with
+        # other PRs that merge in the same window.
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           REPO: ${{ github.repository }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SHA: ${{ github.sha }}
         run: |
-          # Prefer explicit input (workflow_dispatch), then commit message, then gh CLI
-          PR_NUM="$INPUT_PR_NUMBER"
-
-          if [ -z "$PR_NUM" ]; then
-            PR_NUM=$(echo "$HEAD_COMMIT_MESSAGE" | grep -oP '(?<=pull request #)\d+' | head -1 || true)
+          # 1. Explicit dispatch input wins, but only if it parses as digits.
+          #    Anything else is dropped so we fall through to auto-detect
+          #    (and so non-numeric input can't poison GITHUB_OUTPUT).
+          PR_NUM=""
+          if [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            PR_NUM="$INPUT_PR_NUMBER"
           fi
 
+          # 2. Otherwise: which PR introduced this exact commit?
           if [ -z "$PR_NUM" ]; then
-            PR_NUM=$(gh pr list \
-              --repo "$REPO" \
-              --state merged \
-              --base "$DEFAULT_BRANCH" \
-              --limit 1 \
-              --json number \
-              -q '.[0].number' 2>/dev/null || true)
+            PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" \
+              --jq '.[0].number' 2>/dev/null || true)
           fi
 
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
@@ -103,11 +103,11 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          DRY_RUN_FLAG=""
+          DRY_RUN_FLAG=()
           if [ "$DRY_RUN" = "true" ]; then
-            DRY_RUN_FLAG="--dry-run"
+            DRY_RUN_FLAG=(--dry-run)
           fi
-          ai-reviewer update-docs "$REPO" "$PR_NUMBER" $DRY_RUN_FLAG
+          ai-reviewer update-docs "$REPO" "$PR_NUMBER" "${DRY_RUN_FLAG[@]}"
 
       - name: No PR detected
         if: steps.pr.outputs.number == ''

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -17,6 +17,10 @@ on:
     branches: [main, master]
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: "PR number to generate docs for (leave blank to auto-detect)"
+        type: string
+        required: false
       dry_run:
         description: "Dry run: print changes without opening a PR"
         type: boolean
@@ -56,22 +60,31 @@ jobs:
 
       - name: Get merged PR number
         id: pr
+        # Untrusted values (commit message, dispatch inputs) flow through `env`
+        # so the shell only sees `"$VAR"` references — never string-interpolated
+        # via `${{ ... }}` directly into a script. Without this, a merged PR
+        # whose commit message contained backticks or `$(...)` could execute
+        # arbitrary commands with this job's `contents: write` /
+        # `pull-requests: write` permissions.
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Prefer explicit input (workflow_dispatch), then commit message, then gh CLI
-          PR_NUM="${{ github.event.inputs.pr_number }}"
+          PR_NUM="$INPUT_PR_NUMBER"
 
           if [ -z "$PR_NUM" ]; then
-            MSG="${{ github.event.head_commit.message }}"
-            PR_NUM=$(echo "$MSG" | grep -oP '(?<=pull request #)\d+' | head -1 || true)
+            PR_NUM=$(echo "$HEAD_COMMIT_MESSAGE" | grep -oP '(?<=pull request #)\d+' | head -1 || true)
           fi
 
           if [ -z "$PR_NUM" ]; then
             PR_NUM=$(gh pr list \
-              --repo "${{ github.repository }}" \
+              --repo "$REPO" \
               --state merged \
-              --base "${{ github.event.repository.default_branch }}" \
+              --base "$DEFAULT_BRANCH" \
               --limit 1 \
               --json number \
               -q '.[0].number' 2>/dev/null || true)
@@ -81,15 +94,20 @@ jobs:
 
       - name: Generate and open doc update PR
         if: steps.pr.outputs.number != ''
+        # Same defense-in-depth pattern as above: untrusted-ish values go
+        # through `env` so the shell never string-interpolates them.
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
-          ai-reviewer update-docs "${{ github.repository }}" "${{ steps.pr.outputs.number }}" $DRY_RUN_FLAG
+          ai-reviewer update-docs "$REPO" "$PR_NUMBER" $DRY_RUN_FLAG
 
       - name: No PR detected
         if: steps.pr.outputs.number == ''


### PR DESCRIPTION
## Summary

The Doc Auto-Update workflow (added in #2234) has been failing on every push to `master` with this error at the `actions/setup-python@v5` step:

> `No file in /home/runner/work/core/core matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository`

Failing run example: https://github.com/calimero-network/core/actions/runs/25499553430

## Root cause

The reusable workflow we delegate to — `calimero-network/ai-code-reviewer/.github/workflows/doc-update.yaml@71b0895c` — sets `cache: pip` unconditionally on `actions/setup-python@v5`. The pip cache key is derived from a `requirements.txt` or `pyproject.toml` in the **calling** repository (here, `core`), but `core` is a Rust workspace and has neither file. setup-python errors out before pip can run, the job fails, and no doc-update PR is ever opened.

This is an upstream defect that hits any non-Python consumer of the reusable workflow. It didn't surface during #2234's review because `doc-update.yaml` only triggers on `push: master` — never on PR events. The first run happened post-merge.

## Fix

Inline the upstream's steps directly into our `doc-update.yaml`, copying verbatim from the same SHA we previously pinned, with **one change**: `cache: pip` removed. The pip-install line is pinned to the same SHA used by `ai-review.yaml` so both workflows install the audited version of `ai-code-reviewer`.

### Why inline rather than fork or wait for upstream
- Inline unbreaks CI immediately. Waiting for an upstream PR to merge before fixing master is unnecessary downtime.
- We had already pinned the upstream to a specific SHA, so the "automatic upstream updates" benefit of `uses:` was gone anyway.
- Single file, ~70 lines. Maintainable.

### Follow-up
I'll open a separate PR upstream on `calimero-network/ai-code-reviewer` to make `cache: pip` opt-in (or guard it with a `hashFiles()` check). Once that lands and we bump the install SHA, this file can revert to a thin caller of the reusable workflow.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the next push to `master` triggers Doc Auto-Update and the `setup-python` step succeeds
- [ ] Verify the rest of the workflow (`Install ai-code-reviewer`, `Get merged PR number`, `Generate and open doc update PR`) executes without regressions
- [ ] If a doc-update PR is opened, sanity-check that it targets `master` and has the correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI automation that uses `GH_PAT` and opens PRs; misconfiguration could break doc-update runs or affect how PR numbers are detected.
> 
> **Overview**
> The `Doc Auto-Update` GitHub Actions workflow is no longer a thin `uses:` wrapper; it now **inlines** the upstream `ai-code-reviewer` doc-update steps while staying pinned to the same audited SHA.
> 
> As part of the inline, it **removes `cache: pip`** from `actions/setup-python@v5` to stop failures in this Rust repo, adds an optional `workflow_dispatch` `pr_number` input, and updates PR auto-detection to use `gh api /commits/{sha}/pulls` with input sanitization before running `ai-reviewer update-docs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4610b2999fec287be61d413ab6426c1c45fe9224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->