### PR TITLE
test(context): pin forward-only invariant + drop internal roadmap codes

### DIFF
--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -317,8 +317,8 @@ pub const MAX_GOVERNANCE_DAG_HEADS: usize = 32;
 ///
 /// Names the exact governance DAG cut the signer relied on when producing the
 /// state op. Receivers use it to perform the apply-time authorization check
-/// (B3): "was this signer a member at the named cut?" Buffered when the
-/// referenced `governance_dag_heads` are not yet known locally (B2).
+/// — "was this signer a member at the named cut?" — and buffer the delta when
+/// the referenced `governance_dag_heads` are not yet known locally.
 ///
 /// `governance_dag_heads` entries are content-hashes of [`SignedNamespaceOp`]
 /// — the same identity scheme used by `parent_op_hashes` and the persisted

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -831,15 +831,22 @@ mod tests {
     }
 
     #[test]
-    fn prefix_walk_forward_only_property_random() {
-        // Property test: for any prefix of a transition sequence whose
-        // final transition is an Add (the signer's status at the prefix
-        // boundary is Member, regardless of any earlier Remove/re-add
-        // cycles in the prefix), the resolver must return Member.
-        // Generate random sequences, take a prefix that ends right
-        // after an Add, verify Member is returned. The prefix CAN
-        // contain earlier Removes — what matters is the last
-        // transition.
+    fn resolver_state_machine_add_ending_prefix_is_member() {
+        // Resolver state-machine property (not the BFS boundary
+        // property — that's exercised by the explicit per-transition
+        // tests above and the canary test below): for any random
+        // transition sequence and any prefix of that sequence whose
+        // *last* transition is an Add, the resolver returns Member.
+        // The prefix CAN contain earlier Removes; what matters is the
+        // last transition.
+        //
+        // This is one half of forward-only: given that the BFS has
+        // produced the right truncated transition list for a prefix
+        // boundary, the resolver maps it correctly. The other half
+        // (the BFS truncates at the boundary in the first place) is
+        // not testable here without a real DAG — `prefix_walk_membership`
+        // is unit-testable only via its inputs/outputs, and we
+        // exercise the canary case explicitly below.
         const SEED: u64 = 0xC4FA_DEFE_EDBE_EF42;
         let mut state = SEED;
         let mut next = || {

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -764,15 +764,53 @@ mod tests {
 
     #[test]
     fn prefix_walk_forward_only_pre_remove_then_readd_still_member() {
-        // The Add → Remove → Add sequence: a position pointing at the
-        // *first* Add (before the Remove) must resolve to Member with
-        // the original role, regardless of any later Remove + re-add
-        // activity in the DAG. The walker only sees the prefix.
-        let early_prefix = &[MembershipTransition::Added(GroupMemberRole::Member)];
-        let result = resolve_membership_from_transitions(early_prefix);
+        // The Add → Remove → Add scenario, exercised end-to-end. The
+        // full transition sequence represents the local DAG state on a
+        // receiver that has observed all three ops; the prefixes are
+        // the governance positions a sender might have signed against.
+        //
+        // Each prefix's resolution must depend only on what's in the
+        // prefix — not on the trailing ops the receiver has since
+        // applied. That's the forward-only property.
+        let full_sequence = [
+            MembershipTransition::Added(GroupMemberRole::Member),
+            MembershipTransition::Removed,
+            MembershipTransition::Added(GroupMemberRole::Admin),
+        ];
+
+        // Position points at the first Add. The receiver has since
+        // applied the Remove and the re-add, but neither is in this
+        // prefix — must resolve to Member(Member).
+        let at_first_add = &full_sequence[..=0];
         assert!(
-            matches!(result, MembershipStatus::Member(GroupMemberRole::Member)),
-            "forward-only: position at first Add must be Member regardless of later DAG, got {result:?}"
+            matches!(
+                resolve_membership_from_transitions(at_first_add),
+                MembershipStatus::Member(GroupMemberRole::Member)
+            ),
+            "forward-only: position at first Add stays Member(Member) even though \
+             receiver has since seen Remove+re-add"
+        );
+
+        // Position points after the Remove. Must resolve to Removed
+        // with last_role = Member. The receiver's later re-add is
+        // outside the prefix.
+        let at_remove = &full_sequence[..=1];
+        match resolve_membership_from_transitions(at_remove) {
+            MembershipStatus::Removed { last_role } => {
+                assert!(matches!(last_role, GroupMemberRole::Member));
+            }
+            other => panic!("position at Remove must be Removed, got {other:?}"),
+        }
+
+        // Position points at the re-add. Must resolve to Member(Admin)
+        // — the new role from the re-add, not the original Member role.
+        let at_readd = &full_sequence[..=2];
+        assert!(
+            matches!(
+                resolve_membership_from_transitions(at_readd),
+                MembershipStatus::Member(GroupMemberRole::Admin)
+            ),
+            "position at re-add must reflect the new role"
         );
     }
 
@@ -794,11 +832,14 @@ mod tests {
 
     #[test]
     fn prefix_walk_forward_only_property_random() {
-        // Property test: for any prefix of a transition sequence ending
-        // in Add (no Remove yet at the prefix boundary), the resolver
-        // must return Member. Generate 1000 sequences, take a random
-        // prefix that ends right after an Add, verify Member is
-        // returned.
+        // Property test: for any prefix of a transition sequence whose
+        // final transition is an Add (the signer's status at the prefix
+        // boundary is Member, regardless of any earlier Remove/re-add
+        // cycles in the prefix), the resolver must return Member.
+        // Generate random sequences, take a prefix that ends right
+        // after an Add, verify Member is returned. The prefix CAN
+        // contain earlier Removes — what matters is the last
+        // transition.
         const SEED: u64 = 0xC4FA_DEFE_EDBE_EF42;
         let mut state = SEED;
         let mut next = || {

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -1,8 +1,9 @@
-//! Position-aware membership lookup (cross-DAG authorization, decision #20).
+//! Position-aware membership lookup for cross-DAG authorization.
 //!
-//! [`MembershipStatus`] is the type B3's apply-time authorization check
-//! consumes. It distinguishes the four answers a position-aware lookup can
-//! produce:
+//! [`MembershipStatus`] is the type the apply-time membership check consumes
+//! to decide whether a state delta signed against a specific governance cut
+//! should be applied. It distinguishes the four answers a position-aware
+//! lookup can produce:
 //!
 //! - [`Member`](MembershipStatus::Member) — signer is a member at the named
 //!   cut, with role known.
@@ -11,14 +12,13 @@
 //! - [`NeverMember`](MembershipStatus::NeverMember) — signer is not in the
 //!   member set at the named cut, and no record of removal exists.
 //! - [`Unknown`](MembershipStatus::Unknown) — local governance state hasn't
-//!   advanced to the named cut yet, so the answer can't be determined. B2
-//!   buffers state ops on this signal.
+//!   advanced to the named cut yet, so the answer can't be determined. The
+//!   state-delta receive path buffers ops on this signal until governance
+//!   catches up.
 //!
 //! Collapsing these into `Option<GroupMemberRole>` (as the legacy
 //! `get_member_role` API does) makes "forgot to check" a silent runtime bug;
-//! [`MembershipStatus`] makes it a non-exhaustive-match warning. See the
-//! cross-DAG authorization roadmap (issue S13) for the broader design
-//! context.
+//! [`MembershipStatus`] makes it a non-exhaustive-match warning.
 
 use std::collections::{HashSet, VecDeque};
 
@@ -47,16 +47,17 @@ pub const MAX_PREFIX_WALK_NODES: usize = 10_000;
 
 /// Position-aware membership state.
 ///
-/// Always carries enough information for B3 to decide whether a state op
-/// signed at `position` can be applied. Receivers must match all four
-/// variants — `_` arms are a smell that suggests a missing case.
+/// Always carries enough information for the apply-time membership check to
+/// decide whether a state op signed at `position` can be applied. Receivers
+/// must match all four variants — `_` arms are a smell that suggests a
+/// missing case.
 #[derive(Clone, Debug, PartialEq)]
 pub enum MembershipStatus {
     /// Signer is a member at the named cut.
     Member(GroupMemberRole),
     /// Signer was a member at some earlier cut but removed on or before
     /// `position`. `last_role` is the role they held at the time of removal,
-    /// useful for diagnostics and the deny-list (D1).
+    /// useful for diagnostics and any downstream deny-list logic.
     Removed { last_role: GroupMemberRole },
     /// Signer never appears in any `MemberAdded` op in the prefix up to
     /// `position`.
@@ -66,9 +67,9 @@ pub enum MembershipStatus {
     /// op hash from `position.governance_dag_heads` that is missing locally.
     ///
     /// Returning the full set (rather than just the first missing head) lets
-    /// B2 buffer once and request all missing ops in parallel instead of
-    /// O(n) sequential buffer-and-retry round-trips. Always non-empty when
-    /// this variant is returned.
+    /// the receiver's pending-buffer wait for all of them in parallel
+    /// instead of O(n) sequential buffer-and-retry round-trips. Always
+    /// non-empty when this variant is returned.
     Unknown { needed: Vec<[u8; 32]> },
 }
 
@@ -84,15 +85,16 @@ pub enum MembershipStatus {
 ///    mismatch surfaces as `Err` (tampering or local divergence). On this
 ///    path `get_group_member_role` returning `None` does not distinguish
 ///    "never added" from "was added then removed" — the fast path
-///    therefore conflates `Removed` into `NeverMember`. Callers using B3
-///    enforcement should treat both as "not currently a member" on this
-///    path; the distinction is recovered by the prefix walk below when
-///    receivers are slightly behind senders.
+///    therefore conflates `Removed` into `NeverMember`. Callers must treat
+///    both as "not currently a member" on this path; the distinction is
+///    recovered by the prefix walk below when receivers are slightly
+///    behind senders.
 ///
 /// 2. **Unknown** — any head in `position.governance_dag_heads` is missing
 ///    from the local namespace op log. Returns
 ///    [`Unknown { needed }`](MembershipStatus::Unknown) listing every
-///    missing head so B2 can buffer once and request them all in parallel.
+///    missing head so the receiver can buffer once and request them all
+///    in parallel.
 ///
 /// 3. **Prefix walk** — all heads are known but `position` differs from
 ///    current local state (the receiver is ahead of the sender). Walks the
@@ -124,21 +126,21 @@ pub fn membership_status_at(
     // creator does **not** emit a self-`MemberJoined` op at namespace
     // genesis: their membership lives in `GroupMeta::admin_identity`,
     // not in a `GroupMember` row. Without this short-circuit, both the
-    // fast-path (Branch 1, `get_group_member_role` returns `None`) and
-    // the prefix walk (Branch 3, no `RootOp::MemberJoined` or
-    // `GroupOp::MemberAdded` for the creator) return `NeverMember`,
-    // and B3 hard-rejects every state delta authored by the namespace
-    // creator. This was the root cause of the flaky `group-3node`
-    // e2e: when receivers' governance heads hadn't yet caught up to
-    // node-1's at write time, the prefix-walk branch fired and
-    // rejected the legitimate write.
+    // fast-path (`get_group_member_role` returns `None`) and the
+    // prefix walk (no `RootOp::MemberJoined` or `GroupOp::MemberAdded`
+    // for the creator) return `NeverMember`, and the apply-time
+    // membership check hard-rejects every state delta authored by the
+    // namespace creator. This was the root cause of the flaky
+    // `group-3node` e2e: when receivers' governance heads hadn't yet
+    // caught up to node-1's at write time, the prefix-walk branch
+    // fired and rejected the legitimate write.
     //
     // `is_group_admin` already does the same admin-identity carve-out
     // for the `MemberJoined`-less creator (see its doc and the
     // companion `namespace_member_pubkeys` helper at
     // `membership.rs::namespace_member_pubkeys`). Using the same path
     // here keeps the semantics aligned: any signer that
-    // `is_group_admin` accepts must also pass B3.
+    // `is_group_admin` accepts must also pass the cross-DAG check.
     if super::membership::is_group_admin(store, &group_id, signer)? {
         return Ok(MembershipStatus::Member(
             calimero_primitives::context::GroupMemberRole::Admin,
@@ -169,7 +171,7 @@ pub fn membership_status_at(
             );
         }
         // See function-level doc for the `Removed` vs `NeverMember`
-        // conflation caveat — the prefix walk (B3) resolves it.
+        // conflation caveat — the prefix walk recovers the distinction.
         return Ok(
             match super::membership::get_group_member_role(store, &group_id, signer)? {
                 Some(role) => MembershipStatus::Member(role),
@@ -213,6 +215,22 @@ pub fn membership_status_at(
 /// `parent_op_hashes`, replaying every membership-affecting op for `signer`
 /// in `group_id`, and return the resulting [`MembershipStatus`].
 ///
+/// **Forward-only invariant** — load-bearing for cross-DAG correctness.
+/// The walk visits *only* the ancestry of `target_heads`: an op that is in
+/// the local DAG but *causally after* `target_heads` (i.e., not reachable
+/// by walking `parent_op_hashes` from any head in `target_heads`) is NEVER
+/// observed by this walk. This is the mechanism by which pre-removal
+/// writes from a now-removed member remain valid forever, regardless of
+/// arrival order: a state delta signed at position `H_pre` (before the
+/// signer's `MemberRemoved` at `H_rem`) resolves to `Member(role)` here
+/// even on a receiver whose local DAG has already applied `H_rem`,
+/// because `H_rem ∉ ancestry(H_pre)`. Without this property, taint
+/// cascade returns (see the cross-DAG authorization RFC's taint-cascade
+/// scenario). **Any change to the BFS frontier — e.g., visiting
+/// descendants of `target_heads` to "catch up" — breaks the invariant
+/// and reintroduces the taint surface.** Regression-tested by
+/// `prefix_walk_forward_only_*` cases below.
+///
 /// **Walk extent**: the BFS visits the entire ancestry of `target_heads`
 /// (transitive closure of `parent_op_hashes` until ops with no parents).
 /// Membership at the target cut is a function of the *full* prefix, not a
@@ -245,7 +263,7 @@ pub fn membership_status_at(
 /// as `MembershipStatus::Unknown { needed: parent_hashes }`, not as a hard
 /// error: gossip can deliver a head before its ancestors during partial
 /// sync, and treating the gap as permanent rejection would lose the
-/// delta. B2 buffers + retries when the gap fills in.
+/// delta. The receiver's pending buffer retries when the gap fills in.
 fn prefix_walk_membership(
     store: &Store,
     namespace_id: [u8; 32],
@@ -287,8 +305,9 @@ fn prefix_walk_membership(
         }
         // A parent that's not in the local op log means our DAG has a gap
         // (partial sync, or the op was pruned). Surface this as `Unknown`
-        // rather than a hard error so B2 can buffer + retry — the apply
-        // path of the missing ancestor will eventually populate the gap.
+        // rather than a hard error so the receiver's pending buffer can
+        // retry — the apply path of the missing ancestor will eventually
+        // populate the gap.
         let signed_op = match op_log.get_signed_op(hash)? {
             Some(op) => op,
             None => {
@@ -691,6 +710,185 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------
+    // Forward-only invariant regression tests
+    //
+    // These tests pin the property that pre-removal writes from a
+    // now-removed member must still resolve to `Member` when the
+    // position points at the *prefix* before the removal. The prefix
+    // walk implements this by visiting only the ancestry of
+    // `target_heads`; any code change that walks beyond that frontier
+    // (e.g., scanning forward to "catch up" on later ops) breaks the
+    // invariant and reintroduces the taint-cascade surface.
+    //
+    // The `resolve_membership_from_transitions` helper here mirrors
+    // what `prefix_walk_membership` does after the BFS collects the
+    // relevant ops — so testing the resolver on prefix-truncated
+    // transition sequences is equivalent to testing forward-only on
+    // the corresponding DAG positions.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn prefix_walk_forward_only_pre_removal_position_is_member() {
+        // Position points at the prefix [Added] — the removal that
+        // happens later in the DAG is NOT in this prefix, so the
+        // resolver must return Member.
+        let pre_removal_prefix = &[MembershipTransition::Added(GroupMemberRole::Member)];
+        let result = resolve_membership_from_transitions(pre_removal_prefix);
+        assert!(
+            matches!(result, MembershipStatus::Member(GroupMemberRole::Member)),
+            "forward-only: pre-removal position must resolve to Member, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn prefix_walk_forward_only_post_removal_position_is_removed() {
+        // Position points at the full prefix including the removal —
+        // the resolver must return Removed. (Counterpart to the
+        // pre-removal test: both must hold for forward-only to mean
+        // anything.)
+        let post_removal_prefix = &[
+            MembershipTransition::Added(GroupMemberRole::Admin),
+            MembershipTransition::Removed,
+        ];
+        let result = resolve_membership_from_transitions(post_removal_prefix);
+        match result {
+            MembershipStatus::Removed { last_role } => {
+                assert!(matches!(last_role, GroupMemberRole::Admin));
+            }
+            other => {
+                panic!("forward-only: post-removal position must resolve to Removed, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn prefix_walk_forward_only_pre_remove_then_readd_still_member() {
+        // The Add → Remove → Add sequence: a position pointing at the
+        // *first* Add (before the Remove) must resolve to Member with
+        // the original role, regardless of any later Remove + re-add
+        // activity in the DAG. The walker only sees the prefix.
+        let early_prefix = &[MembershipTransition::Added(GroupMemberRole::Member)];
+        let result = resolve_membership_from_transitions(early_prefix);
+        assert!(
+            matches!(result, MembershipStatus::Member(GroupMemberRole::Member)),
+            "forward-only: position at first Add must be Member regardless of later DAG, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn prefix_walk_forward_only_role_change_pre_position_uses_pre_position_role() {
+        // The position points after the second RoleSet but before
+        // any removal — the resolver must use the role at the
+        // position, not the role at the latest known op.
+        let position_prefix = &[
+            MembershipTransition::Added(GroupMemberRole::Member),
+            MembershipTransition::RoleSet(GroupMemberRole::Admin),
+        ];
+        let result = resolve_membership_from_transitions(position_prefix);
+        assert!(
+            matches!(result, MembershipStatus::Member(GroupMemberRole::Admin)),
+            "forward-only: role at position governs, not role at later DAG ops, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn prefix_walk_forward_only_property_random() {
+        // Property test: for any prefix of a transition sequence ending
+        // in Add (no Remove yet at the prefix boundary), the resolver
+        // must return Member. Generate 1000 sequences, take a random
+        // prefix that ends right after an Add, verify Member is
+        // returned.
+        const SEED: u64 = 0xC4FA_DEFE_EDBE_EF42;
+        let mut state = SEED;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let roles = [
+            GroupMemberRole::Admin,
+            GroupMemberRole::Member,
+            GroupMemberRole::ReadOnly,
+        ];
+        let mut tested = 0_usize;
+        for _ in 0..2000 {
+            // Build a random sequence of length 1..=8 ending with an
+            // Add op. The position is the prefix up to and including
+            // that Add. Any later transitions in the original
+            // sequence are *not* part of the prefix and must not
+            // affect the answer.
+            let len = ((next() as usize) % 8) + 1;
+            let mut transitions = Vec::with_capacity(len);
+            for i in 0..len {
+                let kind = (next() as usize) % 4;
+                let role = roles[(next() as usize) % roles.len()].clone();
+                let t = match kind {
+                    0 => MembershipTransition::Added(role),
+                    1 => MembershipTransition::RoleSet(role),
+                    2 => MembershipTransition::Removed,
+                    _ => MembershipTransition::Left,
+                };
+                transitions.push(t);
+                // Find a prefix that ends in Add — that's the position.
+                if matches!(transitions[i], MembershipTransition::Added(_)) {
+                    let prefix = &transitions[..=i];
+                    let result = resolve_membership_from_transitions(prefix);
+                    assert!(
+                        matches!(result, MembershipStatus::Member(_)),
+                        "forward-only property violated: prefix={prefix:?} resolved to {result:?}"
+                    );
+                    tested += 1;
+                }
+            }
+        }
+        assert!(
+            tested > 100,
+            "property test must exercise the Member case at least 100 times (got {tested})"
+        );
+    }
+
+    #[test]
+    fn prefix_walk_forward_only_canary_retroactive_invalidation_would_break() {
+        // Canary: if someone were to "fix" the resolver to look at the
+        // full transition sequence rather than the prefix, this test
+        // would catch it. Specifically: if the resolver were changed
+        // to honor a Remove transition that comes *after* the queried
+        // position, the returned status would shift from Member to
+        // Removed for the pre-removal prefix.
+        //
+        // We can't directly test "the wrong code would fail" without
+        // the wrong code, but we can pin the behavior at the prefix
+        // boundary: the same Added op must produce different answers
+        // depending on whether the prefix includes a later Remove,
+        // demonstrating that the resolver IS sensitive to the prefix
+        // boundary (not to the full sequence).
+        let added_only = &[MembershipTransition::Added(GroupMemberRole::Member)];
+        let added_then_removed = &[
+            MembershipTransition::Added(GroupMemberRole::Member),
+            MembershipTransition::Removed,
+        ];
+
+        let pre = resolve_membership_from_transitions(added_only);
+        let post = resolve_membership_from_transitions(added_then_removed);
+
+        // The prefix [Added] must be Member; the prefix [Added,
+        // Removed] must be Removed. If both returned the same status
+        // (either both Member or both Removed), the resolver would be
+        // ignoring the prefix boundary and forward-only would be
+        // either lost (both Removed → no forward-only) or
+        // over-applied (both Member → impossible-to-remove).
+        assert!(
+            matches!(pre, MembershipStatus::Member(_)),
+            "canary: pre-removal prefix must be Member, got {pre:?}"
+        );
+        assert!(
+            matches!(post, MembershipStatus::Removed { .. }),
+            "canary: post-removal prefix must be Removed, got {post:?}"
+        );
+    }
+
     #[test]
     fn membership_status_at_recognises_namespace_creator_as_admin() {
         // Regression test for the `group-3node` flake — see
@@ -702,7 +900,7 @@ mod tests {
         // both the fast-path (no `GroupMember` row → `NeverMember`) and
         // the prefix walk (no `MemberJoined` op for the creator →
         // `NeverMember`) reject every state delta authored by the
-        // creator with `B3: not a member`.
+        // creator with "not a member at governance cut."
         use calimero_primitives::application::ApplicationId;
         use calimero_primitives::context::UpgradePolicy;
         use calimero_store::key::GroupMetaValue;

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5204,29 +5204,38 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
 }
 
 // ---------------------------------------------------------------------
-// Forward-only invariant integration tests
+// Fast-path integration tests for `membership_status_at`
 //
-// These exercise the property end-to-end through `membership_status_at`
-// against a real in-memory `Store`. The fast path (Branch 1, heads
-// equal) is enough to demonstrate the materialized-state-snapshot
-// semantics that the apply-time membership check consumes: at any point
-// in time, the check sees the set as it is *now*, and the forward-only
-// property of the
-// prefix walk (which is unit-tested in `membership_status.rs`) means
-// that pre-removal positions resolve to Member even when the local
-// receiver has already applied a `MemberRemoved` for that signer.
+// These exercise Branch 1 of `membership_status_at` against a real
+// in-memory `Store`: a `GovernancePosition` whose heads equal the local
+// DAG heads (both empty here), so the resolver short-circuits to a
+// materialized-set lookup and never invokes `prefix_walk_membership`.
 //
-// Full DAG-level integration tests for the prefix walk (encrypted op
-// construction, keyring setup, ancestor chain) are tracked separately
-// — the per-transition resolver tests in `membership_status.rs` cover
-// the BFS state-machine logic.
+// What's covered:
+//   * The fast path's read of the materialized member set is consistent
+//     with what the apply-time check expects when the sender and the
+//     receiver are at the same governance cut.
+//   * The documented Branch 1 conflation of `Removed` into `NeverMember`
+//     (the materialized set has no row for a removed signer, so the
+//     fast path cannot distinguish "removed" from "was never a member"
+//     without consulting the DAG).
+//
+// What's NOT covered here:
+//   * The forward-only invariant — that lives in `prefix_walk_membership`
+//     (Branch 3), where the BFS visits only the ancestry of the
+//     position's heads. Exercising it end-to-end requires a non-empty
+//     DAG with diverging heads, which means signed namespace ops,
+//     keyring setup, and ancestor chains. That harness is tracked
+//     separately. The per-transition resolver tests in
+//     `membership_status.rs` (`prefix_walk_forward_only_*`) cover the
+//     state-machine logic that the BFS feeds into.
 // ---------------------------------------------------------------------
 
 #[test]
-fn forward_only_current_member_resolves_to_member() {
+fn fast_path_current_member_resolves_to_member() {
     // Baseline: a member who exists in the materialized set resolves
-    // to `Member(role)` when the position points at the current cut.
-    // Required precondition for any forward-only test — if this
+    // to `Member(role)` when the position's heads equal local heads.
+    // Required precondition for the other Branch 1 tests — if this
     // baseline fails, the others say nothing.
     use calimero_context_config::types::GovernancePosition;
     let store = test_store();
@@ -5247,13 +5256,15 @@ fn forward_only_current_member_resolves_to_member() {
 }
 
 #[test]
-fn forward_only_removed_member_in_current_set_resolves_to_nevermember() {
-    // After a removal, the materialized member set no longer contains
-    // the removed signer. On the fast path (heads equal), the
-    // resolver returns NeverMember — the documented conflation. The check
-    // treats this as "not authorized" and rejects the delta, which
-    // is the correct outcome for a delta whose position equals the
-    // post-removal cut.
+fn fast_path_removed_member_conflates_to_nevermember() {
+    // Documented Branch 1 conflation: with heads equal, the resolver
+    // only consults the materialized member set, which has no row for
+    // a removed signer. It returns `NeverMember` — it cannot
+    // distinguish "removed" from "was never a member" without the DAG.
+    // The distinction is recovered by Branch 3 (prefix walk) when the
+    // sender's position predates the removal. The apply-time check
+    // treats both `Removed` and `NeverMember` as rejection, so the
+    // practical security outcome is identical on this path.
     use calimero_context_config::types::GovernancePosition;
     let store = test_store();
     let gid = test_group_id();
@@ -5261,18 +5272,12 @@ fn forward_only_removed_member_in_current_set_resolves_to_nevermember() {
 
     save_group_meta(&store, &gid, &test_meta()).unwrap();
     add_group_member(&store, &gid, &signer, GroupMemberRole::Member).unwrap();
-    // Removal flips the materialized set; the signer is no longer
-    // findable by `get_group_member_role`.
     remove_group_member(&store, &gid, &signer).unwrap();
 
     let state_hash = compute_group_state_hash(&store, &gid).unwrap();
     let position = GovernancePosition::new(gid, state_hash, vec![]).unwrap();
 
     let status = membership_status_at(&store, &signer, &position).unwrap();
-    // Fast path conflates Removed into NeverMember — documented
-    // limitation. The prefix walk (when heads differ) recovers the
-    // distinction. The apply-time check treats both as rejection, so
-    // the practical security outcome is identical.
     assert!(
         matches!(status, MembershipStatus::NeverMember),
         "removed signer on heads-equal fast path is NeverMember, got {status:?}"
@@ -5280,11 +5285,11 @@ fn forward_only_removed_member_in_current_set_resolves_to_nevermember() {
 }
 
 #[test]
-fn forward_only_re_added_member_resolves_to_member() {
+fn fast_path_re_added_member_resolves_to_member() {
     // Add → Remove → Add: the materialized set contains the signer
     // again, so the fast path returns Member with the latest role.
-    // This is the "rehabilitation" case — the resolver doesn't
-    // remember that they were ever removed.
+    // The resolver doesn't remember that they were ever removed —
+    // the deny-list elsewhere handles "currently removed" semantics.
     use calimero_context_config::types::GovernancePosition;
     let store = test_store();
     let gid = test_group_id();
@@ -5306,9 +5311,10 @@ fn forward_only_re_added_member_resolves_to_member() {
 }
 
 #[test]
-fn forward_only_role_promotion_picks_current_role() {
+fn fast_path_role_promotion_picks_current_role() {
     // Role changes between Add and present don't cause spurious
-    // rejection. The materialized set reflects the latest role.
+    // rejection on the fast path — the materialized set reflects the
+    // latest role.
     use calimero_context_config::types::GovernancePosition;
     let store = test_store();
     let gid = test_group_id();

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5202,3 +5202,131 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
         .expect("CAN_DELETE_SUBGROUP holder can delete a subgroup");
     assert!(load_group_meta(&store, &s3_gid).unwrap().is_none());
 }
+
+// ---------------------------------------------------------------------
+// Forward-only invariant integration tests
+//
+// These exercise the property end-to-end through `membership_status_at`
+// against a real in-memory `Store`. The fast path (Branch 1, heads
+// equal) is enough to demonstrate the materialized-state-snapshot
+// semantics that the apply-time membership check consumes: at any point
+// in time, the check sees the set as it is *now*, and the forward-only
+// property of the
+// prefix walk (which is unit-tested in `membership_status.rs`) means
+// that pre-removal positions resolve to Member even when the local
+// receiver has already applied a `MemberRemoved` for that signer.
+//
+// Full DAG-level integration tests for the prefix walk (encrypted op
+// construction, keyring setup, ancestor chain) are tracked separately
+// — the per-transition resolver tests in `membership_status.rs` cover
+// the BFS state-machine logic.
+// ---------------------------------------------------------------------
+
+#[test]
+fn forward_only_current_member_resolves_to_member() {
+    // Baseline: a member who exists in the materialized set resolves
+    // to `Member(role)` when the position points at the current cut.
+    // Required precondition for any forward-only test — if this
+    // baseline fails, the others say nothing.
+    use calimero_context_config::types::GovernancePosition;
+    let store = test_store();
+    let gid = test_group_id();
+    let signer = PublicKey::from([0x77; 32]);
+
+    save_group_meta(&store, &gid, &test_meta()).unwrap();
+    add_group_member(&store, &gid, &signer, GroupMemberRole::Member).unwrap();
+
+    let state_hash = compute_group_state_hash(&store, &gid).unwrap();
+    let position = GovernancePosition::new(gid, state_hash, vec![]).unwrap();
+
+    let status = membership_status_at(&store, &signer, &position).unwrap();
+    assert!(
+        matches!(status, MembershipStatus::Member(GroupMemberRole::Member)),
+        "current member must resolve to Member, got {status:?}"
+    );
+}
+
+#[test]
+fn forward_only_removed_member_in_current_set_resolves_to_nevermember() {
+    // After a removal, the materialized member set no longer contains
+    // the removed signer. On the fast path (heads equal), the
+    // resolver returns NeverMember — the documented conflation. The check
+    // treats this as "not authorized" and rejects the delta, which
+    // is the correct outcome for a delta whose position equals the
+    // post-removal cut.
+    use calimero_context_config::types::GovernancePosition;
+    let store = test_store();
+    let gid = test_group_id();
+    let signer = PublicKey::from([0x78; 32]);
+
+    save_group_meta(&store, &gid, &test_meta()).unwrap();
+    add_group_member(&store, &gid, &signer, GroupMemberRole::Member).unwrap();
+    // Removal flips the materialized set; the signer is no longer
+    // findable by `get_group_member_role`.
+    remove_group_member(&store, &gid, &signer).unwrap();
+
+    let state_hash = compute_group_state_hash(&store, &gid).unwrap();
+    let position = GovernancePosition::new(gid, state_hash, vec![]).unwrap();
+
+    let status = membership_status_at(&store, &signer, &position).unwrap();
+    // Fast path conflates Removed into NeverMember — documented
+    // limitation. The prefix walk (when heads differ) recovers the
+    // distinction. The apply-time check treats both as rejection, so
+    // the practical security outcome is identical.
+    assert!(
+        matches!(status, MembershipStatus::NeverMember),
+        "removed signer on heads-equal fast path is NeverMember, got {status:?}"
+    );
+}
+
+#[test]
+fn forward_only_re_added_member_resolves_to_member() {
+    // Add → Remove → Add: the materialized set contains the signer
+    // again, so the fast path returns Member with the latest role.
+    // This is the "rehabilitation" case — the resolver doesn't
+    // remember that they were ever removed.
+    use calimero_context_config::types::GovernancePosition;
+    let store = test_store();
+    let gid = test_group_id();
+    let signer = PublicKey::from([0x79; 32]);
+
+    save_group_meta(&store, &gid, &test_meta()).unwrap();
+    add_group_member(&store, &gid, &signer, GroupMemberRole::Member).unwrap();
+    remove_group_member(&store, &gid, &signer).unwrap();
+    add_group_member(&store, &gid, &signer, GroupMemberRole::Admin).unwrap();
+
+    let state_hash = compute_group_state_hash(&store, &gid).unwrap();
+    let position = GovernancePosition::new(gid, state_hash, vec![]).unwrap();
+
+    let status = membership_status_at(&store, &signer, &position).unwrap();
+    assert!(
+        matches!(status, MembershipStatus::Member(GroupMemberRole::Admin)),
+        "re-added signer resolves with new role on fast path, got {status:?}"
+    );
+}
+
+#[test]
+fn forward_only_role_promotion_picks_current_role() {
+    // Role changes between Add and present don't cause spurious
+    // rejection. The materialized set reflects the latest role.
+    use calimero_context_config::types::GovernancePosition;
+    let store = test_store();
+    let gid = test_group_id();
+    let signer = PublicKey::from([0x7A; 32]);
+
+    save_group_meta(&store, &gid, &test_meta()).unwrap();
+    add_group_member(&store, &gid, &signer, GroupMemberRole::Member).unwrap();
+    // Re-add with Admin role (simulates a role change in the
+    // materialized layer — at the namespace governance layer this
+    // would be a `MemberRoleSet`).
+    add_group_member(&store, &gid, &signer, GroupMemberRole::Admin).unwrap();
+
+    let state_hash = compute_group_state_hash(&store, &gid).unwrap();
+    let position = GovernancePosition::new(gid, state_hash, vec![]).unwrap();
+
+    let status = membership_status_at(&store, &signer, &position).unwrap();
+    assert!(
+        matches!(status, MembershipStatus::Member(GroupMemberRole::Admin)),
+        "current role wins on fast path, got {status:?}"
+    );
+}

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -736,12 +736,11 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 Some(serialized)
                             };
 
-                            // Cross-DAG reference (B1): names the governance
-                            // cut this delta was signed against. `None` for
-                            // legacy non-group contexts. Read failures are
-                            // logged but not fatal — the receiver-side B3
-                            // check will reject if the position is missing
-                            // or stale.
+                            // Cross-DAG reference: names the governance cut
+                            // this delta was signed against. `None` for legacy
+                            // non-group contexts. Read failures are logged but
+                            // not fatal — the receiver-side membership check
+                            // will reject if the position is missing or stale.
                             let governance_position = compute_governance_position_for_context(
                                 &datastore_for_broadcast,
                                 &context.id,
@@ -1076,7 +1075,8 @@ enum CachedOrBlob {
 ///
 /// Returns `None` for non-group contexts (which have no governance DAG to
 /// reference) and on any read failure — receivers will surface the missing
-/// position via the B3 apply-time check rather than silently relying on it.
+/// position via the apply-time membership check rather than silently
+/// relying on it.
 fn compute_governance_position_for_context(
     datastore: &Store,
     context_id: &ContextId,
@@ -1112,9 +1112,9 @@ fn compute_governance_position_for_context(
     // Double-read pattern: governance ops can apply between reading heads
     // and computing the state hash, producing an internally-inconsistent
     // position whose hash and heads disagree. Re-read heads after the hash
-    // and bail if they changed — the receiver's B3 fast path treats hash
-    // mismatch as a hard rejection, so shipping a stale value would
-    // spuriously reject legitimate deltas. A true atomic read would
+    // and bail if they changed — the receiver's heads-equal fast path
+    // treats hash mismatch as a hard rejection, so shipping a stale value
+    // would spuriously reject legitimate deltas. A true atomic read would
     // require refactoring `compute_group_state_hash` and `read_head_record`
     // to share a `Handle` (snapshot view); the double-read covers the
     // race window with a single extra cheap read.
@@ -1161,8 +1161,9 @@ fn compute_governance_position_for_context(
     // Set-equality, not Vec equality. Storage iteration order isn't guaranteed
     // to be stable across two reads, so a Vec equality check would treat
     // [h1, h2] vs [h2, h1] as a stale read and emit None for every state delta
-    // — receivers then reject the delta on the B3 None-position branch and the
-    // wire wedges even when the underlying head set didn't actually change.
+    // — receivers then reject the delta on the no-position-on-group-context
+    // anti-bypass branch and the wire wedges even when the underlying head
+    // set didn't actually change.
     let heads_changed = {
         use std::collections::HashSet;
         heads_before.len() != heads_after.len()

--- a/crates/node/primitives/src/delta_buffer.rs
+++ b/crates/node/primitives/src/delta_buffer.rs
@@ -110,14 +110,14 @@ pub struct BufferedDelta {
     pub source_peer: libp2p::PeerId,
     /// Group key identifier for decryption.
     pub key_id: [u8; 32],
-    /// Cross-DAG reference (B1) — must survive snapshot-sync buffering so
-    /// that B3's apply-time authorization check fires correctly on replay.
-    /// Dropping it here would silently bypass B3 for every delta that
-    /// happened to arrive during a sync. `None` for legacy non-group
-    /// contexts that have no governance DAG.
+    /// Cross-DAG reference — must survive snapshot-sync buffering so that
+    /// the apply-time authorization check fires correctly on replay.
+    /// Dropping it here would silently bypass the membership check for
+    /// every delta that happened to arrive during a sync. `None` for
+    /// legacy non-group contexts that have no governance DAG.
     pub governance_position: Option<GovernancePosition>,
-    /// Number of times the governance-pending drain (B2) has re-buffered
-    /// this delta because its governance heads are still unknown locally.
+    /// Number of times the governance-pending drain has re-buffered this
+    /// delta because its governance heads are still unknown locally.
     /// Bounded by `MAX_GOVERNANCE_DRAIN_ATTEMPTS` — after that, the drain
     /// drops the delta with a warn log rather than re-buffering forever.
     /// Prevents indefinite resource consumption when governance heads are

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -123,7 +123,7 @@ pub(super) fn handle_namespace_governance_delta(
                     addr.do_send(crate::readiness::NamespaceOpApplied { namespace_id });
                 }
 
-                // B2 active drain: a governance op that just applied may
+                // Governance-pending active drain:a governance op that just applied may
                 // unblock state deltas previously buffered as `Unknown`.
                 // Without this hook the lazy on-state-delta drain
                 // deadlocks when the only state delta in flight is one
@@ -450,7 +450,7 @@ async fn fetch_and_apply_namespace_backfill(
                 // gossip-receive path (line 120).
                 node_client.notify_namespace_op_applied(namespace_id);
 
-                // B2 active drain: backfilled governance ops may unblock
+                // Governance-pending active drain:backfilled governance ops may unblock
                 // state deltas previously buffered as `Unknown`. Same
                 // hook as the gossip-apply path.
                 let drain_input = crate::handlers::state_delta::StateDeltaContext {

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -123,7 +123,7 @@ pub(super) fn handle_namespace_governance_delta(
                     addr.do_send(crate::readiness::NamespaceOpApplied { namespace_id });
                 }
 
-                // Governance-pending active drain:a governance op that just applied may
+                // Governance-pending active drain: a governance op that just applied may
                 // unblock state deltas previously buffered as `Unknown`.
                 // Without this hook the lazy on-state-delta drain
                 // deadlocks when the only state delta in flight is one
@@ -450,7 +450,7 @@ async fn fetch_and_apply_namespace_backfill(
                 // gossip-receive path (line 120).
                 node_client.notify_namespace_op_applied(namespace_id);
 
-                // Governance-pending active drain:backfilled governance ops may unblock
+                // Governance-pending active drain: backfilled governance ops may unblock
                 // state deltas previously buffered as `Unknown`. Same
                 // hook as the gossip-apply path.
                 let drain_input = crate::handlers::state_delta::StateDeltaContext {

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -157,7 +157,7 @@ pub(crate) struct StateDeltaContext {
 ///
 /// Calls `apply_authorized_state_delta` directly (not `handle_state_delta`)
 /// so the call graph stays linear — no async recursion, no per-recurse
-/// future allocation. The B3 check we just performed via
+/// future allocation. The cross-DAG check we just performed via
 /// `membership_status_at` is the same check `handle_state_delta` would have
 /// performed; skipping back through the entry handler would also re-drain
 /// the (now-empty) pending buffer, wasted work.
@@ -182,7 +182,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
     debug!(
         %context_id,
         count = snapshot_len,
-        "B2: draining governance-pending buffer"
+        "governance-pending drain:draining governance-pending buffer"
     );
     for _ in 0..snapshot_len {
         let Some(buffered) = input.node_state.pop_governance_pending(context_id) else {
@@ -192,7 +192,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
             warn!(
                 %context_id,
                 delta_id = ?buffered.id,
-                "B2: pending delta has no governance_position; dropping"
+                "governance-pending drain:pending delta has no governance_position; dropping"
             );
             continue;
         };
@@ -204,7 +204,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %context_id,
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
-                    "B2: pending delta now authorized; re-applying"
+                    "governance-pending drain:pending delta now authorized; re-applying"
                 );
                 crate::node_metrics::record_governance_drain_outcome("applied");
                 let reconstructed = state_delta_message_from_buffered(buffered, *context_id);
@@ -212,7 +212,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     warn!(
                         %context_id,
                         %err,
-                        "B2: re-apply of authorized buffered delta failed"
+                        "governance-pending drain:re-apply of authorized buffered delta failed"
                     );
                 }
             }
@@ -222,7 +222,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
                     last_role = ?last_role,
-                    "B2: pending delta from removed author; dropping"
+                    "governance-pending drain:pending delta from removed author; dropping"
                 );
                 crate::node_metrics::record_governance_drain_outcome("removed");
             }
@@ -231,7 +231,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %context_id,
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
-                    "B2: pending delta from non-member; dropping"
+                    "governance-pending drain:pending delta from non-member; dropping"
                 );
                 crate::node_metrics::record_governance_drain_outcome("never_member");
             }
@@ -246,7 +246,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                         %context_id,
                         delta_id = ?buffered.id,
                         attempts = buffered.governance_drain_attempts,
-                        "B2: dropping pending delta after exhausting drain attempts \
+                        "governance-pending drain:dropping pending delta after exhausting drain attempts \
                          (governance heads still unknown — likely permanently missing)"
                     );
                     crate::node_metrics::record_governance_drain_outcome("dropped_max_attempts");
@@ -256,7 +256,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                         delta_id = ?buffered.id,
                         needed_count = needed.len(),
                         attempts = buffered.governance_drain_attempts,
-                        "B2: still pending governance catchup; re-buffering"
+                        "governance-pending drain:still pending governance catchup; re-buffering"
                     );
                     crate::node_metrics::record_governance_drain_outcome("rebuffered");
                     input
@@ -269,7 +269,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %context_id,
                     delta_id = ?buffered.id,
                     %err,
-                    "B2: membership lookup failed for pending delta; dropping"
+                    "governance-pending drain:membership lookup failed for pending delta; dropping"
                 );
                 crate::node_metrics::record_governance_drain_outcome("lookup_error");
             }
@@ -297,7 +297,7 @@ pub(crate) async fn drain_all_governance_pending(input: &StateDeltaContext) {
     }
     debug!(
         count = context_ids.len(),
-        "B2: governance-apply hook draining pending buffers across contexts"
+        "governance-pending drain:governance-apply hook draining pending buffers across contexts"
     );
     for context_id in context_ids {
         drain_governance_pending(input, &context_id).await;
@@ -355,7 +355,7 @@ pub(crate) struct ReplayBufferedDeltaInput {
 /// Apply path for an authorized state delta — runs the snapshot-sync buffer
 /// check, decryption, DAG insert, handler execution, and heartbeat broadcast.
 ///
-/// Both [`handle_state_delta`] (after the B3 check passes) and
+/// Both [`handle_state_delta`] (after the cross-DAG check passes) and
 /// [`drain_governance_pending`] (when re-applying a buffered delta whose
 /// status is now `Member`) call into this function. Splitting the apply
 /// tail off from `handle_state_delta` lets the drain path re-apply directly
@@ -397,7 +397,7 @@ pub(crate) async fn apply_authorized_state_delta(
     // when re-applying a buffered delta whose status is now `Member` — gets
     // the same enforcement. Without it, a member who became ReadOnly
     // between the delta being authored and the drain could slip a write
-    // through, since the B3 check via `membership_status_at` returns
+    // through, since the cross-DAG check via `membership_status_at` returns
     // `Member(role)` with a wildcard role that the drain matches against.
     if calimero_context::group_store::is_read_only_for_context(
         node_clients.context.datastore(),
@@ -858,8 +858,8 @@ pub async fn handle_state_delta(
 
     // Fast-path ReadOnly rejection — `apply_authorized_state_delta` also
     // performs this check (so the governance-pending drain path is
-    // covered), but doing it here too avoids paying for drain + B3 +
-    // membership_status_at on a delta we'll reject anyway.
+    // covered), but doing it here too avoids paying for drain plus the
+    // cross-DAG membership lookup on a delta we'll reject anyway.
     if calimero_context::group_store::is_read_only_for_context(
         node_clients.context.datastore(),
         &context_id,
@@ -889,7 +889,7 @@ pub async fn handle_state_delta(
         "Received state delta"
     );
 
-    // B2 — drain governance-pending buffer for this context. Each pending
+    // Drain governance-pending buffer for this context. Each pending
     // delta is re-evaluated against current local governance state; if the
     // signer's status is now decidable, the delta is re-applied (Member)
     // or rejected (Removed/NeverMember/Err). If still Unknown, push it
@@ -904,18 +904,18 @@ pub async fn handle_state_delta(
     };
     drain_governance_pending(&drain_input, &context_id).await;
 
-    // B3 — apply-time authorization check. If the delta carries a
+    // Apply-time cross-DAG membership check. If the delta carries a
     // `governance_position`, ask `membership_status_at` whether `author_id`
     // was a member at the named cut. Reject ineligible ops; buffer when
     // governance state hasn't caught up; otherwise fall through to the
     // existing apply path.
     //
-    // Anti-bypass: a delta with `governance_position == None` skips B3
-    // entirely. That's the legacy behaviour for non-group contexts (which
-    // have no governance DAG to reference), but it's also what a malicious
-    // sender would set to bypass enforcement. So we verify here that the
-    // missing position genuinely matches a non-group context locally —
-    // any mismatch (group context with no position) is rejected.
+    // Anti-bypass: a delta with `governance_position == None` skips the
+    // membership check entirely. That's the legacy behaviour for non-group
+    // contexts (which have no governance DAG to reference), but it's also
+    // what a malicious sender would set to bypass enforcement. So we verify
+    // here that the missing position genuinely matches a non-group context
+    // locally — any mismatch (group context with no position) is rejected.
     if governance_position.is_none() {
         let store = node_clients.context.datastore();
         match calimero_context::group_store::get_group_for_context(store, &context_id) {
@@ -928,7 +928,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     group_id = ?gid,
                     delta_id = ?delta_id,
-                    "B3: rejecting state delta — group context but no governance_position \
+                    "cross-DAG check:rejecting state delta — group context but no governance_position \
                      (likely a malicious bypass attempt)"
                 );
                 return Ok(());
@@ -938,7 +938,7 @@ pub async fn handle_state_delta(
                     %context_id,
                     %author_id,
                     %err,
-                    "B3: get_group_for_context failed; rejecting delta to avoid silent bypass"
+                    "cross-DAG check:get_group_for_context failed; rejecting delta to avoid silent bypass"
                 );
                 return Ok(());
             }
@@ -954,7 +954,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     role = ?role,
                     group_id = ?pos.group_id,
-                    "B3: author authorized at governance cut"
+                    "cross-DAG check:author authorized at governance cut"
                 );
             }
             Ok(MembershipStatus::Removed { last_role }) => {
@@ -963,7 +963,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     last_role = ?last_role,
                     group_id = ?pos.group_id,
-                    "B3: rejecting state delta — author was removed from group at governance cut"
+                    "cross-DAG check:rejecting state delta — author was removed from group at governance cut"
                 );
                 return Ok(());
             }
@@ -972,7 +972,7 @@ pub async fn handle_state_delta(
                     %context_id,
                     %author_id,
                     group_id = ?pos.group_id,
-                    "B3: rejecting state delta — author is not a member of the group at governance cut"
+                    "cross-DAG check:rejecting state delta — author is not a member of the group at governance cut"
                 );
                 return Ok(());
             }
@@ -982,7 +982,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     group_id = ?pos.group_id,
                     needed_count = needed.len(),
-                    "B3: governance state behind position; buffering delta until catchup"
+                    "cross-DAG check:governance state behind position; buffering delta until catchup"
                 );
                 let buffered = calimero_node_primitives::delta_buffer::BufferedDelta {
                     id: delta_id,
@@ -1007,7 +1007,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     group_id = ?pos.group_id,
                     %err,
-                    "B3: rejecting state delta — membership lookup failed (hash mismatch / corruption)"
+                    "cross-DAG check:rejecting state delta — membership lookup failed (hash mismatch / corruption)"
                 );
                 return Ok(());
             }
@@ -1866,11 +1866,12 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
         return Ok(false);
     }
 
-    // B3 — apply-time authorization check, parallel to `handle_state_delta`.
+    // Apply-time cross-DAG membership check, parallel to `handle_state_delta`.
     // Snapshot sync establishes a context-state baseline but says nothing
     // about governance state, so a delta buffered during sync must still
-    // pass B3 before its actions are applied. Without this, every delta
-    // arriving inside the sync window bypasses cross-DAG authorization.
+    // pass the membership check before its actions are applied. Without
+    // this, every delta arriving inside the sync window bypasses cross-DAG
+    // authorization.
     //
     // Anti-bypass: a missing position is only legitimate for non-group
     // contexts. Mirror the check in `handle_state_delta`: if the local
@@ -1888,7 +1889,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     group_id = ?gid,
                     delta_id = ?delta_id,
-                    "B3 (replay): rejecting buffered delta — group context but no \
+                    "cross-DAG check (replay):rejecting buffered delta — group context but no \
                      governance_position (likely a malicious bypass attempt)"
                 );
                 return Ok(false);
@@ -1898,7 +1899,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     %context_id,
                     author = %buffered.author_id,
                     %err,
-                    "B3 (replay): get_group_for_context failed; rejecting buffered \
+                    "cross-DAG check (replay):get_group_for_context failed; rejecting buffered \
                      delta to avoid silent bypass"
                 );
                 return Ok(false);
@@ -1915,7 +1916,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     role = ?role,
                     group_id = ?pos.group_id,
-                    "B3 (replay): author authorized at governance cut"
+                    "cross-DAG check (replay):author authorized at governance cut"
                 );
             }
             Ok(MembershipStatus::Removed { last_role }) => {
@@ -1924,7 +1925,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     last_role = ?last_role,
                     group_id = ?pos.group_id,
-                    "B3 (replay): rejecting buffered delta — author was removed at governance cut"
+                    "cross-DAG check (replay):rejecting buffered delta — author was removed at governance cut"
                 );
                 return Ok(false);
             }
@@ -1933,7 +1934,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     %context_id,
                     author = %buffered.author_id,
                     group_id = ?pos.group_id,
-                    "B3 (replay): rejecting buffered delta — author is not a member at governance cut"
+                    "cross-DAG check (replay):rejecting buffered delta — author is not a member at governance cut"
                 );
                 return Ok(false);
             }
@@ -1950,7 +1951,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     group_id = ?pos.group_id,
                     needed_count = needed.len(),
-                    "B3 (replay): governance heads still unknown after sync — dropping"
+                    "cross-DAG check (replay):governance heads still unknown after sync — dropping"
                 );
                 return Ok(false);
             }
@@ -1960,7 +1961,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     group_id = ?pos.group_id,
                     %err,
-                    "B3 (replay): rejecting buffered delta — membership lookup failed"
+                    "cross-DAG check (replay):rejecting buffered delta — membership lookup failed"
                 );
                 return Ok(false);
             }

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -182,7 +182,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
     debug!(
         %context_id,
         count = snapshot_len,
-        "governance-pending drain:draining governance-pending buffer"
+        "governance-pending drain: draining governance-pending buffer"
     );
     for _ in 0..snapshot_len {
         let Some(buffered) = input.node_state.pop_governance_pending(context_id) else {
@@ -192,7 +192,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
             warn!(
                 %context_id,
                 delta_id = ?buffered.id,
-                "governance-pending drain:pending delta has no governance_position; dropping"
+                "governance-pending drain: pending delta has no governance_position; dropping"
             );
             continue;
         };
@@ -204,7 +204,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %context_id,
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
-                    "governance-pending drain:pending delta now authorized; re-applying"
+                    "governance-pending drain: pending delta now authorized; re-applying"
                 );
                 crate::node_metrics::record_governance_drain_outcome("applied");
                 let reconstructed = state_delta_message_from_buffered(buffered, *context_id);
@@ -212,7 +212,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     warn!(
                         %context_id,
                         %err,
-                        "governance-pending drain:re-apply of authorized buffered delta failed"
+                        "governance-pending drain: re-apply of authorized buffered delta failed"
                     );
                 }
             }
@@ -222,7 +222,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
                     last_role = ?last_role,
-                    "governance-pending drain:pending delta from removed author; dropping"
+                    "governance-pending drain: pending delta from removed author; dropping"
                 );
                 crate::node_metrics::record_governance_drain_outcome("removed");
             }
@@ -231,7 +231,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %context_id,
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
-                    "governance-pending drain:pending delta from non-member; dropping"
+                    "governance-pending drain: pending delta from non-member; dropping"
                 );
                 crate::node_metrics::record_governance_drain_outcome("never_member");
             }
@@ -246,7 +246,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                         %context_id,
                         delta_id = ?buffered.id,
                         attempts = buffered.governance_drain_attempts,
-                        "governance-pending drain:dropping pending delta after exhausting drain attempts \
+                        "governance-pending drain: dropping pending delta after exhausting drain attempts \
                          (governance heads still unknown — likely permanently missing)"
                     );
                     crate::node_metrics::record_governance_drain_outcome("dropped_max_attempts");
@@ -256,7 +256,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                         delta_id = ?buffered.id,
                         needed_count = needed.len(),
                         attempts = buffered.governance_drain_attempts,
-                        "governance-pending drain:still pending governance catchup; re-buffering"
+                        "governance-pending drain: still pending governance catchup; re-buffering"
                     );
                     crate::node_metrics::record_governance_drain_outcome("rebuffered");
                     input
@@ -269,7 +269,7 @@ async fn drain_governance_pending(input: &StateDeltaContext, context_id: &Contex
                     %context_id,
                     delta_id = ?buffered.id,
                     %err,
-                    "governance-pending drain:membership lookup failed for pending delta; dropping"
+                    "governance-pending drain: membership lookup failed for pending delta; dropping"
                 );
                 crate::node_metrics::record_governance_drain_outcome("lookup_error");
             }
@@ -297,7 +297,7 @@ pub(crate) async fn drain_all_governance_pending(input: &StateDeltaContext) {
     }
     debug!(
         count = context_ids.len(),
-        "governance-pending drain:governance-apply hook draining pending buffers across contexts"
+        "governance-pending drain: governance-apply hook draining pending buffers across contexts"
     );
     for context_id in context_ids {
         drain_governance_pending(input, &context_id).await;
@@ -928,7 +928,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     group_id = ?gid,
                     delta_id = ?delta_id,
-                    "cross-DAG check:rejecting state delta — group context but no governance_position \
+                    "cross-DAG check: rejecting state delta — group context but no governance_position \
                      (likely a malicious bypass attempt)"
                 );
                 return Ok(());
@@ -938,7 +938,7 @@ pub async fn handle_state_delta(
                     %context_id,
                     %author_id,
                     %err,
-                    "cross-DAG check:get_group_for_context failed; rejecting delta to avoid silent bypass"
+                    "cross-DAG check: get_group_for_context failed; rejecting delta to avoid silent bypass"
                 );
                 return Ok(());
             }
@@ -954,7 +954,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     role = ?role,
                     group_id = ?pos.group_id,
-                    "cross-DAG check:author authorized at governance cut"
+                    "cross-DAG check: author authorized at governance cut"
                 );
             }
             Ok(MembershipStatus::Removed { last_role }) => {
@@ -963,7 +963,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     last_role = ?last_role,
                     group_id = ?pos.group_id,
-                    "cross-DAG check:rejecting state delta — author was removed from group at governance cut"
+                    "cross-DAG check: rejecting state delta — author was removed from group at governance cut"
                 );
                 return Ok(());
             }
@@ -972,7 +972,7 @@ pub async fn handle_state_delta(
                     %context_id,
                     %author_id,
                     group_id = ?pos.group_id,
-                    "cross-DAG check:rejecting state delta — author is not a member of the group at governance cut"
+                    "cross-DAG check: rejecting state delta — author is not a member of the group at governance cut"
                 );
                 return Ok(());
             }
@@ -982,7 +982,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     group_id = ?pos.group_id,
                     needed_count = needed.len(),
-                    "cross-DAG check:governance state behind position; buffering delta until catchup"
+                    "cross-DAG check: governance state behind position; buffering delta until catchup"
                 );
                 let buffered = calimero_node_primitives::delta_buffer::BufferedDelta {
                     id: delta_id,
@@ -1007,7 +1007,7 @@ pub async fn handle_state_delta(
                     %author_id,
                     group_id = ?pos.group_id,
                     %err,
-                    "cross-DAG check:rejecting state delta — membership lookup failed (hash mismatch / corruption)"
+                    "cross-DAG check: rejecting state delta — membership lookup failed (hash mismatch / corruption)"
                 );
                 return Ok(());
             }
@@ -1889,7 +1889,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     group_id = ?gid,
                     delta_id = ?delta_id,
-                    "cross-DAG check (replay):rejecting buffered delta — group context but no \
+                    "cross-DAG check (replay): rejecting buffered delta — group context but no \
                      governance_position (likely a malicious bypass attempt)"
                 );
                 return Ok(false);
@@ -1899,7 +1899,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     %context_id,
                     author = %buffered.author_id,
                     %err,
-                    "cross-DAG check (replay):get_group_for_context failed; rejecting buffered \
+                    "cross-DAG check (replay): get_group_for_context failed; rejecting buffered \
                      delta to avoid silent bypass"
                 );
                 return Ok(false);
@@ -1916,7 +1916,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     role = ?role,
                     group_id = ?pos.group_id,
-                    "cross-DAG check (replay):author authorized at governance cut"
+                    "cross-DAG check (replay): author authorized at governance cut"
                 );
             }
             Ok(MembershipStatus::Removed { last_role }) => {
@@ -1925,7 +1925,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     last_role = ?last_role,
                     group_id = ?pos.group_id,
-                    "cross-DAG check (replay):rejecting buffered delta — author was removed at governance cut"
+                    "cross-DAG check (replay): rejecting buffered delta — author was removed at governance cut"
                 );
                 return Ok(false);
             }
@@ -1934,7 +1934,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     %context_id,
                     author = %buffered.author_id,
                     group_id = ?pos.group_id,
-                    "cross-DAG check (replay):rejecting buffered delta — author is not a member at governance cut"
+                    "cross-DAG check (replay): rejecting buffered delta — author is not a member at governance cut"
                 );
                 return Ok(false);
             }
@@ -1951,7 +1951,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     group_id = ?pos.group_id,
                     needed_count = needed.len(),
-                    "cross-DAG check (replay):governance heads still unknown after sync — dropping"
+                    "cross-DAG check (replay): governance heads still unknown after sync — dropping"
                 );
                 return Ok(false);
             }
@@ -1961,7 +1961,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     author = %buffered.author_id,
                     group_id = ?pos.group_id,
                     %err,
-                    "cross-DAG check (replay):rejecting buffered delta — membership lookup failed"
+                    "cross-DAG check (replay): rejecting buffered delta — membership lookup failed"
                 );
                 return Ok(false);
             }

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -90,12 +90,16 @@ pub(crate) struct NodeState {
     /// Active sync sessions (for delta buffering during snapshot sync).
     pub(crate) sync_sessions: Arc<DashMap<ContextId, SyncSession>>,
     /// Per-context queue of state deltas whose `governance_position` references
-    /// governance heads that aren't yet known locally (B2 buffer-on-Unknown).
+    /// governance heads that aren't yet known locally — i.e., the cross-DAG
+    /// membership lookup returned `Unknown { needed }`, indicating the
+    /// receiver's governance state hasn't caught up to what the sender
+    /// signed against.
     ///
     /// Drained lazily on the next state-delta receive for the same context: each
     /// pending delta is re-evaluated via `membership_status_at`; if governance has
-    /// caught up the delta is processed (applied or rejected by B3), otherwise it
-    /// is pushed back. Lazy drain trades a small worst-case latency (until the
+    /// caught up the delta is processed (applied or rejected by the cross-DAG
+    /// check), otherwise it is pushed back. Lazy drain trades a small
+    /// worst-case latency (until the
     /// next state delta arrives in the same context) for not having to plumb a
     /// notification path from the governance-apply path into this buffer.
     ///
@@ -151,7 +155,7 @@ impl NodeState {
         }
     }
 
-    /// Push a state delta into the governance-pending buffer. Used by B2 when
+    /// Push a state delta into the governance-pending buffer. Called when
     /// `membership_status_at` returns `Unknown { needed }` — the referenced
     /// governance heads aren't yet known locally, so the delta cannot be
     /// authorized until governance catches up.

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -71,8 +71,8 @@ pub struct VMContext<'a> {
     ///
     /// `Some(pos)` for group-context executions; `None` for legacy non-group
     /// contexts that have no governance DAG. Receivers use this to perform
-    /// the apply-time authorization check (B3): "was the executor a member
-    /// at this cut?"
+    /// the apply-time membership check: "was the executor a member at this
+    /// cut?"
     pub governance_position: Option<GovernancePosition>,
 }
 


### PR DESCRIPTION
## Summary

Two related changes on top of the recently-merged cross-DAG authorization work (#2298):

1. **Pin the forward-only invariant** with property tests + load-bearing doc.
2. **Strip internal roadmap codes** (`B1`/`B2`/`B3`/`S13`/`C4`/`D1`) from code comments and log messages; they're confusing without RFC context.

## Forward-only invariant

The prefix walk in `membership_status_at` implements forward-only implicitly — BFS from `target_heads` visits only the *ancestry*, so an op causally after `target_heads` is never observed. This means a state delta signed at a position before the signer's removal still resolves to `Member(role)` even on receivers whose local DAG has already applied the removal — pre-cut writes from a now-removed member remain valid forever, regardless of arrival order.

Without this property, the taint-cascade scenario returns. **Any change that broadens the BFS frontier (e.g., "catching up" to descendants of `target_heads`) breaks the invariant.**

* Audit confirmed all three call sites (`handle_state_delta`, `apply_authorized_state_delta`, `replay_buffered_delta`) inherit the invariant from the resolver.
* **5 new unit tests** on the resolver state machine: pre-removal-is-Member, post-removal-is-Removed, re-add-still-Member, role-change-uses-prefix-role, randomized property test, plus a canary that fails if a future refactor walks past the prefix boundary.
* **4 new integration tests** against an in-memory `Store` covering the materialized-state-snapshot semantics the apply-time check consumes.
* Promoted the invariant to a doc block on `prefix_walk_membership` with explicit warning.

Out of scope (separate work): e2e partition-heal tests, architecture-doc update.

## Roadmap-code strip

The merged PR carried internal codes — `B1`, `B2`, `B3`, `S13`, `C4`, `D1` — in code comments and log messages. These map cleanly to descriptive shortforms:

| Was | Now |
|---|---|
| `"B3: rejecting state delta..."` | `"cross-DAG check: rejecting..."` |
| `"B2: still pending..."` | `"governance-pending drain: still pending..."` |
| `// B2 — drain governance-pending` | `// Drain governance-pending` |
| `// B3 — apply-time authorization` | `// Apply-time cross-DAG membership check` |
| `Cross-DAG reference (B1):` | `Cross-DAG reference:` |
| `**Forward-only invariant (C4)**` | `**Forward-only invariant**` |
| `fn c4_forward_only_*` | `fn forward_only_*` |

The underlying RFC remains the authoritative spec; the code now describes what it does without leaking tracking codes.

## Test plan

- [x] `cargo test -p calimero-context --lib forward_only` — 10/10 new tests pass
- [x] `cargo test -p calimero-context -p calimero-node -p calimero-context-config -p calimero-node-primitives --lib` — 647 pass (was 636; +11 net)
- [x] `cargo fmt --check` clean
- [x] `cargo check --workspace --tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds regression/integration tests and strengthens documentation around cross-DAG membership lookup; runtime behavior changes are limited to log/comment wording, so risk is low.
> 
> **Overview**
> Pins the **forward-only** behavior of `prefix_walk_membership` by adding targeted regression/property tests to ensure pre-removal positions continue to resolve as `Member` and are not retroactively invalidated.
> 
> Adds **fast-path integration tests** for `membership_status_at` (heads-equal branch) to codify expected snapshot/materialized-set semantics, including the documented `Removed`→`NeverMember` conflation.
> 
> Cleans up comments and log prefixes across context/node/runtime to replace internal roadmap labels (`B1`/`B2`/`B3`, etc.) with descriptive wording like `cross-DAG check` and `governance-pending drain`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0934b7e09fe45ffe0fa24999f1bb7633656ede95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->