### PR TITLE
chore: bump 0.10.1 rc.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.35"
+version = "0.10.1-rc.36"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
## Summary

Cuts release 0.10.1-rc.36. Carries the post-rc.35 master commits, including:

- `b21acfda` fix(governance): carry application_id in group invitation payload (#2292)
- `caffd37d` fix(governance): owner_identity in state hash + reject leave_group on namespace root (#2284)
- `26bfed25` feat(governance): leave_context + leave_group + leave_namespace + Owner role (#2280)
- `1be25152` fix(node, dag): StateDelta actor isolation + apply-path stall hardening (#2299) (#2315)
- `a403cfed` fix(node, sync): SyncSessionActor isolates sync sessions on dedicated arbiter (#2316) (#2317)
- `f6c3c999` fix(governance): post-#2270 KeyDelivery hardening + FSM-observation invariant + fuzzy coverage (#2237) (#2271)

The first one in particular unblocks downstream curb workflows that have node-2 join a namespace via invitation and then create a context — those failed on rc.35 with `application not found` because the invitation payload was missing `application_id`.

## Test plan

- [ ] CI green
- [ ] Tag `0.10.1-rc.36` after merge
- [ ] Smoke-test downstream curb `workflows/non-admin-creates.yml` once the new merod image is built

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the workspace metadata version string for the next release candidate and does not change runtime code paths.
> 
> **Overview**
> Bumps the workspace shared crate version in `Cargo.toml` from `0.10.1-rc.35` to `0.10.1-rc.36` to cut the next release candidate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc702a7bcf6398b1ff9944a99366c0fac18660e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->