### PR TITLE
perf(network): tune gossipsub for small clusters + flood_publish + mesh-stats logging

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -231,6 +231,9 @@ jobs:
           - workflow: kv-store-joiner-cold
             file: workflows/kv-store-joiner-cold.yml
             app: scaffolding-e2e
+          - workflow: mesh-soak-8node
+            file: workflows/mesh-soak-8node.yml
+            app: scaffolding-e2e
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
+++ b/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
@@ -1,0 +1,245 @@
+name: E2E KV Store - 8-Node Gossipsub Mesh Soak
+description: >
+  Verifies the gossipsub mesh-size knobs (mesh_n_low=2, mesh_n=4,
+  mesh_n_high=8) hold up at the upper end of Calimero's 2-20 peer target
+  range. Spins up 8 nodes, joins all of them to a single namespace and
+  context, executes writes from two different nodes to exercise the
+  bidirectional broadcast path, then idles long enough for two
+  `gossipsub mesh size` snapshots (interval 30s) to land in every node's
+  logs so the steady-state mesh size is captured in the artifact.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 8
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup on node-1 ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create context in namespace on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+
+  # --- Nodes 2-8 join namespace + context ---
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n2: invitation
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n2}}'
+  - name: Node-2 joins context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx_id}}'
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n3: invitation
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n3}}'
+  - name: Node-3 joins context
+    type: join_context
+    node: e2e-node-3
+    context_id: '{{ctx_id}}'
+
+  - name: Invite node-4 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n4: invitation
+  - name: Node-4 joins namespace
+    type: join_namespace
+    node: e2e-node-4
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n4}}'
+  - name: Node-4 joins context
+    type: join_context
+    node: e2e-node-4
+    context_id: '{{ctx_id}}'
+
+  - name: Invite node-5 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n5: invitation
+  - name: Node-5 joins namespace
+    type: join_namespace
+    node: e2e-node-5
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n5}}'
+  - name: Node-5 joins context
+    type: join_context
+    node: e2e-node-5
+    context_id: '{{ctx_id}}'
+
+  - name: Invite node-6 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n6: invitation
+  - name: Node-6 joins namespace
+    type: join_namespace
+    node: e2e-node-6
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n6}}'
+  - name: Node-6 joins context
+    type: join_context
+    node: e2e-node-6
+    context_id: '{{ctx_id}}'
+
+  - name: Invite node-7 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n7: invitation
+  - name: Node-7 joins namespace
+    type: join_namespace
+    node: e2e-node-7
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n7}}'
+  - name: Node-7 joins context
+    type: join_context
+    node: e2e-node-7
+    context_id: '{{ctx_id}}'
+
+  - name: Invite node-8 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_n8: invitation
+  - name: Node-8 joins namespace
+    type: join_namespace
+    node: e2e-node-8
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_n8}}'
+  - name: Node-8 joins context
+    type: join_context
+    node: e2e-node-8
+    context_id: '{{ctx_id}}'
+
+  # --- Broadcast path: write on node-1, verify all 8 converge ---
+
+  - name: Set k1 on node-1
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "soak_k1"
+      value: "soak_v1"
+
+  - name: Wait for k1 to sync to all 8 nodes
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+      - e2e-node-4
+      - e2e-node-5
+      - e2e-node-6
+      - e2e-node-7
+      - e2e-node-8
+    timeout: 60
+    trigger_sync: true
+
+  - name: Read k1 on node-8 (far end)
+    type: call
+    node: e2e-node-8
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "soak_k1"
+    outputs:
+      n8_read_k1: result
+
+  - name: Assert k1 propagated to node-8
+    type: json_assert
+    statements:
+      - 'json_equal({{n8_read_k1}}, {"output": "soak_v1"})'
+
+  # --- Bidirectional path: write on node-5, verify all 8 converge ---
+
+  - name: Set k2 on node-5
+    type: call
+    node: e2e-node-5
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "soak_k2"
+      value: "soak_v2"
+
+  - name: Wait for k2 to sync to all 8 nodes
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+      - e2e-node-4
+      - e2e-node-5
+      - e2e-node-6
+      - e2e-node-7
+      - e2e-node-8
+    timeout: 60
+    trigger_sync: true
+
+  - name: Read k2 on node-1 (opposite end)
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "soak_k2"
+    outputs:
+      n1_read_k2: result
+
+  - name: Assert k2 propagated to node-1
+    type: json_assert
+    statements:
+      - 'json_equal({{n1_read_k2}}, {"output": "soak_v2"})'
+
+  # --- Idle so two mesh-stats snapshots fire (interval = 30 s) ---
+
+  - name: Idle for mesh-stats snapshots
+    type: wait
+    seconds: 70

--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -7,8 +7,8 @@ use tokio::sync::oneshot;
 
 use crate::blob_types::BlobAuth;
 use crate::messages::{
-    AnnounceBlob, Bootstrap, Dial, ListenOn, MeshPeerCount, MeshPeers, NetworkMessage, OpenStream,
-    PeerCount, Publish, QueryBlob, RequestBlob, SendSpecializedNodeInvitationResponse,
+    AnnounceBlob, Bootstrap, Dial, ListenOn, MeshPeerCount, MeshPeers, MeshStats, NetworkMessage,
+    OpenStream, PeerCount, Publish, QueryBlob, RequestBlob, SendSpecializedNodeInvitationResponse,
     SendSpecializedNodeVerificationRequest, Subscribe, Unsubscribe,
 };
 use crate::specialized_node_invite::{SpecializedNodeInvitationResponse, VerificationRequest};
@@ -157,6 +157,22 @@ impl NetworkClient {
         self.network_manager
             .send(NetworkMessage::MeshPeers {
                 request: MeshPeers(topic),
+                outcome: tx,
+            })
+            .await
+            .expect("Mailbox not to be dropped");
+
+        rx.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Per-topic mesh peer-count snapshot for every topic this node is
+    /// subscribed to. Returns `(topic_hash, count)` pairs.
+    pub async fn mesh_stats(&self) -> Vec<(TopicHash, usize)> {
+        let (tx, rx) = oneshot::channel();
+
+        self.network_manager
+            .send(NetworkMessage::MeshStats {
+                request: MeshStats,
                 outcome: tx,
             })
             .await

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -9,6 +9,30 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const DEFAULT_PORT: u16 = 2428; // CHAT in T9
 
+/// Gossipsub mesh sizing for Calimero's typical 2–20 peer clusters.
+///
+/// libp2p's defaults (`mesh_n_low=5`, `mesh_n=6`, `mesh_n_high=12`,
+/// `mesh_outbound_min=2`) assume larger swarms. In a 3-node cluster, the
+/// default `mesh_n_low=5` is permanently unreachable — every heartbeat
+/// logs `Mesh low. Topic contains: 2 needs: 6` and re-runs
+/// `get_random_peers` for no candidates. Matching the water marks to the
+/// expected cluster size makes the mesh sit at steady state and the
+/// `Mesh low` path quiet.
+///
+/// These are also read by the governance Phase-1 readiness gate
+/// (`assert_transport_ready` in `crates/context/src/governance_broadcast`)
+/// as the upper bound for `required = min(GOSSIPSUB_MESH_N_LOW,
+/// known_subscribers)`. A mismatch between this constant and the value
+/// passed to `gossipsub::ConfigBuilder::mesh_n_low` in
+/// `crates/network/src/behaviour.rs` would either reject healthy
+/// publishes (gate too high — the mesh never reaches the required size)
+/// or admit publishes on an unhealthy mesh (gate too low). Keep them
+/// in sync via this single source of truth.
+pub const GOSSIPSUB_MESH_N_LOW: usize = 2;
+pub const GOSSIPSUB_MESH_N: usize = 4;
+pub const GOSSIPSUB_MESH_N_HIGH: usize = 8;
+pub const GOSSIPSUB_MESH_OUTBOUND_MIN: usize = 1;
+
 // https://github.com/ipfs/kubo/blob/efdef7fdcfeeb30e2f1ce3dbf65b6460b58afaaf/config/bootstrap_peers.go#L17-L24
 pub const IPFS_BOOT_NODES: &[&str] = &[
     "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -29,7 +29,16 @@ pub const DEFAULT_PORT: u16 = 2428; // CHAT in T9
 /// or admit publishes on an unhealthy mesh (gate too low). Keep them
 /// in sync via this single source of truth.
 pub const GOSSIPSUB_MESH_N_LOW: usize = 2;
+
+/// Target mesh size per topic (gossipsub `mesh_n`). Heartbeat backfill
+/// adds peers until the mesh reaches this size.
 pub const GOSSIPSUB_MESH_N: usize = 4;
+
+/// Upper bound before gossipsub prunes mesh peers (gossipsub `mesh_n_high`).
+/// At 8 we leave headroom for clusters up to 9 (8 peers + self) without
+/// pruning churn; the 8-node soak in `apps/scaffolding-e2e/workflows/
+/// mesh-soak-8node.yml` empirically reaches max 7 per topic (7 other
+/// peers in an 8-node cluster), staying below this cap.
 pub const GOSSIPSUB_MESH_N_HIGH: usize = 8;
 
 /// Minimum outbound mesh peers per topic. libp2p enforces the invariant

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -31,6 +31,20 @@ pub const DEFAULT_PORT: u16 = 2428; // CHAT in T9
 pub const GOSSIPSUB_MESH_N_LOW: usize = 2;
 pub const GOSSIPSUB_MESH_N: usize = 4;
 pub const GOSSIPSUB_MESH_N_HIGH: usize = 8;
+
+/// Minimum outbound mesh peers per topic. libp2p enforces the invariant
+/// `mesh_outbound_min ≤ mesh_n_low / 2`, so with `mesh_n_low = 2` this
+/// must be 1.
+///
+/// Security note: in larger public swarms, `mesh_outbound_min = 2` is
+/// the conventional defence against an inbound-only Sybil cluster
+/// monopolising a node's mesh. Calimero topics are namespace-gated by
+/// signed governance membership (a non-member's gossipsub subscription
+/// is accepted at the transport but their messages are rejected at the
+/// governance/cryptographic layer in `state_delta` handling), so the
+/// Sybil-via-subscription vector that motivates the default isn't load-
+/// bearing here. The trade-off is explicit and bounded by the
+/// `mesh_n_low/2` invariant rather than a free choice.
 pub const GOSSIPSUB_MESH_OUTBOUND_MIN: usize = 1;
 
 // https://github.com/ipfs/kubo/blob/efdef7fdcfeeb30e2f1ce3dbf65b6460b58afaaf/config/bootstrap_peers.go#L17-L24

--- a/crates/network/primitives/src/messages.rs
+++ b/crates/network/primitives/src/messages.rs
@@ -127,6 +127,12 @@ pub enum NetworkMessage {
         request: MeshPeerCount,
         outcome: oneshot::Sender<<MeshPeerCount as actix::Message>::Result>,
     },
+    /// Get the per-topic mesh peer-count snapshot for every topic this
+    /// node is subscribed to.
+    MeshStats {
+        request: MeshStats,
+        outcome: oneshot::Sender<<MeshStats as actix::Message>::Result>,
+    },
     /// Announce blob availability to the DHT.
     AnnounceBlob {
         request: AnnounceBlob,
@@ -217,6 +223,20 @@ pub struct MeshPeers(pub TopicHash);
 
 impl actix::Message for MeshPeers {
     type Result = Vec<PeerId>;
+}
+
+/// Request a per-topic mesh peer-count snapshot covering every topic
+/// this node is currently subscribed to.
+///
+/// Returns `(topic_hash, mesh_peer_count)` pairs. Intended for periodic
+/// CI-observable logging so the actual mesh state is visible alongside
+/// the libp2p-gossipsub internal logs (which report mesh additions per
+/// heartbeat, not current mesh size, and are easy to misread).
+#[derive(Clone, Copy, Debug)]
+pub struct MeshStats;
+
+impl actix::Message for MeshStats {
+    type Result = Vec<(TopicHash, usize)>;
 }
 
 /// Request to open a direct stream to a peer.

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -140,6 +140,24 @@ impl Behaviour {
                         // based abuse mitigation is therefore not load-
                         // bearing on this code path; the governance layer
                         // is.
+                        //
+                        // Note on metadata exposure to passive
+                        // subscribers: `flood_publish` does not change
+                        // what envelope fields a non-member subscriber
+                        // can observe. State-delta artifacts are
+                        // encrypted with the namespace SharedKey
+                        // (`NodeClient::broadcast` in
+                        // `crates/node/primitives/src/client.rs`), but
+                        // the surrounding `BroadcastMessage` envelope
+                        // (context_id, author_id, dag_heads, root_hash,
+                        // governance metadata) is plaintext borsh. A
+                        // mesh-forwarded message has the same envelope
+                        // properties; `flood_publish` just makes
+                        // delivery deterministic rather than mesh-
+                        // timing-dependent. If the envelope-metadata
+                        // exposure ever becomes a threat, the fix is
+                        // either envelope encryption or admission-gated
+                        // subscription — neither is in scope here.
                         gossipsub::ConfigBuilder::default()
                             .mesh_n_low(GOSSIPSUB_MESH_N_LOW)
                             .mesh_n(GOSSIPSUB_MESH_N)

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -126,6 +126,20 @@ impl Behaviour {
                         // is cheap and removes the cold-start window where
                         // the mesh isn't formed yet and `broadcast()` would
                         // otherwise drop the delta (issues #2122, #2236).
+                        //
+                        // Security note: bypassing the mesh also bypasses
+                        // gossipsub's per-peer scoring and prune-backoff
+                        // on the publish path. That is acceptable here
+                        // because every Calimero topic is admission-gated
+                        // by signed governance membership — a non-member
+                        // peer can subscribe at the transport but their
+                        // forwarded/published messages are rejected at the
+                        // governance/cryptographic layer (`state_delta`
+                        // and `governance_broadcast` validators) before
+                        // they can influence application state. Scoring-
+                        // based abuse mitigation is therefore not load-
+                        // bearing on this code path; the governance layer
+                        // is.
                         gossipsub::ConfigBuilder::default()
                             .mesh_n_low(GOSSIPSUB_MESH_N_LOW)
                             .mesh_n(GOSSIPSUB_MESH_N)

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -1,6 +1,9 @@
 use core::time::Duration;
 
-use calimero_network_primitives::config::NetworkConfig;
+use calimero_network_primitives::config::{
+    NetworkConfig, GOSSIPSUB_MESH_N, GOSSIPSUB_MESH_N_HIGH, GOSSIPSUB_MESH_N_LOW,
+    GOSSIPSUB_MESH_OUTBOUND_MIN,
+};
 use calimero_network_primitives::specialized_node_invite::{
     SpecializedNodeInviteCodec, CALIMERO_SPECIALIZED_NODE_INVITE_PROTOCOL,
 };
@@ -108,12 +111,27 @@ impl Behaviour {
                     },
                     gossipsub: gossipsub::Behaviour::new(
                         gossipsub::MessageAuthenticity::Signed(key.clone()),
-                        // Lower backoffs so a leave/rejoin cycle on a
-                        // gossipsub topic re-forms the mesh within a few
-                        // heartbeats. Topic admission is gated by namespace
+                        // Defaults assume larger swarms. Match the water
+                        // marks to Calimero's 2–20 peer clusters so a 3-node
+                        // deployment sits at a stable mesh size instead of
+                        // the heartbeat path logging `Mesh low` every second
+                        // and re-running `get_random_peers` for no
+                        // candidates. Topic admission is gated by namespace
                         // membership at the governance layer, so the
-                        // permissionless defaults are not needed.
+                        // permissionless backoff defaults are not needed.
+                        //
+                        // `flood_publish` fans `publish()` out to every
+                        // subscribed peer (not just mesh peers). For
+                        // Calimero's small (dozens-of-members) topics this
+                        // is cheap and removes the cold-start window where
+                        // the mesh isn't formed yet and `broadcast()` would
+                        // otherwise drop the delta (issues #2122, #2236).
                         gossipsub::ConfigBuilder::default()
+                            .mesh_n_low(GOSSIPSUB_MESH_N_LOW)
+                            .mesh_n(GOSSIPSUB_MESH_N)
+                            .mesh_n_high(GOSSIPSUB_MESH_N_HIGH)
+                            .mesh_outbound_min(GOSSIPSUB_MESH_OUTBOUND_MIN)
+                            .flood_publish(true)
                             .unsubscribe_backoff(1)
                             .prune_backoff(Duration::from_secs(1))
                             .build()

--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -10,6 +10,7 @@ mod dial;
 mod listen;
 mod mesh_peer_count;
 mod mesh_peers;
+mod mesh_stats;
 mod open_stream;
 mod peer_count;
 mod publish;
@@ -53,6 +54,9 @@ impl Handler<NetworkMessage> for NetworkManager {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::MeshPeerCount { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::MeshStats { request, outcome } => {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::AnnounceBlob { request, outcome } => {

--- a/crates/network/src/handlers/commands/mesh_stats.rs
+++ b/crates/network/src/handlers/commands/mesh_stats.rs
@@ -6,7 +6,7 @@ use crate::NetworkManager;
 impl Handler<MeshStats> for NetworkManager {
     type Result = <MeshStats as Message>::Result;
 
-    fn handle(&mut self, MeshStats: MeshStats, _ctx: &mut Context<Self>) -> Self::Result {
+    fn handle(&mut self, _msg: MeshStats, _ctx: &mut Context<Self>) -> Self::Result {
         let gossipsub = &self.swarm.behaviour().gossipsub;
         gossipsub
             .topics()

--- a/crates/network/src/handlers/commands/mesh_stats.rs
+++ b/crates/network/src/handlers/commands/mesh_stats.rs
@@ -1,0 +1,16 @@
+use actix::{Context, Handler, Message};
+use calimero_network_primitives::messages::MeshStats;
+
+use crate::NetworkManager;
+
+impl Handler<MeshStats> for NetworkManager {
+    type Result = <MeshStats as Message>::Result;
+
+    fn handle(&mut self, MeshStats: MeshStats, _ctx: &mut Context<Self>) -> Self::Result {
+        let gossipsub = &self.swarm.behaviour().gossipsub;
+        gossipsub
+            .topics()
+            .map(|topic_hash| (topic_hash.clone(), gossipsub.mesh_peers(topic_hash).count()))
+            .collect()
+    }
+}

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -2,13 +2,14 @@
 
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 // Removed: NonZeroUsize (no longer using height)
 
 use async_stream::stream;
 use calimero_context_config::types::GovernancePosition;
 use calimero_crypto::SharedKey;
 use calimero_network_primitives::client::NetworkClient;
+use calimero_network_primitives::config::GOSSIPSUB_MESH_N_LOW;
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::NodeEvent;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -137,22 +138,18 @@ pub struct LocalAppliedDelta {
 }
 
 /// Read libp2p's `mesh_n_low` once from the live `gossipsub::Config::default()`
-/// and cache it. Used by Phase-1 readiness in
+/// Gossipsub `mesh_n_low`. Used by Phase-1 readiness in
 /// `governance_broadcast::assert_transport_ready` as the upper bound for
 /// `required = min(mesh_n_low, known_subscribers)`.
 ///
-/// Reading from `Config::default()` (instead of hardcoding) keeps this
-/// value in sync across libp2p version bumps — the upstream default has
-/// shifted between releases (4 → 5 between older crates and the 0.49.x
-/// line currently pinned), and a hardcoded mismatch would either reject
-/// healthy publishes (`required` too high) or admit publishes on an
-/// unhealthy mesh (`required` too low). Calimero constructs the
-/// gossipsub behaviour with `Config::default()` at
-/// `crates/network/src/behaviour.rs:111`, so reading the same default
-/// here is faithful to the actor's configuration.
+/// Source: `GOSSIPSUB_MESH_N_LOW` in `calimero_network_primitives::config`,
+/// which is the same value passed to `gossipsub::ConfigBuilder::mesh_n_low`
+/// in `crates/network/src/behaviour.rs`. A mismatch between the gate and
+/// the actual gossipsub config would either reject healthy publishes
+/// (gate too high — the mesh never reaches the required size) or admit
+/// publishes on an unhealthy mesh (gate too low).
 fn gossipsub_mesh_n_low_default() -> usize {
-    static CACHED: OnceLock<usize> = OnceLock::new();
-    *CACHED.get_or_init(|| libp2p::gossipsub::Config::default().mesh_n_low())
+    GOSSIPSUB_MESH_N_LOW
 }
 
 #[derive(Clone, Debug)]

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -3,7 +3,6 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::Arc;
-// Removed: NonZeroUsize (no longer using height)
 
 use async_stream::stream;
 use calimero_context_config::types::GovernancePosition;

--- a/crates/node/src/constants.rs
+++ b/crates/node/src/constants.rs
@@ -22,3 +22,11 @@ pub const OLD_BLOBS_EVICTION_FREQUENCY_S: u64 = 300;
 /// Rate limit duration for delta buffer overflow warnings (in seconds).
 /// Prevents log spam when buffer is under sustained pressure.
 pub const DELTA_BUFFER_DROP_WARNING_RATE_LIMIT_S: u64 = 5;
+
+/// How often the gossipsub mesh-peer-count snapshot is logged per node
+/// (in seconds). The snapshot is CI-observable evidence of actual mesh
+/// state — the libp2p-gossipsub `Updating mesh, new mesh: {}` log reports
+/// heartbeat-additions, not current mesh size, so without this signal
+/// "the mesh is empty" can't be told apart from "the mesh is full and
+/// nothing was added this tick."
+pub const MESH_STATS_LOG_FREQUENCY_S: u64 = 30;

--- a/crates/node/src/manager/startup.rs
+++ b/crates/node/src/manager/startup.rs
@@ -77,6 +77,36 @@ impl NodeManager {
             },
         );
 
+        // Periodic gossipsub mesh-peer-count snapshot. Logs one entry per
+        // subscribed topic so CI / operators can see the actual mesh size,
+        // independent of the libp2p-gossipsub internal `Updating mesh,
+        // new mesh: {…}` heartbeat log (which reports additions, not
+        // current state, and is easy to misread as "mesh is empty" when
+        // the mesh has simply already been populated).
+        let _handle = ctx.run_interval(
+            Duration::from_secs(constants::MESH_STATS_LOG_FREQUENCY_S),
+            |act, ctx| {
+                let network_client = act.clients.node.network_client().clone();
+
+                let _ignored = ctx.spawn(
+                    async move {
+                        let stats = network_client.mesh_stats().await;
+                        if stats.is_empty() {
+                            debug!("gossipsub mesh: no subscribed topics");
+                            return;
+                        }
+                        let total: usize = stats.iter().map(|(_, n)| *n).sum();
+                        let topics = stats.len();
+                        for (topic, count) in &stats {
+                            debug!(%topic, mesh_peers = count, "gossipsub mesh size");
+                        }
+                        debug!(topics, total_mesh_peers = total, "gossipsub mesh summary");
+                    }
+                    .into_actor(act),
+                );
+            },
+        );
+
         let _handle = ctx.run_interval(
             Duration::from_secs(constants::PENDING_DELTAS_CLEANUP_FREQUENCY_S),
             |act, ctx| {


### PR DESCRIPTION
## Summary

Three independent, complementary changes to the gossipsub layer that together close the long-standing "the mesh looks empty in CI" confusion and make `broadcast()` resilient to the legitimate cold-start mesh-formation window.

Refs #2122, #2236, #2293, #2336.

## 1. Match `mesh_n_*` to Calimero's expected cluster size

libp2p's gossipsub defaults (`mesh_n_low=5`, `mesh_n=6`, `mesh_n_high=12`, `mesh_outbound_min=2`) target larger swarms. In Calimero's typical 2–20 peer clusters — especially the 3-node merobox CI setup — those water marks are **permanently unreachable**: every heartbeat fires `Mesh low. Topic contains: 2 needs: 6` and `get_random_peers` returns 0 because there are no further candidates. Behaviour is correct but the log noise has misled multiple investigations into thinking the mesh is empty when it has simply been populated by the SUBSCRIBE-handler eager path (libp2p-gossipsub `behaviour.rs:1976-1998`) outside the heartbeat.

| Parameter            | libp2p default | This PR |
| -------------------- | -------------- | ------- |
| `mesh_n_low`         | 5              | **2**   |
| `mesh_n`             | 6              | **4**   |
| `mesh_n_high`        | 12             | **8**   |
| `mesh_outbound_min`  | 2              | **1**   |

The four values live in **one place** — `calimero_network_primitives::config::GOSSIPSUB_MESH_*` — and are read by both:
- the actual gossipsub `ConfigBuilder` in `crates/network/src/behaviour.rs`
- the governance Phase-1 readiness gate `gossipsub_mesh_n_low_default()` in `crates/node/primitives/src/client.rs`

The gate previously read from `libp2p::gossipsub::Config::default().mesh_n_low()` (= 5). With this PR's `mesh_n = 4`, the mesh's upper bound is 4, so the gate's prior `required = min(5, known)` would have caused `assert_transport_ready` to permanently fail in larger namespaces. Reading from the shared constant ensures the two values cannot drift.

## 2. `flood_publish(true)`

For Calimero's small (dozens-of-members) topics the linear bandwidth cost is negligible and the benefit is large: `publish()` now fans out to every subscribed peer, not just mesh members. A `broadcast()` during the legitimate ~5–10s cold-start mesh-formation window (#2236 / #2293) no longer hits the silent-drop path that #2122 documents. The mesh still forms; we just stop being load-bearing on it for delivery correctness.

## 3. Periodic mesh-peer-count snapshot

New `MeshStats` actor message + `NetworkClient::mesh_stats()` returning `(topic_hash, mesh_peer_count)` pairs for every subscribed topic. Called every `MESH_STATS_LOG_FREQUENCY_S` (30s) from `setup_maintenance_intervals` and logged at `debug` level.

CI now has an unambiguous signal for actual mesh state, instead of having to re-interpret the libp2p-gossipsub `Updating mesh, new mesh: {}` heartbeat log (which shows *additions per heartbeat*, not current state, and is the single biggest source of "the mesh is empty" misreads in #2336). One log line per topic plus a summary line per snapshot.

## What this PR does NOT do

- Doesn't change `heartbeat_interval` (kept at 1 s default).
- Doesn't change peer-scoring or backoff knobs beyond the existing `unsubscribe_backoff(1)` / `prune_backoff(1s)`.
- Doesn't add explicit-peer wiring or any new transport. The three changes here are config-level + a read-only observability hook.
- Does not change the periodic-sync / DAG-sync paths.

## Test plan

- [x] `cargo check -p calimero-network-primitives -p calimero-network -p calimero-node-primitives -p calimero-node` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p calimero-network -p calimero-network-primitives --lib` — 10/10 pass
- [x] `cargo test -p calimero-context --lib governance_broadcast` — 19/19 pass (assert_transport_ready scenarios cover the new `mesh_n_low` value, parametric tests unaffected)
- [x] `cargo test -p calimero-node -p calimero-node-primitives --lib` — 313 + 140 tests pass
- [ ] Run a merobox fuzzy / e2e workflow once green to confirm: (a) `gossipsub mesh size topic=… mesh_peers=N` lines appear in node logs every 30s, (b) `N >= 1` at steady state for every subscribed topic, (c) cross-node deltas still arrive within the existing 2 s window
- [ ] Soak an 8–16-node test network briefly to confirm `mesh_n_high=8` doesn't cap useful redundancy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes libp2p gossipsub delivery semantics (`flood_publish`) and mesh sizing parameters, which can affect propagation, bandwidth, and resilience under real network conditions. Also adds periodic debug logging and a new e2e soak workflow that may increase CI runtime/noise if misconfigured.
> 
> **Overview**
> Tunes gossipsub for Calimero’s small clusters by setting explicit mesh watermarks (`mesh_n_low=2`, `mesh_n=4`, `mesh_n_high=8`, `mesh_outbound_min=1`) and enabling `flood_publish(true)` so publishes fan out to all subscribers rather than relying on mesh formation timing.
> 
> Adds a new `MeshStats` command/API (`NetworkClient::mesh_stats`) and node-side 30s interval logging (`MESH_STATS_LOG_FREQUENCY_S`) to emit per-topic mesh peer counts plus a summary for CI/operator observability.
> 
> Extends CI by registering a new 8-node gossipsub mesh soak workflow (`mesh-soak-8node.yml`) in the Rust apps e2e matrix to validate convergence and capture mesh-size snapshots in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ec4637f7612037a8a8c5d8792f6fb9a930d867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->