### PR TITLE
feat(context): signed cut + canonical state hashes on MemberRemoved /…

### DIFF
--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -113,7 +113,11 @@ pub enum GroupOp {
     /// Carries the same three convergence claims as `MemberRemoved`,
     /// signed by the leaver. The leaver is honest by definition for
     /// self-leave; a Byzantine leaver claiming false canonical hashes
-    /// is caught by other peers' hash verification on apply.
+    /// triggers a divergence warning on apply at each receiver but the
+    /// op is **not rejected** — the apply path logs the mismatch and
+    /// moves on, leaving the canonical view to be re-established by an
+    /// admin-signed `MemberRemoved` or anchor-sync reconcile. The
+    /// signed hashes are a detection signal, not an adoption gate.
     MemberLeft {
         member: PublicKey,
         cut: GovernancePosition,

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -94,6 +94,15 @@ pub enum GroupOp {
     /// Apply-time mismatch is logged as a structured warning but does
     /// not roll back the apply; the canonical view is the admin's, and
     /// reconciliation against an anchor is the recovery path.
+    ///
+    /// **Two different group-state hashes travel in this op, by
+    /// design:** `cut.group_state_hash` is the **pre-apply** snapshot
+    /// (the state the signer signed against — used by receivers as
+    /// the descend-from boundary for the membership walk), while
+    /// `expected_group_state_hash` is the **post-apply** simulation
+    /// (used by receivers as the convergence target after they apply
+    /// the op). They have different values, different roles, and
+    /// different consumers; do not collapse them.
     MemberRemoved {
         member: PublicKey,
         cut: GovernancePosition,

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -12,7 +12,7 @@
 //! group-scoped ops they cannot decrypt.
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_context_config::types::SignedGroupOpenInvitation;
+use calimero_context_config::types::{GovernancePosition, SignedGroupOpenInvitation};
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -31,6 +31,12 @@ pub use ack_router::AckRouter;
 
 /// Wire/schema version for [`SignedGroupOp`].
 ///
+/// v4: `MemberRemoved` and `MemberLeft` now carry the signed governance-DAG
+/// cut, the expected post-apply group state hash, and the expected
+/// post-apply per-context CRDT state hashes. Receivers detect divergence by
+/// comparing their computed hashes against the signed values after apply.
+/// Pre-1.0 wire change; old-shape ops are rejected outright.
+///
 /// v3: Added `state_hash: [u8; 32]` — each op commits to the group's
 /// authorization-relevant state at signing time. On apply, a non-zero
 /// state hash is verified against the current state to reject stale ops.
@@ -40,7 +46,7 @@ pub use ack_router::AckRouter;
 ///
 /// v1 was internal to feature branch development and never deployed to any
 /// persistent network. No backward-compatible deserialization is needed.
-pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 3;
+pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 4;
 
 /// Domain separation prefix for Ed25519 signatures over group ops.
 pub const GROUP_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.group.v1";
@@ -60,7 +66,40 @@ pub enum GroupOp {
         role: GroupMemberRole,
     },
     /// Remove a member.
-    MemberRemoved { member: PublicKey },
+    ///
+    /// Carries three signed claims for cross-DAG convergence:
+    ///
+    /// - `cut`: the namespace governance-DAG position the admin signed
+    ///   against. Receivers use this — not their own local heads — as
+    ///   the descend-from boundary for the apply-time cross-DAG
+    ///   membership check. Two peers at different governance positions
+    ///   evaluate the same answer for any in-flight delta from the
+    ///   removed member.
+    ///
+    /// - `expected_group_state_hash`: governance state hash
+    ///   (`compute_group_state_hash`) AFTER the admin's local apply.
+    ///   Receivers compute their own post-apply hash and compare;
+    ///   mismatch signals divergence in membership rows / capabilities
+    ///   / meta. Computed by simulating the removal pre-apply (pure
+    ///   function of current members minus the removed identity).
+    ///
+    /// - `expected_context_state_hashes`: per-context CRDT root hash at
+    ///   sign time, one entry per context registered under `group_id`,
+    ///   sorted by `context_id` for deterministic op-content hashing.
+    ///   Catches the case where a receiver applied legitimate
+    ///   pre-removal state-DAG deltas from the now-removed member that
+    ///   never reached the admin — the receiver's post-apply context
+    ///   hash differs, divergence is detectable, anchor-sync reconcile fires.
+    ///
+    /// Apply-time mismatch is logged as a structured warning but does
+    /// not roll back the apply; the canonical view is the admin's, and
+    /// reconciliation against an anchor is the recovery path.
+    MemberRemoved {
+        member: PublicKey,
+        cut: GovernancePosition,
+        expected_group_state_hash: [u8; 32],
+        expected_context_state_hashes: Vec<(ContextId, [u8; 32])>,
+    },
     /// Self-leave: a member voluntarily exits the group. Distinct from
     /// `MemberRemoved` for audit clarity (this is a member choosing to
     /// leave; `MemberRemoved` is admin-initiated). Apply requires
@@ -70,7 +109,17 @@ pub enum GroupOp {
     /// (planned as a follow-up). For full cryptographic leave today,
     /// pair with admin-initiated `MemberRemoved`.
     /// See `architecture/membership-and-leave.html` § 5.
-    MemberLeft { member: PublicKey },
+    ///
+    /// Carries the same three convergence claims as `MemberRemoved`,
+    /// signed by the leaver. The leaver is honest by definition for
+    /// self-leave; a Byzantine leaver claiming false canonical hashes
+    /// is caught by other peers' hash verification on apply.
+    MemberLeft {
+        member: PublicKey,
+        cut: GovernancePosition,
+        expected_group_state_hash: [u8; 32],
+        expected_context_state_hashes: Vec<(ContextId, [u8; 32])>,
+    },
     /// Set a member’s role (same as upsert member with new role).
     MemberRoleSet {
         member: PublicKey,

--- a/crates/context/src/group_store/group_governance_publisher.rs
+++ b/crates/context/src/group_store/group_governance_publisher.rs
@@ -56,11 +56,29 @@ impl<'a> GroupGovernancePublisher<'a> {
         signer_sk: &PrivateKey,
         removed_member: &PublicKey,
     ) -> EyreResult<Option<DeliveryReport>> {
+        // Sign-time hash precomputation: simulate the post-apply state
+        // before the apply runs, so the signed op carries the admin's
+        // canonical view that receivers can verify against. Apply order
+        // (compute → sign → apply locally) avoids needing transactional
+        // rollback in the local apply pipeline — the hashes are pure
+        // functions of pre-apply state and a deterministic op effect.
+        let cut = super::build_governance_cut(self.store, &self.group_id)?;
+        let expected_group_state_hash = super::compute_group_state_hash_after_remove(
+            self.store,
+            &self.group_id,
+            removed_member,
+        )?;
+        let expected_context_state_hashes =
+            super::snapshot_context_state_hashes(self.store, &self.group_id)?;
+
         self.sign_apply_and_publish_inner(
             ack_router,
             signer_sk,
             GroupOp::MemberRemoved {
                 member: *removed_member,
+                cut,
+                expected_group_state_hash,
+                expected_context_state_hashes,
             },
             Some(removed_member),
         )

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -414,10 +414,10 @@ fn prefix_walk_membership(
                         current_role = Some(role.clone());
                         last_known_role = Some(role);
                     }
-                    GroupOp::MemberRemoved { member } if member == *signer => {
+                    GroupOp::MemberRemoved { member, .. } if member == *signer => {
                         current_role = None;
                     }
-                    GroupOp::MemberLeft { member } if member == *signer => {
+                    GroupOp::MemberLeft { member, .. } if member == *signer => {
                         current_role = None;
                     }
                     _ => {}

--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -102,6 +102,15 @@ fn hash_group_state(
     meta: &GroupMetaValue,
     members_sorted: &[(PublicKey, GroupMemberRole)],
 ) -> EyreResult<[u8; 32]> {
+    // Sorted-input contract enforced in dev / test, compiled out in
+    // release. Catches a caller that forgets to sort before
+    // delegating — the same shape used by `diff_sorted_context_hashes`.
+    debug_assert!(
+        members_sorted
+            .windows(2)
+            .all(|w| AsRef::<[u8]>::as_ref(&w[0].0) < AsRef::<[u8]>::as_ref(&w[1].0)),
+        "hash_group_state: members must be strictly sorted by PublicKey byte order"
+    );
     let mut hasher = Sha256::new();
     hasher.update(group_id.to_bytes());
     hasher.update(AsRef::<[u8]>::as_ref(&meta.admin_identity));
@@ -168,6 +177,18 @@ pub fn compute_group_state_hash_after_remove(
 /// joined yet) are skipped, not errored. Hashing what isn't there
 /// would put zero bytes in the snapshot and force a divergence on
 /// every receiver that has the context materialized.
+///
+/// **Asymmetric skip behavior between signer and receiver — by
+/// design.** The signer's call (at op-construction time) writes
+/// whichever contexts it has materialized into the signed claim. The
+/// receiver's call (during apply-time verification) reads its own
+/// materialized set. A context the signer had but the receiver
+/// doesn't appears as "only in expected" in the diff — and that's
+/// exactly the partition-window signal the anchor-sync reconcile
+/// path consumes to heal. On freshly-joined receivers many contexts
+/// may be unmaterialized and produce this signal in bulk; the
+/// per-context debug log in `diff_sorted_context_hashes` lets
+/// operators distinguish bootstrap catchup from real divergence.
 pub fn snapshot_context_state_hashes(
     store: &Store,
     group_id: &ContextGroupId,
@@ -192,12 +213,21 @@ pub fn snapshot_context_state_hashes(
 /// same descend-from boundary the signer signed against (not against
 /// each receiver's possibly-different local namespace heads).
 ///
-/// No double-read race window — the cut is captured once and travels
-/// in the signed op. If governance heads advance between this read
-/// and signing, the cut is slightly stale but still a valid
-/// descend-from boundary; the membership walk only requires the heads
-/// to exist in the receiver's DAG, not to be the receiver's current
-/// heads.
+/// The two store reads (DAG heads and group state hash) are NOT
+/// atomic. Callers must invoke this from a serializing context where
+/// no concurrent namespace governance op can land between the reads —
+/// in practice the `ContextManager` actor that owns all governance
+/// publishing. A reader running outside that serialization could
+/// receive a position whose `governance_dag_heads` and
+/// `group_state_hash` describe different points in time. The receiver
+/// would detect the resulting hash mismatch in
+/// `verify_post_apply_state_hashes` and trip a spurious divergence
+/// warning, but no state is adopted from the mismatch, so the worst
+/// case is operator noise.
+///
+/// Once the cut is built it travels intact in the signed op — there's
+/// no second read by receivers, so the only race is on the signer's
+/// side.
 pub fn build_governance_cut(
     store: &Store,
     group_id: &ContextGroupId,

--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -1,10 +1,15 @@
-use calimero_context_config::types::ContextGroupId;
-use calimero_store::key::{GroupMeta, GroupMetaValue, GROUP_META_PREFIX};
+use calimero_context_config::types::{ContextGroupId, GovernancePosition};
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use calimero_store::key::{ContextMeta, GroupMeta, GroupMetaValue, GROUP_META_PREFIX};
 use calimero_store::Store;
 use eyre::{eyre, Result as EyreResult};
 use sha2::{Digest, Sha256};
 
-use super::{collect_keys_with_prefix_paginated, list_group_members};
+use super::{
+    collect_keys_with_prefix_paginated, enumerate_group_contexts, list_group_members,
+    resolve_namespace, NamespaceDagService,
+};
 
 pub fn load_group_meta(
     store: &Store,
@@ -91,4 +96,109 @@ pub fn compute_group_state_hash(store: &Store, group_id: &ContextGroupId) -> Eyr
         hasher.update(&role_bytes);
     }
     Ok(hasher.finalize().into())
+}
+
+/// Return the group state hash that would result if `removed_member`
+/// were dropped from the group's member set. Pure simulation: reads
+/// the current materialized state, removes the named identity from the
+/// sorted-by-pubkey member list in-memory, and hashes — mirrors what
+/// [`compute_group_state_hash`] would compute after a `MemberRemoved`
+/// or `MemberLeft` apply.
+///
+/// Used at sign time so the admin (or leaver) can populate the
+/// `expected_group_state_hash` field on `MemberRemoved` / `MemberLeft`
+/// before the apply runs locally. Receivers compute the real hash
+/// after their own apply and compare; mismatch surfaces membership-row
+/// divergence.
+///
+/// Idempotent on a non-member input — if `removed_member` isn't in the
+/// set, the result is the same as `compute_group_state_hash` on the
+/// current state. The op apply path bails on non-members independently;
+/// this helper just computes deterministically over whatever set it
+/// finds.
+pub fn compute_group_state_hash_after_remove(
+    store: &Store,
+    group_id: &ContextGroupId,
+    removed_member: &PublicKey,
+) -> EyreResult<[u8; 32]> {
+    let meta = load_group_meta(store, group_id)?
+        .ok_or_else(|| eyre!("group not found for state hash computation"))?;
+
+    let mut members = list_group_members(store, group_id, 0, usize::MAX)?;
+    members.retain(|(pk, _role)| pk != removed_member);
+    members.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    hasher.update(group_id.to_bytes());
+    hasher.update(AsRef::<[u8]>::as_ref(&meta.admin_identity));
+    hasher.update(AsRef::<[u8]>::as_ref(&meta.owner_identity));
+    hasher.update(meta.target_application_id.as_ref());
+    for (pk, role) in &members {
+        hasher.update(AsRef::<[u8]>::as_ref(pk));
+        let role_bytes =
+            borsh::to_vec(role).map_err(|e| eyre!("role serialization failed: {e}"))?;
+        hasher.update(&role_bytes);
+    }
+    Ok(hasher.finalize().into())
+}
+
+/// Snapshot the current CRDT root hash for every context registered
+/// under `group_id`. Returned sorted by `context_id` for deterministic
+/// op-content hashing (the result lands inside a signed governance op
+/// whose content hash is the dedup key).
+///
+/// `MemberRemoved` / `MemberLeft` don't directly mutate per-context
+/// CRDT state, so this is simply the admin's view of "what these
+/// contexts look like right now" at sign time. Receivers compare
+/// against their own context roots after applying the removal; a
+/// divergent root means the receiver applied legitimate pre-removal
+/// state-DAG deltas from the now-removed member that admin's view
+/// didn't include — the partition-window case the anchor-sync
+/// reconcile path will heal.
+///
+/// Contexts whose `ContextMeta` row is missing (registered in the
+/// group index but not yet materialized — e.g. fresh node that hasn't
+/// joined yet) are skipped, not errored. Hashing what isn't there
+/// would put zero bytes in the snapshot and force a divergence on
+/// every receiver that has the context materialized.
+pub fn snapshot_context_state_hashes(
+    store: &Store,
+    group_id: &ContextGroupId,
+) -> EyreResult<Vec<(ContextId, [u8; 32])>> {
+    let context_ids = enumerate_group_contexts(store, group_id, 0, usize::MAX)?;
+    let handle = store.handle();
+    let mut entries = Vec::new();
+    for context_id in context_ids {
+        let key = ContextMeta::new(context_id);
+        if let Some(meta) = handle.get(&key)? {
+            entries.push((context_id, meta.root_hash));
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries)
+}
+
+/// Build the current cross-DAG cut for `group_id` — pre-apply group
+/// state hash bundled with the namespace governance DAG heads at this
+/// moment. Used as the `cut` field in `MemberRemoved` / `MemberLeft`
+/// ops so receivers' apply-time membership check evaluates against the
+/// same descend-from boundary the signer signed against (not against
+/// each receiver's possibly-different local namespace heads).
+///
+/// No double-read race window — the cut is captured once and travels
+/// in the signed op. If governance heads advance between this read
+/// and signing, the cut is slightly stale but still a valid
+/// descend-from boundary; the membership walk only requires the heads
+/// to exist in the receiver's DAG, not to be the receiver's current
+/// heads.
+pub fn build_governance_cut(
+    store: &Store,
+    group_id: &ContextGroupId,
+) -> EyreResult<GovernancePosition> {
+    let namespace_id = resolve_namespace(store, group_id)?;
+    let dag = NamespaceDagService::new(store, namespace_id.to_bytes());
+    let governance_dag_heads = dag.read_head_record()?.parent_hashes;
+    let group_state_hash = compute_group_state_hash(store, group_id)?;
+    GovernancePosition::new(*group_id, group_state_hash, governance_dag_heads)
+        .map_err(|e| eyre!("invalid governance position at sign time: {e}"))
 }

--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -233,13 +233,17 @@ pub fn snapshot_context_state_hashes(
 ///
 /// Defense-in-depth: this function uses a **read-twice / bail on
 /// mismatch** pattern (mirrors `compute_governance_position_for_context`
-/// at `handlers/execute/mod.rs`). Read the heads, compute the hash,
-/// re-read the heads — if the set changed we know a concurrent
-/// governance op landed and the captured position is internally
-/// inconsistent. Bail with an error rather than sign a malformed
-/// cut. A caller running outside the actor serialization gets a hard
-/// error instead of a silently-wrong position that would generate
-/// spurious divergence warnings on every honest receiver.
+/// at `handlers/execute/mod.rs`) for **both** the namespace DAG
+/// heads and the group state hash. A concurrent namespace
+/// governance op would change the heads set; a concurrent
+/// group-level op (e.g. `MemberAdded` racing this read) would
+/// change the group state hash without touching the heads. Both
+/// are detected and produce a hard error rather than a malformed
+/// cut that would generate spurious divergence warnings on every
+/// honest receiver.
+///
+/// The price is one extra hash recompute + one extra heads read per
+/// `MemberRemoved` / `MemberLeft` sign — cold path, not a hot loop.
 ///
 /// Once the cut is built it travels intact in the signed op — there's
 /// no second read by receivers, so the only race is on the signer's
@@ -251,7 +255,8 @@ pub fn build_governance_cut(
     let namespace_id = resolve_namespace(store, group_id)?;
     let dag = NamespaceDagService::new(store, namespace_id.to_bytes());
     let heads_before = dag.read_head_record()?.parent_hashes;
-    let group_state_hash = compute_group_state_hash(store, group_id)?;
+    let group_state_hash_before = compute_group_state_hash(store, group_id)?;
+    let group_state_hash_after = compute_group_state_hash(store, group_id)?;
     let heads_after = dag.read_head_record()?.parent_hashes;
     // Set-equality, not Vec-equality. Storage iteration order isn't
     // guaranteed to be stable across reads, so a Vec compare would
@@ -270,6 +275,13 @@ pub fn build_governance_cut(
             hex::encode(group_id.to_bytes())
         ));
     }
-    GovernancePosition::new(*group_id, group_state_hash, heads_before)
+    if group_state_hash_before != group_state_hash_after {
+        return Err(eyre!(
+            "build_governance_cut: group state hash changed mid-read for group {} — \
+             a concurrent group-level op landed; refusing to emit a stale-hash cut",
+            hex::encode(group_id.to_bytes())
+        ));
+    }
+    GovernancePosition::new(*group_id, group_state_hash_before, heads_before)
         .map_err(|e| eyre!("invalid governance position at sign time: {e}"))
 }

--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -1,5 +1,5 @@
 use calimero_context_config::types::{ContextGroupId, GovernancePosition};
-use calimero_primitives::context::ContextId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use calimero_store::key::{ContextMeta, GroupMeta, GroupMetaValue, GROUP_META_PREFIX};
 use calimero_store::Store;
@@ -84,12 +84,30 @@ pub fn compute_group_state_hash(store: &Store, group_id: &ContextGroupId) -> Eyr
     let mut members = list_group_members(store, group_id, 0, usize::MAX)?;
     members.sort_by(|a, b| a.0.cmp(&b.0));
 
+    hash_group_state(group_id, &meta, &members)
+}
+
+/// Single source of truth for the group state hash byte layout. Both
+/// `compute_group_state_hash` (post-apply, reads real store state) and
+/// `compute_group_state_hash_after_remove` (pre-apply simulation) feed
+/// their prepared sorted-member list here so any change to the hash
+/// format is structurally guaranteed to apply to both paths — no
+/// silent sign/verify divergence from a one-sided update.
+///
+/// **Caller contract**: `members` MUST be sorted by `PublicKey` byte
+/// ordering. The hash is order-sensitive; an unsorted slice produces a
+/// different digest for the same logical set and breaks convergence.
+fn hash_group_state(
+    group_id: &ContextGroupId,
+    meta: &GroupMetaValue,
+    members_sorted: &[(PublicKey, GroupMemberRole)],
+) -> EyreResult<[u8; 32]> {
     let mut hasher = Sha256::new();
     hasher.update(group_id.to_bytes());
     hasher.update(AsRef::<[u8]>::as_ref(&meta.admin_identity));
     hasher.update(AsRef::<[u8]>::as_ref(&meta.owner_identity));
     hasher.update(meta.target_application_id.as_ref());
-    for (pk, role) in &members {
+    for (pk, role) in members_sorted {
         hasher.update(AsRef::<[u8]>::as_ref(pk));
         let role_bytes =
             borsh::to_vec(role).map_err(|e| eyre!("role serialization failed: {e}"))?;
@@ -128,18 +146,7 @@ pub fn compute_group_state_hash_after_remove(
     members.retain(|(pk, _role)| pk != removed_member);
     members.sort_by(|a, b| a.0.cmp(&b.0));
 
-    let mut hasher = Sha256::new();
-    hasher.update(group_id.to_bytes());
-    hasher.update(AsRef::<[u8]>::as_ref(&meta.admin_identity));
-    hasher.update(AsRef::<[u8]>::as_ref(&meta.owner_identity));
-    hasher.update(meta.target_application_id.as_ref());
-    for (pk, role) in &members {
-        hasher.update(AsRef::<[u8]>::as_ref(pk));
-        let role_bytes =
-            borsh::to_vec(role).map_err(|e| eyre!("role serialization failed: {e}"))?;
-        hasher.update(&role_bytes);
-    }
-    Ok(hasher.finalize().into())
+    hash_group_state(group_id, &meta, &members)
 }
 
 /// Snapshot the current CRDT root hash for every context registered

--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -83,6 +83,14 @@ pub fn compute_group_state_hash(store: &Store, group_id: &ContextGroupId) -> Eyr
 
     let mut members = list_group_members(store, group_id, 0, usize::MAX)?;
     members.sort_by(|a, b| a.0.cmp(&b.0));
+    // Dedup-by-key against the theoretical case of duplicate
+    // `GroupMember` rows for the same public key (would only happen
+    // under store corruption — `list_group_members` is a prefix scan
+    // over uniquely-keyed rows in normal operation). Without this,
+    // `hash_group_state`'s strict-less-than `debug_assert` would fire
+    // in dev / test on duplicates and silently double-hash the same
+    // member in release. Defensive only.
+    members.dedup_by(|a, b| a.0 == b.0);
 
     hash_group_state(group_id, &meta, &members)
 }
@@ -154,6 +162,10 @@ pub fn compute_group_state_hash_after_remove(
     let mut members = list_group_members(store, group_id, 0, usize::MAX)?;
     members.retain(|(pk, _role)| pk != removed_member);
     members.sort_by(|a, b| a.0.cmp(&b.0));
+    // Same dedup-against-corrupt-store defense as
+    // `compute_group_state_hash`. Both helpers must stay in lockstep
+    // — they hash the same logical input set.
+    members.dedup_by(|a, b| a.0 == b.0);
 
     hash_group_state(group_id, &meta, &members)
 }
@@ -217,25 +229,47 @@ pub fn snapshot_context_state_hashes(
 /// atomic. Callers must invoke this from a serializing context where
 /// no concurrent namespace governance op can land between the reads —
 /// in practice the `ContextManager` actor that owns all governance
-/// publishing. A reader running outside that serialization could
-/// receive a position whose `governance_dag_heads` and
-/// `group_state_hash` describe different points in time. The receiver
-/// would detect the resulting hash mismatch in
-/// `verify_post_apply_state_hashes` and trip a spurious divergence
-/// warning, but no state is adopted from the mismatch, so the worst
-/// case is operator noise.
+/// publishing.
+///
+/// Defense-in-depth: this function uses a **read-twice / bail on
+/// mismatch** pattern (mirrors `compute_governance_position_for_context`
+/// at `handlers/execute/mod.rs`). Read the heads, compute the hash,
+/// re-read the heads — if the set changed we know a concurrent
+/// governance op landed and the captured position is internally
+/// inconsistent. Bail with an error rather than sign a malformed
+/// cut. A caller running outside the actor serialization gets a hard
+/// error instead of a silently-wrong position that would generate
+/// spurious divergence warnings on every honest receiver.
 ///
 /// Once the cut is built it travels intact in the signed op — there's
 /// no second read by receivers, so the only race is on the signer's
-/// side.
+/// side and is now caught here.
 pub fn build_governance_cut(
     store: &Store,
     group_id: &ContextGroupId,
 ) -> EyreResult<GovernancePosition> {
     let namespace_id = resolve_namespace(store, group_id)?;
     let dag = NamespaceDagService::new(store, namespace_id.to_bytes());
-    let governance_dag_heads = dag.read_head_record()?.parent_hashes;
+    let heads_before = dag.read_head_record()?.parent_hashes;
     let group_state_hash = compute_group_state_hash(store, group_id)?;
-    GovernancePosition::new(*group_id, group_state_hash, governance_dag_heads)
+    let heads_after = dag.read_head_record()?.parent_hashes;
+    // Set-equality, not Vec-equality. Storage iteration order isn't
+    // guaranteed to be stable across reads, so a Vec compare would
+    // false-positive on every reorder. A concurrent op landing
+    // changes the SET of heads, which is what we want to catch.
+    let heads_changed = {
+        use std::collections::HashSet;
+        heads_before.len() != heads_after.len()
+            || heads_before.iter().collect::<HashSet<_>>()
+                != heads_after.iter().collect::<HashSet<_>>()
+    };
+    if heads_changed {
+        return Err(eyre!(
+            "build_governance_cut: namespace DAG heads changed mid-read for group {} — \
+             refusing to emit an internally-inconsistent cut",
+            hex::encode(group_id.to_bytes())
+        ));
+    }
+    GovernancePosition::new(*group_id, group_state_hash, heads_before)
         .map_err(|e| eyre!("invalid governance position at sign time: {e}"))
 }

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -802,12 +802,23 @@ const MAX_DAG_HEADS: usize = 64;
 ///    are checked independently: an all-zero `expected_group_state_hash`
 ///    skips only the group-state comparison, an empty
 ///    `expected_context_state_hashes` skips only the per-context
-///    comparison. **Groups with zero registered contexts correctly
-///    trigger only the group-state check** — empty actual + empty
-///    expected match, no per-context divergence is reported, and the
-///    group-state half is what catches membership-row drift. Once the
-///    network has fully rolled forward to signed-claim ops these
-///    sentinels become dead and can be removed.
+///    comparison.
+///
+///    **Ambiguity acknowledged:** an empty list is "no claim" from a
+///    legacy sender AND "no contexts to claim" from a current
+///    sender on a context-less group. The two cases are
+///    indistinguishable on the wire, so the per-context check is
+///    skipped in both. This is acceptable because a context-less
+///    group has nothing per-context to compare anyway — the empty
+///    actual would match the empty expected. The group-state half
+///    still runs and catches any membership-row drift, which is the
+///    interesting failure mode for context-less groups. Wrapping the
+///    field in `Option<Vec<...>>` to disambiguate would be a
+///    wire-format churn for no behavioral gain.
+///
+///    Once the network has fully rolled forward to signed-claim ops
+///    the zero sentinel becomes dead and can be removed; the
+///    empty-list "no contexts" case stays valid forever.
 fn verify_post_apply_state_hashes(
     store: &Store,
     group_id: &ContextGroupId,
@@ -821,9 +832,13 @@ fn verify_post_apply_state_hashes(
         return;
     }
 
-    let (group_hash_diverges, actual_group_state_hash) = if check_group_hash {
+    // Group-state half. `None` here means the check was either
+    // skipped (no claim) or the recompute itself errored — in both
+    // cases we suppress the hash fields from the divergence warn so
+    // an operator doesn't see misleading `0000…` values.
+    let group_outcome: Option<(bool, [u8; 32])> = if check_group_hash {
         match compute_group_state_hash(store, group_id) {
-            Ok(actual) => (actual != *expected_group_state_hash, actual),
+            Ok(actual) => Some((actual != *expected_group_state_hash, actual)),
             Err(err) => {
                 tracing::warn!(
                     group_id = %hex::encode(group_id.to_bytes()),
@@ -831,50 +846,95 @@ fn verify_post_apply_state_hashes(
                     %err,
                     "post-apply group-state hash recompute failed; skipping convergence check"
                 );
-                (false, [0u8; 32])
+                None
             }
         }
     } else {
-        (false, [0u8; 32])
+        None
     };
 
-    let divergent: Vec<ContextId> = if check_context_hashes {
-        let actual_context_state_hashes = match snapshot_context_state_hashes(store, group_id) {
-            Ok(v) => v,
+    // Per-context half. A snapshot error must NOT fall through to
+    // the diff with an empty `actual` — that would report every
+    // signed expected context as divergent (false-positive storm).
+    // `None` here means the check was skipped or the snapshot
+    // errored; the warn omits the per-context fields in that case.
+    let divergent: Option<Vec<ContextId>> = if check_context_hashes {
+        match snapshot_context_state_hashes(store, group_id) {
+            Ok(actual_context_state_hashes) => Some(diff_sorted_context_hashes(
+                group_id,
+                op_kind,
+                expected_context_state_hashes,
+                &actual_context_state_hashes,
+            )),
             Err(err) => {
                 tracing::warn!(
                     group_id = %hex::encode(group_id.to_bytes()),
                     op_kind,
                     %err,
-                    "post-apply per-context state-hash snapshot failed; skipping convergence check"
+                    "post-apply per-context state-hash snapshot failed; skipping per-context \
+                     convergence check"
                 );
-                Vec::new()
+                None
             }
-        };
-        diff_sorted_context_hashes(
-            group_id,
-            op_kind,
-            expected_context_state_hashes,
-            &actual_context_state_hashes,
-        )
+        }
     } else {
-        Vec::new()
+        None
     };
 
-    if group_hash_diverges || !divergent.is_empty() {
-        tracing::warn!(
-            group_id = %hex::encode(group_id.to_bytes()),
-            op_kind,
-            group_hash_diverges,
-            expected_group_state_hash = %hex::encode(expected_group_state_hash),
-            actual_group_state_hash = %hex::encode(actual_group_state_hash),
-            divergent_context_count = divergent.len(),
-            divergent_context_ids = ?divergent
-                .iter()
-                .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
-                .collect::<Vec<_>>(),
-            "cross-DAG state-hash divergence detected on apply — reconcile-via-anchor will heal"
-        );
+    let group_diverges = matches!(group_outcome, Some((true, _)));
+    let context_diverges = divergent.as_ref().is_some_and(|v| !v.is_empty());
+    if !group_diverges && !context_diverges {
+        return;
+    }
+
+    // Branch the warn so the operator can tell which half ran. When
+    // a half was skipped we omit its fields entirely rather than
+    // logging `0000…` as the actual value.
+    match (group_outcome, divergent) {
+        (Some((_, actual_group)), Some(divergent_vec)) => {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                op_kind,
+                group_hash_diverges = group_diverges,
+                expected_group_state_hash = %hex::encode(expected_group_state_hash),
+                actual_group_state_hash = %hex::encode(actual_group),
+                divergent_context_count = divergent_vec.len(),
+                divergent_context_ids = ?divergent_vec
+                    .iter()
+                    .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
+                    .collect::<Vec<_>>(),
+                "cross-DAG state-hash divergence detected on apply — reconcile-via-anchor will heal"
+            );
+        }
+        (Some((_, actual_group)), None) => {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                op_kind,
+                group_hash_diverges = group_diverges,
+                expected_group_state_hash = %hex::encode(expected_group_state_hash),
+                actual_group_state_hash = %hex::encode(actual_group),
+                per_context_check = "skipped",
+                "cross-DAG group-state hash divergence detected on apply — reconcile-via-anchor will heal"
+            );
+        }
+        (None, Some(divergent_vec)) => {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                op_kind,
+                group_hash_check = "skipped",
+                divergent_context_count = divergent_vec.len(),
+                divergent_context_ids = ?divergent_vec
+                    .iter()
+                    .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
+                    .collect::<Vec<_>>(),
+                "cross-DAG per-context state-hash divergence detected on apply — reconcile-via-anchor will heal"
+            );
+        }
+        (None, None) => {
+            // Unreachable: both halves skipped means we'd have
+            // early-returned above (`!group_diverges && !context_diverges`).
+            // Listed for exhaustiveness; no log line.
+        }
     }
 }
 
@@ -898,6 +958,23 @@ fn diff_sorted_context_hashes(
     expected: &[(ContextId, [u8; 32])],
     actual: &[(ContextId, [u8; 32])],
 ) -> Vec<ContextId> {
+    // The merge-scan is only correct when both inputs are sorted by
+    // `ContextId`. `actual` comes from `snapshot_context_state_hashes`
+    // which sorts before returning. `expected` rides on a signed op
+    // whose deterministic content hash requires the sender's
+    // `snapshot_context_state_hashes` to have sorted before signing,
+    // so a peer that didn't sort would have produced a different
+    // op content hash and been dedup'd / rejected at the wire layer.
+    // The assertion catches dev / test misuse where the contract is
+    // violated before it becomes a quiet divergence-report bug.
+    debug_assert!(
+        expected.windows(2).all(|w| w[0].0 < w[1].0),
+        "expected context-hash snapshot must be strictly sorted by ContextId"
+    );
+    debug_assert!(
+        actual.windows(2).all(|w| w[0].0 < w[1].0),
+        "actual context-hash snapshot must be strictly sorted by ContextId"
+    );
     let mut divergent = Vec::new();
     let mut i = 0;
     let mut j = 0;

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -779,10 +779,6 @@ const MAX_PARENT_OP_HASHES: usize = 256;
 /// growth from many concurrent admins operating without merges.
 const MAX_DAG_HEADS: usize = 64;
 
-/// Apply the mutation described by a [`GroupOp`] to the local store.
-///
-/// Handles authorization checks and state mutations for ALL `GroupOp` variants.
-/// Returns `Ok(true)` if the op was handled, `Ok(false)` if the variant is not
 /// Compare local post-apply state hashes against the values signed
 /// into `MemberRemoved` / `MemberLeft` and emit a structured warn log
 /// on mismatch. Does NOT roll back the apply or return an error — the
@@ -798,15 +794,20 @@ const MAX_DAG_HEADS: usize = 64;
 ///    recompute the hash should not fail under normal conditions; if
 ///    it does we log the failure and move on — the apply already
 ///    happened, no rollback is possible at this layer.
-/// 2. **Empty signed values** (zero hash, no per-context entries). A
-///    sender that didn't precompute the signed claims (older op
-///    shapes from before the signed-claim wire change, or test
-///    helpers using placeholder values) signs zeros; comparing against
-///    a real post-apply hash would spuriously trigger a mismatch every
-///    time. Treat all-zero `expected_group_state_hash` AND empty
-///    `expected_context_state_hashes` as "no claim made" — skip the
-///    check entirely. Once the network has fully rolled forward to
-///    signed-claim ops this branch becomes dead and can be removed.
+/// 2. **Empty signed values per field.** A sender that didn't
+///    precompute the signed claims (older op shapes from before the
+///    signed-claim wire change, or test helpers using placeholder
+///    values) signs zeros; comparing against a real post-apply hash
+///    would spuriously trigger a mismatch every time. The two fields
+///    are checked independently: an all-zero `expected_group_state_hash`
+///    skips only the group-state comparison, an empty
+///    `expected_context_state_hashes` skips only the per-context
+///    comparison. **Groups with zero registered contexts correctly
+///    trigger only the group-state check** — empty actual + empty
+///    expected match, no per-context divergence is reported, and the
+///    group-state half is what catches membership-row drift. Once the
+///    network has fully rolled forward to signed-claim ops these
+///    sentinels become dead and can be removed.
 fn verify_post_apply_state_hashes(
     store: &Store,
     group_id: &ContextGroupId,
@@ -814,60 +815,51 @@ fn verify_post_apply_state_hashes(
     expected_group_state_hash: &[u8; 32],
     expected_context_state_hashes: &[(ContextId, [u8; 32])],
 ) {
-    // No-claim sentinel — see #2 above.
-    if *expected_group_state_hash == [0u8; 32] && expected_context_state_hashes.is_empty() {
+    let check_group_hash = *expected_group_state_hash != [0u8; 32];
+    let check_context_hashes = !expected_context_state_hashes.is_empty();
+    if !check_group_hash && !check_context_hashes {
         return;
     }
 
-    let actual_group_state_hash = match compute_group_state_hash(store, group_id) {
-        Ok(h) => h,
-        Err(err) => {
-            tracing::warn!(
-                group_id = %hex::encode(group_id.to_bytes()),
-                op_kind,
-                %err,
-                "post-apply group-state hash recompute failed; skipping convergence check"
-            );
-            return;
+    let (group_hash_diverges, actual_group_state_hash) = if check_group_hash {
+        match compute_group_state_hash(store, group_id) {
+            Ok(actual) => (actual != *expected_group_state_hash, actual),
+            Err(err) => {
+                tracing::warn!(
+                    group_id = %hex::encode(group_id.to_bytes()),
+                    op_kind,
+                    %err,
+                    "post-apply group-state hash recompute failed; skipping convergence check"
+                );
+                (false, [0u8; 32])
+            }
         }
+    } else {
+        (false, [0u8; 32])
     };
 
-    let actual_context_state_hashes = match snapshot_context_state_hashes(store, group_id) {
-        Ok(v) => v,
-        Err(err) => {
-            tracing::warn!(
-                group_id = %hex::encode(group_id.to_bytes()),
-                op_kind,
-                %err,
-                "post-apply per-context state-hash snapshot failed; skipping convergence check"
-            );
-            return;
-        }
+    let divergent: Vec<ContextId> = if check_context_hashes {
+        let actual_context_state_hashes = match snapshot_context_state_hashes(store, group_id) {
+            Ok(v) => v,
+            Err(err) => {
+                tracing::warn!(
+                    group_id = %hex::encode(group_id.to_bytes()),
+                    op_kind,
+                    %err,
+                    "post-apply per-context state-hash snapshot failed; skipping convergence check"
+                );
+                Vec::new()
+            }
+        };
+        diff_sorted_context_hashes(
+            group_id,
+            op_kind,
+            expected_context_state_hashes,
+            &actual_context_state_hashes,
+        )
+    } else {
+        Vec::new()
     };
-
-    let group_hash_diverges = actual_group_state_hash != *expected_group_state_hash;
-
-    // Build the divergent-context-id list from set comparison: an
-    // entry diverges if the receiver's hash for that context differs
-    // from the admin's, OR if the receiver has a context the admin
-    // didn't include (admin's view was missing it), OR vice versa.
-    // For the §8.3.2 partition case the second form is what fires.
-    let expected_map: std::collections::BTreeMap<ContextId, [u8; 32]> =
-        expected_context_state_hashes.iter().copied().collect();
-    let actual_map: std::collections::BTreeMap<ContextId, [u8; 32]> =
-        actual_context_state_hashes.iter().copied().collect();
-    let mut divergent: Vec<ContextId> = Vec::new();
-    for (cid, expected) in &expected_map {
-        match actual_map.get(cid) {
-            Some(actual) if actual == expected => {}
-            _ => divergent.push(*cid),
-        }
-    }
-    for cid in actual_map.keys() {
-        if !expected_map.contains_key(cid) {
-            divergent.push(*cid);
-        }
-    }
 
     if group_hash_diverges || !divergent.is_empty() {
         tracing::warn!(
@@ -886,6 +878,96 @@ fn verify_post_apply_state_hashes(
     }
 }
 
+/// Linear merge-scan of two `(ContextId, [u8; 32])` slices both
+/// pre-sorted by `ContextId`. Returns the ids that diverge — hash
+/// differs, or the id is present in only one side. O(n) time and
+/// O(divergent.len()) space; replaces an earlier two-`BTreeMap`
+/// approach that was O(n log n) on an apply-time hot path.
+///
+/// Emits a debug log for ids present only in `actual` (the receiver
+/// has a context the sender didn't include in the snapshot) and for
+/// ids present only in `expected` (the sender snapshotted a context
+/// the receiver hasn't materialized yet). The "only in expected"
+/// case is the dominant noise source on freshly-joined nodes whose
+/// `ContextMeta` rows haven't been written yet — operators can
+/// filter on this debug line to distinguish bootstrap catchup from
+/// real partition-window divergence.
+fn diff_sorted_context_hashes(
+    group_id: &ContextGroupId,
+    op_kind: &'static str,
+    expected: &[(ContextId, [u8; 32])],
+    actual: &[(ContextId, [u8; 32])],
+) -> Vec<ContextId> {
+    let mut divergent = Vec::new();
+    let mut i = 0;
+    let mut j = 0;
+    while i < expected.len() && j < actual.len() {
+        let (e_cid, e_hash) = &expected[i];
+        let (a_cid, a_hash) = &actual[j];
+        match e_cid.cmp(a_cid) {
+            std::cmp::Ordering::Equal => {
+                if e_hash != a_hash {
+                    divergent.push(*e_cid);
+                }
+                i += 1;
+                j += 1;
+            }
+            std::cmp::Ordering::Less => {
+                tracing::debug!(
+                    group_id = %hex::encode(group_id.to_bytes()),
+                    op_kind,
+                    context_id = %hex::encode(AsRef::<[u8; 32]>::as_ref(e_cid)),
+                    "context in signed snapshot but not materialized locally — \
+                     fresh node catchup or partition-window divergence"
+                );
+                divergent.push(*e_cid);
+                i += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                tracing::debug!(
+                    group_id = %hex::encode(group_id.to_bytes()),
+                    op_kind,
+                    context_id = %hex::encode(AsRef::<[u8; 32]>::as_ref(a_cid)),
+                    "context materialized locally but not in signed snapshot — \
+                     receiver applied a registration the signer's view missed"
+                );
+                divergent.push(*a_cid);
+                j += 1;
+            }
+        }
+    }
+    // Tail handling: anything left on either side is one-sided.
+    while i < expected.len() {
+        let (cid, _) = &expected[i];
+        tracing::debug!(
+            group_id = %hex::encode(group_id.to_bytes()),
+            op_kind,
+            context_id = %hex::encode(AsRef::<[u8; 32]>::as_ref(cid)),
+            "context in signed snapshot but not materialized locally — \
+             fresh node catchup or partition-window divergence"
+        );
+        divergent.push(*cid);
+        i += 1;
+    }
+    while j < actual.len() {
+        let (cid, _) = &actual[j];
+        tracing::debug!(
+            group_id = %hex::encode(group_id.to_bytes()),
+            op_kind,
+            context_id = %hex::encode(AsRef::<[u8; 32]>::as_ref(cid)),
+            "context materialized locally but not in signed snapshot — \
+             receiver applied a registration the signer's view missed"
+        );
+        divergent.push(*cid);
+        j += 1;
+    }
+    divergent
+}
+
+/// Apply the mutation described by a [`GroupOp`] to the local store.
+///
+/// Handles authorization checks and state mutations for ALL `GroupOp` variants.
+/// Returns `Ok(true)` if the op was handled, `Ok(false)` if the variant is not
 /// recognized (callers decide whether to error or log).
 ///
 /// This is the single source of truth for group governance mutations -- both

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -931,9 +931,11 @@ fn verify_post_apply_state_hashes(
             );
         }
         (None, None) => {
-            // Unreachable: both halves skipped means we'd have
-            // early-returned above (`!group_diverges && !context_diverges`).
-            // Listed for exhaustiveness; no log line.
+            // Reachable when both halves errored — each error path
+            // already emitted its own warn upstream, so nothing to add
+            // here. Also reachable if both checks were skipped (the
+            // early return at the top of the function catches that
+            // ordinarily, but listing it keeps the match exhaustive).
         }
     }
 }
@@ -1106,6 +1108,16 @@ fn apply_group_op_mutations(
             // dropped at the receive entry point before the cross-DAG
             // check runs. Cleared if/when the member is re-added.
             mark_denied(store, group_id, member)?;
+            // Ordering invariant: `verify_post_apply_state_hashes`
+            // must run AFTER the last membership-mutating step of
+            // this op (here `remove_group_member` — `mark_denied`
+            // and `cascade_remove_member_from_group_tree` don't
+            // change `compute_group_state_hash`'s inputs) so the
+            // local post-apply hash matches the signer's pre-apply
+            // simulation. Adding any further membership-row
+            // mutation between `remove_group_member` and this call
+            // will make the recomputed hash diverge from the signed
+            // claim on every honest receiver.
             verify_post_apply_state_hashes(
                 store,
                 group_id,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -89,8 +89,9 @@ pub use self::membership_policy::MembershipPolicy;
 pub use self::membership_status::{membership_status_at, MembershipStatus};
 pub use self::membership_view::GroupMembershipView;
 pub use self::meta::{
-    compute_group_state_hash, delete_group_meta, enumerate_all_groups, load_group_meta,
-    save_group_meta,
+    build_governance_cut, compute_group_state_hash, compute_group_state_hash_after_remove,
+    delete_group_meta, enumerate_all_groups, load_group_meta, save_group_meta,
+    snapshot_context_state_hashes,
 };
 pub use self::migrations::{
     delete_all_context_last_migrations, get_context_last_migration, set_context_last_migration,
@@ -782,6 +783,109 @@ const MAX_DAG_HEADS: usize = 64;
 ///
 /// Handles authorization checks and state mutations for ALL `GroupOp` variants.
 /// Returns `Ok(true)` if the op was handled, `Ok(false)` if the variant is not
+/// Compare local post-apply state hashes against the values signed
+/// into `MemberRemoved` / `MemberLeft` and emit a structured warn log
+/// on mismatch. Does NOT roll back the apply or return an error — the
+/// signed op is already valid (signature verified earlier), and the
+/// admin's view is canonical by definition. The mismatch is a signal
+/// that this receiver's state has diverged from the canonical view,
+/// to be resolved by reconcile-via-anchor sync (a future PR); until
+/// then the warn line is what surfaces the divergence to operators.
+///
+/// Two failure modes deliberately accept-and-log rather than error:
+///
+/// 1. **Hash computation fails.** Reading the post-apply state to
+///    recompute the hash should not fail under normal conditions; if
+///    it does we log the failure and move on — the apply already
+///    happened, no rollback is possible at this layer.
+/// 2. **Empty signed values** (zero hash, no per-context entries). A
+///    sender that didn't precompute the signed claims (older op
+///    shapes from before the signed-claim wire change, or test
+///    helpers using placeholder values) signs zeros; comparing against
+///    a real post-apply hash would spuriously trigger a mismatch every
+///    time. Treat all-zero `expected_group_state_hash` AND empty
+///    `expected_context_state_hashes` as "no claim made" — skip the
+///    check entirely. Once the network has fully rolled forward to
+///    signed-claim ops this branch becomes dead and can be removed.
+fn verify_post_apply_state_hashes(
+    store: &Store,
+    group_id: &ContextGroupId,
+    op_kind: &'static str,
+    expected_group_state_hash: &[u8; 32],
+    expected_context_state_hashes: &[(ContextId, [u8; 32])],
+) {
+    // No-claim sentinel — see #2 above.
+    if *expected_group_state_hash == [0u8; 32] && expected_context_state_hashes.is_empty() {
+        return;
+    }
+
+    let actual_group_state_hash = match compute_group_state_hash(store, group_id) {
+        Ok(h) => h,
+        Err(err) => {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                op_kind,
+                %err,
+                "post-apply group-state hash recompute failed; skipping convergence check"
+            );
+            return;
+        }
+    };
+
+    let actual_context_state_hashes = match snapshot_context_state_hashes(store, group_id) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                op_kind,
+                %err,
+                "post-apply per-context state-hash snapshot failed; skipping convergence check"
+            );
+            return;
+        }
+    };
+
+    let group_hash_diverges = actual_group_state_hash != *expected_group_state_hash;
+
+    // Build the divergent-context-id list from set comparison: an
+    // entry diverges if the receiver's hash for that context differs
+    // from the admin's, OR if the receiver has a context the admin
+    // didn't include (admin's view was missing it), OR vice versa.
+    // For the §8.3.2 partition case the second form is what fires.
+    let expected_map: std::collections::BTreeMap<ContextId, [u8; 32]> =
+        expected_context_state_hashes.iter().copied().collect();
+    let actual_map: std::collections::BTreeMap<ContextId, [u8; 32]> =
+        actual_context_state_hashes.iter().copied().collect();
+    let mut divergent: Vec<ContextId> = Vec::new();
+    for (cid, expected) in &expected_map {
+        match actual_map.get(cid) {
+            Some(actual) if actual == expected => {}
+            _ => divergent.push(*cid),
+        }
+    }
+    for cid in actual_map.keys() {
+        if !expected_map.contains_key(cid) {
+            divergent.push(*cid);
+        }
+    }
+
+    if group_hash_diverges || !divergent.is_empty() {
+        tracing::warn!(
+            group_id = %hex::encode(group_id.to_bytes()),
+            op_kind,
+            group_hash_diverges,
+            expected_group_state_hash = %hex::encode(expected_group_state_hash),
+            actual_group_state_hash = %hex::encode(actual_group_state_hash),
+            divergent_context_count = divergent.len(),
+            divergent_context_ids = ?divergent
+                .iter()
+                .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
+                .collect::<Vec<_>>(),
+            "cross-DAG state-hash divergence detected on apply — reconcile-via-anchor will heal"
+        );
+    }
+}
+
 /// recognized (callers decide whether to error or log).
 ///
 /// This is the single source of truth for group governance mutations -- both
@@ -816,7 +920,12 @@ fn apply_group_op_mutations(
                 role: role.clone(),
             });
         }
-        GroupOp::MemberRemoved { member } => {
+        GroupOp::MemberRemoved {
+            member,
+            expected_group_state_hash,
+            expected_context_state_hashes,
+            ..
+        } => {
             permissions.require_manage_members(signer, "remove member")?;
             permissions.require_admin_to_remove_admin(signer, member)?;
             // Owner is immune to involuntary removal. Owner must
@@ -838,6 +947,13 @@ fn apply_group_op_mutations(
             // dropped at the receive entry point before the cross-DAG
             // check runs. Cleared if/when the member is re-added.
             mark_denied(store, group_id, member)?;
+            verify_post_apply_state_hashes(
+                store,
+                group_id,
+                "MemberRemoved",
+                expected_group_state_hash,
+                expected_context_state_hashes,
+            );
             crate::op_events::notify(crate::op_events::OpEvent::MemberRemoved {
                 group_id: group_id.to_bytes(),
                 member: *member,
@@ -1035,7 +1151,12 @@ fn apply_group_op_mutations(
                 subgroups: *auto_follow_subgroups,
             });
         }
-        GroupOp::MemberLeft { member } => {
+        GroupOp::MemberLeft {
+            member,
+            expected_group_state_hash,
+            expected_context_state_hashes,
+            ..
+        } => {
             // Self-leave: signer must equal the member being removed.
             // No capability check beyond self-equality — any member can
             // leave themselves without admin involvement.
@@ -1136,6 +1257,13 @@ fn apply_group_op_mutations(
             // governance-level departure (membership row removed, peers
             // observe the leave) without the rotation. Same caveat applies
             // to the namespace cascade above — row-removal only.
+            verify_post_apply_state_hashes(
+                store,
+                group_id,
+                "MemberLeft",
+                expected_group_state_hash,
+                expected_context_state_hashes,
+            );
             crate::op_events::notify(crate::op_events::OpEvent::MemberRemoved {
                 group_id: group_id.to_bytes(),
                 member: *member,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -1109,15 +1109,29 @@ fn apply_group_op_mutations(
             // check runs. Cleared if/when the member is re-added.
             mark_denied(store, group_id, member)?;
             // Ordering invariant: `verify_post_apply_state_hashes`
-            // must run AFTER the last membership-mutating step of
-            // this op (here `remove_group_member` — `mark_denied`
-            // and `cascade_remove_member_from_group_tree` don't
-            // change `compute_group_state_hash`'s inputs) so the
-            // local post-apply hash matches the signer's pre-apply
-            // simulation. Adding any further membership-row
-            // mutation between `remove_group_member` and this call
-            // will make the recomputed hash diverge from the signed
-            // claim on every honest receiver.
+            // must run AFTER the last mutation that touches inputs
+            // to `compute_group_state_hash` (i.e. `GroupMeta` rows
+            // and `GroupMember` rows for this `group_id`). Of the
+            // three preceding steps here only `remove_group_member`
+            // touches those inputs:
+            //
+            // * `cascade_remove_member_from_group_tree` deletes
+            //   `ContextIdentity` rows in the state-DAG-layer
+            //   column — disjoint from `GroupMember`. Does not
+            //   affect the hash.
+            // * `mark_denied` writes a `GroupDeniedMember` row — a
+            //   separate column. Does not affect the hash.
+            // * `remove_group_member` deletes the `GroupMember`
+            //   row — this is the step the pre-apply simulation
+            //   in `compute_group_state_hash_after_remove` mirrors.
+            //
+            // Adding any future mutation between
+            // `remove_group_member` and this call that DOES touch
+            // `GroupMeta` or `GroupMember` rows for `group_id` will
+            // make the recomputed hash diverge from the signed
+            // claim on every honest receiver. The pre-apply
+            // simulation only models the single removal; any extra
+            // mutation here is invisible to it.
             verify_post_apply_state_hashes(
                 store,
                 group_id,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -858,7 +858,7 @@ fn verify_post_apply_state_hashes(
     // signed expected context as divergent (false-positive storm).
     // `None` here means the check was skipped or the snapshot
     // errored; the warn omits the per-context fields in that case.
-    let divergent: Option<Vec<ContextId>> = if check_context_hashes {
+    let context_diff: Option<ContextHashDiff> = if check_context_hashes {
         match snapshot_context_state_hashes(store, group_id) {
             Ok(actual_context_state_hashes) => Some(diff_sorted_context_hashes(
                 group_id,
@@ -882,27 +882,40 @@ fn verify_post_apply_state_hashes(
     };
 
     let group_diverges = matches!(group_outcome, Some((true, _)));
-    let context_diverges = divergent.as_ref().is_some_and(|v| !v.is_empty());
+    let context_diverges = context_diff.as_ref().is_some_and(|d| !d.is_empty());
     if !group_diverges && !context_diverges {
         return;
     }
 
-    // Branch the warn so the operator can tell which half ran. When
-    // a half was skipped we omit its fields entirely rather than
-    // logging `0000…` as the actual value.
-    match (group_outcome, divergent) {
-        (Some((_, actual_group)), Some(divergent_vec)) => {
+    // Branch the warn so the operator can tell which half ran AND
+    // which kind of context divergence fired. The three context
+    // buckets — hash_differs, only_in_expected, only_in_actual —
+    // distinguish the partition-window CRDT case (`hash_differs`),
+    // the fresh-node-catchup case (`only_in_expected`), and the
+    // receiver-ahead case (`only_in_actual`). Operators that see
+    // only `only_in_expected` populated on a freshly-joined node
+    // can recognise normal bootstrap noise; a populated
+    // `hash_differs` is the real signal anchor-sync reconcile
+    // consumes.
+    let format_ids = |ids: &[ContextId]| -> Vec<String> {
+        ids.iter()
+            .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
+            .collect()
+    };
+    match (group_outcome, context_diff) {
+        (Some((_, actual_group)), Some(diff)) => {
             tracing::warn!(
                 group_id = %hex::encode(group_id.to_bytes()),
                 op_kind,
                 group_hash_diverges = group_diverges,
                 expected_group_state_hash = %hex::encode(expected_group_state_hash),
                 actual_group_state_hash = %hex::encode(actual_group),
-                divergent_context_count = divergent_vec.len(),
-                divergent_context_ids = ?divergent_vec
-                    .iter()
-                    .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
-                    .collect::<Vec<_>>(),
+                hash_differs_count = diff.hash_differs.len(),
+                only_in_expected_count = diff.only_in_expected.len(),
+                only_in_actual_count = diff.only_in_actual.len(),
+                hash_differs = ?format_ids(&diff.hash_differs),
+                only_in_expected = ?format_ids(&diff.only_in_expected),
+                only_in_actual = ?format_ids(&diff.only_in_actual),
                 "cross-DAG state-hash divergence detected on apply — reconcile-via-anchor will heal"
             );
         }
@@ -917,16 +930,17 @@ fn verify_post_apply_state_hashes(
                 "cross-DAG group-state hash divergence detected on apply — reconcile-via-anchor will heal"
             );
         }
-        (None, Some(divergent_vec)) => {
+        (None, Some(diff)) => {
             tracing::warn!(
                 group_id = %hex::encode(group_id.to_bytes()),
                 op_kind,
                 group_hash_check = "skipped",
-                divergent_context_count = divergent_vec.len(),
-                divergent_context_ids = ?divergent_vec
-                    .iter()
-                    .map(|c| hex::encode(AsRef::<[u8; 32]>::as_ref(c)))
-                    .collect::<Vec<_>>(),
+                hash_differs_count = diff.hash_differs.len(),
+                only_in_expected_count = diff.only_in_expected.len(),
+                only_in_actual_count = diff.only_in_actual.len(),
+                hash_differs = ?format_ids(&diff.hash_differs),
+                only_in_expected = ?format_ids(&diff.only_in_expected),
+                only_in_actual = ?format_ids(&diff.only_in_actual),
                 "cross-DAG per-context state-hash divergence detected on apply — reconcile-via-anchor will heal"
             );
         }
@@ -941,25 +955,46 @@ fn verify_post_apply_state_hashes(
 }
 
 /// Linear merge-scan of two `(ContextId, [u8; 32])` slices both
-/// pre-sorted by `ContextId`. Returns the ids that diverge — hash
-/// differs, or the id is present in only one side. O(n) time and
-/// O(divergent.len()) space; replaces an earlier two-`BTreeMap`
-/// approach that was O(n log n) on an apply-time hot path.
+/// pre-sorted by `ContextId`. Returns a [`ContextHashDiff`] grouping
+/// divergent ids by category — hash differs, only in expected,
+/// only in actual. O(n) time and O(divergent.len()) space; replaces
+/// an earlier two-`BTreeMap` approach that was O(n log n) on an
+/// apply-time hot path.
 ///
-/// Emits a debug log for ids present only in `actual` (the receiver
-/// has a context the sender didn't include in the snapshot) and for
-/// ids present only in `expected` (the sender snapshotted a context
-/// the receiver hasn't materialized yet). The "only in expected"
-/// case is the dominant noise source on freshly-joined nodes whose
-/// `ContextMeta` rows haven't been written yet — operators can
-/// filter on this debug line to distinguish bootstrap catchup from
-/// real partition-window divergence.
+/// Emits a debug log per id for the only-in-actual and only-in-expected
+/// paths. The "only in expected" case is the dominant noise source on
+/// freshly-joined nodes whose `ContextMeta` rows haven't been written
+/// yet; the parent warn log distinguishes the three buckets so
+/// operators can recognise bootstrap noise (only-in-expected populated,
+/// hash-differs empty) from real partition-window divergence
+/// (hash-differs populated).
+/// Categorized divergence report from `diff_sorted_context_hashes`.
+/// The three buckets distinguish the three cases an operator cares
+/// about in the warn log: a real hash mismatch on a shared context
+/// (the partition-window state-DAG case), a context the signer
+/// snapshotted that the receiver hasn't materialized (fresh-node
+/// catchup, expected noise), and a context the receiver materialized
+/// after the signer signed (receiver-ahead, also expected noise).
+struct ContextHashDiff {
+    hash_differs: Vec<ContextId>,
+    only_in_expected: Vec<ContextId>,
+    only_in_actual: Vec<ContextId>,
+}
+
+impl ContextHashDiff {
+    fn is_empty(&self) -> bool {
+        self.hash_differs.is_empty()
+            && self.only_in_expected.is_empty()
+            && self.only_in_actual.is_empty()
+    }
+}
+
 fn diff_sorted_context_hashes(
     group_id: &ContextGroupId,
     op_kind: &'static str,
     expected: &[(ContextId, [u8; 32])],
     actual: &[(ContextId, [u8; 32])],
-) -> Vec<ContextId> {
+) -> ContextHashDiff {
     // The merge-scan is only correct when both inputs are sorted by
     // `ContextId`. `actual` comes from `snapshot_context_state_hashes`
     // which sorts before returning. `expected` rides on a signed op
@@ -977,7 +1012,11 @@ fn diff_sorted_context_hashes(
         actual.windows(2).all(|w| w[0].0 < w[1].0),
         "actual context-hash snapshot must be strictly sorted by ContextId"
     );
-    let mut divergent = Vec::new();
+    let mut diff = ContextHashDiff {
+        hash_differs: Vec::new(),
+        only_in_expected: Vec::new(),
+        only_in_actual: Vec::new(),
+    };
     let mut i = 0;
     let mut j = 0;
     while i < expected.len() && j < actual.len() {
@@ -986,7 +1025,7 @@ fn diff_sorted_context_hashes(
         match e_cid.cmp(a_cid) {
             std::cmp::Ordering::Equal => {
                 if e_hash != a_hash {
-                    divergent.push(*e_cid);
+                    diff.hash_differs.push(*e_cid);
                 }
                 i += 1;
                 j += 1;
@@ -999,7 +1038,7 @@ fn diff_sorted_context_hashes(
                     "context in signed snapshot but not materialized locally — \
                      fresh node catchup or partition-window divergence"
                 );
-                divergent.push(*e_cid);
+                diff.only_in_expected.push(*e_cid);
                 i += 1;
             }
             std::cmp::Ordering::Greater => {
@@ -1010,7 +1049,7 @@ fn diff_sorted_context_hashes(
                     "context materialized locally but not in signed snapshot — \
                      receiver applied a registration the signer's view missed"
                 );
-                divergent.push(*a_cid);
+                diff.only_in_actual.push(*a_cid);
                 j += 1;
             }
         }
@@ -1025,7 +1064,7 @@ fn diff_sorted_context_hashes(
             "context in signed snapshot but not materialized locally — \
              fresh node catchup or partition-window divergence"
         );
-        divergent.push(*cid);
+        diff.only_in_expected.push(*cid);
         i += 1;
     }
     while j < actual.len() {
@@ -1037,10 +1076,10 @@ fn diff_sorted_context_hashes(
             "context materialized locally but not in signed snapshot — \
              receiver applied a registration the signer's view missed"
         );
-        divergent.push(*cid);
+        diff.only_in_actual.push(*cid);
         j += 1;
     }
-    divergent
+    diff
 }
 
 /// Apply the mutation described by a [`GroupOp`] to the local store.

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -816,6 +816,20 @@ const MAX_DAG_HEADS: usize = 64;
 ///    field in `Option<Vec<...>>` to disambiguate would be a
 ///    wire-format churn for no behavioral gain.
 ///
+///    **Bounded residual**: if a group transitions from "has
+///    contexts" to "has no contexts" (every registered context was
+///    detached), a removal signed in that state would carry an
+///    empty list. A receiver that hasn't yet applied the matching
+///    `ContextDetached` ops still has its registrations and the
+///    per-context check would be skipped on it. This is not a
+///    silent gap — the receiver's namespace DAG heads disagree with
+///    the signer's `cut.governance_dag_heads` in this scenario, so
+///    the cross-DAG membership check on subsequent state deltas
+///    returns `Unknown { needed }` and buffers them until the
+///    detach ops arrive (or anchor-sync reconciles). The hash
+///    check skip is therefore additive to an existing detection
+///    path, not the sole defense.
+///
 ///    Once the network has fully rolled forward to signed-claim ops
 ///    the zero sentinel becomes dead and can be removed; the
 ///    empty-list "no contexts" case stays valid forever.
@@ -1481,6 +1495,23 @@ fn apply_group_op_mutations(
             // governance-level departure (membership row removed, peers
             // observe the leave) without the rotation. Same caveat applies
             // to the namespace cascade above — row-removal only.
+            //
+            // Ordering invariant (mirrors `MemberRemoved`'s call site):
+            // `verify_post_apply_state_hashes` must run after the last
+            // mutation that touches `GroupMeta` or `GroupMember` rows
+            // for `group_id`. The namespace-leave cascade above operates
+            // on DESCENDANT group ids — those mutations don't change
+            // `compute_group_state_hash(group_id)`'s inputs (the hash
+            // only reads members of THIS group, not descendants). The
+            // `remove_group_member(store, group_id, member)` call just
+            // above is the only mutation here that affects the hash;
+            // `cascade_remove_member_from_group_tree` touches
+            // `ContextIdentity` rows and `mark_denied` touches
+            // `GroupDeniedMember` rows, both in separate columns. If a
+            // future mutation between `remove_group_member` and this
+            // call DOES touch `GroupMeta` or `GroupMember` rows for
+            // `group_id`, the recomputed hash will diverge from the
+            // signer's pre-apply simulation on every honest receiver.
             verify_post_apply_state_hashes(
                 store,
                 group_id,

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -6203,3 +6203,83 @@ fn build_governance_cut_carries_current_group_state_hash() {
         "fresh namespace has no DAG heads"
     );
 }
+
+#[test]
+fn diff_sorted_context_hashes_pins_merge_scan_semantics() {
+    // Pin the linear-merge divergence logic that replaced the
+    // earlier two-`BTreeMap` build. Identical, hash-differs,
+    // only-in-expected, and only-in-actual all return the expected
+    // divergent-id set in input order (which equals sorted order
+    // since both inputs are sorted by `ContextId`).
+    use super::diff_sorted_context_hashes;
+    let group_id = test_group_id();
+    let cid_a = ContextId::from([0x01; 32]);
+    let cid_b = ContextId::from([0x02; 32]);
+    let cid_c = ContextId::from([0x03; 32]);
+    let cid_d = ContextId::from([0x04; 32]);
+    let h_a = [0xAA; 32];
+    let h_b = [0xBB; 32];
+    let h_b_alt = [0xB0; 32];
+    let h_c = [0xCC; 32];
+    let h_d = [0xDD; 32];
+
+    // Identical — empty divergent set.
+    let expected = vec![(cid_a, h_a), (cid_b, h_b)];
+    let actual = vec![(cid_a, h_a), (cid_b, h_b)];
+    assert!(diff_sorted_context_hashes(&group_id, "test", &expected, &actual).is_empty());
+
+    // Same ids, different hash on one — only that id is divergent.
+    let actual = vec![(cid_a, h_a), (cid_b, h_b_alt)];
+    assert_eq!(
+        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
+        vec![cid_b]
+    );
+
+    // Expected has an id actual lacks (fresh-node case) — that id is
+    // divergent.
+    let expected = vec![(cid_a, h_a), (cid_b, h_b), (cid_c, h_c)];
+    let actual = vec![(cid_a, h_a), (cid_c, h_c)];
+    assert_eq!(
+        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
+        vec![cid_b]
+    );
+
+    // Actual has an id expected lacks (receiver applied a
+    // registration the signer's view missed).
+    let expected = vec![(cid_a, h_a), (cid_c, h_c)];
+    let actual = vec![(cid_a, h_a), (cid_b, h_b), (cid_c, h_c)];
+    assert_eq!(
+        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
+        vec![cid_b]
+    );
+
+    // Mixed: one matching, one hash-diff, one only-in-expected, one
+    // only-in-actual. Order follows the merge advance — expected[1]
+    // hash-diffs first (cid_b), then expected[2] only (cid_c), then
+    // actual tail (cid_d).
+    let expected = vec![(cid_a, h_a), (cid_b, h_b), (cid_c, h_c)];
+    let actual = vec![(cid_a, h_a), (cid_b, h_b_alt), (cid_d, h_d)];
+    assert_eq!(
+        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
+        vec![cid_b, cid_c, cid_d]
+    );
+
+    // One side empty.
+    let actual: Vec<(ContextId, [u8; 32])> = Vec::new();
+    let expected = vec![(cid_a, h_a), (cid_b, h_b)];
+    assert_eq!(
+        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
+        vec![cid_a, cid_b]
+    );
+    let expected: Vec<(ContextId, [u8; 32])> = Vec::new();
+    let actual = vec![(cid_a, h_a), (cid_b, h_b)];
+    assert_eq!(
+        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
+        vec![cid_a, cid_b]
+    );
+
+    // Both empty.
+    let expected: Vec<(ContextId, [u8; 32])> = Vec::new();
+    let actual: Vec<(ContextId, [u8; 32])> = Vec::new();
+    assert!(diff_sorted_context_hashes(&group_id, "test", &expected, &actual).is_empty());
+}

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -6207,10 +6207,10 @@ fn build_governance_cut_carries_current_group_state_hash() {
 #[test]
 fn diff_sorted_context_hashes_pins_merge_scan_semantics() {
     // Pin the linear-merge divergence logic that replaced the
-    // earlier two-`BTreeMap` build. Identical, hash-differs,
-    // only-in-expected, and only-in-actual all return the expected
-    // divergent-id set in input order (which equals sorted order
-    // since both inputs are sorted by `ContextId`).
+    // earlier two-`BTreeMap` build. Each case asserts on the
+    // categorized buckets — hash_differs, only_in_expected,
+    // only_in_actual — so the warn-log routing at the call site is
+    // also covered.
     use super::diff_sorted_context_hashes;
     let group_id = test_group_id();
     let cid_a = ContextId::from([0x01; 32]);
@@ -6223,65 +6223,64 @@ fn diff_sorted_context_hashes_pins_merge_scan_semantics() {
     let h_c = [0xCC; 32];
     let h_d = [0xDD; 32];
 
-    // Identical — empty divergent set.
+    // Identical — every bucket empty.
     let expected = vec![(cid_a, h_a), (cid_b, h_b)];
     let actual = vec![(cid_a, h_a), (cid_b, h_b)];
-    assert!(diff_sorted_context_hashes(&group_id, "test", &expected, &actual).is_empty());
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert!(diff.is_empty());
 
-    // Same ids, different hash on one — only that id is divergent.
+    // Same ids, different hash on one — that id lands in hash_differs.
     let actual = vec![(cid_a, h_a), (cid_b, h_b_alt)];
-    assert_eq!(
-        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
-        vec![cid_b]
-    );
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert_eq!(diff.hash_differs, vec![cid_b]);
+    assert!(diff.only_in_expected.is_empty());
+    assert!(diff.only_in_actual.is_empty());
 
-    // Expected has an id actual lacks (fresh-node case) — that id is
-    // divergent.
+    // Expected has an id actual lacks (fresh-node case) — only_in_expected.
     let expected = vec![(cid_a, h_a), (cid_b, h_b), (cid_c, h_c)];
     let actual = vec![(cid_a, h_a), (cid_c, h_c)];
-    assert_eq!(
-        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
-        vec![cid_b]
-    );
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert!(diff.hash_differs.is_empty());
+    assert_eq!(diff.only_in_expected, vec![cid_b]);
+    assert!(diff.only_in_actual.is_empty());
 
-    // Actual has an id expected lacks (receiver applied a
-    // registration the signer's view missed).
+    // Actual has an id expected lacks (receiver-ahead) — only_in_actual.
     let expected = vec![(cid_a, h_a), (cid_c, h_c)];
     let actual = vec![(cid_a, h_a), (cid_b, h_b), (cid_c, h_c)];
-    assert_eq!(
-        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
-        vec![cid_b]
-    );
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert!(diff.hash_differs.is_empty());
+    assert!(diff.only_in_expected.is_empty());
+    assert_eq!(diff.only_in_actual, vec![cid_b]);
 
-    // Mixed: one matching, one hash-diff, one only-in-expected, one
-    // only-in-actual. Order follows the merge advance — expected[1]
-    // hash-diffs first (cid_b), then expected[2] only (cid_c), then
-    // actual tail (cid_d).
+    // Mixed: one matching (cid_a), one hash-diff (cid_b), one
+    // only-in-expected (cid_c), one only-in-actual (cid_d).
     let expected = vec![(cid_a, h_a), (cid_b, h_b), (cid_c, h_c)];
     let actual = vec![(cid_a, h_a), (cid_b, h_b_alt), (cid_d, h_d)];
-    assert_eq!(
-        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
-        vec![cid_b, cid_c, cid_d]
-    );
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert_eq!(diff.hash_differs, vec![cid_b]);
+    assert_eq!(diff.only_in_expected, vec![cid_c]);
+    assert_eq!(diff.only_in_actual, vec![cid_d]);
 
-    // One side empty.
+    // One side empty — everything lands in the other bucket.
     let actual: Vec<(ContextId, [u8; 32])> = Vec::new();
     let expected = vec![(cid_a, h_a), (cid_b, h_b)];
-    assert_eq!(
-        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
-        vec![cid_a, cid_b]
-    );
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert_eq!(diff.only_in_expected, vec![cid_a, cid_b]);
+    assert!(diff.hash_differs.is_empty());
+    assert!(diff.only_in_actual.is_empty());
+
     let expected: Vec<(ContextId, [u8; 32])> = Vec::new();
     let actual = vec![(cid_a, h_a), (cid_b, h_b)];
-    assert_eq!(
-        diff_sorted_context_hashes(&group_id, "test", &expected, &actual),
-        vec![cid_a, cid_b]
-    );
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert_eq!(diff.only_in_actual, vec![cid_a, cid_b]);
+    assert!(diff.hash_differs.is_empty());
+    assert!(diff.only_in_expected.is_empty());
 
-    // Both empty.
+    // Both empty — every bucket empty.
     let expected: Vec<(ContextId, [u8; 32])> = Vec::new();
     let actual: Vec<(ContextId, [u8; 32])> = Vec::new();
-    assert!(diff_sorted_context_hashes(&group_id, "test", &expected, &actual).is_empty());
+    let diff = diff_sorted_context_hashes(&group_id, "test", &expected, &actual);
+    assert!(diff.is_empty());
 }
 
 #[test]
@@ -6446,5 +6445,65 @@ fn cascade_remove_member_does_not_change_group_state_hash() {
     assert!(
         !handle.has(&id_key).unwrap(),
         "cascade should have deleted target's ContextIdentity row"
+    );
+}
+
+#[test]
+fn mark_denied_does_not_change_group_state_hash() {
+    // Mirrors the cascade invariant test: the verify-call-site
+    // ordering comment claims `mark_denied` doesn't touch
+    // `compute_group_state_hash`'s inputs. This pins it — a future
+    // refactor that moves the denial flag into the `GroupMember`
+    // row (instead of a separate `GroupDeniedMember` column) would
+    // trip this test and force a rethink of where the verify call
+    // sits relative to other mutations.
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    let target = PublicKey::from([0xD0; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &target, GroupMemberRole::Member).unwrap();
+    remove_group_member(&store, &gid, &target).unwrap();
+
+    let hash_before = compute_group_state_hash(&store, &gid).unwrap();
+    mark_denied(&store, &gid, &target).unwrap();
+    let hash_after = compute_group_state_hash(&store, &gid).unwrap();
+
+    assert_eq!(
+        hash_before, hash_after,
+        "mark_denied must not change the group state hash — \
+         it writes a GroupDeniedMember row, not GroupMeta or GroupMember"
+    );
+}
+
+#[test]
+fn compute_group_state_hash_after_remove_never_returns_zeros_for_real_group() {
+    // SHA-256 of any real `GroupMeta` + member set is astronomically
+    // unlikely to produce all-zeros. This test pins the practical
+    // guarantee: for a populated group with a real meta and at least
+    // one member, the precomputed post-remove hash must NOT be the
+    // sentinel value `[0u8; 32]`. If a future bug short-circuits the
+    // hasher and returns zeros, every receiver would silently treat
+    // the signed claim as "no claim" and the convergence check would
+    // be effectively disabled. This catches that class of regression
+    // at the helper boundary.
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    let target = PublicKey::from([0xD0; 32]);
+    let bystander = PublicKey::from([0xD1; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &target, GroupMemberRole::Member).unwrap();
+    add_group_member(&store, &gid, &bystander, GroupMemberRole::Member).unwrap();
+
+    let hash = compute_group_state_hash_after_remove(&store, &gid, &target).unwrap();
+    assert_ne!(
+        hash, [0u8; 32],
+        "post-remove hash collided with the no-claim sentinel — \
+         convergence check would be silently disabled"
     );
 }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -18,6 +18,22 @@ fn test_group_id() -> ContextGroupId {
     ContextGroupId::from([0xAA; 32])
 }
 
+/// Build a `MemberRemoved` op with placeholder cross-DAG claims for
+/// tests that don't exercise the convergence-detection path. The
+/// claims here are deliberately zero/empty so a receiver verifying
+/// against actual post-apply state will see a mismatch — tests that
+/// hit the apply path either ignore the mismatch (it's a warn-log,
+/// not a hard reject) or use the real `compute_*` helpers.
+fn dummy_member_removed_op(group_id: ContextGroupId, member: PublicKey) -> GroupOp {
+    GroupOp::MemberRemoved {
+        member,
+        cut: calimero_context_config::types::GovernancePosition::new(group_id, [0u8; 32], vec![])
+            .expect("empty heads is a valid GovernancePosition"),
+        expected_group_state_hash: [0u8; 32],
+        expected_context_state_hashes: Vec::new(),
+    }
+}
+
 fn test_meta() -> GroupMetaValue {
     GroupMetaValue {
         app_key: [0xBB; 32],
@@ -1318,7 +1334,7 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
 
 #[test]
 fn apply_local_signed_group_op_rejects_last_admin_removal() {
-    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_context_client::local_governance::SignedGroupOp;
     use calimero_primitives::identity::PrivateKey;
     use rand::rngs::OsRng;
 
@@ -1338,7 +1354,7 @@ fn apply_local_signed_group_op_rejects_last_admin_removal() {
         vec![],
         [0u8; 32],
         1,
-        GroupOp::MemberRemoved { member: admin_pk },
+        dummy_member_removed_op(test_group_id(), admin_pk),
     )
     .unwrap();
     assert!(apply_local_signed_group_op(&store, &op_bad).is_err());
@@ -5487,7 +5503,7 @@ fn fast_path_role_promotion_picks_current_role() {
 }
 
 // ---------------------------------------------------------------------
-// Per-group deny-list (D1) tests
+// Per-group deny-list tests
 //
 // Exercise the marking / clearing primitives directly. Apply-path
 // integration (MemberAdded clearing on re-add, MemberRemoved /
@@ -5656,7 +5672,7 @@ fn deny_list_member_removed_op_marks_entry() {
         vec![],
         compute_group_state_hash(&store, &gid).unwrap(),
         1,
-        GroupOp::MemberRemoved { member: target_pk },
+        dummy_member_removed_op(gid, target_pk),
     )
     .expect("sign MemberRemoved");
     apply_local_signed_group_op(&store, &op).expect("apply MemberRemoved");
@@ -5690,7 +5706,7 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
         vec![],
         compute_group_state_hash(&store, &gid).unwrap(),
         1,
-        GroupOp::MemberRemoved { member: target_pk },
+        dummy_member_removed_op(gid, target_pk),
     )
     .expect("sign MemberRemoved");
     apply_local_signed_group_op(&store, &rm).expect("apply MemberRemoved");
@@ -5717,7 +5733,7 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
 }
 
 // ---------------------------------------------------------------------
-// Trusted-anchor set (E5) — `trusted_anchors_for_group`
+// Trusted-anchor set — `trusted_anchors_for_group`
 //
 // Anchor set per RFC decision #22: `{Owner} ∪ {Admins} ∪ {ReadOnlyTee}`.
 // These tests pin the membership rule against the materialized member
@@ -5887,4 +5903,167 @@ fn trusted_anchors_mixed_roles() {
         .into_iter()
         .collect();
     assert_eq!(anchors, expected, "anchor set mismatch");
+}
+
+// ---------------------------------------------------------------------
+// Cross-DAG state-hash claims on MemberRemoved / MemberLeft
+//
+// `MemberRemoved` and `MemberLeft` carry signed `expected_group_state_hash`
+// and `expected_context_state_hashes`. Receivers compute the same hashes
+// post-apply and compare; mismatch surfaces a structured warn log
+// (does not roll back the apply). These tests pin the precomputation
+// helpers and the equivalence between precomputed and actually-applied
+// state hashes.
+// ---------------------------------------------------------------------
+
+#[test]
+fn compute_group_state_hash_after_remove_matches_post_apply_hash() {
+    // The sign-time precompute must produce the same hash that
+    // `compute_group_state_hash` returns AFTER a real apply.
+    // Without this equivalence, every honest receiver would observe a
+    // spurious mismatch on every MemberRemoved.
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    let to_remove = PublicKey::from([0xB1; 32]);
+    let bystander = PublicKey::from([0xB2; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &to_remove, GroupMemberRole::Member).unwrap();
+    add_group_member(&store, &gid, &bystander, GroupMemberRole::Member).unwrap();
+
+    let precomputed = compute_group_state_hash_after_remove(&store, &gid, &to_remove).unwrap();
+
+    // Actually remove and recompute via the real helper.
+    remove_group_member(&store, &gid, &to_remove).unwrap();
+    let actual = compute_group_state_hash(&store, &gid).unwrap();
+
+    assert_eq!(
+        precomputed, actual,
+        "precomputed post-remove hash must equal actually-applied hash"
+    );
+}
+
+#[test]
+fn compute_group_state_hash_after_remove_non_member_is_idempotent() {
+    // If `removed_member` isn't currently in the set, the precompute
+    // returns the same hash as `compute_group_state_hash` on the
+    // current state. The op apply path bails on non-members
+    // separately; this helper just hashes deterministically over
+    // whatever it finds.
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    let stranger = PublicKey::from([0xCC; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+
+    let current = compute_group_state_hash(&store, &gid).unwrap();
+    let precomputed = compute_group_state_hash_after_remove(&store, &gid, &stranger).unwrap();
+
+    assert_eq!(current, precomputed);
+}
+
+#[test]
+fn snapshot_context_state_hashes_returns_sorted_by_context_id() {
+    // Deterministic ordering is required because the snapshot lands
+    // inside a signed op whose content hash is the dedup key; a
+    // non-deterministic order would produce different content hashes
+    // for the same logical op and break gossip dedup.
+    use calimero_store::key::ContextMeta;
+    use calimero_store::types::ContextMeta as ContextMetaValue;
+
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+
+    // Register three contexts in non-sorted order, give each a
+    // distinct root_hash so we can verify the values come back paired
+    // with the right context.
+    let cid_c = ContextId::from([0xCC; 32]);
+    let cid_a = ContextId::from([0xAA; 32]);
+    let cid_b = ContextId::from([0xBB; 32]);
+    for cid in [cid_c, cid_a, cid_b] {
+        register_context_in_group(&store, &gid, &cid).unwrap();
+        let mut handle = store.handle();
+        let meta = ContextMetaValue::new(
+            calimero_store::key::ApplicationMeta::new(
+                calimero_primitives::application::ApplicationId::from([0u8; 32]),
+            ),
+            *AsRef::<[u8; 32]>::as_ref(&cid),
+            vec![],
+            None,
+        );
+        handle.put(&ContextMeta::new(cid), &meta).unwrap();
+    }
+
+    let snapshot = snapshot_context_state_hashes(&store, &gid).unwrap();
+    let ids: Vec<ContextId> = snapshot.iter().map(|(c, _)| *c).collect();
+
+    assert_eq!(
+        ids,
+        vec![cid_a, cid_b, cid_c],
+        "must be sorted by ContextId"
+    );
+    // Per-entry root_hash matches the meta we wrote.
+    for (cid, root) in &snapshot {
+        assert_eq!(
+            root,
+            AsRef::<[u8; 32]>::as_ref(cid),
+            "snapshot root_hash must equal the value in ContextMeta"
+        );
+    }
+}
+
+#[test]
+fn snapshot_context_state_hashes_skips_unmaterialized_contexts() {
+    // A context registered in the group index but missing its
+    // ContextMeta (fresh node not joined yet) must be skipped, not
+    // hashed as zeros — zero-hashing would force a spurious mismatch
+    // on every receiver that has the context materialized.
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+
+    let cid = ContextId::from([0xAB; 32]);
+    register_context_in_group(&store, &gid, &cid).unwrap();
+    // Deliberately do NOT write a ContextMeta for this context.
+
+    let snapshot = snapshot_context_state_hashes(&store, &gid).unwrap();
+    assert!(
+        snapshot.is_empty(),
+        "unmaterialized contexts must be skipped, got {snapshot:?}"
+    );
+}
+
+#[test]
+fn build_governance_cut_carries_current_group_state_hash() {
+    // The `cut` field's `group_state_hash` is the PRE-apply hash
+    // (admin's view at sign time, not the post-apply view). Receivers
+    // use the cut to identify which namespace-DAG position to walk
+    // for the membership check — that walk needs the current group
+    // state to make sense.
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+
+    let pre_apply_hash = compute_group_state_hash(&store, &gid).unwrap();
+    let cut = build_governance_cut(&store, &gid).unwrap();
+
+    assert_eq!(
+        cut.group_state_hash, pre_apply_hash,
+        "cut must carry the pre-apply (current) group state hash"
+    );
+    assert_eq!(cut.group_id, gid);
+    // No namespace governance ops have run, so heads are empty.
+    assert!(
+        cut.governance_dag_heads.is_empty(),
+        "fresh namespace has no DAG heads"
+    );
 }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -6393,3 +6393,58 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
         "receiver's post-apply per-context snapshot must equal the signer's"
     );
 }
+
+#[test]
+fn cascade_remove_member_does_not_change_group_state_hash() {
+    // Pins the invariant relied on by the ordering comment at the
+    // `verify_post_apply_state_hashes` call site: cascade-removal
+    // touches `ContextIdentity` rows only, never `GroupMeta` or
+    // `GroupMember` rows, so the group state hash before and after
+    // a cascade is identical. If a future refactor makes cascade
+    // also touch group-level rows, this test fires and the ordering
+    // comment in `apply_group_op_mutations` must be revisited
+    // (otherwise the post-apply hash would diverge from the
+    // pre-apply simulation on every honest receiver).
+    let store = test_store();
+    let gid = test_group_id();
+    let admin = PublicKey::from([0x01; 32]);
+    let target = PublicKey::from([0xD0; 32]);
+    let context_id = ContextId::from([0xE0; 32]);
+
+    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &target, GroupMemberRole::Member).unwrap();
+
+    // Register a context and write a ContextIdentity for `target`
+    // — exactly the row cascade_remove_member_from_group_tree
+    // deletes.
+    register_context_in_group(&store, &gid, &context_id).unwrap();
+    let id_key = calimero_store::key::ContextIdentity::new(context_id, target);
+    let mut handle = store.handle();
+    handle
+        .put(
+            &id_key,
+            &calimero_store::types::ContextIdentity {
+                private_key: None,
+                sender_key: None,
+            },
+        )
+        .unwrap();
+    drop(handle);
+
+    let hash_before = compute_group_state_hash(&store, &gid).unwrap();
+    cascade_remove_member_from_group_tree(&store, &gid, &target).unwrap();
+    let hash_after = compute_group_state_hash(&store, &gid).unwrap();
+
+    assert_eq!(
+        hash_before, hash_after,
+        "cascade-removal must not change the group state hash — \
+         it touches ContextIdentity rows, which are not in the hash inputs"
+    );
+    // Sanity: the row it WAS supposed to delete is gone.
+    let handle = store.handle();
+    assert!(
+        !handle.has(&id_key).unwrap(),
+        "cascade should have deleted target's ContextIdentity row"
+    );
+}

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -6313,3 +6313,83 @@ fn diff_sorted_context_hashes_panics_on_unsorted_actual() {
     let unsorted = vec![(cid_b, [0u8; 32]), (cid_a, [0u8; 32])];
     let _ = diff_sorted_context_hashes(&group_id, "test", &sorted, &unsorted);
 }
+
+#[test]
+fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
+    // End-to-end sanity check that the convergence pipeline closes
+    // on the happy path: an admin precomputes the signed claims via
+    // the real sign-time helpers, signs and applies a `MemberRemoved`,
+    // and the receiver's post-apply state matches the signer's
+    // simulation. Every other test in this crate uses the
+    // `dummy_member_removed_op` helper which signs zeros — those
+    // tests cover apply semantics but not the verify path, so a
+    // future regression in the precompute-vs-actual equivalence
+    // would slip through without this one.
+    use calimero_context_client::local_governance::SignedGroupOp;
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    let target_pk = PublicKey::from([0xD0; 32]);
+    let bystander_pk = PublicKey::from([0xD1; 32]);
+
+    // Bootstrap: a meta + admin + target + bystander member set.
+    let mut meta = test_meta();
+    meta.admin_identity = admin_pk;
+    meta.owner_identity = admin_pk;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &target_pk, GroupMemberRole::Member).unwrap();
+    add_group_member(&store, &gid, &bystander_pk, GroupMemberRole::Member).unwrap();
+
+    // Real sign-time precomputation: admin's view of the post-apply
+    // state, signed alongside the op.
+    let cut = build_governance_cut(&store, &gid).unwrap();
+    let expected_group_state_hash =
+        compute_group_state_hash_after_remove(&store, &gid, &target_pk).unwrap();
+    let expected_context_state_hashes = snapshot_context_state_hashes(&store, &gid).unwrap();
+
+    let signed = SignedGroupOp::sign(
+        &admin_sk,
+        gid.to_bytes(),
+        vec![],
+        compute_group_state_hash(&store, &gid).unwrap(),
+        1,
+        GroupOp::MemberRemoved {
+            member: target_pk,
+            cut,
+            expected_group_state_hash,
+            expected_context_state_hashes: expected_context_state_hashes.clone(),
+        },
+    )
+    .expect("sign MemberRemoved with real claims");
+
+    // Apply on a sibling store that started from the same state.
+    let receiver = test_store();
+    save_group_meta(&receiver, &gid, &meta).unwrap();
+    add_group_member(&receiver, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&receiver, &gid, &target_pk, GroupMemberRole::Member).unwrap();
+    add_group_member(&receiver, &gid, &bystander_pk, GroupMemberRole::Member).unwrap();
+    apply_local_signed_group_op(&receiver, &signed).expect("apply MemberRemoved");
+
+    // Receiver's actual post-apply hashes match the signed expected.
+    // This is what `verify_post_apply_state_hashes` checks internally;
+    // the apply succeeds with no warning when these match. If the
+    // helpers ever drift from the live `compute_group_state_hash` /
+    // `Snapshot::root_hash` semantics, this assertion catches it
+    // before the warn-log path fires on every honest apply.
+    let receiver_group_hash = compute_group_state_hash(&receiver, &gid).unwrap();
+    assert_eq!(
+        receiver_group_hash, expected_group_state_hash,
+        "receiver's post-apply group state hash must equal the signer's pre-apply simulation"
+    );
+    let receiver_context_hashes = snapshot_context_state_hashes(&receiver, &gid).unwrap();
+    assert_eq!(
+        receiver_context_hashes, expected_context_state_hashes,
+        "receiver's post-apply per-context snapshot must equal the signer's"
+    );
+}

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -6337,6 +6337,13 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
     let bystander_pk = PublicKey::from([0xD1; 32]);
 
     // Bootstrap: a meta + admin + target + bystander member set.
+    // No parent group is set, which means `resolve_namespace` treats
+    // `gid` as its own namespace (the no-parent case). That lets
+    // `build_governance_cut` succeed below with empty
+    // `governance_dag_heads` — a deterministic empty namespace DAG
+    // for a self-rooted group. If `resolve_namespace`'s no-parent
+    // semantics ever change, this test's bootstrap shape will need
+    // an explicit `nest_group` call.
     let mut meta = test_meta();
     meta.admin_identity = admin_pk;
     meta.owner_identity = admin_pk;

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -6283,3 +6283,33 @@ fn diff_sorted_context_hashes_pins_merge_scan_semantics() {
     let actual: Vec<(ContextId, [u8; 32])> = Vec::new();
     assert!(diff_sorted_context_hashes(&group_id, "test", &expected, &actual).is_empty());
 }
+
+#[test]
+#[should_panic(expected = "expected context-hash snapshot must be strictly sorted")]
+fn diff_sorted_context_hashes_panics_on_unsorted_expected() {
+    // Pins the sorted-input debug assertion. Catches dev / test
+    // misuse before it becomes a quiet false-divergence-report bug.
+    // The signed-op wire content hash is computed over the snapshot
+    // as sorted, so an unsorted `expected` on the wire would have
+    // failed dedup / verification upstream — this assertion is a
+    // safety net for in-process callers.
+    use super::diff_sorted_context_hashes;
+    let group_id = test_group_id();
+    let cid_a = ContextId::from([0x01; 32]);
+    let cid_b = ContextId::from([0x02; 32]);
+    let unsorted = vec![(cid_b, [0u8; 32]), (cid_a, [0u8; 32])];
+    let sorted = vec![(cid_a, [0u8; 32]), (cid_b, [0u8; 32])];
+    let _ = diff_sorted_context_hashes(&group_id, "test", &unsorted, &sorted);
+}
+
+#[test]
+#[should_panic(expected = "actual context-hash snapshot must be strictly sorted")]
+fn diff_sorted_context_hashes_panics_on_unsorted_actual() {
+    use super::diff_sorted_context_hashes;
+    let group_id = test_group_id();
+    let cid_a = ContextId::from([0x01; 32]);
+    let cid_b = ContextId::from([0x02; 32]);
+    let sorted = vec![(cid_a, [0u8; 32]), (cid_b, [0u8; 32])];
+    let unsorted = vec![(cid_b, [0u8; 32]), (cid_a, [0u8; 32])];
+    let _ = diff_sorted_context_hashes(&group_id, "test", &sorted, &unsorted);
+}

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -84,10 +84,34 @@ impl Handler<LeaveGroupRequest> for ContextManager {
         let node_client = self.node_client.clone();
         let ack_router = Arc::clone(&self.ack_router);
 
+        // Sign-time hash precomputation, mirroring `MemberRemoved`. The
+        // leaver simulates the post-leave state so receivers can detect
+        // divergence.
+        let cut = match group_store::build_governance_cut(&self.datastore, &group_id) {
+            Ok(c) => c,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+        let expected_group_state_hash = match group_store::compute_group_state_hash_after_remove(
+            &self.datastore,
+            &group_id,
+            &member_public_key,
+        ) {
+            Ok(h) => h,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+        let expected_context_state_hashes =
+            match group_store::snapshot_context_state_hashes(&self.datastore, &group_id) {
+                Ok(v) => v,
+                Err(err) => return ActorResponse::reply(Err(err)),
+            };
+
         ActorResponse::r#async(
             async move {
                 let op = calimero_context_client::local_governance::GroupOp::MemberLeft {
                     member: member_public_key,
+                    cut,
+                    expected_group_state_hash,
+                    expected_context_state_hashes,
                 };
 
                 // sign_apply_and_publish runs the apply path locally

--- a/crates/context/src/handlers/leave_namespace.rs
+++ b/crates/context/src/handlers/leave_namespace.rs
@@ -75,10 +75,35 @@ impl Handler<LeaveNamespaceRequest> for ContextManager {
         let node_client = self.node_client.clone();
         let ack_router = Arc::clone(&self.ack_router);
 
+        // Sign-time hash precomputation, mirroring `MemberRemoved`. The
+        // leaver simulates the post-leave state so receivers can detect
+        // divergence. See `compute_group_state_hash_after_remove` and
+        // `snapshot_context_state_hashes`.
+        let cut = match group_store::build_governance_cut(&self.datastore, &namespace_id) {
+            Ok(c) => c,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+        let expected_group_state_hash = match group_store::compute_group_state_hash_after_remove(
+            &self.datastore,
+            &namespace_id,
+            &member_public_key,
+        ) {
+            Ok(h) => h,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+        let expected_context_state_hashes =
+            match group_store::snapshot_context_state_hashes(&self.datastore, &namespace_id) {
+                Ok(v) => v,
+                Err(err) => return ActorResponse::reply(Err(err)),
+            };
+
         ActorResponse::r#async(
             async move {
                 let op = calimero_context_client::local_governance::GroupOp::MemberLeft {
                     member: member_public_key,
+                    cut,
+                    expected_group_state_hash,
+                    expected_context_state_hashes,
                 };
 
                 // The apply path detects "this group is the namespace" and

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -14,7 +14,8 @@ use calimero_context::group_store::{
 };
 use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
 use calimero_context_config::types::{
-    ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
+    ContextGroupId, GovernancePosition, GroupInvitationFromAdmin, SignedGroupOpenInvitation,
+    SignerId,
 };
 use calimero_context_config::MemberCapabilities;
 use calimero_dag::DagStore;
@@ -33,6 +34,21 @@ fn empty_store() -> Store {
 
 fn sample_group_id() -> ContextGroupId {
     ContextGroupId::from([0x77u8; 32])
+}
+
+/// `MemberRemoved` with placeholder cross-DAG claims for tests that
+/// only exercise convergence on the membership-row mutation. The
+/// hashes intentionally don't match real post-apply state — these
+/// tests don't verify the mismatch-detection path (that's covered
+/// separately by `compute_group_state_hash_after_remove` unit tests).
+fn dummy_member_removed(group_id: ContextGroupId, member: PublicKey) -> GroupOp {
+    GroupOp::MemberRemoved {
+        member,
+        cut: GovernancePosition::new(group_id, [0u8; 32], vec![])
+            .expect("empty heads is a valid GovernancePosition"),
+        expected_group_state_hash: [0u8; 32],
+        expected_context_state_hashes: Vec::new(),
+    }
 }
 
 fn sample_meta(admin: PublicKey) -> GroupMetaValue {
@@ -999,7 +1015,7 @@ fn state_hash_prevents_concurrent_op_divergence() {
         vec![[0u8; 32]],
         state_hash_c,
         1,
-        GroupOp::MemberRemoved { member: admin_a_pk },
+        dummy_member_removed(sample_group_id(), admin_a_pk),
     )
     .unwrap();
 
@@ -1084,7 +1100,7 @@ fn cascade_removal_on_member_kick() {
         vec![[0u8; 32]],
         [0u8; 32],
         1,
-        GroupOp::MemberRemoved { member: member_pk },
+        dummy_member_removed(sample_group_id(), member_pk),
     )
     .unwrap();
     apply_local_signed_group_op(&store, &op).unwrap();
@@ -1147,7 +1163,7 @@ fn cascade_removal_deterministic_across_nodes() {
         vec![[0u8; 32]],
         [0u8; 32],
         1,
-        GroupOp::MemberRemoved { member: member_pk },
+        dummy_member_removed(sample_group_id(), member_pk),
     )
     .unwrap();
     apply_local_signed_group_op(&node_a, &op).unwrap();


### PR DESCRIPTION
… MemberLeft

`MemberRemoved` and `MemberLeft` now carry three signed claims that let receivers detect divergence after apply:

1. `cut: GovernancePosition` — the namespace governance-DAG position the signer signed against. Receivers use this as the descend-from boundary for the apply-time membership check on subsequent deltas from the removed/left member, so two peers at different governance positions evaluate the same answer.

2. `expected_group_state_hash: [u8; 32]` — what the governance state hash will be after the apply, computed pre-apply via a pure in-memory simulation of the removal.

3. `expected_context_state_hashes: Vec<(ContextId, [u8; 32])>` — per-context CRDT root hash at sign time, sorted by `context_id` for deterministic op-content hashing. Catches the partition-window case where a receiver applied legitimate pre-removal state-DAG deltas from the now-removed member that the admin's view didn't include.

Sign-time precomputation:
* `compute_group_state_hash_after_remove(store, group_id, member)` — pure function, simulates the removal by filtering the sorted member list in-memory and hashing. Idempotent on non-members.
* `snapshot_context_state_hashes(store, group_id)` — enumerates registered contexts and reads each `ContextMeta::root_hash`. Unmaterialized contexts (registered but no meta row yet) are skipped, not zero-hashed.
* `build_governance_cut(store, group_id)` — bundles the pre-apply group state hash with the namespace DAG heads. Shared by the admin-removal path and both self-leave paths.

Apply-time verification:
* `verify_post_apply_state_hashes` runs after the apply path completes for both ops. On mismatch it emits a structured warn log carrying the group id, op kind, both hashes, and the list of divergent context ids — does NOT roll back the apply or reject the op. The admin's view is canonical by definition; reconcile-via-anchor sync is the recovery path (separate work).
* An all-zero `expected_group_state_hash` plus an empty `expected_context_state_hashes` is treated as "no claim made" and skips the check — keeps test helpers using placeholder claims from triggering spurious warnings. Once the network has fully rolled forward to signed-claim ops this branch becomes dead.

Schema version bumped from 3 to 4 (hard cut, no backwards compat per the pre-1.0 wire-change policy).

Tests:
* 5 new unit tests covering precompute equivalence with post-apply hash, non-member idempotency, snapshot sort order, snapshot skip for unmaterialized contexts, and cut carrying the pre-apply hash.
* All 233 existing context-lib tests + 22 convergence integration tests still pass — destructuring sites updated with `..` and test helpers (`dummy_member_removed_op`, `dummy_member_removed`) added for sites that don't exercise the divergence path.

Receiver-side reconcile-via-anchor (consumes these signed claims and adopts canonical state) is the next planned PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a wire/schema bump to v4 (old ops now rejected) and new sign/apply-time hashing logic in the membership governance path that could surface unexpected divergence warnings if assumptions about ordering/materialization are wrong.
> 
> **Overview**
> `MemberRemoved` and `MemberLeft` are expanded to include a signed `cut: GovernancePosition`, an `expected_group_state_hash`, and `expected_context_state_hashes`, and the `SignedGroupOp` schema version is bumped to `v4` (older shapes are rejected).
> 
> Publishing `MemberRemoved`/self-`MemberLeft` now precomputes these values at sign time via new helpers (`build_governance_cut`, `compute_group_state_hash_after_remove`, `snapshot_context_state_hashes`). Apply-time paths recompute post-apply hashes and **log structured warnings on mismatch** (no rollback) using a new linear diff of per-context hashes.
> 
> Tests are updated to construct v4 removal ops (dummy helpers where divergence claims aren’t under test) and new unit tests are added to pin the precompute/verify invariants and snapshot ordering/skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbac55409b79ef852528e8c158d1e80520503e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->