### PR TITLE
ci: bump ai-code-reviewer pin to fix HTML doc deletion

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -58,7 +58,7 @@ jobs:
       # prevent an upstream change from running with this repo's secrets.
       # Bump deliberately when adopting new reviewer features.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@9e08631e34f889271cb2d419fc9a2f74f01c34c4
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@25f51a9d76278b55cbfed813fb35a80ae2c458e9
 
       - name: Determine PR number and agent count
         id: pr

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -2,7 +2,16 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `synchronize` (re-run on every push) deliberately omitted to control
+    # cost — a review fires on PR open / reopen / draft→ready, not on each
+    # push. Re-trigger a review by toggling draft or via workflow_dispatch.
+    types: [opened, reopened, ready_for_review]
+    # Doc-only PRs are owned by the `Doc Auto-Update` workflow; skipping
+    # them here avoids paying twice for the same diff.
+    paths-ignore:
+      - 'docs/**'
+      - 'architecture/**'
+      - 'docs-static/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -59,7 +68,8 @@ jobs:
             echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
           else
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            echo "agents=3"                                        >> $GITHUB_OUTPUT
+            # Default to 1 agent for cost; bump via workflow_dispatch when needed.
+            echo "agents=1"                                        >> $GITHUB_OUTPUT
           fi
 
       - name: Run AI Code Review

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -6,8 +6,10 @@ on:
     # cost — a review fires on PR open / reopen / draft→ready, not on each
     # push. Re-trigger a review by toggling draft or via workflow_dispatch.
     types: [opened, reopened, ready_for_review]
-    # Doc-only PRs are owned by the `Doc Auto-Update` workflow; skipping
-    # them here avoids paying twice for the same diff.
+    # Skipped only when ALL changed files are under docs/architecture/docs-static —
+    # mixed PRs still trigger a review (standard GitHub Actions paths-ignore semantics).
+    # Pure-doc PRs are owned by the `Doc Auto-Update` workflow; this avoids paying
+    # twice for the same diff.
     paths-ignore:
       - 'docs/**'
       - 'architecture/**'

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -49,7 +49,7 @@ jobs:
       # prevent an upstream change from running with this repo's secrets.
       # Bump deliberately when adopting new reviewer features.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@71b0895c1908504b18f07f2856adfc9c8c8d1e4e
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@9e08631e34f889271cb2d419fc9a2f74f01c34c4
 
       - name: Determine PR number and agent count
         id: pr

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,7 +1,7 @@
 name: Doc Auto-Update
 
 # Inlined from calimero-network/ai-code-reviewer reusable workflow at
-# SHA 9e08631e34f889271cb2d419fc9a2f74f01c34c4, with one fix:
+# SHA 25f51a9d76278b55cbfed813fb35a80ae2c458e9, with one fix:
 # `cache: pip` removed from `actions/setup-python@v5`. The upstream sets
 # it unconditionally, but setup-python's pip cache requires a
 # requirements.txt or pyproject.toml in the calling repo — neither
@@ -56,7 +56,7 @@ jobs:
       # Pinned to the same SHA as ai-review.yaml so both workflows install
       # the audited version of ai-code-reviewer. Bump deliberately.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@9e08631e34f889271cb2d419fc9a2f74f01c34c4
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@25f51a9d76278b55cbfed813fb35a80ae2c458e9
 
       - name: Get merged PR number
         id: pr

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,7 +1,7 @@
 name: Doc Auto-Update
 
 # Inlined from calimero-network/ai-code-reviewer reusable workflow at
-# SHA 71b0895c1908504b18f07f2856adfc9c8c8d1e4e, with one fix:
+# SHA 9e08631e34f889271cb2d419fc9a2f74f01c34c4, with one fix:
 # `cache: pip` removed from `actions/setup-python@v5`. The upstream sets
 # it unconditionally, but setup-python's pip cache requires a
 # requirements.txt or pyproject.toml in the calling repo — neither
@@ -56,7 +56,7 @@ jobs:
       # Pinned to the same SHA as ai-review.yaml so both workflows install
       # the audited version of ai-code-reviewer. Bump deliberately.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@71b0895c1908504b18f07f2856adfc9c8c8d1e4e
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@9e08631e34f889271cb2d419fc9a2f74f01c34c4
 
       - name: Get merged PR number
         id: pr


### PR DESCRIPTION
## Summary

- Bumps the pinned `ai-code-reviewer` SHA in `.github/workflows/ai-review.yaml` and `.github/workflows/doc-update.yaml` to `25f51a9d76278b55cbfed813fb35a80ae2c458e9` — the merge commit of [calimero-network/ai-code-reviewer#63](https://github.com/calimero-network/ai-code-reviewer/pull/63) on `master`.
- Clarifies the `paths-ignore` comment to spell out that the skip only fires when ALL changed files are under doc paths; mixed PRs still trigger a review.
- Without this bump, the next `update-docs` run can repeat the failure that produced #2296 — 15 architecture pages overwritten with the literal `NO_UPDATE_NEEDED` plus the model's justification (~5365 lines deleted).

## Context

PR #2296 was opened automatically by `ai-reviewer update-docs` after #2295 (the `cache:pip` fix) merged. The upstream tool used `content == "NO_UPDATE_NEEDED"` to detect "no update needed" responses, which silently failed when the model added a trailing explanation — and the entire response was written to disk as the new HTML. Every one of the 15 deleted files had the same 3-line "sentinel + reasoning" pattern, confirming the model judged correctly per file but the post-processor wrote it anyway.

The upstream fix:
- Replaces equality with a parser that accepts the sentinel as the first non-empty line (handles bare sentinel, sentinel + trailing reasoning, and sentinel inside a markdown fence).
- Adds an HTML-shape sanity check: if the model returns prose for an HTML target, the draft is marked failed instead of overwriting the file.
- Tightens the system prompt.
- Adds tests for each variant including the exact #2296 shape.

## Pin choice

The pinned commit (`25f51a9`) is the merge commit of upstream PR #63 on `master` — keeps the "pin to merged-master commits only" policy that earlier reviews on this PR asked for.

## Test plan

- [ ] After merge, the next merged PR triggers `doc-update.yaml`. The run either:
  - opens a PR with real HTML edits, or
  - logs `no doc updates needed after scanning all candidates` and opens nothing (which is the expected outcome for non-architecture changes).
- [ ] PR #2296 (already broken) is unaffected — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
