### PR TITLE
ci(profiling): DWARF call-graph + libc6-dbg to cut [unknown] flamegraph frames

### DIFF
--- a/.github/workflows/deps/prebuilt.profiling.Dockerfile
+++ b/.github/workflows/deps/prebuilt.profiling.Dockerfile
@@ -37,6 +37,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     # libunwind for proper stack unwinding in jemalloc heap profiling
     libunwind-dev \
+    # glibc debug symbols so perf can resolve frames inside libc (e.g.
+    # malloc/free/pthread/syscall wrappers). Without this, every transition
+    # through libc shows up as [unknown] in the CPU flamegraph.
+    libc6-dbg \
     # binutils for addr2line (symbol resolution)
     binutils \
     # Python for additional processing

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -103,8 +103,13 @@ start_profiling() {
     local perf_output="$PROFILING_OUTPUT_DIR/perf-${node_name}.data"
     local perf_log="$PROFILING_OUTPUT_DIR/perf-${node_name}.log"
     
-    echo "[Profiling] Starting perf record (freq: $PERF_SAMPLE_FREQ Hz)..."
-    perf record -F "$PERF_SAMPLE_FREQ" -g -p "$pid" -o "$perf_output" > "$perf_log" 2>&1 &
+    echo "[Profiling] Starting perf record (freq: $PERF_SAMPLE_FREQ Hz, call-graph: dwarf)..."
+    # DWARF unwinding instead of frame-pointer (-g): even with
+    # -C force-frame-pointers=yes on merod, transitions through libc,
+    # libstdc++, jemalloc, and kernel break frame-pointer chains and produce
+    # [unknown] frames. DWARF unwinds via .debug_frame and is robust across
+    # those boundaries. 16384-byte stack dumps cover deep async stacks.
+    perf record -F "$PERF_SAMPLE_FREQ" --call-graph dwarf,16384 -p "$pid" -o "$perf_output" > "$perf_log" 2>&1 &
     PERF_PID=$!
     echo $PERF_PID > "$PROFILING_OUTPUT_DIR/perf.pid"
     


### PR DESCRIPTION
## Summary

CPU flamegraphs from fuzzy load tests (e.g. [PR #2342's run 25815933188](https://github.com/calimero-network/core/actions/runs/25815933188)) had **2021 \`[unknown]\` frames** in the group-governance node-1 flamegraph alone, with individual blocks consuming up to ~4.4% of samples. This made the CPU profile largely unreadable above the JIT/runtime boundary. Two targeted fixes:

- **DWARF call-graph instead of frame-pointer (`-g`).** Even with `-C force-frame-pointers=yes` on merod, frame-pointer unwinding breaks across libc / libstdc++ / jemalloc / kernel transitions, producing `[unknown]` everywhere those boundaries appear in a stack. `--call-graph dwarf,16384` unwinds via `.debug_frame` and stays intact across those boundaries.
- **`libc6-dbg` in the profiling image.** So `perf script` can resolve `malloc`/`free`/`pthread_*`/syscall wrappers that currently show as `[unknown]` when sampled on a stack.

WASM JIT symbolization via Cranelift's `enable_perfmap` is unchanged — this PR addresses the *non-WASM* `[unknown]` frames (the dominant source).

## Trade-offs

- `--call-graph dwarf` produces ~3-5× larger `perf.data` files. Acceptable for CI artifacts; the existing harvest path already handles them.
- The Dockerfile change retriggers the profiling-image republish gate (per the comment at the top of `fuzzy-load-test.yml`), so the first CI run on this PR will rebuild `merod:edge-profiling` before the fuzzy job consumes it.

## Test plan

- [ ] Profiling image rebuilds without error
- [ ] Group Governance fuzzy run completes and produces `flamegraph-cpu-fuzzy-gov-node-1.svg`
- [ ] `[unknown]` count in the new CPU flamegraph is materially lower than the 2021 baseline from run 25815933188
- [ ] Largest non-`[unknown]` frames (axum/tokio/wasmer/calimero_runtime/calimero_storage) still resolve cleanly
- [ ] `perf-fuzzy-gov-node-1-<PID>.map` is still produced and the "Restoring perf.map file" log line still fires in `generate-flamegraph.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/profiling-only changes; main impact is larger `perf.data` artifacts and slightly heavier profiling image due to added debug symbols.
> 
> **Overview**
> CPU profiling in `entrypoint-profiling.sh` now records stacks with `--call-graph dwarf,16384` (instead of frame-pointer `-g`) to reduce `[unknown]` frames across libc/libstdc++/jemalloc/kernel transitions.
> 
> The prebuilt profiling Docker image now installs `libc6-dbg` so `perf`/`perf script` can resolve symbols inside glibc (e.g., `malloc`/`free`/pthread wrappers) when generating flamegraphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f51d43c4b8c03e86ca67d878483242aa50d7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->