### PR TITLE
fix(context): restore ContextIdentity on member rejoin + e2e coverage

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -173,6 +173,21 @@ jobs:
           - workflow: group-leave-namespace
             file: workflows/group-leave-namespace.yml
             app: scaffolding-e2e
+          - workflow: group-kick-and-rejoin-keyshare
+            file: workflows/group-kick-and-rejoin-keyshare.yml
+            app: scaffolding-e2e
+          - workflow: group-kick-and-readd-deny-list
+            file: workflows/group-kick-and-readd-deny-list.yml
+            app: scaffolding-e2e
+          - workflow: group-leave-then-rejoin-via-inheritance
+            file: workflows/group-leave-then-rejoin-via-inheritance.yml
+            app: scaffolding-e2e
+          - workflow: group-private-add-then-write
+            file: workflows/group-private-add-then-write.yml
+            app: scaffolding-e2e
+          - workflow: group-remove-from-root-revokes-inherited
+            file: workflows/group-remove-from-root-revokes-inherited.yml
+            app: scaffolding-e2e
           - workflow: group-capabilities
             file: workflows/group-capabilities.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -1,0 +1,347 @@
+name: E2E KV Store - Kick And Re-Add Deny-List Cycle (Restricted Subgroup)
+description: >
+  Wire-level coverage for the deny-list add → remove → re-add cycle
+  whose store-level invariants are pinned by the unit tests
+  `deny_list_add_remove_add_cycle_ends_cleared` (group_store/tests.rs:5887)
+  and `deny_list_remove_then_readd_clears_entry_via_apply_path` (5988).
+  No existing E2E exercises this on a real cluster — `group-membership.yml`
+  adds → removes → asserts revoked, then stops.
+
+  Scenario (3 nodes, single Restricted subgroup):
+
+    1. Admin (node-1) adds node-2 to a Restricted subgroup via
+       `add_group_members`. node-3 is also added so it can act as
+       the cross-peer reader and prove convergence.
+    2. node-2 writes; node-3 reads — establishes the post-add path.
+    3. Admin removes node-2 via `remove_group_members`. The signed
+       `MemberRemoved` op stamps the deny-list at every peer
+       (`group_store/mod.rs:1248` — `mark_denied`).
+    4. node-2's next write must NOT reach node-3 (deny-list filter).
+    5. Admin re-adds node-2 via `add_group_members`. The
+       `MemberAdded` apply arm clears node-2's deny-list entry on
+       every peer (the only end-to-end path that exercises the
+       `clear_denied` call inside the apply pipeline).
+    6. node-2 writes again; node-3 reads. Convergence proves the
+       deny-list was actually cleared on node-3 — without that, the
+       new write would still be dropped at node-3's filter.
+
+  Why Restricted (not Open): the inheritance path doesn't apply for
+  Restricted subgroups, so the only way back in is admin-initiated
+  `add_group_members`. The Open / inheritance path is covered by
+  `group-kick-and-rejoin-keyshare.yml`.
+
+  Mero-chat user-visible failure mode this guards against: "I was
+  removed from a private channel, the admin added me back, but my
+  messages still don't show up for the other members" — the
+  symptom of a stale deny-list entry on the receiver side.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: kick-readd-node
+
+steps:
+  # ── Phase 1: Bootstrap namespace + Restricted subgroup + context ──
+
+  - name: Install application on node-1
+    type: install_application
+    node: kick-readd-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: kick-readd-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Install application on node-3
+    type: install_application
+    node: kick-readd-node-3
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: kick-readd-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: kick-readd-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: kick-readd-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Wait for namespace governance to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: kick-readd-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: kick-readd-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  # Default subgroup visibility is Restricted; no `set_subgroup_visibility`
+  # call is needed. Inheritance via CAN_JOIN_OPEN_SUBGROUPS does not apply.
+  - name: Node-1 creates Restricted subgroup
+    type: create_group_in_namespace
+    node: kick-readd-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: private-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Admin adds node-2 and node-3 to subgroup
+    type: add_group_members
+    node: kick-readd-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{identity_node2}}'
+        role: Member
+      - identity: '{{identity_node3}}'
+        role: Member
+
+  - name: Node-1 creates context inside Restricted subgroup
+    type: create_context
+    node: kick-readd-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for MemberAdded + ContextRegistered to propagate
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins context
+    type: join_context
+    node: kick-readd-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Node-3 joins context
+    type: join_context
+    node: kick-readd-node-3
+    context_id: '{{ctx_id}}'
+    outputs:
+      node3_key: memberPublicKey
+
+  - name: Initial sync to settle Root state
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - kick-readd-node-1
+      - kick-readd-node-2
+      - kick-readd-node-3
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 2: Pre-kick — node-2 writes, node-3 reads ───────────────
+
+  - name: Pre-kick — node-2 writes
+    type: call
+    node: kick-readd-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_kick"
+      value: "node2_first_msg"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Pre-kick sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - kick-readd-node-1
+      - kick-readd-node-2
+      - kick-readd-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Pre-kick — node-3 reads node-2's write
+    type: call
+    node: kick-readd-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_kick"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      pre_kick_read: result
+
+  - name: Assert pre-kick converged
+    type: json_assert
+    statements:
+      - 'json_equal({{pre_kick_read}}, {"output": "node2_first_msg"})'
+
+  # ── Phase 3: Admin kicks node-2 ───────────────────────────────────
+
+  - name: Admin removes node-2 from subgroup
+    type: remove_group_members
+    node: kick-readd-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - '{{identity_node2}}'
+
+  - name: Wait for MemberRemoved + deny-list to propagate
+    type: wait_for_sync
+    group_id: '{{subgroup_id}}'
+    nodes:
+      - kick-readd-node-1
+      - kick-readd-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Confirm node-2 absent from subgroup membership
+    type: list_group_members
+    node: kick-readd-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_kick: members
+
+  - name: Assert node-2 absent after kick
+    type: assert
+    statements:
+      - "not_contains({{members_after_kick}}, {{identity_node2}})"
+      - "contains({{members_after_kick}}, {{identity_node3}})"
+
+  # ── Phase 4: Kicked node's write must not reach node-3 ────────────
+
+  - name: Post-kick — node-2 attempts write (must fail or be dropped)
+    type: call
+    node: kick-readd-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "while_kicked"
+      value: "this_must_not_appear"
+    executor_public_key: '{{node2_key}}'
+    expected_failure: true
+
+  # ── Phase 5: Admin re-adds node-2 ─────────────────────────────────
+  # The MemberAdded apply arm clears node-2's deny-list entry on
+  # every peer. Without this, Phase 6 would silently fail because
+  # node-3 would drop the new write at the receive filter.
+
+  - name: Admin re-adds node-2 to subgroup
+    type: add_group_members
+    node: kick-readd-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{identity_node2}}'
+        role: Member
+
+  - name: Wait for MemberAdded + KeyDelivery to propagate
+    type: wait_for_sync
+    group_id: '{{subgroup_id}}'
+    nodes:
+      - kick-readd-node-1
+      - kick-readd-node-2
+      - kick-readd-node-3
+    timeout: 60
+    check_interval: 2
+
+  - name: Confirm node-2 is back in subgroup membership
+    type: list_group_members
+    node: kick-readd-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_readd: members
+
+  - name: Assert node-2 present after re-add
+    type: assert
+    statements:
+      - "contains({{members_after_readd}}, {{identity_node2}})"
+      - "contains({{members_after_readd}}, {{identity_node3}})"
+
+  # ── Phase 6: Post-readd write must reach node-3 ───────────────────
+  # The end-to-end signal that node-3's deny-list entry for node-2
+  # was actually cleared by the MemberAdded apply arm on node-3.
+
+  - name: Post-readd — node-2 writes
+    type: call
+    node: kick-readd-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_readd"
+      value: "node2_back_msg"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Post-readd sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - kick-readd-node-1
+      - kick-readd-node-2
+      - kick-readd-node-3
+    timeout: 60
+    check_interval: 2
+
+  - name: Post-readd — node-3 reads node-2's write
+    type: call
+    node: kick-readd-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_readd"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      post_readd_read: result
+
+  - name: Assert post-readd write reached node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{post_readd_read}}, {"output": "node2_back_msg"})'
+
+  # The dropped-during-kick value must NOT be visible post-readd:
+  # `MemberAdded` clears the deny-list going forward but does not
+  # retroactively deliver state-deltas that were dropped during the
+  # banned window.
+  - name: Confirm dropped-during-kick write was NOT delivered post-readd
+    type: call
+    node: kick-readd-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "while_kicked"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      dropped_lookup: result
+
+  - name: Assert dropped value was indeed dropped
+    type: json_assert
+    statements:
+      - 'json_equal({{dropped_lookup}}, {"output": null})'
+
+stop_all_nodes: false
+restart: false
+wait_timeout: 120

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -73,12 +73,10 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture node-1 namespace identity
-    type: get_namespace_identity
-    node: kick-readd-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      node1_key: publicKey
+  # node-1's namespace identity not captured here — admin doesn't
+  # write to the context in this workflow (only members write +
+  # cross-peer reads), so the executor_public_key for admin would be
+  # unused. Removed to avoid dead output noise flagged in code review.
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -72,7 +72,13 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
+
+  - name: Capture node-1 namespace identity
+    type: get_namespace_identity
+    node: kick-readd-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      node1_key: publicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -234,6 +240,12 @@ steps:
       - "contains({{members_after_kick}}, {{identity_node3}})"
 
   # ── Phase 4: Kicked node's write must not reach node-3 ────────────
+  # The follow-on cross-peer read on node-3 is the strict negative
+  # control: a silent local-success-then-gossip-drop must be caught
+  # HERE, not deferred to the end-of-workflow assertion. If we only
+  # checked at the end, a regression that lifted the deny-list AND
+  # retroactively delivered the buffered write during the re-add
+  # could pass for the wrong reason.
 
   - name: Post-kick — node-2 attempts write (must fail or be dropped)
     type: call
@@ -245,6 +257,29 @@ steps:
       value: "this_must_not_appear"
     executor_public_key: '{{node2_key}}'
     expected_failure: true
+
+  # Drain in-flight gossip from a possible local-success before the
+  # negative-control read. A purely-local rejection produces no traffic
+  # to wait on, but a silent gossip race needs propagation time.
+  - name: Drain in-flight gossip before negative-control read
+    type: wait
+    seconds: 5
+
+  - name: Negative control — node-3 must NOT see the dropped write
+    type: call
+    node: kick-readd-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "while_kicked"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      while_kicked_pre_readd: result
+
+  - name: Assert dropped value is genuinely absent on node-3 BEFORE re-add
+    type: json_assert
+    statements:
+      - 'json_equal({{while_kicked_pre_readd}}, {"output": null})'
 
   # ── Phase 5: Admin re-adds node-2 ─────────────────────────────────
   # The MemberAdded apply arm clears node-2's deny-list entry on

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -78,7 +78,18 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
+
+  - name: Capture node-1 namespace identity
+    # `create_namespace` only exports `namespaceId`; the namespace
+    # identity public key (which subsequent admin `executor_public_key`
+    # bindings need) is materialized lazily and surfaced via
+    # `get_namespace_identity`. Mirrors the pattern in
+    # `group-leave-member.yml:61-66`.
+    type: get_namespace_identity
+    node: kick-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      node1_key: publicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -262,6 +273,22 @@ steps:
     statements:
       - "not_contains({{members_after_kick}}, {{identity_node2}})"
 
+  # Cross-peer check: node-3 must also see node-2 gone after the kick.
+  # Catches a fan-out bug where MemberRemoved applied locally on the
+  # admin but didn't propagate to the rest of the cluster (mirrors the
+  # pattern in `group-leave-member.yml:122-133`).
+  - name: Cross-peer confirm node-3 also sees node-2 gone
+    type: list_group_members
+    node: kick-rejoin-node-3
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_kick_node3: members
+
+  - name: Assert cross-peer view agrees on the kick
+    type: assert
+    statements:
+      - "not_contains({{members_after_kick_node3}}, {{identity_node2}})"
+
   # ── Phase 5: Kicked node's write must NOT reach the cluster ───────
   # Two failure modes are acceptable signals here, both surface as
   # `expected_failure: true`:
@@ -269,8 +296,12 @@ steps:
   #       row was deleted (cascade ran on the local peer too), or
   #   (b) the write reaches peers but is silently dropped at the
   #       deny-list filter.
-  # If neither fires, node-3 would later read the value and the
-  # post-kick assert would fail — that's the regression signal.
+  # The follow-on cross-peer read on node-3 below is the strict
+  # negative-control: a silent local-success-then-gossip-drop must be
+  # caught HERE, not deferred to the end-of-workflow assertion. If we
+  # only checked at the end, a regression that lifted the deny-list
+  # AND retroactively delivered the buffered write during the rejoin
+  # could pass for the wrong reason.
 
   - name: Post-kick — node-2 attempts to write (must fail or be dropped)
     type: call
@@ -282,6 +313,32 @@ steps:
       value: "this_must_not_appear"
     executor_public_key: '{{node2_key}}'
     expected_failure: true
+
+  # Drain any in-flight gossip from a possible local-success before
+  # the negative-control read. Without this, a write that was rejected
+  # locally produces no traffic to wait on, but a write that succeeded
+  # locally and is racing the deny-list filter at peers would not have
+  # propagated yet — biasing the negative-control toward false-pass.
+  - name: Drain in-flight gossip before negative-control read
+    type: wait
+    seconds: 5
+
+  - name: Negative control — node-3 must NOT see the dropped write
+    type: call
+    node: kick-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_kick_should_drop"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      post_kick_drop_check: result
+
+  - name: Assert dropped value is genuinely absent on node-3 BEFORE rejoin
+    # The KV app returns `{"output": null}` for missing keys.
+    type: json_assert
+    statements:
+      - 'json_equal({{post_kick_drop_check}}, {"output": null})'
 
   # ── Phase 6: node-2 self-rejoins via inheritance + verifies key ───
   # The path under test. node-2's CAN_JOIN_OPEN_SUBGROUPS cap at the
@@ -308,17 +365,26 @@ steps:
     timeout: 60
     check_interval: 2
 
-  - name: Confirm node-2 is back in subgroup membership
+  - name: Confirm subgroup direct-membership shape post-rejoin
     type: list_group_members
     node: kick-rejoin-node-1
     group_id: '{{subgroup_id}}'
     outputs:
       members_after_rejoin: members
 
-  - name: Assert node-2 present in subgroup after rejoin
+  # IMPORTANT: `MemberJoinedOpen` apply at
+  # `crates/context/src/group_store/namespace_governance.rs:1226-1245`
+  # accepts ONLY `MembershipPath::Inherited` and rejects `Direct`. So
+  # the inheritance rejoin does NOT create a direct membership row —
+  # node-2's authority comes from their inherited path
+  # (CAN_JOIN_OPEN_SUBGROUPS at the namespace + Open subgroup
+  # visibility), not a row in `list_group_members`. The original
+  # version of this workflow asserted `contains` here; that was wrong
+  # and matches the false-positive expectation `cursor[bot]` flagged.
+  - name: Assert direct-row list still excludes inherited rejoiner
     type: assert
     statements:
-      - "contains({{members_after_rejoin}}, {{identity_node2}})"
+      - "not_contains({{members_after_rejoin}}, {{identity_node2}})"
 
   # ── Phase 7: Post-rejoin write must reach node-3 ──────────────────
   # The end-to-end signal that:

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -358,26 +358,28 @@ steps:
     timeout: 60
     check_interval: 2
 
-  - name: Confirm subgroup direct-membership shape post-rejoin
+  - name: Confirm subgroup membership shape post-rejoin
     type: list_group_members
     node: kick-rejoin-node-1
     group_id: '{{subgroup_id}}'
     outputs:
       members_after_rejoin: members
 
-  # IMPORTANT: `MemberJoinedOpen` apply at
-  # `crates/context/src/group_store/namespace_governance.rs:1226-1245`
-  # accepts ONLY `MembershipPath::Inherited` and rejects `Direct`. So
-  # the inheritance rejoin does NOT create a direct membership row —
-  # node-2's authority comes from their inherited path
+  # `MemberJoinedOpen` apply does NOT create a direct membership row —
+  # node-2's authority comes from the inherited path
   # (CAN_JOIN_OPEN_SUBGROUPS at the namespace + Open subgroup
-  # visibility), not a row in `list_group_members`. The original
-  # version of this workflow asserted `contains` here; that was wrong
-  # and matches the false-positive expectation `cursor[bot]` flagged.
-  - name: Assert direct-row list still excludes inherited rejoiner
+  # visibility). But `list_group_members` since #2371/#2372 unions the
+  # stored direct rows with `enumerate_inherited_members`, so an
+  # inherited member DOES appear in the list. While node-2 was
+  # kicked it was deny-listed and the enumeration filter excluded it
+  # (asserted above); the rejoin's `MemberJoinedOpen` apply clears the
+  # deny-list, so node-2 reappears here as an inherited member. node-3
+  # — never kicked — stays listed throughout.
+  - name: Assert rejoiner is back in the (inherited) member list
     type: assert
     statements:
-      - "not_contains({{members_after_rejoin}}, {{identity_node2}})"
+      - "contains({{members_after_rejoin}}, {{identity_node2}})"
+      - "contains({{members_after_rejoin}}, {{identity_node3}})"
 
   # ── Phase 7: Post-rejoin write must reach node-3 ──────────────────
   # The end-to-end signal that:

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -79,17 +79,10 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture node-1 namespace identity
-    # `create_namespace` only exports `namespaceId`; the namespace
-    # identity public key (which subsequent admin `executor_public_key`
-    # bindings need) is materialized lazily and surfaced via
-    # `get_namespace_identity`. Mirrors the pattern in
-    # `group-leave-member.yml:61-66`.
-    type: get_namespace_identity
-    node: kick-rejoin-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      node1_key: publicKey
+  # node-1's namespace identity not captured here — admin doesn't
+  # write to the context in this workflow (only members write +
+  # cross-peer reads), so the executor_public_key for admin would be
+  # unused. Removed to avoid dead output noise flagged in code review.
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -160,11 +153,12 @@ steps:
   # ── Phase 2: node-2 inherits + self-joins, node-3 also joins ──────
 
   - name: Node-2 self-joins Open subgroup via inheritance endpoint (#2360)
+    # No `outputs` capture — `memberPublicKey` from this step is the
+    # same as the one captured by the subsequent `join_context` into
+    # `node2_key`. Holding only one binding avoids dead-output noise.
     type: join_subgroup_inheritance
     node: kick-rejoin-node-2
     group_id: '{{subgroup_id}}'
-    outputs:
-      node2_inherit_pk: memberPublicKey
 
   - name: Node-2 joins context (key already local from inheritance)
     type: join_context
@@ -174,11 +168,10 @@ steps:
       node2_key: memberPublicKey
 
   - name: Node-3 self-joins Open subgroup via inheritance endpoint (#2360)
+    # Same dead-output rationale as node-2's inheritance step above.
     type: join_subgroup_inheritance
     node: kick-rejoin-node-3
     group_id: '{{subgroup_id}}'
-    outputs:
-      node3_inherit_pk: memberPublicKey
 
   - name: Node-3 joins context (key already local from inheritance)
     type: join_context

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -1,0 +1,389 @@
+name: E2E KV Store - Kick And Rejoin Keyshare (Open Subgroup)
+description: >
+  Coverage gap unlocked by PR #2360 (`feat(context, server): add
+  join-via-inheritance admin endpoint`). Pre-#2360 there was no
+  deterministic wire-level path for a kicked member to re-acquire
+  the subgroup key without an admin re-issuing
+  `add_group_members`; with the new endpoint the full
+  kick → write-rejected → self-rejoin → fresh `KeyDelivery` cycle is
+  finally testable end-to-end.
+
+  Scenario (3 nodes, single Open subgroup):
+
+    1. node-2 inherits Open-subgroup membership and self-joins via
+       `join_subgroup_inheritance` so the subgroup key lands locally.
+    2. node-2 writes; node-3 reads — proves the joiner-as-author
+       direction works pre-kick.
+    3. Admin (node-1) removes node-2 from the subgroup. The signed
+       `MemberRemoved` op stamps node-2 on the subgroup deny-list at
+       every peer; subsequent state-delta traffic from node-2 is
+       dropped at the receive entry point.
+    4. node-2's next write is rejected by the local apply path or the
+       peers' deny-list filter. `expected_failure: true` asserts the
+       write does not reach node-3.
+    5. node-2 calls `join_subgroup_inheritance` again. The handler at
+       `crates/context/src/handlers/join_subgroup_inheritance.rs:94`
+       has a `key_already_local` short-circuit; this test exercises
+       the path where the local key may be stale from the pre-kick
+       window. The fresh `MemberJoinedOpen` op clears the deny-list
+       on every peer and triggers a new `KeyDelivery`.
+    6. node-2 writes again; node-3 reads. Bidirectional convergence
+       is the post-rejoin success signal.
+
+  What this test does NOT cover (intentionally — different test):
+    * Admin-issued `add_group_members` after a removal (the
+      Restricted-subgroup deny-list-cycle path) is covered by
+      `group-kick-and-readd-deny-list.yml`.
+    * Voluntary `leave_group` followed by inheritance rejoin is
+      covered by `group-leave-then-rejoin-via-inheritance.yml`.
+
+  Mero-chat user-visible failure mode this guards against: "got
+  kicked from a public channel, can't rejoin — messages I send
+  after rejoin don't appear for anyone, or I can't decrypt new ones."
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: kick-rejoin-node
+
+steps:
+  # ── Phase 1: Bootstrap namespace + Open subgroup + context ────────
+
+  - name: Install application on node-1
+    type: install_application
+    node: kick-rejoin-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: kick-rejoin-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Install application on node-3
+    type: install_application
+    node: kick-rejoin-node-3
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: kick-rejoin-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: kick-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: kick-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Wait for namespace governance to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    # Default member capabilities include CAN_JOIN_OPEN_SUBGROUPS, so
+    # node-2 inherits eligibility for any Open subgroup beneath this
+    # namespace without an explicit add_group_members at the subgroup.
+    type: join_namespace
+    node: kick-rejoin-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: kick-rejoin-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  - name: Node-1 creates Open subgroup inside namespace
+    type: create_group_in_namespace
+    node: kick-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: kick-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    visibility: open
+
+  - name: Node-1 creates context inside Open subgroup
+    type: create_context
+    node: kick-rejoin-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for subgroup visibility + context-registered ops to propagate
+    # node-2 and node-3 need the Open-visibility row + the context
+    # registration before their inheritance check / join_context can
+    # see the Open subgroup as joinable.
+    type: wait
+    seconds: 10
+
+  # ── Phase 2: node-2 inherits + self-joins, node-3 also joins ──────
+
+  - name: Node-2 self-joins Open subgroup via inheritance endpoint (#2360)
+    type: join_subgroup_inheritance
+    node: kick-rejoin-node-2
+    group_id: '{{subgroup_id}}'
+    outputs:
+      node2_inherit_pk: memberPublicKey
+
+  - name: Node-2 joins context (key already local from inheritance)
+    type: join_context
+    node: kick-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Node-3 self-joins Open subgroup via inheritance endpoint (#2360)
+    type: join_subgroup_inheritance
+    node: kick-rejoin-node-3
+    group_id: '{{subgroup_id}}'
+    outputs:
+      node3_inherit_pk: memberPublicKey
+
+  - name: Node-3 joins context (key already local from inheritance)
+    type: join_context
+    node: kick-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    outputs:
+      node3_key: memberPublicKey
+
+  - name: Initial sync to settle Root state
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - kick-rejoin-node-1
+      - kick-rejoin-node-2
+      - kick-rejoin-node-3
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 3: Pre-kick — node-2 writes, node-3 reads ───────────────
+  # Establishes the joiner-as-author direction works before the kick,
+  # so a Phase 6 failure is unambiguously caused by the rejoin path
+  # rather than a stale bug from #2351 / #2360.
+
+  - name: Pre-kick — node-2 writes
+    type: call
+    node: kick-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_kick"
+      value: "node2_msg_before_kick"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Pre-kick sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - kick-rejoin-node-1
+      - kick-rejoin-node-2
+      - kick-rejoin-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Pre-kick — node-3 reads node-2's write
+    type: call
+    node: kick-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_kick"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      pre_kick_read: result
+
+  - name: Assert pre-kick converged
+    type: json_assert
+    statements:
+      - 'json_equal({{pre_kick_read}}, {"output": "node2_msg_before_kick"})'
+
+  # ── Phase 4: Admin kicks node-2 from the subgroup ─────────────────
+  # Signed `MemberRemoved` op against the subgroup id. On every peer
+  # the apply arm at `crates/context/src/group_store/mod.rs:1222`
+  # deletes node-2's direct row and stamps them on the per-subgroup
+  # deny-list (`mark_denied`). State-delta traffic from node-2 on this
+  # subgroup is dropped at the receive entry point until cleared.
+
+  - name: Admin (node-1) removes node-2 from Open subgroup
+    type: remove_group_members
+    node: kick-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - '{{identity_node2}}'
+
+  - name: Wait for MemberRemoved + deny-list to propagate
+    type: wait_for_sync
+    group_id: '{{subgroup_id}}'
+    nodes:
+      - kick-rejoin-node-1
+      - kick-rejoin-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Confirm node-2 is gone from subgroup membership on admin
+    type: list_group_members
+    node: kick-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_kick: members
+
+  - name: Assert node-2 absent from subgroup after kick
+    type: assert
+    statements:
+      - "not_contains({{members_after_kick}}, {{identity_node2}})"
+
+  # ── Phase 5: Kicked node's write must NOT reach the cluster ───────
+  # Two failure modes are acceptable signals here, both surface as
+  # `expected_failure: true`:
+  #   (a) node-2's local apply rejects the write because its direct
+  #       row was deleted (cascade ran on the local peer too), or
+  #   (b) the write reaches peers but is silently dropped at the
+  #       deny-list filter.
+  # If neither fires, node-3 would later read the value and the
+  # post-kick assert would fail — that's the regression signal.
+
+  - name: Post-kick — node-2 attempts to write (must fail or be dropped)
+    type: call
+    node: kick-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_kick_should_drop"
+      value: "this_must_not_appear"
+    executor_public_key: '{{node2_key}}'
+    expected_failure: true
+
+  # ── Phase 6: node-2 self-rejoins via inheritance + verifies key ───
+  # The path under test. node-2's CAN_JOIN_OPEN_SUBGROUPS cap at the
+  # namespace is intact, so the inheritance check still resolves to
+  # `MembershipPath::Inherited`. The handler must (a) clear the
+  # deny-list via the `MemberJoinedOpen` apply arm on every peer,
+  # (b) deliver a fresh subgroup key, and (c) populate node-2's
+  # `sender_key` so subsequent ops sign with the current key.
+
+  - name: Node-2 self-rejoins Open subgroup via inheritance endpoint
+    type: join_subgroup_inheritance
+    node: kick-rejoin-node-2
+    group_id: '{{subgroup_id}}'
+    outputs:
+      node2_rejoin_pk: memberPublicKey
+
+  - name: Wait for MemberJoinedOpen + KeyDelivery to propagate
+    type: wait_for_sync
+    group_id: '{{subgroup_id}}'
+    nodes:
+      - kick-rejoin-node-1
+      - kick-rejoin-node-2
+      - kick-rejoin-node-3
+    timeout: 60
+    check_interval: 2
+
+  - name: Confirm node-2 is back in subgroup membership
+    type: list_group_members
+    node: kick-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_rejoin: members
+
+  - name: Assert node-2 present in subgroup after rejoin
+    type: assert
+    statements:
+      - "contains({{members_after_rejoin}}, {{identity_node2}})"
+
+  # ── Phase 7: Post-rejoin write must reach node-3 ──────────────────
+  # The end-to-end signal that:
+  #   * deny-list was cleared on node-3 (otherwise drop at filter),
+  #   * fresh KeyDelivery landed on node-2 (otherwise can't sign),
+  #   * node-2's local stale-key short-circuit didn't latch the
+  #     pre-kick key (otherwise node-3 can't decrypt).
+
+  - name: Post-rejoin — node-2 writes
+    type: call
+    node: kick-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_rejoin"
+      value: "node2_msg_after_rejoin"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Post-rejoin sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - kick-rejoin-node-1
+      - kick-rejoin-node-2
+      - kick-rejoin-node-3
+    timeout: 60
+    check_interval: 2
+
+  - name: Post-rejoin — node-3 reads node-2's write
+    type: call
+    node: kick-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_rejoin"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      post_rejoin_read: result
+
+  - name: Assert post-rejoin write reached node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{post_rejoin_read}}, {"output": "node2_msg_after_rejoin"})'
+
+  # The dropped-during-kick value must still NOT be visible on
+  # node-3, even after rejoin: the deny-list was active at the time
+  # of the publish and dropped the delta; the rejoin doesn't
+  # retroactively replay it.
+  - name: Confirm dropped-during-kick write was NOT delivered post-rejoin
+    type: call
+    node: kick-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_kick_should_drop"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      dropped_lookup: result
+
+  - name: Assert dropped value was indeed dropped
+    # The KV app returns `{"output": null}` for missing keys.
+    type: json_assert
+    statements:
+      - 'json_equal({{dropped_lookup}}, {"output": null})'
+
+stop_all_nodes: false
+restart: false
+wait_timeout: 120

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -386,6 +386,14 @@ steps:
   #   * node-2's local stale-key short-circuit didn't latch the
   #     pre-kick key (otherwise node-3 can't decrypt).
 
+  # Use `node2_rejoin_pk` (captured from the `join_subgroup_inheritance`
+  # rejoin step) rather than the pre-kick `node2_key`. The two are in
+  # fact identical — a node's namespace-derived identity is stable
+  # across kick/rejoin, so `memberPublicKey` from `join_context` and
+  # from `join_subgroup_inheritance` resolve to the same key — but
+  # binding the post-rejoin write to the rejoin step's output makes
+  # the dataflow self-documenting and removes any doubt about a stale
+  # pre-kick key.
   - name: Post-rejoin — node-2 writes
     type: call
     node: kick-rejoin-node-2
@@ -394,7 +402,7 @@ steps:
     args:
       key: "post_rejoin"
       value: "node2_msg_after_rejoin"
-    executor_public_key: '{{node2_key}}'
+    executor_public_key: '{{node2_rejoin_pk}}'
 
   - name: Post-rejoin sync
     type: wait_for_sync

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -1,0 +1,358 @@
+name: E2E KV Store - Voluntary Leave Then Rejoin Via Inheritance
+description: >
+  Tests the cycle: voluntary `leave_group` (publishes `MemberLeft`,
+  stamps deny-list at every peer) → self-rejoin via the new
+  `join_subgroup_inheritance` endpoint (#2360, publishes
+  `MemberJoinedOpen` and triggers `KeyDelivery`) → bidirectional
+  read/write resumes.
+
+  Pre-#2360 there was no straight-line wire path for the rejoiner:
+  admin-issued `add_group_members` was the only way back, so
+  `MemberLeft` → admin-readd was the only deny-list-cleared cycle
+  exercised at the wire level. With #2360 the joiner can rejoin
+  themselves; this test pins that the deny-list set during
+  `MemberLeft` apply is properly cleared by the rejoin path.
+
+  Direct-row prerequisite: the `leave_group` handler at
+  `crates/context/src/handlers/leave_group.rs` requires the leaver
+  to be a *direct* member of the subgroup (an inherited-only member
+  has no row to remove and the handler bails with "leave the
+  parent group where the membership anchor lives instead"). So the
+  test admin first adds node-2 via `add_group_members` to give them
+  a direct row; the inherited path remains available afterwards
+  because node-2 still holds `CAN_JOIN_OPEN_SUBGROUPS` at the
+  namespace and the subgroup is `Open`.
+
+  Distinct from siblings:
+    * `group-leave-context.yml` covers `leave_context` (local opt-out,
+      no DAG op) → `join_context` rejoin. No `MemberLeft`, no
+      deny-list, no inheritance.
+    * `group-kick-and-rejoin-keyshare.yml` covers `MemberRemoved`
+      (admin kick) → inheritance rejoin. Deny-list set by an
+      admin-signed op.
+    * This workflow covers the `MemberLeft` (self-published) →
+      inheritance rejoin path — the third corner of the cycle.
+
+  Mero-chat user-visible failure mode this guards against: "I left
+  a public channel manually, tried to rejoin, my messages don't
+  show up to anyone afterwards" — symptom of the deny-list entry
+  that `MemberLeft` apply stamps not being cleared on rejoin.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: leave-rejoin-node
+
+steps:
+  # ── Phase 1: Bootstrap namespace + Open subgroup + context ────────
+
+  - name: Install application on node-1
+    type: install_application
+    node: leave-rejoin-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: leave-rejoin-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Install application on node-3
+    type: install_application
+    node: leave-rejoin-node-3
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: leave-rejoin-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: leave-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: leave-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Wait for namespace governance to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: leave-rejoin-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: leave-rejoin-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  - name: Node-1 creates Open subgroup
+    type: create_group_in_namespace
+    node: leave-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: leave-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    visibility: open
+
+  # Direct-row prerequisite: node-2 needs a direct membership row to
+  # call `leave_group`. node-3 is added direct as well so it can
+  # serve as the cross-peer reader and stays in the subgroup the
+  # whole time.
+  - name: Admin adds node-2 and node-3 to subgroup directly
+    type: add_group_members
+    node: leave-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{identity_node2}}'
+        role: Member
+      - identity: '{{identity_node3}}'
+        role: Member
+
+  - name: Node-1 creates context inside Open subgroup
+    type: create_context
+    node: leave-rejoin-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for MemberAdded + ContextRegistered to propagate
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins context
+    type: join_context
+    node: leave-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Node-3 joins context
+    type: join_context
+    node: leave-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    outputs:
+      node3_key: memberPublicKey
+
+  - name: Initial sync to settle Root state
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - leave-rejoin-node-1
+      - leave-rejoin-node-2
+      - leave-rejoin-node-3
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 2: Pre-leave — node-2 writes, node-3 reads ──────────────
+
+  - name: Pre-leave — node-2 writes
+    type: call
+    node: leave-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_leave"
+      value: "node2_msg_before_leave"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Pre-leave sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - leave-rejoin-node-1
+      - leave-rejoin-node-2
+      - leave-rejoin-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Pre-leave — node-3 reads node-2's write
+    type: call
+    node: leave-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_leave"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      pre_leave_read: result
+
+  - name: Assert pre-leave converged
+    type: json_assert
+    statements:
+      - 'json_equal({{pre_leave_read}}, {"output": "node2_msg_before_leave"})'
+
+  # ── Phase 3: node-2 voluntarily leaves the subgroup ───────────────
+  # Publishes `MemberLeft` against the subgroup. The apply arm at
+  # `group_store/mod.rs:1535` deletes node-2's direct row and stamps
+  # them on the per-subgroup deny-list (`mark_denied` at line 1627).
+
+  - name: Node-2 leaves subgroup voluntarily
+    type: leave_group
+    node: leave-rejoin-node-2
+    group_id: '{{subgroup_id}}'
+
+  - name: Wait for MemberLeft + deny-list to propagate
+    type: wait_for_sync
+    group_id: '{{subgroup_id}}'
+    nodes:
+      - leave-rejoin-node-1
+      - leave-rejoin-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Confirm node-2 absent from subgroup membership
+    type: list_group_members
+    node: leave-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_leave: members
+
+  - name: Assert node-2 absent after leave
+    type: assert
+    statements:
+      - "not_contains({{members_after_leave}}, {{identity_node2}})"
+      - "contains({{members_after_leave}}, {{identity_node3}})"
+
+  # ── Phase 4: Departed node's write must NOT reach node-3 ──────────
+
+  - name: Post-leave — node-2 attempts write (must fail or be dropped)
+    type: call
+    node: leave-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "while_left"
+      value: "this_must_not_appear"
+    executor_public_key: '{{node2_key}}'
+    expected_failure: true
+
+  # ── Phase 5: node-2 self-rejoins via inheritance endpoint ─────────
+  # Inheritance is intact: node-2 still holds CAN_JOIN_OPEN_SUBGROUPS
+  # at the namespace and the subgroup is still Open. The endpoint
+  # publishes `MemberJoinedOpen` which (per the apply path at
+  # `namespace_governance.rs:281` + `:843` + `:1194`) validates the
+  # inherited path and queues a `PendingKeyDelivery` on every peer
+  # holding the subgroup key.
+  #
+  # KEY INVARIANT THIS TEST PINS: the deny-list entry stamped by
+  # the prior `MemberLeft` apply must be cleared on every peer
+  # before node-2's next state-delta op fires, otherwise Phase 7
+  # silently fails because node-3 drops the new write at the
+  # receive filter. If the apply path doesn't clear the deny-list
+  # on `MemberJoinedOpen` (only `MemberAdded` and
+  # `MemberJoinedViaTeeAttestation` call `clear_denied` today —
+  # see `group_store/mod.rs:1215` and `:1502`), this test will
+  # surface that as a Phase 7 read failure.
+
+  - name: Node-2 self-rejoins Open subgroup via inheritance endpoint
+    type: join_subgroup_inheritance
+    node: leave-rejoin-node-2
+    group_id: '{{subgroup_id}}'
+    outputs:
+      node2_rejoin_pk: memberPublicKey
+
+  - name: Wait for MemberJoinedOpen + KeyDelivery to propagate
+    type: wait_for_sync
+    group_id: '{{subgroup_id}}'
+    nodes:
+      - leave-rejoin-node-1
+      - leave-rejoin-node-2
+      - leave-rejoin-node-3
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 6: Membership row check ─────────────────────────────────
+  # Note: `MemberJoinedOpen` does NOT create a direct membership row —
+  # it only proves and propagates the inherited path + delivers the
+  # key. `list_group_members` returns direct rows only, so node-2
+  # will NOT appear here. This is intentional and distinguishes the
+  # inheritance rejoin from an admin-issued `add_group_members`.
+
+  - name: Confirm subgroup direct-membership shape post-rejoin
+    type: list_group_members
+    node: leave-rejoin-node-1
+    group_id: '{{subgroup_id}}'
+    outputs:
+      members_after_rejoin: members
+
+  - name: Assert direct-row list still excludes inherited rejoiner
+    type: assert
+    statements:
+      - "not_contains({{members_after_rejoin}}, {{identity_node2}})"
+      - "contains({{members_after_rejoin}}, {{identity_node3}})"
+
+  # ── Phase 7: Post-rejoin write must reach node-3 ──────────────────
+  # The end-to-end signal that the inheritance rejoin path properly
+  # cleared the per-peer deny-list and delivered a usable group key.
+
+  - name: Post-rejoin — node-2 writes
+    type: call
+    node: leave-rejoin-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_rejoin"
+      value: "node2_msg_after_rejoin"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Post-rejoin sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - leave-rejoin-node-1
+      - leave-rejoin-node-2
+      - leave-rejoin-node-3
+    timeout: 60
+    check_interval: 2
+
+  - name: Post-rejoin — node-3 reads node-2's write
+    type: call
+    node: leave-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_rejoin"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      post_rejoin_read: result
+
+  - name: Assert post-rejoin write reached node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{post_rejoin_read}}, {"output": "node2_msg_after_rejoin"})'
+
+stop_all_nodes: false
+restart: false
+wait_timeout: 120

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -76,12 +76,10 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture node-1 namespace identity
-    type: get_namespace_identity
-    node: leave-rejoin-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      node1_key: publicKey
+  # node-1's namespace identity not captured here — admin doesn't
+  # write to the context in this workflow (only members write +
+  # cross-peer reads), so the executor_public_key for admin would be
+  # unused. Removed to avoid dead output noise flagged in code review.
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -321,24 +321,30 @@ steps:
     timeout: 60
     check_interval: 2
 
-  # ── Phase 6: Membership row check ─────────────────────────────────
-  # Note: `MemberJoinedOpen` does NOT create a direct membership row —
-  # it only proves and propagates the inherited path + delivers the
-  # key. `list_group_members` returns direct rows only, so node-2
-  # will NOT appear here. This is intentional and distinguishes the
-  # inheritance rejoin from an admin-issued `add_group_members`.
+  # ── Phase 6: Membership shape check ───────────────────────────────
+  # `MemberJoinedOpen` does NOT create a direct membership row — the
+  # rejoiner's authority is the inherited path (namespace membership +
+  # CAN_JOIN_OPEN_SUBGROUPS + Open visibility). But `list_group_members`
+  # since #2371/#2372 unions the stored direct rows with
+  # `enumerate_inherited_members`, so an inherited member appears in
+  # the list. node-2's `leave_group` deleted its direct row AND
+  # deny-listed it — while deny-listed the enumeration filter excluded
+  # it (asserted in Phase 4). The rejoin's `MemberJoinedOpen` apply
+  # clears the deny-list, so node-2 reappears here as an *inherited*
+  # member (not a direct row — that distinguishes the inheritance
+  # rejoin from an admin-issued `add_group_members`).
 
-  - name: Confirm subgroup direct-membership shape post-rejoin
+  - name: Confirm subgroup membership shape post-rejoin
     type: list_group_members
     node: leave-rejoin-node-1
     group_id: '{{subgroup_id}}'
     outputs:
       members_after_rejoin: members
 
-  - name: Assert direct-row list still excludes inherited rejoiner
+  - name: Assert rejoiner is back in the (inherited) member list
     type: assert
     statements:
-      - "not_contains({{members_after_rejoin}}, {{identity_node2}})"
+      - "contains({{members_after_rejoin}}, {{identity_node2}})"
       - "contains({{members_after_rejoin}}, {{identity_node3}})"
 
   # ── Phase 7: Post-rejoin write must reach node-3 ──────────────────

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -75,7 +75,13 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
+
+  - name: Capture node-1 namespace identity
+    type: get_namespace_identity
+    node: leave-rejoin-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      node1_key: publicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -246,6 +252,10 @@ steps:
       - "contains({{members_after_leave}}, {{identity_node3}})"
 
   # ── Phase 4: Departed node's write must NOT reach node-3 ──────────
+  # Same negative-control discipline as the kick-rejoin and
+  # kick-readd workflows: the cross-peer read on node-3 below catches
+  # silent local-success-then-gossip-drop before the rejoin, instead
+  # of deferring it to the end-of-workflow assertion.
 
   - name: Post-leave — node-2 attempts write (must fail or be dropped)
     type: call
@@ -257,6 +267,26 @@ steps:
       value: "this_must_not_appear"
     executor_public_key: '{{node2_key}}'
     expected_failure: true
+
+  - name: Drain in-flight gossip before negative-control read
+    type: wait
+    seconds: 5
+
+  - name: Negative control — node-3 must NOT see the dropped write
+    type: call
+    node: leave-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "while_left"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      while_left_pre_rejoin: result
+
+  - name: Assert dropped value is genuinely absent on node-3 BEFORE rejoin
+    type: json_assert
+    statements:
+      - 'json_equal({{while_left_pre_rejoin}}, {"output": null})'
 
   # ── Phase 5: node-2 self-rejoins via inheritance endpoint ─────────
   # Inheritance is intact: node-2 still holds CAN_JOIN_OPEN_SUBGROUPS
@@ -352,6 +382,28 @@ steps:
     type: json_assert
     statements:
       - 'json_equal({{post_rejoin_read}}, {"output": "node2_msg_after_rejoin"})'
+
+  # Mirror of the kick-rejoin / kick-readd end-of-workflow check: the
+  # `while_left` write was dropped during the banned window, the
+  # rejoin must NOT retroactively replay it. A regression that
+  # buffered the dropped write and re-delivered on deny-list-clear
+  # would surface here as `while_left` being visible post-rejoin.
+
+  - name: Confirm dropped-during-leave write was NOT delivered post-rejoin
+    type: call
+    node: leave-rejoin-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "while_left"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      while_left_post_rejoin: result
+
+  - name: Assert dropped-during-leave value stays dropped after rejoin
+    type: json_assert
+    statements:
+      - 'json_equal({{while_left_post_rejoin}}, {"output": null})'
 
 stop_all_nodes: false
 restart: false

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -345,6 +345,12 @@ steps:
   # The end-to-end signal that the inheritance rejoin path properly
   # cleared the per-peer deny-list and delivered a usable group key.
 
+  # Use `node2_rejoin_pk` (captured from the `join_subgroup_inheritance`
+  # rejoin step) rather than the pre-leave `node2_key`. The two are in
+  # fact identical — a node's namespace-derived identity is stable
+  # across leave/rejoin — but binding the post-rejoin write to the
+  # rejoin step's output makes the dataflow self-documenting and
+  # removes any doubt about a stale pre-leave key.
   - name: Post-rejoin — node-2 writes
     type: call
     node: leave-rejoin-node-2
@@ -353,7 +359,7 @@ steps:
     args:
       key: "post_rejoin"
       value: "node2_msg_after_rejoin"
-    executor_public_key: '{{node2_key}}'
+    executor_public_key: '{{node2_rejoin_pk}}'
 
   - name: Post-rejoin sync
     type: wait_for_sync

--- a/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
+++ b/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
@@ -1,0 +1,258 @@
+name: E2E KV Store - Restricted Subgroup Add Then Bidirectional Write
+description: >
+  Regression guard for the admin-issued add path on Restricted
+  subgroups. Today `group-membership.yml` adds → removes → asserts
+  revoked, but never asserts the post-add write actually authors
+  cleanly and decrypts on a third peer. That gap means a regression
+  in the `MemberAdded` → `KeyDelivery` chain for Restricted
+  subgroups could ship without an E2E catching it.
+
+  Distinguishes itself from sibling tests:
+    * `group-open-self-join-key-delivery.yml` — Open subgroup,
+      inheritance path. The joiner publishes `MemberJoinedOpen`,
+      not the admin.
+    * `group-join-via-inheritance.yml` — Open subgroup, new
+      inheritance endpoint. Same direction problem as above.
+    * `group-membership.yml` — adds then removes; doesn't
+      bidirectionally read after add.
+  This workflow exercises the admin-issued direct-add path
+  (`add_group_members`), which publishes a regular `MemberJoined`
+  governance op carrying the wrapped subgroup key. The receiver's
+  apply must (a) install node-2's direct row and (b) populate
+  `sender_key` so node-2 can author state-DAG ops that node-3 can
+  decrypt.
+
+  Default subgroup visibility is `Restricted`, so no
+  `set_subgroup_visibility` step is needed — relying on the default
+  also catches a future regression that flipped the default.
+
+  Mero-chat user-visible failure mode this guards against: "I
+  added someone to a private channel via Members → Add, they
+  appear in the member list, but their messages never show up
+  for the rest of us (and vice-versa)" — symptom of a regression
+  in the `MemberJoined` → `KeyDelivery` → `sender_key` populate
+  chain on the admin-add path.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: private-add-node
+
+steps:
+  # ── Phase 1: Bootstrap namespace + Restricted subgroup ────────────
+
+  - name: Install application on node-1
+    type: install_application
+    node: private-add-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: private-add-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Install application on node-3
+    type: install_application
+    node: private-add-node-3
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: private-add-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: private-add-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: private-add-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Wait for namespace governance to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: private-add-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: private-add-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  # Default visibility is Restricted; intentional that this test
+  # does NOT call `set_subgroup_visibility`. A regression that
+  # flipped the default would surface as node-3 being able to read
+  # the subgroup context before being explicitly added — which the
+  # negative-control assertion below would catch.
+  - name: Node-1 creates Restricted subgroup
+    type: create_group_in_namespace
+    node: private-add-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: private-channel
+    outputs:
+      subgroup_id: groupId
+
+  # Add ONLY node-2. node-3 stays a namespace member without
+  # subgroup access — used as a negative control to confirm the
+  # subgroup is genuinely Restricted (no inherited path leaks).
+  - name: Admin adds only node-2 to subgroup
+    type: add_group_members
+    node: private-add-node-1
+    group_id: '{{subgroup_id}}'
+    members:
+      - identity: '{{identity_node2}}'
+        role: Member
+
+  - name: Node-1 creates context inside Restricted subgroup
+    type: create_context
+    node: private-add-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for MemberJoined + ContextRegistered to propagate
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins context
+    type: join_context
+    node: private-add-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Initial sync to settle Root state
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - private-add-node-1
+      - private-add-node-2
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 2: Negative control — node-3 must NOT have access ───────
+  # Confirms the subgroup is actually Restricted. If a regression
+  # flipped the default visibility to Open, node-3 (a namespace
+  # member with default capabilities) would inherit access and this
+  # call would unexpectedly succeed.
+
+  - name: Negative control — node-3 (namespace-only) cannot join context
+    type: join_context
+    node: private-add-node-3
+    context_id: '{{ctx_id}}'
+    expected_failure: true
+
+  # ── Phase 3: Round 1 — admin writes, node-2 reads ─────────────────
+  # Verifies the inbound direction: node-2's join_context populated
+  # whatever it needs to decrypt admin-authored ops.
+
+  - name: Round 1 — admin writes
+    type: call
+    node: private-add-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "from_admin"
+      value: "admin_msg"
+    executor_public_key: '{{node1_key}}'
+
+  - name: Round 1 sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - private-add-node-1
+      - private-add-node-2
+    timeout: 30
+    check_interval: 2
+
+  - name: Round 1 — node-2 reads admin's write
+    type: call
+    node: private-add-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "from_admin"
+    executor_public_key: '{{node2_key}}'
+    outputs:
+      node2_read_admin: result
+
+  - name: Assert inbound direction works
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_read_admin}}, {"output": "admin_msg"})'
+
+  # ── Phase 4: Round 2 — node-2 writes, admin reads ─────────────────
+  # The critical assertion. Pre-regression: `MemberJoined` apply
+  # populates node-2's `sender_key` via the wrapped `KeyDelivery`,
+  # so their next state-DAG op is signed/encrypted with the
+  # subgroup key and admin can decrypt it. A regression that broke
+  # the admin-add `KeyDelivery` chain (the symmetric counterpart
+  # to the #2351 inheritance-path bug) would surface as admin
+  # reading null/empty here.
+
+  - name: Round 2 — node-2 (admin-added member) writes
+    type: call
+    node: private-add-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "from_member"
+      value: "node2_msg"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Round 2 sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - private-add-node-1
+      - private-add-node-2
+    timeout: 30
+    check_interval: 2
+
+  - name: Round 2 — admin reads node-2's write
+    type: call
+    node: private-add-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "from_member"
+    executor_public_key: '{{node1_key}}'
+    outputs:
+      admin_read_node2: result
+
+  - name: Assert outbound direction works (admin reads member's write)
+    type: json_assert
+    statements:
+      - 'json_equal({{admin_read_node2}}, {"output": "node2_msg"})'
+
+stop_all_nodes: false
+restart: false
+wait_timeout: 120

--- a/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
+++ b/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
@@ -70,7 +70,13 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
+
+  - name: Capture node-1 namespace identity
+    type: get_namespace_identity
+    node: private-add-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      node1_key: publicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -163,6 +169,18 @@ steps:
   # flipped the default visibility to Open, node-3 (a namespace
   # member with default capabilities) would inherit access and this
   # call would unexpectedly succeed.
+  #
+  # Important: node-3 must have already received the
+  # `ContextRegistered` op before we make the negative-control call,
+  # otherwise `expected_failure: true` would pass for the wrong
+  # reason — node-3 simply hasn't seen the context yet, not because
+  # the subgroup is Restricted. Wait an additional fixed interval
+  # for namespace-DAG propagation to node-3 (which was excluded from
+  # the context-id-keyed sync above because it has no
+  # ContextIdentity for `ctx_id` yet).
+  - name: Wait for ContextRegistered to propagate to node-3
+    type: wait
+    seconds: 10
 
   - name: Negative control — node-3 (namespace-only) cannot join context
     type: join_context

--- a/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
+++ b/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
@@ -1,0 +1,374 @@
+name: E2E KV Store - Remove From Namespace Revokes Inherited Subgroup Access
+description: >
+  Wire-level coverage for the unit-test invariant
+  `recursive_remove_skips_inherited_only_members`
+  (group_store/tests.rs:3656), inverted: instead of asserting that
+  removal at a descendant subgroup is a no-op for inherited members,
+  this asserts that removal at the *anchor* (the namespace root)
+  properly cuts the inheritance chain so descendant Open-subgroup
+  access is revoked end-to-end.
+
+  Scenario (3 nodes, namespace + Open subgroup):
+
+    1. node-2 inherits Open-subgroup access via default
+       `CAN_JOIN_OPEN_SUBGROUPS` capability at the namespace root,
+       materializes the membership via `join_subgroup_inheritance`
+       (#2360), joins the subgroup's context, and writes a value
+       that node-3 reads.
+    2. Admin (node-1) removes node-2 from the *namespace root*
+       only — never touching the subgroup directly. node-2 still
+       has the local subgroup key cached and a populated
+       ContextIdentity for the subgroup context.
+    3. Asserts:
+       (a) node-2's namespace membership row is gone (cross-peer);
+       (b) node-2's next write to the subgroup context does NOT
+           reach node-3 (no inheritance anchor → permission to
+           publish governance/state-delta is gone, and on receiver
+           side the inheritance walk no longer finds an anchor);
+       (c) node-2 cannot re-`join_subgroup_inheritance` for the
+           subgroup — the handler's
+           `MembershipPath::None` arm at
+           `crates/context/src/handlers/join_subgroup_inheritance.rs:73`
+           must reject with `NotEligible`. This is the "is the
+           anchor *really* gone" smoke test.
+
+  What this test does NOT cover (different code paths):
+    * Removal of a *direct* member from a descendant subgroup —
+      that's `group-membership.yml`'s SCENARIO 6.
+    * Recursive removal of a member who has direct rows at every
+      level in the subtree — there is no admin-issued governance
+      op for that today (the `recursive_remove_member` helper at
+      `group_store/namespace.rs:343` is internal-only). Indirectly
+      exercised by `group-leave-namespace.yml` via `MemberLeft`
+      cascade at the namespace root.
+
+  Mero-chat user-visible failure mode this guards against: "an
+  admin removed a member from the workspace, but they could
+  still post in the public channels they had inherited access
+  to" — symptom of incomplete revocation when the anchor is the
+  namespace and the descendant access was purely inherited.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: revoke-inherit-node
+
+steps:
+  # ── Phase 1: Bootstrap namespace + Open subgroup + context ────────
+
+  - name: Install application on node-1
+    type: install_application
+    node: revoke-inherit-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: revoke-inherit-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Install application on node-3
+    type: install_application
+    node: revoke-inherit-node-3
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: revoke-inherit-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: revoke-inherit-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: revoke-inherit-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Wait for namespace governance to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: revoke-inherit-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node2}}'
+    outputs:
+      identity_node2: memberIdentity
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: revoke-inherit-node-3
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invite_node3}}'
+    outputs:
+      identity_node3: memberIdentity
+
+  - name: Node-1 creates Open subgroup
+    type: create_group_in_namespace
+    node: revoke-inherit-node-1
+    namespace_id: '{{namespace_id}}'
+    group_alias: open-channel
+    outputs:
+      subgroup_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: revoke-inherit-node-1
+    group_id: '{{subgroup_id}}'
+    visibility: open
+
+  - name: Node-1 creates context inside Open subgroup
+    type: create_context
+    node: revoke-inherit-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{subgroup_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for visibility + context-registered ops to propagate
+    type: wait
+    seconds: 10
+
+  # ── Phase 2: Both joiners materialize inherited access ────────────
+  # node-2 is the eventual revocation target; node-3 is the
+  # cross-peer reader, kept inherited the whole time so we can
+  # confirm Phase 5's "inherited members not targeted by the
+  # removal stay functional" invariant.
+
+  - name: Node-2 self-joins Open subgroup via inheritance
+    type: join_subgroup_inheritance
+    node: revoke-inherit-node-2
+    group_id: '{{subgroup_id}}'
+
+  - name: Node-2 joins context
+    type: join_context
+    node: revoke-inherit-node-2
+    context_id: '{{ctx_id}}'
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Node-3 self-joins Open subgroup via inheritance
+    type: join_subgroup_inheritance
+    node: revoke-inherit-node-3
+    group_id: '{{subgroup_id}}'
+
+  - name: Node-3 joins context
+    type: join_context
+    node: revoke-inherit-node-3
+    context_id: '{{ctx_id}}'
+    outputs:
+      node3_key: memberPublicKey
+
+  - name: Initial sync to settle Root state
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - revoke-inherit-node-1
+      - revoke-inherit-node-2
+      - revoke-inherit-node-3
+    timeout: 60
+    check_interval: 2
+
+  # ── Phase 3: Pre-revoke — node-2 writes, node-3 reads ─────────────
+
+  - name: Pre-revoke — node-2 writes
+    type: call
+    node: revoke-inherit-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "pre_revoke"
+      value: "node2_msg_before_revoke"
+    executor_public_key: '{{node2_key}}'
+
+  - name: Pre-revoke sync
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - revoke-inherit-node-1
+      - revoke-inherit-node-2
+      - revoke-inherit-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Pre-revoke — node-3 reads node-2's write
+    type: call
+    node: revoke-inherit-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "pre_revoke"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      pre_revoke_read: result
+
+  - name: Assert pre-revoke converged
+    type: json_assert
+    statements:
+      - 'json_equal({{pre_revoke_read}}, {"output": "node2_msg_before_revoke"})'
+
+  # ── Phase 4: Admin removes node-2 from namespace ROOT only ────────
+  # Critical: the removal target is `{{namespace_id}}`, NOT
+  # `{{subgroup_id}}`. The subgroup is never touched by this op.
+  # The expected effect is that node-2 loses CAN_JOIN_OPEN_SUBGROUPS
+  # and their direct namespace row, which severs the inheritance
+  # chain to the subgroup on every honest peer.
+
+  - name: Admin removes node-2 from namespace root
+    type: remove_group_members
+    node: revoke-inherit-node-1
+    group_id: '{{namespace_id}}'
+    members:
+      - '{{identity_node2}}'
+
+  - name: Wait for MemberRemoved to propagate at namespace
+    type: wait_for_sync
+    group_id: '{{namespace_id}}'
+    nodes:
+      - revoke-inherit-node-1
+      - revoke-inherit-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Confirm node-2 absent from namespace membership
+    type: list_group_members
+    node: revoke-inherit-node-1
+    group_id: '{{namespace_id}}'
+    outputs:
+      ns_members_after: members
+
+  - name: Assert node-2 absent from namespace, node-3 present
+    type: assert
+    statements:
+      - "not_contains({{ns_members_after}}, {{identity_node2}})"
+      - "contains({{ns_members_after}}, {{identity_node3}})"
+
+  # Cross-peer check: node-3 also sees node-2 gone from the
+  # namespace. Catches a fan-out bug where the removal applied
+  # locally on the admin but didn't propagate.
+  - name: Cross-peer confirm node-3 sees node-2 gone from namespace
+    type: list_group_members
+    node: revoke-inherit-node-3
+    group_id: '{{namespace_id}}'
+    outputs:
+      ns_members_after_node3: members
+
+  - name: Assert cross-peer view agrees
+    type: assert
+    statements:
+      - "not_contains({{ns_members_after_node3}}, {{identity_node2}})"
+
+  # ── Phase 5: node-3 (untouched inherited member) still works ──────
+  # Negative-control complement to the Phase 6 / 7 revocation
+  # check: a removal targeting node-2 must NOT affect node-3.
+  # Catches a regression where the namespace-level removal
+  # accidentally fan-outs to descendant subgroup deny-lists for
+  # all inherited members instead of just the target.
+
+  - name: Untouched inherited member node-3 writes
+    type: call
+    node: revoke-inherit-node-3
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "node3_after_revoke"
+      value: "node3_still_works"
+    executor_public_key: '{{node3_key}}'
+
+  - name: Sync node-3's write
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - revoke-inherit-node-1
+      - revoke-inherit-node-3
+    timeout: 30
+    check_interval: 2
+
+  - name: Admin reads node-3's write
+    type: call
+    node: revoke-inherit-node-1
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "node3_after_revoke"
+    executor_public_key: '{{node1_key}}'
+    outputs:
+      admin_reads_node3: result
+
+  - name: Assert untouched inherited member's writes still flow
+    type: json_assert
+    statements:
+      - 'json_equal({{admin_reads_node3}}, {"output": "node3_still_works"})'
+
+  # ── Phase 6: Revoked node's write must NOT reach the cluster ──────
+  # The end-to-end revocation signal. Without an inheritance anchor
+  # node-2 has no membership path to the subgroup; their attempt to
+  # publish a state-delta should either fail at their local apply
+  # (no signing identity left) or be dropped at receivers (no path
+  # in the inheritance check). `expected_failure: true` accepts
+  # either local failure mode; the real assertion is the next read
+  # on node-3.
+
+  - name: Post-revoke — node-2 attempts write (must fail or be dropped)
+    type: call
+    node: revoke-inherit-node-2
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: "post_revoke_should_drop"
+      value: "this_must_not_appear"
+    executor_public_key: '{{node2_key}}'
+    expected_failure: true
+
+  # Even if the local write succeeded (loose invariant), the write
+  # must NOT be visible on node-3.
+  - name: Confirm post-revoke write is NOT visible on node-3
+    type: call
+    node: revoke-inherit-node-3
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: "post_revoke_should_drop"
+    executor_public_key: '{{node3_key}}'
+    outputs:
+      post_revoke_lookup: result
+
+  - name: Assert revoked write was indeed dropped
+    type: json_assert
+    statements:
+      - 'json_equal({{post_revoke_lookup}}, {"output": null})'
+
+  # ── Phase 7: Anchor-gone smoke test via inheritance endpoint ──────
+  # Confirms the inheritance chain is genuinely cut: with node-2's
+  # namespace membership gone, `join_subgroup_inheritance` must
+  # reject with `NotEligible`. If this succeeds, the anchor is
+  # not actually revoked at the namespace level on node-2 (or the
+  # path-check has a bug).
+
+  - name: Node-2 cannot re-join via inheritance (anchor gone)
+    type: join_subgroup_inheritance
+    node: revoke-inherit-node-2
+    group_id: '{{subgroup_id}}'
+    expected_failure: true
+
+stop_all_nodes: false
+restart: false
+wait_timeout: 120

--- a/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
+++ b/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
@@ -85,7 +85,13 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
+
+  - name: Capture node-1 namespace identity
+    type: get_namespace_identity
+    node: revoke-inherit-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      node1_key: publicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -337,6 +343,13 @@ steps:
       value: "this_must_not_appear"
     executor_public_key: '{{node2_key}}'
     expected_failure: true
+
+  # Drain in-flight gossip from a possible local-success before the
+  # cross-peer read. Without this, the read could race past any delta
+  # actually emitted by node-2's loose-failure mode and false-pass.
+  - name: Drain in-flight gossip before negative-control read
+    type: wait
+    seconds: 5
 
   # Even if the local write succeeded (loose invariant), the write
   # must NOT be visible on node-3.

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -60,15 +60,27 @@ pub fn cascade_remove_member_from_group_tree(
 /// shape `join_context` writes — so KeyDelivery can then populate
 /// `sender_key` exactly as it would on first-join.
 ///
-/// **Caller responsibility — local-rejoiner gate.** This function
-/// unconditionally writes `private_key: Some(private_key)` to every
-/// row it touches. Writing a `Some(_)` row on a peer that does NOT
-/// own that private key would let that peer spoof state-DAG ops as
-/// the rejoiner. **Callers must invoke only on the local rejoiner's
-/// node**, identified by `get_namespace_identity(resolved_namespace)`
-/// returning the rejoiner's pk. The two apply-path call sites
-/// (`MemberAdded` in `mod.rs` and `MemberJoinedOpen` in
-/// `namespace_governance.rs`) already gate on this check.
+/// **Anti-spoof gate is enforced inside this function.** Writing a
+/// `private_key: Some(_)` row for `member` would let the writing node
+/// author state-DAG ops as `member`. The function therefore resolves
+/// the namespace for `group_id`, reads THIS node's namespace identity,
+/// and returns early (a no-op) unless the local identity *is*
+/// `member` — i.e. this node genuinely owns the private key. The
+/// private key is derived internally from that identity; callers
+/// cannot pass in an arbitrary key. Both apply-path call sites
+/// (`MemberAdded` in `mod.rs`, `MemberJoinedOpen` in
+/// `namespace_governance.rs`) invoke this unconditionally and rely on
+/// the internal gate — a future call site cannot accidentally omit it.
+///
+/// **Crash-consistency.** Rows are written one `put` at a time with
+/// no batch transaction, so a crash mid-loop leaves a partial restore
+/// (identity present for some contexts, absent for others). This is
+/// self-healing: the function is idempotent and the apply path that
+/// calls it re-runs on every receipt of the governance op (including
+/// catch-up sync re-application), so the next apply completes the
+/// remaining rows. The symmetric `cascade_remove_member` uses the
+/// same one-`handle`-loop pattern; if either is ever made
+/// transactional, both should be.
 ///
 /// **Why `enumerate_group_contexts(.., 0, usize::MAX)` is fine here.**
 /// The hot-path concern is unbounded reads. In this codebase the
@@ -86,8 +98,21 @@ pub fn restore_member_context_identities(
     store: &Store,
     group_id: &ContextGroupId,
     member: &PublicKey,
-    private_key: [u8; 32],
 ) -> EyreResult<()> {
+    // Internal anti-spoof gate (see doc comment). Only the local
+    // rejoiner's own node holds the namespace identity bytes for
+    // `member`; on every other peer this resolves to a different pk
+    // (or `None`) and the function is a no-op.
+    let namespace_id = super::resolve_namespace(store, group_id)?;
+    let Some((local_pk, private_key, _sender_key)) =
+        super::get_namespace_identity(store, &namespace_id)?
+    else {
+        return Ok(());
+    };
+    if local_pk != *member {
+        return Ok(());
+    }
+
     let contexts = enumerate_group_contexts(store, group_id, 0, usize::MAX)?;
     let mut handle = store.handle();
     for context_id in &contexts {

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -52,13 +52,15 @@ pub fn cascade_remove_member_from_group_tree(
 /// `ContextIdentity` rows for the rejoiner under every context registered
 /// directly beneath `group_id`.
 ///
-/// Idempotent on rows that already exist (e.g., first-time join via the
-/// `join_context` handler beats the apply-path call to here). A rejoiner
-/// who never had a `ContextIdentity` row for a given context (because the
-/// context was registered after they were removed) gets a freshly-written
-/// row with `private_key: Some(_)` and `sender_key: None` — the same
-/// shape `join_context` writes — so KeyDelivery can then populate
-/// `sender_key` exactly as it would on first-join.
+/// Idempotent on rows that already carry a usable `private_key: Some(_)`
+/// (e.g., a first-time join via the `join_context` handler beat the
+/// apply-path call to here). A rejoiner who never had a `ContextIdentity`
+/// row for a given context gets a freshly-written row with
+/// `private_key: Some(_)` and `sender_key: None` — the same shape
+/// `join_context` writes — so KeyDelivery can then populate `sender_key`.
+/// A pre-existing row with `private_key: None` is repaired in place
+/// (`private_key` filled, `sender_key` preserved) rather than skipped,
+/// since a keyless row would leave the rejoiner unable to sign.
 ///
 /// **Anti-spoof gate is enforced inside this function.** Writing a
 /// `private_key: Some(_)` row for `member` would let the writing node
@@ -117,12 +119,31 @@ pub fn restore_member_context_identities(
     let mut handle = store.handle();
     for context_id in &contexts {
         let identity_key = calimero_store::key::ContextIdentity::new(*context_id, (*member).into());
-        if !handle.has(&identity_key)? {
+        // Three cases:
+        //   * No row              → write a fresh `Some(private_key)` row.
+        //   * Row, private_key None → repair it: the rejoiner can't sign
+        //     with a `None` key. Overwrite `private_key` but PRESERVE
+        //     `sender_key` so an already-delivered key isn't clobbered.
+        //   * Row, private_key Some → leave untouched (idempotent — a
+        //     prior `join_context` already wrote a usable row).
+        // The `None` case shouldn't arise on the local rejoiner's own
+        // store today (the cascade deletes the whole row, and the
+        // anti-spoof gate above means peers never write a `None` row
+        // for a member they don't own), but repairing it rather than
+        // skipping keeps the restore robust against any future path
+        // that leaves a keyless row behind.
+        let existing = handle.get(&identity_key)?;
+        let needs_write = match &existing {
+            None => true,
+            Some(row) => row.private_key.is_none(),
+        };
+        if needs_write {
+            let sender_key = existing.and_then(|row| row.sender_key);
             handle.put(
                 &identity_key,
                 &calimero_store::types::ContextIdentity {
                     private_key: Some(private_key),
-                    sender_key: None,
+                    sender_key,
                 },
             )?;
             tracing::info!(

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -60,14 +60,28 @@ pub fn cascade_remove_member_from_group_tree(
 /// shape `join_context` writes — so KeyDelivery can then populate
 /// `sender_key` exactly as it would on first-join.
 ///
-/// This is the *local* half of rejoin recovery. Other peers do not hold
-/// `ContextIdentity` rows for this rejoiner (only the rejoiner's own
-/// store does — that's the row the cascade deleted), so the apply path
-/// only needs to do anything on the rejoiner's own node. Callers must
-/// gate on `private_key.is_some()` (i.e., they must have access to the
-/// rejoiner's namespace identity bytes) before invoking — peers without
-/// the key cannot and should not write a row claiming to own a private
-/// key they don't have.
+/// **Caller responsibility — local-rejoiner gate.** This function
+/// unconditionally writes `private_key: Some(private_key)` to every
+/// row it touches. Writing a `Some(_)` row on a peer that does NOT
+/// own that private key would let that peer spoof state-DAG ops as
+/// the rejoiner. **Callers must invoke only on the local rejoiner's
+/// node**, identified by `get_namespace_identity(resolved_namespace)`
+/// returning the rejoiner's pk. The two apply-path call sites
+/// (`MemberAdded` in `mod.rs` and `MemberJoinedOpen` in
+/// `namespace_governance.rs`) already gate on this check.
+///
+/// **Why `enumerate_group_contexts(.., 0, usize::MAX)` is fine here.**
+/// The hot-path concern is unbounded reads. In this codebase the
+/// number of contexts directly registered under a single
+/// `ContextGroupId` is the count of contexts in one channel
+/// (subgroup), which is bounded by application-level use — typically
+/// 1, rarely more than a handful. The same unbounded-enumerate
+/// pattern is used by `cascade_remove_member_from_group_tree` /
+/// `ContextTreeService::cascade_remove_member` (see this file) and
+/// has not surfaced as a memory or latency hotspot. If a future use
+/// case starts pushing tens of contexts into a single subgroup, both
+/// paths should be paginated together — they share the same
+/// invariant.
 pub fn restore_member_context_identities(
     store: &Store,
     group_id: &ContextGroupId,

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -48,6 +48,55 @@ pub fn cascade_remove_member_from_group_tree(
     ContextTreeService::new(store, *group_id).cascade_remove_member(member)
 }
 
+/// Inverse of [`cascade_remove_member_from_group_tree`]: re-create
+/// `ContextIdentity` rows for the rejoiner under every context registered
+/// directly beneath `group_id`.
+///
+/// Idempotent on rows that already exist (e.g., first-time join via the
+/// `join_context` handler beats the apply-path call to here). A rejoiner
+/// who never had a `ContextIdentity` row for a given context (because the
+/// context was registered after they were removed) gets a freshly-written
+/// row with `private_key: Some(_)` and `sender_key: None` — the same
+/// shape `join_context` writes — so KeyDelivery can then populate
+/// `sender_key` exactly as it would on first-join.
+///
+/// This is the *local* half of rejoin recovery. Other peers do not hold
+/// `ContextIdentity` rows for this rejoiner (only the rejoiner's own
+/// store does — that's the row the cascade deleted), so the apply path
+/// only needs to do anything on the rejoiner's own node. Callers must
+/// gate on `private_key.is_some()` (i.e., they must have access to the
+/// rejoiner's namespace identity bytes) before invoking — peers without
+/// the key cannot and should not write a row claiming to own a private
+/// key they don't have.
+pub fn restore_member_context_identities(
+    store: &Store,
+    group_id: &ContextGroupId,
+    member: &PublicKey,
+    private_key: [u8; 32],
+) -> EyreResult<()> {
+    let contexts = enumerate_group_contexts(store, group_id, 0, usize::MAX)?;
+    let mut handle = store.handle();
+    for context_id in &contexts {
+        let identity_key = calimero_store::key::ContextIdentity::new(*context_id, (*member).into());
+        if !handle.has(&identity_key)? {
+            handle.put(
+                &identity_key,
+                &calimero_store::types::ContextIdentity {
+                    private_key: Some(private_key),
+                    sender_key: None,
+                },
+            )?;
+            tracing::info!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                context_id = %hex::encode(context_id.as_ref()),
+                member = %member,
+                "rejoin: restored ContextIdentity row for local rejoiner"
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Scans the ContextIdentity column for the given context and returns the first
 /// `PublicKey` for which the node holds a local private key. Used to find a
 /// valid signer when performing group upgrades on behalf of a context that the

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -77,12 +77,34 @@ pub fn cascade_remove_member_from_group_tree(
 /// **Crash-consistency.** Rows are written one `put` at a time with
 /// no batch transaction, so a crash mid-loop leaves a partial restore
 /// (identity present for some contexts, absent for others). This is
-/// self-healing: the function is idempotent and the apply path that
-/// calls it re-runs on every receipt of the governance op (including
-/// catch-up sync re-application), so the next apply completes the
-/// remaining rows. The symmetric `cascade_remove_member` uses the
-/// same one-`handle`-loop pattern; if either is ever made
-/// transactional, both should be.
+/// self-healing, and the reason is the *ordering* of the apply
+/// pipeline — not blind re-application. Both call sites run this
+/// function as part of the op mutation, and the governance nonce /
+/// DAG head only advances *after* the entire mutation returns:
+/// `apply_local_signed_group_op` calls `apply_group_op_mutations`
+/// (which contains this loop) and only then `persist_group_governance_progress`
+/// (which advances the nonce); the `MemberJoinedOpen` path advances
+/// the namespace-DAG head likewise after `apply_signed_op` completes.
+/// So a crash that left rows unwritten necessarily crashed *before*
+/// the nonce/head advanced — the op is therefore NOT yet
+/// nonce-deduplicated and is re-applied on the next receipt, and the
+/// idempotent loop here fills the remaining rows. (Conversely, once
+/// the nonce advances and re-receipt becomes a no-op, the loop had
+/// already completed — there is nothing left to heal.) Worst case if
+/// that reasoning is ever broken by a refactor: the member calls
+/// `join_context` for the affected context, which writes the row
+/// directly. The symmetric `cascade_remove_member` uses the same
+/// one-`handle`-loop pattern; if either is ever made transactional,
+/// both should be.
+///
+/// **No concurrent-registration gap.** The enumerate and the write
+/// loop use separate store handles, but a context cannot be
+/// registered between them: governance ops for a namespace apply
+/// sequentially through a single actor, so no `ContextRegistered`
+/// can interleave with this `MemberAdded` / `MemberJoinedOpen`
+/// apply. A context registered by a *later* governance op is a
+/// no-op for membership — the rejoiner's row already exists by then,
+/// and `register_context` does not touch `ContextIdentity`.
 ///
 /// **Why `enumerate_group_contexts(.., 0, usize::MAX)` is fine here.**
 /// The hot-path concern is unbounded reads. In this codebase the

--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -11,8 +11,8 @@ use eyre::{bail, Result as EyreResult};
 use super::namespace::{get_parent_group, MAX_NAMESPACE_DEPTH};
 use super::{
     collect_keys_with_prefix, collect_keys_with_prefix_paginated, count_keys_with_prefix,
-    delete_member_metadata, get_member_capability, get_subgroup_visibility, load_group_meta,
-    set_member_capability, GroupStoreError,
+    delete_member_metadata, get_member_capability, get_subgroup_visibility, is_denied,
+    load_group_meta, set_member_capability, GroupStoreError,
 };
 
 pub fn add_group_member(
@@ -382,6 +382,24 @@ pub fn enumerate_inherited_members(
             // (a direct member of `group_id`, or processed at a deeper
             // ancestor) — skip the redundant path check in that case.
             if !seen.insert(candidate) {
+                continue;
+            }
+            // A candidate deny-listed on `group_id` has been kicked
+            // from this subgroup (`MemberRemoved` / `MemberLeft` stamp
+            // the per-group deny-list). For an `Open` subgroup the
+            // kick cannot delete a direct row — the member is there by
+            // namespace-level inheritance — so the deny-list IS the
+            // removal: their state-delta traffic is dropped at the
+            // receive filter. `list_group_members` must reflect that;
+            // otherwise an admin who kicks a member still sees them in
+            // the list. The entry reappears once `MemberAdded` /
+            // `MemberJoinedOpen` clears the deny-list on rejoin. This
+            // filter is intentionally NOT applied in
+            // `check_group_membership_path`: that path is also run by
+            // `MemberJoinedOpen` apply, where the rejoiner is still
+            // deny-listed at check time (the same op clears it
+            // afterwards) — filtering there would reject every rejoin.
+            if is_denied(store, group_id, &candidate)? {
                 continue;
             }
             if let MembershipPath::Inherited { via_admin, .. } =

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -1217,19 +1217,12 @@ fn apply_group_op_mutations(
             clear_denied(store, group_id, member)?;
             // Restore per-context `ContextIdentity` rows that
             // `cascade_remove_member_from_group_tree` deleted on a prior
-            // `MemberRemoved`. Only the local rejoiner has access to the
-            // namespace identity bytes needed to write a usable row, so
-            // we gate on `get_namespace_identity` returning the
-            // rejoiner's pk. On peers (admin or other members applying
-            // this op), `local_pk != *member` and the call is a no-op.
-            // Idempotent on first-time adds: the joiner's later
+            // `MemberRemoved`. The local-rejoiner anti-spoof gate is
+            // enforced inside `restore_member_context_identities` — on
+            // peers (admin or other members applying this op) it is a
+            // no-op. Idempotent on first-time adds: the joiner's later
             // `join_context` sees an existing row and skips.
-            let ns_id = resolve_namespace(store, group_id)?;
-            if let Some((local_pk, sk_bytes, _)) = get_namespace_identity(store, &ns_id)? {
-                if local_pk == *member {
-                    restore_member_context_identities(store, group_id, member, sk_bytes)?;
-                }
-            }
+            restore_member_context_identities(store, group_id, member)?;
             crate::op_events::notify(crate::op_events::OpEvent::MemberAdded {
                 group_id: group_id.to_bytes(),
                 member: *member,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -54,7 +54,8 @@ pub use self::context_registration::ContextRegistrationService;
 pub use self::context_tree::ContextTreeService;
 pub use self::contexts::{
     cascade_remove_member_from_group_tree, enumerate_group_contexts, find_local_signing_identity,
-    get_group_for_context, register_context_in_group, unregister_context_from_group,
+    get_group_for_context, register_context_in_group, restore_member_context_identities,
+    unregister_context_from_group,
 };
 pub use self::deny_list::{
     clear_all_denied, clear_denied, is_author_denied_for_context, is_denied, mark_denied,
@@ -1213,6 +1214,21 @@ fn apply_group_op_mutations(
             // removed member transparently restores their network-level
             // access. Idempotent on a member who was never denied.
             clear_denied(store, group_id, member)?;
+            // Restore per-context `ContextIdentity` rows that
+            // `cascade_remove_member_from_group_tree` deleted on a prior
+            // `MemberRemoved`. Only the local rejoiner has access to the
+            // namespace identity bytes needed to write a usable row, so
+            // we gate on `get_namespace_identity` returning the
+            // rejoiner's pk. On peers (admin or other members applying
+            // this op), `local_pk != *member` and the call is a no-op.
+            // Idempotent on first-time adds: the joiner's later
+            // `join_context` sees an existing row and skips.
+            let ns_id = resolve_namespace(store, group_id)?;
+            if let Some((local_pk, sk_bytes, _)) = get_namespace_identity(store, &ns_id)? {
+                if local_pk == *member {
+                    restore_member_context_identities(store, group_id, member, sk_bytes)?;
+                }
+            }
             crate::op_events::notify(crate::op_events::OpEvent::MemberAdded {
                 group_id: group_id.to_bytes(),
                 member: *member,

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -17,8 +17,8 @@ use crate::metrics::{record_governance_publish_mesh_peers, record_namespace_retr
 use crate::op_events::{notify as notify_op_event, OpEvent};
 
 use super::{
-    add_group_member, apply_group_op_mutations, decrypt_group_op, get_local_gov_nonce,
-    get_namespace_identity, get_namespace_identity_record, is_group_admin,
+    add_group_member, apply_group_op_mutations, clear_denied, decrypt_group_op,
+    get_local_gov_nonce, get_namespace_identity, get_namespace_identity_record, is_group_admin,
     is_group_admin_or_has_capability, load_current_group_key_record, load_group_key_by_id,
     load_group_meta,
     namespace_dag::{NamespaceDagService, NamespaceHead},
@@ -296,6 +296,25 @@ impl<'a> NamespaceGovernance<'a> {
                                 joiner_pk: *member,
                             });
                         }
+                        // Clear deny-list on EVERY peer, not just the
+                        // local rejoiner. A prior `MemberLeft` (or
+                        // `MemberRemoved` followed by inheritance rejoin)
+                        // stamped node-2 on each peer's per-subgroup
+                        // deny-list at `mod.rs:1248` / `:1627`; without
+                        // clearing it here, peers continue to drop
+                        // node-2's state-delta traffic at the receive
+                        // filter even after the rejoin completes. The
+                        // sibling `MemberAdded` arm at `mod.rs:1215`
+                        // already does this; `MemberJoinedViaTeeAttestation`
+                        // at `mod.rs:1502` does this; `MemberJoinedOpen`
+                        // was the missing third arm. Without it the
+                        // `kick → inheritance-rejoin → write` and
+                        // `leave → inheritance-rejoin → write` flows
+                        // converge on the rejoiner's local store but
+                        // never replicate to peers — symptom: post-rejoin
+                        // sync diverges in the kick/leave-rejoin e2e.
+                        // Idempotent on a member who was never denied.
+                        clear_denied(self.store, &group_id_typed, member)?;
                         // Local rejoiner recovery: if THIS node IS the
                         // joiner (its namespace identity matches `member`),
                         // restore any per-context `ContextIdentity` rows

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -327,11 +327,7 @@ impl<'a> NamespaceGovernance<'a> {
                         // `KeyDelivery` populates `sender_key`. Idempotent:
                         // an existing row from a prior `join_context` is
                         // left untouched.
-                        restore_member_context_identities(
-                            self.store,
-                            &group_id_typed,
-                            member,
-                        )?;
+                        restore_member_context_identities(self.store, &group_id_typed, member)?;
                     }
                     _ => {}
                 }

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -18,13 +18,15 @@ use crate::op_events::{notify as notify_op_event, OpEvent};
 
 use super::{
     add_group_member, apply_group_op_mutations, decrypt_group_op, get_local_gov_nonce,
-    get_namespace_identity_record, is_group_admin, is_group_admin_or_has_capability,
-    load_current_group_key_record, load_group_key_by_id, load_group_meta,
+    get_namespace_identity, get_namespace_identity_record, is_group_admin,
+    is_group_admin_or_has_capability, load_current_group_key_record, load_group_key_by_id,
+    load_group_meta,
     namespace_dag::{NamespaceDagService, NamespaceHead},
     namespace_membership::NamespaceMembershipService,
     namespace_op_log::NamespaceOpLogService,
     namespace_retry::NamespaceRetryService,
-    save_group_meta, set_local_gov_nonce, store_group_key, unwrap_group_key, PermissionChecker,
+    restore_member_context_identities, save_group_meta, set_local_gov_nonce, store_group_key,
+    unwrap_group_key, PermissionChecker,
 };
 
 /// Side effect returned by namespace-op application when an existing
@@ -293,6 +295,31 @@ impl<'a> NamespaceGovernance<'a> {
                                 group_id: group_id_typed.to_bytes(),
                                 joiner_pk: *member,
                             });
+                        }
+                        // Local rejoiner recovery: if THIS node IS the
+                        // joiner (its namespace identity matches `member`),
+                        // restore any per-context `ContextIdentity` rows
+                        // that a prior `MemberLeft` cascade deleted.
+                        // Mirrors the `MemberAdded` arm in `mod.rs`. On
+                        // peers where the local namespace identity differs
+                        // from `member`, this is a no-op. On first-time
+                        // inheritance joiners the row may not exist yet —
+                        // we write it so the joiner can author state-DAG
+                        // ops as soon as `KeyDelivery` populates
+                        // `sender_key`. Idempotent: an existing row from
+                        // a prior `join_context` is left untouched.
+                        let ns_gid = ContextGroupId::from(op.namespace_id);
+                        if let Some((local_pk, sk_bytes, _)) =
+                            get_namespace_identity(self.store, &ns_gid)?
+                        {
+                            if local_pk == *member {
+                                restore_member_context_identities(
+                                    self.store,
+                                    &group_id_typed,
+                                    member,
+                                    sk_bytes,
+                                )?;
+                            }
                         }
                     }
                     _ => {}

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -18,7 +18,7 @@ use crate::op_events::{notify as notify_op_event, OpEvent};
 
 use super::{
     add_group_member, apply_group_op_mutations, clear_denied, decrypt_group_op,
-    get_local_gov_nonce, get_namespace_identity, get_namespace_identity_record, is_group_admin,
+    get_local_gov_nonce, get_namespace_identity_record, is_group_admin,
     is_group_admin_or_has_capability, load_current_group_key_record, load_group_key_by_id,
     load_group_meta,
     namespace_dag::{NamespaceDagService, NamespaceHead},
@@ -315,31 +315,23 @@ impl<'a> NamespaceGovernance<'a> {
                         // sync diverges in the kick/leave-rejoin e2e.
                         // Idempotent on a member who was never denied.
                         clear_denied(self.store, &group_id_typed, member)?;
-                        // Local rejoiner recovery: if THIS node IS the
-                        // joiner (its namespace identity matches `member`),
-                        // restore any per-context `ContextIdentity` rows
-                        // that a prior `MemberLeft` cascade deleted.
-                        // Mirrors the `MemberAdded` arm in `mod.rs`. On
-                        // peers where the local namespace identity differs
-                        // from `member`, this is a no-op. On first-time
-                        // inheritance joiners the row may not exist yet —
-                        // we write it so the joiner can author state-DAG
-                        // ops as soon as `KeyDelivery` populates
-                        // `sender_key`. Idempotent: an existing row from
-                        // a prior `join_context` is left untouched.
-                        let ns_gid = ContextGroupId::from(op.namespace_id);
-                        if let Some((local_pk, sk_bytes, _)) =
-                            get_namespace_identity(self.store, &ns_gid)?
-                        {
-                            if local_pk == *member {
-                                restore_member_context_identities(
-                                    self.store,
-                                    &group_id_typed,
-                                    member,
-                                    sk_bytes,
-                                )?;
-                            }
-                        }
+                        // Local rejoiner recovery: restore any per-context
+                        // `ContextIdentity` rows that a prior `MemberLeft`
+                        // cascade deleted. The local-rejoiner anti-spoof
+                        // gate is enforced inside
+                        // `restore_member_context_identities` — on peers
+                        // whose namespace identity differs from `member`
+                        // it is a no-op. On first-time inheritance joiners
+                        // the row may not exist yet — it is written so the
+                        // joiner can author state-DAG ops as soon as
+                        // `KeyDelivery` populates `sender_key`. Idempotent:
+                        // an existing row from a prior `join_context` is
+                        // left untouched.
+                        restore_member_context_identities(
+                            self.store,
+                            &group_id_typed,
+                            member,
+                        )?;
                     }
                     _ => {}
                 }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3723,6 +3723,243 @@ fn recursive_remove_nonexistent_member_returns_empty() {
 }
 
 // -----------------------------------------------------------------------
+// restore_member_context_identities — local rejoiner ContextIdentity
+// recovery on `MemberAdded` / `MemberJoinedOpen` apply. The cascade
+// helper at `cascade_remove_member_from_group_tree` deletes per-context
+// `ContextIdentity` rows for the leaver/removed member; the rejoin
+// arms must invert that on the local rejoiner's node so the rejoiner
+// can author state-DAG ops again. Other peers don't hold a row for
+// the rejoiner (only the rejoiner's own store does), so this restore
+// is a no-op everywhere except on the local rejoiner.
+// -----------------------------------------------------------------------
+
+#[test]
+fn restore_member_context_identities_writes_missing_rows() {
+    let store = test_store();
+    let gid = test_group_id();
+    let member = PublicKey::from([0x21; 32]);
+    let sk_bytes = [0x99u8; 32];
+    let ctx_a = ContextId::from([0xC1; 32]);
+    let ctx_b = ContextId::from([0xC2; 32]);
+
+    register_context_in_group(&store, &gid, &ctx_a).unwrap();
+    register_context_in_group(&store, &gid, &ctx_b).unwrap();
+
+    restore_member_context_identities(&store, &gid, &member, sk_bytes).unwrap();
+
+    let handle = store.handle();
+    for ctx in [&ctx_a, &ctx_b] {
+        let key = calimero_store::key::ContextIdentity::new(*ctx, member.into());
+        let row = handle.get(&key).unwrap().expect("row should be created");
+        assert_eq!(
+            row.private_key,
+            Some(sk_bytes),
+            "private_key must be the local rejoiner's namespace sk"
+        );
+        assert_eq!(
+            row.sender_key, None,
+            "sender_key starts None; KeyDelivery populates it"
+        );
+    }
+}
+
+#[test]
+fn restore_member_context_identities_is_idempotent() {
+    let store = test_store();
+    let gid = test_group_id();
+    let member = PublicKey::from([0x22; 32]);
+    let original_sk = [0x11u8; 32];
+    let original_sender = [0x44u8; 32];
+    let ctx = ContextId::from([0xD1; 32]);
+    register_context_in_group(&store, &gid, &ctx).unwrap();
+
+    // Pre-existing row from a (notional) successful prior `join_context`
+    // — already populated with a real sender_key from a delivered
+    // KeyDelivery. The restore must NOT overwrite it.
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &calimero_store::key::ContextIdentity::new(ctx, member.into()),
+                &calimero_store::types::ContextIdentity {
+                    private_key: Some(original_sk),
+                    sender_key: Some(original_sender),
+                },
+            )
+            .unwrap();
+    }
+
+    let bogus_sk = [0xFFu8; 32]; // restore would write this if it overwrote
+    restore_member_context_identities(&store, &gid, &member, bogus_sk).unwrap();
+
+    let handle = store.handle();
+    let row = handle
+        .get(&calimero_store::key::ContextIdentity::new(
+            ctx,
+            member.into(),
+        ))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.private_key,
+        Some(original_sk),
+        "existing private_key must be preserved (no overwrite)"
+    );
+    assert_eq!(
+        row.sender_key,
+        Some(original_sender),
+        "existing sender_key must be preserved (would clobber an already-delivered key otherwise)"
+    );
+}
+
+#[test]
+fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    // The local rejoiner: their namespace identity is stored. Note
+    // `gid` here is treated as both the group and the namespace root —
+    // for a real subgroup the resolve_namespace walk would find the
+    // parent, but for this unit test gid IS the namespace.
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+    let member_sk_bytes = *member_sk;
+    store_namespace_identity(&store, &gid, &member_pk, &member_sk_bytes, &[0u8; 32]).unwrap();
+
+    // Pre-state: member already added once + has ContextIdentity for
+    // the context, then admin removes them which cascades the row
+    // delete. Simulate by adding via add_group_member, registering the
+    // context, writing the ContextIdentity directly, then issuing
+    // MemberRemoved (which cascade-deletes).
+    add_group_member(&store, &gid, &member_pk, GroupMemberRole::Member).unwrap();
+    let ctx = ContextId::from([0xE7; 32]);
+    register_context_in_group(&store, &gid, &ctx).unwrap();
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &calimero_store::key::ContextIdentity::new(ctx, member_pk.into()),
+                &calimero_store::types::ContextIdentity {
+                    private_key: Some(member_sk_bytes),
+                    sender_key: Some([0x77; 32]),
+                },
+            )
+            .unwrap();
+    }
+
+    let removed = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes,
+        vec![],
+        [0u8; 32],
+        1,
+        dummy_member_removed_op(member_pk),
+    )
+    .unwrap();
+    apply_local_signed_group_op(&store, &removed).unwrap();
+
+    // Confirm cascade ran — row gone.
+    {
+        let handle = store.handle();
+        let key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+        assert!(
+            !handle.has(&key).unwrap(),
+            "cascade must have deleted the ContextIdentity row"
+        );
+    }
+
+    // Re-add via signed MemberAdded — the apply arm must invoke the
+    // restore on the local rejoiner.
+    let readded = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes,
+        vec![],
+        [0u8; 32],
+        2,
+        GroupOp::MemberAdded {
+            member: member_pk,
+            role: GroupMemberRole::Member,
+        },
+    )
+    .unwrap();
+    apply_local_signed_group_op(&store, &readded).unwrap();
+
+    let handle = store.handle();
+    let key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+    let row = handle
+        .get(&key)
+        .unwrap()
+        .expect("MemberAdded apply must restore ContextIdentity for local rejoiner");
+    assert_eq!(
+        row.private_key,
+        Some(member_sk_bytes),
+        "row must carry the rejoiner's namespace sk so they can sign again"
+    );
+    assert_eq!(
+        row.sender_key, None,
+        "sender_key starts None — KeyDelivery will populate"
+    );
+}
+
+#[test]
+fn member_added_does_nothing_for_non_rejoiner_peers() {
+    // On peers whose local namespace identity is NOT the rejoiner,
+    // applying MemberAdded must NOT create a ContextIdentity row for
+    // the rejoiner — those peers would write a row claiming to own a
+    // private key they don't have, which would let them spoof state-
+    // DAG ops as the rejoiner.
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    // This node IS the admin — its namespace identity is admin_pk, not
+    // the rejoiner's pk.
+    let admin_sk_bytes = *admin_sk;
+    store_namespace_identity(&store, &gid, &admin_pk, &admin_sk_bytes, &[0u8; 32]).unwrap();
+
+    let rejoiner_pk = PrivateKey::random(&mut rng).public_key();
+    let ctx = ContextId::from([0xE8; 32]);
+    register_context_in_group(&store, &gid, &ctx).unwrap();
+
+    let added = SignedGroupOp::sign(
+        &admin_sk,
+        gid.to_bytes(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::MemberAdded {
+            member: rejoiner_pk,
+            role: GroupMemberRole::Member,
+        },
+    )
+    .unwrap();
+    apply_local_signed_group_op(&store, &added).unwrap();
+
+    let handle = store.handle();
+    let key = calimero_store::key::ContextIdentity::new(ctx, rejoiner_pk.into());
+    assert!(
+        !handle.has(&key).unwrap(),
+        "non-rejoiner peers must NOT create a ContextIdentity row for someone else"
+    );
+}
+
+// -----------------------------------------------------------------------
 // create_recursive_invitations / collect_visible_descendant_groups —
 // recursive namespace invitations must not leak into (or even enumerate)
 // private subgroups the inviter cannot see.

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -2435,6 +2435,59 @@ fn enumerate_inherited_members_includes_open_subgroup_joiner() {
 }
 
 #[test]
+fn enumerate_inherited_members_excludes_deny_listed_member() {
+    // A member kicked from an Open subgroup via `MemberRemoved` /
+    // `MemberLeft` is deny-listed on that subgroup. Because the kick
+    // cannot delete a row that does not exist (the member is there by
+    // namespace-level inheritance), the deny-list IS the removal.
+    // `enumerate_inherited_members` — and therefore `list_group_members`
+    // — must exclude the deny-listed member so an admin who kicks
+    // someone no longer sees them in the channel's member list.
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    let store = test_store();
+    let namespace = ContextGroupId::from([0x38; 32]);
+    let reports = ContextGroupId::from([0x39; 32]);
+    let bob = PublicKey::from([0x02; 32]);
+
+    nest_for_test(&store, &namespace, &reports);
+    add_group_member(&store, &namespace, &bob, GroupMemberRole::Member).unwrap();
+    set_member_capability(
+        &store,
+        &namespace,
+        &bob,
+        MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS,
+    )
+    .unwrap();
+    set_subgroup_visibility(&store, &reports, VisibilityMode::Open).unwrap();
+
+    // Pre-kick: Bob is an inherited member of `reports`.
+    let inherited = enumerate_inherited_members(&store, &reports).unwrap();
+    assert!(
+        inherited.iter().any(|(pk, _)| *pk == bob),
+        "precondition: Bob inherits membership of the Open subgroup"
+    );
+
+    // Kick: deny-list Bob on `reports` (what `MemberRemoved` /
+    // `MemberLeft` apply does for a subgroup-level removal).
+    mark_denied(&store, &reports, &bob).unwrap();
+
+    let after_kick = enumerate_inherited_members(&store, &reports).unwrap();
+    assert!(
+        after_kick.iter().all(|(pk, _)| *pk != bob),
+        "deny-listed (kicked) member must NOT appear as an inherited member, got {after_kick:?}"
+    );
+
+    // Rejoin clears the deny-list — Bob reappears.
+    clear_denied(&store, &reports, &bob).unwrap();
+    let after_rejoin = enumerate_inherited_members(&store, &reports).unwrap();
+    assert!(
+        after_rejoin.iter().any(|(pk, _)| *pk == bob),
+        "after clear_denied (rejoin) Bob must reappear as an inherited member"
+    );
+}
+
+#[test]
 fn enumerate_inherited_members_reports_inherited_admin_role() {
     use calimero_context_config::VisibilityMode;
 

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3911,6 +3911,214 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
 }
 
 #[test]
+fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_namespace() {
+    // The first integration test conflates `gid` as both group and
+    // namespace, which means `resolve_namespace(group_id)` returns
+    // `gid` itself (no parent walk) and the test does not exercise
+    // the subgroup case. This test sets up a real namespace+subgroup
+    // pair where the subgroup's resolved namespace is a different
+    // ContextGroupId — pinning that the namespace-identity lookup at
+    // the resolved namespace (not at `group_id`) correctly gates the
+    // restore. This is the variant that mirrors the e2e workflow
+    // shape (admin-add to a child subgroup, member rejoins after
+    // remove).
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+
+    // namespace (root) ── subgroup
+    let ns_gid = ContextGroupId::from([0xD0; 32]);
+    let subgroup = ContextGroupId::from([0xD1; 32]);
+    nest_group(&store, &ns_gid, &subgroup).unwrap();
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
+    save_group_meta(&store, &subgroup, &sample_meta_with_admin(admin_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &subgroup, &admin_pk, GroupMemberRole::Admin).unwrap();
+
+    // Local rejoiner: namespace identity is stored under the NAMESPACE
+    // id (not the subgroup id). The MemberAdded apply for the subgroup
+    // must call `resolve_namespace(subgroup)` → `ns_gid` and then read
+    // the namespace identity from there.
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+    let member_sk_bytes: [u8; 32] = *member_sk;
+    store_namespace_identity(&store, &ns_gid, &member_pk, &member_sk_bytes, &[0u8; 32]).unwrap();
+
+    // Pre-state: member was a direct subgroup member with a context
+    // identity, then admin removed them which cascade-deleted the row.
+    add_group_member(&store, &subgroup, &member_pk, GroupMemberRole::Member).unwrap();
+    let ctx = ContextId::from([0xE9; 32]);
+    register_context_in_group(&store, &subgroup, &ctx).unwrap();
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &calimero_store::key::ContextIdentity::new(ctx, member_pk.into()),
+                &calimero_store::types::ContextIdentity {
+                    private_key: Some(member_sk_bytes),
+                    sender_key: Some([0x33; 32]),
+                },
+            )
+            .unwrap();
+    }
+    let removed = SignedGroupOp::sign(
+        &admin_sk,
+        subgroup.to_bytes(),
+        vec![],
+        [0u8; 32],
+        1,
+        dummy_member_removed_op(member_pk),
+    )
+    .unwrap();
+    apply_local_signed_group_op(&store, &removed).unwrap();
+    let id_key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+    assert!(
+        !store.handle().has(&id_key).unwrap(),
+        "cascade must have deleted the ContextIdentity row before the rejoin test"
+    );
+
+    // Re-add via signed MemberAdded targeting the SUBGROUP. The apply
+    // arm must resolve the namespace from `subgroup` (yielding
+    // `ns_gid`), look up the namespace identity there, and find a
+    // match — only then does the restore run.
+    let readded = SignedGroupOp::sign(
+        &admin_sk,
+        subgroup.to_bytes(),
+        vec![],
+        [0u8; 32],
+        2,
+        GroupOp::MemberAdded {
+            member: member_pk,
+            role: GroupMemberRole::Member,
+        },
+    )
+    .unwrap();
+    apply_local_signed_group_op(&store, &readded).unwrap();
+
+    let row = store
+        .handle()
+        .get(&id_key)
+        .unwrap()
+        .expect("ContextIdentity row must be restored when group_id ≠ namespace_id");
+    assert_eq!(row.private_key, Some(member_sk_bytes));
+    assert_eq!(row.sender_key, None);
+}
+
+#[test]
+fn member_joined_open_clears_deny_list_and_restores_context_identity() {
+    // The cursor[bot] HIGH-SEVERITY finding pinned by an integration
+    // test: when `MemberJoinedOpen` applies, it must (a) `clear_denied`
+    // for the rejoiner on the subgroup so peers stop dropping their
+    // state-deltas, and (b) restore the rejoiner's `ContextIdentity`
+    // row on the local rejoiner so they can author state-deltas at
+    // all. Pre-fix the apply arm did neither — the kick→inheritance-
+    // rejoin and leave→inheritance-rejoin e2e flows hung in
+    // post-rejoin sync because the rejoiner's writes were dropped at
+    // every peer's deny-list filter.
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+
+    // Namespace + Open subgroup + context structure:
+    //   namespace (root) ── Open subgroup ── context
+    let ns_id = [0xA0u8; 32];
+    let ns_gid = ContextGroupId::from(ns_id);
+    let subgroup = ContextGroupId::from([0xA1u8; 32]);
+    let ctx = ContextId::from([0xC1u8; 32]);
+
+    // Admin is needed for the `is_group_admin_or_has_capability`
+    // membership-policy gates (CAN_INVITE etc.) even though this
+    // particular op only checks `MembershipPath::Inherited`.
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(admin_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &admin_pk, GroupMemberRole::Admin).unwrap();
+    save_group_meta(&store, &subgroup, &sample_meta_with_admin(admin_pk)).unwrap();
+    add_group_member(&store, &subgroup, &admin_pk, GroupMemberRole::Admin).unwrap();
+    nest_group(&store, &ns_gid, &subgroup).unwrap();
+    set_subgroup_visibility(&store, &subgroup, VisibilityMode::Open).unwrap();
+    register_context_in_group(&store, &subgroup, &ctx).unwrap();
+
+    // Rejoiner: direct namespace member with CAN_JOIN_OPEN_SUBGROUPS,
+    // not a direct subgroup member (post-leave / post-kick state).
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+    let member_sk_bytes: [u8; 32] = *member_sk;
+    add_group_member(&store, &ns_gid, &member_pk, GroupMemberRole::Member).unwrap();
+    set_member_capability(
+        &store,
+        &ns_gid,
+        &member_pk,
+        MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS,
+    )
+    .unwrap();
+
+    // Pre-state from a prior MemberLeft cascade: deny-list stamped,
+    // ContextIdentity row deleted on the local rejoiner.
+    mark_denied(&store, &subgroup, &member_pk).unwrap();
+    assert!(is_denied(&store, &subgroup, &member_pk).unwrap());
+    let id_key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+    assert!(!store.handle().has(&id_key).unwrap());
+
+    // The local node IS the rejoiner — its namespace identity matches
+    // `member_pk`. Without this gate the `restore_member_context_identities`
+    // call would no-op (correctly — peers don't own the rejoiner's sk).
+    store_namespace_identity(&store, &ns_gid, &member_pk, &member_sk_bytes, &[0u8; 32]).unwrap();
+
+    // Sign + apply a fresh `MemberJoinedOpen` for the rejoiner.
+    let signed = SignedNamespaceOp::sign(
+        &member_sk,
+        ns_id,
+        vec![],
+        [0u8; 32],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoinedOpen {
+            member: member_pk,
+            group_id: subgroup.to_bytes(),
+        }),
+    )
+    .unwrap();
+    apply_signed_namespace_op(&store, &signed).unwrap();
+
+    // Assertion 1: deny-list cleared at the subgroup. This is
+    // critical for peers — without it they continue dropping the
+    // rejoiner's state-delta gossip at the receive filter.
+    assert!(
+        !is_denied(&store, &subgroup, &member_pk).unwrap(),
+        "MemberJoinedOpen apply MUST clear the per-subgroup deny-list \
+         entry so peers stop dropping the rejoiner's state-deltas"
+    );
+
+    // Assertion 2: ContextIdentity row restored with the rejoiner's
+    // namespace sk. Without this the local apply path cannot author
+    // state-DAG ops for any context under the subgroup.
+    let row = store
+        .handle()
+        .get(&id_key)
+        .unwrap()
+        .expect("ContextIdentity row must be restored on the local rejoiner");
+    assert_eq!(
+        row.private_key,
+        Some(member_sk_bytes),
+        "row must carry the rejoiner's namespace sk"
+    );
+    assert_eq!(
+        row.sender_key, None,
+        "sender_key starts None — populated later by KeyDelivery"
+    );
+}
+
+#[test]
 fn member_added_does_nothing_for_non_rejoiner_peers() {
     // On peers whose local namespace identity is NOT the rejoiner,
     // applying MemberAdded must NOT create a ContextIdentity row for

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -2117,6 +2117,78 @@ fn check_membership_open_subgroup_inherits_parent_with_default_cap() {
     assert!(check_group_membership(&store, &child, &alice).unwrap());
 }
 
+// -----------------------------------------------------------------------
+// Capability-materialization ordering (PR #2368 root cause for the
+// `MemberJoinedOpen rejected: no membership path` e2e failure).
+//
+// `add_group_member` materializes a non-admin member's per-member
+// capability row by copying the group's `default_capabilities` — but
+// ONLY if those defaults are already set in the store. A member added
+// BEFORE the namespace default caps land therefore has no
+// `CAN_JOIN_OPEN_SUBGROUPS` bit on this node, and a later
+// `MemberJoinedOpen` from them fails `check_group_membership_path`.
+// The `join_group` handler now sets `default_capabilities` before the
+// catch-up apply so every `MemberJoined` in the batch materializes its
+// caps correctly; these two tests pin the underlying invariant.
+// -----------------------------------------------------------------------
+
+#[test]
+fn check_membership_path_inherited_when_member_added_after_default_caps() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    let store = test_store();
+    let ns = ContextGroupId::from([0xB4; 32]);
+    let child = ContextGroupId::from([0xB5; 32]);
+    let bob = PublicKey::from([0x02; 32]);
+
+    nest_for_test(&store, &ns, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Open).unwrap();
+
+    // Correct ordering: default caps set FIRST, then the member is
+    // added — `add_group_member` copies the default into bob's
+    // per-member capability row.
+    set_default_capabilities(&store, &ns, MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS).unwrap();
+    add_group_member(&store, &ns, &bob, GroupMemberRole::Member).unwrap();
+
+    let path = check_group_membership_path(&store, &child, &bob).unwrap();
+    assert!(
+        matches!(path, MembershipPath::Inherited { .. }),
+        "member added after default caps must inherit Open-subgroup membership, got {path:?}"
+    );
+}
+
+#[test]
+fn check_membership_path_none_when_member_added_before_default_caps() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    let store = test_store();
+    let ns = ContextGroupId::from([0xB6; 32]);
+    let child = ContextGroupId::from([0xB7; 32]);
+    let bob = PublicKey::from([0x02; 32]);
+
+    nest_for_test(&store, &ns, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Open).unwrap();
+
+    // Buggy ordering (what the pre-fix `join_group` catch-up did when a
+    // node caught up on an earlier member's `MemberJoined` before its
+    // own `set_default_capabilities` ran): member added while default
+    // caps are still unset → no per-member capability row is written.
+    add_group_member(&store, &ns, &bob, GroupMemberRole::Member).unwrap();
+    set_default_capabilities(&store, &ns, MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS).unwrap();
+
+    // The later `set_default_capabilities` does NOT retroactively
+    // materialize bob's per-member cap, so the inheritance check still
+    // returns `None`. This is exactly the state that produced
+    // `MemberJoinedOpen rejected: no membership path` on the
+    // later-joining peer; the `join_group` handler fix prevents it by
+    // ordering `set_default_capabilities` before the catch-up apply.
+    let path = check_group_membership_path(&store, &child, &bob).unwrap();
+    assert!(
+        matches!(path, MembershipPath::None),
+        "member added before default caps has no per-member cap row → no inherited path, got {path:?}"
+    );
+}
+
 #[test]
 fn check_membership_restricted_subgroup_does_not_inherit() {
     use calimero_context_config::{MemberCapabilities, VisibilityMode};

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3949,7 +3949,13 @@ fn restore_member_context_identities_writes_missing_rows() {
     register_context_in_group(&store, &gid, &ctx_a).unwrap();
     register_context_in_group(&store, &gid, &ctx_b).unwrap();
 
-    restore_member_context_identities(&store, &gid, &member, sk_bytes).unwrap();
+    // The internal anti-spoof gate reads THIS node's namespace identity
+    // (via `resolve_namespace(gid)` → `gid` itself, since the test gid
+    // has no parent). Storing it for `member` makes this node the
+    // local rejoiner; the function then derives `private_key` from it.
+    store_namespace_identity(&store, &gid, &member, &sk_bytes, &[0u8; 32]).unwrap();
+
+    restore_member_context_identities(&store, &gid, &member).unwrap();
 
     let handle = store.handle();
     for ctx in [&ctx_a, &ctx_b] {
@@ -3958,13 +3964,45 @@ fn restore_member_context_identities_writes_missing_rows() {
         assert_eq!(
             row.private_key,
             Some(sk_bytes),
-            "private_key must be the local rejoiner's namespace sk"
+            "private_key must be derived from the local rejoiner's namespace identity"
         );
         assert_eq!(
             row.sender_key, None,
             "sender_key starts None; KeyDelivery populates it"
         );
     }
+}
+
+#[test]
+fn restore_member_context_identities_no_op_when_not_local_rejoiner() {
+    // The internal anti-spoof gate: a node whose stored namespace
+    // identity is NOT `member` must not write a `private_key: Some(_)`
+    // row for `member` — that would let it spoof state-DAG ops as the
+    // rejoiner. With no namespace identity stored at all, the function
+    // is likewise a no-op.
+    let store = test_store();
+    let gid = test_group_id();
+    let member = PublicKey::from([0x21; 32]);
+    let someone_else = PublicKey::from([0x42; 32]);
+    let ctx = ContextId::from([0xC3; 32]);
+    register_context_in_group(&store, &gid, &ctx).unwrap();
+
+    // No namespace identity at all → no-op.
+    restore_member_context_identities(&store, &gid, &member).unwrap();
+    let key = calimero_store::key::ContextIdentity::new(ctx, member.into());
+    assert!(
+        !store.handle().has(&key).unwrap(),
+        "no namespace identity stored → must not write a row"
+    );
+
+    // Namespace identity belongs to a different pk → still a no-op for
+    // `member`.
+    store_namespace_identity(&store, &gid, &someone_else, &[0x55; 32], &[0u8; 32]).unwrap();
+    restore_member_context_identities(&store, &gid, &member).unwrap();
+    assert!(
+        !store.handle().has(&key).unwrap(),
+        "namespace identity ≠ member → must not write a row for member"
+    );
 }
 
 #[test]
@@ -3976,6 +4014,10 @@ fn restore_member_context_identities_is_idempotent() {
     let original_sender = [0x44u8; 32];
     let ctx = ContextId::from([0xD1; 32]);
     register_context_in_group(&store, &gid, &ctx).unwrap();
+
+    // This node is the local rejoiner — namespace identity stored for
+    // `member`. The function will derive `original_sk` from it.
+    store_namespace_identity(&store, &gid, &member, &original_sk, &[0u8; 32]).unwrap();
 
     // Pre-existing row from a (notional) successful prior `join_context`
     // — already populated with a real sender_key from a delivered
@@ -3993,8 +4035,7 @@ fn restore_member_context_identities_is_idempotent() {
             .unwrap();
     }
 
-    let bogus_sk = [0xFFu8; 32]; // restore would write this if it overwrote
-    restore_member_context_identities(&store, &gid, &member, bogus_sk).unwrap();
+    restore_member_context_identities(&store, &gid, &member).unwrap();
 
     let handle = store.handle();
     let row = handle

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -4058,6 +4058,58 @@ fn restore_member_context_identities_is_idempotent() {
 }
 
 #[test]
+fn restore_member_context_identities_repairs_keyless_row() {
+    // A pre-existing row with `private_key: None` leaves the rejoiner
+    // unable to sign. The restore must REPAIR it (fill `private_key`)
+    // rather than skip it on the `has` check — while preserving any
+    // `sender_key` already delivered onto that row.
+    let store = test_store();
+    let gid = test_group_id();
+    let member = PublicKey::from([0x23; 32]);
+    let sk_bytes = [0x66u8; 32];
+    let delivered_sender = [0x77u8; 32];
+    let ctx = ContextId::from([0xD2; 32]);
+    register_context_in_group(&store, &gid, &ctx).unwrap();
+    store_namespace_identity(&store, &gid, &member, &sk_bytes, &[0u8; 32]).unwrap();
+
+    // Keyless row with a delivered sender_key — the shape a restore
+    // must repair without clobbering the sender_key.
+    {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &calimero_store::key::ContextIdentity::new(ctx, member.into()),
+                &calimero_store::types::ContextIdentity {
+                    private_key: None,
+                    sender_key: Some(delivered_sender),
+                },
+            )
+            .unwrap();
+    }
+
+    restore_member_context_identities(&store, &gid, &member).unwrap();
+
+    let row = store
+        .handle()
+        .get(&calimero_store::key::ContextIdentity::new(
+            ctx,
+            member.into(),
+        ))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.private_key,
+        Some(sk_bytes),
+        "keyless row must be repaired with the rejoiner's namespace sk"
+    );
+    assert_eq!(
+        row.sender_key,
+        Some(delivered_sender),
+        "an already-delivered sender_key must survive the repair"
+    );
+}
+
+#[test]
 fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
     use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
     use calimero_primitives::identity::PrivateKey;
@@ -4074,7 +4126,17 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
     // The local rejoiner: their namespace identity is stored. Note
     // `gid` here is treated as both the group and the namespace root —
     // for a real subgroup the resolve_namespace walk would find the
-    // parent, but for this unit test gid IS the namespace.
+    // parent, but for this unit test gid IS the namespace. The
+    // subgroup-with-real-namespace variant is covered separately by
+    // `member_added_after_remove_restores_context_identity_for_subgroup_with_real_namespace`.
+    // Pin the flat-namespace assumption explicitly so a future change
+    // to `resolve_namespace` that breaks the no-parent case is caught
+    // here rather than silently passing.
+    assert_eq!(
+        resolve_namespace(&store, &gid).unwrap(),
+        gid,
+        "flat-namespace test precondition: gid must resolve to itself"
+    );
     let member_sk = PrivateKey::random(&mut rng);
     let member_pk = member_sk.public_key();
     let member_sk_bytes = *member_sk;

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -167,6 +167,39 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     info!("received group key via direct join response");
                 }
 
+                // Issue #2256 / PR #2368: write the namespace's
+                // `default_capabilities` from the join bundle BEFORE
+                // applying the catch-up governance ops below.
+                //
+                // The catch-up batch contains the `MemberJoined` ops of
+                // OTHER members who joined before us. Each one runs
+                // `add_group_member` → `add_group_member_with_keys`,
+                // which materializes that member's per-member
+                // capability row by copying `default_capabilities` — but
+                // ONLY if `default_capabilities` is already set in the
+                // local store. If we set it afterwards (the previous
+                // ordering), every member applied during catch-up was
+                // recorded with NO per-member capability row, so a later
+                // `MemberJoinedOpen` from them failed
+                // `check_group_membership_path` with "no membership
+                // path" (their `CAN_JOIN_OPEN_SUBGROUPS` bit was never
+                // materialized on this node). Setting it first fixes
+                // that for the catch-up apply AND the `sync_namespace`
+                // pull below.
+                //
+                // A `DefaultCapabilitiesSet` op inside the catch-up
+                // batch still wins: it is applied after this write and
+                // overwrites the bundle value (authoritative-op-wins).
+                // The `is_none()` guard keeps this a no-op when a prior
+                // op already set the value.
+                if group_store::get_default_capabilities(&datastore, &group_id)?.is_none() {
+                    group_store::set_default_capabilities(
+                        &datastore,
+                        &group_id,
+                        join_result.default_capabilities,
+                    )?;
+                }
+
                 // Apply governance ops so the local DAG is up to date.
                 //
                 // Note on dropped divergence reports: the `divergence`
@@ -219,30 +252,11 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     );
                 }
 
-                // Issue #2256: write the namespace's `default_capabilities`
-                // from the bundle if no governance op set it. Governance
-                // ops are authoritative when present (they were applied
-                // above); the bundle's value is a fallback for the case
-                // where `create_group` populated defaults locally but
-                // never published a `DefaultCapabilitiesSet` op (today's
-                // codebase). Doing this *before* `add_group_member`
-                // ensures the joiner's individual capability inherits
-                // the right default — and reflects any admin-issued
-                // override that travelled in the bundle, closing the
-                // race where a stale joiner-side hard-coded constant
-                // could otherwise override admin intent.
-                if group_store::get_default_capabilities(&datastore, &group_id)?.is_none() {
-                    group_store::set_default_capabilities(
-                        &datastore,
-                        &group_id,
-                        join_result.default_capabilities,
-                    )?;
-                }
-
                 // Add the joiner as a direct member of the namespace. The
                 // call reads `default_capabilities` from the local store
-                // (just populated above) and assigns the bit set to the
-                // new member. Idempotent on the *direct*-row check — the
+                // (populated before the catch-up apply above) and assigns
+                // the bit set to the new member. Idempotent on the
+                // *direct*-row check — the
                 // inheritance-aware `check_group_membership` would
                 // wrongly skip the add when the joiner already inherits
                 // membership from a parent namespace, leaving them

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4230,17 +4230,28 @@ impl SyncManager {
             }
         }
 
-        // No peer yielded the key. Surface the most informative cause.
+        // No peer yielded the key. Surface the most informative cause,
+        // always including the full per-peer tally so a mixed failure
+        // (some peers key-less, one peer rejecting, some transport
+        // errors) is fully diagnosable from a single line.
+        let tally = format!(
+            "{} peer(s): {} key-less, {} transport error(s)",
+            peers.len(),
+            keyless_peers,
+            transport_errors
+        );
         if let Some(reason) = last_rejection {
-            eyre::bail!("open-subgroup join rejected by all peers: {}", reason);
+            eyre::bail!(
+                "open-subgroup join for {} served by no peer — last rejection: {} [{}]",
+                hex::encode(params.subgroup_id),
+                reason,
+                tally
+            );
         }
         eyre::bail!(
-            "no mesh peer held the subgroup key for {} \
-             ({} key-less peer(s), {} transport error(s) across {} peer(s))",
+            "no mesh peer held the subgroup key for {} [{}]",
             hex::encode(params.subgroup_id),
-            keyless_peers,
-            transport_errors,
-            peers.len()
+            tally
         );
     }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4123,58 +4123,125 @@ impl SyncManager {
             }
         }
 
-        let peer = peers.first().ok_or_else(|| {
-            eyre::eyre!(
+        if peers.is_empty() {
+            eyre::bail!(
                 "no mesh peers for namespace {} (open-subgroup join)",
                 hex::encode(params.namespace_id)
-            )
-        })?;
+            );
+        }
 
-        let mut stream = self
-            .network_client
-            .open_stream(*peer)
-            .await
-            .wrap_err("open stream for open-subgroup join")?;
+        // Try every mesh peer, not just the first. Only peers that
+        // already hold the subgroup key can serve the request — for an
+        // `Open` subgroup that is the creator plus anyone who has
+        // already inherited in. A freshly-joined namespace member
+        // (which is also on the `ns/<hex>` topic) replies with an empty
+        // envelope ("responder did not hold the subgroup key"); picking
+        // `peers.first()` would fail the whole join whenever that peer
+        // happened to be key-less. Walk the list: return on the first
+        // peer that yields a key, skip key-less peers, and remember the
+        // last authorization rejection so it surfaces if NO peer
+        // accepts (a rejection from one peer can be a stale cold-start
+        // view while another peer accepts).
+        let mut last_rejection: Option<String> = None;
+        let mut keyless_peers = 0usize;
+        let mut transport_errors = 0usize;
 
-        let msg = StreamMessage::Init {
-            context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
-            party_id: params.joiner_public_key,
-            payload: InitPayload::OpenSubgroupJoinRequest {
-                namespace_id: params.namespace_id,
-                subgroup_id: params.subgroup_id,
-                joiner_public_key: params.joiner_public_key,
-            },
-            next_nonce: rand::thread_rng().gen(),
-        };
-
-        super::stream::send(&mut stream, &msg, None).await?;
-
-        match super::stream::recv(&mut stream, None, self.sync_config.timeout).await? {
-            Some(StreamMessage::Message {
-                payload: MessagePayload::OpenSubgroupJoinResponse { key_envelope_bytes },
-                ..
-            }) => {
-                if key_envelope_bytes.is_empty() {
-                    eyre::bail!(
-                        "responder did not hold the subgroup key for {}",
-                        hex::encode(params.subgroup_id)
+        for peer in &peers {
+            let mut stream = match self.network_client.open_stream(*peer).await {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!(
+                        peer = %peer,
+                        subgroup_id = %hex::encode(params.subgroup_id),
+                        error = %e,
+                        "open-subgroup join: failed to open stream, trying next peer"
                     );
+                    transport_errors += 1;
+                    continue;
                 }
-                Ok(key_envelope_bytes)
+            };
+
+            let msg = StreamMessage::Init {
+                context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
+                party_id: params.joiner_public_key,
+                payload: InitPayload::OpenSubgroupJoinRequest {
+                    namespace_id: params.namespace_id,
+                    subgroup_id: params.subgroup_id,
+                    joiner_public_key: params.joiner_public_key,
+                },
+                next_nonce: rand::thread_rng().gen(),
+            };
+
+            if let Err(e) = super::stream::send(&mut stream, &msg, None).await {
+                debug!(
+                    peer = %peer,
+                    error = %e,
+                    "open-subgroup join: send failed, trying next peer"
+                );
+                transport_errors += 1;
+                continue;
             }
-            Some(StreamMessage::Message {
-                payload: MessagePayload::OpenSubgroupJoinRejected { reason },
-                ..
-            }) => {
-                eyre::bail!("open-subgroup join rejected: {}", reason)
-            }
-            other => {
-                eyre::bail!(
-                    "unexpected response to open-subgroup join request: {:?}",
-                    other.as_ref().map(|m| std::mem::discriminant(m))
-                )
+
+            match super::stream::recv(&mut stream, None, self.sync_config.timeout).await {
+                Ok(Some(StreamMessage::Message {
+                    payload: MessagePayload::OpenSubgroupJoinResponse { key_envelope_bytes },
+                    ..
+                })) => {
+                    if key_envelope_bytes.is_empty() {
+                        // Peer is on the namespace topic but doesn't
+                        // hold the subgroup key — try the next one.
+                        keyless_peers += 1;
+                        continue;
+                    }
+                    return Ok(key_envelope_bytes);
+                }
+                Ok(Some(StreamMessage::Message {
+                    payload: MessagePayload::OpenSubgroupJoinRejected { reason },
+                    ..
+                })) => {
+                    // A rejection may be a stale cold-start view on this
+                    // peer; keep trying others before surfacing it.
+                    debug!(
+                        peer = %peer,
+                        reason = %reason,
+                        "open-subgroup join: peer rejected, trying next peer"
+                    );
+                    last_rejection = Some(reason);
+                    continue;
+                }
+                Ok(other) => {
+                    debug!(
+                        peer = %peer,
+                        "open-subgroup join: unexpected response {:?}, trying next peer",
+                        other.as_ref().map(std::mem::discriminant)
+                    );
+                    transport_errors += 1;
+                    continue;
+                }
+                Err(e) => {
+                    debug!(
+                        peer = %peer,
+                        error = %e,
+                        "open-subgroup join: recv failed, trying next peer"
+                    );
+                    transport_errors += 1;
+                    continue;
+                }
             }
         }
+
+        // No peer yielded the key. Surface the most informative cause.
+        if let Some(reason) = last_rejection {
+            eyre::bail!("open-subgroup join rejected by all peers: {}", reason);
+        }
+        eyre::bail!(
+            "no mesh peer held the subgroup key for {} \
+             ({} key-less peer(s), {} transport error(s) across {} peer(s))",
+            hex::encode(params.subgroup_id),
+            keyless_peers,
+            transport_errors,
+            peers.len()
+        );
     }
 
     /// Collect all governance ops for a namespace (reused by the join responder).


### PR DESCRIPTION
## Summary

Bundles two narrow core fixes in `MemberAdded` / `MemberJoinedOpen` apply paths with the e2e workflows that surfaced why they were needed. Plus one residual gap (Bug 3 below) that the workflows now also surface — left for a follow-up because it's in the `#2367` family.

**Core fix 1 — `ContextIdentity` restored on rejoin.** When `MemberRemoved` / `MemberLeft` apply, `cascade_remove_member_from_group_tree` deletes the rejoiner's per-context signing identity rows. Pre-fix, `MemberAdded` (admin re-add) and `MemberJoinedOpen` (inheritance rejoin) didn't recreate them — the rejoiner's next write failed with `function call error: No owned identity found for this context`. Fix: symmetric `restore_member_context_identities` helper called from both apply arms, gated on local-namespace-identity match (anti-spoof — only the rejoiner's own node has the namespace `sk_bytes`).

**Core fix 2 — `clear_denied` on `MemberJoinedOpen`.** cursor[bot] HIGH-SEVERITY review finding, confirmed by node-3 logs: the sibling `MemberAdded` arm at `mod.rs:1215` and `MemberJoinedViaTeeAttestation` at `mod.rs:1502` clear the per-group deny-list when a member rejoins; `MemberJoinedOpen` was the missing third arm. Without it, even after Core fix 1 restored the local rejoiner's identity, peers continued to drop their state-delta gossip at the receive filter — symptom: `Post-rejoin sync` step diverges in the leave-rejoin-via-inheritance e2e workflow.

## What's in this PR

### Core (3 files)

| File | Change |
|---|---|
| `crates/context/src/group_store/contexts.rs` | New `restore_member_context_identities` helper — symmetric inverse of `cascade_remove_member_from_group_tree`. Doc explicitly calls out the local-rejoiner gate (anti-spoof) and the bounded-context-count assumption behind `usize::MAX`. |
| `crates/context/src/group_store/mod.rs` | `MemberAdded` apply arm calls helper, gated on local namespace identity match. |
| `crates/context/src/group_store/namespace_governance.rs` | `MemberJoinedOpen` apply side-effect block: unconditional `clear_denied` (runs on every peer) + gated `restore_member_context_identities` (runs on local rejoiner). |

### Unit tests (6 new, all pass; 188 group_store tests total)

| Test | Pins |
|---|---|
| `restore_member_context_identities_writes_missing_rows` | Helper happy path |
| `restore_member_context_identities_is_idempotent` | Helper preserves `Some(sender_key)` from a prior delivery |
| `member_added_after_remove_restores_context_identity_for_local_rejoiner` | Apply-path integration on flat (group=namespace) shape |
| `member_added_after_remove_restores_context_identity_for_subgroup_with_real_namespace` | Apply-path integration with real namespace+subgroup hierarchy where `resolve_namespace(group_id) ≠ group_id` (meroreviewer feedback) |
| `member_added_does_nothing_for_non_rejoiner_peers` | Anti-spoof guard — peers without the rejoiner's sk MUST NOT write `Some(_)` row |
| `member_joined_open_clears_deny_list_and_restores_context_identity` | End-to-end through `apply_signed_namespace_op` — pins both `clear_denied` AND `restore_member_context_identities` side-effects (cursor[bot] HIGH-severity coverage) |

### E2E coverage (5 workflows + matrix wiring)

| Workflow | Status (post-fix) |
|---|---|
| `group-private-add-then-write.yml` | ✅ already passed (regression guard for the post-#2351 admin-add KeyDelivery chain) |
| `group-kick-and-readd-deny-list.yml` | ✅ passed in last CI on commit `d9c372d2` (Option B's MemberAdded restore worked) |
| `group-leave-then-rejoin-via-inheritance.yml` | ⚠️ should now pass with Core fix 2 — still gated on Bug 3 below |
| `group-kick-and-rejoin-keyshare.yml` | ⚠️ should now pass with Core fix 2 — still gated on Bug 3 below |
| `group-remove-from-root-revokes-inherited.yml` | ❌ blocked on responder-side cold-start race per #2367 family |

### Workflow review-comment pass

* Added intermediate cross-peer negative-control read-back after every `expected_failure: true` write, with 5s gossip-drains.
* Cross-peer membership check on node-3 after kick (mirrors `group-leave-member.yml:122-133`).
* Fixed wrong `contains` → `not_contains` for post-inheritance-rejoin direct-row assertion (`MemberJoinedOpen` apply explicitly does NOT create a direct row — `namespace_governance.rs:1226-1245`).
* Symmetric "dropped-during-leave write was NOT delivered post-rejoin" assertion in `leave-rejoin` workflow.
* `private-add-then-write` negative-control timing: wait for `ContextRegistered` to propagate to node-3 before `expected_failure` join.
* Removed dead output captures (`node1_key`, `node2_inherit_pk`, `node3_inherit_pk`) flagged by meroreviewer.

## Bug 3 — known residual, not fixed in this PR

Logs from the leave-rejoin workflow on commit `d9c372d2` revealed a third bug beyond the two predicted ones:

```
namespace DAG apply error: Failed to apply delta: MemberJoinedOpen rejected:
  signer ... has no membership path to ContextGroupId(...)
  at crates/node/src/sync/manager/mod.rs:4169
```

Same family as the `OpenSubgroupJoinRequest` responder-side cold-start race (currently tracked under #2367). The sequence:

1. node-2 publishes `MemberJoinedOpen` after `join_subgroup_inheritance`.
2. node-3 receives it via gossipsub.
3. node-3's `execute_member_joined_open` runs `check_group_membership_path` against ITS local view of node-2's namespace membership.
4. node-3's view doesn't yet have node-2's namespace `MemberJoined` applied → returns `MembershipPath::None` → rejects.
5. Because the apply rejected, neither `clear_denied` nor `restore_member_context_identities` (this PR's fixes) ran on node-3.
6. node-3's deny-list remains stamped → drops the rejoiner's state-delta → post-rejoin sync diverges.

**The fix path for Bug 3** is the same as the publisher-side mesh-empty fix (PR #2369) is doing for the publisher case: a wait-and-retry or buffer-on-arrival mechanism in the responder when the membership-path check returns `None` for a recently-joined identity. Likely solved by:
- (a) PR #2369 indirectly — if the actual cause was that node-2's `MemberJoined` was dropped at the publisher-side mesh-empty drop site (before propagating to node-3); OR
- (b) An additional bullet on #2367 for the responder-side `execute_member_joined_open` apply-time wait — analogous to what would also fix `OpenSubgroupJoinRequest` at `sync/manager/mod.rs:4169` for the `remove-from-root-revokes-inherited` workflow.

Easiest verification: once #2369 merges, re-trigger this PR's CI. If `leave-rejoin-via-inheritance` AND `kick-and-rejoin-keyshare` start passing while `remove-from-root-revokes-inherited` continues to fail, Bug 3 was just the publisher-side drop. If all three continue to fail with `no membership path`, the responder-side wait-and-retry fix needs to land separately.

## Test plan

- [x] `cargo test -p calimero-context --lib` — 188 tests pass (was 186, +2 new).
- [x] All five workflow YAMLs lint clean under `merobox bootstrap validate` (modulo pre-existing 0.6.14 validator bug on `leave_group` step type).
- [ ] CI runs all five new workflows in matrix.
- [ ] Verify Core fix 1 + Core fix 2 land the predicted improvements (kick-readd was ✅ on `d9c372d2`; expect leave-rejoin and kick-rejoin to now also pass once Bug 3 is unblocked or unmasked).
- [ ] `group-remove-from-root-revokes-inherited.yml` continues to fail by design until #2367 family fix lands; confirms the gap-marker role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches membership/authorization and key distribution paths (deny-list handling, identity restoration, open-subgroup join selection), which can affect access control and message replication, but the change is targeted and backed by new unit + E2E coverage.
> 
> **Overview**
> Fixes rejoin regressions where a previously removed/left member could not author or replicate context updates after rejoining: adds `restore_member_context_identities` and invokes it on `MemberAdded` and `MemberJoinedOpen`, and ensures `MemberJoinedOpen` also clears the subgroup deny-list on all peers.
> 
> Improves correctness/observability around membership: inherited member enumeration now excludes deny-listed members, and `join_group` now persists `default_capabilities` *before* applying catch-up governance ops to avoid missing capability materialization.
> 
> Hardens open-subgroup keyshare join by trying all namespace mesh peers (handling key-less peers, transport errors, and rejections) instead of only the first, and adds several new `scaffolding-e2e` workflows (kick/readd, kick/rejoin, leave/rejoin, private add/write, root revocation) wired into the CI E2E matrix, alongside extensive new unit tests for the new restore/deny-list behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b2ca0366bae72dfd4a600dd1f2b131cb2596da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->