### PR TITLE
feat(node, context): prefer trusted-anchor peers for sync

### DIFF
--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -539,15 +539,17 @@ pub fn trusted_anchors_for_group(
     store: &Store,
     group_id: &ContextGroupId,
 ) -> EyreResult<std::collections::BTreeSet<PublicKey>> {
+    // BTreeSet deduplicates the common `owner_identity == admin_identity`
+    // shape automatically; no explicit conditional needed.
     let mut anchors = std::collections::BTreeSet::new();
     if let Some(meta) = load_group_meta(store, group_id)? {
-        let _inserted = anchors.insert(meta.owner_identity);
-        let _inserted = anchors.insert(meta.admin_identity);
+        let _ = anchors.insert(meta.owner_identity);
+        let _ = anchors.insert(meta.admin_identity);
     }
     for (pk, role) in list_group_members(store, group_id, 0, usize::MAX)? {
         match role {
             GroupMemberRole::Admin | GroupMemberRole::ReadOnlyTee => {
-                let _inserted = anchors.insert(pk);
+                let _ = anchors.insert(pk);
             }
             GroupMemberRole::Member | GroupMemberRole::ReadOnly => {}
         }

--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -511,6 +511,50 @@ pub fn namespace_member_pubkeys(
     Ok(pubkeys)
 }
 
+/// Enumerate the trusted-anchor set for `group_id` per RFC decision #22:
+/// `{Owner} ∪ {Admins} ∪ {ReadOnlyTee members}`.
+///
+/// Anchors are the preferred targets for sync requests — they're the
+/// peers whose canonical view the cross-DAG authorization model treats
+/// as authoritative. Plain `Member` / `ReadOnly` peers can still serve
+/// sync if asked; clients just shouldn't preferentially target them.
+///
+/// **Returns identities, not peer-ids.** Mapping identity → libp2p
+/// peer-id is the caller's job (today: via the `peer_identities` cache
+/// populated by verified message receive paths).
+///
+/// **Direct anchors only.** This does not walk up the namespace tree
+/// for inherited admins of Open subgroups. The inherited-admin case is
+/// covered by `is_inherited_admin` at the apply-time authorization
+/// layer; missing an inherited anchor at peer-selection time degrades
+/// to random fallback (not a correctness bug).
+///
+/// **TeeAdmissionPolicy is already enforced.** A member only holds the
+/// `ReadOnlyTee` role if `MemberJoinedViaTeeAttestation` admitted them
+/// (see `apply_group_op_mutations`). The role in the store IS the
+/// admission proof — no need to re-verify the TEE policy here. A peer
+/// self-declaring `ReadOnlyTee` without a valid attestation cannot
+/// reach this code path.
+pub fn trusted_anchors_for_group(
+    store: &Store,
+    group_id: &ContextGroupId,
+) -> EyreResult<std::collections::BTreeSet<PublicKey>> {
+    let mut anchors = std::collections::BTreeSet::new();
+    if let Some(meta) = load_group_meta(store, group_id)? {
+        let _inserted = anchors.insert(meta.owner_identity);
+        let _inserted = anchors.insert(meta.admin_identity);
+    }
+    for (pk, role) in list_group_members(store, group_id, 0, usize::MAX)? {
+        match role {
+            GroupMemberRole::Admin | GroupMemberRole::ReadOnlyTee => {
+                let _inserted = anchors.insert(pk);
+            }
+            GroupMemberRole::Member | GroupMemberRole::ReadOnly => {}
+        }
+    }
+    Ok(anchors)
+}
+
 pub fn count_group_members(store: &Store, group_id: &ContextGroupId) -> EyreResult<usize> {
     let gid = group_id.to_bytes();
     count_keys_with_prefix(

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -82,7 +82,8 @@ pub use self::membership::{
     get_group_member_value, has_direct_group_member, is_direct_group_admin, is_group_admin,
     is_group_admin_or_has_capability, is_inherited_admin, list_group_members,
     namespace_member_pubkeys, remove_group_member, require_group_admin,
-    require_group_admin_or_capability, set_member_auto_follow, MembershipPath,
+    require_group_admin_or_capability, set_member_auto_follow, trusted_anchors_for_group,
+    MembershipPath,
 };
 pub use self::membership_policy::MembershipPolicy;
 pub use self::membership_status::{membership_status_at, MembershipStatus};

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5883,7 +5883,8 @@ fn trusted_anchors_mixed_roles() {
     add_group_member(&store, &gid, &read_only, GroupMemberRole::ReadOnly).unwrap();
 
     let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
-    let expected: std::collections::BTreeSet<_> =
-        [owner, legacy_admin, admin_a, admin_b, tee].into_iter().collect();
+    let expected: std::collections::BTreeSet<_> = [owner, legacy_admin, admin_a, admin_b, tee]
+        .into_iter()
+        .collect();
     assert_eq!(anchors, expected, "anchor set mismatch");
 }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -5715,3 +5715,175 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
         "re-add must clear the deny-list entry — semantics from design discussion"
     );
 }
+
+// ---------------------------------------------------------------------
+// Trusted-anchor set (E5) — `trusted_anchors_for_group`
+//
+// Anchor set per RFC decision #22: `{Owner} ∪ {Admins} ∪ {ReadOnlyTee}`.
+// These tests pin the membership rule against the materialized member
+// set; the peer-selection wiring that consumes this is tested
+// separately in the node crate.
+// ---------------------------------------------------------------------
+
+#[test]
+fn trusted_anchors_empty_when_meta_absent() {
+    // No `save_group_meta` call — no group exists. Should return an
+    // empty set, not error. Caller falls back to random selection.
+    let store = test_store();
+    let gid = test_group_id();
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    assert!(anchors.is_empty(), "expected empty set, got {anchors:?}");
+}
+
+#[test]
+fn trusted_anchors_includes_owner_and_legacy_admin() {
+    // Fresh group: owner_identity == admin_identity (the creator).
+    // Anchor set contains just that one pubkey.
+    let store = test_store();
+    let gid = test_group_id();
+    let creator = PublicKey::from([0x01; 32]);
+    save_group_meta(&store, &gid, &sample_meta_with_admin(creator)).unwrap();
+
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    assert!(anchors.contains(&creator), "creator must be an anchor");
+    assert_eq!(
+        anchors.len(),
+        1,
+        "fresh group: owner == admin, exactly one anchor expected, got {anchors:?}"
+    );
+}
+
+#[test]
+fn trusted_anchors_includes_owner_distinct_from_legacy_admin() {
+    // Post-`TransferOwnership` shape: owner_identity != admin_identity.
+    // Both must be in the anchor set — admin_identity is the legacy
+    // fallback creator marker that `is_group_admin` still honors.
+    use calimero_store::key::GroupMetaValue;
+    let store = test_store();
+    let gid = test_group_id();
+    let creator = PublicKey::from([0x01; 32]);
+    let new_owner = PublicKey::from([0x02; 32]);
+    let meta = GroupMetaValue {
+        app_key: [0xBB; 32],
+        target_application_id: calimero_primitives::application::ApplicationId::from([0xCC; 32]),
+        upgrade_policy: calimero_primitives::context::UpgradePolicy::Automatic,
+        created_at: 1_700_000_000,
+        admin_identity: creator,
+        owner_identity: new_owner,
+        migration: None,
+        auto_join: true,
+    };
+    save_group_meta(&store, &gid, &meta).unwrap();
+
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    assert!(anchors.contains(&creator), "legacy admin must be an anchor");
+    assert!(
+        anchors.contains(&new_owner),
+        "owner (post-transfer) must be an anchor"
+    );
+    assert_eq!(anchors.len(), 2);
+}
+
+#[test]
+fn trusted_anchors_includes_admin_members() {
+    let store = test_store();
+    let gid = test_group_id();
+    let creator = PublicKey::from([0x01; 32]);
+    let admin_a = PublicKey::from([0xA1; 32]);
+    let admin_b = PublicKey::from([0xA2; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(creator)).unwrap();
+    add_group_member(&store, &gid, &admin_a, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &admin_b, GroupMemberRole::Admin).unwrap();
+
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    assert!(anchors.contains(&creator));
+    assert!(anchors.contains(&admin_a));
+    assert!(anchors.contains(&admin_b));
+    assert_eq!(anchors.len(), 3);
+}
+
+#[test]
+fn trusted_anchors_includes_read_only_tee_members() {
+    // ReadOnlyTee members are in the anchor set because the role is
+    // gated at apply-time by `MemberJoinedViaTeeAttestation` (see the
+    // `apply_group_op_mutations` carve-out): a peer cannot
+    // self-declare `ReadOnlyTee` without admission. The role in the
+    // store IS the admission proof.
+    let store = test_store();
+    let gid = test_group_id();
+    let creator = PublicKey::from([0x01; 32]);
+    let tee_attested = PublicKey::from([0xC1; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(creator)).unwrap();
+    add_group_member(&store, &gid, &tee_attested, GroupMemberRole::ReadOnlyTee).unwrap();
+
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    assert!(anchors.contains(&tee_attested));
+    assert_eq!(anchors.len(), 2);
+}
+
+#[test]
+fn trusted_anchors_excludes_plain_members_and_read_only() {
+    // Plain `Member` and `ReadOnly` peers can still serve sync if
+    // asked, but clients should NOT preferentially target them.
+    let store = test_store();
+    let gid = test_group_id();
+    let creator = PublicKey::from([0x01; 32]);
+    let member = PublicKey::from([0xB1; 32]);
+    let read_only = PublicKey::from([0xB2; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(creator)).unwrap();
+    add_group_member(&store, &gid, &member, GroupMemberRole::Member).unwrap();
+    add_group_member(&store, &gid, &read_only, GroupMemberRole::ReadOnly).unwrap();
+
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    assert!(
+        !anchors.contains(&member),
+        "plain Member must not be an anchor"
+    );
+    assert!(
+        !anchors.contains(&read_only),
+        "plain ReadOnly must not be an anchor"
+    );
+    assert_eq!(anchors.len(), 1, "only the creator should be in the set");
+}
+
+#[test]
+fn trusted_anchors_mixed_roles() {
+    // Full mix: owner, separate legacy admin, two admin members, one
+    // ReadOnlyTee, one plain Member, one ReadOnly. Anchor set should
+    // be {owner, legacy_admin, admin_a, admin_b, tee} — size 5.
+    use calimero_store::key::GroupMetaValue;
+    let store = test_store();
+    let gid = test_group_id();
+    let owner = PublicKey::from([0x01; 32]);
+    let legacy_admin = PublicKey::from([0x02; 32]);
+    let admin_a = PublicKey::from([0xA1; 32]);
+    let admin_b = PublicKey::from([0xA2; 32]);
+    let tee = PublicKey::from([0xC1; 32]);
+    let member = PublicKey::from([0xB1; 32]);
+    let read_only = PublicKey::from([0xB2; 32]);
+
+    let meta = GroupMetaValue {
+        app_key: [0xBB; 32],
+        target_application_id: calimero_primitives::application::ApplicationId::from([0xCC; 32]),
+        upgrade_policy: calimero_primitives::context::UpgradePolicy::Automatic,
+        created_at: 1_700_000_000,
+        admin_identity: legacy_admin,
+        owner_identity: owner,
+        migration: None,
+        auto_join: true,
+    };
+    save_group_meta(&store, &gid, &meta).unwrap();
+    add_group_member(&store, &gid, &admin_a, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &admin_b, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &tee, GroupMemberRole::ReadOnlyTee).unwrap();
+    add_group_member(&store, &gid, &member, GroupMemberRole::Member).unwrap();
+    add_group_member(&store, &gid, &read_only, GroupMemberRole::ReadOnly).unwrap();
+
+    let anchors = trusted_anchors_for_group(&store, &gid).unwrap();
+    let expected: std::collections::BTreeSet<_> =
+        [owner, legacy_admin, admin_a, admin_b, tee].into_iter().collect();
+    assert_eq!(anchors, expected, "anchor set mismatch");
+}

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -101,6 +101,13 @@ pub(super) fn handle_namespace_governance_delta(
     let readiness_addr = this.readiness_addr.clone();
 
     let op_for_ack = op.clone();
+    // Capture the signer for the peer-identity cache before `op` is
+    // consumed by `apply_signed_namespace_op` below. Signature was
+    // already verified above, so the identity is real; the recording
+    // itself is gated on `Applied` below to skip relayed duplicates and
+    // pending ops where the delivering peer didn't necessarily originate
+    // the message.
+    let signer = op.signer;
     let _ignored = ctx.spawn(
         async move {
             let outcome = match context_client.apply_signed_namespace_op(op).await {
@@ -122,6 +129,12 @@ pub(super) fn handle_namespace_governance_delta(
                 if let Some(addr) = &readiness_addr {
                     addr.do_send(crate::readiness::NamespaceOpApplied { namespace_id });
                 }
+
+                // Record the (peer, identity) pair now that the
+                // signature verified, the nonce was monotonic, and the
+                // op applied successfully. Consumed by anchor-preferred
+                // sync peer selection. See `NodeState::peer_identities`.
+                node_state.observe_peer_identity(source, signer);
 
                 // Governance-pending active drain: a governance op that just applied may
                 // unblock state deltas previously buffered as `Unknown`.

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -1009,6 +1009,11 @@ pub async fn handle_state_delta(
                     group_id = ?pos.group_id,
                     "cross-DAG check: author authorized at governance cut"
                 );
+                // Record the (peer, identity) pair now that we know the
+                // signature verified AND the author is an authorized
+                // member at the named cut. Consumed by anchor-preferred
+                // sync peer selection. See `NodeState::peer_identities`.
+                node_state.observe_peer_identity(source, author_id);
             }
             Ok(MembershipStatus::Removed { last_role }) => {
                 warn!(

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1,11 +1,14 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
+use calimero_primitives::identity::PublicKey;
 use calimero_primitives::{blobs::BlobId, context::ContextId};
 use dashmap::DashMap;
+use libp2p::PeerId;
 use tracing::{debug, warn};
 
 use crate::constants;
@@ -114,6 +117,31 @@ pub(crate) struct NodeState {
             std::collections::VecDeque<calimero_node_primitives::delta_buffer::BufferedDelta>,
         >,
     >,
+    /// Cache of `peer_id → identities observed signing applied messages`,
+    /// populated by `observe_peer_identity` after a state-delta or
+    /// namespace-governance op from `peer_id` successfully applies
+    /// (signature verified, nonce monotonic, cross-DAG membership check
+    /// passed). Consumed by sync-peer selection to preferentially target
+    /// peers in the trusted-anchor set (`{Owner} ∪ {Admins} ∪
+    /// {ReadOnlyTee}` — see
+    /// `calimero_context::group_store::trusted_anchors_for_group`).
+    ///
+    /// **Trust model**: entries reflect identities a peer has *proven*
+    /// to control via signed-and-applied messages — spoofing is bounded
+    /// by signature verification at apply time. The cache itself is not
+    /// a trust gate: downstream reconcile paths verify received state
+    /// against a signed expected hash, so cache poisoning that
+    /// mis-routes a sync request gets caught at adoption time, never
+    /// used to authorize anything. A `peer_id` legitimately maps to
+    /// multiple identities — a node hosts one libp2p key but joins
+    /// many contexts, each with its own signing identity.
+    ///
+    /// **Lifetime**: entries persist for the process lifetime. Peer
+    /// disconnect does not evict — the same peer may reconnect and the
+    /// mapping is still valid. Bounded by the unique
+    /// `(peer_id, identity)` pairs observed, which is itself bounded by
+    /// group member count.
+    pub(crate) peer_identities: Arc<DashMap<PeerId, BTreeSet<PublicKey>>>,
 }
 
 /// Maximum number of state deltas that may sit in the governance-pending
@@ -152,7 +180,16 @@ impl NodeState {
             node_mode,
             sync_sessions: Arc::new(DashMap::new()),
             governance_pending: Arc::new(DashMap::new()),
+            peer_identities: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Record that `peer_id` has successfully delivered a message
+    /// authored by `identity`. Called from receive paths after the
+    /// message verifies and applies — see field-level docs on
+    /// `peer_identities` for the trust model. Idempotent.
+    pub(crate) fn observe_peer_identity(&self, peer_id: PeerId, identity: PublicKey) {
+        let _inserted = self.peer_identities.entry(peer_id).or_default().insert(identity);
     }
 
     /// Push a state delta into the governance-pending buffer. Called when

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -189,7 +189,11 @@ impl NodeState {
     /// message verifies and applies — see field-level docs on
     /// `peer_identities` for the trust model. Idempotent.
     pub(crate) fn observe_peer_identity(&self, peer_id: PeerId, identity: PublicKey) {
-        let _inserted = self.peer_identities.entry(peer_id).or_default().insert(identity);
+        let _inserted = self
+            .peer_identities
+            .entry(peer_id)
+            .or_default()
+            .insert(identity);
     }
 
     /// Push a state delta into the governance-pending buffer. Called when

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -848,14 +848,64 @@ impl SyncManager {
         // `should_buffer_delta` to return true permanently. Tail-latency
         // benefit is still obtained from the parallel probe above, which
         // narrows this loop to "try a known-good peer first".
-        debug!(%context_id, "Using random peer selection for sync");
-        for peer_id in peers.choose_multiple(&mut rand::thread_rng(), peers.len()) {
+        //
+        // Peer order: random shuffle, then stable-partition so peers we
+        // have observed signing applied messages with an
+        // Owner/Admin/ReadOnlyTee identity come first. Anchors are the
+        // peers whose canonical view is authoritative — targeting them
+        // first reduces the chance of pulling from a peer that's
+        // behind or divergent. Plain members still get tried if all
+        // anchors fail. Empty cache or context with no observed anchor
+        // peers degrades to plain random selection.
+        let mut shuffled: Vec<libp2p::PeerId> = peers
+            .choose_multiple(&mut rand::thread_rng(), peers.len())
+            .copied()
+            .collect();
+        let anchor_count = partition_peers_anchor_first(
+            &mut shuffled,
+            &self.node_state.peer_identities,
+            &self.anchor_identities_for_context(&context_id),
+        );
+        if anchor_count > 0 {
+            debug!(
+                %context_id,
+                anchor_peer_count = anchor_count,
+                non_anchor_peer_count = shuffled.len() - anchor_count,
+                "Preferring anchor peers for sync"
+            );
+        } else {
+            debug!(
+                %context_id,
+                peer_count = shuffled.len(),
+                "No anchor peers connected — falling back to random selection"
+            );
+        }
+        for peer_id in &shuffled {
             if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
                 return Ok(result);
             }
         }
 
         bail!("Failed to sync with any peer for context {}", context_id)
+    }
+
+    /// Look up the trusted-anchor identity set for the group that owns
+    /// `context_id` (Owner, Admins, ReadOnlyTee members). Returns an
+    /// empty set on any failure — context not registered to a group,
+    /// store read error, or no meta written yet. Callers fall back to
+    /// plain random peer selection on an empty set.
+    fn anchor_identities_for_context(
+        &self,
+        context_id: &ContextId,
+    ) -> std::collections::BTreeSet<calimero_primitives::identity::PublicKey> {
+        let store = self.context_client.datastore_handle().into_inner();
+        let Ok(Some(group_id)) =
+            calimero_context::group_store::get_group_for_context(&store, context_id)
+        else {
+            return std::collections::BTreeSet::new();
+        };
+        calimero_context::group_store::trusted_anchors_for_group(&store, &group_id)
+            .unwrap_or_default()
     }
 
     /// Find a peer that has state (non-zero root_hash and non-empty DAG heads)
@@ -2886,6 +2936,41 @@ impl SyncManager {
 
         Ok(Some(()))
     }
+}
+
+/// Stable-partition `peers` so peers with an observed trusted-anchor
+/// identity come first while preserving the relative order within each
+/// partition. Returns the index at which non-anchor peers start (i.e.
+/// the count of anchor peers).
+///
+/// A peer is an anchor if at least one identity recorded in
+/// `peer_identities` for that peer appears in `anchors`. An empty
+/// `anchors` set returns 0 immediately — no point sorting if every
+/// peer is going to be non-anchor.
+///
+/// Free function (not a method) so it can be unit-tested against
+/// synthetic inputs without spinning up a sync manager.
+fn partition_peers_anchor_first(
+    peers: &mut [libp2p::PeerId],
+    peer_identities: &dashmap::DashMap<
+        libp2p::PeerId,
+        std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
+    >,
+    anchors: &std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
+) -> usize {
+    if anchors.is_empty() {
+        return 0;
+    }
+    let is_anchor = |peer: &libp2p::PeerId| -> bool {
+        peer_identities
+            .get(peer)
+            .map(|ids| ids.iter().any(|id| anchors.contains(id)))
+            .unwrap_or(false)
+    };
+    // sort_by_key is stable, so the caller's random shuffle order is
+    // preserved within each partition.
+    peers.sort_by_key(|p| !is_anchor(p));
+    peers.iter().filter(|p| is_anchor(p)).count()
 }
 
 impl SyncManager {

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2948,6 +2948,14 @@ impl SyncManager {
 /// `anchors` set returns 0 immediately — no point sorting if every
 /// peer is going to be non-anchor.
 ///
+/// The anchor predicate is materialized into a `Vec<bool>` keyed by
+/// the peer's original index before sorting. This avoids reacquiring
+/// the `DashMap` shard lock O(n log n) times during `sort_by_key`'s
+/// comparisons, and prevents a concurrent cache mutation from causing
+/// the post-sort anchor count to disagree with the actual partition
+/// boundary — both `sort_by_key` and the count read from the same
+/// snapshot.
+///
 /// Free function (not a method) so it can be unit-tested against
 /// synthetic inputs without spinning up a sync manager.
 fn partition_peers_anchor_first(
@@ -2961,16 +2969,23 @@ fn partition_peers_anchor_first(
     if anchors.is_empty() {
         return 0;
     }
-    let is_anchor = |peer: &libp2p::PeerId| -> bool {
-        peer_identities
-            .get(peer)
-            .map(|ids| ids.iter().any(|id| anchors.contains(id)))
-            .unwrap_or(false)
-    };
-    // sort_by_key is stable, so the caller's random shuffle order is
-    // preserved within each partition.
-    peers.sort_by_key(|p| !is_anchor(p));
-    peers.iter().filter(|p| is_anchor(p)).count()
+    let anchor_flags: Vec<bool> = peers
+        .iter()
+        .map(|peer| {
+            peer_identities
+                .get(peer)
+                .map(|ids| ids.iter().any(|id| anchors.contains(id)))
+                .unwrap_or(false)
+        })
+        .collect();
+    // sort_by_key over a pre-indexed flag table — stable, so the
+    // caller's random shuffle order is preserved within each partition.
+    let mut indices: Vec<usize> = (0..peers.len()).collect();
+    indices.sort_by_key(|&i| !anchor_flags[i]);
+    let anchor_count = anchor_flags.iter().filter(|&&f| f).count();
+    let reordered: Vec<libp2p::PeerId> = indices.iter().map(|&i| peers[i]).collect();
+    peers.copy_from_slice(&reordered);
+    anchor_count
 }
 
 impl SyncManager {

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -334,3 +334,135 @@ mod session_watchdog_tests {
         ));
     }
 }
+
+// =========================================================================
+// `partition_peers_anchor_first` — anchor-preferred peer ordering
+// =========================================================================
+//
+// Contract: stable order within each (anchor / non-anchor) partition.
+// The caller pre-shuffles for randomness; this helper just hoists the
+// anchor partition to the front without reordering within it.
+//
+// These exercise the pure-function shape. The integration (looking up
+// the anchor identity set from the store and threading it through
+// `perform_interval_sync`) is covered by the `trusted_anchors_*`
+// helper-level tests in `calimero-context` and end-to-end by multi-node
+// e2e runs.
+
+use std::collections::BTreeSet;
+
+use calimero_primitives::identity::PublicKey;
+use dashmap::DashMap;
+use libp2p::PeerId;
+
+use super::partition_peers_anchor_first;
+
+fn dummy_peer(n: u8) -> PeerId {
+    // Deterministic peer-id keyed by a single byte — only equality
+    // matters here, not the byte structure.
+    let seed = [n; 32];
+    let kp = libp2p::identity::Keypair::ed25519_from_bytes(seed).expect("valid seed");
+    PeerId::from_public_key(&kp.public())
+}
+
+fn dummy_pk(n: u8) -> PublicKey {
+    PublicKey::from([n; 32])
+}
+
+#[test]
+fn partition_empty_anchors_set_returns_zero() {
+    // No anchor set defined → no preference; every peer is non-anchor.
+    let mut peers = vec![dummy_peer(1), dummy_peer(2), dummy_peer(3)];
+    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let anchors: BTreeSet<PublicKey> = BTreeSet::new();
+
+    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn partition_empty_cache_no_anchors_found() {
+    // Anchor set non-empty but we've observed nothing → fall back to
+    // non-anchor; relative order preserved.
+    let mut peers = vec![dummy_peer(1), dummy_peer(2)];
+    let original = peers.clone();
+    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let anchors: BTreeSet<PublicKey> = [dummy_pk(0xAA)].into_iter().collect();
+
+    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    assert_eq!(count, 0);
+    assert_eq!(peers, original);
+}
+
+#[test]
+fn partition_all_peers_are_anchors() {
+    let peer1 = dummy_peer(1);
+    let peer2 = dummy_peer(2);
+    let pk_admin = dummy_pk(0xAA);
+    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let _replaced = cache.insert(peer1, [pk_admin].into_iter().collect());
+    let _replaced = cache.insert(peer2, [pk_admin].into_iter().collect());
+    let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
+
+    let mut peers = vec![peer1, peer2];
+    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    assert_eq!(count, 2);
+    assert_eq!(peers, vec![peer1, peer2]);
+}
+
+#[test]
+fn partition_mixed_anchor_and_non_anchor_preserves_relative_order() {
+    let anchor_a = dummy_peer(1);
+    let anchor_b = dummy_peer(2);
+    let plain_a = dummy_peer(3);
+    let plain_b = dummy_peer(4);
+    let pk_admin = dummy_pk(0xAA);
+
+    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let _replaced = cache.insert(anchor_a, [pk_admin].into_iter().collect());
+    let _replaced = cache.insert(anchor_b, [pk_admin].into_iter().collect());
+
+    let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
+
+    // Pre-shuffled order interleaves the two partitions.
+    let mut peers = vec![plain_a, anchor_a, plain_b, anchor_b];
+    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    assert_eq!(count, 2);
+    // Anchors first (anchor_a before anchor_b, preserved from input),
+    // then non-anchors (plain_a before plain_b, preserved).
+    assert_eq!(peers, vec![anchor_a, anchor_b, plain_a, plain_b]);
+}
+
+#[test]
+fn partition_peer_with_one_anchor_identity_among_many_qualifies() {
+    // A peer can host multiple context identities — partition matches
+    // if ANY identity intersects the anchor set.
+    let peer = dummy_peer(1);
+    let pk_admin = dummy_pk(0xAA);
+    let pk_other_context = dummy_pk(0xBB);
+
+    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let _replaced = cache.insert(peer, [pk_admin, pk_other_context].into_iter().collect());
+
+    let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
+
+    let mut peers = vec![peer];
+    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn partition_peer_with_only_non_anchor_identities_does_not_qualify() {
+    let peer = dummy_peer(1);
+    let pk_member = dummy_pk(0xCC);
+    let pk_admin = dummy_pk(0xAA);
+
+    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let _replaced = cache.insert(peer, [pk_member].into_iter().collect());
+
+    let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
+
+    let mut peers = vec![peer];
+    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    assert_eq!(count, 0);
+}


### PR DESCRIPTION
## Summary

The sync manager today picks peers randomly (`crates/node/src/sync/manager/mod.rs:679`). This PR makes it prefer peers the local node has observed signing applied messages with a trusted-anchor identity — Owner / Admin / ReadOnlyTee — while keeping plain Member / ReadOnly peers as fallbacks. Anchors are the peers whose canonical view is authoritative; targeting them first reduces the chance of pulling from a peer that's behind or divergent.

This is the foundation for upcoming reconcile-on-mismatch work (anchor-targeted snapshot sync triggered by signed-hash mismatches on `MemberRemoved` / `MemberLeft` ops). It lands independently and improves every sync path, not just reconcile.

## Three pieces

### 1. `trusted_anchors_for_group` helper

In `calimero-context::group_store`. Returns the union of `owner_identity`, `admin_identity` (the legacy fallback admin recognised by `is_group_admin`), and members whose role is `Admin` or `ReadOnlyTee`.

- Direct anchors only — does not walk up the namespace tree for inherited admins of Open subgroups. Missing an inherited anchor degrades to random fallback at peer-selection, not a correctness bug.
- `ReadOnlyTee` is gated at apply time by `MemberJoinedViaTeeAttestation` (see the carve-out in `apply_group_op_mutations`). The role-in-store IS the admission proof — no need to re-verify the TEE policy here. A peer self-declaring `ReadOnlyTee` without a valid attestation cannot reach this code path.

7 unit tests cover: empty meta, owner == admin, owner ≠ admin, admin members included, ReadOnlyTee members included, plain Member / ReadOnly excluded, mixed-role group.

### 2. `peer_identities` cache on `NodeState`

`Arc<DashMap<PeerId, BTreeSet<PublicKey>>>`. A node hosts one libp2p key but joins many contexts, each with its own signing identity — so a `PeerId` legitimately maps to a *set* of `PublicKey`s.

Populated via `observe_peer_identity` only after a state-delta or namespace-governance op verifies AND applies. Entries reflect identities a peer has *proven* to control via signed-and-applied messages.

Trust model: the cache is not a trust gate. Downstream reconcile paths verify received state against a signed hash, so cache poisoning that mis-routes a sync request gets caught at adoption time — never used to authorise anything.

Two hook sites:
- `handle_state_delta`, after the cross-DAG membership check passes (signature verified, nonce monotonic, author authorized at the named cut).
- `handle_namespace_governance_delta`, after `apply_signed_namespace_op` returns `Applied`. `Pending` and `Duplicate` outcomes are skipped — the delivering peer didn't necessarily originate those.

### 3. `partition_peers_anchor_first` + wiring

In `crates/node/src/sync/manager/mod.rs`. Stable-partitions the existing random-shuffled peer list so anchors come first while preserving within-partition order. Wired into `perform_interval_sync` at line ~679.

Empty anchor set returns 0 early. Empty cache or context with no observed anchor peers degrades to plain random selection with a debug log.

6 unit tests cover: empty anchors, empty cache, all peers are anchors, mixed preserves relative order, peer with one anchor identity among many qualifies, peer with only non-anchor identities does not qualify.

## What this is NOT

- Not a wire-format change. No new messages, no protocol breaking changes.
- Not a trust gate. The cache is opportunistic and unverified-by-itself; the actual security gates live elsewhere (apply-time membership check; reconcile-time hash verification, when that lands).
- Not bootstrap-affecting. The cache populates over time as messages flow. A fresh node's first sync still uses random selection (bootstrap is `find_peer_with_state`'s domain). Anchor preference kicks in once verified messages have been seen — typical case for any context that's been alive for more than a few seconds.

## Test plan

- [x] `cargo test -p calimero-context --lib` — 228 passed (includes 7 new helper tests)
- [x] `cargo test -p calimero-node --lib` — 121 passed (includes 6 new partition tests)
- [ ] e2e suite (CI)
- [ ] Manually verify: on a 3-node group, when node-1 (admin) is connected, syncs from node-3 land on node-1 first (visible in the new `Preferring anchor peers for sync` debug log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync peer selection logic to prefer certain peers based on observed identities, which can affect network behavior and sync reliability if the cache/anchor computation is wrong; falls back to random selection when unavailable.
> 
> **Overview**
> Adds a new `trusted_anchors_for_group` helper in `calimero-context` to compute the RFC-defined trusted-anchor identity set (`Owner ∪ Admins ∪ ReadOnlyTee`) and exports it for consumers, with unit tests covering role/metadata edge cases.
> 
> Updates `calimero-node` to track a `peer_identities` cache on `NodeState`, populated only after successfully applied namespace ops and authorized state deltas, and uses it in `SyncManager` to stable-partition the shuffled peer list so *anchor* peers are tried first during interval sync (with random fallback when no anchors are known). Includes unit tests for the partitioning helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d86edbb0ba23630fe544234da99073e95b07ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->