### PR TITLE
fix(context): trigger KeyDelivery for self-join of Open subgroups

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -185,6 +185,9 @@ jobs:
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e
+          - workflow: group-open-self-join-key-delivery
+            file: workflows/group-open-self-join-key-delivery.yml
+            app: scaffolding-e2e
           - workflow: dm-subgroup-privacy
             file: workflows/dm-subgroup-privacy.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -114,6 +114,17 @@ steps:
     outputs:
       ctx_id: contextId
 
+  - name: Wait for subgroup visibility + context-registered ops to propagate
+    # `set_subgroup_visibility` and `create_context` issue governance
+    # ops that need to reach node-2 before its `join_context` runs the
+    # parent-walk inheritance check. Without this wait, node-2 may
+    # still see the subgroup as Restricted (or not yet know the
+    # context exists at all) when it tries to join — the inheritance
+    # check returns `MembershipPath::None` and `join_context` bails
+    # with "identity is not a member of the group".
+    type: wait
+    seconds: 10
+
   # ── Phase 2: node-2 self-joins via inherited path ─────────────────
   # This is the critical operation. No `add_group_members` is run for
   # node-2 on the Open subgroup — they're inherited from the parent

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -1,0 +1,241 @@
+name: E2E KV Store - Open Subgroup Self-Join Key Delivery
+description: >
+  Regression guard for PR #2351 (`fix(context): trigger KeyDelivery for
+  self-join of Open subgroups`).
+
+  Pre-fix bug: when a namespace member self-joins an `Open` subgroup
+  context via the `CAN_JOIN_OPEN_SUBGROUPS` parent-walk (no
+  admin-issued `add_group_members`), `join_context` inserts a
+  `ContextIdentity` row with `sender_key: None`. No `MemberJoined`
+  governance op is published for them, so no peer ever wraps the
+  current group key in a `KeyDelivery` for the joiner. Their
+  outgoing state-DAG ops can't be signed/encrypted with the group
+  key, so peers reject/ignore them; symmetrically, the joiner can't
+  decrypt incoming ops. Symptom: "joined a public channel, sends
+  messages, no one sees them; can't see others either."
+
+  Fix: `join_context.rs` now publishes a self-signed
+  `RootOp::MemberJoinedOpen { member, group_id }` whenever the join
+  path was `MembershipPath::Inherited`. Peers holding the group key
+  queue a `PendingKeyDelivery` (same struct the existing
+  `MemberJoined` path uses); the delivery dispatcher publishes a
+  wrapped `KeyDelivery`, populating the joiner's `sender_key`.
+
+  This workflow differs from `group-subgroup-visibility-inheritance.yml`
+  by exercising the *joiner-as-author* direction explicitly: that
+  existing test only confirms node-1's writes flow to node-2, which
+  passes on master because the joiner can DECRYPT incoming ops using
+  the namespace-level group key delivered through a different path.
+  The bug is that the joiner can't AUTHOR ops because `sender_key`
+  was never populated — that's what this test asserts by having
+  node-2 write and node-1 read the result.
+
+  Pre-fix expectation: Round 2 wait_for_sync times out, or the
+  node-1 read of node-2's write returns null/empty (node-1 can't
+  decrypt the joiner's ops). Post-fix expectation: both directions
+  succeed.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: merod:local
+  prefix: open-selfjoin-node
+
+steps:
+  # ── Phase 1: Bootstrap mesh, namespace, Open subgroup, context ────
+
+  - name: Install application on node-1
+    type: install_application
+    node: open-selfjoin-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: open-selfjoin-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: open-selfjoin-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: open-selfjoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      ns_invite: invitation
+
+  - name: Wait for namespace governance to gossip
+    # 10s matches the post-#2344 opaque-leaf-regression timing; covers
+    # invitation visibility so `join_namespace` doesn't 404.
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    # Default member capabilities include CAN_JOIN_OPEN_SUBGROUPS, so
+    # node-2 inherits the right to join any Open subgroup beneath
+    # this namespace without an explicit add_group_members.
+    type: join_namespace
+    node: open-selfjoin-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{ns_invite}}'
+    outputs:
+      node2_identity: memberIdentity
+
+  - name: Node-1 creates Open subgroup inside namespace
+    type: create_group_in_namespace
+    node: open-selfjoin-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: open-selfjoin-node-1
+    group_id: '{{subgroup_id}}'
+    visibility: open
+
+  - name: Node-1 creates context inside Open subgroup
+    type: create_context
+    node: open-selfjoin-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  # ── Phase 2: node-2 self-joins via inherited path ─────────────────
+  # This is the critical operation. No `add_group_members` is run for
+  # node-2 on the Open subgroup — they're inherited from the parent
+  # namespace + CAN_JOIN_OPEN_SUBGROUPS. Pre-fix this leaves their
+  # ContextIdentity row with sender_key:None; post-fix the joiner
+  # publishes MemberJoinedOpen which triggers KeyDelivery.
+
+  - name: Node-2 self-joins Open-subgroup context (inherited path)
+    type: join_context
+    node: open-selfjoin-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Assert bootstrap shape
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+      - "is_set({{subgroup_id}})"
+      - "is_set({{ctx_id}})"
+      - "is_set({{node1_key}})"
+      - "is_set({{node2_identity}})"
+      - "is_set({{node2_key}})"
+
+  - name: Initial sync (empty Root state)
+    # Lets the post-join_context flow settle — including (post-fix)
+    # the MemberJoinedOpen publish + KeyDelivery round-trip that
+    # populates node-2's sender_key. Pre-fix this is a no-op because
+    # there's nothing to deliver.
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - open-selfjoin-node-1
+      - open-selfjoin-node-2
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 3: Round 1 — node-1 writes, node-2 reads ────────────────
+  # Control case. This direction works on master too (matches the
+  # existing group-subgroup-visibility-inheritance test). Asserts the
+  # fix doesn't regress the inbound-decrypt path.
+
+  - name: Round 1 — node-1 writes
+    type: call
+    node: open-selfjoin-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "from_admin"
+      value: "node1_msg"
+    executor_public_key: '{{node1_key}}'
+
+  - name: Round 1 sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - open-selfjoin-node-1
+      - open-selfjoin-node-2
+    timeout: 30
+    check_interval: 2
+
+  - name: Node-2 reads node-1's write
+    type: call
+    node: open-selfjoin-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "from_admin"
+    executor_public_key: '{{node2_key}}'
+    outputs:
+      node2_read_admin: result
+
+  # ── Phase 4: Round 2 — node-2 writes, node-1 reads ────────────────
+  # THIS IS THE BUG. Pre-fix, node-2 has sender_key:None so their op
+  # can't be signed with the group key. Either:
+  #   (a) the write attempt fails locally with a key-missing error, or
+  #   (b) the op is produced but peers reject it as malformed/unsigned, or
+  #   (c) the op propagates as plaintext but node-1's apply path
+  #       refuses to apply ops not encrypted with the current group key.
+  # In all three sub-modes, node-1's read of "from_joiner" returns
+  # null/empty after Round 2 sync. Post-fix, the key has been
+  # delivered to node-2 so the write authors cleanly and node-1
+  # decrypts it.
+
+  - name: Round 2 — node-2 (inherited self-joiner) writes
+    type: call
+    node: open-selfjoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "from_joiner"
+      value: "node2_msg"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Round 2 sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - open-selfjoin-node-1
+      - open-selfjoin-node-2
+    timeout: 30
+    check_interval: 2
+
+  - name: Node-1 reads node-2's write (THE BUG)
+    type: call
+    node: open-selfjoin-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "from_joiner"
+    executor_public_key: '{{node1_key}}'
+    outputs:
+      node1_read_joiner: result
+
+  # ── Phase 5: Assertions ───────────────────────────────────────────
+
+  - name: Assert both directions converged
+    type: assert
+    statements:
+      - "is_set({{node2_read_admin}})"
+      - "is_set({{node1_read_joiner}})"
+      - 'contains({{node2_read_admin}}, "node1_msg")'
+      - 'contains({{node1_read_joiner}}, "node2_msg")'
+
+stop_all_nodes: false

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -383,6 +383,16 @@ pub enum RootOp {
         /// signature. Peers use this to verify the join was authorized.
         signed_invitation: SignedGroupOpenInvitation,
     },
+    /// Delivers the current group key to a specific member.
+    ///
+    /// Published by an existing member after seeing `MemberJoined` on the
+    /// DAG. The group key is ECDH-wrapped so only the recipient can
+    /// decrypt it. No P2P handshake or online requirement — the joiner
+    /// picks this up when it processes the DAG.
+    KeyDelivery {
+        group_id: [u8; 32],
+        envelope: KeyEnvelope,
+    },
     /// A namespace member just self-joined an `Open` subgroup whose
     /// `Open` visibility (+ their namespace-level
     /// `CAN_JOIN_OPEN_SUBGROUPS` capability) is the authorisation —
@@ -402,19 +412,16 @@ pub enum RootOp {
     /// a `ContextIdentity` with `sender_key: None` for the inherited
     /// case and never asked any holder of the group key to deliver
     /// it. See `handlers/join_context.rs`.
+    ///
+    /// **Borsh ordering**: this variant is intentionally placed AFTER
+    /// `KeyDelivery` so that `KeyDelivery`'s discriminant is unchanged
+    /// from pre-fix releases — existing on-disk DAG ops continue to
+    /// deserialize correctly. Only the new `MemberJoinedOpen`
+    /// discriminant is added; older peers will fail to decode this
+    /// variant but won't mis-decode existing ones.
     MemberJoinedOpen {
         member: PublicKey,
         group_id: [u8; 32],
-    },
-    /// Delivers the current group key to a specific member.
-    ///
-    /// Published by an existing member after seeing `MemberJoined` on the
-    /// DAG. The group key is ECDH-wrapped so only the recipient can
-    /// decrypt it. No P2P handshake or online requirement — the joiner
-    /// picks this up when it processes the DAG.
-    KeyDelivery {
-        group_id: [u8; 32],
-        envelope: KeyEnvelope,
     },
 }
 

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -383,6 +383,29 @@ pub enum RootOp {
         /// signature. Peers use this to verify the join was authorized.
         signed_invitation: SignedGroupOpenInvitation,
     },
+    /// A namespace member just self-joined an `Open` subgroup whose
+    /// `Open` visibility (+ their namespace-level
+    /// `CAN_JOIN_OPEN_SUBGROUPS` capability) is the authorisation —
+    /// there is no admin-signed invitation in this case.
+    ///
+    /// **Cleartext.** The outer `SignedNamespaceOp` MUST be signed by
+    /// the joining member (proves key ownership). On apply, peers
+    /// verify the joiner has an Inherited membership path to
+    /// `group_id` via `check_group_membership_path`; if so, any peer
+    /// that holds the group key publishes a
+    /// [`KeyDelivery`](RootOp::KeyDelivery) wrapping it for the
+    /// joiner. The peer that locally holds the key is the one whose
+    /// `pending_deliveries` accumulates this delivery on apply.
+    ///
+    /// This op closes the "self-join Open subgroup, can't decrypt
+    /// state-DAG messages" gap — `join_context` previously inserted
+    /// a `ContextIdentity` with `sender_key: None` for the inherited
+    /// case and never asked any holder of the group key to deliver
+    /// it. See `handlers/join_context.rs`.
+    MemberJoinedOpen {
+        member: PublicKey,
+        group_id: [u8; 32],
+    },
     /// Delivers the current group key to a specific member.
     ///
     /// Published by an existing member after seeing `MemberJoined` on the
@@ -410,6 +433,7 @@ impl NamespaceOp {
             NamespaceOp::Root(RootOp::AdminChanged { .. }) => "admin_changed",
             NamespaceOp::Root(RootOp::PolicyUpdated { .. }) => "policy_updated",
             NamespaceOp::Root(RootOp::MemberJoined { .. }) => "member_joined",
+            NamespaceOp::Root(RootOp::MemberJoinedOpen { .. }) => "member_joined_open",
             NamespaceOp::Root(RootOp::KeyDelivery { .. }) => "key_delivery",
             NamespaceOp::Group { .. } => "group_op",
         }

--- a/crates/context/src/governance_broadcast.rs
+++ b/crates/context/src/governance_broadcast.rs
@@ -102,6 +102,7 @@ pub fn timeout_for_namespace_op(op: &NamespaceOp) -> Duration {
         }
         NamespaceOp::Root(
             RootOp::MemberJoined { .. }
+            | RootOp::MemberJoinedOpen { .. }
             | RootOp::GroupCreated { .. }
             | RootOp::GroupReparented { .. },
         ) => OP_ACK_MEMBER_CHANGE_TIMEOUT,

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -170,14 +170,40 @@ pub fn membership_status_at(
                 hex::encode(local_state_hash),
             );
         }
-        // See function-level doc for the `Removed` vs `NeverMember`
-        // conflation caveat — the prefix walk recovers the distinction.
-        return Ok(
-            match super::membership::get_group_member_role(store, &group_id, signer)? {
-                Some(role) => MembershipStatus::Member(role),
-                None => MembershipStatus::NeverMember,
-            },
-        );
+        // Direct membership (GroupMember row at the named group) — the
+        // common case for Restricted subgroups and for explicit-add flows.
+        if let Some(role) = super::membership::get_group_member_role(store, &group_id, signer)? {
+            return Ok(MembershipStatus::Member(role));
+        }
+        // Inherited membership — the signer doesn't have a `GroupMember`
+        // row on this subgroup, but reaches it via the Open-subgroup
+        // parent-walk with `CAN_JOIN_OPEN_SUBGROUPS` at the anchor. Open
+        // subgroups don't require an admin-issued `MemberAdded`, so
+        // inherited members produce state deltas with no corresponding
+        // direct-membership row — and without this branch every such
+        // delta was hard-rejected at the cross-DAG check, even though
+        // the same member was authorized to JOIN the context.
+        //
+        // We fold Inherited → Member(Member). The actor's effective role
+        // in this subgroup is the inherited one from `check_group_*`;
+        // we don't have a more precise role at the cross-DAG layer.
+        return match super::membership::check_group_membership_path(store, &group_id, signer)? {
+            super::membership::MembershipPath::Direct => {
+                // Already handled by `get_group_member_role` above.
+                Ok(MembershipStatus::NeverMember)
+            }
+            super::membership::MembershipPath::Inherited { .. } => Ok(
+                MembershipStatus::Member(
+                    calimero_primitives::context::GroupMemberRole::Member,
+                ),
+            ),
+            super::membership::MembershipPath::None => {
+                // See function-level doc for the `Removed` vs
+                // `NeverMember` conflation caveat — the prefix walk
+                // recovers the distinction.
+                Ok(MembershipStatus::NeverMember)
+            }
+        };
     }
 
     // Branch 2 — collect every referenced head that is not present in our

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -189,8 +189,18 @@ pub fn membership_status_at(
         // we don't have a more precise role at the cross-DAG layer.
         return match super::membership::check_group_membership_path(store, &group_id, signer)? {
             super::membership::MembershipPath::Direct => {
-                // Already handled by `get_group_member_role` above.
-                Ok(MembershipStatus::NeverMember)
+                // Practically unreachable: `check_group_membership_path`
+                // returns `Direct` iff `has_direct_member` returned
+                // `true`, which reads the same store row that
+                // `get_group_member_role` reads above. The only way to
+                // arrive here is a write-race where a concurrent
+                // `MemberAdded` applied between the two reads. In that
+                // case the signer just became a direct member with the
+                // default `Member` role — return that rather than the
+                // misleading `NeverMember` an earlier revision used.
+                Ok(MembershipStatus::Member(
+                    calimero_primitives::context::GroupMemberRole::Member,
+                ))
             }
             super::membership::MembershipPath::Inherited { .. } => Ok(MembershipStatus::Member(
                 calimero_primitives::context::GroupMemberRole::Member,

--- a/crates/context/src/group_store/membership_status.rs
+++ b/crates/context/src/group_store/membership_status.rs
@@ -192,11 +192,9 @@ pub fn membership_status_at(
                 // Already handled by `get_group_member_role` above.
                 Ok(MembershipStatus::NeverMember)
             }
-            super::membership::MembershipPath::Inherited { .. } => Ok(
-                MembershipStatus::Member(
-                    calimero_primitives::context::GroupMemberRole::Member,
-                ),
-            ),
+            super::membership::MembershipPath::Inherited { .. } => Ok(MembershipStatus::Member(
+                calimero_primitives::context::GroupMemberRole::Member,
+            )),
             super::membership::MembershipPath::None => {
                 // See function-level doc for the `Removed` vs
                 // `NeverMember` conflation caveat — the prefix walk
@@ -389,6 +387,27 @@ fn prefix_walk_membership(
                     continue;
                 }
                 let role = role_from_invited_role(signed_invitation.invitation.invited_role);
+                current_role = Some(role.clone());
+                last_known_role = Some(role);
+            }
+            // Open-subgroup self-join via `CAN_JOIN_OPEN_SUBGROUPS`
+            // parent-walk. The op is the joiner's proof of membership in
+            // an Open subgroup; without recognising it here, the
+            // cross-DAG check returns `NeverMember` for inherited
+            // joiners and their state deltas get rejected — defeating
+            // the fix's intent on any peer whose heads don't match the
+            // writer's heads (i.e. any non-fast-path resolution). The
+            // op carries no role information — Open-subgroup inheritance
+            // grants `Member` role, matching the fold in
+            // `membership_status_at`'s Branch 1.
+            NamespaceOp::Root(RootOp::MemberJoinedOpen {
+                member,
+                group_id: op_gid,
+            }) => {
+                if member != signer || *op_gid != group_id.to_bytes() {
+                    continue;
+                }
+                let role = GroupMemberRole::Member;
                 current_role = Some(role.clone());
                 last_known_role = Some(role);
             }

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -278,6 +278,23 @@ impl<'a> NamespaceGovernance<'a> {
                             });
                         }
                     }
+                    RootOp::MemberJoinedOpen { member, group_id } => {
+                        // Same delivery-trigger semantics as `MemberJoined` —
+                        // any peer that holds the group key publishes a
+                        // `KeyDelivery` wrapped for the joiner. Authority
+                        // for this op is validated in `execute_member_joined_open`
+                        // (we ran it via `apply_root_op` above before this
+                        // match), so by the time we get here the path is
+                        // confirmed Inherited.
+                        let group_id_typed = ContextGroupId::from(*group_id);
+                        if load_current_group_key_record(self.store, &group_id_typed)?.is_some() {
+                            result.pending_deliveries.push(PendingKeyDelivery {
+                                namespace_id: op.namespace_id,
+                                group_id: group_id_typed.to_bytes(),
+                                joiner_pk: *member,
+                            });
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -823,6 +840,9 @@ impl<'a> NamespaceGovernance<'a> {
                 member,
                 signed_invitation,
             } => self.execute_member_joined(op, member, signed_invitation),
+            RootOp::MemberJoinedOpen { member, group_id } => {
+                self.execute_member_joined_open(op, *member, *group_id)
+            }
             RootOp::KeyDelivery { .. } => Ok(()),
         }
     }
@@ -1160,6 +1180,51 @@ impl<'a> NamespaceGovernance<'a> {
             member,
             signed_invitation,
         )
+    }
+
+    /// Apply check for `RootOp::MemberJoinedOpen`. The op is cleartext,
+    /// the outer `SignedNamespaceOp.signer` MUST equal `member` (proves
+    /// key ownership), and `member` MUST have an Inherited membership
+    /// path to `group_id` — i.e. the subgroup is `Open` and they hold
+    /// `CAN_JOIN_OPEN_SUBGROUPS` at the namespace root (the same
+    /// check `join_context.rs` runs locally before letting the joiner
+    /// proceed). We don't mutate state here — the side-effect (pushing
+    /// a `PendingKeyDelivery` if we hold the key) happens in the outer
+    /// `apply_signed_op` match.
+    fn execute_member_joined_open(
+        &self,
+        op: &SignedNamespaceOp,
+        member: PublicKey,
+        group_id: [u8; 32],
+    ) -> EyreResult<()> {
+        if op.signer != member {
+            eyre::bail!(
+                "MemberJoinedOpen rejected: outer signer {} doesn't match member {}",
+                op.signer,
+                member
+            );
+        }
+        let gid = ContextGroupId::from(group_id);
+        match super::check_group_membership_path(self.store, &gid, &member)? {
+            super::MembershipPath::Inherited { .. } => Ok(()),
+            super::MembershipPath::Direct => {
+                // Direct members go through `MemberJoined` or `add_group_members`
+                // — they shouldn't be using this op.
+                eyre::bail!(
+                    "MemberJoinedOpen rejected: signer {} is a direct member of {:?}; \
+                     use MemberJoined or add_group_members instead",
+                    member,
+                    gid
+                );
+            }
+            super::MembershipPath::None => {
+                eyre::bail!(
+                    "MemberJoinedOpen rejected: signer {} has no membership path to {:?}",
+                    member,
+                    gid
+                );
+            }
+        }
     }
 }
 

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -1205,6 +1205,24 @@ impl<'a> NamespaceGovernance<'a> {
             );
         }
         let gid = ContextGroupId::from(group_id);
+        // Cross-namespace forgery guard: without this check, an attacker
+        // on namespace A could publish a MemberJoinedOpen naming a
+        // `group_id` from namespace B; `check_group_membership_path`
+        // walks parents up to whichever namespace root owns `gid`, so
+        // the path check below could succeed against B's data when this
+        // op is being applied in namespace A. Pin `gid` to this
+        // namespace — matches the implicit assumption in the sibling
+        // `MemberJoined` apply path.
+        let resolved_ns = super::resolve_namespace(self.store, &gid)?;
+        if resolved_ns.to_bytes() != self.namespace_id {
+            eyre::bail!(
+                "MemberJoinedOpen rejected: group_id {:?} resolves to namespace {:?}, \
+                 not this namespace {:?}",
+                gid,
+                resolved_ns,
+                ContextGroupId::from(self.namespace_id)
+            );
+        }
         match super::check_group_membership_path(self.store, &gid, &member)? {
             super::MembershipPath::Inherited { .. } => Ok(()),
             super::MembershipPath::Direct => {

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -33,6 +33,7 @@ impl Handler<JoinContextRequest> for ContextManager {
         let datastore = self.datastore.clone();
         let context_client = self.context_client.clone();
         let node_client = self.node_client.clone();
+        let ack_router = std::sync::Arc::clone(&self.ack_router);
         ActorResponse::r#async(
             async move {
                 let mut group_id = group_store::get_group_for_context(&datastore, &context_id)?;
@@ -142,6 +143,7 @@ impl Handler<JoinContextRequest> for ContextManager {
                     &group_id,
                     &joiner_identity,
                 )?;
+                let mut was_inherited = false;
                 match membership_path {
                     group_store::MembershipPath::None => {
                         bail!("identity is not a member of the group");
@@ -162,6 +164,7 @@ impl Handler<JoinContextRequest> for ContextManager {
                             via_admin,
                             "context join authorized via inherited subgroup membership"
                         );
+                        was_inherited = true;
                     }
                 }
 
@@ -231,6 +234,51 @@ impl Handler<JoinContextRequest> for ContextManager {
                     %joiner_identity,
                     "joined context via group membership"
                 );
+
+                // Inherited members (Open subgroup, joined via the
+                // CAN_JOIN_OPEN_SUBGROUPS parent-walk) don't get a
+                // `KeyDelivery` from any admin — admin never called
+                // `add_group_members` for them. Without the group key
+                // their `sender_key` stays None on the ContextIdentity
+                // row above, which means they can't decrypt state-DAG
+                // messages and others can't decrypt theirs. Publish
+                // `RootOp::MemberJoinedOpen` signed by us so any peer
+                // holding the key responds with a `KeyDelivery` (same
+                // mechanism `MemberJoined` uses for invitation-based
+                // joins).
+                //
+                // Direct members are explicit-add via
+                // `add_group_members` and already get a `KeyDelivery`
+                // emitted alongside their `MemberAdded` — skip this
+                // path for them.
+                if was_inherited {
+                    let signer_sk = calimero_primitives::identity::PrivateKey::from(sk_bytes);
+                    let op = calimero_context_client::local_governance::NamespaceOp::Root(
+                        calimero_context_client::local_governance::RootOp::MemberJoinedOpen {
+                            member: joiner_identity,
+                            group_id: group_id.to_bytes(),
+                        },
+                    );
+                    if let Err(e) = group_store::sign_apply_and_publish_namespace_op(
+                        &datastore,
+                        &node_client,
+                        &ack_router,
+                        ns_id.to_bytes(),
+                        &signer_sk,
+                        op,
+                    )
+                    .await
+                    {
+                        warn!(
+                            ?e,
+                            %joiner_identity,
+                            %context_id,
+                            "failed to publish MemberJoinedOpen — key delivery to this \
+                             inherited joiner will be skipped; messages will appear local-only \
+                             until an admin explicitly add_group_members the joiner"
+                        );
+                    }
+                }
 
                 Ok(JoinContextResponse {
                     context_id,


### PR DESCRIPTION
Self-join via the inherited (Open-subgroup) path leaves the user with a ContextIdentity row whose `sender_key` is `None`. No admin runs `add_group_members` for them, so no `KeyDelivery` is ever published wrapping the current group key for the joiner. They subscribe to gossipsub and sync, but the state-DAG is encrypted with the group key they don't hold — so messages they send appear only locally, and they can't decrypt anyone else's. Symptom: "joined a public channel, sends messages, no one sees them; can't see others either."

This adds `RootOp::MemberJoinedOpen { member, group_id }`, mirroring `MemberJoined`'s key-delivery trigger semantics but without an admin-signed invitation (Open subgroup + `CAN_JOIN_OPEN_SUBGROUPS` at the namespace root IS the authorisation). The joiner signs and publishes the op at the end of `join_context.rs` when their membership path was `Inherited`. On apply, every peer that holds the current group key for `group_id` records a `PendingKeyDelivery` (same struct the existing `MemberJoined` path uses); the delivery dispatcher then publishes a `KeyDelivery` wrapped for the joiner, who unwraps and populates their `sender_key`.

`execute_member_joined_open` rejects ops where the outer signer disagrees with `member` (key-ownership proof), or where the joiner's membership path is `Direct` (admin should use `add_group_members`) or `None`. The check uses the same `check_group_membership_path` the join handler already runs locally.

Backward compatibility: adds a new Borsh enum variant to `RootOp` — old peers will fail to decode this op. Fine for coordinated dev cluster upgrades; release notes need to flag a network-wide upgrade requirement.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new governance wire-op (`RootOp::MemberJoinedOpen`) and changes membership/authorization evaluation, which is consensus-adjacent and requires coordinated upgrades because older peers cannot decode the new variant.
> 
> **Overview**
> Fixes Open-subgroup inherited self-joins by having the joiner publish a new cleartext governance op `RootOp::MemberJoinedOpen` from `join_context`, allowing peers that already hold the subgroup key to enqueue a `PendingKeyDelivery` and publish `KeyDelivery` so the joiner’s `sender_key` can be populated.
> 
> Extends governance apply and cross-DAG membership checks to recognize `MemberJoinedOpen` (including validation that the signer matches the joiner and that the membership path is *Inherited*, plus a namespace-resolution guard), updates publish timeout classification/metrics labels accordingly, and adds a new scaffolding E2E workflow (wired into CI) that asserts bidirectional reads/writes after an inherited Open-subgroup join.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eeb4c55c87b8b8248812f1e52fef5f5ebe43c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->