### PR TITLE
fix(ci): point vmagent at merobox's actual host RPC ports (2528+i)

### DIFF
--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -276,7 +276,7 @@ jobs:
             "${{ steps.setup-vmagent.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent.outputs.bearer_token_file }}" \
-            "8429" "fuzzy-kv-node" "4" "3001" "2"; then
+            "8429" "fuzzy-kv-node" "4" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -538,7 +538,7 @@ jobs:
             "${{ steps.setup-vmagent-handlers.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent-handlers.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent-handlers.outputs.bearer_token_file }}" \
-            "8430" "fuzzy-handlers-node" "4" "3001" "2"; then
+            "8430" "fuzzy-handlers-node" "4" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -788,7 +788,7 @@ jobs:
             "${{ steps.setup-vmagent-e2e.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent-e2e.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent-e2e.outputs.bearer_token_file }}" \
-            "8431" "fuzzy-e2e-node" "4" "3001" "2"; then
+            "8431" "fuzzy-e2e-node" "4" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -1035,7 +1035,7 @@ jobs:
             "${{ steps.setup-vmagent-gov.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent-gov.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent-gov.outputs.bearer_token_file }}" \
-            "8432" "fuzzy-gov-node" "4" "3001" "2"; then
+            "8432" "fuzzy-gov-node" "4" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -268,6 +268,9 @@ jobs:
           SHORT_COMMIT="${COMMIT_HASH:0:7}"
           INSTANCE_NAME="${TEST_CASE}-${SHORT_COMMIT}"
           IMAGE="ghcr.io/calimero-network/merod:${{ steps.image.outputs.tag }}"
+          FUZZY_CONFIG="workflows/fuzzy-tests/kv-store/fuzzy-test.yml"
+          NODE_COUNT=$(yq '.nodes.count' "$FUZZY_CONFIG")
+          NODE_PREFIX=$(yq '.nodes.prefix' "$FUZZY_CONFIG")
 
           VMAGENT_STARTED="false"
           if "$GITHUB_WORKSPACE/scripts/run-vmagent.sh" \
@@ -276,7 +279,7 @@ jobs:
             "${{ steps.setup-vmagent.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent.outputs.bearer_token_file }}" \
-            "8429" "fuzzy-kv-node" "4" "2528" "1"; then
+            "8429" "$NODE_PREFIX" "$NODE_COUNT" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -318,7 +321,7 @@ jobs:
           set +e
           set -o pipefail
           merobox bootstrap run \
-              workflows/fuzzy-tests/kv-store/fuzzy-test.yml \
+              "$FUZZY_CONFIG" \
               --image "$IMAGE" \
               --e2e-mode \
               --verbose 2>&1 | tee fuzzy-test-logs/kv-store/merobox-output.log
@@ -530,6 +533,9 @@ jobs:
           SHORT_COMMIT="${COMMIT_HASH:0:7}"
           INSTANCE_NAME="${TEST_CASE}-${SHORT_COMMIT}"
           IMAGE="ghcr.io/calimero-network/merod:${{ steps.image.outputs.tag }}"
+          FUZZY_CONFIG="workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml"
+          NODE_COUNT=$(yq '.nodes.count' "$FUZZY_CONFIG")
+          NODE_PREFIX=$(yq '.nodes.prefix' "$FUZZY_CONFIG")
 
           VMAGENT_STARTED="false"
           if "$GITHUB_WORKSPACE/scripts/run-vmagent.sh" \
@@ -538,7 +544,7 @@ jobs:
             "${{ steps.setup-vmagent-handlers.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent-handlers.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent-handlers.outputs.bearer_token_file }}" \
-            "8430" "fuzzy-handlers-node" "4" "2528" "1"; then
+            "8430" "$NODE_PREFIX" "$NODE_COUNT" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -574,7 +580,7 @@ jobs:
           set +e
           set -o pipefail
           merobox bootstrap run \
-              workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml \
+              "$FUZZY_CONFIG" \
               --image "$IMAGE" \
               --e2e-mode \
               --verbose 2>&1 | tee fuzzy-test-logs/kv-store-with-handlers/merobox-output.log
@@ -780,6 +786,9 @@ jobs:
           SHORT_COMMIT="${COMMIT_HASH:0:7}"
           INSTANCE_NAME="${TEST_CASE}-${SHORT_COMMIT}"
           IMAGE="ghcr.io/calimero-network/merod:${{ steps.image.outputs.tag }}"
+          FUZZY_CONFIG="workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml"
+          NODE_COUNT=$(yq '.nodes.count' "$FUZZY_CONFIG")
+          NODE_PREFIX=$(yq '.nodes.prefix' "$FUZZY_CONFIG")
 
           VMAGENT_STARTED="false"
           if "$GITHUB_WORKSPACE/scripts/run-vmagent.sh" \
@@ -788,7 +797,7 @@ jobs:
             "${{ steps.setup-vmagent-e2e.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent-e2e.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent-e2e.outputs.bearer_token_file }}" \
-            "8431" "fuzzy-e2e-node" "4" "2528" "1"; then
+            "8431" "$NODE_PREFIX" "$NODE_COUNT" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -822,7 +831,7 @@ jobs:
           set +e
           set -o pipefail
           merobox bootstrap run \
-              workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml \
+              "$FUZZY_CONFIG" \
               --image "$IMAGE" \
               --e2e-mode \
               --verbose 2>&1 | tee fuzzy-test-logs/scaffolding-e2e/merobox-output.log
@@ -1027,6 +1036,9 @@ jobs:
           SHORT_COMMIT="${COMMIT_HASH:0:7}"
           INSTANCE_NAME="${TEST_CASE}-${SHORT_COMMIT}"
           IMAGE="ghcr.io/calimero-network/merod:${{ steps.image.outputs.tag }}"
+          FUZZY_CONFIG="workflows/fuzzy-tests/group-governance/fuzzy-test.yml"
+          NODE_COUNT=$(yq '.nodes.count' "$FUZZY_CONFIG")
+          NODE_PREFIX=$(yq '.nodes.prefix' "$FUZZY_CONFIG")
 
           VMAGENT_STARTED="false"
           if "$GITHUB_WORKSPACE/scripts/run-vmagent.sh" \
@@ -1035,7 +1047,7 @@ jobs:
             "${{ steps.setup-vmagent-gov.outputs.victoria_url }}" \
             "${{ steps.setup-vmagent-gov.outputs.auth_enabled }}" \
             "${{ steps.setup-vmagent-gov.outputs.bearer_token_file }}" \
-            "8432" "fuzzy-gov-node" "4" "2528" "1"; then
+            "8432" "$NODE_PREFIX" "$NODE_COUNT" "2528" "1"; then
             VMAGENT_STARTED="true"
           fi
 
@@ -1069,7 +1081,7 @@ jobs:
           set +e
           set -o pipefail
           merobox bootstrap run \
-              workflows/fuzzy-tests/group-governance/fuzzy-test.yml \
+              "$FUZZY_CONFIG" \
               --image "$IMAGE" \
               --e2e-mode \
               --verbose 2>&1 | tee fuzzy-test-logs/group-governance/merobox-output.log

--- a/scripts/run-vmagent.sh
+++ b/scripts/run-vmagent.sh
@@ -40,7 +40,7 @@ generate_scrape_config() {
     local node_pattern="$7"
     local node_count="$8"
     local base_port="$9"
-    local port_increment="${10:-2}"
+    local port_increment="${10:-1}"
     
     cat > "$config_file" <<EOF
 global:
@@ -184,7 +184,7 @@ update_scrape_config_background() {
     local node_pattern="$8"
     local node_count="$9"
     local base_port="${10}"
-    local port_increment="${11:-2}"
+    local port_increment="${11:-1}"
     
     while kill -0 "$pid" 2>/dev/null; do
         sleep 60  # Update every 60 seconds to refresh process info

--- a/scripts/run-vmagent.sh
+++ b/scripts/run-vmagent.sh
@@ -16,8 +16,8 @@ BEARER_TOKEN_FILE="${9:-}"
 HTTP_PORT="${10:-8429}"
 NODE_PATTERN="${11:-}"  # e.g., "fuzzy-kv-node" or "fuzzy-handlers-node"
 NODE_COUNT="${12:-4}"   # Number of nodes (default: 4)
-BASE_PORT="${13:-3001}" # Starting port (default: 3001 for e2e_mode RPC ports)
-PORT_INCREMENT="${14:-2}" # Port increment between nodes (default: 2 for e2e_mode)
+BASE_PORT="${13:-2528}" # Starting host RPC port (merobox DEFAULT_RPC_PORT = 2528)
+PORT_INCREMENT="${14:-1}" # Host RPC port increment between nodes (merobox bootstrap uses base+i)
 
 if [ -z "$TEST_CASE" ] || [ -z "$VMAGENT_DIR" ] || [ -z "$VICTORIA_URL" ] || [ -z "$NODE_PATTERN" ]; then
     echo "Usage: $0 <test_case> <instance_name> <workflow_run_id> <commit_hash> <branch> <vmagent_dir> <victoria_url> <auth_enabled> <bearer_token_file> <http_port> <node_pattern> [node_count] [base_port] [port_increment]"
@@ -61,9 +61,12 @@ global:
 scrape_configs:
 EOF
     
-    # Generate static targets for predictable ports
-    # Ports start from base_port and increment by port_increment for each node
-    # e.g., base_port=3001, port_increment=2: 3001, 3003, 3005, 3007
+    # Generate static targets for predictable ports.
+    # Ports start from base_port and increment by port_increment for each node.
+    # For merobox `bootstrap run` (no explicit base_rpc_port), allocation is
+    # base + i — i.e. base_port=2528, port_increment=1 produces 2528, 2529,
+    # 2530, 2531. Matches the host port-binding emitted by merobox's
+    # `_find_available_ports(DEFAULT_RPC_PORT)` path.
     local ports_found=0
     local port
     local node_idx


### PR DESCRIPTION
The fuzzy-load-test workflow has been recording only the synthetic `up` series in VictoriaMetrics because vmagent gets `connection refused` on every scrape attempt. The vmagent log artifact from run 25606938612 shows nothing else for the entire 15-minute test:

  cannot scrape target "http://localhost:3001/metrics" ...
  dial tcp4 127.0.0.1:3001: connect: connection refused

Root cause: run-vmagent.sh was called with `base_port=3001 port_increment=2` and built a scrape config for ports 3001/3003/3005/3007. merobox `bootstrap run` (no explicit base_rpc_port) actually allocates host ports starting at DEFAULT_RPC_PORT=2528 with `base + i`, so the real merod RPC/metrics ports are 2528/2529/2530/2531. The merobox output log from the same run confirms:

  - RPC/Admin Port: 2528
  - Non Auth Node URL: http://localhost:2528
  - RPC/Admin Port: 2529 ...

Fix:
- Update all four fuzzy jobs (kv-store, handlers, scaffolding-e2e, governance) to pass `"2528" "1"` instead of `"3001" "2"`.
- Update the script's default args and inline docs to reflect the actual merobox port scheme. The previous comments referenced an "e2e_mode RPC ports" convention that no longer matches merobox's bootstrap allocator (and may never have — manager.py:1167 uses `_find_available_ports(DEFAULT_RPC_PORT)` which is sequential from 2528).

After this lands, vmagent should successfully scrape /metrics on each node and VictoriaMetrics will surface the libp2p_*, context_*, and network_event_channel_* families that merod already registers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts vmagent scrape target port calculation; main failure mode is metrics not being collected if the port assumptions are still wrong.
> 
> **Overview**
> Fixes the `fuzzy-load-test` GitHub Actions workflow so vmagent scrapes each merobox node’s `/metrics` endpoint on the **actual host-bound ports** (defaulting to `2528+i` instead of `3001,3003,...`).
> 
> Each fuzzy job now reads `nodes.count` and `nodes.prefix` from the per-test `fuzzy-test.yml`, passes those into `scripts/run-vmagent.sh`, and the script’s defaults/docs are updated to match merobox’s sequential port allocation (`base_port=2528`, `port_increment=1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5cce23d22b34d3bcba85bfe3eea863eb4b840a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->