### PR TITLE
fix(server): hide Restricted subgroups from non-members in list_subgroups

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -209,6 +209,9 @@ jobs:
           - workflow: dm-subgroup-privacy
             file: workflows/dm-subgroup-privacy.yml
             app: scaffolding-e2e
+          - workflow: group-list-subgroups-restricted-hidden
+            file: workflows/group-list-subgroups-restricted-hidden.yml
+            app: scaffolding-e2e
           - workflow: member-removed-multi-context-convergence
             file: workflows/member-removed-multi-context-convergence.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
+++ b/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
@@ -1,4 +1,4 @@
-name: E2E KV Store - list_subgroups Restricted Visibility
+name: E2E Scaffolding - list_subgroups Restricted Visibility
 description: >
   End-to-end coverage for PR #2361: the `list_subgroups` admin endpoint
   must not leak `Restricted` subgroups to callers who are neither an

--- a/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
+++ b/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
@@ -1,0 +1,232 @@
+name: E2E KV Store - list_subgroups Restricted Visibility
+description: >
+  End-to-end coverage for PR #2361: the `list_subgroups` admin endpoint
+  must not leak `Restricted` subgroups to callers who are neither an
+  admin of the parent group nor a member of the restricted child.
+
+  Before #2361 `list_subgroups` returned *every* direct child of the
+  parent — including `Restricted` ones — to anyone. A plain namespace
+  member could therefore enumerate the existence (and metadata) of
+  private DMs / private channels it had no access to. The membership
+  wall in `check_group_membership` stopped non-members from *joining* or
+  *calling* such a subgroup, but the enumeration endpoint bypassed it.
+
+  Topology: a namespace with one `Restricted` and one `Open` subgroup,
+  both direct children of the namespace root.
+
+    * node-1 — the namespace owner/admin. Creates both subgroups.
+    * node-2 — a plain namespace member. NOT an admin of the namespace,
+      NOT a member of the Restricted subgroup.
+    * node-3 — a namespace member that node-1 adds to the Restricted
+      subgroup.
+
+  Headline assertions on `list_subgroups(namespace)`:
+
+    * node-2 (non-admin, non-member) sees ONLY the `Open` subgroup. The
+      `Restricted` subgroup is hidden — this is the leak #2361 closes.
+    * node-3 (member of the Restricted child) sees BOTH subgroups.
+    * node-1 (admin of the parent namespace) sees BOTH subgroups —
+      admins govern the space and must enumerate every child.
+
+  The per-decision logic is also pinned by the `calimero-context` unit
+  tests `subgroup_visible_to_*` in `group_store/tests.rs`.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: app + namespace on node-1 (the namespace owner) ---
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Assert application installed
+    type: assert
+    statements:
+      - "is_set({{app_id}})"
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Assert namespace created
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+
+  # --- node-2 and node-3 join the namespace as ordinary members ---
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  # --- node-1 creates the two subgroups directly under the namespace ---
+
+  - name: Node-1 creates a Restricted subgroup (private channel)
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    group_name: restricted-channel
+    outputs:
+      restricted_sub: groupId
+
+  - name: Assert Restricted subgroup created
+    type: assert
+    statements:
+      - "is_set({{restricted_sub}})"
+
+  # Freshly created subgroups default to Restricted; set it explicitly so
+  # the intent is unambiguous and the visibility op is on the namespace
+  # governance DAG for the other nodes to converge on.
+  - name: Node-1 marks the subgroup Restricted
+    type: set_subgroup_visibility
+    node: e2e-node-1
+    group_id: '{{restricted_sub}}'
+    visibility: restricted
+
+  - name: Node-1 creates an Open subgroup (public channel)
+    type: create_group_in_namespace
+    node: e2e-node-1
+    namespace_id: '{{namespace_id}}'
+    group_name: open-channel
+    outputs:
+      open_sub: groupId
+
+  - name: Assert Open subgroup created
+    type: assert
+    statements:
+      - "is_set({{open_sub}})"
+
+  - name: Node-1 marks the subgroup Open
+    type: set_subgroup_visibility
+    node: e2e-node-1
+    group_id: '{{open_sub}}'
+    visibility: open
+
+  # node-3 is added to the Restricted subgroup; node-2 is deliberately
+  # left out so it stays a pure non-member of that child.
+  - name: Node-1 adds node-3 to the Restricted subgroup
+    type: add_group_members
+    node: e2e-node-1
+    group_id: '{{restricted_sub}}'
+    members:
+      - identity: '{{identity_node3}}'
+        role: Member
+
+  # node-2 and node-3 must converge on the namespace governance DAG
+  # before they can enumerate its subgroups: `list_subgroups` /
+  # `get_subgroup_visibility` read the *local* store, so the
+  # GroupCreated, visibility and membership ops node-1 just published
+  # have to land first. Sized for a realistic two-hop propagation delay
+  # between locally-connected nodes — not padded to mask a slow path.
+  - name: Converge node-2 and node-3 on the namespace governance state
+    type: wait_for_sync
+    group_id: '{{namespace_id}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  - name: Brief settle for namespace-DAG propagation
+    type: wait
+    seconds: 5
+
+  # --- HEADLINE: node-2 (non-admin, non-member) must see ONLY Open ---
+
+  - name: Node-2 lists the namespace subgroups
+    type: list_subgroups
+    node: e2e-node-2
+    group_id: '{{namespace_id}}'
+    outputs:
+      subgroups_node2: subgroups
+
+  - name: Assert node-2 sees the Open subgroup
+    type: assert
+    statements:
+      - "contains({{subgroups_node2}}, {{open_sub}})"
+
+  - name: Assert node-2 does NOT see the Restricted subgroup
+    type: assert
+    statements:
+      - "not_contains({{subgroups_node2}}, {{restricted_sub}})"
+
+  # --- node-3 (member of the Restricted child) must see BOTH ---
+
+  - name: Node-3 lists the namespace subgroups
+    type: list_subgroups
+    node: e2e-node-3
+    group_id: '{{namespace_id}}'
+    outputs:
+      subgroups_node3: subgroups
+
+  - name: Assert node-3 sees the Open subgroup
+    type: assert
+    statements:
+      - "contains({{subgroups_node3}}, {{open_sub}})"
+
+  - name: Assert node-3 (Restricted-subgroup member) sees the Restricted subgroup
+    type: assert
+    statements:
+      - "contains({{subgroups_node3}}, {{restricted_sub}})"
+
+  # --- node-1 (parent-namespace admin) must see BOTH ---
+
+  - name: Node-1 lists the namespace subgroups
+    type: list_subgroups
+    node: e2e-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      subgroups_node1: subgroups
+
+  - name: Assert node-1 sees the Open subgroup
+    type: assert
+    statements:
+      - "contains({{subgroups_node1}}, {{open_sub}})"
+
+  - name: Assert node-1 (namespace admin) sees the Restricted subgroup
+    type: assert
+    statements:
+      - "contains({{subgroups_node1}}, {{restricted_sub}})"
+
+stop_all_nodes: false

--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -556,7 +556,7 @@ pub fn subgroup_visible_to(
     let Some(caller_pk) = caller else {
         return Ok(false);
     };
-    if is_group_admin(store, parent_group_id, caller_pk)? {
+    if is_inherited_admin(store, parent_group_id, caller_pk)? {
         return Ok(true);
     }
     check_group_membership(store, child_group_id, caller_pk)

--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -550,7 +550,7 @@ pub fn subgroup_visible_to(
     child_group_id: &ContextGroupId,
     caller: Option<&PublicKey>,
 ) -> EyreResult<bool> {
-    if get_subgroup_visibility(store, child_group_id)? != VisibilityMode::Restricted {
+    if get_subgroup_visibility(store, child_group_id)? == VisibilityMode::Open {
         return Ok(true);
     }
     let Some(caller_pk) = caller else {

--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -525,6 +525,43 @@ pub fn require_group_admin(
     Ok(())
 }
 
+/// Decide whether `child_group_id` — a direct subgroup of
+/// `parent_group_id` — should appear in a subgroup *listing* for
+/// `caller` (the `list_subgroups` admin endpoint).
+///
+/// `Open` subgroups are always visible: their existence is public by
+/// design — that is what `CAN_JOIN_OPEN_SUBGROUPS` at the namespace root
+/// authorises against. A `Restricted` subgroup is visible only when the
+/// caller can be identified (`caller` is `Some`) **and** is either an
+/// admin of the parent group (admins govern the space and must be able
+/// to enumerate every child) or an explicit member of the restricted
+/// child itself.
+///
+/// `caller` is `None` when the listing node has no namespace identity
+/// for the parent group; `Restricted` children are then hidden —
+/// membership cannot be verified, so the conservative choice is to treat
+/// the caller as a non-member. This keeps the existence and metadata of
+/// private subgroups (DMs, private channels) from leaking through
+/// enumeration, complementing the membership wall in
+/// [`check_group_membership`] that already blocks joining/calling them.
+pub fn subgroup_visible_to(
+    store: &Store,
+    parent_group_id: &ContextGroupId,
+    child_group_id: &ContextGroupId,
+    caller: Option<&PublicKey>,
+) -> EyreResult<bool> {
+    if get_subgroup_visibility(store, child_group_id)? != VisibilityMode::Restricted {
+        return Ok(true);
+    }
+    let Some(caller_pk) = caller else {
+        return Ok(false);
+    };
+    if is_group_admin(store, parent_group_id, caller_pk)? {
+        return Ok(true);
+    }
+    check_group_membership(store, child_group_id, caller_pk)
+}
+
 /// Returns `true` if `identity` is a group admin **or** holds the given capability bit.
 /// Admins always pass regardless of capability bits.
 pub fn is_group_admin_or_has_capability(

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -80,8 +80,8 @@ pub use self::membership::{
     has_direct_group_member, is_direct_group_admin, is_group_admin,
     is_group_admin_or_has_capability, is_inherited_admin, list_group_members,
     namespace_member_pubkeys, remove_group_member, require_group_admin,
-    require_group_admin_or_capability, set_member_auto_follow, trusted_anchors_for_group,
-    MembershipPath,
+    require_group_admin_or_capability, set_member_auto_follow, subgroup_visible_to,
+    trusted_anchors_for_group, MembershipPath,
 };
 pub use self::membership_policy::MembershipPolicy;
 pub use self::membership_status::{membership_status_at, MembershipStatus};

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -7815,3 +7815,101 @@ fn apply_group_op_mutations_no_divergence_on_matching_hash() {
         "no divergence expected when hashes match, got {divergence:?}"
     );
 }
+
+// -----------------------------------------------------------------------
+// `subgroup_visible_to` — the visibility decision behind the
+// `list_subgroups` admin endpoint (PR #2361). `Open` children are
+// public; `Restricted` children are listed only for the parent-group
+// admin or a direct member of the child. These pin every cell of the
+// visibility matrix the handler relies on.
+// -----------------------------------------------------------------------
+
+#[test]
+fn subgroup_visible_to_open_child_is_public_to_everyone() {
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let parent = ContextGroupId::from([0xD0; 32]);
+    let child = ContextGroupId::from([0xD1; 32]);
+    let stranger = PublicKey::from([0x09; 32]);
+
+    nest_for_test(&store, &parent, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Open).unwrap();
+
+    // An `Open` subgroup's existence is public by design — it is listed
+    // even for a caller that cannot be identified and one that is a
+    // total non-member.
+    assert!(subgroup_visible_to(&store, &parent, &child, None).unwrap());
+    assert!(subgroup_visible_to(&store, &parent, &child, Some(&stranger)).unwrap());
+}
+
+#[test]
+fn subgroup_visible_to_restricted_child_hidden_from_non_member() {
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let parent = ContextGroupId::from([0xD2; 32]);
+    let child = ContextGroupId::from([0xD3; 32]);
+    let stranger = PublicKey::from([0x09; 32]);
+
+    nest_for_test(&store, &parent, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Restricted).unwrap();
+
+    // The caller is neither a parent admin nor a member of the
+    // restricted child — its existence must not leak through the list.
+    assert!(!subgroup_visible_to(&store, &parent, &child, Some(&stranger)).unwrap());
+}
+
+#[test]
+fn subgroup_visible_to_restricted_child_hidden_when_caller_unknown() {
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let parent = ContextGroupId::from([0xD4; 32]);
+    let child = ContextGroupId::from([0xD5; 32]);
+
+    nest_for_test(&store, &parent, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Restricted).unwrap();
+
+    // `caller == None` (node has no namespace identity for the parent):
+    // membership cannot be verified, so the conservative choice hides
+    // the restricted child.
+    assert!(!subgroup_visible_to(&store, &parent, &child, None).unwrap());
+}
+
+#[test]
+fn subgroup_visible_to_restricted_child_visible_to_parent_admin() {
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let parent = ContextGroupId::from([0xD6; 32]);
+    let child = ContextGroupId::from([0xD7; 32]);
+    let admin = PublicKey::from([0x0A; 32]);
+
+    nest_for_test(&store, &parent, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Restricted).unwrap();
+
+    // An admin of the parent group governs the space and must be able
+    // to enumerate every child — even restricted ones it is not itself
+    // a member of.
+    add_group_member(&store, &parent, &admin, GroupMemberRole::Admin).unwrap();
+    assert!(subgroup_visible_to(&store, &parent, &child, Some(&admin)).unwrap());
+}
+
+#[test]
+fn subgroup_visible_to_restricted_child_visible_to_its_member() {
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let parent = ContextGroupId::from([0xD8; 32]);
+    let child = ContextGroupId::from([0xD9; 32]);
+    let member = PublicKey::from([0x0B; 32]);
+
+    nest_for_test(&store, &parent, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Restricted).unwrap();
+
+    // A direct member of the restricted child sees it, even though it
+    // is not an admin of the parent group.
+    add_group_member(&store, &child, &member, GroupMemberRole::Member).unwrap();
+    assert!(subgroup_visible_to(&store, &parent, &child, Some(&member)).unwrap());
+}

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -53,32 +53,36 @@ pub async fn handler(
         // subgroups are always listed — their existence is public by
         // design (that's what CAN_JOIN_OPEN_SUBGROUPS at the namespace
         // root authorises against).
-        if let Some(ref caller_pk) = caller {
-            let visibility =
-                match calimero_context::group_store::get_subgroup_visibility(&state.store, &child) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        warn!(?err, group_id=%hex::encode(child.to_bytes()),
-                              "get_subgroup_visibility failed; skipping from list");
-                        continue;
-                    }
-                };
-            if matches!(visibility, VisibilityMode::Restricted) {
-                let is_member = match calimero_context::group_store::check_group_membership(
-                    &state.store,
-                    &child,
-                    caller_pk,
-                ) {
-                    Ok(b) => b,
-                    Err(err) => {
-                        warn!(?err, group_id=%hex::encode(child.to_bytes()),
-                              "check_group_membership failed; skipping from list");
-                        continue;
-                    }
-                };
-                if !is_member {
+        //
+        // We always check visibility first. When caller is None (this node
+        // has no namespace identity for the parent group), Restricted
+        // subgroups are hidden — we can't verify membership so the
+        // conservative choice is to treat the caller as a non-member.
+        let visibility =
+            match calimero_context::group_store::get_subgroup_visibility(&state.store, &child) {
+                Ok(v) => v,
+                Err(err) => {
+                    warn!(?err, group_id=%hex::encode(child.to_bytes()),
+                          "get_subgroup_visibility failed; skipping from list");
                     continue;
                 }
+            };
+        if matches!(visibility, VisibilityMode::Restricted) {
+            let Some(ref caller_pk) = caller else { continue; };
+            let is_member = match calimero_context::group_store::check_group_membership(
+                &state.store,
+                &child,
+                caller_pk,
+            ) {
+                Ok(b) => b,
+                Err(err) => {
+                    warn!(?err, group_id=%hex::encode(child.to_bytes()),
+                          "check_group_membership failed; skipping from list");
+                    continue;
+                }
+            };
+            if !is_member {
+                continue;
             }
         }
 

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -68,7 +68,8 @@ pub async fn handler(
             Err(err) => {
                 warn!(
                     ?err,
-                    group_id = %hex::encode(child.to_bytes()),
+                    parent_group_id = %group_id_str,
+                    child_group_id = %hex::encode(child.to_bytes()),
                     "subgroup visibility check failed; hiding subgroup from list"
                 );
                 continue;

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -42,7 +42,8 @@ pub async fn handler(
         Ok(None) => None,
         Err(err) => {
             warn!(?err, group_id=%group_id_str,
-                  "resolve_namespace_identity failed; falling back to unfiltered listing");
+                  "resolve_namespace_identity failed; falling back to conservative listing \
+                   (all Restricted subgroups hidden)");
             None
         }
     };

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
+use calimero_context_config::VisibilityMode;
 use calimero_server_primitives::admin::{ListSubgroupsApiResponse, SubgroupEntryApiResponse};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::admin::handlers::groups::parse_group_id;
 use crate::admin::service::{parse_api_error, ApiResponse};
@@ -26,8 +27,61 @@ pub async fn handler(
         Err(err) => return parse_api_error(err).into_response(),
     };
 
+    // Caller identity comes from the node's *own* namespace identity for
+    // the parent group — NOT from the JWT subject. The JWT's `sub` is a
+    // node-level key fingerprint that doesn't parse as a `PublicKey`
+    // (see calimero_server::auth — emits a WARN and skips the
+    // AuthenticatedKey extension). Using `resolve_namespace_identity`
+    // matches what `list_group_members` already does to populate
+    // `selfIdentity`.
+    let caller = match calimero_context::group_store::resolve_namespace_identity(
+        &state.store,
+        &group_id,
+    ) {
+        Ok(Some((pk, _, _))) => Some(pk),
+        Ok(None) => None,
+        Err(err) => {
+            warn!(?err, group_id=%group_id_str,
+                  "resolve_namespace_identity failed; falling back to unfiltered listing");
+            None
+        }
+    };
+
     let mut subgroups = Vec::with_capacity(children.len());
     for child in children {
+        // Restricted subgroups stay hidden from non-members. Open
+        // subgroups are always listed — their existence is public by
+        // design (that's what CAN_JOIN_OPEN_SUBGROUPS at the namespace
+        // root authorises against).
+        if let Some(ref caller_pk) = caller {
+            let visibility =
+                match calimero_context::group_store::get_subgroup_visibility(&state.store, &child) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        warn!(?err, group_id=%hex::encode(child.to_bytes()),
+                              "get_subgroup_visibility failed; skipping from list");
+                        continue;
+                    }
+                };
+            if matches!(visibility, VisibilityMode::Restricted) {
+                let is_member = match calimero_context::group_store::check_group_membership(
+                    &state.store,
+                    &child,
+                    caller_pk,
+                ) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(?err, group_id=%hex::encode(child.to_bytes()),
+                              "check_group_membership failed; skipping from list");
+                        continue;
+                    }
+                };
+                if !is_member {
+                    continue;
+                }
+            }
+        }
+
         let name = match calimero_context::group_store::get_group_metadata(&state.store, &child) {
             Ok(rec) => rec.and_then(|r| r.name),
             Err(err) => return parse_api_error(err).into_response(),

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -34,19 +34,20 @@ pub async fn handler(
     // AuthenticatedKey extension). Using `resolve_namespace_identity`
     // matches what `list_group_members` already does to populate
     // `selfIdentity`.
-    let caller = match calimero_context::group_store::resolve_namespace_identity(
-        &state.store,
-        &group_id,
-    ) {
-        Ok(Some((pk, _, _))) => Some(pk),
-        Ok(None) => None,
-        Err(err) => {
-            warn!(?err, group_id=%group_id_str,
-                  "resolve_namespace_identity failed; falling back to conservative listing \
-                   (all Restricted subgroups hidden)");
-            None
-        }
-    };
+    let caller =
+        match calimero_context::group_store::resolve_namespace_identity(&state.store, &group_id) {
+            Ok(Some((pk, _, _))) => Some(pk),
+            Ok(None) => None,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    group_id = %group_id_str,
+                    "resolve_namespace_identity failed; falling back to conservative listing \
+                     (all Restricted subgroups hidden)"
+                );
+                None
+            }
+        };
 
     let mut subgroups = Vec::with_capacity(children.len());
     for child in children {
@@ -63,27 +64,56 @@ pub async fn handler(
             match calimero_context::group_store::get_subgroup_visibility(&state.store, &child) {
                 Ok(v) => v,
                 Err(err) => {
-                    warn!(?err, group_id=%hex::encode(child.to_bytes()),
-                          "get_subgroup_visibility failed; skipping from list");
+                    warn!(
+                        ?err,
+                        group_id = %hex::encode(child.to_bytes()),
+                        "get_subgroup_visibility failed; skipping from list"
+                    );
                     continue;
                 }
             };
         if matches!(visibility, VisibilityMode::Restricted) {
-            let Some(ref caller_pk) = caller else { continue; };
-            let is_member = match calimero_context::group_store::check_group_membership(
+            let Some(ref caller_pk) = caller else {
+                continue;
+            };
+            // Admins of the parent group can enumerate all direct children
+            // even if those children are Restricted — they govern the space
+            // and need to know what subgroups exist. Non-admins must be an
+            // explicit member of the child to see it.
+            let is_parent_admin = match calimero_context::group_store::is_group_admin(
                 &state.store,
-                &child,
+                &group_id,
                 caller_pk,
             ) {
                 Ok(b) => b,
                 Err(err) => {
-                    warn!(?err, group_id=%hex::encode(child.to_bytes()),
-                          "check_group_membership failed; skipping from list");
+                    warn!(
+                        ?err,
+                        group_id = %group_id_str,
+                        "is_group_admin failed; skipping restricted subgroup from list"
+                    );
                     continue;
                 }
             };
-            if !is_member {
-                continue;
+            if !is_parent_admin {
+                let is_member = match calimero_context::group_store::check_group_membership(
+                    &state.store,
+                    &child,
+                    caller_pk,
+                ) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            group_id = %hex::encode(child.to_bytes()),
+                            "check_group_membership failed; skipping from list"
+                        );
+                        continue;
+                    }
+                };
+                if !is_member {
+                    continue;
+                }
             }
         }
 

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
-use calimero_context_config::VisibilityMode;
 use calimero_server_primitives::admin::{ListSubgroupsApiResponse, SubgroupEntryApiResponse};
 use tracing::{info, warn};
 
@@ -51,69 +50,28 @@ pub async fn handler(
 
     let mut subgroups = Vec::with_capacity(children.len());
     for child in children {
-        // Restricted subgroups stay hidden from non-members. Open
-        // subgroups are always listed — their existence is public by
-        // design (that's what CAN_JOIN_OPEN_SUBGROUPS at the namespace
-        // root authorises against).
-        //
-        // We always check visibility first. When caller is None (this node
-        // has no namespace identity for the parent group), Restricted
-        // subgroups are hidden — we can't verify membership so the
-        // conservative choice is to treat the caller as a non-member.
-        let visibility =
-            match calimero_context::group_store::get_subgroup_visibility(&state.store, &child) {
-                Ok(v) => v,
-                Err(err) => {
-                    warn!(
-                        ?err,
-                        group_id = %hex::encode(child.to_bytes()),
-                        "get_subgroup_visibility failed; skipping from list"
-                    );
-                    continue;
-                }
-            };
-        if matches!(visibility, VisibilityMode::Restricted) {
-            let Some(ref caller_pk) = caller else {
+        // `Open` subgroups are always listed; `Restricted` subgroups are
+        // listed only for the parent-group admin or a member of the
+        // child (see `subgroup_visible_to`). On any visibility/membership
+        // lookup error we skip the child — the conservative choice never
+        // leaks a private subgroup. A `caller` of `None` (this node has
+        // no namespace identity for the parent group) likewise hides all
+        // `Restricted` children.
+        match calimero_context::group_store::subgroup_visible_to(
+            &state.store,
+            &group_id,
+            &child,
+            caller.as_ref(),
+        ) {
+            Ok(true) => {}
+            Ok(false) => continue,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    group_id = %hex::encode(child.to_bytes()),
+                    "subgroup visibility check failed; hiding subgroup from list"
+                );
                 continue;
-            };
-            // Admins of the parent group can enumerate all direct children
-            // even if those children are Restricted — they govern the space
-            // and need to know what subgroups exist. Non-admins must be an
-            // explicit member of the child to see it.
-            let is_parent_admin = match calimero_context::group_store::is_group_admin(
-                &state.store,
-                &group_id,
-                caller_pk,
-            ) {
-                Ok(b) => b,
-                Err(err) => {
-                    warn!(
-                        ?err,
-                        group_id = %group_id_str,
-                        "is_group_admin failed; skipping restricted subgroup from list"
-                    );
-                    continue;
-                }
-            };
-            if !is_parent_admin {
-                let is_member = match calimero_context::group_store::check_group_membership(
-                    &state.store,
-                    &child,
-                    caller_pk,
-                ) {
-                    Ok(b) => b,
-                    Err(err) => {
-                        warn!(
-                            ?err,
-                            group_id = %hex::encode(child.to_bytes()),
-                            "check_group_membership failed; skipping from list"
-                        );
-                        continue;
-                    }
-                };
-                if !is_member {
-                    continue;
-                }
             }
         }
 


### PR DESCRIPTION
## Problem

`GET /admin-api/.../groups/{id}/subgroups` (`list_subgroups`) returned **every** direct child of the parent group — including `Restricted` subgroups — to any caller. A node that is not a member of a `Restricted` subgroup (and not an admin of the parent) could still see that the subgroup *exists* and learn its name. That leaks the existence and metadata of private DMs / private channels.

The membership wall (`check_group_membership`) already stops non-members from *joining* or *calling* a `Restricted` subgroup, but the enumeration endpoint bypassed it entirely.

## Fix

`list_subgroups` now enforces subgroup **visibility** before adding a child to the response:

- **`Open` subgroups** — always listed. Their existence is public by design (that's what `CAN_JOIN_OPEN_SUBGROUPS` at the namespace root authorises against).
- **`Restricted` subgroups** — listed only when the caller is either:
  - an **admin of the parent group** (governs the space, needs to see all children), or
  - an explicit **member of the child** subgroup.

Caller identity is resolved via `resolve_namespace_identity` (the node's own namespace identity for the parent group), matching what `list_group_members` already does to populate `selfIdentity` — **not** the JWT `sub`, which is a node-level key fingerprint that doesn't parse as a `PublicKey`.

The per-child decision lives in a single testable helper, `group_store::subgroup_visible_to`; the handler calls it per child.

### Fail-safe behavior

Every identity / visibility / admin / membership lookup that errors falls back to the **conservative** choice — the `Restricted` subgroup is hidden / skipped, never leaked. If the node has no namespace identity for the parent (`caller = None`), all `Restricted` subgroups are hidden.

### Visibility matrix

| Caller | `Open` child | `Restricted` child |
|---|---|---|
| Parent-group admin | ✅ listed | ✅ listed |
| Member of the child | ✅ listed | ✅ listed |
| Non-member, non-admin | ✅ listed | ❌ hidden |
| No namespace identity / lookup error | ✅ listed | ❌ hidden |

## Scope

Touches the `list_subgroups` admin handler plus the extracted `subgroup_visible_to` helper. Orthogonal to #2368 (kick/rejoin `ContextIdentity` restoration) — no overlap.

## Tests

- **Unit** — 5 `subgroup_visible_to_*` tests in `group_store/tests.rs` pinning every cell of the visibility matrix: `Open` public to everyone; `Restricted` hidden from a non-member and from an unidentifiable caller; `Restricted` visible to the parent-group admin and to a direct member of the child.
- **E2E** — new merobox workflow `group-list-subgroups-restricted-hidden` (3 nodes), wired into the `e2e-rust-apps` CI matrix: a non-admin non-member calling `list_subgroups` on the namespace sees only the `Open` subgroup, while the `Restricted`-child member and the namespace admin see both. (merobox already ships the `list_subgroups` step type — no merobox change needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes access-control behavior of the `list_subgroups` admin endpoint to filter results based on membership/admin status; mistakes could hide legitimate subgroups or reintroduce metadata leakage.
> 
> **Overview**
> Fixes an information leak in `GET .../groups/{id}/subgroups` by filtering `Restricted` children out of the response unless the caller is an inherited admin of the parent group or a direct member of the child (while `Open` children remain publicly listable).
> 
> Adds `group_store::subgroup_visible_to` (and unit tests) to centralize the visibility decision, updates the server handler to resolve the caller via `resolve_namespace_identity` and conservatively hide subgroups on lookup errors, and introduces a 3-node scaffolding E2E workflow wired into CI to validate the visibility matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987c59b5ae3d10cb6e9466f8eded4c18032ac624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->