### PR TITLE
refactor(context): drop unused MemberRemoved/MemberLeft cut field

### DIFF
--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -14,7 +14,7 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_context_config::types::{GovernancePosition, SignedGroupOpenInvitation};
+use calimero_context_config::types::SignedGroupOpenInvitation;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -33,7 +33,18 @@ pub use ack_router::AckRouter;
 
 /// Wire/schema version for [`SignedGroupOp`].
 ///
-/// v4: `MemberRemoved` and `MemberLeft` now carry the signed governance-DAG
+/// v5: Drop the `cut: GovernancePosition` field from `MemberRemoved` and
+/// `MemberLeft`. The field was added in v4 with the intent that B3's
+/// descend-from check would consult it; in the actually-shipped B3 the
+/// descend-from boundary comes from the **state delta's** governance
+/// position, and `cut.governance_dag_heads` was redundant with the
+/// signed `SignedNamespaceOp.parent_op_hashes` carrying the same data.
+/// The `expected_group_state_hash` and `expected_context_state_hashes`
+/// fields (the post-apply convergence claims that drive
+/// reconcile-on-mismatch) remain. Pre-1.0 wire break; old-shape ops are
+/// rejected outright.
+///
+/// v4: `MemberRemoved` and `MemberLeft` carry the signed governance-DAG
 /// cut, the expected post-apply group state hash, and the expected
 /// post-apply per-context CRDT state hashes. Receivers detect divergence by
 /// comparing their computed hashes against the signed values after apply.
@@ -48,7 +59,7 @@ pub use ack_router::AckRouter;
 ///
 /// v1 was internal to feature branch development and never deployed to any
 /// persistent network. No backward-compatible deserialization is needed.
-pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 4;
+pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 5;
 
 /// Domain separation prefix for Ed25519 signatures over group ops.
 pub const GROUP_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.group.v1";
@@ -69,14 +80,8 @@ pub enum GroupOp {
     },
     /// Remove a member.
     ///
-    /// Carries three signed claims for cross-DAG convergence:
-    ///
-    /// - `cut`: the namespace governance-DAG position the admin signed
-    ///   against. Receivers use this — not their own local heads — as
-    ///   the descend-from boundary for the apply-time cross-DAG
-    ///   membership check. Two peers at different governance positions
-    ///   evaluate the same answer for any in-flight delta from the
-    ///   removed member.
+    /// Carries two signed claims that drive cross-DAG convergence on
+    /// receive:
     ///
     /// - `expected_group_state_hash`: governance state hash
     ///   (`compute_group_state_hash`) AFTER the admin's local apply.
@@ -97,17 +102,14 @@ pub enum GroupOp {
     /// not roll back the apply; the canonical view is the admin's, and
     /// reconciliation against an anchor is the recovery path.
     ///
-    /// **Two different group-state hashes travel in this op, by
-    /// design:** `cut.group_state_hash` is the **pre-apply** snapshot
-    /// (the state the signer signed against — used by receivers as
-    /// the descend-from boundary for the membership walk), while
-    /// `expected_group_state_hash` is the **post-apply** simulation
-    /// (used by receivers as the convergence target after they apply
-    /// the op). They have different values, different roles, and
-    /// different consumers; do not collapse them.
+    /// **DAG ordering** is established by the enclosing signed envelope's
+    /// `parent_op_hashes` (which receivers consult via the namespace
+    /// governance DAG's `Pending` → backfill machinery). The B3 cross-DAG
+    /// descend-from check uses the **state delta's** governance position,
+    /// not a cut embedded here — every state delta carries its own
+    /// `governance_position` against which `membership_status_at` walks.
     MemberRemoved {
         member: PublicKey,
-        cut: GovernancePosition,
         expected_group_state_hash: [u8; 32],
         expected_context_state_hashes: Vec<(ContextId, [u8; 32])>,
     },
@@ -121,7 +123,7 @@ pub enum GroupOp {
     /// pair with admin-initiated `MemberRemoved`.
     /// See `architecture/membership-and-leave.html` § 5.
     ///
-    /// Carries the same three convergence claims as `MemberRemoved`,
+    /// Carries the same two convergence claims as `MemberRemoved`,
     /// signed by the leaver. The leaver is honest by definition for
     /// self-leave; a Byzantine leaver claiming false canonical hashes
     /// triggers a divergence warning on apply at each receiver but the
@@ -131,7 +133,6 @@ pub enum GroupOp {
     /// signed hashes are a detection signal, not an adoption gate.
     MemberLeft {
         member: PublicKey,
-        cut: GovernancePosition,
         expected_group_state_hash: [u8; 32],
         expected_context_state_hashes: Vec<(ContextId, [u8; 32])>,
     },

--- a/crates/context/src/group_store/group_governance_publisher.rs
+++ b/crates/context/src/group_store/group_governance_publisher.rs
@@ -62,7 +62,6 @@ impl<'a> GroupGovernancePublisher<'a> {
         // (compute → sign → apply locally) avoids needing transactional
         // rollback in the local apply pipeline — the hashes are pure
         // functions of pre-apply state and a deterministic op effect.
-        let cut = super::build_governance_cut(self.store, &self.group_id)?;
         let expected_group_state_hash = super::compute_group_state_hash_after_remove(
             self.store,
             &self.group_id,
@@ -76,7 +75,6 @@ impl<'a> GroupGovernancePublisher<'a> {
             signer_sk,
             GroupOp::MemberRemoved {
                 member: *removed_member,
-                cut,
                 expected_group_state_hash,
                 expected_context_state_hashes,
             },

--- a/crates/context/src/group_store/meta.rs
+++ b/crates/context/src/group_store/meta.rs
@@ -1,4 +1,4 @@
-use calimero_context_config::types::{ContextGroupId, GovernancePosition};
+use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use calimero_store::key::{ContextMeta, GroupMeta, GroupMetaValue, GROUP_META_PREFIX};
@@ -6,10 +6,7 @@ use calimero_store::Store;
 use eyre::{eyre, Result as EyreResult};
 use sha2::{Digest, Sha256};
 
-use super::{
-    collect_keys_with_prefix_paginated, enumerate_group_contexts, list_group_members,
-    resolve_namespace, NamespaceDagService,
-};
+use super::{collect_keys_with_prefix_paginated, enumerate_group_contexts, list_group_members};
 
 pub fn load_group_meta(
     store: &Store,
@@ -223,72 +220,4 @@ pub fn snapshot_context_state_hashes(
     }
     entries.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(entries)
-}
-
-/// Build the current cross-DAG cut for `group_id` — pre-apply group
-/// state hash bundled with the namespace governance DAG heads at this
-/// moment. Used as the `cut` field in `MemberRemoved` / `MemberLeft`
-/// ops so receivers' apply-time membership check evaluates against the
-/// same descend-from boundary the signer signed against (not against
-/// each receiver's possibly-different local namespace heads).
-///
-/// The two store reads (DAG heads and group state hash) are NOT
-/// atomic. Callers must invoke this from a serializing context where
-/// no concurrent namespace governance op can land between the reads —
-/// in practice the `ContextManager` actor that owns all governance
-/// publishing.
-///
-/// Defense-in-depth: this function uses a **read-twice / bail on
-/// mismatch** pattern (mirrors `compute_governance_position_for_context`
-/// at `handlers/execute/mod.rs`) for **both** the namespace DAG
-/// heads and the group state hash. A concurrent namespace
-/// governance op would change the heads set; a concurrent
-/// group-level op (e.g. `MemberAdded` racing this read) would
-/// change the group state hash without touching the heads. Both
-/// are detected and produce a hard error rather than a malformed
-/// cut that would generate spurious divergence warnings on every
-/// honest receiver.
-///
-/// The price is one extra hash recompute + one extra heads read per
-/// `MemberRemoved` / `MemberLeft` sign — cold path, not a hot loop.
-///
-/// Once the cut is built it travels intact in the signed op — there's
-/// no second read by receivers, so the only race is on the signer's
-/// side and is now caught here.
-pub fn build_governance_cut(
-    store: &Store,
-    group_id: &ContextGroupId,
-) -> EyreResult<GovernancePosition> {
-    let namespace_id = resolve_namespace(store, group_id)?;
-    let dag = NamespaceDagService::new(store, namespace_id.to_bytes());
-    let heads_before = dag.read_head_record()?.parent_hashes;
-    let group_state_hash_before = compute_group_state_hash(store, group_id)?;
-    let group_state_hash_after = compute_group_state_hash(store, group_id)?;
-    let heads_after = dag.read_head_record()?.parent_hashes;
-    // Set-equality, not Vec-equality. Storage iteration order isn't
-    // guaranteed to be stable across reads, so a Vec compare would
-    // false-positive on every reorder. A concurrent op landing
-    // changes the SET of heads, which is what we want to catch.
-    let heads_changed = {
-        use std::collections::HashSet;
-        heads_before.len() != heads_after.len()
-            || heads_before.iter().collect::<HashSet<_>>()
-                != heads_after.iter().collect::<HashSet<_>>()
-    };
-    if heads_changed {
-        return Err(eyre!(
-            "build_governance_cut: namespace DAG heads changed mid-read for group {} — \
-             refusing to emit an internally-inconsistent cut",
-            hex::encode(group_id.to_bytes())
-        ));
-    }
-    if group_state_hash_before != group_state_hash_after {
-        return Err(eyre!(
-            "build_governance_cut: group state hash changed mid-read for group {} — \
-             a concurrent group-level op landed; refusing to emit a stale-hash cut",
-            hex::encode(group_id.to_bytes())
-        ));
-    }
-    GovernancePosition::new(*group_id, group_state_hash_before, heads_before)
-        .map_err(|e| eyre!("invalid governance position at sign time: {e}"))
 }

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -85,9 +85,8 @@ pub use self::membership_policy::MembershipPolicy;
 pub use self::membership_status::{membership_status_at, MembershipStatus};
 pub use self::membership_view::GroupMembershipView;
 pub use self::meta::{
-    build_governance_cut, compute_group_state_hash, compute_group_state_hash_after_remove,
-    delete_group_meta, enumerate_all_groups, load_group_meta, save_group_meta,
-    snapshot_context_state_hashes,
+    compute_group_state_hash, compute_group_state_hash_after_remove, delete_group_meta,
+    enumerate_all_groups, load_group_meta, save_group_meta, snapshot_context_state_hashes,
 };
 pub use self::metadata::{
     build_namespace_summary, count_group_contexts, delete_all_member_metadata,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -845,11 +845,11 @@ pub fn now_millis() -> u64 {
 ///    `ContextDetached` ops still has its registrations and the
 ///    per-context check would be skipped on it. This is not a
 ///    silent gap — the receiver's namespace DAG heads disagree with
-///    the signer's `cut.governance_dag_heads` in this scenario, so
-///    the cross-DAG membership check on subsequent state deltas
-///    returns `Unknown { needed }` and buffers them until the
-///    detach ops arrive (or anchor-sync reconciles). The hash
-///    check skip is therefore additive to an existing detection
+///    the signer's `SignedNamespaceOp.parent_op_hashes` in this
+///    scenario, so the cross-DAG membership check on subsequent
+///    state deltas returns `Unknown { needed }` and buffers them
+///    until the detach ops arrive (or anchor-sync reconciles). The
+///    hash check skip is therefore additive to an existing detection
 ///    path, not the sole defense.
 ///
 ///    Once the network has fully rolled forward to signed-claim ops

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -24,11 +24,9 @@ fn test_group_id() -> ContextGroupId {
 /// against actual post-apply state will see a mismatch — tests that
 /// hit the apply path either ignore the mismatch (it's a warn-log,
 /// not a hard reject) or use the real `compute_*` helpers.
-fn dummy_member_removed_op(group_id: ContextGroupId, member: PublicKey) -> GroupOp {
+fn dummy_member_removed_op(_group_id: ContextGroupId, member: PublicKey) -> GroupOp {
     GroupOp::MemberRemoved {
         member,
-        cut: calimero_context_config::types::GovernancePosition::new(group_id, [0u8; 32], vec![])
-            .expect("empty heads is a valid GovernancePosition"),
         expected_group_state_hash: [0u8; 32],
         expected_context_state_hashes: Vec::new(),
     }
@@ -6425,34 +6423,6 @@ fn snapshot_context_state_hashes_skips_unmaterialized_contexts() {
 }
 
 #[test]
-fn build_governance_cut_carries_current_group_state_hash() {
-    // The `cut` field's `group_state_hash` is the PRE-apply hash
-    // (admin's view at sign time, not the post-apply view). Receivers
-    // use the cut to identify which namespace-DAG position to walk
-    // for the membership check — that walk needs the current group
-    // state to make sense.
-    let store = test_store();
-    let gid = test_group_id();
-    let admin = PublicKey::from([0x01; 32]);
-    save_group_meta(&store, &gid, &sample_meta_with_admin(admin)).unwrap();
-    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
-
-    let pre_apply_hash = compute_group_state_hash(&store, &gid).unwrap();
-    let cut = build_governance_cut(&store, &gid).unwrap();
-
-    assert_eq!(
-        cut.group_state_hash, pre_apply_hash,
-        "cut must carry the pre-apply (current) group state hash"
-    );
-    assert_eq!(cut.group_id, gid);
-    // No namespace governance ops have run, so heads are empty.
-    assert!(
-        cut.governance_dag_heads.is_empty(),
-        "fresh namespace has no DAG heads"
-    );
-}
-
-#[test]
 fn diff_sorted_context_hashes_pins_merge_scan_semantics() {
     // Pin the linear-merge divergence logic that replaced the
     // earlier two-`BTreeMap` build. Each case asserts on the
@@ -6588,13 +6558,6 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
     let bystander_pk = PublicKey::from([0xD1; 32]);
 
     // Bootstrap: a meta + admin + target + bystander member set.
-    // No parent group is set, which means `resolve_namespace` treats
-    // `gid` as its own namespace (the no-parent case). That lets
-    // `build_governance_cut` succeed below with empty
-    // `governance_dag_heads` — a deterministic empty namespace DAG
-    // for a self-rooted group. If `resolve_namespace`'s no-parent
-    // semantics ever change, this test's bootstrap shape will need
-    // an explicit `nest_group` call.
     let mut meta = test_meta();
     meta.admin_identity = admin_pk;
     meta.owner_identity = admin_pk;
@@ -6605,7 +6568,6 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
 
     // Real sign-time precomputation: admin's view of the post-apply
     // state, signed alongside the op.
-    let cut = build_governance_cut(&store, &gid).unwrap();
     let expected_group_state_hash =
         compute_group_state_hash_after_remove(&store, &gid, &target_pk).unwrap();
     let expected_context_state_hashes = snapshot_context_state_hashes(&store, &gid).unwrap();
@@ -6618,7 +6580,6 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
         1,
         GroupOp::MemberRemoved {
             member: target_pk,
-            cut,
             expected_group_state_hash,
             expected_context_state_hashes: expected_context_state_hashes.clone(),
         },
@@ -6795,8 +6756,6 @@ fn apply_group_op_mutations_surfaces_divergence_on_hash_mismatch() {
     let wrong_hash = [0xFFu8; 32];
     let op = GroupOp::MemberRemoved {
         member: target,
-        cut: calimero_context_config::types::GovernancePosition::new(gid, [0u8; 32], vec![])
-            .expect("empty heads is valid"),
         expected_group_state_hash: wrong_hash,
         expected_context_state_hashes: Vec::new(),
     };
@@ -6837,8 +6796,6 @@ fn apply_group_op_mutations_no_divergence_on_matching_hash() {
         compute_group_state_hash_after_remove(&store, &gid, &target).unwrap();
     let op = GroupOp::MemberRemoved {
         member: target,
-        cut: calimero_context_config::types::GovernancePosition::new(gid, [0u8; 32], vec![])
-            .expect("empty heads is valid"),
         expected_group_state_hash: real_post_apply_hash,
         expected_context_state_hashes: Vec::new(),
     };

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -24,7 +24,7 @@ fn test_group_id() -> ContextGroupId {
 /// against actual post-apply state will see a mismatch — tests that
 /// hit the apply path either ignore the mismatch (it's a warn-log,
 /// not a hard reject) or use the real `compute_*` helpers.
-fn dummy_member_removed_op(_group_id: ContextGroupId, member: PublicKey) -> GroupOp {
+fn dummy_member_removed_op(member: PublicKey) -> GroupOp {
     GroupOp::MemberRemoved {
         member,
         expected_group_state_hash: [0u8; 32],
@@ -1447,7 +1447,7 @@ fn apply_local_signed_group_op_rejects_last_admin_removal() {
         vec![],
         [0u8; 32],
         1,
-        dummy_member_removed_op(test_group_id(), admin_pk),
+        dummy_member_removed_op(admin_pk),
     )
     .unwrap();
     assert!(apply_local_signed_group_op(&store, &op_bad).is_err());
@@ -5842,7 +5842,7 @@ fn deny_list_member_removed_op_marks_entry() {
         vec![],
         compute_group_state_hash(&store, &gid).unwrap(),
         1,
-        dummy_member_removed_op(gid, target_pk),
+        dummy_member_removed_op(target_pk),
     )
     .expect("sign MemberRemoved");
     apply_local_signed_group_op(&store, &op).expect("apply MemberRemoved");
@@ -5876,7 +5876,7 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
         vec![],
         compute_group_state_hash(&store, &gid).unwrap(),
         1,
-        dummy_member_removed_op(gid, target_pk),
+        dummy_member_removed_op(target_pk),
     )
     .expect("sign MemberRemoved");
     apply_local_signed_group_op(&store, &rm).expect("apply MemberRemoved");

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -87,10 +87,6 @@ impl Handler<LeaveGroupRequest> for ContextManager {
         // Sign-time hash precomputation, mirroring `MemberRemoved`. The
         // leaver simulates the post-leave state so receivers can detect
         // divergence.
-        let cut = match group_store::build_governance_cut(&self.datastore, &group_id) {
-            Ok(c) => c,
-            Err(err) => return ActorResponse::reply(Err(err)),
-        };
         let expected_group_state_hash = match group_store::compute_group_state_hash_after_remove(
             &self.datastore,
             &group_id,
@@ -109,7 +105,6 @@ impl Handler<LeaveGroupRequest> for ContextManager {
             async move {
                 let op = calimero_context_client::local_governance::GroupOp::MemberLeft {
                     member: member_public_key,
-                    cut,
                     expected_group_state_hash,
                     expected_context_state_hashes,
                 };

--- a/crates/context/src/handlers/leave_namespace.rs
+++ b/crates/context/src/handlers/leave_namespace.rs
@@ -79,10 +79,6 @@ impl Handler<LeaveNamespaceRequest> for ContextManager {
         // leaver simulates the post-leave state so receivers can detect
         // divergence. See `compute_group_state_hash_after_remove` and
         // `snapshot_context_state_hashes`.
-        let cut = match group_store::build_governance_cut(&self.datastore, &namespace_id) {
-            Ok(c) => c,
-            Err(err) => return ActorResponse::reply(Err(err)),
-        };
         let expected_group_state_hash = match group_store::compute_group_state_hash_after_remove(
             &self.datastore,
             &namespace_id,
@@ -101,7 +97,6 @@ impl Handler<LeaveNamespaceRequest> for ContextManager {
             async move {
                 let op = calimero_context_client::local_governance::GroupOp::MemberLeft {
                     member: member_public_key,
-                    cut,
                     expected_group_state_hash,
                     expected_context_state_hashes,
                 };

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -41,7 +41,7 @@ fn sample_group_id() -> ContextGroupId {
 /// hashes intentionally don't match real post-apply state — these
 /// tests don't verify the mismatch-detection path (that's covered
 /// separately by `compute_group_state_hash_after_remove` unit tests).
-fn dummy_member_removed(_group_id: ContextGroupId, member: PublicKey) -> GroupOp {
+fn dummy_member_removed(member: PublicKey) -> GroupOp {
     GroupOp::MemberRemoved {
         member,
         expected_group_state_hash: [0u8; 32],
@@ -1016,7 +1016,7 @@ fn state_hash_prevents_concurrent_op_divergence() {
         vec![[0u8; 32]],
         state_hash_c,
         1,
-        dummy_member_removed(sample_group_id(), admin_a_pk),
+        dummy_member_removed(admin_a_pk),
     )
     .unwrap();
 
@@ -1101,7 +1101,7 @@ fn cascade_removal_on_member_kick() {
         vec![[0u8; 32]],
         [0u8; 32],
         1,
-        dummy_member_removed(sample_group_id(), member_pk),
+        dummy_member_removed(member_pk),
     )
     .unwrap();
     apply_local_signed_group_op(&store, &op).unwrap();
@@ -1164,7 +1164,7 @@ fn cascade_removal_deterministic_across_nodes() {
         vec![[0u8; 32]],
         [0u8; 32],
         1,
-        dummy_member_removed(sample_group_id(), member_pk),
+        dummy_member_removed(member_pk),
     )
     .unwrap();
     apply_local_signed_group_op(&node_a, &op).unwrap();

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -41,11 +41,9 @@ fn sample_group_id() -> ContextGroupId {
 /// hashes intentionally don't match real post-apply state — these
 /// tests don't verify the mismatch-detection path (that's covered
 /// separately by `compute_group_state_hash_after_remove` unit tests).
-fn dummy_member_removed(group_id: ContextGroupId, member: PublicKey) -> GroupOp {
+fn dummy_member_removed(_group_id: ContextGroupId, member: PublicKey) -> GroupOp {
     GroupOp::MemberRemoved {
         member,
-        cut: GovernancePosition::new(group_id, [0u8; 32], vec![])
-            .expect("empty heads is a valid GovernancePosition"),
         expected_group_state_hash: [0u8; 32],
         expected_context_state_hashes: Vec::new(),
     }


### PR DESCRIPTION
## Summary

Delete the `cut: GovernancePosition` field from `MemberRemoved` and `MemberLeft` ops. The field was shipped in PR #2340 / wire version 4 with the RFC's intent that B3's descend-from check would consult it; the actually-shipped B3 (#2298) consults the **state delta's** `governance_position` instead. The cut on the governance op itself never got a consumer.

Net **−128 LOC**, wire-format bump v4 → v5.

## Audit details

Grep over the whole tree confirms no production consumer of the `cut` field on either variant. Every `MemberRemoved` / `MemberLeft` destructure binds it as `{ .. }`. The only references were:

- 3 construction sites (`group_governance_publisher.rs` admin-remove; `handlers/leave_group.rs`; `handlers/leave_namespace.rs`) — all call `build_governance_cut()` and pass the result.
- Test fixtures that pin placeholder values (`[0u8; 32]`, `vec![]`) — no assertion ever reads cut content.

### Field-by-field redundancy

| Field | Status |
|---|---|
| `cut.governance_dag_heads` | Identical to `SignedNamespaceOp.parent_op_hashes` already on the wire. Same data, same signature envelope. |
| `cut.group_state_hash` | Pre-apply group state hash. Unique data on the wire — but a pre-apply convergence check would be redundant with the existing post-apply `expected_group_state_hash` check, with added false-positive surface (pre-apply diverged + post-apply converged via deterministic CRDT merge). Same recovery path either way (reconcile-via-anchor). |

## Changes

- `crates/context/primitives/src/local_governance/mod.rs`: drop the field; bump `SIGNED_GROUP_OP_SCHEMA_VERSION` to 5 with rationale.
- `crates/context/src/group_store/meta.rs`: delete `build_governance_cut()` helper (~50 LOC).
- `crates/context/src/group_store/mod.rs`: drop the re-export.
- 3 construction sites updated.
- 4 test sites updated (`dummy_member_removed_op`, `dummy_member_removed`, two `apply_group_op_mutations_*` tests). The dedicated `build_governance_cut_carries_current_group_state_hash` test deleted along with the helper.

## Side finding — S2 (`is_read_only_for_context`) is NOT subsumed by B3

While auditing this work I also dug into RFC item S2 ("Remove `is_read_only_for_context` (subsumed by B3)"). That listing turns out to be wrong — leaving a note here so the next person doesn't have to repeat the audit.

`is_read_only_for_context` is still called from 4 production sites with explicit comments documenting why each is needed:

| Site | Role |
|---|---|
| `handlers/execute/mod.rs:1215` | Local execute path — blocks the local user from running mutation methods if their current role is ReadOnly. B3 covers remote deltas, not local executes. |
| `state_delta/mod.rs:402` | Catches "member became ReadOnly between authoring and apply." B3 sees `Member(role)` at the **signed cut** (forward-only); this checks **current** role. |
| `state_delta/mod.rs:863` | Fast-path to skip drain + cross-DAG lookup. |
| `state_delta/mod.rs:1912` | Snapshot-sync replay path, same purpose as :402. |

B3 enforces forward-only at the signed cut: pre-cut writes from a member who is now ReadOnly would still be accepted (correct per the forward-only invariant for membership *removals*). `is_read_only_for_context` enforces live current role and rejects all writes from now-ReadOnly members regardless of when they were authored.

Whether role demotions should be forward-only too (mirroring removals) is a **semantic** decision, not pure cleanup. S2 either needs that design conversation first, or should be reframed/closed. Leaving the call sites intact for now.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p calimero-context --lib` — 248 passed (was 249, −1 for deleted `build_governance_cut_carries_current_group_state_hash`)
- [x] `cargo test -p calimero-context --test local_group_governance_convergence` — 23 passed
- [ ] CI green on push

## Notes

Pre-1.0 wire break per project stance (`feedback_pre_1_0_break_freely.md`). Old-shape ops are rejected outright by the v5 schema-version check on receive; nodes upgrading need a state wipe if they have persisted v4 `MemberRemoved` / `MemberLeft` ops in their op log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pre-1.0 wire-format break (group-op schema v4→v5) that will reject older persisted `MemberRemoved`/`MemberLeft` ops and requires all peers to upgrade in lockstep for those variants.
> 
> **Overview**
> Drops the `cut: GovernancePosition` field from `GroupOp::MemberRemoved` and `GroupOp::MemberLeft`, bumping `SIGNED_GROUP_OP_SCHEMA_VERSION` to `5` and updating docs/comments to reflect that DAG ordering/authorization boundaries come from existing signed envelopes and state-delta `governance_position`.
> 
> Removes the now-dead `build_governance_cut()` helper and updates all publishers/handlers/tests that constructed leave/remove ops to stop computing/passing the cut, including deleting the associated unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c33b8619ae1e03140c9bcc75d103d9561b5a04ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->