### PR TITLE
fix(context): recognise namespace creator as admin in B3 check

### DIFF
--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -119,6 +119,32 @@ pub fn membership_status_at(
     }
 
     let group_id = position.group_id;
+
+    // Namespace creator / root admin carve-out — required because the
+    // creator does **not** emit a self-`MemberJoined` op at namespace
+    // genesis: their membership lives in `GroupMeta::admin_identity`,
+    // not in a `GroupMember` row. Without this short-circuit, both the
+    // fast-path (Branch 1, `get_group_member_role` returns `None`) and
+    // the prefix walk (Branch 3, no `RootOp::MemberJoined` or
+    // `GroupOp::MemberAdded` for the creator) return `NeverMember`,
+    // and B3 hard-rejects every state delta authored by the namespace
+    // creator. This was the root cause of the flaky `group-3node`
+    // e2e: when receivers' governance heads hadn't yet caught up to
+    // node-1's at write time, the prefix-walk branch fired and
+    // rejected the legitimate write.
+    //
+    // `is_group_admin` already does the same admin-identity carve-out
+    // for the `MemberJoined`-less creator (see its doc and the
+    // companion `namespace_member_pubkeys` helper at
+    // `membership.rs::namespace_member_pubkeys`). Using the same path
+    // here keeps the semantics aligned: any signer that
+    // `is_group_admin` accepts must also pass B3.
+    if super::membership::is_group_admin(store, &group_id, signer)? {
+        return Ok(MembershipStatus::Member(
+            calimero_primitives::context::GroupMemberRole::Admin,
+        ));
+    }
+
     let namespace_id = super::namespace::resolve_namespace(store, &group_id)?;
     let dag = super::namespace_dag::NamespaceDagService::new(store, namespace_id.to_bytes());
     let local_heads = dag.read_head_record()?.parent_hashes;
@@ -663,6 +689,73 @@ mod tests {
             }
             other => panic!("expected Removed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn membership_status_at_recognises_namespace_creator_as_admin() {
+        // Regression test for the `group-3node` flake — see
+        // `cross-DAG authorization` notes in this module's docs.
+        //
+        // The namespace creator does not emit a self-`MemberJoined` op at
+        // genesis; their membership lives in `GroupMeta::admin_identity`.
+        // Without the carve-out at the top of `membership_status_at`,
+        // both the fast-path (no `GroupMember` row → `NeverMember`) and
+        // the prefix walk (no `MemberJoined` op for the creator →
+        // `NeverMember`) reject every state delta authored by the
+        // creator with `B3: not a member`.
+        use calimero_primitives::application::ApplicationId;
+        use calimero_primitives::context::UpgradePolicy;
+        use calimero_store::key::GroupMetaValue;
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let admin = PublicKey::from([0xAA; 32]);
+        let group_id = ContextGroupId::from([0xAB; 32]);
+
+        // Persist a GroupMeta with admin_identity == admin so
+        // is_group_admin returns true without needing any GroupMember
+        // rows or a populated namespace DAG.
+        let meta = GroupMetaValue {
+            app_key: [0u8; 32],
+            target_application_id: ApplicationId::from([0u8; 32]),
+            upgrade_policy: UpgradePolicy::LazyOnAccess,
+            created_at: 0,
+            admin_identity: admin.into(),
+            owner_identity: admin.into(),
+            migration: None,
+            auto_join: false,
+        };
+        super::super::meta::save_group_meta(&store, &group_id, &meta)
+            .expect("save_group_meta");
+
+        // Any well-formed position will do — the admin carve-out short-
+        // circuits before we ever look at heads or `namespace_dag`.
+        let position = GovernancePosition {
+            group_id,
+            group_state_hash: [0xCD; 32],
+            governance_dag_heads: vec![[0u8; 32]],
+        };
+
+        let status = membership_status_at(&store, &admin, &position)
+            .expect("admin carve-out must short-circuit cleanly");
+        assert!(
+            matches!(status, MembershipStatus::Member(GroupMemberRole::Admin)),
+            "creator must be recognised as Member(Admin), got {status:?}"
+        );
+
+        // Non-admin signer falls through past the carve-out. Without a
+        // namespace_dag set up, the call returns Err — that's fine for
+        // this regression test (we only need to prove the carve-out
+        // doesn't claim every signer is an admin).
+        let other = PublicKey::from([0x99; 32]);
+        let other_result = membership_status_at(&store, &other, &position);
+        assert!(
+            other_result.is_err()
+                || !matches!(
+                    other_result.unwrap(),
+                    MembershipStatus::Member(GroupMemberRole::Admin)
+                ),
+            "non-admin signer must NOT be classified as Member(Admin)"
+        );
     }
 
     #[test]

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -724,8 +724,7 @@ mod tests {
             migration: None,
             auto_join: false,
         };
-        super::super::meta::save_group_meta(&store, &group_id, &meta)
-            .expect("save_group_meta");
+        super::super::meta::save_group_meta(&store, &group_id, &meta).expect("save_group_meta");
 
         // Any well-formed position will do — the admin carve-out short-
         // circuits before we ever look at heads or `namespace_dag`.


### PR DESCRIPTION
## Why

The `group-3node` e2e is flaky. Three confirmed failures in the last week (#2272, #2298, #2321 PRs) all show the same shape:

```
e2e-node-1: <root-A>          ← the writer
e2e-node-2: <root-B>          ← converged with node-3
e2e-node-3: <root-B>          ← converged with node-2
```

Node-1 writes a delta, node-2 and node-3 reject it. Receiver logs show:

```
WARN B3: rejecting state delta — author is not a member of the group at governance cut
     author_id=<node-1 pubkey>
```

## Root cause

`membership_status_at` doesn't recognise the namespace creator as a member. The creator never emits a self-`MemberJoined` op at namespace genesis — their admin status lives in `GroupMeta::admin_identity`, not in a `GroupMember` row. Both branches that resolve membership miss this:

- **Branch 1** (heads-equal fast path) falls back to `get_group_member_role`, which only reads the materialized `GroupMember` rows. No row for the creator → `None` → `NeverMember`.
- **Branch 3** (prefix walk) matches `RootOp::MemberJoined` / `GroupOp::MemberAdded` / `MemberRoleSet` / `MemberJoinedViaTeeAttestation` but nothing that captures \"this signer is the creator.\" Walks the whole prefix, sees no add-op for the creator, returns `NeverMember`.

`namespace_member_pubkeys` and `is_group_admin` already patch around the same gap by checking `meta.admin_identity` after the membership lookup. B3 needed the equivalent carve-out.

## Why ~30% flake

The fast path only fires when sender and receiver heads match. On the unlucky runs (post-join governance ops haven't fully propagated to all 3 nodes when node-1 calls `set`), the receivers fall into Branch 3 → prefix walk → admin gap → reject. The active-drain hook never fires either (no further governance op is published in the steady-state write phase), so the receivers stay stuck until the 60s test timeout.

## Fix

Short-circuit at the top of `membership_status_at`: if `is_group_admin(store, group_id, signer)` returns true, return `Member(Admin)` immediately. Mirrors the existing carve-out in `namespace_member_pubkeys`. Touches both branches uniformly.

**Caveat**: `is_group_admin` reads the *current* meta, so an admin who transferred ownership and signed at an earlier cut would still be recognised as admin (over-permissive). This matches the existing semantics of `namespace_member_pubkeys` and `is_group_admin`. Correcting it requires a historical-admin DAG walk, which is out of scope here.

## Secondary finding (separate PR)

The HashComparison recovery path is also broken — when heartbeat divergence triggers a HashComparison sync, it errors with `Cannot change StorageType` (`Shared→Public` action) and the recovery never completes. Tracked separately; doesn't affect this fix.

## Test plan

- [x] New unit test: `membership_status_at_recognises_namespace_creator_as_admin`
- [x] All existing `membership_status` tests pass (15 total)
- [x] `cargo test -p calimero-context --lib` — 195 passed
- [x] `cargo test -p calimero-node --lib` — 115 passed
- [ ] After merge: confirm `group-3node` stabilises (was failing 3/recent ~10 PR runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches apply-time authorization (B3) by granting `Member(Admin)` based on `GroupMeta.admin_identity`, which could affect who is allowed to author state deltas if meta/admin identity handling is wrong or stale.
> 
> **Overview**
> Fixes a B3 authorization edge case where the namespace creator (stored only in `GroupMeta.admin_identity`) could be misclassified as `NeverMember` when resolving membership at a governance cut.
> 
> `membership_status_at` now short-circuits to `Member(Admin)` when `is_group_admin` returns true, and a regression unit test ensures the creator is accepted while non-admin signers are not accidentally elevated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ac8b34f014f3a4854c942109e6ed6287f33d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->