### PR TITLE
refactor(context): drop dead compute_namespace_governance_epoch (S3)

### DIFF
--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -100,11 +100,10 @@ pub use self::migrations::{
 };
 pub use self::namespace::{
     collect_descendant_groups, collect_subtree_for_cascade, collect_visible_descendant_groups,
-    compute_namespace_governance_epoch, create_recursive_invitations, get_namespace_identity,
-    get_namespace_identity_record, get_or_create_namespace_identity,
-    get_or_create_namespace_identity_bundle, get_parent_group, is_descendant_of,
-    is_read_only_for_context, list_child_groups, nest_group, recursive_remove_member,
-    reparent_group, resolve_namespace, resolve_namespace_identity,
+    create_recursive_invitations, get_namespace_identity, get_namespace_identity_record,
+    get_or_create_namespace_identity, get_or_create_namespace_identity_bundle, get_parent_group,
+    is_descendant_of, is_read_only_for_context, list_child_groups, nest_group,
+    recursive_remove_member, reparent_group, resolve_namespace, resolve_namespace_identity,
     resolve_namespace_identity_record, store_namespace_identity, unnest_group, CascadePayload,
     NamespaceIdentityRecord, ReparentOutcome, ResolvedNamespaceIdentity,
 };

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -13,7 +13,7 @@ use sha2::Digest;
 
 use super::{
     cascade_remove_member_from_group_tree, collect_keys_with_prefix, get_group_for_context,
-    get_group_member_role, get_op_head, remove_group_member,
+    get_group_member_role, remove_group_member,
 };
 
 pub(crate) const MAX_NAMESPACE_DEPTH: usize = 16;
@@ -29,32 +29,6 @@ pub struct NamespaceIdentityRecord {
 pub struct ResolvedNamespaceIdentity {
     pub namespace_id: ContextGroupId,
     pub identity: NamespaceIdentityRecord,
-}
-
-/// Namespace governance epoch: just the namespace DAG heads.
-///
-/// With the single-DAG model, governance epoch is simply the heads of
-/// the namespace DAG that contains this context's group.
-pub fn compute_namespace_governance_epoch(
-    store: &Store,
-    context_id: &ContextId,
-) -> EyreResult<Vec<[u8; 32]>> {
-    let Some(owning_gid) = get_group_for_context(store, context_id)? else {
-        return Ok(vec![]);
-    };
-
-    let ns_id = resolve_namespace(store, &owning_gid)?;
-    let ns_key = calimero_store::key::NamespaceGovHead::new(ns_id.to_bytes());
-    let handle = store.handle();
-    match handle.get(&ns_key)? {
-        Some(head) => Ok(head.dag_heads),
-        None => {
-            // Fall back to the old per-group DAG heads during migration.
-            get_op_head(store, &owning_gid)?
-                .map(|h| Ok(h.dag_heads))
-                .unwrap_or_else(|| Ok(vec![]))
-        }
-    }
 }
 
 /// Returns `true` if the member has a read-only role (`ReadOnly` or `ReadOnlyTee`)


### PR DESCRIPTION
## Summary

RFC item S3 — drop the dead `compute_namespace_governance_epoch` helper. The function survived a B1-era refactor with zero callers. Pure deletion, **−28 LOC**.

## Audit

The `governance_epoch` wire field on state-delta envelopes was removed by PR #2298 (B1) when `GovernancePosition` replaced it. The helper that computed values for that field — `compute_namespace_governance_epoch` in `crates/context/src/group_store/namespace.rs` — survived but lost every caller in the same change.

```
$ grep -rn "compute_namespace_governance_epoch" crates/
crates/context/src/group_store/mod.rs:103         # re-export
crates/context/src/group_store/namespace.rs:38    # definition

$ grep -rn "governance_epoch:" crates/
# (no matches — no struct field by this name remains in the Rust code)
```

## Changes

- `crates/context/src/group_store/namespace.rs`: delete `compute_namespace_governance_epoch` + the orphaned `get_op_head` import it had been the only user of.
- `crates/context/src/group_store/mod.rs`: drop the `pub use` re-export.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p calimero-context --lib` — 248 passed
- [x] `cargo test -p calimero-context --test local_group_governance_convergence` — 23 passed
- [ ] CI green on push

## Stale HTML docs (out of scope)

The architecture HTML pages still reference `governance_epoch` as a state-delta wire field:

- `architecture/local-governance.html`
- `architecture/wire-protocol.html`
- `architecture/glossary.html`
- `architecture/crates/runtime.html`

These were already stale before this PR — the wire field has been gone since #2298. They're not auto-generated from the Rust source; the `update-docs` automation that runs on merge should catch them. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely deletes an unused helper and its re-export, with no behavior changes or data-path modifications.
> 
> **Overview**
> Removes the dead `compute_namespace_governance_epoch` helper from `group_store/namespace.rs` and drops its `pub use` re-export from `group_store/mod.rs`.
> 
> Also cleans up the now-unused `get_op_head` import that existed only to support that helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a8e58047271df6fcb4e80c67e5b049b156ba67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->