### PR TITLE
fix(node): don't abandon a spawn_blocking WASM apply on timeout (#2330)

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -42,10 +42,17 @@ use crate::sync::rotation_log_reader;
 /// across restarts. Per #2272 review.
 const MAX_TOPOLOGY_ENTRIES: usize = 10_000;
 
-/// Bound on `context_client.execute(...)` inside `apply()`. The caller
-/// holds the DAG write lock during this await; without a bound, a slow
-/// WASM merge-apply (#2199) propagates as a 30s+ lock hold. Returning
-/// `ApplyError` here releases the lock and lets sync recovery retry.
+/// Soft budget for `context_client.execute(...)` inside `apply()`. The
+/// caller holds the DAG write lock during this await; a slow WASM
+/// merge-apply (#2199) therefore pins it. This is *not* a hard cap: the
+/// apply runs on a `spawn_blocking` thread that cannot be cancelled, and
+/// abandoning it here would release the DAG write lock while the apply
+/// completes and `commit()`s its storage writes anyway — late, racing the
+/// next delta (the delta would be in storage but absent from the DAG, then
+/// re-synced and re-applied → divergent root hash). The merge-apply is
+/// gas-bounded so it terminates, and post-#2238 is fast enough that holding
+/// the lock for its duration is acceptable; exceeding this threshold only
+/// produces a warning. See #2199 / #2238.
 const WASM_APPLY_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Result of adding a delta with cascaded event information
@@ -222,26 +229,39 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
 
         let wasm_start = std::time::Instant::now();
 
-        // Bounded so the caller's DAG write lock can't be pinned by a
-        // slow WASM merge-apply (#2199).
-        let outcome = tokio::time::timeout(
-            WASM_APPLY_TIMEOUT,
-            self.context_client.execute(
-                &self.context_id,
-                &self.our_identity,
-                "__calimero_sync_next".to_owned(),
-                artifact,
-                vec![],
-                None,
-            ),
-        )
-        .await
-        .map_err(|_elapsed| {
-            ApplyError::Application(format!(
-                "WASM execution exceeded {}s budget (#2186)",
-                WASM_APPLY_TIMEOUT.as_secs()
-            ))
-        })?
+        // Do NOT bound this with a hard `timeout`: `context_client.execute`
+        // runs the WASM merge-apply on a `spawn_blocking` thread, which
+        // can't be cancelled. If we timed out and dropped this future, the
+        // caller's DAG write lock would be released and the delta recorded
+        // as not-applied, while the blocking apply ran to completion and
+        // then `commit()`d its storage writes + bumped `context.root_hash`
+        // anyway — late, racing the next delta's apply. Storage would hold
+        // a delta the DAG doesn't know about (re-synced, re-applied,
+        // divergent root hash). So we keep waiting; the apply is gas-bounded
+        // (it terminates) and post-#2238 is fast. Only warn if it runs long.
+        // See #2199 / #2238.
+        let execute = self.context_client.execute(
+            &self.context_id,
+            &self.our_identity,
+            "__calimero_sync_next".to_owned(),
+            artifact,
+            vec![],
+            None,
+        );
+        tokio::pin!(execute);
+        let outcome = match tokio::time::timeout(WASM_APPLY_TIMEOUT, &mut execute).await {
+            Ok(res) => res,
+            Err(_elapsed) => {
+                warn!(
+                    context_id = %self.context_id,
+                    delta_id = %Hash::from(delta.id),
+                    over_budget_secs = WASM_APPLY_TIMEOUT.as_secs(),
+                    is_merge = is_merge_scenario,
+                    "WASM merge-apply over soft budget — still waiting (a spawn_blocking apply can't be cancelled without leaving storage/DAG divergent); see #2199/#2238"
+                );
+                execute.await
+            }
+        }
         .map_err(|e| ApplyError::Application(format!("WASM execution failed: {e}")))?;
 
         let wasm_elapsed_ms = wasm_start.elapsed().as_secs_f64() * 1000.0;

--- a/crates/node/src/state_delta_bridge.rs
+++ b/crates/node/src/state_delta_bridge.rs
@@ -35,9 +35,14 @@ use crate::handlers::state_delta::{handle_state_delta, StateDeltaContext, StateD
 /// rebroadcast path.
 pub const STATE_DELTA_CHANNEL_CAPACITY: usize = 2048;
 
-/// Per-delta processing budget. Bounds the worst case where any
-/// downstream await wedges (e.g. slow WASM merge-apply, #2199); on
-/// timeout the delta is dropped and sync recovery retries.
+/// Soft per-delta processing budget. *Not* a hard cap: `handle_state_delta`
+/// drives `context_client.execute`, whose WASM merge-apply runs on a
+/// `spawn_blocking` thread that can't be cancelled. Abandoning the job on a
+/// hard timeout would release the DAG write lock while that apply completes
+/// and `commit()`s its writes anyway — late, racing the next delta and
+/// leaving storage holding a delta the DAG doesn't have. So exceeding this
+/// threshold only logs a warning and bumps `over_budget_total`; the job runs
+/// to completion. The durable fix for the underlying slowness is #2199/#2238.
 const STATE_DELTA_PROCESSING_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Periodic summary log interval.
@@ -116,12 +121,13 @@ pub struct StateDeltaActor {
     /// Successful `handle_state_delta` returns.
     processed_total: Arc<AtomicU64>,
     /// Failed `handle_state_delta` returns (decryption, DAG apply,
-    /// handler exec). Distinct from `timeout_total`.
+    /// handler exec). Distinct from `over_budget_total`.
     error_total: Arc<AtomicU64>,
-    /// Per-delta processing budget exceeded — separate from
-    /// `error_total` so a timeout storm is distinguishable from a
-    /// pure application-error storm in the summary log.
-    timeout_total: Arc<AtomicU64>,
+    /// Jobs that exceeded [`STATE_DELTA_PROCESSING_TIMEOUT`] (and kept
+    /// running — see that const). Separate from `error_total` so a
+    /// slow-merge storm is distinguishable from an application-error
+    /// storm in the summary log.
+    over_budget_total: Arc<AtomicU64>,
     dropped_total: Arc<AtomicU64>,
 }
 
@@ -131,7 +137,7 @@ impl StateDeltaActor {
             in_flight: Arc::new(AtomicU64::new(0)),
             processed_total: Arc::new(AtomicU64::new(0)),
             error_total: Arc::new(AtomicU64::new(0)),
-            timeout_total: Arc::new(AtomicU64::new(0)),
+            over_budget_total: Arc::new(AtomicU64::new(0)),
             dropped_total,
         }
     }
@@ -139,13 +145,13 @@ impl StateDeltaActor {
     fn log_summary(&self) {
         let processed = self.processed_total.load(Ordering::Relaxed);
         let errors = self.error_total.load(Ordering::Relaxed);
-        let timeouts = self.timeout_total.load(Ordering::Relaxed);
+        let over_budget = self.over_budget_total.load(Ordering::Relaxed);
         let dropped = self.dropped_total.load(Ordering::Relaxed);
         let in_flight = self.in_flight.load(Ordering::Relaxed);
         info!(
             processed_total = processed,
             error_total = errors,
-            timeout_total = timeouts,
+            over_budget_total = over_budget,
             dropped_total = dropped,
             in_flight,
             "StateDelta actor summary"
@@ -175,7 +181,7 @@ impl Handler<StateDeltaJob> for StateDeltaActor {
     fn handle(&mut self, job: StateDeltaJob, ctx: &mut Self::Context) {
         let processed_total = Arc::clone(&self.processed_total);
         let error_total = Arc::clone(&self.error_total);
-        let timeout_total = Arc::clone(&self.timeout_total);
+        let over_budget_total = Arc::clone(&self.over_budget_total);
 
         // RAII guard so `in_flight` is decremented even on panic.
         let in_flight_guard = InFlightGuard::new(Arc::clone(&self.in_flight));
@@ -190,28 +196,44 @@ impl Handler<StateDeltaJob> for StateDeltaActor {
         let work = async move {
             let _guard = in_flight_guard;
             let started = Instant::now();
-            let outcome = tokio::time::timeout(
-                STATE_DELTA_PROCESSING_TIMEOUT,
-                handle_state_delta(context, message),
-            )
-            .await;
-            match &outcome {
-                Ok(Ok(())) => {
+            let fut = handle_state_delta(context, message);
+            tokio::pin!(fut);
+            // Soft budget: if `handle_state_delta` runs long, warn and bump
+            // a counter, but DO NOT abandon it. Its downstream WASM apply
+            // runs on a `spawn_blocking` thread that can't be cancelled;
+            // dropping this future would release the DAG write lock while
+            // that apply completes and commits late, racing the next delta
+            // (storage holds a delta the DAG doesn't — re-synced, re-applied,
+            // divergent). The merge-apply is gas-bounded so it terminates.
+            // See #2199 / #2238.
+            let result = match tokio::time::timeout(STATE_DELTA_PROCESSING_TIMEOUT, &mut fut).await
+            {
+                Ok(r) => r,
+                Err(_elapsed) => {
+                    let _prev = over_budget_total.fetch_add(1, Ordering::Relaxed);
+                    warn!(
+                        %context_id,
+                        ?delta_id,
+                        over_budget_secs = STATE_DELTA_PROCESSING_TIMEOUT.as_secs(),
+                        "StateDelta worker over soft budget — still processing (a spawn_blocking apply can't be cancelled without leaving storage/DAG divergent); see #2199/#2238"
+                    );
+                    fut.await
+                }
+            };
+            match &result {
+                Ok(()) => {
                     let _prev = processed_total.fetch_add(1, Ordering::Relaxed);
                 }
-                Ok(Err(_)) => {
+                Err(_) => {
                     let _prev = error_total.fetch_add(1, Ordering::Relaxed);
                 }
-                Err(_elapsed) => {
-                    let _prev = timeout_total.fetch_add(1, Ordering::Relaxed);
-                }
             }
-            (outcome, started)
+            (result, started)
         };
 
         let _spawn_handle = ctx.spawn(work.into_actor(self).map(
-            move |(outcome, started), _act, _ctx| match outcome {
-                Ok(Ok(())) => {
+            move |(result, started), _act, _ctx| match result {
+                Ok(()) => {
                     debug!(
                         %context_id,
                         ?delta_id,
@@ -219,17 +241,8 @@ impl Handler<StateDeltaJob> for StateDeltaActor {
                         "StateDelta worker completed"
                     );
                 }
-                Ok(Err(err)) => {
+                Err(err) => {
                     warn!(?err, %context_id, ?delta_id, "Failed to handle state delta");
-                }
-                Err(_elapsed) => {
-                    warn!(
-                        %context_id,
-                        ?delta_id,
-                        timeout_secs = STATE_DELTA_PROCESSING_TIMEOUT.as_secs(),
-                        elapsed_ms = started.elapsed().as_millis(),
-                        "StateDelta worker exceeded processing budget — dropping delta, sync recovery will retry (#2199)"
-                    );
                 }
             },
         ));


### PR DESCRIPTION
## Summary

Addresses #2330. The state-delta apply path wrapped `context_client.execute("__calimero_sync_next", …)` in a hard `tokio::time::timeout` — `WASM_APPLY_TIMEOUT` (15s) in `delta_store.rs`, `STATE_DELTA_PROCESSING_TIMEOUT` (60s) in `state_delta_bridge.rs`. But the WASM merge-apply it drives runs on a **`spawn_blocking` thread** (`crates/context/src/handlers/execute/mod.rs:1521`), and `spawn_blocking` tasks **cannot be cancelled**. So when the timeout fired:

1. the future was dropped → the caller's DAG write lock (held by `add_delta_with_outcome` around `apply().await`) was released and the delta recorded as **not applied**;
2. but `ContextManager`'s `ExecuteRequest` handler kept running `internal_execute` → `module.run` finished → `storage.commit()` + `context.root_hash = new` + `local_delta_tx.send(…)` landed **anyway, late** — after the lock was gone and the next delta's apply may already have started.

Net: storage holds a delta the DAG doesn't know about → it gets re-synced and re-applied → divergent root hash, plus a stale `root_hash` overwrite racing the gap. (The 60s actor-level timeout has the same shape one level up.) This is one of the latent hazards behind the #2330 / fuzzy-flake symptoms.

`module.run`'s writes all go into a `Temporal` buffer (`ContextStorage`) flushed only on `commit()`, and `module.run` is gas-bounded so it always terminates — so the **correct** behaviour, given we can't cancel it, is to *not abandon it*: keep waiting, let it commit properly, hold the per-context DAG write lock for its duration. The "don't pin the DAG write lock on a slow merge-apply" concern that motivated the timeout (#2186 / #2199) is now largely closed by #2238 (binary-search insert, batched ancestor-hash recompute, read-don't-rehash).

## Change

- `delta_store.rs::ContextStorageApplier::apply` — replace the hard `timeout` around `execute()` with a one-shot race against `WASM_APPLY_TIMEOUT` that only **warns** if it fires, then awaits `execute()` to completion. `WASM_APPLY_TIMEOUT` is now a soft warning threshold; doc comment updated.
- `state_delta_bridge.rs::Handler<StateDeltaJob>` — same for `STATE_DELTA_PROCESSING_TIMEOUT` around `handle_state_delta`: warn + bump `over_budget_total` (renamed from `timeout_total`, since "timeout" is no longer accurate), never abandon. Dropped the `Err(_elapsed)` arm and the "dropping delta" log line accordingly; summary log field renamed.
- Heavy comments at both sites explaining why a hard timeout here is unsafe, so it doesn't get re-added.

No behaviour change on the happy path. The durable fix for the underlying merge-apply slowness remains #2199 / #2238.

## Verification

- `cargo build -p calimero-node` — clean
- `cargo test -p calimero-node` — all pass
- `cargo fmt --check`, `cargo clippy --lib --tests` — clean on touched files

There's no good unit test for the timing itself; the apply path's behaviour under slow merges is exercised by the `kv-store-with-handlers` fuzzy soak (#2299 acceptance), which is master-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the state-delta apply path and changes timeout semantics while holding the DAG write lock; correctness improves but long-running applies can now block longer, so reviewers should consider performance/operational impact.
> 
> **Overview**
> Prevents the node from **abandoning** a `spawn_blocking` WASM merge-apply when a `tokio::time::timeout` fires, which could previously let the DAG write lock drop while storage commits still landed, risking DAG/storage divergence.
> 
> `delta_store.rs` and `state_delta_bridge.rs` now treat `WASM_APPLY_TIMEOUT` / `STATE_DELTA_PROCESSING_TIMEOUT` as **soft budgets**: they race the budget to emit a warning (and increment a new `over_budget_total` counter in the actor), then continue awaiting the original future to completion instead of returning an error/dropping the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64377ebfafd3951158586df2dc4ec3fa43d4e973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->