### PR TITLE
test(e2e): regression guard for Open-subgroup self-join key delivery (#2351)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -185,6 +185,9 @@ jobs:
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e
+          - workflow: group-open-self-join-key-delivery
+            file: workflows/group-open-self-join-key-delivery.yml
+            app: scaffolding-e2e
           - workflow: dm-subgroup-privacy
             file: workflows/dm-subgroup-privacy.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -1,0 +1,241 @@
+name: E2E KV Store - Open Subgroup Self-Join Key Delivery
+description: >
+  Regression guard for PR #2351 (`fix(context): trigger KeyDelivery for
+  self-join of Open subgroups`).
+
+  Pre-fix bug: when a namespace member self-joins an `Open` subgroup
+  context via the `CAN_JOIN_OPEN_SUBGROUPS` parent-walk (no
+  admin-issued `add_group_members`), `join_context` inserts a
+  `ContextIdentity` row with `sender_key: None`. No `MemberJoined`
+  governance op is published for them, so no peer ever wraps the
+  current group key in a `KeyDelivery` for the joiner. Their
+  outgoing state-DAG ops can't be signed/encrypted with the group
+  key, so peers reject/ignore them; symmetrically, the joiner can't
+  decrypt incoming ops. Symptom: "joined a public channel, sends
+  messages, no one sees them; can't see others either."
+
+  Fix: `join_context.rs` now publishes a self-signed
+  `RootOp::MemberJoinedOpen { member, group_id }` whenever the join
+  path was `MembershipPath::Inherited`. Peers holding the group key
+  queue a `PendingKeyDelivery` (same struct the existing
+  `MemberJoined` path uses); the delivery dispatcher publishes a
+  wrapped `KeyDelivery`, populating the joiner's `sender_key`.
+
+  This workflow differs from `group-subgroup-visibility-inheritance.yml`
+  by exercising the *joiner-as-author* direction explicitly: that
+  existing test only confirms node-1's writes flow to node-2, which
+  passes on master because the joiner can DECRYPT incoming ops using
+  the namespace-level group key delivered through a different path.
+  The bug is that the joiner can't AUTHOR ops because `sender_key`
+  was never populated — that's what this test asserts by having
+  node-2 write and node-1 read the result.
+
+  Pre-fix expectation: Round 2 wait_for_sync times out, or the
+  node-1 read of node-2's write returns null/empty (node-1 can't
+  decrypt the joiner's ops). Post-fix expectation: both directions
+  succeed.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 2
+  image: merod:local
+  prefix: open-selfjoin-node
+
+steps:
+  # ── Phase 1: Bootstrap mesh, namespace, Open subgroup, context ────
+
+  - name: Install application on node-1
+    type: install_application
+    node: open-selfjoin-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: open-selfjoin-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: open-selfjoin-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: open-selfjoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      ns_invite: invitation
+
+  - name: Wait for namespace governance to gossip
+    # 10s matches the post-#2344 opaque-leaf-regression timing; covers
+    # invitation visibility so `join_namespace` doesn't 404.
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    # Default member capabilities include CAN_JOIN_OPEN_SUBGROUPS, so
+    # node-2 inherits the right to join any Open subgroup beneath
+    # this namespace without an explicit add_group_members.
+    type: join_namespace
+    node: open-selfjoin-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{ns_invite}}'
+    outputs:
+      node2_identity: memberIdentity
+
+  - name: Node-1 creates Open subgroup inside namespace
+    type: create_group_in_namespace
+    node: open-selfjoin-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: open-selfjoin-node-1
+    group_id: '{{subgroup_id}}'
+    visibility: open
+
+  - name: Node-1 creates context inside Open subgroup
+    type: create_context
+    node: open-selfjoin-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  # ── Phase 2: node-2 self-joins via inherited path ─────────────────
+  # This is the critical operation. No `add_group_members` is run for
+  # node-2 on the Open subgroup — they're inherited from the parent
+  # namespace + CAN_JOIN_OPEN_SUBGROUPS. Pre-fix this leaves their
+  # ContextIdentity row with sender_key:None; post-fix the joiner
+  # publishes MemberJoinedOpen which triggers KeyDelivery.
+
+  - name: Node-2 self-joins Open-subgroup context (inherited path)
+    type: join_context
+    node: open-selfjoin-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Assert bootstrap shape
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+      - "is_set({{subgroup_id}})"
+      - "is_set({{ctx_id}})"
+      - "is_set({{node1_key}})"
+      - "is_set({{node2_identity}})"
+      - "is_set({{node2_key}})"
+
+  - name: Initial sync (empty Root state)
+    # Lets the post-join_context flow settle — including (post-fix)
+    # the MemberJoinedOpen publish + KeyDelivery round-trip that
+    # populates node-2's sender_key. Pre-fix this is a no-op because
+    # there's nothing to deliver.
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - open-selfjoin-node-1
+      - open-selfjoin-node-2
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 3: Round 1 — node-1 writes, node-2 reads ────────────────
+  # Control case. This direction works on master too (matches the
+  # existing group-subgroup-visibility-inheritance test). Asserts the
+  # fix doesn't regress the inbound-decrypt path.
+
+  - name: Round 1 — node-1 writes
+    type: call
+    node: open-selfjoin-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "from_admin"
+      value: "node1_msg"
+    executor_public_key: '{{node1_key}}'
+
+  - name: Round 1 sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - open-selfjoin-node-1
+      - open-selfjoin-node-2
+    timeout: 30
+    check_interval: 2
+
+  - name: Node-2 reads node-1's write
+    type: call
+    node: open-selfjoin-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "from_admin"
+    executor_public_key: '{{node2_key}}'
+    outputs:
+      node2_read_admin: result
+
+  # ── Phase 4: Round 2 — node-2 writes, node-1 reads ────────────────
+  # THIS IS THE BUG. Pre-fix, node-2 has sender_key:None so their op
+  # can't be signed with the group key. Either:
+  #   (a) the write attempt fails locally with a key-missing error, or
+  #   (b) the op is produced but peers reject it as malformed/unsigned, or
+  #   (c) the op propagates as plaintext but node-1's apply path
+  #       refuses to apply ops not encrypted with the current group key.
+  # In all three sub-modes, node-1's read of "from_joiner" returns
+  # null/empty after Round 2 sync. Post-fix, the key has been
+  # delivered to node-2 so the write authors cleanly and node-1
+  # decrypts it.
+
+  - name: Round 2 — node-2 (inherited self-joiner) writes
+    type: call
+    node: open-selfjoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "from_joiner"
+      value: "node2_msg"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Round 2 sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - open-selfjoin-node-1
+      - open-selfjoin-node-2
+    timeout: 30
+    check_interval: 2
+
+  - name: Node-1 reads node-2's write (THE BUG)
+    type: call
+    node: open-selfjoin-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "from_joiner"
+    executor_public_key: '{{node1_key}}'
+    outputs:
+      node1_read_joiner: result
+
+  # ── Phase 5: Assertions ───────────────────────────────────────────
+
+  - name: Assert both directions converged
+    type: assert
+    statements:
+      - "is_set({{node2_read_admin}})"
+      - "is_set({{node1_read_joiner}})"
+      - 'contains({{node2_read_admin}}, "node1_msg")'
+      - 'contains({{node1_read_joiner}}, "node2_msg")'
+
+stop_all_nodes: false


### PR DESCRIPTION
## Summary

Targeted e2e regression guard for **#2351** (`fix(context): trigger KeyDelivery for self-join of Open subgroups`). Adds a new merobox workflow and a matrix entry that exercises the buggy outbound-author direction the existing `group-subgroup-visibility-inheritance` test does not.

## Why we need another inheritance test

The existing `group-subgroup-visibility-inheritance.yml` already tests **inbound-decrypt** for an inherited self-joiner (node-1 writes → node-2 reads). That direction passes on master because the joiner can still decrypt incoming ops using the group key they receive through the namespace identity path.

The bug #2351 fixes is in the **outbound-author** direction: an inherited joiner gets a `ContextIdentity` row with `sender_key: None`, no admin runs `add_group_members` for them, no `KeyDelivery` ever wraps the current group key for them. Their writes can't be signed/encrypted, so peers ignore or fail to decrypt them. User-visible symptom: *"joined a public channel, sends messages, no one sees them; can't see others either."*

This workflow drives the broken direction explicitly:

1. Bootstrap namespace + Open subgroup + context (single admin)
2. Node-2 self-joins via `CAN_JOIN_OPEN_SUBGROUPS` parent-walk (no `add_group_members`)
3. **Round 1 (control)**: node-1 writes → node-2 reads — confirms fix doesn't regress the working direction
4. **Round 2 (the bug)**: node-2 writes → node-1 reads — pre-fix returns null/empty or `wait_for_sync` times out

## Expected CI behaviour

- **On master (no fix)**: `Test (group-open-self-join-key-delivery)` **fails**. That failure is the proof the test catches the bug — intentional, not a regression of this PR.
- **Once #2351 lands** (or is rebased onto this branch): test goes green. Lock-in.

This PR is not mergeable on master until #2351 (or an equivalent fix) merges. Suggested merge sequence:
1. Land #2351 on master
2. Rebase this PR onto new master
3. CI goes green → merge

Alternatively, rebase #2351 onto this branch first to verify locally that the fix unbreaks the test.

## Test plan
- [ ] CI runs the new matrix entry `Test (group-open-self-join-key-delivery)` on this branch (master code)
- [ ] CI on this branch reports the new test as failing (confirms test catches the bug)
- [ ] Once #2351 merges, rebase + re-run; new test passes
- [ ] No regression in `group-subgroup-visibility-inheritance` or other group-subgroup-* matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new E2E workflow to the CI matrix, which increases runtime and can block merges if the underlying fix is not present or the scenario is flaky.
> 
> **Overview**
> Adds a new merobox E2E workflow, `group-open-self-join-key-delivery.yml`, that reproduces the Open-subgroup *inherited self-join* key-delivery regression by asserting **both** directions of sync (admin write → joiner read, and joiner write → admin read).
> 
> Registers this workflow in the `e2e-rust-apps.yml` GitHub Actions matrix so it runs alongside the existing scaffolding E2E suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1883b55f7ca6099a65b400e1b84fd70edd688361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->