### PR TITLE
fix(context): keep namespace governance DAG head set duplicate-free (#2327)

### DIFF
--- a/crates/context/src/group_store/namespace_dag.rs
+++ b/crates/context/src/group_store/namespace_dag.rs
@@ -34,14 +34,34 @@ impl<'a> NamespaceDagService<'a> {
     }
 
     /// Returns current DAG head as parent hashes + next nonce.
+    ///
+    /// The persisted head set is unique by construction (see
+    /// [`Self::advance_dag_head`]), but a node that was corrupted by an older
+    /// build — or any not-yet-found path that double-appends — would otherwise
+    /// keep emitting a `GovernancePosition` whose duplicate `governance_dag_heads`
+    /// every peer rejects (issue #2327). De-dup defensively on read so such a
+    /// store self-heals on its next governance op; the `warn!` makes the
+    /// condition observable rather than silent.
     pub fn read_head_record(&self) -> EyreResult<NamespaceHead> {
         let handle = self.store.handle();
         let key = calimero_store::key::NamespaceGovHead::new(self.namespace_id);
         let head = handle.get(&key)?;
-        let parent_hashes = head
+        let raw_heads = head
             .as_ref()
             .map(|h| h.dag_heads.clone())
             .unwrap_or_default();
+        let parent_hashes = dedup_preserving_order(raw_heads);
+        if let Some(h) = head.as_ref() {
+            if h.dag_heads.len() != parent_hashes.len() {
+                tracing::warn!(
+                    namespace_id = %hex::encode(self.namespace_id),
+                    stored = h.dag_heads.len(),
+                    deduped = parent_hashes.len(),
+                    "namespace governance DAG head set contained duplicates; \
+                     de-duplicated on read (#2327)"
+                );
+            }
+        }
         let next_nonce = head.as_ref().map_or(1, |h| h.sequence.saturating_add(1));
         Ok(NamespaceHead {
             parent_hashes,
@@ -66,13 +86,35 @@ impl<'a> NamespaceDagService<'a> {
         drop(handle);
 
         let parent_set: HashSet<[u8; 32]> = parent_ids.iter().copied().collect();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
         let mut new_heads: Vec<[u8; 32]> = current
             .map(|h| h.dag_heads)
             .unwrap_or_default()
             .into_iter()
+            // drop heads this op supersedes (they're its parents) ...
             .filter(|h| !parent_set.contains(h))
+            // ... and never carry a duplicate forward: a stored head set must
+            // be unique, otherwise `compute_governance_position` refuses to
+            // embed a position and every peer rejects the node's deltas
+            // ("author is not a member of the group at governance cut") — see
+            // issue #2327.
+            .filter(|h| seen.insert(*h))
             .collect();
-        new_heads.push(delta_id);
+        // `delta_id` may already be a head when this exact op is applied more
+        // than once (e.g. a node re-receives, via sync backfill, an op it had
+        // already applied or published locally — the in-memory DagStore's
+        // dedup set doesn't cover the publisher path). Re-applying it must be
+        // a no-op for the head set, not a second entry.
+        if seen.insert(delta_id) {
+            new_heads.push(delta_id);
+        }
+        debug_assert!(
+            {
+                let mut s = HashSet::with_capacity(new_heads.len());
+                new_heads.iter().all(|h| s.insert(*h))
+            },
+            "advance_dag_head produced a head set with duplicate entries"
+        );
 
         let mut wh = self.store.handle();
         wh.put(
@@ -97,4 +139,10 @@ impl<'a> NamespaceDagService<'a> {
         let op_log = NamespaceOpLogService::new(self.store, self.namespace_id);
         op_log.collect_opaque_skeleton_delta_ids_for_group(group_id)
     }
+}
+
+/// Drop repeated entries, keeping the first occurrence and the original order.
+fn dedup_preserving_order(heads: Vec<[u8; 32]>) -> Vec<[u8; 32]> {
+    let mut seen: HashSet<[u8; 32]> = HashSet::with_capacity(heads.len());
+    heads.into_iter().filter(|h| seen.insert(*h)).collect()
 }

--- a/crates/context/src/group_store/namespace_dag.rs
+++ b/crates/context/src/group_store/namespace_dag.rs
@@ -74,6 +74,14 @@ impl<'a> NamespaceDagService<'a> {
         Ok(self.read_head_record()?.into_tuple())
     }
 
+    /// Advance the namespace DAG head: drop the heads this op supersedes (its
+    /// parents) and add `delta_id`.
+    ///
+    /// This is a read-modify-write on the single `NamespaceGovHead` key; it is
+    /// safe because namespace governance op application is serialized at the
+    /// call site (the `ContextManager` actor handler holds the per-namespace
+    /// `DagStore` lock — see `Handler<ApplySignedNamespaceOpRequest>`), so
+    /// there is no concurrent writer to lose an update to.
     pub fn advance_dag_head(
         &self,
         delta_id: [u8; 32],
@@ -86,26 +94,26 @@ impl<'a> NamespaceDagService<'a> {
         drop(handle);
 
         let parent_set: HashSet<[u8; 32]> = parent_ids.iter().copied().collect();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        let mut new_heads: Vec<[u8; 32]> = current
-            .map(|h| h.dag_heads)
-            .unwrap_or_default()
-            .into_iter()
-            // drop heads this op supersedes (they're its parents) ...
-            .filter(|h| !parent_set.contains(h))
-            // ... and never carry a duplicate forward: a stored head set must
-            // be unique, otherwise `compute_governance_position` refuses to
-            // embed a position and every peer rejects the node's deltas
-            // ("author is not a member of the group at governance cut") — see
-            // issue #2327.
-            .filter(|h| seen.insert(*h))
-            .collect();
+        // Drop the heads this op supersedes (its parents) and collapse any
+        // pre-existing duplicates: a stored head set must be unique, otherwise
+        // `compute_governance_position` refuses to embed a position and every
+        // peer rejects the node's deltas ("author is not a member of the group
+        // at governance cut") — see issue #2327. (Collapsing here also heals a
+        // store corrupted by an older build on its next governance op.)
+        let mut new_heads = dedup_preserving_order(
+            current
+                .map(|h| h.dag_heads)
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|h| !parent_set.contains(h))
+                .collect(),
+        );
         // `delta_id` may already be a head when this exact op is applied more
         // than once (e.g. a node re-receives, via sync backfill, an op it had
         // already applied or published locally — the in-memory DagStore's
         // dedup set doesn't cover the publisher path). Re-applying it must be
         // a no-op for the head set, not a second entry.
-        if seen.insert(delta_id) {
+        if !new_heads.contains(&delta_id) {
             new_heads.push(delta_id);
         }
         debug_assert!(

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -324,16 +324,18 @@ impl<'a> NamespaceGovernance<'a> {
             }
         }
 
-        // Ordering: advance the head first, then write the op to the log. The
-        // store gives us no transaction across the two, so on a crash in
-        // between, retry sees `contains_op == false` and re-applies — which
-        // re-runs the (replay-safe) side effects above and calls
-        // `advance_dag_head` again, where the dedup makes the second add a
-        // no-op. The reverse order (log then advance) would instead leave the
-        // op logged but the head un-advanced, and the idempotency guard would
-        // then *skip* the retry, permanently dropping `delta_id` from the head
-        // set — strictly worse. A truly atomic update would need a
-        // single-batch write spanning both keys.
+        // Ordering: advance the head first, then write the op to the log —
+        // `publish_post_gate` uses the same order. The store gives us no
+        // transaction across the two keys, so this ordering is the one that
+        // keeps the idempotency guard's invariant ("op in the log ⟹ its head
+        // advance already ran"): a crash between the two writes leaves the op
+        // *not* in the log, so a retry sees `contains_op == false` and
+        // re-applies — re-running the (replay-safe) side effects above and
+        // calling `advance_dag_head` again, where the dedup makes the second
+        // add a no-op. The reverse order would leave the op logged but the
+        // head un-advanced, and a later re-receive would hit the guard, skip
+        // the apply, and never advance the head for it. A truly atomic update
+        // would need a single-batch write spanning both keys.
         let head = self.read_head_record()?;
         self.advance_dag_head(delta_id, &op.parent_op_hashes, head.next_nonce)?;
         self.store_operation(op)?;
@@ -517,8 +519,15 @@ impl<'a> NamespaceGovernance<'a> {
             .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
         let parent_ids = signed.parent_op_hashes.clone();
 
-        self.store_operation(&signed)?;
+        // Advance the head first, then write the op to the log — same order as
+        // `apply_signed_op`. This keeps the invariant the idempotency guard in
+        // `apply_signed_op` relies on: "op in the local op-log ⟹ its head
+        // advance already ran". If these were reversed, a crash in between
+        // would leave the op logged but the head un-advanced, and a later
+        // re-receive of that op would hit the guard, skip the apply, and never
+        // advance the head for it — orphaning it from the DAG head lineage.
         self.advance_dag_head(delta_id, &parent_ids, head.next_nonce)?;
+        self.store_operation(&signed)?;
 
         // Same signal as in `sign_apply_and_publish` above — the local DAG
         // just advanced on the publisher path, so the readiness FSM needs

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -22,6 +22,7 @@ use super::{
     load_current_group_key_record, load_group_key_by_id, load_group_meta,
     namespace_dag::{NamespaceDagService, NamespaceHead},
     namespace_membership::NamespaceMembershipService,
+    namespace_op_log::NamespaceOpLogService,
     namespace_retry::NamespaceRetryService,
     save_group_meta, set_local_gov_nonce, store_group_key, unwrap_group_key, PermissionChecker,
 };
@@ -110,6 +111,28 @@ impl<'a> NamespaceGovernance<'a> {
     pub fn apply_signed_op(&self, op: &SignedNamespaceOp) -> EyreResult<ApplyNamespaceOpResult> {
         op.verify_signature()
             .map_err(|e| eyre::eyre!("signed namespace op: {e}"))?;
+
+        let delta_id = op
+            .content_hash()
+            .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
+
+        // Idempotency guard. If this exact op is already in our local op-log
+        // it has already been applied — `advance_dag_head` ran for it and any
+        // side effects fired. A re-receive (typically a node's *own* published
+        // op coming back via sync backfill — the in-memory `DagStore` dedup
+        // set never saw the publisher path, so it can't filter it) must be a
+        // no-op: re-running `advance_dag_head` here would append `delta_id` to
+        // the head set a second time, and a head set with duplicates makes
+        // `compute_governance_position` refuse to embed a position, so every
+        // peer then rejects all of this node's state deltas (#2327).
+        if NamespaceOpLogService::new(self.store, self.namespace_id).contains_op(delta_id)? {
+            tracing::debug!(
+                namespace_id = %hex::encode(self.namespace_id),
+                delta_id = %hex::encode(delta_id),
+                "namespace governance op already applied; skipping re-apply (#2327)"
+            );
+            return Ok(ApplyNamespaceOpResult::default());
+        }
 
         let mut result = ApplyNamespaceOpResult::default();
 
@@ -291,9 +314,6 @@ impl<'a> NamespaceGovernance<'a> {
             }
         }
 
-        let delta_id = op
-            .content_hash()
-            .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
         let head = self.read_head_record()?;
         self.advance_dag_head(delta_id, &op.parent_op_hashes, head.next_nonce)?;
         self.store_operation(op)?;

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -117,14 +117,24 @@ impl<'a> NamespaceGovernance<'a> {
             .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
 
         // Idempotency guard. If this exact op is already in our local op-log
-        // it has already been applied — `advance_dag_head` ran for it and any
-        // side effects fired. A re-receive (typically a node's *own* published
-        // op coming back via sync backfill — the in-memory `DagStore` dedup
-        // set never saw the publisher path, so it can't filter it) must be a
-        // no-op: re-running `advance_dag_head` here would append `delta_id` to
-        // the head set a second time, and a head set with duplicates makes
+        // it has already been applied — `advance_dag_head` ran for it (see the
+        // store/advance ordering note below) and any side effects fired. A
+        // re-receive (typically a node's *own* published op coming back via
+        // sync backfill — the in-memory `DagStore` dedup set never saw the
+        // publisher path, so it can't filter it) must be a no-op: re-running
+        // `advance_dag_head` here would append `delta_id` to the head set a
+        // second time, and a head set with duplicates makes
         // `compute_governance_position` refuse to embed a position, so every
         // peer then rejects all of this node's state deltas (#2327).
+        //
+        // The guard suppresses *all* of the apply work below — the per-op-kind
+        // side effects in the match arms included. Re-running them would either
+        // be redundant (they're written replay-safe) or actively wrong (a
+        // second `PendingKeyDelivery`); a maintainer adding a new side effect
+        // should keep it replay-safe rather than rely on this guard never
+        // firing. The encrypted-op *retry* path is unaffected: it re-applies
+        // via `decrypt_and_apply_group_op` → `apply_group_op_inner`, not
+        // `apply_signed_op`, and is bounded by the per-signer nonce check there.
         if NamespaceOpLogService::new(self.store, self.namespace_id).contains_op(delta_id)? {
             tracing::debug!(
                 namespace_id = %hex::encode(self.namespace_id),
@@ -314,6 +324,16 @@ impl<'a> NamespaceGovernance<'a> {
             }
         }
 
+        // Ordering: advance the head first, then write the op to the log. The
+        // store gives us no transaction across the two, so on a crash in
+        // between, retry sees `contains_op == false` and re-applies — which
+        // re-runs the (replay-safe) side effects above and calls
+        // `advance_dag_head` again, where the dedup makes the second add a
+        // no-op. The reverse order (log then advance) would instead leave the
+        // op logged but the head un-advanced, and the idempotency guard would
+        // then *skip* the retry, permanently dropping `delta_id` from the head
+        // set — strictly worse. A truly atomic update would need a
+        // single-batch write spanning both keys.
         let head = self.read_head_record()?;
         self.advance_dag_head(delta_id, &op.parent_op_hashes, head.next_nonce)?;
         self.store_operation(op)?;

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -588,6 +588,82 @@ fn namespace_dag_service_advance_dag_head_prunes_parent_hashes() {
     assert_eq!(head.next_nonce, 4);
 }
 
+/// Re-applying the same op (e.g. a node's own published op coming back via
+/// sync backfill, which the in-memory `DagStore` dedup set doesn't cover)
+/// must not append `delta_id` to the head set a second time — a head set
+/// with duplicates makes `compute_governance_position` refuse to embed a
+/// position and every peer then rejects the node's deltas (#2327).
+#[test]
+fn namespace_dag_service_advance_dag_head_is_idempotent_for_same_delta() {
+    let store = test_store();
+    let namespace_id = [0x77; 32];
+    let dag = NamespaceDagService::new(&store, namespace_id);
+
+    let delta_a = [0xA1; 32];
+    let delta_b = [0xB2; 32];
+
+    dag.advance_dag_head(delta_a, &[], 1).unwrap();
+    dag.advance_dag_head(delta_b, &[], 2).unwrap();
+    // Same op replayed — parents are unchanged, so it doesn't supersede any
+    // existing head; it must still not duplicate itself.
+    dag.advance_dag_head(delta_b, &[], 2).unwrap();
+    dag.advance_dag_head(delta_b, &[], 2).unwrap();
+
+    let raw = raw_namespace_dag_heads(&store, namespace_id);
+    assert_eq!(
+        raw,
+        vec![delta_a, delta_b],
+        "head set must stay duplicate-free"
+    );
+}
+
+/// A head set that is *already* corrupted with duplicates (older build, or a
+/// not-yet-found path) must self-heal: the next `advance_dag_head` collapses
+/// the duplicates, and `read_head_record` de-dups defensively on read.
+#[test]
+fn namespace_dag_service_heals_pre_existing_duplicate_heads() {
+    let store = test_store();
+    let namespace_id = [0x78; 32];
+
+    let delta_a = [0xA1; 32];
+    let delta_b = [0xB2; 32];
+    let delta_c = [0xC3; 32];
+
+    // Plant a corrupted head set directly.
+    let mut handle = store.handle();
+    handle
+        .put(
+            &calimero_store::key::NamespaceGovHead::new(namespace_id),
+            &calimero_store::key::NamespaceGovHeadValue {
+                sequence: 5,
+                dag_heads: vec![delta_a, delta_b, delta_a, delta_b],
+            },
+        )
+        .unwrap();
+    drop(handle);
+
+    // Read de-dups on the fly (preserving first-seen order).
+    let dag = NamespaceDagService::new(&store, namespace_id);
+    let head = dag.read_head_record().unwrap();
+    assert_eq!(head.parent_hashes, vec![delta_a, delta_b]);
+    assert_eq!(head.next_nonce, 6);
+
+    // The next governance op heals the persisted value too: it supersedes
+    // `delta_b` (a parent) and appends `delta_c` exactly once.
+    dag.advance_dag_head(delta_c, &[delta_b], 6).unwrap();
+    let raw = raw_namespace_dag_heads(&store, namespace_id);
+    assert_eq!(raw, vec![delta_a, delta_c]);
+}
+
+fn raw_namespace_dag_heads(store: &Store, namespace_id: [u8; 32]) -> Vec<[u8; 32]> {
+    store
+        .handle()
+        .get(&calimero_store::key::NamespaceGovHead::new(namespace_id))
+        .unwrap()
+        .map(|h| h.dag_heads)
+        .unwrap_or_default()
+}
+
 #[test]
 fn namespace_dag_service_collects_skeleton_delta_ids_by_group() {
     use calimero_context_client::local_governance::{OpaqueSkeleton, StoredNamespaceEntry};
@@ -3680,6 +3756,66 @@ fn governance_group_reparented_via_signed_op() {
     assert!(
         new_children.contains(&leaf_gid),
         "leaf attached to new_parent"
+    );
+}
+
+/// Re-applying an already-applied `SignedNamespaceOp` is a no-op: the
+/// op-log already has it, so `apply_signed_op` short-circuits and doesn't
+/// re-run side effects or re-append `delta_id` to the namespace DAG head
+/// set. Regression for #2327 (duplicate heads → empty `GovernancePosition`
+/// → peers reject all of the node's deltas).
+#[test]
+fn governance_apply_signed_op_is_idempotent_on_replay() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+    let admin_sk_bytes: [u8; 32] = rand::Rng::gen(&mut rng);
+    let admin_sk = PrivateKey::from(admin_sk_bytes);
+    let admin_pk = admin_sk.public_key();
+
+    let ns_id = [0xC0u8; 32];
+    let ns_gid = ContextGroupId::from(ns_id);
+
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    store_namespace_identity(&store, &ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
+
+    let gov = NamespaceGovernance::new(&store, ns_id);
+
+    let op = SignedNamespaceOp::sign(
+        &admin_sk,
+        ns_id,
+        vec![],
+        [0u8; 32],
+        1,
+        NamespaceOp::Root(RootOp::GroupCreated {
+            group_id: [0xC1; 32],
+            parent_id: ns_id,
+        }),
+    )
+    .expect("sign create op");
+    let delta_id = op.content_hash().expect("content_hash");
+
+    gov.apply_signed_op(&op).expect("first apply");
+    assert_eq!(
+        raw_namespace_dag_heads(&store, ns_id),
+        vec![delta_id],
+        "head set after first apply"
+    );
+
+    // Replay the exact same op — should be a no-op, not a duplicate head.
+    let replay = gov.apply_signed_op(&op).expect("replay apply");
+    assert!(replay.pending_deliveries.is_empty());
+    assert!(replay.key_unwrap_failures.is_empty());
+    assert_eq!(
+        raw_namespace_dag_heads(&store, ns_id),
+        vec![delta_id],
+        "head set must stay duplicate-free after replay"
     );
 }
 

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1370,27 +1370,37 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
     .expect("sign MemberJoined");
     let op_hash = ns_op.content_hash().expect("content_hash");
 
+    // The bug is in one store's head-set bookkeeping, so a single store that
+    // re-applies its own op is the full repro (a two-node variant — A publishes,
+    // B receives via gossip, A receives back via sync — adds nothing here).
+    // Check after *every* apply so a defect that only surfaces on the Nth
+    // replay (e.g. a counter-based dedup that tolerates one duplicate) is
+    // still caught, not just the final state.
+    let read_state = |label: &str| {
+        let (heads, _next_nonce) = NamespaceDagService::new(&store, ns_id)
+            .read_head()
+            .expect("read namespace dag head");
+        assert_eq!(
+            heads,
+            vec![op_hash],
+            "namespace DAG head set must stay duplicate-free ({label})"
+        );
+        // A node at this cut can embed a non-empty GovernancePosition — i.e.
+        // `governance_dag_heads_len == 1`, so peers accept its state deltas.
+        let state_hash = compute_group_state_hash(&store, &gid).expect("compute_group_state_hash");
+        let position = GovernancePosition::new(gid, state_hash, heads)
+            .unwrap_or_else(|e| panic!("GovernancePosition must be embeddable ({label}): {e}"));
+        assert_eq!(position.governance_dag_heads, vec![op_hash]);
+    };
+
     // 1) "Publish locally": apply the op once.
     group_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
-    // 2) "Re-receive via sync backfill": the same op arrives again.
+    read_state("after publish");
+    // 2) "Re-receive via sync backfill": the same op arrives again, twice.
     group_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
+    read_state("after 1st re-receive");
     group_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
+    read_state("after 2nd re-receive");
 
-    // The namespace DAG head set must contain the op exactly once.
-    let (heads, _next_nonce) = NamespaceDagService::new(&store, ns_id)
-        .read_head()
-        .expect("read namespace dag head");
-    assert_eq!(
-        heads,
-        vec![op_hash],
-        "namespace DAG head set must stay duplicate-free across re-applies"
-    );
-
-    // And a node at this cut can embed a non-empty GovernancePosition — i.e.
-    // `governance_dag_heads_len == 1`, so peers will accept its state deltas.
-    let state_hash = compute_group_state_hash(&store, &gid).expect("compute_group_state_hash");
-    let position = GovernancePosition::new(gid, state_hash, heads.clone())
-        .expect("GovernancePosition must be embeddable (non-duplicate heads)");
-    assert_eq!(position.governance_dag_heads, vec![op_hash]);
     assert!(group_store::check_group_membership(&store, &gid, &joiner_pk).unwrap());
 }

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1310,3 +1310,87 @@ fn group_member_without_keys_has_none_keys() {
     assert_eq!(value.private_key, None);
     assert_eq!(value.sender_key, None);
 }
+
+/// Regression for #2327: a node that applies a namespace governance op it
+/// already has (e.g. its own published op coming back via sync backfill —
+/// the `group_store` apply path doesn't dedup against the actor's in-memory
+/// `DagStore`) must NOT accumulate a duplicate in its namespace DAG head
+/// set. A duplicated head set makes `GovernancePosition::new` fail, so the
+/// node ships state deltas with an empty governance position and every peer
+/// rejects all of its writes ("author is not a member of the group at
+/// governance cut").
+#[test]
+fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
+    use calimero_context::group_store::NamespaceDagService;
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_context_config::types::GovernancePosition;
+
+    let mut rng = OsRng;
+    let gid = sample_group_id();
+    let ns_id = gid.to_bytes();
+
+    let store = empty_store();
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    let joiner_sk = PrivateKey::random(&mut rng);
+    let joiner_pk = joiner_sk.public_key();
+
+    save_group_meta(&store, &gid, &sample_meta(admin_pk)).unwrap();
+    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    // A real MemberJoined op (signer = joiner, with an admin-signed invitation),
+    // matching the `two_nodes_converge_on_namespace_member_joined` setup.
+    let invitation = GroupInvitationFromAdmin {
+        inviter_identity: SignerId::from(*admin_pk.digest()),
+        group_id: gid,
+        expiration_timestamp: 9_999_999_999,
+        secret_salt: [0x42; 32],
+        invited_role: 1,
+    };
+    let inv_bytes = borsh::to_vec(&invitation).expect("borsh invitation");
+    let inv_hash = Sha256::digest(&inv_bytes);
+    let inv_sig = admin_sk.sign(&inv_hash).expect("sign invitation");
+    let signed_invitation = SignedGroupOpenInvitation {
+        invitation,
+        inviter_signature: hex::encode(inv_sig.to_bytes()),
+        application_id: None,
+    };
+
+    let ns_op = SignedNamespaceOp::sign(
+        &joiner_sk,
+        ns_id,
+        vec![],
+        [0u8; 32],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoined {
+            member: joiner_pk,
+            signed_invitation,
+        }),
+    )
+    .expect("sign MemberJoined");
+    let op_hash = ns_op.content_hash().expect("content_hash");
+
+    // 1) "Publish locally": apply the op once.
+    group_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
+    // 2) "Re-receive via sync backfill": the same op arrives again.
+    group_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
+    group_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
+
+    // The namespace DAG head set must contain the op exactly once.
+    let (heads, _next_nonce) = NamespaceDagService::new(&store, ns_id)
+        .read_head()
+        .expect("read namespace dag head");
+    assert_eq!(
+        heads,
+        vec![op_hash],
+        "namespace DAG head set must stay duplicate-free across re-applies"
+    );
+
+    // And a node at this cut can embed a non-empty GovernancePosition — i.e.
+    // `governance_dag_heads_len == 1`, so peers will accept its state deltas.
+    let state_hash = compute_group_state_hash(&store, &gid).expect("compute_group_state_hash");
+    let position = GovernancePosition::new(gid, state_hash, heads.clone())
+        .expect("GovernancePosition must be embeddable (non-duplicate heads)");
+    assert_eq!(position.governance_dag_heads, vec![op_hash]);
+    assert!(group_store::check_group_membership(&store, &gid, &joiner_pk).unwrap());
+}


### PR DESCRIPTION
## Summary

Fixes #2327. A node could accumulate **duplicate entries in its local namespace governance DAG head set**; `compute_governance_position` then refuses to embed a `GovernancePosition`, so the node ships state deltas with an empty position and **every peer rejects all of that node's writes** ("author is not a member of the group at governance cut"). The node looks healthy locally but is a cluster-wide write black hole — directly causes `cross_node_*` fuzzy-test failures while single-node ops stay 100%.

## Root cause

`NamespaceDagService::advance_dag_head` (`crates/context/src/group_store/namespace_dag.rs`) drops the new op's parents from the head set and then **unconditionally `push(delta_id)`** — without checking whether `delta_id` is already a head. So when a node re-applies an op it already has — typically its **own published op coming back via sync backfill**; the in-memory `DagStore` dedup set only covers the receive path, not the publisher path — the head set grows `[…, X, X]`. (`#2298` added the `GovernancePosition` machinery; this is a latent bookkeeping bug in it. Observed on node-4 in fuzzy run `25663237150`, where a wedged sync session made backfills like this more likely.)

## Changes (all in `crates/context/`)

1. **`advance_dag_head`** — drop superseded parents, never carry a duplicate forward, and append `delta_id` only if it isn't already present. `debug_assert!` the result is unique. *(The construction-site fix issue #2327 asked for.)*
2. **`apply_signed_op`** — idempotency guard: if the op is already in the local op-log it has already been applied (`advance_dag_head` ran, side effects fired), so short-circuit and return an empty result. *(The root-cause fix — this is the path that produced the duplicate. Does not affect the encrypted-op retry path, which goes through `decrypt_and_apply_group_op`, not `apply_signed_op`.)*
3. **`read_head_record`** — de-dup defensively on read, with a `warn!` so it's observable. A store already corrupted by an older build self-heals on its next governance op, and `GovernancePosition` construction never sees duplicates.
4. **Tests** — `advance_dag_head` idempotent on replay; a pre-existing duplicate head set heals (on read + on the next op); `apply_signed_op` is a no-op on replay.

The receiver-side rejection of duplicate `governance_dag_heads` on the wire (in `crates/context/config/src/types.rs`) is intentionally left in place — that's correct defense against a malicious sender; this PR fixes the *producer/storage* side so a well-behaved node never builds such a set.

## Verification

- `cargo build -p calimero-context -p calimero-node` — clean
- `cargo test -p calimero-context` — 246 pass
- `cargo fmt --check`, `cargo clippy --all-targets` — clean on touched code

## Note on CI

The fuzzy load test is `master`-only (`workflow_run`), so this change won't get fuzzy coverage pre-merge. Happy to temporarily widen the fuzzy `pull_request.paths` to `crates/context/**` for this PR if reviewers want that, or validate post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace governance apply/persistence ordering and DAG head bookkeeping; mistakes could orphan ops or affect cross-node convergence, but changes are localized and covered by new regression tests.
> 
> **Overview**
> Prevents nodes from persisting or emitting **duplicate namespace governance DAG heads** (root cause of empty `GovernancePosition` and cluster-wide write rejection, #2327).
> 
> `NamespaceDagService` now de-dups stored heads on read (with a `warn!`) and makes `advance_dag_head` idempotent by collapsing duplicates and only appending `delta_id` if absent. `NamespaceGovernance::apply_signed_op` adds an op-log existence guard to skip re-applying already-stored ops, and both apply/publish paths enforce **advance-head-then-store-op** ordering to preserve that invariant.
> 
> Adds regression tests covering replay idempotency, self-healing of pre-corrupted head sets, and an end-to-end replay scenario ensuring the head set stays clean and `GovernancePosition` remains embeddable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c0dc1735401f058248a52fc0dfebb77e842e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->