### PR TITLE
feat(observability): expose node-level metrics + wire sync collector

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1427,6 +1427,23 @@ impl DeltaStore {
                 Vec::new()
             };
 
+        // Metrics — one increment per add_delta call so dashboards can
+        // chart raw apply rate, plus a separate `cascaded` increment per
+        // delta unblocked by this call's cascade. Cascade size is also
+        // recorded as a histogram so tail values are visible.
+        if result {
+            crate::node_metrics::record_delta_outcome("applied");
+        } else {
+            crate::node_metrics::record_delta_outcome("pending");
+        }
+        let cascade_size = cascaded_deltas.len();
+        if cascade_size > 0 {
+            crate::node_metrics::observe_delta_cascade(cascade_size);
+            for _ in 0..cascade_size {
+                crate::node_metrics::record_delta_outcome("cascaded");
+            }
+        }
+
         Ok(AddDeltaResult {
             applied: result,
             cascaded_events: cascaded_with_events,

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -206,6 +206,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     author = %buffered.author_id,
                     "B2: pending delta now authorized; re-applying"
                 );
+                crate::node_metrics::record_governance_drain_outcome("applied");
                 let reconstructed = state_delta_message_from_buffered(buffered, *context_id);
                 if let Err(err) = apply_authorized_state_delta(input.clone(), reconstructed).await {
                     warn!(
@@ -223,6 +224,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     last_role = ?last_role,
                     "B2: pending delta from removed author; dropping"
                 );
+                crate::node_metrics::record_governance_drain_outcome("removed");
             }
             Ok(MembershipStatus::NeverMember) => {
                 warn!(
@@ -231,6 +233,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     author = %buffered.author_id,
                     "B2: pending delta from non-member; dropping"
                 );
+                crate::node_metrics::record_governance_drain_outcome("never_member");
             }
             Ok(MembershipStatus::Unknown { needed }) => {
                 let mut buffered = buffered;
@@ -246,6 +249,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                         "B2: dropping pending delta after exhausting drain attempts \
                          (governance heads still unknown — likely permanently missing)"
                     );
+                    crate::node_metrics::record_governance_drain_outcome("dropped_max_attempts");
                 } else {
                     debug!(
                         %context_id,
@@ -254,6 +258,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                         attempts = buffered.governance_drain_attempts,
                         "B2: still pending governance catchup; re-buffering"
                     );
+                    crate::node_metrics::record_governance_drain_outcome("rebuffered");
                     input
                         .node_state
                         .buffer_governance_pending(*context_id, buffered);
@@ -266,6 +271,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %err,
                     "B2: membership lookup failed for pending delta; dropping"
                 );
+                crate::node_metrics::record_governance_drain_outcome("lookup_error");
             }
         }
     }
@@ -1549,6 +1555,11 @@ async fn request_missing_deltas(
     delta_store: DeltaStore,
 ) -> Result<Vec<([u8; 32], Vec<u8>)>> {
     use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
+
+    // Metric: number of missing-parent IDs the caller is about to fetch.
+    // Recorded *before* the stream open so a peer-stream failure doesn't
+    // hide the demand signal in dashboards.
+    crate::node_metrics::record_missing_parents_request(missing_ids.len());
 
     // Open stream to peer
     let mut stream = network_client.open_stream(source).await?;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -23,6 +23,7 @@ pub mod key_delivery;
 mod manager;
 pub mod network_event_channel;
 pub mod network_event_processor;
+mod node_metrics;
 pub mod readiness;
 mod run;
 mod specialized_node_invite_state;

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -527,12 +527,3 @@ pub(crate) fn record_blob_cache_eviction(reason: &str, n: u64) {
         counter.inc_by(n);
     }
 }
-
-/// Internal helper for unit tests — return a fresh, unregistered
-/// `NodeMetrics` against a throwaway registry.
-#[cfg(test)]
-pub(crate) fn test_metrics() -> (Registry, NodeMetrics) {
-    let mut r = Registry::default();
-    let m = NodeMetrics::new(&mut r);
-    (r, m)
-}

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -1,0 +1,515 @@
+//! Centralised metric families for node-level observability.
+//!
+//! Holds the families that don't naturally belong to a single submodule (blob
+//! cache, sync sessions, governance-pending buffer, delta-store apply rate,
+//! HTTP request volume, build info, process resources) and the periodic
+//! gauge-snapshot tick that polls the [`NodeState`] DashMaps so operators
+//! can chart memory-leak shapes without instrumenting every mutation site.
+//!
+//! All series here are registered once at startup via [`NodeMetrics::new`].
+//! Recording is via owned handles (counters / families / gauges) cloned out
+//! of [`NodeMetrics`]; clones share the underlying atomic so updates from
+//! any thread land on the same series.
+//!
+//! ## Cardinality discipline
+//!
+//! Per-context labels are deliberately avoided on hot-path counters. A
+//! merod node can host hundreds of contexts; multiplying that by the
+//! per-counter Prometheus storage (~1 KB resident) blows the scraper's
+//! budget. Where per-context detail is genuinely useful (e.g.
+//! `governance_pending_queue_depth`) we expose the *sum* over contexts as
+//! a single gauge and rely on logs for per-context drill-down. Histograms
+//! with high-cardinality labels (`http_request_duration_seconds{path}`)
+//! use coarse path templates rather than raw URIs.
+
+use std::time::Duration;
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+use tracing::trace;
+
+/// Build-info beacon labels.
+///
+/// `version` is `calimero-node`'s `CARGO_PKG_VERSION` at compile time;
+/// `peer_id` is the node's libp2p PeerId. The beacon is a constant `1`
+/// gauge — operators querying `merod_build_info` confirm both that the
+/// scrape pipeline is alive and which build / identity is responding,
+/// independent of whether the node has yet produced any other metric.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct BuildInfoLabels {
+    pub(crate) version: String,
+    pub(crate) peer_id: String,
+}
+
+/// Outcome label for delta-store events.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct DeltaApplyLabels {
+    /// One of: `applied`, `pending`, `cascaded`, `duplicate`, `error`.
+    pub(crate) outcome: String,
+}
+
+/// Outcome label for governance-pending drain events.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct GovernanceDrainLabels {
+    /// One of: `applied`, `removed`, `never_member`, `rebuffered`,
+    /// `dropped_max_attempts`, `lookup_error`.
+    pub(crate) outcome: String,
+}
+
+/// Snapshot of all node-level metric handles.
+///
+/// Clone-friendly: the families and counters are wrapped in `Arc` by
+/// `prometheus-client`, so a cheap clone hands a thread its own recording
+/// surface without re-registering anything.
+#[derive(Clone, Debug)]
+pub(crate) struct NodeMetrics {
+    // Build-info beacon — constant 1 gauge.
+    pub(crate) build_info: Family<BuildInfoLabels, Gauge>,
+
+    // NodeState DashMap sizes — polled periodically; never recorded on a
+    // hot path.
+    pub(crate) blob_cache_entries: Gauge,
+    pub(crate) blob_cache_size_bytes: Gauge,
+    pub(crate) delta_stores_count: Gauge,
+    pub(crate) sync_sessions_active: Gauge,
+    pub(crate) governance_pending_contexts: Gauge,
+    pub(crate) governance_pending_queue_depth: Gauge,
+    pub(crate) specialized_node_pending_invites: Gauge,
+
+    // Blob cache eviction counters — recorded on the eviction hot path
+    // (state.rs::evict_old_blobs).
+    pub(crate) blob_cache_evictions_age_total: Counter,
+    pub(crate) blob_cache_evictions_count_total: Counter,
+    pub(crate) blob_cache_evictions_memory_total: Counter,
+
+    // Delta-store outcomes — high-volume but bounded label cardinality.
+    pub(crate) delta_outcomes_total: Family<DeltaApplyLabels, Counter>,
+    pub(crate) delta_cascade_size: Histogram,
+    pub(crate) delta_missing_parents_total: Counter,
+
+    // Governance-pending drain outcomes (B2 buffer-on-unknown lifecycle).
+    pub(crate) governance_drain_outcomes_total: Family<GovernanceDrainLabels, Counter>,
+
+    // Process resource gauges — polled periodically on linux via
+    // /proc/self/status + /proc/self/fd; no-op on other platforms.
+    pub(crate) process_resident_memory_bytes: Gauge,
+    pub(crate) process_virtual_memory_bytes: Gauge,
+    pub(crate) process_threads: Gauge,
+    pub(crate) process_open_fds: Gauge,
+}
+
+impl NodeMetrics {
+    /// Register every family on `registry` and return the recording handles.
+    /// Called once from `run::start` before the metrics service is mounted.
+    pub(crate) fn new(registry: &mut Registry) -> Self {
+        let build_info: Family<BuildInfoLabels, Gauge> = Family::default();
+        registry.register(
+            "merod_build_info",
+            "Constant 1 gauge labeled with merod version and peer_id — \
+             operators use it to verify the metrics pipeline end-to-end",
+            build_info.clone(),
+        );
+
+        let blob_cache_entries = Gauge::default();
+        registry.register(
+            "blob_cache_entries",
+            "Number of blobs currently held in the in-memory blob cache",
+            blob_cache_entries.clone(),
+        );
+        let blob_cache_size_bytes = Gauge::default();
+        registry.register(
+            "blob_cache_size_bytes",
+            "Total resident bytes across all blobs in the blob cache",
+            blob_cache_size_bytes.clone(),
+        );
+        let delta_stores_count = Gauge::default();
+        registry.register(
+            "delta_stores_count",
+            "Number of contexts with a live in-memory DeltaStore",
+            delta_stores_count.clone(),
+        );
+        let sync_sessions_active = Gauge::default();
+        registry.register(
+            "sync_sessions_active",
+            "Number of contexts with an open snapshot-sync session (buffering deltas)",
+            sync_sessions_active.clone(),
+        );
+        let governance_pending_contexts = Gauge::default();
+        registry.register(
+            "governance_pending_contexts",
+            "Number of contexts that currently have at least one delta in the \
+             B2 governance-pending buffer",
+            governance_pending_contexts.clone(),
+        );
+        let governance_pending_queue_depth = Gauge::default();
+        registry.register(
+            "governance_pending_queue_depth",
+            "Sum of governance-pending buffer depths across all contexts — \
+             monotonic growth indicates B2 buffer cannot drain",
+            governance_pending_queue_depth.clone(),
+        );
+        let specialized_node_pending_invites = Gauge::default();
+        registry.register(
+            "specialized_node_pending_invites",
+            "Number of in-flight specialized-node invite verifications",
+            specialized_node_pending_invites.clone(),
+        );
+
+        let blob_cache_evictions_age_total = Counter::default();
+        registry.register(
+            "blob_cache_evictions_age_total",
+            "Blob cache entries evicted because they exceeded MAX_BLOB_AGE_S",
+            blob_cache_evictions_age_total.clone(),
+        );
+        let blob_cache_evictions_count_total = Counter::default();
+        registry.register(
+            "blob_cache_evictions_count_total",
+            "Blob cache entries evicted to keep entry count under MAX_BLOB_CACHE_COUNT",
+            blob_cache_evictions_count_total.clone(),
+        );
+        let blob_cache_evictions_memory_total = Counter::default();
+        registry.register(
+            "blob_cache_evictions_memory_total",
+            "Blob cache entries evicted to keep resident bytes under MAX_BLOB_CACHE_SIZE_BYTES",
+            blob_cache_evictions_memory_total.clone(),
+        );
+
+        let delta_outcomes_total: Family<DeltaApplyLabels, Counter> = Family::default();
+        registry.register(
+            "delta_outcomes_total",
+            "DAG delta-apply outcomes, sliced by outcome \
+             (applied, pending, cascaded, duplicate, error)",
+            delta_outcomes_total.clone(),
+        );
+        // Buckets for cascade fan-out — typical value is 0 or 1 (no cascade
+        // or single child), pathological partition-heal flows can produce
+        // chains of dozens. The 256 ceiling exists because a pathological
+        // run that produces 1000s is an apply-loop pathology that should
+        // page someone, and we'd rather see it pinned to "overflow" than
+        // distort the histogram.
+        let delta_cascade_size = Histogram::new([0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 256.0]);
+        registry.register(
+            "delta_cascade_size",
+            "Number of pending deltas applied via cascade when a parent finally lands",
+            delta_cascade_size.clone(),
+        );
+        let delta_missing_parents_total = Counter::default();
+        registry.register(
+            "delta_missing_parents_total",
+            "Number of missing-parent requests issued to peers across all contexts",
+            delta_missing_parents_total.clone(),
+        );
+
+        let governance_drain_outcomes_total: Family<GovernanceDrainLabels, Counter> =
+            Family::default();
+        registry.register(
+            "governance_drain_outcomes_total",
+            "B2 governance-pending drain outcomes per delta",
+            governance_drain_outcomes_total.clone(),
+        );
+
+        let process_resident_memory_bytes = Gauge::default();
+        registry.register(
+            "process_resident_memory_bytes",
+            "Resident set size of the merod process, in bytes (linux only; 0 elsewhere)",
+            process_resident_memory_bytes.clone(),
+        );
+        let process_virtual_memory_bytes = Gauge::default();
+        registry.register(
+            "process_virtual_memory_bytes",
+            "Virtual memory size of the merod process, in bytes (linux only; 0 elsewhere)",
+            process_virtual_memory_bytes.clone(),
+        );
+        let process_threads = Gauge::default();
+        registry.register(
+            "process_threads",
+            "Thread count of the merod process (linux only; 0 elsewhere)",
+            process_threads.clone(),
+        );
+        let process_open_fds = Gauge::default();
+        registry.register(
+            "process_open_fds",
+            "Open file descriptors of the merod process (linux only; 0 elsewhere)",
+            process_open_fds.clone(),
+        );
+
+        Self {
+            build_info,
+            blob_cache_entries,
+            blob_cache_size_bytes,
+            delta_stores_count,
+            sync_sessions_active,
+            governance_pending_contexts,
+            governance_pending_queue_depth,
+            specialized_node_pending_invites,
+            blob_cache_evictions_age_total,
+            blob_cache_evictions_count_total,
+            blob_cache_evictions_memory_total,
+            delta_outcomes_total,
+            delta_cascade_size,
+            delta_missing_parents_total,
+            governance_drain_outcomes_total,
+            process_resident_memory_bytes,
+            process_virtual_memory_bytes,
+            process_threads,
+            process_open_fds,
+        }
+    }
+
+    /// Set the constant-1 build-info beacon. Called once at startup with the
+    /// node's identity and crate version.
+    pub(crate) fn set_build_info(&self, version: &str, peer_id: &str) {
+        self.build_info
+            .get_or_create(&BuildInfoLabels {
+                version: version.to_owned(),
+                peer_id: peer_id.to_owned(),
+            })
+            .set(1);
+    }
+}
+
+/// Snapshot of the DashMap-backed [`crate::NodeState`] sizes that the
+/// periodic tick will publish into [`NodeMetrics`]. Kept as a plain struct
+/// so the tick can be unit-tested without spinning up a real `NodeState`.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct NodeStateSnapshot {
+    pub blob_cache_entries: usize,
+    pub blob_cache_size_bytes: usize,
+    pub delta_stores_count: usize,
+    pub sync_sessions_active: usize,
+    pub governance_pending_contexts: usize,
+    pub governance_pending_queue_depth: usize,
+    pub specialized_node_pending_invites: usize,
+}
+
+impl NodeStateSnapshot {
+    /// Read every DashMap once. Cheap (`len()` is O(shards)), but the
+    /// blob_cache_size_bytes walk is O(entries) because every entry stores
+    /// its data size — that's fine at the 30s scrape interval (a few
+    /// thousand entries max).
+    pub(crate) fn capture(state: &crate::state::NodeState) -> Self {
+        let blob_cache_entries = state.blob_cache.len();
+        let blob_cache_size_bytes = state
+            .blob_cache
+            .iter()
+            .map(|entry| entry.value().data.len())
+            .sum();
+        let delta_stores_count = state.delta_stores.len();
+        let sync_sessions_active = state.sync_sessions.len();
+        // `governance_pending_contexts` is the number of distinct context
+        // entries; `governance_pending_queue_depth` is the sum of their
+        // queue lengths. Two gauges, one DashMap pass.
+        let mut governance_pending_contexts = 0;
+        let mut governance_pending_queue_depth = 0;
+        for entry in state.governance_pending.iter() {
+            governance_pending_contexts += 1;
+            governance_pending_queue_depth += entry.value().len();
+        }
+        let specialized_node_pending_invites =
+            state.pending_specialized_node_invites.len();
+        Self {
+            blob_cache_entries,
+            blob_cache_size_bytes,
+            delta_stores_count,
+            sync_sessions_active,
+            governance_pending_contexts,
+            governance_pending_queue_depth,
+            specialized_node_pending_invites,
+        }
+    }
+
+    /// Apply this snapshot to the gauges. Separate from `capture` so the
+    /// tick can log + clamp before writing if a future need arises.
+    pub(crate) fn publish(&self, metrics: &NodeMetrics) {
+        metrics
+            .blob_cache_entries
+            .set(self.blob_cache_entries as i64);
+        metrics
+            .blob_cache_size_bytes
+            .set(self.blob_cache_size_bytes as i64);
+        metrics
+            .delta_stores_count
+            .set(self.delta_stores_count as i64);
+        metrics
+            .sync_sessions_active
+            .set(self.sync_sessions_active as i64);
+        metrics
+            .governance_pending_contexts
+            .set(self.governance_pending_contexts as i64);
+        metrics
+            .governance_pending_queue_depth
+            .set(self.governance_pending_queue_depth as i64);
+        metrics
+            .specialized_node_pending_invites
+            .set(self.specialized_node_pending_invites as i64);
+    }
+}
+
+/// Period for the gauge-snapshot tick. Matched to the default scrape
+/// interval (30s) so each scrape sees a value at most 30s stale.
+pub(crate) const METRICS_TICK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Spawn the periodic metrics tick. The returned task captures clones of
+/// the metric handles and a weak handle to the `NodeState`'s DashMaps via
+/// the `state` clone (NodeState is itself Clone over Arc'd inner maps).
+///
+/// The task lives until the runtime shuts down. It deliberately holds a
+/// strong reference: a missing scrape during shutdown is harmless, and
+/// adding shutdown plumbing here would inflate the surface for no real
+/// benefit.
+pub(crate) fn spawn_metrics_tick(
+    metrics: NodeMetrics,
+    state: crate::state::NodeState,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(METRICS_TICK_INTERVAL);
+        // Skip the immediate-fire on first poll — give the node a moment
+        // to settle before the first gauge snapshot lands. Without this
+        // the first scrape returns zeros for everything.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let _ = interval.tick().await; // consume the immediate-fire tick
+        loop {
+            interval.tick().await;
+            let snapshot = NodeStateSnapshot::capture(&state);
+            trace!(?snapshot, "node_metrics tick");
+            snapshot.publish(&metrics);
+            update_process_metrics(&metrics);
+        }
+    })
+}
+
+/// Read process resource counters from `/proc/self/*` on linux and publish
+/// them as gauges. No-op on non-linux platforms (RSS/threads/FDs stay at
+/// their default 0).
+///
+/// We intentionally do this inline (no `procfs` / `sysinfo` crate) — the
+/// file format is stable, the parse is small, and an extra dep purely for
+/// 20 lines of /proc reading is overkill.
+fn update_process_metrics(metrics: &NodeMetrics) {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
+            for line in status.lines() {
+                // VmRSS / VmSize fields are reported in kB.
+                if let Some(rest) = line.strip_prefix("VmRSS:") {
+                    if let Some(kb) = rest.split_whitespace().next().and_then(|v| v.parse::<i64>().ok()) {
+                        metrics.process_resident_memory_bytes.set(kb.saturating_mul(1024));
+                    }
+                } else if let Some(rest) = line.strip_prefix("VmSize:") {
+                    if let Some(kb) = rest.split_whitespace().next().and_then(|v| v.parse::<i64>().ok()) {
+                        metrics.process_virtual_memory_bytes.set(kb.saturating_mul(1024));
+                    }
+                } else if let Some(rest) = line.strip_prefix("Threads:") {
+                    if let Some(n) = rest.split_whitespace().next().and_then(|v| v.parse::<i64>().ok()) {
+                        metrics.process_threads.set(n);
+                    }
+                }
+            }
+        }
+        // /proc/self/fd is a directory whose entry count is the open-fd
+        // count. Skip on read errors (sandboxes occasionally restrict
+        // this).
+        if let Ok(fd_dir) = std::fs::read_dir("/proc/self/fd") {
+            let count = fd_dir.filter_map(Result::ok).count() as i64;
+            metrics.process_open_fds.set(count);
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // No-op: gauges stay at default 0 on non-linux platforms.
+        let _ = metrics;
+    }
+}
+
+/// Helper for callers (delta store, governance drain, network bridge,
+/// HTTP middleware) that need to bump counters but don't carry a
+/// `NodeMetrics` clone yet. The global `OnceLock` is set exactly once
+/// at startup; clones from `get()` are cheap.
+///
+/// Why a global: half the recording sites live in synchronous code paths
+/// (e.g. blob-cache eviction inside `NodeState`) where plumbing a metric
+/// handle would require changing many signatures. The global is the
+/// pragmatic alternative — single-write/multi-read, identical to the
+/// existing `GROUP_STORE_METRICS` pattern in `crates/context/src/metrics.rs`.
+static GLOBAL: std::sync::OnceLock<NodeMetrics> = std::sync::OnceLock::new();
+
+/// Install `metrics` as the global. Idempotent on second call — extra calls
+/// are silently discarded so test harnesses that spin up multiple nodes in
+/// one process don't panic. The "winner" is whichever `start()` runs first.
+pub(crate) fn install_global(metrics: NodeMetrics) {
+    let _ = GLOBAL.set(metrics);
+}
+
+/// Fetch a clone of the global handles. Returns `None` before
+/// [`install_global`] has been called (the unit-test path, or early
+/// startup before `run::start` mounts the registry). Recording sites
+/// must tolerate `None` — a missing metric is never a correctness issue.
+pub(crate) fn global() -> Option<&'static NodeMetrics> {
+    GLOBAL.get()
+}
+
+/// Bump a delta-outcome counter via the global handle. Silent no-op if
+/// the global is not yet installed.
+pub(crate) fn record_delta_outcome(outcome: &str) {
+    if let Some(m) = global() {
+        m.delta_outcomes_total
+            .get_or_create(&DeltaApplyLabels {
+                outcome: outcome.to_owned(),
+            })
+            .inc();
+    }
+}
+
+/// Observe a delta-cascade size. Used at the end of an `apply_pending`
+/// pass to record how many deltas the cascade unblocked.
+pub(crate) fn observe_delta_cascade(size: usize) {
+    if let Some(m) = global() {
+        m.delta_cascade_size.observe(size as f64);
+    }
+}
+
+/// Bump the missing-parents request counter once per `request_missing_deltas`
+/// dispatch.
+pub(crate) fn record_missing_parents_request(count: usize) {
+    if let Some(m) = global() {
+        m.delta_missing_parents_total.inc_by(count as u64);
+    }
+}
+
+/// Bump a governance-drain outcome counter.
+pub(crate) fn record_governance_drain_outcome(outcome: &str) {
+    if let Some(m) = global() {
+        m.governance_drain_outcomes_total
+            .get_or_create(&GovernanceDrainLabels {
+                outcome: outcome.to_owned(),
+            })
+            .inc();
+    }
+}
+
+/// Bump a blob-cache eviction counter for the given reason
+/// (`"age"`, `"count"`, `"memory"`).
+pub(crate) fn record_blob_cache_eviction(reason: &str, n: u64) {
+    if let Some(m) = global() {
+        let counter = match reason {
+            "age" => &m.blob_cache_evictions_age_total,
+            "count" => &m.blob_cache_evictions_count_total,
+            "memory" => &m.blob_cache_evictions_memory_total,
+            _ => return,
+        };
+        counter.inc_by(n);
+    }
+}
+
+/// Internal helper for unit tests — return a fresh, unregistered
+/// `NodeMetrics` against a throwaway registry.
+#[cfg(test)]
+pub(crate) fn test_metrics() -> (Registry, NodeMetrics) {
+    let mut r = Registry::default();
+    let m = NodeMetrics::new(&mut r);
+    (r, m)
+}

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -366,11 +366,17 @@ pub(crate) fn spawn_metrics_tick(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(METRICS_TICK_INTERVAL);
-        // Skip the immediate-fire on first poll — give the node a moment
-        // to settle before the first gauge snapshot lands. Without this
-        // the first scrape returns zeros for everything.
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        let _ = interval.tick().await; // consume the immediate-fire tick
+        // `tokio::time::interval` returns immediately on the first
+        // `.tick()` call ("immediate-fire") and then ticks every
+        // `METRICS_TICK_INTERVAL` thereafter. We *consume* that
+        // first immediate-fire so the very first gauge snapshot
+        // lands at startup_time + INTERVAL, not at startup_time:
+        // recording zero-valued gauges before the node has stood up
+        // its DashMaps would pin a misleading "all zero" point on
+        // every dashboard. After this, the loop awaits the regular
+        // 30s cadence and snapshots once per fire.
+        let _ = interval.tick().await;
         loop {
             interval.tick().await;
             let snapshot = NodeStateSnapshot::capture(&state);
@@ -426,10 +432,12 @@ fn update_process_metrics(metrics: &NodeMetrics) {
             }
         }
         // /proc/self/fd is a directory whose entry count is the open-fd
-        // count. Skip on read errors (sandboxes occasionally restrict
-        // this).
+        // count. `read_dir` itself opens a transient FD on the directory
+        // that appears in the listing — we subtract 1 so the reported
+        // value matches what `lsof -p $PID | wc -l` would show.
+        // Skip on read errors (sandboxes occasionally restrict this).
         if let Ok(fd_dir) = std::fs::read_dir("/proc/self/fd") {
-            let count = fd_dir.filter_map(Result::ok).count() as i64;
+            let count = (fd_dir.filter_map(Result::ok).count() as i64).saturating_sub(1);
             metrics.process_open_fds.set(count);
         }
     }

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -309,8 +309,7 @@ impl NodeStateSnapshot {
             governance_pending_contexts += 1;
             governance_pending_queue_depth += entry.value().len();
         }
-        let specialized_node_pending_invites =
-            state.pending_specialized_node_invites.len();
+        let specialized_node_pending_invites = state.pending_specialized_node_invites.len();
         Self {
             blob_cache_entries,
             blob_cache_size_bytes,
@@ -396,15 +395,31 @@ fn update_process_metrics(metrics: &NodeMetrics) {
             for line in status.lines() {
                 // VmRSS / VmSize fields are reported in kB.
                 if let Some(rest) = line.strip_prefix("VmRSS:") {
-                    if let Some(kb) = rest.split_whitespace().next().and_then(|v| v.parse::<i64>().ok()) {
-                        metrics.process_resident_memory_bytes.set(kb.saturating_mul(1024));
+                    if let Some(kb) = rest
+                        .split_whitespace()
+                        .next()
+                        .and_then(|v| v.parse::<i64>().ok())
+                    {
+                        metrics
+                            .process_resident_memory_bytes
+                            .set(kb.saturating_mul(1024));
                     }
                 } else if let Some(rest) = line.strip_prefix("VmSize:") {
-                    if let Some(kb) = rest.split_whitespace().next().and_then(|v| v.parse::<i64>().ok()) {
-                        metrics.process_virtual_memory_bytes.set(kb.saturating_mul(1024));
+                    if let Some(kb) = rest
+                        .split_whitespace()
+                        .next()
+                        .and_then(|v| v.parse::<i64>().ok())
+                    {
+                        metrics
+                            .process_virtual_memory_bytes
+                            .set(kb.saturating_mul(1024));
                     }
                 } else if let Some(rest) = line.strip_prefix("Threads:") {
-                    if let Some(n) = rest.split_whitespace().next().and_then(|v| v.parse::<i64>().ok()) {
+                    if let Some(n) = rest
+                        .split_whitespace()
+                        .next()
+                        .and_then(|v| v.parse::<i64>().ok())
+                    {
                         metrics.process_threads.set(n);
                     }
                 }

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -35,8 +35,9 @@ use crate::arbiter_pool::ArbiterPool;
 use crate::gc::GarbageCollector;
 use crate::network_event_channel::{self, NetworkEventChannelConfig};
 use crate::network_event_processor::NetworkEventBridge;
+use crate::node_metrics::{self, NodeMetrics};
 use crate::state_delta_bridge::{start_state_delta_actor, STATE_DELTA_CHANNEL_CAPACITY};
-use crate::sync::{SyncConfig, SyncManager};
+use crate::sync::{PrometheusSyncMetrics, SyncConfig, SyncManager};
 use crate::sync_session_bridge::{start_sync_session_actor, SYNC_SESSION_CHANNEL_CAPACITY};
 use crate::NodeManager;
 
@@ -72,6 +73,27 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     let peer_id = config.identity.public().to_peer_id();
 
     info!("Peer ID: {}", peer_id);
+
+    // Centralised node-level observability families (build-info beacon,
+    // NodeState DashMap gauges, blob-cache eviction counters, HTTP request
+    // histograms, process resource gauges). Registered into the same
+    // `Registry` that all other subsystems write to, then installed as a
+    // process-global handle so synchronous recording sites (blob-cache
+    // eviction, delta-store apply, HTTP middleware) can record without
+    // plumbing.
+    let node_metrics = NodeMetrics::new(&mut registry);
+    node_metrics.set_build_info(env!("CARGO_PKG_VERSION"), &peer_id.to_string());
+    node_metrics::install_global(node_metrics.clone());
+
+    // Sync protocol metric families (`sync_*` — messages_sent, bytes_sent,
+    // round_trips, phase_duration_seconds, snapshot_blocked, verification_
+    // failures, buffer_drops, …). The recording sites live behind the
+    // `SyncMetricsCollector` trait inside the sync module; the registry
+    // entries surface them on /metrics so operators can chart whichever
+    // recording sites are wired (and so empty families self-document the
+    // schema for future wiring).
+    let sync_metrics: Arc<dyn crate::sync::SyncMetricsCollector> =
+        Arc::new(PrometheusSyncMetrics::new(&mut registry));
 
     // Open datastore with optional encryption
     let datastore = if let Some(ref key) = config.datastore.encryption_key {
@@ -176,6 +198,14 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
 
     let node_state = crate::NodeState::new(config.specialized_node.accept_mock_tee, config.mode);
 
+    // Periodic gauge-snapshot tick — once per `METRICS_TICK_INTERVAL`,
+    // reads NodeState DashMap sizes and process resource counters and
+    // updates the registered gauges. Gives operators a dashboard view
+    // of buffer / cache / session counts without instrumenting every
+    // mutation site.
+    let _metrics_tick =
+        crate::node_metrics::spawn_metrics_tick(node_metrics.clone(), node_state.clone());
+
     // Drain locally-applied delta notifications from the execute path
     // and register them into the in-memory DeltaStore. Replaces the
     // per-interval-sync `load_persisted_deltas` rescan that existed
@@ -251,6 +281,11 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
         ns_sync_rx,
         ns_join_rx,
     );
+
+    // Attach the sync-protocol metrics collector. Must happen before any
+    // clones are taken — every responder/initiator clone shares the
+    // recording handle via `Arc`.
+    sync_manager.set_metrics(sync_metrics);
 
     // Spin up the dedicated StateDelta actor on its own Arbiter
     // BEFORE constructing NodeManager so the sender can be threaded

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -506,15 +506,25 @@ impl NodeState {
         }
 
         let total_evicted = before_count.saturating_sub(self.blob_cache.len());
+        let time_evicted = before_count.saturating_sub(after_time_eviction);
+        let count_evicted = after_time_eviction.saturating_sub(after_count_eviction);
+        let memory_evicted = after_count_eviction.saturating_sub(self.blob_cache.len());
         if total_evicted > 0 {
             tracing::debug!(
                 total_evicted,
-                time_evicted = before_count.saturating_sub(after_time_eviction),
-                count_evicted = after_time_eviction.saturating_sub(after_count_eviction),
-                memory_evicted = after_count_eviction.saturating_sub(self.blob_cache.len()),
+                time_evicted,
+                count_evicted,
+                memory_evicted,
                 remaining_count = self.blob_cache.len(),
                 "Blob cache eviction completed"
             );
+            // Bump per-reason eviction counters. Recorded after all three
+            // eviction passes so each reason gets its share without double
+            // counting (each pass strictly removes entries the next pass
+            // would otherwise also see).
+            crate::node_metrics::record_blob_cache_eviction("age", time_evicted as u64);
+            crate::node_metrics::record_blob_cache_eviction("count", count_evicted as u64);
+            crate::node_metrics::record_blob_cache_eviction("memory", memory_evicted as u64);
         }
     }
 }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::pin::pin;
+use std::sync::Arc;
 
 use calimero_context_client::client::ContextClient;
 use calimero_crypto::{Nonce, SharedKey};
@@ -49,7 +50,6 @@ use calimero_node_primitives::sync::{
 /// Network synchronization manager.
 ///
 /// Orchestrates sync protocols: full resync, delta sync, state sync.
-#[derive(Debug)]
 pub struct SyncManager {
     pub(crate) sync_config: SyncConfig,
 
@@ -76,6 +76,28 @@ pub struct SyncManager {
     /// `start` can update per-context tracking state. Consumed once by
     /// `start`; `None` on clones.
     pub(super) session_result_rx: Option<mpsc::UnboundedReceiver<SyncSessionResult>>,
+
+    /// Sync-protocol metrics collector. Installed by `run.rs::start` via
+    /// [`SyncManager::set_metrics`] after the [`crate::sync::PrometheusSyncMetrics`]
+    /// instance is registered against the global registry. `None` means
+    /// recording sites use [`crate::sync::no_op_metrics`] as a silent
+    /// fallback — never a panic and never a runtime cost beyond a vtable
+    /// no-op.
+    ///
+    /// `dyn SyncMetricsCollector` does not implement `Debug`, so we
+    /// hand-write a `Debug` impl on `SyncManager` (below) that prints
+    /// only the presence/absence of this field — the inner vtable is
+    /// opaque anyway.
+    pub(crate) metrics: Option<Arc<dyn super::metrics::SyncMetricsCollector>>,
+}
+
+impl std::fmt::Debug for SyncManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncManager")
+            .field("sync_config", &self.sync_config)
+            .field("metrics_installed", &self.metrics.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl Clone for SyncManager {
@@ -95,6 +117,10 @@ impl Clone for SyncManager {
             // SyncManager for issuing sessions.
             session_tx: None,
             session_result_rx: None,
+            // Clones share the same metrics handle — Arc keeps the
+            // recording surface unified across the original (which runs
+            // `start`) and every responder/initiator clone.
+            metrics: self.metrics.clone(),
         }
     }
 }
@@ -124,6 +150,7 @@ impl SyncManager {
             ns_join_rx: Some(ns_join_rx),
             session_tx: None,
             session_result_rx: None,
+            metrics: None,
         }
     }
 
@@ -138,6 +165,32 @@ impl SyncManager {
     ) {
         self.session_tx = Some(session_tx);
         self.session_result_rx = Some(session_result_rx);
+    }
+
+    /// Install the sync-protocol metrics collector. Must be called before
+    /// any clones are taken; recording sites resolve `self.metrics` via
+    /// [`SyncManager::metrics`] (which falls back to a no-op collector if
+    /// this hasn't been called).
+    pub(crate) fn set_metrics(
+        &mut self,
+        metrics: Arc<dyn super::metrics::SyncMetricsCollector>,
+    ) {
+        self.metrics = Some(metrics);
+    }
+
+    /// Resolve the metrics collector. Returns a static no-op handle when
+    /// no collector was installed so call sites never have to branch on
+    /// `Option` — `self.metrics().record_*()` is always valid.
+    pub(crate) fn metrics(&self) -> &dyn super::metrics::SyncMetricsCollector {
+        // The no-op fallback lives in a static OnceLock so it isn't
+        // allocated per call. `NoOpMetrics` is a unit struct with
+        // `Default`, so the init closure is `default()`.
+        static NOOP: std::sync::OnceLock<super::metrics::NoOpMetrics> =
+            std::sync::OnceLock::new();
+        match self.metrics.as_deref() {
+            Some(m) => m,
+            None => NOOP.get_or_init(super::metrics::NoOpMetrics::default),
+        }
     }
 
     /// Build `SyncHandshake` from local context state for protocol negotiation.
@@ -776,6 +829,14 @@ impl SyncManager {
 
         info!(%context_id, %peer_id, "Attempting to sync with peer");
 
+        // Metrics: every sync attempt goes through this chokepoint, so
+        // `sync_start / sync_complete / sync_failure` here covers every
+        // protocol path. We don't yet know the protocol on entry — pass
+        // "unknown"; the success arm overwrites with the protocol the
+        // negotiated path actually chose.
+        self.metrics()
+            .record_sync_start(&context_id.to_string(), "unknown", "interval");
+
         let protocol = match self.initiate_sync_inner(context_id, peer_id).await {
             Ok(protocol) => protocol,
             Err(err) => {
@@ -785,6 +846,11 @@ impl SyncManager {
                     error = %err,
                     "Sync attempt failed for peer"
                 );
+                self.metrics().record_sync_failure(
+                    &context_id.to_string(),
+                    "unknown",
+                    err.to_string().as_str(),
+                );
                 return Err(err);
             }
         };
@@ -792,6 +858,17 @@ impl SyncManager {
         let took = start.elapsed();
 
         info!(%context_id, %peer_id, ?took, ?protocol, "Sync with peer completed successfully");
+
+        // `entities_transferred` is not threaded back to the sync manager
+        // today; pass 0. The collector still records the duration histogram
+        // and a sync_successes increment, which are the two most useful
+        // signals on a dashboard.
+        self.metrics().record_sync_complete(
+            &context_id.to_string(),
+            &format!("{protocol:?}"),
+            took,
+            0,
+        );
 
         Ok((peer_id, protocol))
     }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -171,10 +171,7 @@ impl SyncManager {
     /// any clones are taken; recording sites resolve `self.metrics` via
     /// [`SyncManager::metrics`] (which falls back to a no-op collector if
     /// this hasn't been called).
-    pub(crate) fn set_metrics(
-        &mut self,
-        metrics: Arc<dyn super::metrics::SyncMetricsCollector>,
-    ) {
+    pub(crate) fn set_metrics(&mut self, metrics: Arc<dyn super::metrics::SyncMetricsCollector>) {
         self.metrics = Some(metrics);
     }
 
@@ -185,8 +182,7 @@ impl SyncManager {
         // The no-op fallback lives in a static OnceLock so it isn't
         // allocated per call. `NoOpMetrics` is a unit struct with
         // `Default`, so the init closure is `default()`.
-        static NOOP: std::sync::OnceLock<super::metrics::NoOpMetrics> =
-            std::sync::OnceLock::new();
+        static NOOP: std::sync::OnceLock<super::metrics::NoOpMetrics> = std::sync::OnceLock::new();
         match self.metrics.as_deref() {
             Some(m) => m,
             None => NOOP.get_or_init(super::metrics::NoOpMetrics::default),

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -855,13 +855,22 @@ impl SyncManager {
 
         info!(%context_id, %peer_id, ?took, ?protocol, "Sync with peer completed successfully");
 
+        // Use the variant-only `SyncProtocolKind` for the protocol label
+        // so it matches the fixed `KNOWN_PROTOCOLS` set in
+        // `PrometheusSyncMetrics::sanitize_protocol`. Formatting the
+        // data-carrying `SyncProtocol` with `{:?}` would yield strings
+        // like `HashComparison { root_hash: [...], divergent_subtrees: [...] }`
+        // which never match the sanitiser and would label every sync
+        // `protocol="unknown"`, breaking the per-protocol slicing on
+        // `sync_successes_total` and `sync_duration_seconds`.
+        //
         // `entities_transferred` is not threaded back to the sync manager
         // today; pass 0. The collector still records the duration histogram
         // and a sync_successes increment, which are the two most useful
         // signals on a dashboard.
         self.metrics().record_sync_complete(
             &context_id.to_string(),
-            &format!("{protocol:?}"),
+            &format!("{:?}", protocol.kind()),
             took,
             0,
         );

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tower as _;
 
 use axum::http::Method;
-use axum::Router;
+use axum::{Extension, Router};
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
 use calimero_store::Store;
@@ -53,9 +53,15 @@ pub async fn start(
     ctx_client: ContextClient,
     node_client: NodeClient,
     datastore: Store,
-    prom_registry: Registry,
+    mut prom_registry: Registry,
 ) -> EyreResult<()> {
     let mut config = config;
+
+    // Register HTTP request metrics on the same registry before the
+    // metrics service consumes ownership of it via `mount_runtime_services`
+    // → `metrics::service`. The middleware below will resolve the handle
+    // out of the request `Extension`s.
+    let http_metrics = crate::metrics::HttpMetrics::new(&mut prom_registry);
     let mut addrs = Vec::with_capacity(config.listen.len());
     let mut listeners = Vec::with_capacity(config.listen.len());
     let mut want_listeners = config.listen.into_iter().peekable();
@@ -131,6 +137,14 @@ pub async fn start(
 
         return Ok(());
     }
+
+    // HTTP request observability middleware. Wraps every mounted route
+    // (jsonrpc, ws, sse, admin, auth) — applied *before* CORS so the
+    // recorded latency excludes pre-flight handling but still observes
+    // failed CORS rejections.
+    app = app
+        .layer(axum::middleware::from_fn(crate::metrics::track_request))
+        .layer(Extension(http_metrics));
 
     app = app.layer(
         CorsLayer::new()

--- a/crates/server/src/metrics.rs
+++ b/crates/server/src/metrics.rs
@@ -1,43 +1,139 @@
 //! Prometheus metrics service.
 //!
-//! Exposes the Prometheus registry at `/metrics` endpoint for scraping.
+//! Exposes the Prometheus registry at `/metrics` endpoint for scraping
+//! and provides the HTTP-request observability middleware applied to every
+//! mounted route (jsonrpc / ws / sse / admin).
 //!
 //! # Sync Metrics Integration
 //!
-//! To add sync metrics to the registry, use `calimero_node::sync::PrometheusSyncMetrics`:
+//! Sync-protocol metrics are registered in `crates/node/src/run.rs::start`
+//! via `PrometheusSyncMetrics::new(&mut registry)` before the server is
+//! started. This module exposes:
+//! - `merod_build_info{version, peer_id}` — constant-1 beacon (registered
+//!   by node-side metrics)
+//! - `http_requests_total{method, path, status}` — per-request counter
+//! - `http_request_duration_seconds{method, path, status}` — per-request
+//!   latency histogram
 //!
-//! ```rust,ignore
-//! use calimero_node::sync::PrometheusSyncMetrics;
-//! use prometheus_client::registry::Registry;
-//!
-//! let mut registry = Registry::default();
-//! let sync_metrics = PrometheusSyncMetrics::new(&mut registry);
-//!
-//! // Pass `sync_metrics` to SyncManager during initialization
-//! // Pass `registry` to the server for metrics exposition
-//! ```
-//!
-//! Available sync metrics:
-//! - `sync_messages_sent_total{protocol}`: Messages sent by protocol type
-//! - `sync_bytes_sent_total{protocol}`: Bytes sent
-//! - `sync_round_trips_total{protocol}`: Round trips
-//! - `sync_entities_transferred_total`: Entities transferred
-//! - `sync_merges_total{crdt_type}`: CRDT merges by type
-//! - `sync_phase_duration_seconds{phase}`: Phase timing histogram
-//! - `sync_snapshot_blocked_total`: I5 protection triggers
-//! - `sync_verification_failures_total`: I7 violations
-//! - `sync_buffer_drops_total`: I6 violation risk events
+//! `path` is the matched axum route template (e.g. `/jsonrpc`), never the
+//! raw URI — embedded IDs would blow up cardinality. `status` is the
+//! response code class (`2xx` / `4xx` / `5xx`).
 
 use std::sync::Arc;
+use std::time::Instant;
 
+use axum::body::Body;
+use axum::extract::MatchedPath;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
 use axum::response::IntoResponse;
 use axum::routing::{get, Router};
 use axum::Extension;
 use prometheus_client::encoding::text::encode;
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
 use prometheus_client::registry::Registry;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::config::ServerConfig;
+
+/// HTTP request labels for the middleware. See module-level docs for
+/// cardinality discipline.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct HttpLabels {
+    pub method: String,
+    pub path: String,
+    pub status: String,
+}
+
+/// Recording handles for HTTP-request middleware. Cheap to clone — both
+/// `Family` instances are `Arc<…>` under the hood.
+#[derive(Clone, Debug)]
+pub struct HttpMetrics {
+    pub requests_total: Family<HttpLabels, Counter>,
+    pub duration_seconds: Family<HttpLabels, Histogram>,
+}
+
+impl HttpMetrics {
+    /// Register the two HTTP families against `registry`.
+    pub fn new(registry: &mut Registry) -> Self {
+        let requests_total: Family<HttpLabels, Counter> = Family::default();
+        registry.register(
+            "http_requests_total",
+            "Total HTTP requests served by the merod server, by method / \
+             matched path / status class",
+            requests_total.clone(),
+        );
+        // Buckets cover the realistic merod-server latency range: 1ms →
+        // 32s. Endpoints under 1ms compress into the first bucket; the
+        // 32s tail catches handler hangs without saturating prematurely.
+        let duration_seconds: Family<HttpLabels, Histogram> =
+            Family::new_with_constructor(|| Histogram::new(exponential_buckets(0.001, 2.0, 15)));
+        registry.register(
+            "http_request_duration_seconds",
+            "End-to-end HTTP request duration in seconds",
+            duration_seconds.clone(),
+        );
+        Self {
+            requests_total,
+            duration_seconds,
+        }
+    }
+}
+
+/// Axum middleware that records request latency + count per matched route.
+///
+/// Inserts itself between auth/CORS layers and the route handlers. Uses
+/// [`MatchedPath`] to extract the route template — falls back to `unknown`
+/// when no template is available (the request didn't match any nested
+/// route, typically 404s on unknown URIs).
+pub async fn track_request(
+    Extension(metrics): Extension<HttpMetrics>,
+    req: Request<Body>,
+    next: Next,
+) -> axum::response::Response {
+    let method = req.method().clone();
+    let matched_path = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| p.as_str().to_owned())
+        .unwrap_or_else(|| "unknown".to_owned());
+    let start = Instant::now();
+
+    let response = next.run(req).await;
+
+    let elapsed = start.elapsed().as_secs_f64();
+    let status = response.status();
+    let labels = HttpLabels {
+        method: method.as_str().to_owned(),
+        path: matched_path,
+        status: status_class(status),
+    };
+    metrics.requests_total.get_or_create(&labels).inc();
+    metrics
+        .duration_seconds
+        .get_or_create(&labels)
+        .observe(elapsed);
+    response
+}
+
+/// Collapse a status code into a low-cardinality class label. `1xx`/`2xx`/
+/// `3xx`/`4xx`/`5xx`/`unknown`. Raw status codes would create a label
+/// value per code; the class gives operators ~all the signal they need
+/// without paying per-code storage.
+fn status_class(status: StatusCode) -> String {
+    match status.as_u16() {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    }
+    .to_owned()
+}
 
 pub(crate) struct ServiceState {
     registry: Registry,
@@ -61,5 +157,10 @@ pub(crate) fn service(config: &ServerConfig, registry: Registry) -> Option<(&'st
 async fn handle_request(Extension(state): Extension<Arc<ServiceState>>) -> impl IntoResponse {
     let mut buffer = String::new();
     encode(&mut buffer, &state.registry).unwrap();
+    // Operators triaging "VictoriaMetrics shows only `up`" need to distinguish
+    // "scrape reaches us but body is empty" from "scrape never reaches us."
+    // This log fires once per scrape with the response size, so a Docker-logs
+    // grep on a node under test surfaces both signals.
+    debug!(bytes = buffer.len(), "metrics scrape served");
     buffer
 }


### PR DESCRIPTION
PR fills the gap between metric families defined in the codebase and metric data actually flowing to /metrics. Before this change, a fuzzy e2e dashboard would see libp2p_* and context_* series but nothing about DAG apply rate, blob cache pressure, buffer depth, sync protocol phases, HTTP request volume, or process resource use.

* `merod_build_info{version,peer_id}=1` — constant beacon. Operators use it to confirm the metrics pipeline is alive end-to-end, separate from whether any other metric has yet been recorded. A node that scrapes only `up` plus `merod_build_info` is reachable + registry is wired; missing `merod_build_info` means the scrape never landed a real body.

* `crates/node/src/node_metrics.rs` — centralised module for the node-level families that don't belong to a single subsystem:
  - Blob cache size / entries gauges and per-reason eviction counters (`blob_cache_size_bytes`, `blob_cache_entries`, `blob_cache_evictions_{age,count,memory}_total`)
  - DAG delta outcomes (`delta_outcomes_total{outcome=applied|pending| cascaded}`), cascade-size histogram (`delta_cascade_size`), and missing-parent request counter (`delta_missing_parents_total`)
  - Governance-pending B2 drain outcomes (`governance_drain_outcomes_total{outcome=applied|removed|never_member| rebuffered|dropped_max_attempts|lookup_error}`)
  - NodeState DashMap-size gauges (delta_stores_count, sync_sessions_active, governance_pending_contexts/queue_depth, specialized_node_pending_invites) updated by a 30s tick
  - Process resource gauges (RSS, VMS, threads, open FDs) read from /proc/self on linux; no-op elsewhere Recording uses a process-global `OnceLock<NodeMetrics>` so the blob-cache, delta-store, and drain hot paths can record without signature plumbing. Same pattern as the existing `GROUP_STORE_METRICS` static in `crates/context/src/metrics.rs`.

* `PrometheusSyncMetrics` (16 `sync_*` families that have lived unused in the tree since PR #2007) is now registered in `run::start` and threaded through `SyncManager::set_metrics`. The trait fallback resolves to a static no-op collector when no instance is installed, so test paths don't carry a `Option<...>` branch on every record call. `initiate_sync` records start / complete / failure on every sync attempt.

* HTTP request middleware in `crates/server/src/metrics.rs` — `http_requests_total{method,path,status}` counter and `http_request_duration_seconds{...}` histogram, applied as an axum tower layer wrapping every mounted route. `path` is the matched axum route template (not raw URI); `status` is the response class (`2xx`/`4xx`/`5xx`) — both choices keep label cardinality bounded.

* `metrics::service` handler now emits a `debug!(bytes = …)` log per scrape. Lets operators triaging "VictoriaMetrics shows only `up`" distinguish "scrape reaches us but body is empty" from "scrape never reaches us" with a single docker logs grep.

Deferred to follow-ups (annotated in node_metrics.rs):
* Per-topic gossipsub publish counters (state_delta + heartbeat) — several call sites, each needs care to stay outside the encrypt fast path.
* DAG write-lock hold histogram — needs Instant threaded through `add_delta_with_events`; out of scope for the registry/tick PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds global metrics plumbing and periodic background tasks and instruments hot paths (delta apply, governance drain, HTTP middleware, sync orchestration), which could impact performance or label cardinality if misused, though it should not affect functional correctness.
> 
> **Overview**
> Adds a central `node_metrics` module and startup wiring to register node-level Prometheus families (build-info beacon, NodeState/process gauges, blob-cache eviction counters, delta-store outcomes/cascade histogram, governance-drain outcomes) and publishes gauges via a periodic snapshot tick.
> 
> Instruments core flows to emit these metrics: delta application now records `applied`/`pending` and cascade size/outcomes; governance-pending drain paths record per-outcome counters; missing-parent fetch requests record demand before opening peer streams; blob-cache eviction increments per-reason counters.
> 
> Wires sync metrics by registering `PrometheusSyncMetrics` at startup and threading a collector into `SyncManager` (with a no-op fallback), and adds server-side HTTP request counting/latency middleware plus a per-scrape debug log of the `/metrics` response size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a2ca4a5792a3370f397ba58aa4e810baba4af9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->