### PR TITLE
feat(context): subgroup-management capabilities (CAN_CREATE_SUBGROUP / CAN_DELETE_SUBGROUP / CAN_MANAGE_VISIBILITY)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -176,6 +176,9 @@ jobs:
           - workflow: group-capabilities
             file: workflows/group-capabilities.yml
             app: scaffolding-e2e
+          - workflow: group-member-channel-lifecycle
+            file: workflows/group-member-channel-lifecycle.yml
+            app: scaffolding-e2e
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,14 +306,31 @@ jobs:
 
           # Install the specific version of cargo-workspaces that we know works
           cargo install --git https://github.com/calimero-network/cargo-workspaces --tag v0.3.0 cargo-workspaces
-          # Publish all publishable crates from the workspace, skipping excluded packages
-          # Using --no-verify avoids crates.io index propagation races for freshly published
-          # prerelease dependencies (cargo package verification may resolve the next crate
-          # before the previous crate appears in the index).
-          # Using --no-git flags to avoid git operations during publishing.
-          cargo ws publish --yes --allow-dirty --force '*' \
+
+          # Publish all publishable crates from the workspace, skipping excluded packages.
+          # --no-verify skips the build-verification step; --no-git-* avoids git ops.
+          #
+          # Retry the publish: crates.io index propagation can lag, so cargo's
+          # built-in "wait for the crate to appear in the index" loop after one
+          # crate may time out, and packaging the *next* crate then fails to
+          # resolve the just-published prerelease dependency
+          # ("failed to select a version for ... = ^X.Y.Z-rc.N"). cargo-workspaces
+          # skips crates that are already on crates.io, so re-running resumes from
+          # the failed crate once the index has caught up.
+          publish() {
+            cargo ws publish --yes --allow-dirty --force '*' \
               --no-verify \
               --no-git-tag --no-git-commit --no-git-push
+          }
+          for attempt in 1 2 3 4 5; do
+            if publish; then
+              exit 0
+            fi
+            echo "::warning::cargo ws publish attempt ${attempt} failed (likely crates.io index lag); retrying in 60s"
+            sleep 60
+          done
+          echo "::error::cargo ws publish failed after 5 attempts"
+          exit 1
 
   release-merod-container:
     name: Release Merod container

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.36"
+version = "0.10.1-rc.37"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -76,6 +76,19 @@ steps:
     outputs:
       member_identity_node2: memberIdentity
 
+  # --- NEGATIVE: an ordinary member (only the default CAN_JOIN_OPEN_SUBGROUPS,
+  # not a namespace admin) is rejected when it tries to create a subgroup,
+  # because it lacks CAN_CREATE_SUBGROUP. `expected_failure` turns the merod
+  # rejection into a pass, so the workflow only succeeds if the bit is
+  # actually enforced.
+
+  - name: Node-2 without CAN_CREATE_SUBGROUP is rejected creating a subgroup
+    type: create_group_in_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    group_alias: should-not-exist
+    expected_failure: true
+
   # --- node-1 grants node-2 the subgroup-management capabilities ---
   # 4   = CAN_JOIN_OPEN_SUBGROUPS
   # 32  = CAN_CREATE_SUBGROUP

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -90,6 +90,9 @@ steps:
     expected_failure: true
 
   # --- node-1 grants node-2 the subgroup-management capabilities ---
+  # `set_member_capabilities` *replaces* the member's whole bitmask (it is not
+  # additive), so we include the default CAN_JOIN_OPEN_SUBGROUPS (4) alongside
+  # the three new bits to avoid clearing it:
   # 4   = CAN_JOIN_OPEN_SUBGROUPS
   # 32  = CAN_CREATE_SUBGROUP
   # 64  = CAN_DELETE_SUBGROUP

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -1,0 +1,207 @@
+name: E2E KV Store - Member Channel Lifecycle
+description: >
+  End-to-end coverage for the subgroup-management capabilities
+  (CAN_CREATE_SUBGROUP = 32, CAN_DELETE_SUBGROUP = 64,
+  CAN_MANAGE_VISIBILITY = 128).
+
+  A non-admin namespace member, granted those bits, runs the full
+  "create a channel" lifecycle entirely on their own:
+    1. node-1 installs the app and creates a namespace.
+    2. node-2 joins the namespace as an ordinary member.
+    3. node-1 grants node-2 capabilities 228
+       (CAN_JOIN_OPEN_SUBGROUPS | CAN_CREATE_SUBGROUP |
+        CAN_DELETE_SUBGROUP | CAN_MANAGE_VISIBILITY) and we read them back.
+    4. node-2 — *not* a namespace admin — creates a subgroup directly
+       under the namespace root. It becomes the subgroup's owner/admin.
+    5. node-2 flips the new subgroup's visibility (CAN_MANAGE_VISIBILITY).
+    6. node-2 creates a context inside the subgroup and exercises it
+       (proves the creator is an admin of the new subgroup, so context
+       creation there is allowed without an extra grant).
+    7. node-2 cascade-deletes the subgroup (CAN_DELETE_SUBGROUP); the
+       namespace's subgroup listing is empty again.
+
+  The negative paths (a member *without* each bit being rejected) are
+  covered by the `calimero-context` unit tests.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  # --- node-2 joins the namespace as an ordinary member ---
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{namespace_invitation}}'
+    outputs:
+      member_identity_node2: memberIdentity
+
+  # --- node-1 grants node-2 the subgroup-management capabilities ---
+  # 4   = CAN_JOIN_OPEN_SUBGROUPS
+  # 32  = CAN_CREATE_SUBGROUP
+  # 64  = CAN_DELETE_SUBGROUP
+  # 128 = CAN_MANAGE_VISIBILITY
+  # ----------------------------- = 228
+
+  - name: Grant node-2 subgroup-management capabilities (228)
+    type: set_member_capabilities
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    member_id: '{{member_identity_node2}}'
+    capabilities: 228
+
+  - name: Get node-2 capabilities
+    type: get_member_capabilities
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    member_id: '{{member_identity_node2}}'
+    outputs:
+      node2_caps: capabilities
+
+  - name: Assert node-2 has capabilities 228
+    type: json_assert
+    statements:
+      - "json_equal({{node2_caps}}, 228)"
+
+  # --- node-2 (non-admin) creates a subgroup under the namespace root ---
+
+  - name: Node-2 creates a subgroup under the namespace
+    type: create_group_in_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    group_alias: member-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Assert subgroup created
+    type: assert
+    statements:
+      - "is_set({{subgroup_id}})"
+
+  - name: List subgroups of namespace (should contain the new subgroup)
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      subgroups_after_create: subgroups
+
+  - name: Assert namespace lists the new subgroup
+    type: assert
+    statements:
+      - "is_set({{subgroups_after_create}})"
+
+  # --- node-2 manages the subgroup's visibility ---
+
+  - name: Node-2 sets subgroup visibility to open
+    type: set_subgroup_visibility
+    node: e2e-node-2
+    group_id: '{{subgroup_id}}'
+    visibility: open
+
+  - name: Node-2 sets subgroup visibility back to restricted
+    type: set_subgroup_visibility
+    node: e2e-node-2
+    group_id: '{{subgroup_id}}'
+    visibility: restricted
+
+  # --- node-2 creates and exercises a context inside the subgroup ---
+  # node-2 is the subgroup's admin (it created it), so no extra
+  # CAN_CREATE_CONTEXT grant is needed here.
+
+  - name: Node-2 creates a context in the subgroup
+    type: create_context
+    node: e2e-node-2
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      sub_ctx_id: contextId
+
+  - name: Assert subgroup context created
+    type: assert
+    statements:
+      - "is_set({{sub_ctx_id}})"
+
+  - name: Node-2 writes to the subgroup context
+    type: call
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+    method: set
+    args:
+      key: "channel_key"
+      value: "from_node2"
+
+  - name: Node-2 reads the subgroup context value
+    type: call
+    node: e2e-node-2
+    context_id: '{{sub_ctx_id}}'
+    method: get
+    args:
+      key: "channel_key"
+    outputs:
+      channel_read: result
+
+  - name: Assert the subgroup context is functional
+    type: json_assert
+    statements:
+      - 'json_equal({{channel_read}}, {"output": "from_node2"})'
+
+  # --- node-2 cascade-deletes the subgroup ---
+
+  - name: Node-2 cascade-deletes its subgroup
+    type: delete_group
+    node: e2e-node-2
+    group_id: '{{subgroup_id}}'
+
+  - name: List subgroups of namespace after delete
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      subgroups_after_delete: subgroups
+
+  - name: Assert namespace has no subgroups left
+    type: json_assert
+    statements:
+      - 'json_equal({{subgroups_after_delete}}, [])'
+
+stop_all_nodes: false

--- a/architecture/concepts.html
+++ b/architecture/concepts.html
@@ -90,16 +90,24 @@
 </ul>
 <h3>Flags</h3>
 <p>Each capability corresponds to a bit in the member&rsquo;s capability set (shown conceptually below).</p>
-<div class="typedef" aria-label="Capability bits (conceptual)"><span class="comment">// conceptual bit layout</span><br>
+<div class="typedef" aria-label="Capability bits (conceptual)"><span class="comment">// conceptual bit layout (crates/context/config/src/lib.rs)</span><br>
 <span class="kw">bit</span> <span class="field">0</span> &mdash; <span class="ty">CAN_CREATE_CONTEXT</span><br>
 <span class="kw">bit</span> <span class="field">1</span> &mdash; <span class="ty">CAN_INVITE_MEMBERS</span><br>
-<span class="kw">bit</span> <span class="field">2</span> &mdash; <span class="ty">MANAGE_MEMBERS</span><br>
-<span class="kw">bit</span> <span class="field">3</span> &mdash; <span class="ty">MANAGE_APPLICATION</span></div>
+<span class="kw">bit</span> <span class="field">2</span> &mdash; <span class="ty">CAN_JOIN_OPEN_SUBGROUPS</span><br>
+<span class="kw">bit</span> <span class="field">3</span> &mdash; <span class="ty">MANAGE_MEMBERS</span><br>
+<span class="kw">bit</span> <span class="field">4</span> &mdash; <span class="ty">MANAGE_APPLICATION</span><br>
+<span class="kw">bit</span> <span class="field">5</span> &mdash; <span class="ty">CAN_CREATE_SUBGROUP</span><br>
+<span class="kw">bit</span> <span class="field">6</span> &mdash; <span class="ty">CAN_DELETE_SUBGROUP</span><br>
+<span class="kw">bit</span> <span class="field">7</span> &mdash; <span class="ty">CAN_MANAGE_VISIBILITY</span></div>
 <div class="g3" style="font-size:.82rem;">
-<div class="cb"><h4><span class="code">CAN_CREATE_CONTEXT</span></h4><p>Bit 0. Create new contexts in this group.</p></div>
+<div class="cb"><h4><span class="code">CAN_CREATE_CONTEXT</span></h4><p>Bit 0. Register new contexts in this group.</p></div>
 <div class="cb"><h4><span class="code">CAN_INVITE_MEMBERS</span></h4><p>Bit 1. Issue invitations for new members.</p></div>
-<div class="cb"><h4><span class="code">MANAGE_MEMBERS</span></h4><p>Bit 2. Add or remove non-admin members.</p></div>
-<div class="cb"><h4><span class="code">MANAGE_APPLICATION</span></h4><p>Bit 3. Set the target application and handle migration.</p></div>
+<div class="cb"><h4><span class="code">CAN_JOIN_OPEN_SUBGROUPS</span></h4><p>Bit 2. Be inherited as a member of <code>Open</code> subgroups beneath this group (granted to non-admins by default; admins revoke it per-member as a deny-list).</p></div>
+<div class="cb"><h4><span class="code">MANAGE_MEMBERS</span></h4><p>Bit 3. Add or remove non-admin members and set their roles.</p></div>
+<div class="cb"><h4><span class="code">MANAGE_APPLICATION</span></h4><p>Bit 4. Set the target application and handle migration.</p></div>
+<div class="cb"><h4><span class="code">CAN_CREATE_SUBGROUP</span></h4><p>Bit 5. Create a subgroup directly under the namespace root (the creator becomes its owner/admin). Honored only at root level &mdash; the apply-time check must be verifiable by every namespace member.</p></div>
+<div class="cb"><h4><span class="code">CAN_DELETE_SUBGROUP</span></h4><p>Bit 6. Cascade-delete a subgroup and its subtree. (A subgroup&rsquo;s owner and namespace admins can also delete it.)</p></div>
+<div class="cb"><h4><span class="code">CAN_MANAGE_VISIBILITY</span></h4><p>Bit 7. Flip a subgroup&rsquo;s visibility (<code>Open</code> &harr; <code>Restricted</code>) without full admin on it.</p></div>
 </div>
 </div>
 

--- a/architecture/glossary.html
+++ b/architecture/glossary.html
@@ -110,7 +110,7 @@
 <div class="term-row" data-term="capabilities">
   <div class="term-name">Capabilities</div>
   <div class="term-body">
-    Per-member u32 bitmask controlling group-level permissions (CAN_CREATE_CONTEXT, CAN_INVITE_MEMBERS, MANAGE_MEMBERS, MANAGE_APPLICATION).
+    Per-member u32 bitmask controlling group-level permissions (CAN_CREATE_CONTEXT, CAN_INVITE_MEMBERS, CAN_JOIN_OPEN_SUBGROUPS, MANAGE_MEMBERS, MANAGE_APPLICATION, CAN_CREATE_SUBGROUP, CAN_DELETE_SUBGROUP, CAN_MANAGE_VISIBILITY).
   </div>
 </div>
 

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -115,12 +115,13 @@ Roles defined in <code>crates/primitives/src/context.rs:253-265</code>:
   <li>This proposal adds <code>Owner</code> as a fifth role — exactly one per group, transferable.</li>
 </ul>
 <p>
-Per-member capability bits (<code>crates/context/config/src/lib.rs:144-156</code>):
+Per-member capability bits (<code>crates/context/config/src/lib.rs</code>, <code>MemberCapabilities</code>):
 </p>
 <ul>
   <li><code>CAN_CREATE_CONTEXT</code>, <code>CAN_INVITE_MEMBERS</code>,
   <code>CAN_JOIN_OPEN_SUBGROUPS</code>, <code>MANAGE_MEMBERS</code>,
-  <code>MANAGE_APPLICATION</code>.</li>
+  <code>MANAGE_APPLICATION</code>, <code>CAN_CREATE_SUBGROUP</code>,
+  <code>CAN_DELETE_SUBGROUP</code>, <code>CAN_MANAGE_VISIBILITY</code>.</li>
 </ul>
 
 <h3>Existing protections</h3>

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -154,6 +154,34 @@ impl MemberCapabilities {
     pub const CAN_JOIN_OPEN_SUBGROUPS: u32 = 1 << 2;
     pub const MANAGE_MEMBERS: u32 = 1 << 3;
     pub const MANAGE_APPLICATION: u32 = 1 << 4;
+    /// Permits a non-admin namespace member to create a subgroup **directly
+    /// under the namespace root** (`parent_group_id == namespace_id`). This
+    /// is the "any member can start a channel" primitive.
+    ///
+    /// Scoped to root-level subgroups on purpose: the apply-side
+    /// authorization check in `execute_group_created` runs on every peer,
+    /// and a peer can only verify the creator holds this bit if it can read
+    /// the parent group's member-capability rows — which every namespace
+    /// member can do for the root group (they all hold its key), but not
+    /// necessarily for a deeper subgroup. Delegated creation of nested
+    /// subgroups by non-admins is therefore left to a follow-up; namespace
+    /// admins can still create subgroups at any depth.
+    pub const CAN_CREATE_SUBGROUP: u32 = 1 << 5;
+    /// Permits a non-admin namespace member to delete a subgroup (and its
+    /// whole subtree) via the cascade-delete path. Checked on the namespace
+    /// root, for the same determinism reason as [`Self::CAN_CREATE_SUBGROUP`].
+    ///
+    /// This is a delegation knob, not the default: an ordinary group admin
+    /// does *not* get it implicitly here (and a later change tightens the
+    /// baseline so even admins can't destroy a subtree they don't own — see
+    /// the owner-gated-destruction work).
+    pub const CAN_DELETE_SUBGROUP: u32 = 1 << 6;
+    /// Permits a member to flip a subgroup's [`VisibilityMode`]
+    /// (`Open` ↔ `Restricted`) without holding full admin on it. The
+    /// `SubgroupVisibilitySet` op is group-scoped (encrypted to the target
+    /// subgroup's members), so this check is deterministic among exactly the
+    /// peers that apply it — no root-level restriction needed.
+    pub const CAN_MANAGE_VISIBILITY: u32 = 1 << 7;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/context/src/group_store/group_settings.rs
+++ b/crates/context/src/group_store/group_settings.rs
@@ -66,7 +66,7 @@ impl<'a> GroupSettingsService<'a> {
         mode: VisibilityMode,
     ) -> EyreResult<()> {
         let permissions = self.permissions();
-        permissions.require_admin(signer)?;
+        permissions.require_can_manage_visibility(signer)?;
         set_subgroup_visibility(self.store, &self.group_id, mode)
     }
 

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -948,6 +948,32 @@ impl<'a> NamespaceGovernance<'a> {
                 "GroupDeleted cascade divergence: local subtree has contexts not in payload: {extra:?}"
             );
         }
+        // Inverse direction is *not* an error — it's the expected shape on a
+        // crash-recovery re-apply (the local subtree shrank since the op was
+        // built) — but log it so a genuinely anomalous payload (a publisher
+        // listing IDs this peer has never seen) is visible for debugging.
+        let payload_only_groups: Vec<[u8; 32]> =
+            payload_groups.difference(&local_groups).copied().collect();
+        if !payload_only_groups.is_empty() {
+            tracing::warn!(
+                root_group_id = %hex::encode(root_group_id),
+                groups = ?payload_only_groups.iter().map(hex::encode).collect::<Vec<_>>(),
+                "GroupDeleted payload lists groups not present locally (expected on a \
+                 crash-recovery re-apply; otherwise investigate for divergence)"
+            );
+        }
+        let payload_only_contexts: Vec<[u8; 32]> = payload_contexts
+            .difference(&local_contexts)
+            .copied()
+            .collect();
+        if !payload_only_contexts.is_empty() {
+            tracing::warn!(
+                root_group_id = %hex::encode(root_group_id),
+                contexts = ?payload_only_contexts.iter().map(hex::encode).collect::<Vec<_>>(),
+                "GroupDeleted payload lists contexts not present locally (expected on a \
+                 crash-recovery re-apply; otherwise investigate for divergence)"
+            );
+        }
 
         // Children-first deletion: descendants then root. For each group:
         // 1. Delete contexts registered on this group (cascade-specific).

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -23,7 +23,7 @@ use super::{
     namespace_dag::{NamespaceDagService, NamespaceHead},
     namespace_membership::NamespaceMembershipService,
     namespace_retry::NamespaceRetryService,
-    save_group_meta, set_local_gov_nonce, store_group_key, unwrap_group_key,
+    save_group_meta, set_local_gov_nonce, store_group_key, unwrap_group_key, PermissionChecker,
 };
 
 /// Side effect returned by namespace-op application when an existing
@@ -876,24 +876,20 @@ impl<'a> NamespaceGovernance<'a> {
         // delegation). All three are deterministically verifiable on every
         // peer applying this op — `GroupDeleted` is cleartext, and the
         // deleting peer already enumerates the full subtree (so it holds the
-        // root group's meta) below.
+        // root group's meta) below. The non-owner case routes through
+        // `PermissionChecker` to match the local `delete_group` handler.
         let ns_gid = ContextGroupId::from(self.namespace_id);
         let is_subgroup_owner =
             load_group_meta(self.store, &root_gid)?.is_some_and(|m| m.owner_identity == op.signer);
-        if !is_subgroup_owner
-            && !is_group_admin_or_has_capability(
-                self.store,
-                &ns_gid,
-                &op.signer,
-                calimero_context_config::MemberCapabilities::CAN_DELETE_SUBGROUP,
-            )?
-        {
-            bail!(
-                "GroupDeleted rejected: signer {} is not the subgroup owner, not an admin of \
-                 namespace {}, and does not hold CAN_DELETE_SUBGROUP",
-                op.signer,
-                hex::encode(self.namespace_id)
-            );
+        if !is_subgroup_owner {
+            PermissionChecker::new(self.store, ns_gid)
+                .require_can_delete_subgroup(&op.signer)
+                .map_err(|e| {
+                    eyre::eyre!(
+                        "GroupDeleted rejected: {e} (or be the owner of subgroup {})",
+                        hex::encode(root_group_id)
+                    )
+                })?;
         }
 
         // Determinism check: every surviving element of the local subtree MUST

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -878,6 +878,14 @@ impl<'a> NamespaceGovernance<'a> {
         // deleting peer already enumerates the full subtree (so it holds the
         // root group's meta) below. The non-owner case routes through
         // `PermissionChecker` to match the local `delete_group` handler.
+        //
+        // The owner branch checks only `owner_identity == op.signer`, not
+        // current namespace membership — `owner_identity` is a persistent
+        // record from group creation, and matching it *is* being the owner
+        // (32-byte keys don't "happen to collide"). In practice the owner is
+        // always a current namespace member anyway: `leave_namespace` /
+        // `leave_group` reject an owner with `MustTransferOwnership`, so you
+        // can't leave while owning a subgroup in the subtree.
         let ns_gid = ContextGroupId::from(self.namespace_id);
         let is_subgroup_owner =
             load_group_meta(self.store, &root_gid)?.is_some_and(|m| m.owner_identity == op.signer);

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -875,9 +875,9 @@ impl<'a> NamespaceGovernance<'a> {
         // or a namespace member holding `CAN_DELETE_SUBGROUP` (an explicit
         // delegation). All three are deterministically verifiable on every
         // peer applying this op — `GroupDeleted` is cleartext, and the
-        // deleting peer already enumerates the full subtree (so it holds the
-        // root group's meta) below. The non-owner case routes through
-        // `PermissionChecker` to match the local `delete_group` handler.
+        // deleting peer holds the root group's meta on the *first* apply. The
+        // non-owner case routes through `PermissionChecker` to match the local
+        // `delete_group` handler.
         //
         // The owner branch checks only `owner_identity == op.signer`, not
         // current namespace membership — `owner_identity` is a persistent
@@ -886,18 +886,30 @@ impl<'a> NamespaceGovernance<'a> {
         // always a current namespace member anyway: `leave_namespace` /
         // `leave_group` reject an owner with `MustTransferOwnership`, so you
         // can't leave while owning a subgroup in the subtree.
+        //
+        // Crash-recovery: the cascade below tears the root group's meta down
+        // *last* (after every descendant), and only then does `apply_signed_op`
+        // advance the DAG head. If the process dies in between, the re-apply
+        // finds the root meta already gone — the op was authorized on the
+        // first pass, so we skip the auth check here and let the (idempotent)
+        // cascade finish any remaining cleanup. Without this, an owner who is
+        // not also a namespace admin / `CAN_DELETE_SUBGROUP` holder would
+        // permanently stall the DAG. (The pre-existing `require_namespace_admin`
+        // check was immune because the namespace root is never part of a
+        // cascade.) A `GroupDeleted` for a group that never existed locally
+        // likewise reads `None` here and is a harmless no-op below.
         let ns_gid = ContextGroupId::from(self.namespace_id);
-        let is_subgroup_owner =
-            load_group_meta(self.store, &root_gid)?.is_some_and(|m| m.owner_identity == op.signer);
-        if !is_subgroup_owner {
-            PermissionChecker::new(self.store, ns_gid)
-                .require_can_delete_subgroup(&op.signer)
-                .map_err(|e| {
-                    eyre::eyre!(
-                        "GroupDeleted rejected: {e} (or be the owner of subgroup {})",
-                        hex::encode(root_group_id)
-                    )
-                })?;
+        if let Some(root_meta) = load_group_meta(self.store, &root_gid)? {
+            if root_meta.owner_identity != op.signer {
+                PermissionChecker::new(self.store, ns_gid)
+                    .require_can_delete_subgroup(&op.signer)
+                    .map_err(|e| {
+                        eyre::eyre!(
+                            "GroupDeleted rejected: {e} (or be the owner of subgroup {})",
+                            hex::encode(root_group_id)
+                        )
+                    })?;
+            }
         }
 
         // Determinism check: every surviving element of the local subtree MUST

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -18,8 +18,8 @@ use crate::op_events::{notify as notify_op_event, OpEvent};
 
 use super::{
     add_group_member, apply_group_op_mutations, decrypt_group_op, get_local_gov_nonce,
-    get_namespace_identity_record, is_group_admin, load_current_group_key_record,
-    load_group_key_by_id, load_group_meta,
+    get_namespace_identity_record, is_group_admin, is_group_admin_or_has_capability,
+    load_current_group_key_record, load_group_key_by_id, load_group_meta,
     namespace_dag::{NamespaceDagService, NamespaceHead},
     namespace_membership::NamespaceMembershipService,
     namespace_retry::NamespaceRetryService,
@@ -721,7 +721,6 @@ impl<'a> NamespaceGovernance<'a> {
         group_id: [u8; 32],
         parent_id: [u8; 32],
     ) -> EyreResult<()> {
-        self.require_namespace_admin(&op.signer)?;
         let gid = ContextGroupId::from(group_id);
         let parent_gid = ContextGroupId::from(parent_id);
 
@@ -734,6 +733,31 @@ impl<'a> NamespaceGovernance<'a> {
                 "GroupCreated rejected: self-parent edge (group_id == parent_id). \
                  Namespace roots must not emit GroupCreated — their existence is \
                  recorded by the namespace-identity setup path."
+            );
+        }
+
+        // Authorization. Namespace-root admins may create a subgroup at any
+        // depth (matches `require_namespace_admin`). A non-admin namespace
+        // member may create one *directly under the namespace root* if they
+        // hold `CAN_CREATE_SUBGROUP` — that bit is honored only at root level
+        // because every peer applying this op must be able to verify the
+        // creator's authority, and only the root group's capability rows are
+        // readable by all namespace members (see the capability's doc).
+        let ns_gid = ContextGroupId::from(self.namespace_id);
+        let authorized = is_group_admin(self.store, &ns_gid, &op.signer)?
+            || (parent_id == self.namespace_id
+                && is_group_admin_or_has_capability(
+                    self.store,
+                    &ns_gid,
+                    &op.signer,
+                    calimero_context_config::MemberCapabilities::CAN_CREATE_SUBGROUP,
+                )?);
+        if !authorized {
+            bail!(
+                "GroupCreated rejected: signer {} is neither an admin of namespace {} \
+                 nor a member holding CAN_CREATE_SUBGROUP at the namespace root",
+                op.signer,
+                hex::encode(self.namespace_id)
             );
         }
 
@@ -839,12 +863,36 @@ impl<'a> NamespaceGovernance<'a> {
         cascade_group_ids: &[[u8; 32]],
         cascade_context_ids: &[[u8; 32]],
     ) -> EyreResult<()> {
-        self.require_namespace_admin(&op.signer)?;
-
         let root_gid = ContextGroupId::from(root_group_id);
         if root_group_id == self.namespace_id {
             eyre::bail!(
                 "cannot delete the namespace root '{root_gid:?}' (use delete_namespace instead)"
+            );
+        }
+
+        // Authorization. Cascade-delete is allowed for: the owner of the
+        // subgroup being deleted; an admin of the namespace root (moderation);
+        // or a namespace member holding `CAN_DELETE_SUBGROUP` (an explicit
+        // delegation). All three are deterministically verifiable on every
+        // peer applying this op — `GroupDeleted` is cleartext, and the
+        // deleting peer already enumerates the full subtree (so it holds the
+        // root group's meta) below.
+        let ns_gid = ContextGroupId::from(self.namespace_id);
+        let is_subgroup_owner =
+            load_group_meta(self.store, &root_gid)?.is_some_and(|m| m.owner_identity == op.signer);
+        if !is_subgroup_owner
+            && !is_group_admin_or_has_capability(
+                self.store,
+                &ns_gid,
+                &op.signer,
+                calimero_context_config::MemberCapabilities::CAN_DELETE_SUBGROUP,
+            )?
+        {
+            bail!(
+                "GroupDeleted rejected: signer {} is not the subgroup owner, not an admin of \
+                 namespace {}, and does not hold CAN_DELETE_SUBGROUP",
+                op.signer,
+                hex::encode(self.namespace_id)
             );
         }
 

--- a/crates/context/src/group_store/permission_checker.rs
+++ b/crates/context/src/group_store/permission_checker.rs
@@ -89,6 +89,39 @@ impl<'a> PermissionChecker<'a> {
         bail!("only group admin or members with CAN_CREATE_CONTEXT can register a context")
     }
 
+    /// `self.group_id` is the *parent* group here: a creator may make a
+    /// subgroup under it if they are an admin (direct or inherited via the
+    /// Open chain) or hold `CAN_CREATE_SUBGROUP`. Callers that enforce the
+    /// root-level scoping of that capability (`execute_group_created`,
+    /// `create_group`) layer the `parent == namespace_root` check on top.
+    pub fn require_can_create_subgroup(&self, identity: &PublicKey) -> EyreResult<()> {
+        if self.is_authorized_with_capability(identity, MemberCapabilities::CAN_CREATE_SUBGROUP)? {
+            return Ok(());
+        }
+        bail!("only group admin or members with CAN_CREATE_SUBGROUP can create a subgroup")
+    }
+
+    /// `self.group_id` is the namespace root: a member may cascade-delete a
+    /// subgroup if they are a root admin or hold `CAN_DELETE_SUBGROUP`.
+    pub fn require_can_delete_subgroup(&self, identity: &PublicKey) -> EyreResult<()> {
+        if self.is_authorized_with_capability(identity, MemberCapabilities::CAN_DELETE_SUBGROUP)? {
+            return Ok(());
+        }
+        bail!("only namespace admin or members with CAN_DELETE_SUBGROUP can delete a subgroup")
+    }
+
+    /// `self.group_id` is the subgroup whose visibility is being changed.
+    pub fn require_can_manage_visibility(&self, identity: &PublicKey) -> EyreResult<()> {
+        if self
+            .is_authorized_with_capability(identity, MemberCapabilities::CAN_MANAGE_VISIBILITY)?
+        {
+            return Ok(());
+        }
+        bail!(
+            "only group admin or members with CAN_MANAGE_VISIBILITY can change subgroup visibility"
+        )
+    }
+
     /// Resolves "admin or holds `capability_bit`" with Open-subgroup
     /// inheritance applied (issue #2256).
     ///

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5124,6 +5124,10 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     // that it's the *authorization* check rejecting it (not some other error
     // path): signature verification passes for any valid key, so the op
     // reaches `execute_group_deleted` and fails the owner/admin/cap gate.
+    assert!(
+        !check_group_membership(&store, &ns_gid, &stranger_sk.public_key()).unwrap(),
+        "precondition: the stranger must not be enrolled in the namespace"
+    );
     let err = gov.apply_signed_op(&del(&stranger_sk, s1, 1)).unwrap_err();
     assert!(
         format!("{err}").contains("GroupDeleted rejected"),

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5027,6 +5027,10 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
         member_pk,
         "creator owns the new subgroup"
     );
+    assert!(
+        is_group_admin(&store, &ContextGroupId::from(chan), &member_pk).unwrap(),
+        "creator is added as an admin of the new subgroup"
+    );
 
     // But the capability is scoped to root-level subgroups: the member cannot
     // create a nested subgroup under another subgroup.
@@ -5062,6 +5066,10 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     let owner_sk = PrivateKey::random(&mut rng);
     let owner_pk = owner_sk.public_key();
     let stranger_sk = PrivateKey::random(&mut rng);
+    // A namespace member who is neither the subgroup owner, a namespace admin,
+    // nor a CAN_DELETE_SUBGROUP holder — a distinct case from a total stranger.
+    let plain_member_sk = PrivateKey::random(&mut rng);
+    let plain_member_pk = plain_member_sk.public_key();
     let janitor_sk = PrivateKey::random(&mut rng);
     let janitor_pk = janitor_sk.public_key();
 
@@ -5069,6 +5077,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     let ns_gid = ContextGroupId::from(ns_id);
     save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
     add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &ns_gid, &plain_member_pk, GroupMemberRole::Member).unwrap();
     add_group_member(&store, &ns_gid, &janitor_pk, GroupMemberRole::Member).unwrap();
     store_namespace_identity(&store, &ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
 
@@ -5101,13 +5110,17 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
         .unwrap()
     };
 
-    // A stranger who is neither the subgroup owner, a namespace admin, nor a
-    // CAN_DELETE_SUBGROUP holder is rejected.
+    // A total stranger (not even a namespace member) is rejected.
     assert!(gov.apply_signed_op(&del(&stranger_sk, s1, 1)).is_err());
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
 
+    // A plain namespace member (no CAN_DELETE_SUBGROUP, not the owner, not an
+    // admin) is also rejected.
+    assert!(gov.apply_signed_op(&del(&plain_member_sk, s1, 2)).is_err());
+    assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
+
     // The subgroup's owner can cascade-delete it.
-    gov.apply_signed_op(&del(&owner_sk, s1, 2))
+    gov.apply_signed_op(&del(&owner_sk, s1, 3))
         .expect("subgroup owner can delete it");
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_none());
 

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5077,6 +5077,12 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     let ns_gid = ContextGroupId::from(ns_id);
     save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
     add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    // `owner_pk` is enrolled as an ordinary namespace member — that mirrors the
+    // real model (a subgroup owner got there by being a namespace member and
+    // creating it; `leave_namespace` refuses an owner via `MustTransferOwnership`,
+    // so an owner is always a current member). It holds no caps and no admin
+    // role at the namespace level, so it can only delete via the owner path.
+    add_group_member(&store, &ns_gid, &owner_pk, GroupMemberRole::Member).unwrap();
     add_group_member(&store, &ns_gid, &plain_member_pk, GroupMemberRole::Member).unwrap();
     add_group_member(&store, &ns_gid, &janitor_pk, GroupMemberRole::Member).unwrap();
     store_namespace_identity(&store, &ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
@@ -5094,6 +5100,10 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     let (s3, s3_gid) = mk_subgroup(0xC3);
 
     let gov = NamespaceGovernance::new(&store, ns_id);
+    // `nonce` here is informational only — `apply_signed_op` advances the DAG
+    // head from `read_head_record().next_nonce`, not from `op.nonce`; distinct
+    // `root_group_id`s already give each op a distinct content hash. We still
+    // pass monotonically increasing values for readability.
     let del = |sk: &PrivateKey, root_group_id: [u8; 32], nonce: u64| {
         SignedNamespaceOp::sign(
             sk,
@@ -5115,7 +5125,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
 
     // A plain namespace member (no CAN_DELETE_SUBGROUP, not the owner, not an
-    // admin) is also rejected.
+    // admin) is also rejected — the distinct "member but unauthorized" case.
     assert!(gov.apply_signed_op(&del(&plain_member_sk, s1, 2)).is_err());
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
 
@@ -5125,7 +5135,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_none());
 
     // A namespace admin can delete a subgroup they don't own (moderation).
-    gov.apply_signed_op(&del(&admin_sk, s2, 3))
+    gov.apply_signed_op(&del(&admin_sk, s2, 4))
         .expect("namespace admin can delete any subgroup");
     assert!(load_group_meta(&store, &s2_gid).unwrap().is_none());
 
@@ -5137,7 +5147,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
         MemberCapabilities::CAN_DELETE_SUBGROUP,
     )
     .unwrap();
-    gov.apply_signed_op(&del(&janitor_sk, s3, 4))
+    gov.apply_signed_op(&del(&janitor_sk, s3, 5))
         .expect("CAN_DELETE_SUBGROUP holder can delete a subgroup");
     assert!(load_group_meta(&store, &s3_gid).unwrap().is_none());
 }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5120,18 +5120,41 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
         .unwrap()
     };
 
-    // A total stranger (not even a namespace member) is rejected.
-    assert!(gov.apply_signed_op(&del(&stranger_sk, s1, 1)).is_err());
+    // A total stranger (not even a namespace member) is rejected — and we pin
+    // that it's the *authorization* check rejecting it (not some other error
+    // path): signature verification passes for any valid key, so the op
+    // reaches `execute_group_deleted` and fails the owner/admin/cap gate.
+    let err = gov.apply_signed_op(&del(&stranger_sk, s1, 1)).unwrap_err();
+    assert!(
+        format!("{err}").contains("GroupDeleted rejected"),
+        "stranger should be rejected by the authorization check, got: {err}"
+    );
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
 
     // A plain namespace member (no CAN_DELETE_SUBGROUP, not the owner, not an
-    // admin) is also rejected — the distinct "member but unauthorized" case.
-    assert!(gov.apply_signed_op(&del(&plain_member_sk, s1, 2)).is_err());
+    // admin) is also rejected — the distinct "member but unauthorized" case,
+    // again by the authorization check.
+    let err = gov
+        .apply_signed_op(&del(&plain_member_sk, s1, 2))
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("GroupDeleted rejected"),
+        "plain member should be rejected by the authorization check, got: {err}"
+    );
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
 
     // The subgroup's owner can cascade-delete it.
     gov.apply_signed_op(&del(&owner_sk, s1, 3))
         .expect("subgroup owner can delete it");
+    assert!(load_group_meta(&store, &s1_gid).unwrap().is_none());
+
+    // Re-applying the same GroupDeleted after the root meta is gone (the
+    // crash-recovery shape: cascade finished, DAG head not yet advanced) must
+    // be an idempotent no-op, even though the signer here (`owner_pk`) is not
+    // a namespace admin and holds no CAN_DELETE_SUBGROUP — the auth check is
+    // skipped when the root meta is absent.
+    gov.apply_signed_op(&del(&owner_sk, s1, 6))
+        .expect("re-apply of GroupDeleted after the root meta is gone is an idempotent no-op");
     assert!(load_group_meta(&store, &s1_gid).unwrap().is_none());
 
     // A namespace admin can delete a subgroup they don't own (moderation).

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -4985,6 +4985,11 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
     store_namespace_identity(&store, &ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
 
     let gov = NamespaceGovernance::new(&store, ns_id);
+    // `nonce` is informational only — `apply_signed_op` advances the DAG head
+    // from `read_head_record().next_nonce`, not from `op.nonce`, and a rejected
+    // op never advances the head or gets stored. Distinct `group_id`s already
+    // give each op a distinct content hash; we pass increasing values for
+    // readability. (Same as the `governance_group_deleted_*` test.)
     let create = |sk: &PrivateKey, group_id: [u8; 32], parent_id: [u8; 32], nonce: u64| {
         SignedNamespaceOp::sign(
             sk,

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -4856,3 +4856,275 @@ fn membership_status_at_oversized_governance_dag_heads_runtime_guard() {
         "expected oversize error, got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Subgroup-management capabilities: CAN_CREATE_SUBGROUP / CAN_DELETE_SUBGROUP /
+// CAN_MANAGE_VISIBILITY.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn permission_checker_subgroup_management_capabilities() {
+    use calimero_context_config::MemberCapabilities;
+
+    let store = test_store();
+    let gid = ContextGroupId::from([0x9A; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let member = PublicKey::from([0x02; 32]);
+
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &member, GroupMemberRole::Member).unwrap();
+
+    let checker = PermissionChecker::new(&store, gid);
+
+    // Admins pass all three unconditionally.
+    assert!(checker.require_can_create_subgroup(&admin).is_ok());
+    assert!(checker.require_can_delete_subgroup(&admin).is_ok());
+    assert!(checker.require_can_manage_visibility(&admin).is_ok());
+
+    // A bare member is denied all three.
+    assert!(checker.require_can_create_subgroup(&member).is_err());
+    assert!(checker.require_can_delete_subgroup(&member).is_err());
+    assert!(checker.require_can_manage_visibility(&member).is_err());
+
+    // CAN_CREATE_SUBGROUP only.
+    set_member_capability(
+        &store,
+        &gid,
+        &member,
+        MemberCapabilities::CAN_CREATE_SUBGROUP,
+    )
+    .unwrap();
+    assert!(checker.require_can_create_subgroup(&member).is_ok());
+    assert!(checker.require_can_delete_subgroup(&member).is_err());
+    assert!(checker.require_can_manage_visibility(&member).is_err());
+
+    // All three at once.
+    set_member_capability(
+        &store,
+        &gid,
+        &member,
+        MemberCapabilities::CAN_CREATE_SUBGROUP
+            | MemberCapabilities::CAN_DELETE_SUBGROUP
+            | MemberCapabilities::CAN_MANAGE_VISIBILITY,
+    )
+    .unwrap();
+    assert!(checker.require_can_create_subgroup(&member).is_ok());
+    assert!(checker.require_can_delete_subgroup(&member).is_ok());
+    assert!(checker.require_can_manage_visibility(&member).is_ok());
+}
+
+#[test]
+fn group_settings_subgroup_visibility_honors_can_manage_visibility() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    use super::group_settings::GroupSettingsService;
+
+    let store = test_store();
+    let gid = ContextGroupId::from([0x9B; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let member = PublicKey::from([0x02; 32]);
+
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &member, GroupMemberRole::Member).unwrap();
+
+    let svc = GroupSettingsService::new(&store, gid);
+
+    // Admin can flip it.
+    svc.set_subgroup_visibility(&admin, VisibilityMode::Open)
+        .unwrap();
+    assert_eq!(
+        get_subgroup_visibility(&store, &gid).unwrap(),
+        VisibilityMode::Open
+    );
+
+    // Member without the cap cannot.
+    assert!(svc
+        .set_subgroup_visibility(&member, VisibilityMode::Restricted)
+        .is_err());
+
+    // Granting CAN_MANAGE_VISIBILITY lets the member flip it.
+    set_member_capability(
+        &store,
+        &gid,
+        &member,
+        MemberCapabilities::CAN_MANAGE_VISIBILITY,
+    )
+    .unwrap();
+    svc.set_subgroup_visibility(&member, VisibilityMode::Restricted)
+        .unwrap();
+    assert_eq!(
+        get_subgroup_visibility(&store, &gid).unwrap(),
+        VisibilityMode::Restricted
+    );
+}
+
+#[test]
+fn governance_group_created_honors_can_create_subgroup_at_root_only() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_context_config::MemberCapabilities;
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+    let admin_sk_bytes: [u8; 32] = rand::Rng::gen(&mut rng);
+    let admin_sk = PrivateKey::from(admin_sk_bytes);
+    let admin_pk = admin_sk.public_key();
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+
+    let ns_id = [0xA0u8; 32];
+    let ns_gid = ContextGroupId::from(ns_id);
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &ns_gid, &member_pk, GroupMemberRole::Member).unwrap();
+    store_namespace_identity(&store, &ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
+
+    let gov = NamespaceGovernance::new(&store, ns_id);
+    let create = |sk: &PrivateKey, group_id: [u8; 32], parent_id: [u8; 32], nonce: u64| {
+        SignedNamespaceOp::sign(
+            sk,
+            ns_id,
+            vec![],
+            [0u8; 32],
+            nonce,
+            NamespaceOp::Root(RootOp::GroupCreated {
+                group_id,
+                parent_id,
+            }),
+        )
+        .unwrap()
+    };
+
+    let chan = [0xB1u8; 32];
+
+    // Member without the cap cannot create a subgroup, even under the root.
+    assert!(gov
+        .apply_signed_op(&create(&member_sk, chan, ns_id, 1))
+        .is_err());
+    assert!(load_group_meta(&store, &ContextGroupId::from(chan))
+        .unwrap()
+        .is_none());
+
+    // Granting CAN_CREATE_SUBGROUP at the namespace root lets them create one
+    // directly under the root, and they become its owner.
+    set_member_capability(
+        &store,
+        &ns_gid,
+        &member_pk,
+        MemberCapabilities::CAN_CREATE_SUBGROUP,
+    )
+    .unwrap();
+    gov.apply_signed_op(&create(&member_sk, chan, ns_id, 2))
+        .expect("member with CAN_CREATE_SUBGROUP creates a subgroup under the root");
+    assert_eq!(
+        load_group_meta(&store, &ContextGroupId::from(chan))
+            .unwrap()
+            .unwrap()
+            .owner_identity,
+        member_pk,
+        "creator owns the new subgroup"
+    );
+
+    // But the capability is scoped to root-level subgroups: the member cannot
+    // create a nested subgroup under another subgroup.
+    let nested_parent = [0xB2u8; 32];
+    gov.apply_signed_op(&create(&admin_sk, nested_parent, ns_id, 3))
+        .expect("admin creates an intermediate subgroup");
+    let grandchild = [0xB3u8; 32];
+    assert!(
+        gov.apply_signed_op(&create(&member_sk, grandchild, nested_parent, 4))
+            .is_err(),
+        "CAN_CREATE_SUBGROUP is honored only directly under the namespace root"
+    );
+
+    // A namespace admin is still allowed at any depth.
+    gov.apply_signed_op(&create(&admin_sk, grandchild, nested_parent, 5))
+        .expect("namespace admin may create nested subgroups");
+}
+
+#[test]
+fn governance_group_deleted_owner_admin_or_cap_only() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_context_config::MemberCapabilities;
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+    let admin_sk_bytes: [u8; 32] = rand::Rng::gen(&mut rng);
+    let admin_sk = PrivateKey::from(admin_sk_bytes);
+    let admin_pk = admin_sk.public_key();
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    let stranger_sk = PrivateKey::random(&mut rng);
+    let janitor_sk = PrivateKey::random(&mut rng);
+    let janitor_pk = janitor_sk.public_key();
+
+    let ns_id = [0xA0u8; 32];
+    let ns_gid = ContextGroupId::from(ns_id);
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &ns_gid, &janitor_pk, GroupMemberRole::Member).unwrap();
+    store_namespace_identity(&store, &ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
+
+    // Three leaf subgroups under the root, all owned by `owner_pk`.
+    let mk_subgroup = |tag: u8| {
+        let id = [tag; 32];
+        let gid = ContextGroupId::from(id);
+        save_group_meta(&store, &gid, &sample_meta_with_admin(owner_pk)).unwrap();
+        nest_group(&store, &ns_gid, &gid).unwrap();
+        (id, gid)
+    };
+    let (s1, s1_gid) = mk_subgroup(0xC1);
+    let (s2, s2_gid) = mk_subgroup(0xC2);
+    let (s3, s3_gid) = mk_subgroup(0xC3);
+
+    let gov = NamespaceGovernance::new(&store, ns_id);
+    let del = |sk: &PrivateKey, root_group_id: [u8; 32], nonce: u64| {
+        SignedNamespaceOp::sign(
+            sk,
+            ns_id,
+            vec![],
+            [0u8; 32],
+            nonce,
+            NamespaceOp::Root(RootOp::GroupDeleted {
+                root_group_id,
+                cascade_group_ids: vec![],
+                cascade_context_ids: vec![],
+            }),
+        )
+        .unwrap()
+    };
+
+    // A stranger who is neither the subgroup owner, a namespace admin, nor a
+    // CAN_DELETE_SUBGROUP holder is rejected.
+    assert!(gov.apply_signed_op(&del(&stranger_sk, s1, 1)).is_err());
+    assert!(load_group_meta(&store, &s1_gid).unwrap().is_some());
+
+    // The subgroup's owner can cascade-delete it.
+    gov.apply_signed_op(&del(&owner_sk, s1, 2))
+        .expect("subgroup owner can delete it");
+    assert!(load_group_meta(&store, &s1_gid).unwrap().is_none());
+
+    // A namespace admin can delete a subgroup they don't own (moderation).
+    gov.apply_signed_op(&del(&admin_sk, s2, 3))
+        .expect("namespace admin can delete any subgroup");
+    assert!(load_group_meta(&store, &s2_gid).unwrap().is_none());
+
+    // A namespace member holding CAN_DELETE_SUBGROUP can delete a subgroup.
+    set_member_capability(
+        &store,
+        &ns_gid,
+        &janitor_pk,
+        MemberCapabilities::CAN_DELETE_SUBGROUP,
+    )
+    .unwrap();
+    gov.apply_signed_op(&del(&janitor_sk, s3, 4))
+        .expect("CAN_DELETE_SUBGROUP holder can delete a subgroup");
+    assert!(load_group_meta(&store, &s3_gid).unwrap().is_none());
+}

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -4974,6 +4974,8 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
     let admin_pk = admin_sk.public_key();
     let member_sk = PrivateKey::random(&mut rng);
     let member_pk = member_sk.public_key();
+    // Never added to the namespace — not a member, no capability row.
+    let stranger_sk = PrivateKey::random(&mut rng);
 
     let ns_id = [0xA0u8; 32];
     let ns_gid = ContextGroupId::from(ns_id);
@@ -5000,9 +5002,26 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
 
     let chan = [0xB1u8; 32];
 
+    // A total stranger (not a namespace member, no capability row) cannot
+    // create a subgroup — rejected by the apply-side authorization check.
+    assert!(
+        !check_group_membership(&store, &ns_gid, &stranger_sk.public_key()).unwrap(),
+        "precondition: the stranger must not be enrolled in the namespace"
+    );
+    let err = gov
+        .apply_signed_op(&create(&stranger_sk, chan, ns_id, 1))
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("GroupCreated rejected"),
+        "stranger should be rejected by the authorization check, got: {err}"
+    );
+    assert!(load_group_meta(&store, &ContextGroupId::from(chan))
+        .unwrap()
+        .is_none());
+
     // Member without the cap cannot create a subgroup, even under the root.
     assert!(gov
-        .apply_signed_op(&create(&member_sk, chan, ns_id, 1))
+        .apply_signed_op(&create(&member_sk, chan, ns_id, 2))
         .is_err());
     assert!(load_group_meta(&store, &ContextGroupId::from(chan))
         .unwrap()
@@ -5017,7 +5036,7 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
         MemberCapabilities::CAN_CREATE_SUBGROUP,
     )
     .unwrap();
-    gov.apply_signed_op(&create(&member_sk, chan, ns_id, 2))
+    gov.apply_signed_op(&create(&member_sk, chan, ns_id, 3))
         .expect("member with CAN_CREATE_SUBGROUP creates a subgroup under the root");
     assert_eq!(
         load_group_meta(&store, &ContextGroupId::from(chan))
@@ -5035,17 +5054,17 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
     // But the capability is scoped to root-level subgroups: the member cannot
     // create a nested subgroup under another subgroup.
     let nested_parent = [0xB2u8; 32];
-    gov.apply_signed_op(&create(&admin_sk, nested_parent, ns_id, 3))
+    gov.apply_signed_op(&create(&admin_sk, nested_parent, ns_id, 4))
         .expect("admin creates an intermediate subgroup");
     let grandchild = [0xB3u8; 32];
     assert!(
-        gov.apply_signed_op(&create(&member_sk, grandchild, nested_parent, 4))
+        gov.apply_signed_op(&create(&member_sk, grandchild, nested_parent, 5))
             .is_err(),
         "CAN_CREATE_SUBGROUP is honored only directly under the namespace root"
     );
 
     // A namespace admin is still allowed at any depth.
-    gov.apply_signed_op(&create(&admin_sk, grandchild, nested_parent, 5))
+    gov.apply_signed_op(&create(&admin_sk, grandchild, nested_parent, 6))
         .expect("namespace admin may create nested subgroups");
 }
 

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -68,10 +68,25 @@ impl Handler<CreateGroupRequest> for ContextManager {
                     )));
                 }
             };
-            if let Err(err) =
-                group_store::require_group_admin(&self.datastore, parent_id, &admin_identity)
+            // Authorization. Namespace-root admins may create a subgroup at
+            // any depth. A non-admin namespace member may create one *directly
+            // under the namespace root* if they hold `CAN_CREATE_SUBGROUP`
+            // (honored only at root level — see the capability's doc and
+            // `execute_group_created`, which re-checks this on every peer).
+            if !group_store::is_group_admin(&self.datastore, &namespace_id, &admin_identity)
+                .unwrap_or(false)
             {
-                return ActorResponse::reply(Err(err));
+                if *parent_id != namespace_id {
+                    return ActorResponse::reply(Err(eyre::eyre!(
+                        "creating a subgroup under non-root parent '{parent_id:?}' requires \
+                         namespace admin (delegated nested-subgroup creation is not yet supported)"
+                    )));
+                }
+                if let Err(err) = group_store::PermissionChecker::new(&self.datastore, *parent_id)
+                    .require_can_create_subgroup(&admin_identity)
+                {
+                    return ActorResponse::reply(Err(err));
+                }
             }
             parent_meta.target_application_id
         } else {

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -73,9 +73,15 @@ impl Handler<CreateGroupRequest> for ContextManager {
             // under the namespace root* if they hold `CAN_CREATE_SUBGROUP`
             // (honored only at root level — see the capability's doc and
             // `execute_group_created`, which re-checks this on every peer).
-            if !group_store::is_group_admin(&self.datastore, &namespace_id, &admin_identity)
-                .unwrap_or(false)
-            {
+            let is_namespace_admin = match group_store::is_group_admin(
+                &self.datastore,
+                &namespace_id,
+                &admin_identity,
+            ) {
+                Ok(v) => v,
+                Err(err) => return ActorResponse::reply(Err(err)),
+            };
+            if !is_namespace_admin {
                 if *parent_id != namespace_id {
                     return ActorResponse::reply(Err(eyre::eyre!(
                         "creating a subgroup under non-root parent '{parent_id:?}' requires \

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -58,10 +58,9 @@ impl Handler<DeleteGroupRequest> for ContextManager {
 
         // Sync validation + cascade payload pre-computation.
         let validated = (|| -> eyre::Result<(group_store::CascadePayload, [u8; 32])> {
-            let Some(_meta) = group_store::load_group_meta(&self.datastore, &group_id)? else {
+            let Some(meta) = group_store::load_group_meta(&self.datastore, &group_id)? else {
                 bail!("group '{group_id:?}' not found");
             };
-            group_store::require_group_admin(&self.datastore, &group_id, &requester)?;
 
             // Reject the namespace root explicitly; it has no parent edge to
             // identify it as a subtree, and the namespace-deletion path is
@@ -70,6 +69,23 @@ impl Handler<DeleteGroupRequest> for ContextManager {
             if namespace_id == group_id {
                 bail!(
                     "cannot delete the namespace root '{group_id:?}': use delete_namespace instead"
+                );
+            }
+
+            // Authorization (re-checked on every peer in `execute_group_deleted`):
+            // the subgroup's owner, an admin of the namespace root, or a
+            // namespace member holding CAN_DELETE_SUBGROUP.
+            if meta.owner_identity != requester
+                && !group_store::is_group_admin_or_has_capability(
+                    &self.datastore,
+                    &namespace_id,
+                    &requester,
+                    calimero_context_config::MemberCapabilities::CAN_DELETE_SUBGROUP,
+                )?
+            {
+                bail!(
+                    "deleting subgroup '{group_id:?}' requires being its owner, a namespace \
+                     admin, or holding CAN_DELETE_SUBGROUP"
                 );
             }
 

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -74,19 +74,15 @@ impl Handler<DeleteGroupRequest> for ContextManager {
 
             // Authorization (re-checked on every peer in `execute_group_deleted`):
             // the subgroup's owner, an admin of the namespace root, or a
-            // namespace member holding CAN_DELETE_SUBGROUP.
-            if meta.owner_identity != requester
-                && !group_store::is_group_admin_or_has_capability(
-                    &self.datastore,
-                    &namespace_id,
-                    &requester,
-                    calimero_context_config::MemberCapabilities::CAN_DELETE_SUBGROUP,
-                )?
-            {
-                bail!(
-                    "deleting subgroup '{group_id:?}' requires being its owner, a namespace \
-                     admin, or holding CAN_DELETE_SUBGROUP"
-                );
+            // namespace member holding CAN_DELETE_SUBGROUP. The non-owner case
+            // routes through `PermissionChecker` to stay in step with the
+            // create / set-visibility handlers.
+            if meta.owner_identity != requester {
+                group_store::PermissionChecker::new(&self.datastore, namespace_id)
+                    .require_can_delete_subgroup(&requester)
+                    .map_err(|e| {
+                        eyre::eyre!("deleting subgroup '{group_id:?}': {e} (or be its owner)")
+                    })?;
             }
 
             let payload = group_store::collect_subtree_for_cascade(&self.datastore, &group_id)?;

--- a/crates/context/src/handlers/set_subgroup_visibility.rs
+++ b/crates/context/src/handlers/set_subgroup_visibility.rs
@@ -1,8 +1,11 @@
-use actix::{ActorResponse, Handler, Message};
+use std::sync::Arc;
+
+use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::SetSubgroupVisibilityRequest;
 use calimero_context_client::local_governance::GroupOp;
 use tracing::warn;
 
+use crate::governance_broadcast::ObserveDelivery;
 use crate::{group_store, ContextManager};
 
 impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
@@ -36,16 +39,45 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
             }
         }
 
+        // Preflight without the admin gate (resolves the requester + signing
+        // key, checks the group exists), then require admin **or**
+        // `CAN_MANAGE_VISIBILITY` — re-checked on every peer in
+        // `GroupSettingsService::set_subgroup_visibility`.
+        let preflight = match self.governance_preflight(&group_id, requester, false) {
+            Ok(p) => p,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+        if let Err(err) = group_store::PermissionChecker::new(&self.datastore, group_id)
+            .require_can_manage_visibility(&preflight.requester)
+        {
+            return ActorResponse::reply(Err(err));
+        }
+
         let mode_u8 = match subgroup_visibility {
             calimero_context_config::VisibilityMode::Open => 0u8,
             calimero_context_config::VisibilityMode::Restricted => 1u8,
         };
 
-        self.sign_and_publish_group_op(
-            &group_id,
-            requester,
-            true,
-            GroupOp::SubgroupVisibilitySet { mode: mode_u8 },
+        let datastore = preflight.datastore.clone();
+        let node_client = preflight.node_client.clone();
+        let ack_router = Arc::clone(&self.ack_router);
+        let sk = preflight.signer_sk();
+
+        ActorResponse::r#async(
+            async move {
+                let report = group_store::sign_apply_and_publish(
+                    &datastore,
+                    &node_client,
+                    &ack_router,
+                    &group_id,
+                    &sk,
+                    GroupOp::SubgroupVisibilitySet { mode: mode_u8 },
+                )
+                .await?;
+                report.observe("set_subgroup_visibility", "SubgroupVisibilitySet");
+                Ok(())
+            }
+            .into_actor(self),
         )
     }
 }

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -227,6 +227,24 @@ pub struct SetCapabilitiesCommand {
 
     #[clap(
         long,
+        help = "Allow member to create a subgroup directly under the namespace root"
+    )]
+    pub can_create_subgroup: bool,
+
+    #[clap(
+        long,
+        help = "Allow member to cascade-delete a subgroup and its subtree"
+    )]
+    pub can_delete_subgroup: bool,
+
+    #[clap(
+        long,
+        help = "Allow member to change a subgroup's visibility (open/restricted)"
+    )]
+    pub can_manage_visibility: bool,
+
+    #[clap(
+        long,
         help = "Public key of the requester (group admin). Auto-resolved from node group identity if omitted"
     )]
     pub requester: Option<PublicKey>,
@@ -243,6 +261,15 @@ impl SetCapabilitiesCommand {
         }
         if self.can_join_open_subgroups {
             capabilities |= 1 << 2;
+        }
+        if self.can_create_subgroup {
+            capabilities |= 1 << 5;
+        }
+        if self.can_delete_subgroup {
+            capabilities |= 1 << 6;
+        }
+        if self.can_manage_visibility {
+            capabilities |= 1 << 7;
         }
 
         let identity_hex = hex::encode(self.identity.digest());
@@ -337,6 +364,30 @@ impl CheckAccessCommand {
         println!(
             "CAN_JOIN_OPEN_SUBGROUPS: {}",
             if caps & (1 << 2) != 0 {
+                "true"
+            } else {
+                "false"
+            }
+        );
+        println!(
+            "CAN_CREATE_SUBGROUP:     {}",
+            if caps & (1 << 5) != 0 {
+                "true"
+            } else {
+                "false"
+            }
+        );
+        println!(
+            "CAN_DELETE_SUBGROUP:     {}",
+            if caps & (1 << 6) != 0 {
+                "true"
+            } else {
+                "false"
+            }
+        );
+        println!(
+            "CAN_MANAGE_VISIBILITY:   {}",
+            if caps & (1 << 7) != 0 {
                 "true"
             } else {
                 "false"


### PR DESCRIPTION
## Why

First PR in a small stack toward letting an app (e.g. a Slack-like chat) be built on namespaces + subgroups with proper privacy. Today only a **namespace-root admin** can create or delete a subgroup, and only an admin can flip a subgroup's visibility — there's no way to let an ordinary namespace member "start their own channel". This PR adds the capability bits for that.

## What

Three new `MemberCapabilities` bits (`u32`, plenty of room):

| Bit | Cap | Effect |
|---|---|---|
| `1<<5` | `CAN_CREATE_SUBGROUP` | Create a subgroup **directly under the namespace root**. The creator becomes the new subgroup's `owner_identity`/`Admin` (already true; now reachable without namespace-admin rights). |
| `1<<6` | `CAN_DELETE_SUBGROUP` | Cascade-delete a subgroup + its subtree. |
| `1<<7` | `CAN_MANAGE_VISIBILITY` | Flip a subgroup's `VisibilityMode` (`Open`↔`Restricted`) without full admin on it. |

### Authorization changes

- **Create** — `handlers/create_group.rs` (local pre-check) and `execute_group_created` (apply path, runs on **every peer**): namespace-root admin at any depth, **or** `CAN_CREATE_SUBGROUP` for a subgroup whose parent **is** the namespace root.
  - *Why root-only:* the apply-side check must be deterministically verifiable by every peer that applies the `GroupCreated` op. Every namespace member can read the **root** group's member-capability rows; a deeper subgroup's rows are part of that subgroup's encrypted op stream and aren't readable by non-members. Delegated creation of *nested* subgroups by non-admins is left to a follow-up; namespace admins are unaffected.
- **Delete** — `handlers/delete_group.rs` and `execute_group_deleted`: the subgroup's **owner**, an **admin of the namespace root** (moderation), **or** a holder of `CAN_DELETE_SUBGROUP` — instead of namespace-admin-only. (This also means a member who created a channel can delete it.)
- **Visibility** — `handlers/set_subgroup_visibility.rs` and `GroupSettingsService::set_subgroup_visibility`: admin **or** `CAN_MANAGE_VISIBILITY`. The `SubgroupVisibilitySet` op is group-scoped (encrypted to the target subgroup's members), so this check is deterministic among exactly the peers that apply it — no root-only restriction.

### CLI

`meroctl group members set-caps … --can-create-subgroup --can-delete-subgroup --can-manage-visibility`; the `check-access` diagnostic now prints the three new bits.

## Tests

- **Unit** (`crates/context/src/group_store/tests.rs`):
  - `permission_checker_subgroup_management_capabilities` — admin passes all three; bare member denied; granting each bit flips the corresponding check.
  - `group_settings_subgroup_visibility_honors_can_manage_visibility` — admin can flip; member can't until granted `CAN_MANAGE_VISIBILITY`.
  - `governance_group_created_honors_can_create_subgroup_at_root_only` — member without the bit rejected on the apply path; with the bit, creates a subgroup under the root and becomes its owner; **cannot** create a nested subgroup with that bit (root-only); namespace admin still can at any depth.
  - `governance_group_deleted_owner_admin_or_cap_only` — a stranger is rejected; the subgroup owner, a namespace admin, and a `CAN_DELETE_SUBGROUP` holder each succeed.
  - `cargo test -p calimero-context --lib group_store::tests` → 138 passed, 0 failed.
- **E2E** — new `apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml` + matrix entry in `e2e-rust-apps.yml`: a non-admin member granted the three bits creates a subgroup, flips its visibility, creates+exercises a context inside it, then cascade-deletes it. (Negative paths are covered by the unit tests above.)
- `cargo check --workspace --all-targets` → clean (only pre-existing unrelated warnings in `calimero-node` test files).

## Notes / dependencies

- Stable runs of the new e2e workflow depend on **#2324** (the namespace creator being recognised as admin in the B3 cross-DAG state-delta check) — a member who creates a subgroup becomes its `admin_identity`, and that recognition is what lets their state deltas into the subgroup's contexts be accepted by peers.
- The pre-existing HashComparison / `StorageType: Shared→Public` e2e flake (tracked separately) is unrelated to this change.
- Follow-ups in the stack: owner-gated destruction baseline + `transfer-owner` CLI; private-subgroup/DM privacy e2e + recursive-invite check; generic group metadata (`name` + opaque `data`) replacing the alias-as-name model, with opt-in name uniqueness.

## Also in this PR

- `release.yml`: wrap the `cargo ws publish` step in a retry loop (5 attempts, 60s apart). The rc.36 "Release Crates" run failed on a crates.io index-propagation race — cargo's built-in "wait for the just-published crate to appear in the index" loop timed out (registry backlog), so packaging the *next* crate (`calimero-node-primitives`, which depends on `calimero-network-primitives = "^0.10.1-rc.36"`) couldn't resolve that dependency (`failed to select a version for the requirement ...`). `cargo-workspaces` skips crates already on crates.io, so a retry resumes from the failed crate once the index has caught up.
- `Cargo.toml`: bumped the workspace release version `0.10.1-rc.36` → `0.10.1-rc.37`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization for subgroup creation, cascade deletion, and visibility updates, affecting governance enforcement on both request handlers and apply paths; mistakes could allow unauthorized structural changes or block legitimate ops. Added tests and E2E coverage reduce but do not eliminate the risk.
> 
> **Overview**
> Enables delegated subgroup management via three new `MemberCapabilities` bits: `CAN_CREATE_SUBGROUP`, `CAN_DELETE_SUBGROUP`, and `CAN_MANAGE_VISIBILITY`, and updates enforcement so non-admin namespace members can create *root-level* subgroups, cascade-delete subgroups (owner/admin/capability), and change subgroup visibility without full admin.
> 
> Updates local handlers and namespace apply logic (`execute_group_created`/`execute_group_deleted`) to enforce the new rules deterministically, adds `PermissionChecker` helpers plus unit tests, and introduces a new `group-member-channel-lifecycle` E2E workflow (wired into the CI matrix) to validate the full member-driven channel lifecycle.
> 
> Also updates `meroctl` to set/print the new capability flags, refreshes architecture docs to reflect the new bit layout, bumps workspace version to `0.10.1-rc.37`, and makes `release.yml` crate publishing more robust by retrying `cargo ws publish` up to 5 times to handle crates.io index lag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7271ed13f15792e0e9122724ee219352e520369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

