### PR TITLE
feat(admin): issue ownership proof endpoint for cross-repo claim flow

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -29,19 +29,19 @@ use crate::group::{
     GetGroupForContextRequest, GetGroupInfoRequest, GetGroupMetadataRequest,
     GetGroupUpgradeStatusRequest, GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse,
     GetMemberMetadataRequest, GetNamespaceIdentityRequest, GroupContextEntry, GroupInfoResponse,
-    GroupSummary, GroupUpgradeInfo, JoinContextRequest, JoinContextResponse, JoinGroupRequest,
-    JoinGroupResponse, LeaveContextRequest, LeaveContextResponse, LeaveGroupRequest,
-    LeaveGroupResponse, LeaveNamespaceRequest, LeaveNamespaceResponse, ListAllGroupsRequest,
-    ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
-    ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
-    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetContextMetadataRequest,
-    SetDefaultCapabilitiesRequest, SetGroupMetadataRequest, SetMemberCapabilitiesRequest,
-    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
-    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
-    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
-    SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
-    UpgradeGroupResponse,
+    GroupSummary, GroupUpgradeInfo, IssueOwnershipProofRequest, IssueOwnershipProofResponse,
+    JoinContextRequest, JoinContextResponse, JoinGroupRequest, JoinGroupResponse,
+    LeaveContextRequest, LeaveContextResponse, LeaveGroupRequest, LeaveGroupResponse,
+    LeaveNamespaceRequest, LeaveNamespaceResponse, ListAllGroupsRequest, ListGroupContextsRequest,
+    ListGroupMembersRequest, ListGroupMembersResponse, ListNamespacesForApplicationRequest,
+    ListNamespacesRequest, NamespaceSummary, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
+    SetContextMetadataRequest, SetDefaultCapabilitiesRequest, SetGroupMetadataRequest,
+    SetMemberCapabilitiesRequest, SetMemberMetadataRequest, SetSubgroupVisibilityRequest,
+    SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest,
+    StoreGroupContextRequest, StoreGroupMetaRequest, StoreGroupMetadataRequest,
+    StoreMemberCapabilityRequest, StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest,
+    SyncGroupRequest, SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest,
+    UpgradeGroupRequest, UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1284,6 +1284,12 @@ impl ContextClient {
         LeaveGroup,
         LeaveGroupRequest,
         eyre::Result<LeaveGroupResponse>
+    );
+    forward_to_actor!(
+        issue_ownership_proof,
+        IssueOwnershipProof,
+        IssueOwnershipProofRequest,
+        eyre::Result<IssueOwnershipProofResponse>
     );
     forward_to_actor!(
         leave_namespace,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -480,6 +480,45 @@ impl Message for GetContextMetadataRequest {
     type Result = eyre::Result<Option<MetadataRecord>>;
 }
 
+/// Request issued by an admin client to obtain a signed ownership-claim
+/// payload for a calimero group.
+///
+/// The handler resolves the node's identity for the group's namespace,
+/// verifies it is a direct admin, looks up the group's signing key, and
+/// returns a base64-encoded canonical JSON payload + an ed25519 signature
+/// over `OWNERSHIP_PROOF_DOMAIN || signed_payload_bytes`. The verifier on
+/// the other side (mdma) re-parses the opaque payload bytes; field order
+/// in the payload is fixed by the struct definition order in the handler.
+///
+/// See the issue-ownership-proof handler for the locked wire format.
+#[derive(Debug)]
+pub struct IssueOwnershipProofRequest {
+    pub group_id: ContextGroupId,
+    pub context_id: ContextId,
+    pub audience: String,
+    pub subject: String,
+    /// Hex string, validated by the API layer to be 32..=128 chars.
+    pub nonce: String,
+    /// Caller-requested expiry in unix ms. Clamped server-side to
+    /// `min(expires_at_ms, issued_at_ms + 5*60*1000)`.
+    pub expires_at_ms: u64,
+}
+
+impl Message for IssueOwnershipProofRequest {
+    type Result = eyre::Result<IssueOwnershipProofResponse>;
+}
+
+#[derive(Clone, Debug)]
+pub struct IssueOwnershipProofResponse {
+    /// Ed25519 public key of the signer (the node's group signing identity).
+    pub signer_public_key: PublicKey,
+    /// Opaque UTF-8 JSON bytes of the canonical claim payload. The verifier
+    /// re-parses these bytes; the API layer base64-encodes them on the wire.
+    pub signed_payload: Vec<u8>,
+    /// Raw 64-byte ed25519 signature over `OWNERSHIP_PROOF_DOMAIN || signed_payload`.
+    pub signature: [u8; 64],
+}
+
 // ---- Group Permission Types ----
 
 #[derive(Debug)]

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -15,16 +15,16 @@ use crate::group::{
     DetachContextFromGroupRequest, GetContextMetadataRequest, GetGroupForContextRequest,
     GetGroupInfoRequest, GetGroupMetadataRequest, GetGroupUpgradeStatusRequest,
     GetMemberCapabilitiesRequest, GetMemberMetadataRequest, GetNamespaceIdentityRequest,
-    JoinContextRequest, JoinGroupRequest, LeaveContextRequest, LeaveGroupRequest,
-    LeaveNamespaceRequest, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
-    ListNamespacesForApplicationRequest, ListNamespacesRequest, RemoveGroupMembersRequest,
-    RetryGroupUpgradeRequest, SetContextMetadataRequest, SetDefaultCapabilitiesRequest,
-    SetGroupMetadataRequest, SetMemberCapabilitiesRequest, SetMemberMetadataRequest,
-    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest,
-    StoreDefaultCapabilitiesRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
-    StoreGroupMetadataRequest, StoreMemberCapabilityRequest, StoreMemberMetadataRequest,
-    StoreSubgroupVisibilityRequest, SyncGroupRequest, UpdateGroupSettingsRequest,
-    UpdateMemberRoleRequest, UpgradeGroupRequest,
+    IssueOwnershipProofRequest, JoinContextRequest, JoinGroupRequest, LeaveContextRequest,
+    LeaveGroupRequest, LeaveNamespaceRequest, ListAllGroupsRequest, ListGroupContextsRequest,
+    ListGroupMembersRequest, ListNamespacesForApplicationRequest, ListNamespacesRequest,
+    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetContextMetadataRequest,
+    SetDefaultCapabilitiesRequest, SetGroupMetadataRequest, SetMemberCapabilitiesRequest,
+    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
+    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -467,5 +467,9 @@ pub enum ContextMessage {
     ListNamespacesForApplication {
         request: ListNamespacesForApplicationRequest,
         outcome: oneshot::Sender<<ListNamespacesForApplicationRequest as Message>::Result>,
+    },
+    IssueOwnershipProof {
+        request: IssueOwnershipProofRequest,
+        outcome: oneshot::Sender<<IssueOwnershipProofRequest as Message>::Result>,
     },
 }

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -98,6 +98,7 @@ pub use self::metadata::{
 pub use self::migrations::{
     delete_all_context_last_migrations, get_context_last_migration, set_context_last_migration,
 };
+pub(crate) use self::namespace::MAX_NAMESPACE_DEPTH;
 pub use self::namespace::{
     collect_descendant_groups, collect_subtree_for_cascade, collect_visible_descendant_groups,
     create_recursive_invitations, get_namespace_identity, get_namespace_identity_record,

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -25,6 +25,7 @@ pub mod get_group_upgrade_status;
 pub mod get_member_capabilities;
 pub mod get_member_metadata;
 pub mod get_namespace_identity;
+pub mod issue_ownership_proof;
 pub mod join_context;
 pub mod join_group;
 pub mod leave_context;
@@ -228,6 +229,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::ListNamespacesForApplication { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::IssueOwnershipProof { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
         }

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -10,6 +10,7 @@ use eyre::bail;
 use serde::Serialize;
 
 use crate::group_store;
+use crate::group_store::MAX_NAMESPACE_DEPTH;
 use crate::ContextManager;
 
 /// Domain-separation tag prepended to the serialized payload before signing.
@@ -70,10 +71,28 @@ pub(crate) fn build_ownership_proof(
         bail!("node is not a direct admin of this group");
     }
 
-    // TODO(#73): verify `context_id` actually belongs to `group_id` (via
-    // `enumerate_group_contexts` or a direct lookup). Left as a follow-up
-    // because tying it in here changes the test surface significantly and
-    // the cross-repo contract only depends on the signed payload bytes.
+    let ctx_group = group_store::get_group_for_context(store, &context_id)?
+        .ok_or_else(|| eyre::eyre!("context {context_id:?} is not registered in any group"))?;
+    // The caller scopes the proof to a namespace root; the context may live in
+    // that root or any descendant subgroup. Walk up from the context's group
+    // and require we reach `group_id` within the namespace depth bound.
+    let mut current = ctx_group;
+    let mut contained = current == group_id;
+    for _ in 0..MAX_NAMESPACE_DEPTH {
+        if contained {
+            break;
+        }
+        match group_store::get_parent_group(store, &current)? {
+            Some(parent) => {
+                current = parent;
+                contained = current == group_id;
+            }
+            None => break,
+        }
+    }
+    if !contained {
+        bail!("context {context_id:?} is not within the namespace rooted at {group_id:?}");
+    }
 
     let Some(signing_key_bytes) =
         group_store::resolve_group_signing_key(store, &group_id, &node_identity)?
@@ -87,11 +106,20 @@ pub(crate) fn build_ownership_proof(
         bail!("expires_at_ms must be in the future");
     }
 
+    // Derive the signer identity from the resolved signing key itself rather
+    // than trusting `node_identity`. In all reachable states these are equal
+    // (signing keys are stored keyed by their own public key — see
+    // `register_signing_key.rs`), but mdma cross-checks that
+    // `payload.issuer_identity == response.signer_public_key` byte-for-byte,
+    // so both MUST come from the same source of truth: the private key.
+    let private_key = PrivateKey::from(signing_key_bytes);
+    let signer_public_key = private_key.public_key();
+
     let payload = OwnershipClaimPayload {
         v: 1,
         audience,
         group_id: hex::encode(group_id.to_bytes()),
-        issuer_identity: node_identity.to_string(),
+        issuer_identity: signer_public_key.to_string(),
         context_id: bs58::encode(context_id.as_ref()).into_string(),
         subject,
         nonce,
@@ -104,12 +132,11 @@ pub(crate) fn build_ownership_proof(
     sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
     sign_input.extend_from_slice(&signed_payload);
 
-    let private_key = PrivateKey::from(signing_key_bytes);
     let signature = private_key.sign(&sign_input)?;
     let signature_bytes: [u8; 64] = signature.to_bytes();
 
     Ok(OwnershipProofBuildOutput {
-        signer_public_key: node_identity,
+        signer_public_key,
         signed_payload,
         signature: signature_bytes,
     })
@@ -185,6 +212,8 @@ mod tests {
             .expect("add admin");
         group_store::store_group_signing_key(&store, &group_id, &signing_pub, &signing_priv)
             .expect("store signing key");
+        group_store::register_context_in_group(&store, &group_id, &context_id)
+            .expect("register context");
 
         (store, group_id, context_id, signing_pub, signing_priv)
     }
@@ -264,9 +293,11 @@ mod tests {
         let context_id = ContextId::from([0xBB; 32]);
         let identity = PublicKey::from([0x44; 32]);
 
-        // Admin row exists but no signing key registered.
+        // Admin row exists and context is registered, but no signing key.
         group_store::add_group_member(&store, &group_id, &identity, GroupMemberRole::Admin)
             .expect("add admin");
+        group_store::register_context_in_group(&store, &group_id, &context_id)
+            .expect("register context");
 
         let err = build_ownership_proof(
             &store,
@@ -321,5 +352,143 @@ mod tests {
         )
         .expect_err("expires_at_ms == now must be rejected");
         assert!(err.to_string().contains("expires_at_ms"));
+    }
+
+    #[test]
+    fn context_in_subgroup_of_namespace_root_succeeds() {
+        let store = test_store();
+        // `root` is the namespace root the caller scopes the proof to;
+        // `child` is a descendant subgroup the context actually lives in.
+        let root = ContextGroupId::from([0xAA; 32]);
+        let child = ContextGroupId::from([0xCC; 32]);
+        let context_id = ContextId::from([0xBB; 32]);
+
+        let signing_priv = PrivateKey::from([0x33; 32]);
+        let signing_pub = signing_priv.public_key();
+
+        // Admin + signing key registered at the root (resolve_group_signing_key
+        // walks up from the requested group, so a root key is reachable).
+        group_store::add_group_member(&store, &root, &signing_pub, GroupMemberRole::Admin)
+            .expect("add admin");
+        group_store::store_group_signing_key(&store, &root, &signing_pub, &signing_priv)
+            .expect("store signing key");
+
+        // Context lives in `child`, which is nested under `root`.
+        group_store::nest_group(&store, &root, &child).expect("nest child under root");
+        group_store::register_context_in_group(&store, &child, &context_id)
+            .expect("register context in subgroup");
+
+        let out = build_ownership_proof(
+            &store,
+            signing_pub,
+            root,
+            context_id,
+            "mdma.cloud",
+            "subject-xyz",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect("context in subgroup of namespace root must succeed");
+
+        let mut sign_input =
+            Vec::with_capacity(OWNERSHIP_PROOF_DOMAIN.len() + out.signed_payload.len());
+        sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
+        sign_input.extend_from_slice(&out.signed_payload);
+        out.signer_public_key
+            .verify_raw_signature(&sign_input, &out.signature)
+            .expect("signature must verify");
+    }
+
+    #[test]
+    fn context_in_unrelated_group_bails() {
+        let (store, group_id, _ctx, signing_pub, _signing_priv) = setup_admin_with_signing_key();
+
+        // A context registered in a group that is neither `group_id` nor a
+        // descendant of it must not be claimable under `group_id`.
+        let unrelated = ContextGroupId::from([0xEE; 32]);
+        let foreign_ctx = ContextId::from([0xDD; 32]);
+        group_store::register_context_in_group(&store, &unrelated, &foreign_ctx)
+            .expect("register context in unrelated group");
+
+        let err = build_ownership_proof(
+            &store,
+            signing_pub,
+            group_id,
+            foreign_ctx,
+            "aud",
+            "sub",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect_err("context outside the namespace must bail");
+        assert!(err.to_string().contains("not within the namespace"));
+    }
+
+    #[test]
+    fn signer_public_key_is_derived_from_signing_key_not_node_identity() {
+        // In all states reachable via `register_signing_key.rs` the stored key
+        // is keyed by its own derived public key, so `node_identity` and the
+        // signer key coincide. This test deliberately constructs a divergent
+        // store state (signing key stored under a `node_identity` that does
+        // NOT equal `PrivateKey::from(bytes).public_key()`) to prove the
+        // handler derives `signer_public_key` from the key material itself —
+        // mdma cross-checks `payload.issuer_identity == signer_public_key`.
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+        let context_id = ContextId::from([0xBB; 32]);
+
+        // The real signing key the proof is produced with.
+        let real_priv = PrivateKey::from([0x33; 32]);
+        let real_pub = real_priv.public_key();
+
+        // A distinct admin identity used as `node_identity`; the signing key is
+        // stored *keyed by this identity* but with `real_priv`'s bytes, so the
+        // lookup succeeds yet the derived pubkey differs from node_identity.
+        let node_identity = PublicKey::from([0x77; 32]);
+        assert_ne!(
+            node_identity, real_pub,
+            "scenario requires node_identity != derived signing pubkey"
+        );
+
+        group_store::add_group_member(&store, &group_id, &node_identity, GroupMemberRole::Admin)
+            .expect("add admin");
+        group_store::store_group_signing_key(&store, &group_id, &node_identity, &real_priv)
+            .expect("store signing key keyed by node_identity");
+        group_store::register_context_in_group(&store, &group_id, &context_id)
+            .expect("register context");
+
+        let out = build_ownership_proof(
+            &store,
+            node_identity,
+            group_id,
+            context_id,
+            "mdma.cloud",
+            "subject-xyz",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect("happy path with divergent stored key");
+
+        // signer_public_key derives from the signing key, NOT node_identity.
+        assert_eq!(out.signer_public_key, real_pub);
+        assert_ne!(out.signer_public_key, node_identity);
+
+        // Signature verifies against the derived key.
+        let mut sign_input =
+            Vec::with_capacity(OWNERSHIP_PROOF_DOMAIN.len() + out.signed_payload.len());
+        sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
+        sign_input.extend_from_slice(&out.signed_payload);
+        out.signer_public_key
+            .verify_raw_signature(&sign_input, &out.signature)
+            .expect("signature must verify against derived signer key");
+
+        // payload.issuer_identity must equal response.signer_public_key.
+        let json: Value =
+            serde_json::from_slice(&out.signed_payload).expect("payload must be valid JSON");
+        assert_eq!(json["issuer_identity"], out.signer_public_key.to_string());
+        assert_eq!(json["issuer_identity"], real_pub.to_string());
     }
 }

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -155,7 +155,8 @@ impl Handler<IssueOwnershipProofRequest> for ContextManager {
                 bail!("node has no group identity configured");
             };
 
-            let now_ms = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis() as u64;
+            let now_ms = u64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())
+                .map_err(|_| eyre::eyre!("system clock out of u64 millisecond range"))?;
 
             let built = build_ownership_proof(
                 &self.datastore,

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -1,0 +1,325 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use actix::{ActorResponse, Handler, Message};
+use calimero_context_client::group::{IssueOwnershipProofRequest, IssueOwnershipProofResponse};
+use calimero_context_config::types::ContextGroupId;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::{PrivateKey, PublicKey};
+use calimero_store::Store;
+use eyre::bail;
+use serde::Serialize;
+
+use crate::group_store;
+use crate::ContextManager;
+
+/// Domain-separation tag prepended to the serialized payload before signing.
+/// Verifiers MUST reconstruct the signed bytes as `OWNERSHIP_PROOF_DOMAIN ||
+/// signed_payload_bytes`.
+pub const OWNERSHIP_PROOF_DOMAIN: &[u8] = b"calimero.ownership-claim.v1\x00";
+
+/// Maximum lifetime, in milliseconds, that an issued ownership proof may
+/// remain valid. Caller-supplied `expires_at_ms` is clamped to
+/// `min(expires_at_ms, issued_at_ms + MAX_PROOF_LIFETIME_MS)`.
+pub const MAX_PROOF_LIFETIME_MS: u64 = 5 * 60 * 1000;
+
+/// Canonical ownership-claim payload.
+///
+/// Field order is locked by the struct definition order (serde_json preserves
+/// struct declaration order); changing it changes the byte slice that gets
+/// signed and therefore breaks every verifier.
+#[derive(Debug, Serialize)]
+struct OwnershipClaimPayload<'a> {
+    v: u8,
+    audience: &'a str,
+    group_id: String,
+    issuer_identity: String,
+    context_id: String,
+    subject: &'a str,
+    nonce: &'a str,
+    issued_at_ms: u64,
+    expires_at_ms: u64,
+}
+
+/// Result returned by [`build_ownership_proof`], split out so it can be
+/// exercised by unit tests without spinning up the actix actor system.
+#[derive(Debug)]
+pub(crate) struct OwnershipProofBuildOutput {
+    pub signer_public_key: PublicKey,
+    pub signed_payload: Vec<u8>,
+    pub signature: [u8; 64],
+}
+
+/// Core handler logic, factored so tests can drive it against an in-memory
+/// `Store` and inject a deterministic `now_ms`. The flat argument list is
+/// deliberate — every input is part of the locked signed-payload contract
+/// (see `OwnershipClaimPayload`), so grouping them into a sub-struct would
+/// only obscure the binding between caller fields and signed fields.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_ownership_proof(
+    store: &Store,
+    node_identity: PublicKey,
+    group_id: ContextGroupId,
+    context_id: ContextId,
+    audience: &str,
+    subject: &str,
+    nonce: &str,
+    requested_expires_at_ms: u64,
+    now_ms: u64,
+) -> eyre::Result<OwnershipProofBuildOutput> {
+    if !group_store::is_direct_group_admin(store, &group_id, &node_identity)? {
+        bail!("node is not a direct admin of this group");
+    }
+
+    // TODO(#73): verify `context_id` actually belongs to `group_id` (via
+    // `enumerate_group_contexts` or a direct lookup). Left as a follow-up
+    // because tying it in here changes the test surface significantly and
+    // the cross-repo contract only depends on the signed payload bytes.
+
+    let Some(signing_key_bytes) =
+        group_store::resolve_group_signing_key(store, &group_id, &node_identity)?
+    else {
+        bail!("no signing key registered for self-identity in this group");
+    };
+
+    let max_exp = now_ms.saturating_add(MAX_PROOF_LIFETIME_MS);
+    let expires_at_ms = requested_expires_at_ms.min(max_exp);
+    if expires_at_ms <= now_ms {
+        bail!("expires_at_ms must be in the future");
+    }
+
+    let payload = OwnershipClaimPayload {
+        v: 1,
+        audience,
+        group_id: hex::encode(group_id.to_bytes()),
+        issuer_identity: node_identity.to_string(),
+        context_id: bs58::encode(context_id.as_ref()).into_string(),
+        subject,
+        nonce,
+        issued_at_ms: now_ms,
+        expires_at_ms,
+    };
+    let signed_payload = serde_json::to_vec(&payload)?;
+
+    let mut sign_input = Vec::with_capacity(OWNERSHIP_PROOF_DOMAIN.len() + signed_payload.len());
+    sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
+    sign_input.extend_from_slice(&signed_payload);
+
+    let private_key = PrivateKey::from(signing_key_bytes);
+    let signature = private_key.sign(&sign_input)?;
+    let signature_bytes: [u8; 64] = signature.to_bytes();
+
+    Ok(OwnershipProofBuildOutput {
+        signer_public_key: node_identity,
+        signed_payload,
+        signature: signature_bytes,
+    })
+}
+
+impl Handler<IssueOwnershipProofRequest> for ContextManager {
+    type Result = ActorResponse<Self, <IssueOwnershipProofRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        req: IssueOwnershipProofRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let result = (|| {
+            let Some((node_identity, _)) = self.node_namespace_identity(&req.group_id) else {
+                bail!("node has no group identity configured");
+            };
+
+            let now_ms = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis() as u64;
+
+            let built = build_ownership_proof(
+                &self.datastore,
+                node_identity,
+                req.group_id,
+                req.context_id,
+                &req.audience,
+                &req.subject,
+                &req.nonce,
+                req.expires_at_ms,
+                now_ms,
+            )?;
+
+            Ok(IssueOwnershipProofResponse {
+                signer_public_key: built.signer_public_key,
+                signed_payload: built.signed_payload,
+                signature: built.signature,
+            })
+        })();
+
+        ActorResponse::reply(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_primitives::context::{ContextId, GroupMemberRole};
+    use calimero_primitives::identity::{PrivateKey, PublicKey};
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+    use serde_json::Value;
+
+    use super::{build_ownership_proof, OWNERSHIP_PROOF_DOMAIN};
+    use crate::group_store;
+
+    const NOW_MS: u64 = 1_700_000_000_000;
+
+    fn test_store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    fn setup_admin_with_signing_key() -> (Store, ContextGroupId, ContextId, PublicKey, PrivateKey) {
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+        let context_id = ContextId::from([0xBB; 32]);
+
+        let signing_priv = PrivateKey::from([0x33; 32]);
+        let signing_pub = signing_priv.public_key();
+
+        group_store::add_group_member(&store, &group_id, &signing_pub, GroupMemberRole::Admin)
+            .expect("add admin");
+        group_store::store_group_signing_key(&store, &group_id, &signing_pub, &signing_priv)
+            .expect("store signing key");
+
+        (store, group_id, context_id, signing_pub, signing_priv)
+    }
+
+    #[test]
+    fn happy_path_signature_verifies_and_payload_clamped() {
+        let (store, group_id, context_id, signing_pub, _signing_priv) =
+            setup_admin_with_signing_key();
+
+        // Request a 1-hour expiry; should be clamped to 5 minutes.
+        let requested_expires_at_ms = NOW_MS + (60 * 60 * 1000);
+        let out = build_ownership_proof(
+            &store,
+            signing_pub,
+            group_id,
+            context_id,
+            "mdma.cloud",
+            "subject-xyz",
+            "deadbeefcafebabe1122334455667788",
+            requested_expires_at_ms,
+            NOW_MS,
+        )
+        .expect("happy path");
+
+        // Verify signature: reconstruct sign_input as DOMAIN || signed_payload.
+        let mut sign_input =
+            Vec::with_capacity(OWNERSHIP_PROOF_DOMAIN.len() + out.signed_payload.len());
+        sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
+        sign_input.extend_from_slice(&out.signed_payload);
+        out.signer_public_key
+            .verify_raw_signature(&sign_input, &out.signature)
+            .expect("signature must verify");
+
+        // Inspect the canonical JSON payload.
+        let json: Value =
+            serde_json::from_slice(&out.signed_payload).expect("payload must be valid JSON");
+        assert_eq!(json["v"], 1);
+        assert_eq!(json["audience"], "mdma.cloud");
+        assert_eq!(json["subject"], "subject-xyz");
+        assert_eq!(json["nonce"], "deadbeefcafebabe1122334455667788");
+        assert_eq!(json["issued_at_ms"], NOW_MS);
+        // Clamped to NOW_MS + 5*60*1000.
+        assert_eq!(json["expires_at_ms"], NOW_MS + 5 * 60 * 1000);
+        assert_eq!(json["group_id"], hex::encode([0xAAu8; 32]));
+        assert_eq!(json["issuer_identity"], signing_pub.to_string());
+
+        assert_eq!(out.signer_public_key, signing_pub);
+    }
+
+    #[test]
+    fn errors_when_node_is_not_direct_admin() {
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+        let context_id = ContextId::from([0xBB; 32]);
+        let identity = PublicKey::from([0x44; 32]);
+
+        // Not added as a member at all — not a direct admin.
+        let err = build_ownership_proof(
+            &store,
+            identity,
+            group_id,
+            context_id,
+            "aud",
+            "sub",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect_err("expected not-direct-admin error");
+        assert!(err.to_string().contains("direct admin"));
+    }
+
+    #[test]
+    fn errors_when_no_signing_key_registered() {
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+        let context_id = ContextId::from([0xBB; 32]);
+        let identity = PublicKey::from([0x44; 32]);
+
+        // Admin row exists but no signing key registered.
+        group_store::add_group_member(&store, &group_id, &identity, GroupMemberRole::Admin)
+            .expect("add admin");
+
+        let err = build_ownership_proof(
+            &store,
+            identity,
+            group_id,
+            context_id,
+            "aud",
+            "sub",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect_err("expected missing-signing-key error");
+        assert!(err.to_string().contains("signing key"));
+    }
+
+    #[test]
+    fn errors_when_expires_at_is_in_the_past() {
+        let (store, group_id, context_id, signing_pub, _signing_priv) =
+            setup_admin_with_signing_key();
+
+        let err = build_ownership_proof(
+            &store,
+            signing_pub,
+            group_id,
+            context_id,
+            "aud",
+            "sub",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS - 1,
+            NOW_MS,
+        )
+        .expect_err("expected past-expiry error");
+        assert!(err.to_string().contains("expires_at_ms"));
+    }
+
+    #[test]
+    fn equal_to_now_is_rejected() {
+        let (store, group_id, context_id, signing_pub, _signing_priv) =
+            setup_admin_with_signing_key();
+
+        let err = build_ownership_proof(
+            &store,
+            signing_pub,
+            group_id,
+            context_id,
+            "aud",
+            "sub",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS,
+            NOW_MS,
+        )
+        .expect_err("expires_at_ms == now must be rejected");
+        assert!(err.to_string().contains("expires_at_ms"));
+    }
+}

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2339,6 +2339,13 @@ impl Validate for IssueOwnershipProofApiRequest {
                 field: "nonce",
                 reason: "nonce must be valid hex".into(),
             });
+        } else if n % 2 != 0 {
+            // An odd-length hex string can't decode to whole bytes, which is
+            // inconsistent with the documented "16..=64 raw bytes" contract.
+            errors.push(ValidationError::InvalidFormat {
+                field: "nonce",
+                reason: "nonce hex string must have even length".into(),
+            });
         }
 
         // context_id and expires_at_ms are validated in the handler (the former
@@ -2614,6 +2621,40 @@ mod tests {
         let resp: CreateContextResponseData = serde_json::from_value(json).unwrap();
         assert!(resp.group_id.is_none());
         assert!(!resp.group_created);
+    }
+
+    fn ownership_req(nonce: &str) -> IssueOwnershipProofApiRequest {
+        IssueOwnershipProofApiRequest {
+            audience: "mdma.cloud".into(),
+            context_id: "11111111111111111111111111111111".into(),
+            subject: "subject-xyz".into(),
+            nonce: nonce.into(),
+            expires_at_ms: 1,
+        }
+    }
+
+    #[test]
+    fn ownership_proof_even_length_hex_nonce_passes() {
+        // 32 hex chars (16 bytes) — minimum valid, even length.
+        let errors = ownership_req("deadbeefcafebabe1122334455667788").validate();
+        assert!(
+            errors.is_empty(),
+            "even-length hex nonce must validate cleanly, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn ownership_proof_odd_length_hex_nonce_rejected() {
+        // 33 hex chars: in range, all hex digits, but odd length.
+        let errors = ownership_req("deadbeefcafebabe1122334455667788a").validate();
+        assert!(
+            errors.iter().any(|e| matches!(
+                e,
+                ValidationError::InvalidFormat { field: "nonce", reason }
+                    if reason == "nonce hex string must have even length"
+            )),
+            "odd-length hex nonce must be rejected, got {errors:?}"
+        );
     }
 }
 

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2267,6 +2267,88 @@ pub struct LeaveGroupApiResponseData {
     pub member_public_key: PublicKey,
 }
 
+// ---- Issue Ownership Proof ----
+//
+// Wire format is locked: see github.com/calimero-network/tauri-app#73.
+// mdma and tauri-app are implemented separately against this exact shape.
+//
+// Request: { audience, context_id, subject, nonce, expires_at_ms }
+// Response: { signer_public_key, signed_payload, signature }
+//
+// `signed_payload` is opaque base64-encoded UTF-8 JSON bytes — the verifier
+// re-parses them. The signature input is
+//   `OWNERSHIP_PROOF_DOMAIN || signed_payload_bytes`
+// where `OWNERSHIP_PROOF_DOMAIN` is the 28-byte literal
+// `b"calimero.ownership-claim.v1\x00"` (defined in calimero-context).
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueOwnershipProofApiRequest {
+    pub audience: String,
+    /// Base58 or hex-encoded 32-byte context id. Parsed server-side via
+    /// `parse_context_id`.
+    pub context_id: String,
+    pub subject: String,
+    /// Hex string, 32–128 chars inclusive (16–64 raw bytes).
+    pub nonce: String,
+    /// Caller-requested expiry in unix milliseconds. Server clamps to
+    /// `min(expires_at_ms, issued_at_ms + 5*60*1000)`.
+    pub expires_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueOwnershipProofApiResponse {
+    /// Base58-encoded 32-byte ed25519 public key of the signer.
+    pub signer_public_key: String,
+    /// Base64-encoded opaque UTF-8 JSON bytes of the canonical claim payload.
+    /// Verifiers MUST re-parse this exact byte slice and re-derive the
+    /// signature input as `OWNERSHIP_PROOF_DOMAIN || signed_payload_bytes`.
+    pub signed_payload: String,
+    /// Base64-encoded 64-byte ed25519 signature over the signature input.
+    pub signature: String,
+}
+
+impl Validate for IssueOwnershipProofApiRequest {
+    fn validate(&self) -> Vec<ValidationError> {
+        let mut errors = Vec::new();
+
+        // audience: non-empty, <= 256 chars.
+        if self.audience.is_empty() {
+            errors.push(ValidationError::EmptyField { field: "audience" });
+        } else if let Some(e) = validate_string_length(&self.audience, "audience", 256) {
+            errors.push(e);
+        }
+
+        // subject: non-empty, <= 512 chars.
+        if self.subject.is_empty() {
+            errors.push(ValidationError::EmptyField { field: "subject" });
+        } else if let Some(e) = validate_string_length(&self.subject, "subject", 512) {
+            errors.push(e);
+        }
+
+        // nonce: hex string, 32..=128 chars inclusive (16..=64 raw bytes).
+        let n = self.nonce.len();
+        if !(32..=128).contains(&n) {
+            errors.push(ValidationError::InvalidFormat {
+                field: "nonce",
+                reason: "nonce must be hex-encoded, 32..=128 characters".into(),
+            });
+        } else if !self.nonce.chars().all(|c| c.is_ascii_hexdigit()) {
+            errors.push(ValidationError::InvalidHexEncoding {
+                field: "nonce",
+                reason: "nonce must be valid hex".into(),
+            });
+        }
+
+        // context_id and expires_at_ms are validated in the handler (the former
+        // because parsing is shared with `parse_context_id`, the latter because
+        // it requires comparing against the current wall-clock).
+
+        errors
+    }
+}
+
 // ---- Leave Namespace (cascading self-leave) ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -7,6 +7,7 @@ pub mod get_group_info;
 pub mod get_group_upgrade_status;
 pub mod get_member_capabilities;
 pub mod get_tee_admission_policy;
+pub mod issue_ownership_proof;
 pub mod join_group;
 pub mod leave_group;
 pub mod list_all_groups;

--- a/crates/server/src/admin/handlers/groups/issue_ownership_proof.rs
+++ b/crates/server/src/admin/handlers/groups/issue_ownership_proof.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
+use calimero_context_client::group::IssueOwnershipProofRequest;
+use calimero_server_primitives::admin::{
+    IssueOwnershipProofApiRequest, IssueOwnershipProofApiResponse,
+};
+use tracing::{error, info};
+
+use super::{parse_context_id, parse_group_id};
+use crate::admin::handlers::validation::ValidatedJson;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(group_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+    ValidatedJson(req): ValidatedJson<IssueOwnershipProofApiRequest>,
+) -> impl IntoResponse {
+    let group_id = match parse_group_id(&group_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    let context_id = match parse_context_id(&req.context_id) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(
+        group_id=%group_id_str,
+        context_id=%req.context_id,
+        audience=%req.audience,
+        "Issuing ownership proof"
+    );
+
+    let result = state
+        .ctx_client
+        .issue_ownership_proof(IssueOwnershipProofRequest {
+            group_id,
+            context_id,
+            audience: req.audience,
+            subject: req.subject,
+            nonce: req.nonce,
+            expires_at_ms: req.expires_at_ms,
+        })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(resp) => {
+            info!(
+                group_id=%group_id_str,
+                signer=%resp.signer_public_key,
+                "Ownership proof issued"
+            );
+            ApiResponse {
+                payload: IssueOwnershipProofApiResponse {
+                    // `PublicKey: Display` produces base58 (see calimero-primitives::identity).
+                    signer_public_key: resp.signer_public_key.to_string(),
+                    signed_payload: base64_engine.encode(&resp.signed_payload),
+                    signature: base64_engine.encode(resp.signature),
+                },
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(group_id=%group_id_str, error=?err, "Failed to issue ownership proof");
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -233,6 +233,10 @@ pub(crate) fn setup(
             post(groups::register_signing_key::handler),
         )
         .route(
+            "/groups/:group_id/issue-ownership-proof",
+            post(groups::issue_ownership_proof::handler),
+        )
+        .route(
             "/groups/:group_id/sync",
             post(groups::sync_group::handler),
         )


### PR DESCRIPTION
## Summary

Adds `POST /admin-api/groups/:group_id/issue-ownership-proof` to the merod admin API. The endpoint signs a canonical claim payload with the group's signing key so a remote verifier (mdma cloud) can confirm the caller is the direct admin of a calimero group without itself being a member.

This is the **first of three coordinated PRs** that close the gap described in [calimero-network/tauri-app#73](https://github.com/calimero-network/tauri-app/issues/73): self-hosted desktop users cannot enable HA on a namespace because mdma's `UserContext` table has no row for locally-created contexts. The cross-repo plan:

1. **(this PR)** core — issue the proof.
2. mdma — verify the proof, insert `UserContext` rows under a new `POST /api/cloud/me/contexts/claim`.
3. tauri-app — call (1) per context, batch-submit to (2) inside `enableHaForNamespace`.

## Wire format (locked across the three PRs)

- Request: `{ audience, context_id, subject, nonce, expires_at_ms }`
- Response: `{ signer_public_key (base58), signed_payload (base64 opaque UTF-8 JSON), signature (base64 ed25519) }`
- Signed bytes: `OWNERSHIP_PROOF_DOMAIN || signed_payload`, where `OWNERSHIP_PROOF_DOMAIN = b"calimero.ownership-claim.v1\x00"` (literal 28 bytes).
- `expires_at_ms` clamped to `issued_at_ms + 5min` server-side.

Handler is gated on `is_direct_group_admin == true` for the node's self-identity in the group, and resolves the signing key via `resolve_group_signing_key`. The signed payload bytes are passed opaquely (verifier re-parses them) to avoid canonical-JSON headaches between Rust and Python.

## What's intentionally not included

`TODO(#73)` left at `crates/context/src/handlers/issue_ownership_proof.rs:73` — the handler does not yet verify `context_id` actually belongs to `group_id`. mdma's verifier re-checks the envelope ↔ payload `context_id` match, but the protocol-level "is this context attached to this group" check should land as a follow-up.

## Test plan

- [x] `cargo test -p calimero-context` — 248 passing including 5 new
  - happy path: signature verifies, expires_at_ms clamped to 5min
  - error: node is not direct admin
  - error: no signing key registered
  - error: expires_at_ms in the past
  - error: expires_at_ms == now
- [x] `cargo check` on `calimero-context`, `calimero-server`, `calimero-context-primitives`, `calimero-server-primitives`
- [x] `cargo clippy --all-targets -- -D warnings` clean on changed files
- [x] `cargo fmt --check` clean
- [ ] End-to-end smoke (manual repro from #73) — runs once mdma + tauri-app PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new admin API that issues signed ed25519 ownership proofs based on group membership/signing keys; mistakes could enable unauthorized claims or break a locked cross-repo verification contract.
> 
> **Overview**
> Adds a new `POST /admin-api/groups/:group_id/issue-ownership-proof` endpoint that returns a **locked-format** ownership-claim payload and ed25519 signature for cross-service verification.
> 
> Plumbs a new `IssueOwnershipProof` request/response through `calimero-context` primitives, the `ContextManager` message router, and the `ContextClient` forwarder, then implements the core handler to gate on *direct admin* status, ensure the `context_id` is within the namespace subtree, clamp proof expiry to 5 minutes, and sign `OWNERSHIP_PROOF_DOMAIN || payload_bytes`.
> 
> Adds server-side request/response types with input validation (notably strict hex `nonce` rules) and encodes the response as base58/base64 for the admin API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682997c04a98334f45390640ef4e6c5e123822c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->