### PR TITLE
fix(storage): Root<T> entry gets an LwwRegister crdt_type on creation

### DIFF
--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -263,31 +263,23 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// the id from the field name), this keeps the caller-provided `id` — used
     /// by `Root<T>` whose single entry has the fixed id `Id::new([118; 32])`.
     ///
-    /// `id` must be `Some(_)`: the whole point of this method is to honour a
-    /// caller-provided fixed id. Passing `None` would fall through to
-    /// `Id::random()` and silently undo that contract, which is never what a
-    /// caller of `_with_crdt_type` wants — the assert below holds in release
-    /// builds too so a `None` is a hard, observable failure, not a silent
-    /// random-id entry.
+    /// `id` is a plain `Id` (not `Option<Id>`) so the contract is enforced at
+    /// the type level — the method *requires* a caller-provided fixed id, and
+    /// the type signature reflects that. (`insert_with_storage_type` keeps
+    /// `Option<Id>` because for it `None` is a meaningful "let storage pick".)
     pub(crate) fn insert_with_crdt_type(
         &mut self,
-        id: Option<Id>,
+        id: Id,
         item: T,
         field_name: &str,
         crdt_type: CrdtType,
     ) -> StoreResult<T> {
-        assert!(
-            id.is_some(),
-            "insert_with_crdt_type requires a caller-provided id; use \
-             insert_with_storage_type if you want a random id"
-        );
-
         let mut collection = CollectionMut::new(self);
 
         let mut entry = Entry {
             item,
             storage: Element::new_with_field_name_and_crdt_type(
-                id,
+                Some(id),
                 Some(field_name.to_string()),
                 crdt_type,
             ),

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -266,8 +266,9 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// `id` must be `Some(_)`: the whole point of this method is to honour a
     /// caller-provided fixed id. Passing `None` would fall through to
     /// `Id::random()` and silently undo that contract, which is never what a
-    /// caller of `_with_crdt_type` wants — `debug_assert` catches it in
-    /// development.
+    /// caller of `_with_crdt_type` wants — the assert below holds in release
+    /// builds too so a `None` is a hard, observable failure, not a silent
+    /// random-id entry.
     pub(crate) fn insert_with_crdt_type(
         &mut self,
         id: Option<Id>,
@@ -275,7 +276,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         field_name: &str,
         crdt_type: CrdtType,
     ) -> StoreResult<T> {
-        debug_assert!(
+        assert!(
             id.is_some(),
             "insert_with_crdt_type requires a caller-provided id; use \
              insert_with_storage_type if you want a random id"

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -262,6 +262,12 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// Unlike [`Collection::new_with_field_name_and_crdt_type`] (which *derives*
     /// the id from the field name), this keeps the caller-provided `id` — used
     /// by `Root<T>` whose single entry has the fixed id `Id::new([118; 32])`.
+    ///
+    /// `id` must be `Some(_)`: the whole point of this method is to honour a
+    /// caller-provided fixed id. Passing `None` would fall through to
+    /// `Id::random()` and silently undo that contract, which is never what a
+    /// caller of `_with_crdt_type` wants — `debug_assert` catches it in
+    /// development.
     pub(crate) fn insert_with_crdt_type(
         &mut self,
         id: Option<Id>,
@@ -269,6 +275,12 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         field_name: &str,
         crdt_type: CrdtType,
     ) -> StoreResult<T> {
+        debug_assert!(
+            id.is_some(),
+            "insert_with_crdt_type requires a caller-provided id; use \
+             insert_with_storage_type if you want a random id"
+        );
+
         let mut collection = CollectionMut::new(self);
 
         let mut entry = Entry {

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -256,6 +256,35 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         self.insert_with_storage_type(id, item, StorageType::Public)
     }
 
+    /// Inserts an item into the collection with a fixed `id`, `field_name` and
+    /// `crdt_type` on the entry's storage element.
+    ///
+    /// Unlike [`Collection::new_with_field_name_and_crdt_type`] (which *derives*
+    /// the id from the field name), this keeps the caller-provided `id` — used
+    /// by `Root<T>` whose single entry has the fixed id `Id::new([118; 32])`.
+    pub(crate) fn insert_with_crdt_type(
+        &mut self,
+        id: Option<Id>,
+        item: T,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) -> StoreResult<T> {
+        let mut collection = CollectionMut::new(self);
+
+        let mut entry = Entry {
+            item,
+            storage: Element::new_with_field_name_and_crdt_type(
+                id,
+                Some(field_name.to_string()),
+                crdt_type,
+            ),
+        };
+
+        collection.insert(&mut entry)?;
+
+        Ok(entry.item)
+    }
+
     /// Inserts an item into the collection with a specific StorageType.
     pub(crate) fn insert_with_storage_type(
         &mut self,

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -63,7 +63,7 @@ where
         // of being an "opaque" (`crdt_type: None`) leaf. LWW-on-`updated_at` is
         // the right semantics for the WASM app-root value (more-recently-written
         // side wins). Entries already on disk keep `crdt_type: None` and are
-        // reconciled by the opaque-leaf sync fix (PR A).
+        // reconciled by the opaque-leaf sync fix in #2344.
         //
         // The inner-type label is `std::any::type_name::<T>()` to match the
         // codebase convention (cf. `LwwRegister<T>` in `crdt_impls.rs`); it is

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use super::{Collection, ROOT_ID};
+use super::{Collection, CrdtType, ROOT_ID};
 use crate::address::Id;
 use crate::delta::{push_comparison, StorageDelta};
 use crate::index::DeferredAncestorScope;
@@ -58,7 +58,15 @@ where
 
         let id = Self::entry_id();
 
-        let value = inner.insert(Some(id), f()).unwrap();
+        // Give the `Root<T>` entry an LWW `crdt_type` on creation so it goes
+        // through the normal CRDT leaf path during HashComparison sync instead
+        // of being an "opaque" (`crdt_type: None`) leaf. LWW-on-`updated_at` is
+        // the right semantics for the WASM app-root value (more-recently-written
+        // side wins). Entries already on disk keep `crdt_type: None` and are
+        // reconciled by the opaque-leaf sync fix (PR A).
+        let value = inner
+            .insert_with_crdt_type(Some(id), f(), "root", CrdtType::lww_register("RootValue"))
+            .unwrap();
 
         Self {
             inner,

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -71,7 +71,7 @@ where
         // is stable across versions.
         let value = inner
             .insert_with_crdt_type(
-                Some(id),
+                id,
                 f(),
                 "root",
                 CrdtType::lww_register(std::any::type_name::<T>()),
@@ -85,7 +85,12 @@ where
         }
     }
 
-    fn entry_id() -> Id {
+    /// The fixed id of the single entry under a `Root<T>` collection.
+    ///
+    /// Visible to the storage tests so they can cross-reference the entry's
+    /// index without hardcoding `[118; 32]` and silently going stale if this
+    /// constant ever changes.
+    pub(crate) fn entry_id() -> Id {
         Id::new([118; 32])
     }
 

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -64,8 +64,18 @@ where
         // the right semantics for the WASM app-root value (more-recently-written
         // side wins). Entries already on disk keep `crdt_type: None` and are
         // reconciled by the opaque-leaf sync fix (PR A).
+        //
+        // The inner-type label is `std::any::type_name::<T>()` to match the
+        // codebase convention (cf. `LwwRegister<T>` in `crdt_impls.rs`); it is
+        // metadata only — `crdt_type` is not in the Merkle hash, so the label
+        // is stable across versions.
         let value = inner
-            .insert_with_crdt_type(Some(id), f(), "root", CrdtType::lww_register("RootValue"))
+            .insert_with_crdt_type(
+                Some(id),
+                f(),
+                "root",
+                CrdtType::lww_register(std::any::type_name::<T>()),
+            )
             .unwrap();
 
         Self {

--- a/crates/storage/src/tests/collections.rs
+++ b/crates/storage/src/tests/collections.rs
@@ -3,7 +3,6 @@
 //! Tests all collection types (UnorderedMap, Vector, UnorderedSet)
 //! Moved from inline tests in collections modules for better organization
 
-use crate::address::Id;
 use crate::collections::{CrdtType, Root, UnorderedMap, UnorderedSet, Vector};
 use crate::env;
 use crate::index::Index;
@@ -21,16 +20,17 @@ use serial_test::serial;
 #[serial]
 fn test_root_entry_gets_lww_register_crdt_type() {
     // Other tests in this binary also touch `MainStorage` (a global,
-    // process-wide store) at the same `ROOT_ENTRY_ID`. Reset so we observe a
+    // process-wide store) at the same entry id. Reset so we observe a
     // fresh `Root::new` rather than stale state from a prior test.
     env::reset_for_testing();
 
-    // `Id::new([118; 32])` == `Root::<T>::entry_id()`.
-    const ROOT_ENTRY_ID: [u8; 32] = [118u8; 32];
-
     let _root = Root::new(|| UnorderedMap::<String, String>::new());
 
-    let index = <Index<MainStorage>>::get_index(Id::new(ROOT_ENTRY_ID))
+    // Cross-reference the entry's id by calling `Root::entry_id()` directly
+    // instead of hardcoding `[118; 32]`, so this test moves in lock-step with
+    // the constructor if that ever changes.
+    let entry_id = Root::<UnorderedMap<String, String>>::entry_id();
+    let index = <Index<MainStorage>>::get_index(entry_id)
         .expect("get_index should not error")
         .expect("Root entry index should exist");
 

--- a/crates/storage/src/tests/collections.rs
+++ b/crates/storage/src/tests/collections.rs
@@ -5,8 +5,10 @@
 
 use crate::address::Id;
 use crate::collections::{CrdtType, Root, UnorderedMap, UnorderedSet, Vector};
+use crate::env;
 use crate::index::Index;
 use crate::store::MainStorage;
+use serial_test::serial;
 
 // ============================================================
 // Root Tests
@@ -16,7 +18,13 @@ use crate::store::MainStorage;
 /// must be created with an LWW `crdt_type` so HashComparison sync treats it as
 /// a normal CRDT leaf rather than an "opaque" (`crdt_type: None`) leaf.
 #[test]
+#[serial]
 fn test_root_entry_gets_lww_register_crdt_type() {
+    // Other tests in this binary also touch `MainStorage` (a global,
+    // process-wide store) at the same `ROOT_ENTRY_ID`. Reset so we observe a
+    // fresh `Root::new` rather than stale state from a prior test.
+    env::reset_for_testing();
+
     // `Id::new([118; 32])` == `Root::<T>::entry_id()`.
     const ROOT_ENTRY_ID: [u8; 32] = [118u8; 32];
 
@@ -26,11 +34,26 @@ fn test_root_entry_gets_lww_register_crdt_type() {
         .expect("get_index should not error")
         .expect("Root entry index should exist");
 
+    // Use `type_name::<T>()` to match the convention used by `Root::new_internal`
+    // and the rest of the codebase (cf. `LwwRegister<T>` in `crdt_impls.rs`),
+    // not a hand-written label.
     assert_eq!(
         index.metadata.crdt_type,
-        Some(CrdtType::lww_register("RootValue")),
-        "Root<T> entry must carry an LwwRegister crdt_type on creation, got {:?}",
+        Some(CrdtType::lww_register(std::any::type_name::<
+            UnorderedMap<String, String>,
+        >())),
+        "Root<T> entry must carry an LwwRegister crdt_type matching type_name::<T>(), got {:?}",
         index.metadata.crdt_type
+    );
+
+    // `field_name = "root"` is part of the constructor contract — if it
+    // regresses, a peer's `compare_tree_nodes` could route the leaf
+    // differently. Assert it explicitly so the regression is caught here.
+    assert_eq!(
+        index.metadata.field_name,
+        Some("root".to_string()),
+        "Root<T> entry must carry field_name 'root', got {:?}",
+        index.metadata.field_name
     );
 }
 

--- a/crates/storage/src/tests/collections.rs
+++ b/crates/storage/src/tests/collections.rs
@@ -3,7 +3,36 @@
 //! Tests all collection types (UnorderedMap, Vector, UnorderedSet)
 //! Moved from inline tests in collections modules for better organization
 
-use crate::collections::{Root, UnorderedMap, UnorderedSet, Vector};
+use crate::address::Id;
+use crate::collections::{CrdtType, Root, UnorderedMap, UnorderedSet, Vector};
+use crate::index::Index;
+use crate::store::MainStorage;
+
+// ============================================================
+// Root Tests
+// ============================================================
+
+/// `Root<T>`'s single entry (`Id::new([118; 32])` == `Root::<T>::entry_id()`)
+/// must be created with an LWW `crdt_type` so HashComparison sync treats it as
+/// a normal CRDT leaf rather than an "opaque" (`crdt_type: None`) leaf.
+#[test]
+fn test_root_entry_gets_lww_register_crdt_type() {
+    // `Id::new([118; 32])` == `Root::<T>::entry_id()`.
+    const ROOT_ENTRY_ID: [u8; 32] = [118u8; 32];
+
+    let _root = Root::new(|| UnorderedMap::<String, String>::new());
+
+    let index = <Index<MainStorage>>::get_index(Id::new(ROOT_ENTRY_ID))
+        .expect("get_index should not error")
+        .expect("Root entry index should exist");
+
+    assert_eq!(
+        index.metadata.crdt_type,
+        Some(CrdtType::lww_register("RootValue")),
+        "Root<T> entry must carry an LwwRegister crdt_type on creation, got {:?}",
+        index.metadata.crdt_type
+    );
+}
 
 // ============================================================
 // UnorderedMap Tests (from collections/unordered_map.rs)


### PR DESCRIPTION
## Summary

Follow-up to #2344 (the opaque-leaf HashComparison fix). The WASM app's root-state entry — `Id::new([118;32])` = `Root::<T>::entry_id()` — was created with `crdt_type: None` (`Collection::new(Some(*ROOT_ID))`), making it the prime "opaque leaf" that #2344 had to special-case. This PR gives that entry an `LwwRegister` `crdt_type` on creation, so **newly created** contexts' root entries go through the normal CRDT-typed leaf path instead of the opaque path.

## Change

- `crates/storage/src/collections/root.rs` — `Root::new_internal` now inserts the root entry (`Id::new([118;32])`) with `crdt_type = CrdtType::lww_register("RootValue")` and `field_name = "root"`. (`Root`'s app value is last-writer-wins by `updated_at` semantically — every WASM write goes through a delta — so `LwwRegister` is the right type; it's also merge-equivalent to the previous `None`, so this isn't a behavior change for divergence resolution, just a metadata change.)
- `crates/storage/src/collections.rs` — added `Collection::insert_with_crdt_type(id, value, field_name, crdt_type)` (`pub(crate)`, mirrors the existing `insert_with_storage_type`), because the existing `new_with_field_name_and_crdt_type` *derives* the entry id from the field name, while the root entry needs the fixed id `[118;32]`.
- Unit test `test_root_entry_gets_lww_register_crdt_type` — `Root::new(...)`, then `Index::get_index(Id::new([118;32]))`, asserts `crdt_type == Some(CrdtType::lww_register("RootValue"))`.

## No migration

Entries already on disk keep `crdt_type: None` and are reconciled by #2344. Mixed-version safe: a peer on the old build, syncing a context whose root was created by a new-build peer, receives an `LwwRegister`-typed leaf and stores it with that type (so it propagates), and #2344 covers the `None` case either way. **Depends on #2344 being merged first** (it's stacked on that branch).

## Verification

`cargo test -p calimero-storage` (incl. the new test, plus all `Root` read/write/commit/delta-apply tests) — green. `cargo test -p calimero-context group_store` — green (the `compute_group_state_hash` / `groupStateHash` tests are unaffected, as expected: that hash is over RocksDB state, not the WASM Merkle tree). `cargo test -p calimero-node` — green. `cargo build --workspace` — clean. (Workspace `clippy -D warnings` fails only on pre-existing unrelated lints in `calimero-sys` / `storage-macros` — verbatim on `master`.)

Design + plan: `docs/superpowers/specs/2026-05-13-opaque-leaf-sync-design.md`, `docs/superpowers/plans/2026-05-13-opaque-leaf-sync.md` (in the #2344 branch this is stacked on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the root state entry is created by adding CRDT metadata (`crdt_type`/`field_name`), which can affect sync/merge routing and on-disk metadata for newly created contexts, but does not migrate existing data.
> 
> **Overview**
> Newly created `Root<T>` collections now create their single fixed-id entry with explicit CRDT metadata: `field_name = "root"` and `crdt_type = LwwRegister(type_name::<T>())`, so HashComparison sync treats it as a normal CRDT leaf instead of an opaque leaf.
> 
> To support this, `Collection` gains `insert_with_crdt_type` for inserting entries with a caller-provided fixed `Id` while also setting `field_name`/`crdt_type`. A new storage test asserts the root entry’s index carries the expected `crdt_type` and `field_name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 517b2a7a37c0138deaaa6630481cf2a0880806e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->