### PR TITLE
feat(context): wall recursive namespace invitations out of private subgroups + DM-privacy e2e

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -182,6 +182,9 @@ jobs:
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e
+          - workflow: dm-subgroup-privacy
+            file: workflows/dm-subgroup-privacy.yml
+            app: scaffolding-e2e
           - workflow: group-default-capabilities-propagation
             file: workflows/group-default-capabilities-propagation.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -16,10 +16,10 @@ description: >
       Restricted subgroup (the membership walk in
       `check_group_membership` terminates at the Restricted wall, and
       the subgroup's `admin_identity` is node-2, not node-1).
-    * Contrast: node-2 also creates an *Open* subgroup. There node-1
-      DOES inherit membership (admin authority cascades down an Open
-      chain) and can join + read its context — proving that visibility,
-      not "who happened to be added", is the privacy boundary.
+
+  The complementary direction — a namespace member inheriting into an
+  *Open* subgroup (so visibility, not "who was added", is the boundary) —
+  is covered by `group-subgroup-visibility-inheritance.yml`.
 
   Recursive-invitation leakage (a namespace admin recursively inviting a
   third party must not mint invitations into / enumerate private
@@ -235,77 +235,5 @@ steps:
       key: "owner_was_here"
       value: "should_not_work"
     expected_failure: true
-
-  # --- CONTRAST: an Open subgroup created by the same member DOES let
-  #     the namespace owner in (admin authority cascades down Open
-  #     chains). This isolates "visibility", not "membership accident",
-  #     as the privacy boundary. ---
-
-  - name: Node-2 creates an Open subgroup
-    type: create_group_in_namespace
-    node: e2e-node-2
-    namespace_id: '{{namespace_id}}'
-    group_alias: open-channel
-    outputs:
-      subgroup_open: groupId
-
-  - name: Node-2 marks the subgroup Open
-    type: set_subgroup_visibility
-    node: e2e-node-2
-    group_id: '{{subgroup_open}}'
-    visibility: open
-
-  - name: Node-2 creates a context in the Open subgroup
-    type: create_context
-    node: e2e-node-2
-    application_id: '{{app_id}}'
-    group_id: '{{subgroup_open}}'
-    outputs:
-      ctx_open: contextId
-
-  - name: Node-2 writes into the Open-subgroup context
-    type: call
-    node: e2e-node-2
-    context_id: '{{ctx_open}}'
-    method: set
-    args:
-      key: "open_key"
-      value: "from_node2_open"
-
-  - name: Node-1 (namespace owner) joins the Open-subgroup context via inheritance
-    type: join_context
-    node: e2e-node-1
-    context_id: '{{ctx_open}}'
-    outputs:
-      ctx_key_node1_open: memberPublicKey
-
-  - name: Assert node-1 holds a context identity in the Open subgroup
-    type: assert
-    statements:
-      - "is_set({{ctx_key_node1_open}})"
-
-  - name: Wait for Open-context sync between node-2 and node-1
-    type: wait_for_sync
-    context_id: '{{ctx_open}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-    timeout: 60
-    trigger_sync: true
-
-  - name: Node-1 reads the value from the Open-subgroup context
-    type: call
-    node: e2e-node-1
-    context_id: '{{ctx_open}}'
-    method: get
-    args:
-      key: "open_key"
-    outputs:
-      open_read_node1: result
-
-  - name: Assert node-1 inherits real access to the Open subgroup
-    type: json_assert
-    statements:
-      - 'json_equal({{open_read_node1}}, {"output": "from_node2_open"})'
 
 stop_all_nodes: false

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -16,10 +16,12 @@ description: >
       Restricted subgroup (the membership walk in
       `check_group_membership` terminates at the Restricted wall, and
       the subgroup's `admin_identity` is node-2, not node-1).
-
-  The complementary direction — a namespace member inheriting into an
-  *Open* subgroup (so visibility, not "who was added", is the boundary) —
-  is covered by `group-subgroup-visibility-inheritance.yml`.
+    * Contrast: node-2 also creates an *Open* subgroup with a context.
+      node-1 — without being added to that subgroup — inherits into it
+      (admin authority cascades down an Open chain) and can join + read
+      its context. This proves the privacy boundary is *visibility*, not
+      "who happened to be added": flip the same subgroup to `Open` and
+      the namespace owner is back in.
 
   Recursive-invitation leakage (a namespace admin recursively inviting a
   third party must not mint invitations into / enumerate private
@@ -235,5 +237,95 @@ steps:
       key: "owner_was_here"
       value: "should_not_work"
     expected_failure: true
+
+  # --- CONTRAST: an Open subgroup created by the same member DOES let
+  #     the namespace owner in (admin authority cascades down Open
+  #     chains). This isolates "visibility", not "membership accident",
+  #     as the privacy boundary. ---
+
+  - name: Node-2 creates an Open subgroup
+    type: create_group_in_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_open: groupId
+
+  - name: Node-2 marks the subgroup Open
+    type: set_subgroup_visibility
+    node: e2e-node-2
+    group_id: '{{subgroup_open}}'
+    visibility: open
+
+  - name: Node-2 creates a context in the Open subgroup
+    type: create_context
+    node: e2e-node-2
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_open}}'
+    outputs:
+      ctx_open: contextId
+
+  - name: Node-2 writes into the Open-subgroup context
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_open}}'
+    method: set
+    args:
+      key: "open_key"
+      value: "from_node2_open"
+
+  # node-1 must learn the Open subgroup's GroupCreated/visibility/context
+  # registration ops off the namespace governance DAG before it can
+  # inherit-join the context. node-2 published all of those within a few
+  # ms above; give node-1's background namespace sync time to catch up
+  # (each `set_subgroup_visibility` waiter call also nudges sync along).
+  - name: Wait for node-1 to converge on the Open subgroup's governance state
+    type: wait_for_sync
+    group_id: '{{subgroup_open}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 90
+    trigger_sync: true
+
+  - name: Settle (let node-1 finish syncing the namespace DAG)
+    type: wait
+    seconds: 20
+
+  - name: Node-1 (namespace owner) joins the Open-subgroup context via inheritance
+    type: join_context
+    node: e2e-node-1
+    context_id: '{{ctx_open}}'
+    outputs:
+      ctx_key_node1_open: memberPublicKey
+
+  - name: Assert node-1 holds a context identity in the Open subgroup
+    type: assert
+    statements:
+      - "is_set({{ctx_key_node1_open}})"
+
+  - name: Wait for Open-context sync between node-2 and node-1
+    type: wait_for_sync
+    context_id: '{{ctx_open}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node-1 reads the value from the Open-subgroup context
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_open}}'
+    method: get
+    args:
+      key: "open_key"
+    outputs:
+      open_read_node1: result
+
+  - name: Assert node-1 inherits real access to the Open subgroup
+    type: json_assert
+    statements:
+      - 'json_equal({{open_read_node1}}, {"output": "from_node2_open"})'
 
 stop_all_nodes: false

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -1,0 +1,311 @@
+name: E2E KV Store - Private Subgroup / DM Privacy
+description: >
+  End-to-end privacy coverage for member-created private subgroups (the
+  "DM" / "private channel" shape of the Slack-app stack).
+
+  A non-admin namespace member (node-2), granted CAN_CREATE_SUBGROUP
+  (32) and CAN_JOIN_OPEN_SUBGROUPS (4), creates a Restricted subgroup
+  directly under the namespace root, becomes its owner/admin, adds ONLY
+  node-3 to it, and runs a context inside it. The headline claims:
+
+    * node-3 — directly added by node-2 — can join the subgroup's
+      context and read what node-2 wrote (real, functional access).
+    * node-1 — the *namespace owner/admin* — is walled out of that
+      Restricted subgroup: it can neither `join_context` it nor `call`
+      it. Namespace-root ownership does NOT pierce a member-created
+      Restricted subgroup (the membership walk in
+      `check_group_membership` terminates at the Restricted wall, and
+      the subgroup's `admin_identity` is node-2, not node-1).
+    * Contrast: node-2 also creates an *Open* subgroup. There node-1
+      DOES inherit membership (admin authority cascades down an Open
+      chain) and can join + read its context — proving that visibility,
+      not "who happened to be added", is the privacy boundary.
+
+  Recursive-invitation leakage (a namespace admin recursively inviting a
+  third party must not mint invitations into / enumerate private
+  subgroups it isn't in) is exercised by the `calimero-context` unit
+  tests `create_recursive_invitations_omits_private_subgroups_inviter_not_in`
+  and `collect_visible_descendant_groups_walls_at_restricted_subgroups_inviter_not_in`.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: app + namespace on node-1 (the namespace owner) ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  # --- node-2 and node-3 join the namespace as ordinary members ---
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  # --- node-1 grants node-2 the subgroup-creation capability ---
+  # `set_member_capabilities` REPLACES the whole bitmask (not additive),
+  # so include the default CAN_JOIN_OPEN_SUBGROUPS (4) to avoid clearing it:
+  #   4  = CAN_JOIN_OPEN_SUBGROUPS
+  #   32 = CAN_CREATE_SUBGROUP
+  #   ------------------------------- = 36
+
+  - name: Grant node-2 CAN_CREATE_SUBGROUP (+ keep CAN_JOIN_OPEN_SUBGROUPS) = 36
+    type: set_member_capabilities
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    member_id: '{{identity_node2}}'
+    capabilities: 36
+
+  - name: Read node-2 capabilities back
+    type: get_member_capabilities
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    member_id: '{{identity_node2}}'
+    outputs:
+      node2_caps: capabilities
+
+  - name: Assert node-2 has capabilities 36
+    type: json_assert
+    statements:
+      - "json_equal({{node2_caps}}, 36)"
+
+  # --- node-2 creates a Restricted subgroup (a private DM/channel) and
+  #     adds ONLY node-3 to it. node-2 is the subgroup's owner/admin. ---
+
+  - name: Node-2 creates a Restricted subgroup (private DM)
+    type: create_group_in_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    group_alias: private-dm
+    outputs:
+      subgroup_priv: groupId
+
+  - name: Assert private subgroup created
+    type: assert
+    statements:
+      - "is_set({{subgroup_priv}})"
+
+  # Freshly created subgroups default to Restricted; set it explicitly so
+  # the intent is unambiguous (node-2 is the subgroup admin, so no
+  # CAN_MANAGE_VISIBILITY grant is needed).
+  - name: Node-2 marks the subgroup Restricted
+    type: set_subgroup_visibility
+    node: e2e-node-2
+    group_id: '{{subgroup_priv}}'
+    visibility: restricted
+
+  - name: Node-2 adds node-3 to the private subgroup
+    type: add_group_members
+    node: e2e-node-2
+    group_id: '{{subgroup_priv}}'
+    members:
+      - identity: '{{identity_node3}}'
+        role: Member
+
+  - name: Node-2 creates a context in the private subgroup
+    type: create_context
+    node: e2e-node-2
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_priv}}'
+    outputs:
+      ctx_priv: contextId
+
+  - name: Assert private context created
+    type: assert
+    statements:
+      - "is_set({{ctx_priv}})"
+
+  - name: Node-2 writes a secret into the private context
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_priv}}'
+    method: set
+    args:
+      key: "secret_key"
+      value: "from_node2"
+
+  # --- POSITIVE: node-3 (directly added) has real access ---
+
+  - name: Node-3 joins the private context
+    type: join_context
+    node: e2e-node-3
+    context_id: '{{ctx_priv}}'
+    outputs:
+      ctx_key_node3: memberPublicKey
+
+  - name: Assert node-3 holds a context identity
+    type: assert
+    statements:
+      - "is_set({{ctx_key_node3}})"
+
+  - name: Wait for private-context sync between node-2 and node-3
+    type: wait_for_sync
+    context_id: '{{ctx_priv}}'
+    nodes:
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node-3 reads the secret from the private context
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx_priv}}'
+    method: get
+    args:
+      key: "secret_key"
+    outputs:
+      secret_read_node3: result
+
+  - name: Assert node-3 sees the secret
+    type: json_assert
+    statements:
+      - 'json_equal({{secret_read_node3}}, {"output": "from_node2"})'
+
+  # --- NEGATIVE: node-1, the namespace OWNER, is walled out ---
+  # `expected_failure` turns the merod rejection into a pass, so these
+  # steps only succeed if the Restricted wall is actually enforced
+  # against the namespace owner.
+
+  - name: Node-1 (namespace owner) cannot join the private context
+    type: join_context
+    node: e2e-node-1
+    context_id: '{{ctx_priv}}'
+    expected_failure: true
+
+  - name: Node-1 (namespace owner) cannot write to the private context
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_priv}}'
+    method: set
+    args:
+      key: "owner_was_here"
+      value: "should_not_work"
+    expected_failure: true
+
+  # --- CONTRAST: an Open subgroup created by the same member DOES let
+  #     the namespace owner in (admin authority cascades down Open
+  #     chains). This isolates "visibility", not "membership accident",
+  #     as the privacy boundary. ---
+
+  - name: Node-2 creates an Open subgroup
+    type: create_group_in_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_open: groupId
+
+  - name: Node-2 marks the subgroup Open
+    type: set_subgroup_visibility
+    node: e2e-node-2
+    group_id: '{{subgroup_open}}'
+    visibility: open
+
+  - name: Node-2 creates a context in the Open subgroup
+    type: create_context
+    node: e2e-node-2
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_open}}'
+    outputs:
+      ctx_open: contextId
+
+  - name: Node-2 writes into the Open-subgroup context
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx_open}}'
+    method: set
+    args:
+      key: "open_key"
+      value: "from_node2_open"
+
+  - name: Node-1 (namespace owner) joins the Open-subgroup context via inheritance
+    type: join_context
+    node: e2e-node-1
+    context_id: '{{ctx_open}}'
+    outputs:
+      ctx_key_node1_open: memberPublicKey
+
+  - name: Assert node-1 holds a context identity in the Open subgroup
+    type: assert
+    statements:
+      - "is_set({{ctx_key_node1_open}})"
+
+  - name: Wait for Open-context sync between node-2 and node-1
+    type: wait_for_sync
+    context_id: '{{ctx_open}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node-1 reads the value from the Open-subgroup context
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_open}}'
+    method: get
+    args:
+      key: "open_key"
+    outputs:
+      open_read_node1: result
+
+  - name: Assert node-1 inherits real access to the Open subgroup
+    type: json_assert
+    statements:
+      - 'json_equal({{open_read_node1}}, {"output": "from_node2_open"})'
+
+stop_all_nodes: false

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -276,21 +276,25 @@ steps:
 
   # node-1 must learn the Open subgroup's GroupCreated/visibility/context
   # registration ops off the namespace governance DAG before it can
-  # inherit-join the context. node-2 published all of those within a few
-  # ms above; give node-1's background namespace sync time to catch up
-  # (each `set_subgroup_visibility` waiter call also nudges sync along).
+  # inherit-join the context. node-2 published all of those a moment ago;
+  # let node-1's namespace sync converge. These waits are sized for a
+  # realistic propagation delay between two locally-connected nodes — not
+  # padded to mask a slow path. `join_context` itself also does a bounded
+  # internal sync-and-retry; if a namespace owner still can't reach a
+  # just-created Open subgroup's context after this, that's a core sync
+  # gap to fix, not a knob to widen.
   - name: Wait for node-1 to converge on the Open subgroup's governance state
     type: wait_for_sync
     group_id: '{{subgroup_open}}'
     nodes:
       - e2e-node-1
       - e2e-node-2
-    timeout: 90
+    timeout: 30
     trigger_sync: true
 
-  - name: Settle (let node-1 finish syncing the namespace DAG)
+  - name: Brief settle for namespace-DAG propagation to node-1
     type: wait
-    seconds: 20
+    seconds: 5
 
   - name: Node-1 (namespace owner) joins the Open-subgroup context via inheritance
     type: join_context

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -91,11 +91,12 @@ pub use self::migrations::{
     delete_all_context_last_migrations, get_context_last_migration, set_context_last_migration,
 };
 pub use self::namespace::{
-    collect_descendant_groups, collect_subtree_for_cascade, compute_namespace_governance_epoch,
-    create_recursive_invitations, get_namespace_identity, get_namespace_identity_record,
-    get_or_create_namespace_identity, get_or_create_namespace_identity_bundle, get_parent_group,
-    is_descendant_of, is_read_only_for_context, list_child_groups, nest_group,
-    recursive_remove_member, reparent_group, resolve_namespace, resolve_namespace_identity,
+    collect_descendant_groups, collect_subtree_for_cascade, collect_visible_descendant_groups,
+    compute_namespace_governance_epoch, create_recursive_invitations, get_namespace_identity,
+    get_namespace_identity_record, get_or_create_namespace_identity,
+    get_or_create_namespace_identity_bundle, get_parent_group, is_descendant_of,
+    is_read_only_for_context, list_child_groups, nest_group, recursive_remove_member,
+    reparent_group, resolve_namespace, resolve_namespace_identity,
     resolve_namespace_identity_record, store_namespace_identity, unnest_group, CascadePayload,
     NamespaceIdentityRecord, ReparentOutcome, ResolvedNamespaceIdentity,
 };

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -201,11 +201,55 @@ pub fn collect_descendant_groups(
     Ok(descendants)
 }
 
-/// Create invitations for a group AND all its descendant groups.
+/// Collect descendant group IDs **visible to `viewer`** (recursive BFS),
+/// breadth-first, excluding the starting group itself.
+///
+/// Unlike [`collect_descendant_groups`], the walk does not descend into —
+/// and does not include — a child the `viewer` is not a member of (per
+/// [`super::check_group_membership`]). A `Restricted` subgroup the viewer
+/// has neither a direct row in nor inherited membership of is a wall: it
+/// is skipped along with its entire subtree, because the viewer cannot
+/// observe what lies beyond it. `Open` subgroups beneath a namespace the
+/// viewer belongs to are included (the membership walk inherits them).
+///
+/// This is the correct enumeration for any caller that fans an action out
+/// "down the namespace tree on behalf of `viewer`" — e.g. recursive
+/// invitations: a namespace admin recursively inviting a new member must
+/// not mint invitations into (or even enumerate the existence/aliases of)
+/// member-created private subgroups the admin was never added to.
+pub fn collect_visible_descendant_groups(
+    store: &Store,
+    group_id: &ContextGroupId,
+    viewer: &PublicKey,
+) -> EyreResult<Vec<ContextGroupId>> {
+    let mut descendants = Vec::new();
+    let mut queue = vec![*group_id];
+
+    while let Some(current) = queue.pop() {
+        for child in list_child_groups(store, &current)? {
+            if !super::check_group_membership(store, &child, viewer)? {
+                continue;
+            }
+            descendants.push(child);
+            queue.push(child);
+        }
+    }
+
+    Ok(descendants)
+}
+
+/// Create invitations for a group AND all of its descendant groups that
+/// are **visible to the inviter** (see [`collect_visible_descendant_groups`]).
 ///
 /// Returns a list of `(group_id, SignedGroupOpenInvitation)` pairs — one
 /// per group the member is being invited to. The caller publishes a
 /// `RootOp::MemberJoined` for each.
+///
+/// Privacy note: the descendant set is filtered through the inviter's own
+/// membership view, so `Restricted` subgroups the inviter is not in
+/// (member-created DMs/private channels) are neither invited into nor
+/// disclosed in the returned list. Encrypting the *existence* of such
+/// subgroups from non-members is tracked separately.
 pub fn create_recursive_invitations(
     store: &Store,
     root_group_id: &ContextGroupId,
@@ -223,7 +267,11 @@ pub fn create_recursive_invitations(
     };
 
     let mut groups = vec![*root_group_id];
-    groups.extend(collect_descendant_groups(store, root_group_id)?);
+    groups.extend(collect_visible_descendant_groups(
+        store,
+        root_group_id,
+        &inviter_sk.public_key(),
+    )?);
 
     let inviter_signer_id = SignerId::from(*inviter_sk.public_key());
     let now_secs = std::time::SystemTime::now()

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -181,28 +181,31 @@ pub fn list_child_groups(
         .collect())
 }
 
-/// Collect ALL descendant group IDs (recursive BFS). Returns them in
-/// breadth-first order, excluding the starting group itself.
+/// Collect ALL descendant group IDs by walking the child index
+/// (iterative, depth-first via an explicit stack), excluding the
+/// starting group itself. Iteration order is unspecified — the callers
+/// (cascade-delete, [`recursive_remove_member`]) don't depend on it.
 pub fn collect_descendant_groups(
     store: &Store,
     group_id: &ContextGroupId,
 ) -> EyreResult<Vec<ContextGroupId>> {
     let mut descendants = Vec::new();
-    let mut queue = vec![*group_id];
+    let mut stack = vec![*group_id];
 
-    while let Some(current) = queue.pop() {
+    while let Some(current) = stack.pop() {
         let children = list_child_groups(store, &current)?;
         for child in children {
             descendants.push(child);
-            queue.push(child);
+            stack.push(child);
         }
     }
 
     Ok(descendants)
 }
 
-/// Collect descendant group IDs **visible to `viewer`** (recursive BFS),
-/// breadth-first, excluding the starting group itself.
+/// Collect descendant group IDs **visible to `viewer`**, walking the
+/// child index iteratively (depth-first via an explicit stack), excluding
+/// the starting group itself. Iteration order is unspecified.
 ///
 /// Unlike [`collect_descendant_groups`], the walk does not descend into —
 /// and does not include — a child the `viewer` is not a member of (per
@@ -211,27 +214,37 @@ pub fn collect_descendant_groups(
 /// is skipped along with its entire subtree, because the viewer cannot
 /// observe what lies beyond it. `Open` subgroups beneath a namespace the
 /// viewer belongs to are included (the membership walk inherits them).
+/// Each child is judged independently via `check_group_membership`, which
+/// itself walks the parent chain and terminates at the first `Restricted`
+/// ancestor — that single primitive (shared with governance auth,
+/// crypto-key selection and sync stream-auth; see the module note on
+/// [`super::membership::check_group_membership_path`]) is the one source
+/// of truth for the wall, so this function deliberately does not
+/// re-derive a parallel visibility rule.
 ///
-/// This is the correct enumeration for any caller that fans an action out
-/// "down the namespace tree on behalf of `viewer`" — e.g. recursive
-/// invitations: a namespace admin recursively inviting a new member must
-/// not mint invitations into (or even enumerate the existence/aliases of)
-/// member-created private subgroups the admin was never added to.
+/// **Precondition:** the `viewer` must be a member of `group_id` itself.
+/// This function checks the *children's* membership but takes the start
+/// group's on trust — it is meant to be called on a group the caller has
+/// already authorized the viewer against (e.g.
+/// [`create_recursive_invitations`] is gated on the inviter holding
+/// admin-or-`CAN_INVITE_MEMBERS` at the namespace root, and the namespace
+/// creator may legitimately lack a self `GroupMember` row, so a blanket
+/// `check_group_membership(group_id, viewer)` here would be wrong).
 pub fn collect_visible_descendant_groups(
     store: &Store,
     group_id: &ContextGroupId,
     viewer: &PublicKey,
 ) -> EyreResult<Vec<ContextGroupId>> {
     let mut descendants = Vec::new();
-    let mut queue = vec![*group_id];
+    let mut stack = vec![*group_id];
 
-    while let Some(current) = queue.pop() {
+    while let Some(current) = stack.pop() {
         for child in list_child_groups(store, &current)? {
             if !super::check_group_membership(store, &child, viewer)? {
                 continue;
             }
             descendants.push(child);
-            queue.push(child);
+            stack.push(child);
         }
     }
 

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -230,6 +230,12 @@ pub fn collect_descendant_groups(
 /// admin-or-`CAN_INVITE_MEMBERS` at the namespace root, and the namespace
 /// creator may legitimately lack a self `GroupMember` row, so a blanket
 /// `check_group_membership(group_id, viewer)` here would be wrong).
+///
+/// Cost: one `check_group_membership` per visited group, each of which is
+/// an O(namespace-depth ≤ [`MAX_NAMESPACE_DEPTH`]) parent-chain walk — so
+/// O(visible-subgroups · depth) store reads. That's fine for the caller
+/// (recursive invitations are a rare admin action over a bounded tree);
+/// don't reach for this on a hot path without memoizing the walk.
 pub fn collect_visible_descendant_groups(
     store: &Store,
     group_id: &ContextGroupId,

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3449,6 +3449,140 @@ fn recursive_remove_nonexistent_member_returns_empty() {
 }
 
 // -----------------------------------------------------------------------
+// create_recursive_invitations / collect_visible_descendant_groups —
+// recursive namespace invitations must not leak into (or even enumerate)
+// private subgroups the inviter cannot see.
+// -----------------------------------------------------------------------
+
+#[test]
+fn collect_visible_descendant_groups_walls_at_restricted_subgroups_inviter_not_in() {
+    use calimero_context_config::VisibilityMode;
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let store = test_store();
+    let ns = ContextGroupId::from([0x10; 32]); // namespace root
+    let open_sub = ContextGroupId::from([0x11; 32]); // Open child of ns
+    let owner_priv = ContextGroupId::from([0x12; 32]); // a member's Restricted DM, inviter NOT in
+    let behind_wall = ContextGroupId::from([0x13; 32]); // Open, but under owner_priv -> unreachable
+    let inviter_priv = ContextGroupId::from([0x14; 32]); // Restricted, inviter IS a direct member
+
+    nest_group(&store, &ns, &open_sub).unwrap();
+    nest_group(&store, &ns, &owner_priv).unwrap();
+    nest_group(&store, &owner_priv, &behind_wall).unwrap();
+    nest_group(&store, &ns, &inviter_priv).unwrap();
+    for gid in [&ns, &open_sub, &owner_priv, &behind_wall, &inviter_priv] {
+        save_group_meta(&store, gid, &test_meta()).unwrap();
+    }
+
+    // The recursive inviter is an admin of the namespace root.
+    let inviter_sk = PrivateKey::random(&mut OsRng);
+    let inviter_pk = inviter_sk.public_key();
+    add_group_member(&store, &ns, &inviter_pk, GroupMemberRole::Admin).unwrap();
+
+    // open_sub is Open -> the namespace admin inherits in.
+    set_subgroup_visibility(&store, &open_sub, VisibilityMode::Open).unwrap();
+
+    // owner_priv is a different member's private DM: Restricted, inviter never added.
+    let owner_sk = PrivateKey::random(&mut OsRng);
+    set_subgroup_visibility(&store, &owner_priv, VisibilityMode::Restricted).unwrap();
+    add_group_member(
+        &store,
+        &owner_priv,
+        &owner_sk.public_key(),
+        GroupMemberRole::Admin,
+    )
+    .unwrap();
+    // ...even though there is an Open subgroup *under* it: the wall hides the whole subtree.
+    set_subgroup_visibility(&store, &behind_wall, VisibilityMode::Open).unwrap();
+
+    // inviter_priv is Restricted, but the inviter has a direct member row -> visible.
+    set_subgroup_visibility(&store, &inviter_priv, VisibilityMode::Restricted).unwrap();
+    add_group_member(&store, &inviter_priv, &inviter_pk, GroupMemberRole::Member).unwrap();
+
+    // Sanity on the membership facts the walk depends on.
+    assert!(check_group_membership(&store, &open_sub, &inviter_pk).unwrap());
+    assert!(!check_group_membership(&store, &owner_priv, &inviter_pk).unwrap());
+    assert!(check_group_membership(&store, &inviter_priv, &inviter_pk).unwrap());
+
+    let visible = collect_visible_descendant_groups(&store, &ns, &inviter_pk).unwrap();
+    assert!(visible.contains(&open_sub));
+    assert!(visible.contains(&inviter_priv));
+    assert!(
+        !visible.contains(&owner_priv),
+        "a Restricted subgroup the inviter isn't in must be walled (got {visible:?})"
+    );
+    assert!(
+        !visible.contains(&behind_wall),
+        "the subtree behind a wall is unreachable too (got {visible:?})"
+    );
+
+    // The unfiltered walk still sees everything — cascade-delete / recursive-remove
+    // rely on `collect_descendant_groups` keeping that whole-subtree behavior.
+    let all = collect_descendant_groups(&store, &ns).unwrap();
+    for gid in [&open_sub, &owner_priv, &behind_wall, &inviter_priv] {
+        assert!(
+            all.contains(gid),
+            "{gid:?} missing from unfiltered descendants"
+        );
+    }
+}
+
+#[test]
+fn create_recursive_invitations_omits_private_subgroups_inviter_not_in() {
+    use calimero_context_config::VisibilityMode;
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let store = test_store();
+    let ns = ContextGroupId::from([0x20; 32]);
+    let open_sub = ContextGroupId::from([0x21; 32]);
+    let owner_priv = ContextGroupId::from([0x22; 32]);
+
+    nest_group(&store, &ns, &open_sub).unwrap();
+    nest_group(&store, &ns, &owner_priv).unwrap();
+    for gid in [&ns, &open_sub, &owner_priv] {
+        save_group_meta(&store, gid, &test_meta()).unwrap();
+    }
+
+    let inviter_sk = PrivateKey::random(&mut OsRng);
+    let inviter_pk = inviter_sk.public_key();
+    add_group_member(&store, &ns, &inviter_pk, GroupMemberRole::Admin).unwrap();
+    set_subgroup_visibility(&store, &open_sub, VisibilityMode::Open).unwrap();
+
+    let owner_sk = PrivateKey::random(&mut OsRng);
+    set_subgroup_visibility(&store, &owner_priv, VisibilityMode::Restricted).unwrap();
+    add_group_member(
+        &store,
+        &owner_priv,
+        &owner_sk.public_key(),
+        GroupMemberRole::Admin,
+    )
+    .unwrap();
+
+    let invitations = create_recursive_invitations(&store, &ns, &inviter_sk, 3600, 1).unwrap();
+    let invited: Vec<ContextGroupId> = invitations.iter().map(|(gid, _)| *gid).collect();
+
+    assert!(
+        invited.contains(&ns),
+        "the namespace itself is always invited"
+    );
+    assert!(
+        invited.contains(&open_sub),
+        "Open subgroups stay in the recursive set"
+    );
+    assert!(
+        !invited.contains(&owner_priv),
+        "a Restricted subgroup the inviter was never added to must not be invited into (got {invited:?})"
+    );
+
+    // Each emitted invitation targets exactly the group it is keyed under.
+    for (gid, signed) in &invitations {
+        assert_eq!(signed.invitation.group_id, *gid);
+    }
+}
+
+// -----------------------------------------------------------------------
 // NamespaceGovernance::apply_signed_op — governance state machine tests
 // -----------------------------------------------------------------------
 

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3484,15 +3484,9 @@ fn collect_visible_descendant_groups_walls_at_restricted_subgroups_inviter_not_i
     set_subgroup_visibility(&store, &open_sub, VisibilityMode::Open).unwrap();
 
     // owner_priv is a different member's private DM: Restricted, inviter never added.
-    let owner_sk = PrivateKey::random(&mut OsRng);
+    let owner_pk = PrivateKey::random(&mut OsRng).public_key();
     set_subgroup_visibility(&store, &owner_priv, VisibilityMode::Restricted).unwrap();
-    add_group_member(
-        &store,
-        &owner_priv,
-        &owner_sk.public_key(),
-        GroupMemberRole::Admin,
-    )
-    .unwrap();
+    add_group_member(&store, &owner_priv, &owner_pk, GroupMemberRole::Admin).unwrap();
     // ...even though there is an Open subgroup *under* it: the wall hides the whole subtree.
     set_subgroup_visibility(&store, &behind_wall, VisibilityMode::Open).unwrap();
 
@@ -3515,6 +3509,11 @@ fn collect_visible_descendant_groups_walls_at_restricted_subgroups_inviter_not_i
     assert!(
         !visible.contains(&behind_wall),
         "the subtree behind a wall is unreachable too (got {visible:?})"
+    );
+    assert_eq!(
+        visible.len(),
+        2,
+        "exactly open_sub + inviter_priv should be visible, got {visible:?}"
     );
 
     // The unfiltered walk still sees everything — cascade-delete / recursive-remove
@@ -3550,15 +3549,9 @@ fn create_recursive_invitations_omits_private_subgroups_inviter_not_in() {
     add_group_member(&store, &ns, &inviter_pk, GroupMemberRole::Admin).unwrap();
     set_subgroup_visibility(&store, &open_sub, VisibilityMode::Open).unwrap();
 
-    let owner_sk = PrivateKey::random(&mut OsRng);
+    let owner_pk = PrivateKey::random(&mut OsRng).public_key();
     set_subgroup_visibility(&store, &owner_priv, VisibilityMode::Restricted).unwrap();
-    add_group_member(
-        &store,
-        &owner_priv,
-        &owner_sk.public_key(),
-        GroupMemberRole::Admin,
-    )
-    .unwrap();
+    add_group_member(&store, &owner_priv, &owner_pk, GroupMemberRole::Admin).unwrap();
 
     let invitations = create_recursive_invitations(&store, &ns, &inviter_sk, 3600, 1).unwrap();
     let invited: Vec<ContextGroupId> = invitations.iter().map(|(gid, _)| *gid).collect();
@@ -3574,6 +3567,11 @@ fn create_recursive_invitations_omits_private_subgroups_inviter_not_in() {
     assert!(
         !invited.contains(&owner_priv),
         "a Restricted subgroup the inviter was never added to must not be invited into (got {invited:?})"
+    );
+    assert_eq!(
+        invitations.len(),
+        2,
+        "exactly the namespace + open_sub should be invited, got {invited:?}"
     );
 
     // Each emitted invitation targets exactly the group it is keyed under.


### PR DESCRIPTION
## What

PR 2 of the Slack-app namespace stack (after #2325, which added `CAN_CREATE_SUBGROUP` / `CAN_DELETE_SUBGROUP` / `CAN_MANAGE_VISIBILITY`).

A namespace member granted `CAN_CREATE_SUBGROUP` can stand up a **Restricted** subgroup directly under the namespace root — a private channel or a 2-person DM — and becomes its owner/admin. This PR makes the privacy boundary real:

1. **Fix: recursive namespace invitations no longer leak into invisible subgroups.** `POST /namespaces/:id/invite?recursive=true` → `create_recursive_invitations` walked `collect_descendant_groups` (every subgroup) and minted one signed invitation per group — including `Restricted` subgroups the inviter was never added to. That produced working-looking invitations into member-created DMs *and* enumerated their existence + aliases in the response.

   New `collect_visible_descendant_groups(store, root, viewer)`: a BFS that only descends into / includes a child the `viewer` is a member of (per `check_group_membership`), so it walls at the first `Restricted` ancestor the viewer isn't in — and its whole subtree. `create_recursive_invitations` now uses it, filtered through the inviter's own membership view. `collect_descendant_groups` is unchanged; cascade-delete and `recursive_remove_member` still legitimately need the full subtree.

2. **Tests** proving the namespace owner is walled out of a member-created Restricted subgroup.

## Changes

- `crates/context/src/group_store/namespace.rs` — add `collect_visible_descendant_groups`; `create_recursive_invitations` uses it.
- `crates/context/src/group_store/mod.rs` — re-export `collect_visible_descendant_groups`.
- `crates/context/src/group_store/tests.rs` — `collect_visible_descendant_groups_walls_at_restricted_subgroups_inviter_not_in`, `create_recursive_invitations_omits_private_subgroups_inviter_not_in`.
- `apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml` — NEW 3-node workflow:
  - node-1 owns the namespace; node-2 is granted `CAN_CREATE_SUBGROUP | CAN_JOIN_OPEN_SUBGROUPS` (= 36).
  - node-2 creates a **Restricted** subgroup, adds **only node-3**, runs a context inside it, writes a secret.
  - node-3 (directly added) joins the context and reads the secret — real access.
  - node-1 (the namespace owner) **cannot** `join_context` it and **cannot** `call` it (`expected_failure: true`) — namespace-root ownership does not pierce a member-created Restricted subgroup.
  - Contrast: node-2 also creates an **Open** subgroup + context; node-1 — without being added — inherits into it (admin authority cascades down an Open chain) and can join + read it after a normal propagation delay (`wait_for_sync` on the subgroup's governance state + a brief settle before the join). This pins *visibility*, not "who happened to be added", as the boundary.
- `.github/workflows/e2e-rust-apps.yml` — add `dm-subgroup-privacy` to the matrix.

## Out of scope

Encrypting the *existence* of Restricted subgroups from non-members — node-1 can still see "a subgroup exists" via `list_subgroups` (the `RootOp::GroupCreated` op is cleartext on the namespace DAG). This PR only stops the owner from *acting on* / *being routed into* it. Tracked as a follow-up.

## Testing

- `cargo test -p calimero-context --lib` — 201 passing (incl. the 2 new tests).
- `cargo check --workspace` — clean.
- `merobox bootstrap validate apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml` — valid. CI runs it in the e2e-rust-apps matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace invitation generation and membership visibility checks, which can impact authorization/privacy boundaries and potentially break legitimate recursive-invite flows if the visibility logic is wrong.
> 
> **Overview**
> **Recursive namespace invitations no longer enumerate or mint invitations for `Restricted` subgroups the inviter isn’t a member of.** This introduces `collect_visible_descendant_groups` (membership-filtered subtree walk) and switches `create_recursive_invitations` to use it, while keeping `collect_descendant_groups` for full-subtree operations.
> 
> Adds unit tests covering the visibility wall behavior, plus a new 3-node `scaffolding-e2e` workflow (`dm-subgroup-privacy.yml`) that asserts namespace owners cannot `join_context`/`call` into member-created private subgroups while direct members can. CI’s `e2e-rust-apps` matrix is extended to run this new workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba6df9e245b930a32928a739beefe87d8e85e9f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


