### PR TITLE
fix(context): include inherited members in list_group_members (#2371)

### DIFF
--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -15,6 +15,13 @@ description: >
        context under the subgroup to author *and* decrypt traffic
        successfully — i.e. the joiner's `sender_key` is populated and
        bidirectional read/write converges.
+    3. Surfaces the inherited joiner in `list_group_members` on their
+       own node — the effective-membership contract from issue #2371.
+       `join_subgroup_inheritance` writes no `GroupMember` row (the
+       apply path `execute_member_joined_open` is validate-only), so
+       before the fix `GET /admin-api/groups/<id>/members` returned
+       only the explicit members and apps keying "is the caller a
+       member?" off that list saw `false` for any inherited joiner.
 
   Pre-#2357 the only way to materialize the inherited path was to
   discover a child context id and call `join_context` against it
@@ -137,6 +144,34 @@ steps:
     type: json_assert
     statements:
       - 'json_equal({{inherit_was_inherited}}, true)'
+
+  # ── Phase 2b: list_group_members reflects the inherited joiner ────
+  # Issue #2371 regression. node-2 just joined `subgroup` via
+  # inheritance and has NOT yet called `join_context` — so it holds no
+  # explicit `GroupMember` row anywhere in the subgroup. Listing the
+  # subgroup members on node-2's own node must still include node-2:
+  # the admin-api handler unions the stored rows with
+  # `enumerate_inherited_members`. Before the fix this assertion fails
+  # — node-2's identity appeared only in `selfIdentity`, never in
+  # `members[]`.
+
+  - name: 'Node-2 lists subgroup members (issue #2371)'
+    type: list_group_members
+    node: join-inherit-node-2
+    group_id: '{{subgroup_id}}'
+    outputs:
+      subgroup_members: members
+
+  - name: Assert inherited joiner appears in the member list
+    type: assert
+    statements:
+      # node-2 joined `subgroup` via inheritance and holds no explicit
+      # `GroupMember` row. Before the #2371 fix it was absent from
+      # `members[]` (surfaced only in `selfIdentity`); the admin-api
+      # handler now unions inherited members in, so node-2's identity
+      # (`inherit_member_pk`, exported by the join-via-inheritance step)
+      # must appear in the listed members.
+      - 'contains({{subgroup_members}}, {{inherit_member_pk}})'
 
   # ── Phase 3: node-2 joins the context (key already delivered) ─────
   # This call should now be cheap because the group key is already

--- a/crates/context/src/group_store/membership.rs
+++ b/crates/context/src/group_store/membership.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use calimero_context_config::types::ContextGroupId;
 use calimero_context_config::{MemberCapabilities, VisibilityMode};
 use calimero_primitives::context::GroupMemberRole;
@@ -309,6 +311,100 @@ pub fn check_group_membership(
         check_group_membership_path(store, group_id, identity)?,
         MembershipPath::None,
     ))
+}
+
+/// Enumerate the identities that are members of `group_id` purely by
+/// inheritance — i.e. those with a [`MembershipPath::Inherited`] path
+/// and no stored `GroupMember` row in `group_id` itself.
+///
+/// This is the "list" dual of [`check_group_membership_path`]: rather
+/// than testing one identity, it walks the same `Open` parent-chain and
+/// collects every ancestor's direct members that resolve to `Inherited`
+/// for `group_id`. The role is `Admin` for an inherited-admin path
+/// (`via_admin`) and `Member` otherwise.
+///
+/// Callers union the result with [`list_group_members`] (the stored,
+/// explicit rows) to obtain the *effective* member set — the contract
+/// `check_group_membership` already honours. Membership is recomputed
+/// from current ancestor state on every call, so it never goes stale
+/// when an ancestor's visibility flips or a cap is revoked (issue
+/// #2371).
+pub fn enumerate_inherited_members(
+    store: &Store,
+    group_id: &ContextGroupId,
+) -> EyreResult<Vec<(PublicKey, GroupMemberRole)>> {
+    // Direct members of `group_id` are explicit, not inherited — seed
+    // `seen` with them so they are never reported here. `seen` doubles
+    // as the dedup set across ancestor levels. `BTreeSet` (not
+    // `HashSet`) because `PublicKey` derives `Ord` but not `Hash`;
+    // O(log n) lookups are ample for governance-scale membership.
+    let mut seen: BTreeSet<PublicKey> = list_group_members(store, group_id, 0, usize::MAX)?
+        .into_iter()
+        .map(|(pk, _)| pk)
+        .collect();
+    let mut result = Vec::new();
+
+    // Walk the `Open` parent-chain, mirroring `check_group_membership_path`'s
+    // termination (first `Restricted` ancestor or namespace root, bounded
+    // by `MAX_NAMESPACE_DEPTH`). At each ancestor, every direct member —
+    // plus the `GroupMeta` admin, who may have no direct row of their own
+    // — is a candidate. `check_group_membership_path` then decides, from
+    // `group_id`, whether the candidate actually inherits and via which
+    // path. Reusing it verbatim keeps enumeration and the single-identity
+    // check from ever diverging on the anchor-cap / admin-override rules.
+    let mut current = *group_id;
+    // `terminated` distinguishes a legitimate exit (hit a `Restricted`
+    // wall or the namespace root) from loop-bound exhaustion. If the
+    // bound is hit without terminating, the parent chain has a cycle —
+    // bail rather than silently return a partial set, matching
+    // `check_group_membership_path` / `is_inherited_admin`.
+    let mut terminated = false;
+    for _ in 0..=MAX_NAMESPACE_DEPTH {
+        if get_subgroup_visibility(store, &current)? != VisibilityMode::Open {
+            terminated = true;
+            break;
+        }
+        let Some(parent) = get_parent_group(store, &current)? else {
+            terminated = true;
+            break;
+        };
+
+        let mut candidates: Vec<PublicKey> = list_group_members(store, &parent, 0, usize::MAX)?
+            .into_iter()
+            .map(|(pk, _)| pk)
+            .collect();
+        if let Some(meta) = load_group_meta(store, &parent)? {
+            candidates.push(meta.admin_identity);
+        }
+
+        for candidate in candidates {
+            // `insert` returns false when `candidate` was already seen
+            // (a direct member of `group_id`, or processed at a deeper
+            // ancestor) — skip the redundant path check in that case.
+            if !seen.insert(candidate) {
+                continue;
+            }
+            if let MembershipPath::Inherited { via_admin, .. } =
+                check_group_membership_path(store, group_id, &candidate)?
+            {
+                let role = if via_admin {
+                    GroupMemberRole::Admin
+                } else {
+                    GroupMemberRole::Member
+                };
+                result.push((candidate, role));
+            }
+        }
+
+        current = parent;
+    }
+    if !terminated {
+        bail!(
+            "enumerate_inherited_members exceeded MAX_NAMESPACE_DEPTH \
+             ({MAX_NAMESPACE_DEPTH}); possible cycle in store"
+        );
+    }
+    Ok(result)
 }
 
 /// Returns `true` if `identity` is a direct admin of this specific group

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -74,8 +74,9 @@ pub use self::local_state::{
 };
 pub use self::membership::{
     add_group_member, add_group_member_with_keys, check_group_membership,
-    check_group_membership_path, count_group_admins, count_group_members, get_group_member_role,
-    get_group_member_value, has_direct_group_member, is_direct_group_admin, is_group_admin,
+    check_group_membership_path, count_group_admins, count_group_members,
+    enumerate_inherited_members, get_group_member_role, get_group_member_value,
+    has_direct_group_member, is_direct_group_admin, is_group_admin,
     is_group_admin_or_has_capability, is_inherited_admin, list_group_members,
     namespace_member_pubkeys, remove_group_member, require_group_admin,
     require_group_admin_or_capability, set_member_auto_follow, trusted_anchors_for_group,

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -2293,6 +2293,210 @@ fn check_membership_anchor_cap_check_uses_deepest_direct_membership() {
     assert!(!check_group_membership(&store, &leaf, &alice).unwrap());
 }
 
+// -----------------------------------------------------------------------
+// Effective membership for `Open` subgroups — issue #2371
+//
+// `join_subgroup_inheritance` returns 200 / `wasInherited: true` but
+// writes no `GroupMember` row — `execute_member_joined_open` is a
+// validate-only apply. `check_group_membership` correctly reports the
+// inherited joiner as a member, yet `list_group_members` (which only
+// reads stored rows) omits them, so an app keying "is the caller a
+// member?" off the member list sees `false`. `enumerate_inherited_members`
+// closes the gap: it recomputes inherited members from current ancestor
+// state so callers can union it with the stored rows to get the
+// effective member set the membership contract promises.
+// -----------------------------------------------------------------------
+
+#[test]
+fn enumerate_inherited_members_includes_open_subgroup_joiner() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    // namespace (root) -> reports (Open subgroup).
+    // Alice is a direct Admin of `reports`; Bob is a namespace member
+    // who joined `reports` via inheritance — no direct row in `reports`.
+    let store = test_store();
+    let namespace = ContextGroupId::from([0x30; 32]);
+    let reports = ContextGroupId::from([0x31; 32]);
+    let alice = PublicKey::from([0x01; 32]);
+    let bob = PublicKey::from([0x02; 32]);
+
+    nest_for_test(&store, &namespace, &reports);
+
+    // Bob is a direct member of the namespace root with the join cap.
+    add_group_member(&store, &namespace, &bob, GroupMemberRole::Member).unwrap();
+    set_member_capability(
+        &store,
+        &namespace,
+        &bob,
+        MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS,
+    )
+    .unwrap();
+
+    // Alice is an explicit Admin of the Open `reports` subgroup.
+    add_group_member(&store, &reports, &alice, GroupMemberRole::Admin).unwrap();
+    set_subgroup_visibility(&store, &reports, VisibilityMode::Open).unwrap();
+
+    // Contract sanity: Bob *is* a member of `reports` by inheritance...
+    assert!(check_group_membership(&store, &reports, &bob).unwrap());
+    // ...but he has no stored row, so `list_group_members` omits him —
+    // this is the gap issue #2371 reports.
+    let stored = list_group_members(&store, &reports, 0, usize::MAX).unwrap();
+    assert!(
+        stored.iter().all(|(pk, _)| *pk != bob),
+        "precondition: inherited joiner has no stored GroupMember row"
+    );
+
+    // `enumerate_inherited_members` recovers Bob as an inherited member.
+    let inherited = enumerate_inherited_members(&store, &reports).unwrap();
+    assert!(
+        inherited
+            .iter()
+            .any(|(pk, role)| *pk == bob && *role == GroupMemberRole::Member),
+        "expected inherited joiner Bob (Member) in enumerate_inherited_members, got {inherited:?}"
+    );
+    // Alice is a *direct* member of `reports` — she must not be
+    // double-reported as an inherited member.
+    assert!(
+        inherited.iter().all(|(pk, _)| *pk != alice),
+        "direct member Alice must not appear as an inherited member"
+    );
+}
+
+#[test]
+fn enumerate_inherited_members_reports_inherited_admin_role() {
+    use calimero_context_config::VisibilityMode;
+
+    // A namespace admin who never explicitly joined the Open subgroup
+    // still inherits admin authority into it (admin override). The
+    // enumerated entry must carry the `Admin` role, not `Member`.
+    let store = test_store();
+    let namespace = ContextGroupId::from([0x32; 32]);
+    let reports = ContextGroupId::from([0x33; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+
+    nest_for_test(&store, &namespace, &reports);
+    add_group_member(&store, &namespace, &admin, GroupMemberRole::Admin).unwrap();
+    set_subgroup_visibility(&store, &reports, VisibilityMode::Open).unwrap();
+
+    let inherited = enumerate_inherited_members(&store, &reports).unwrap();
+    assert!(
+        inherited
+            .iter()
+            .any(|(pk, role)| *pk == admin && *role == GroupMemberRole::Admin),
+        "inherited admin must be reported with the Admin role, got {inherited:?}"
+    );
+}
+
+#[test]
+fn enumerate_inherited_members_empty_for_restricted_subgroup() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    // A `Restricted` subgroup is a wall: parent members are not
+    // inherited, so the enumeration is empty.
+    let store = test_store();
+    let namespace = ContextGroupId::from([0x34; 32]);
+    let reports = ContextGroupId::from([0x35; 32]);
+    let bob = PublicKey::from([0x02; 32]);
+
+    nest_for_test(&store, &namespace, &reports);
+    add_group_member(&store, &namespace, &bob, GroupMemberRole::Member).unwrap();
+    set_member_capability(
+        &store,
+        &namespace,
+        &bob,
+        MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS,
+    )
+    .unwrap();
+    set_subgroup_visibility(&store, &reports, VisibilityMode::Restricted).unwrap();
+
+    let inherited = enumerate_inherited_members(&store, &reports).unwrap();
+    assert!(
+        inherited.is_empty(),
+        "Restricted subgroup must inherit no members, got {inherited:?}"
+    );
+}
+
+#[test]
+fn enumerate_inherited_members_bails_on_depth_overflow() {
+    use calimero_context_config::VisibilityMode;
+
+    use super::namespace::MAX_NAMESPACE_DEPTH;
+
+    // A parent chain longer than MAX_NAMESPACE_DEPTH with no Restricted
+    // wall exhausts the walk bound. Like its sibling chain-walkers
+    // (`check_group_membership_path`, `is_inherited_admin`),
+    // `enumerate_inherited_members` must bail on a suspected cycle
+    // rather than silently return a partial member set.
+    let store = test_store();
+    let root = ContextGroupId::from([0x40; 32]);
+    let mut prev = root;
+    for i in 0..(MAX_NAMESPACE_DEPTH + 2) {
+        // Encode `i` across two bytes so distinct levels never alias,
+        // regardless of how large MAX_NAMESPACE_DEPTH grows — a single
+        // wrapping byte would collide past 255 and build a real cycle
+        // instead of a long chain, passing the test for the wrong reason.
+        let mut bytes = [0x41u8; 32];
+        bytes[..2].copy_from_slice(&(i as u16).to_le_bytes());
+        let next = ContextGroupId::from(bytes);
+        nest_for_test(&store, &prev, &next);
+        set_subgroup_visibility(&store, &next, VisibilityMode::Open).unwrap();
+        prev = next;
+    }
+
+    let res = enumerate_inherited_members(&store, &prev);
+    assert!(
+        res.is_err(),
+        "enumerate_inherited_members must bail on MAX_NAMESPACE_DEPTH overflow, got {res:?}"
+    );
+}
+
+#[test]
+fn enumerate_inherited_members_resolves_at_max_namespace_depth_boundary() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    use super::namespace::MAX_NAMESPACE_DEPTH;
+
+    // Refutes the claim that `enumerate_inherited_members` walks one
+    // ancestor short of `check_group_membership_path`. Build a fully
+    // Open chain of exactly MAX_NAMESPACE_DEPTH edges (ns -> g_1 -> ...
+    // -> leaf) with the sole member at the *deepest* ancestor (`ns`).
+    // If the walk fell an iteration short, `alice` would be missed; it
+    // must enumerate her, agreeing with `check_group_membership` (see
+    // `auth_and_crypto_walks_agree_at_max_namespace_depth_boundary`).
+    let store = test_store();
+    let ns = ContextGroupId::from([0x60; 32]);
+    let mut nodes = vec![ns];
+    for i in 1..=MAX_NAMESPACE_DEPTH {
+        let g = ContextGroupId::from([0x60u8.wrapping_add(i as u8); 32]);
+        nest_for_test(&store, nodes.last().unwrap(), &g);
+        set_subgroup_visibility(&store, &g, VisibilityMode::Open).unwrap();
+        nodes.push(g);
+    }
+    let leaf = *nodes.last().unwrap();
+
+    let alice = PublicKey::from([0x01; 32]);
+    add_group_member(&store, &ns, &alice, GroupMemberRole::Member).unwrap();
+    set_member_capability(
+        &store,
+        &ns,
+        &alice,
+        MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS,
+    )
+    .unwrap();
+
+    assert!(
+        check_group_membership(&store, &leaf, &alice).unwrap(),
+        "precondition: check_group_membership resolves at the boundary"
+    );
+
+    let inherited = enumerate_inherited_members(&store, &leaf).unwrap();
+    assert!(
+        inherited.iter().any(|(pk, _)| *pk == alice),
+        "enumerate_inherited_members must reach the deepest ancestor at \
+         MAX_NAMESPACE_DEPTH, matching check_group_membership; got {inherited:?}"
+    );
+}
+
 #[test]
 fn default_capabilities_include_can_join_open_subgroups() {
     use calimero_context_config::MemberCapabilities;

--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -25,7 +25,22 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
                 bail!("node is not a member of group '{group_id:?}'");
             }
 
-            let member_count = group_store::count_group_members(&self.datastore, &group_id)? as u64;
+            // Effective member count = stored rows + inherited members,
+            // kept consistent with the `list_group_members` handler
+            // (#2371). `count_group_members` alone counts only stored
+            // `GroupMember` rows, so on an Open subgroup it would
+            // under-report and a client paginating `list_group_members`
+            // against this count would miss inherited members on the
+            // final page.
+            //
+            // Cost: inherited membership is derived state with no stored
+            // counter, so an accurate count requires resolving it — a
+            // chain walk bounded by `MAX_NAMESPACE_DEPTH`. This is minor
+            // next to `compute_group_state_hash` below, which already
+            // scans the full group state on every call.
+            let member_count = (group_store::count_group_members(&self.datastore, &group_id)?
+                + group_store::enumerate_inherited_members(&self.datastore, &group_id)?.len())
+                as u64;
 
             let context_count =
                 group_store::count_group_contexts(&self.datastore, &group_id)? as u64;

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -27,11 +27,37 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 bail!("node is not a member of group '{group_id:?}'");
             }
 
-            let members =
-                group_store::list_group_members(&self.datastore, &group_id, offset, limit)?;
+            // Effective membership = stored explicit rows ∪ inherited
+            // members of `Open` subgroups. `list_group_members` alone
+            // returns only the stored rows; a peer who joined via
+            // `join_subgroup_inheritance` has no row (the apply path
+            // `execute_member_joined_open` is validate-only), so without
+            // the union they would never surface here even though
+            // `check_group_membership` reports them as members (#2371).
+            //
+            // Pagination must span the union, so the full sets are
+            // collected here and sliced after the merge rather than
+            // pushed down into the store query. Known cost: a paginated
+            // call is O(total effective members) in store reads, not
+            // O(offset+limit). This is acceptable here — group
+            // membership is governance-scale (a permission hierarchy),
+            // not an unbounded user list — and the inherited set cannot
+            // be store-paginated at all since it is computed, not
+            // stored. The inherited set is disjoint from the stored
+            // rows by construction (`enumerate_inherited_members`
+            // excludes direct members of `group_id`), so no dedup is
+            // needed.
+            let mut members =
+                group_store::list_group_members(&self.datastore, &group_id, 0, usize::MAX)?;
+            members.extend(group_store::enumerate_inherited_members(
+                &self.datastore,
+                &group_id,
+            )?);
 
             let entries = members
                 .into_iter()
+                .skip(offset)
+                .take(limit)
                 .map(|(identity, role)| {
                     let name =
                         group_store::get_member_metadata(&self.datastore, &group_id, &identity)


### PR DESCRIPTION
## Summary

Fixes #2371. `POST /admin-api/groups/<id>/join-via-inheritance` returns `200 / wasInherited: true`, but a follow-up `GET /admin-api/groups/<id>/members` on the **same node** omitted the joiner — they surfaced only in `selfIdentity`, never in `members[]`. Apps that key "is the caller a member of this subgroup?" off `list_group_members` therefore saw `isMember = false` for any user who joined via inheritance.

**Root cause** (confirmed against `master`):
- `execute_member_joined_open` (`namespace_governance.rs`) is a validate-only apply — it writes no `GroupMember` row by design.
- `join_subgroup_inheritance` fetches the key and publishes `MemberJoinedOpen`, but never writes a row either.
- `list_group_members` (`membership.rs`) reads only `GROUP_MEMBER_PREFIX` rows, so an inherited joiner is invisible to it — even though `check_group_membership` (used to gate the same endpoint) *does* recognise the inheritance path and returns `true`.

## Approach

Inherited membership is **derived state** — a pure function of the joiner's ancestor memberships and the Open/Restricted visibility of every group on the chain. Both change with no op naming the affected subgroup (a cap revocation, an ancestor flipping Open→Restricted, a namespace leave). Materialising a `GroupMember` row (issue's Option A) would create a stale-cache problem with no invalidation events, so the fix recomputes at query time instead.

- **`enumerate_inherited_members`** — the list-dual of `check_group_membership_path`. Walks the same Open parent-chain and re-runs the single-identity check per ancestor candidate (direct members + each ancestor's `GroupMeta` admin), so enumeration and the single-identity check can never diverge on the anchor-cap / admin-override rules.
- **Handler union** — `list_group_members` handler now returns `stored rows ∪ enumerate_inherited_members`, paginated over the union. `group_store::list_group_members` itself is left direct-rows-only — its internal callers (key distribution, `verify_ack`, …) must keep seeing only stored explicit rows.

App callers need no changes; `list_group_members` becomes self-consistent with `check_group_membership`.

## Tests

- **3 unit tests** (`group_store/tests.rs`) — written test-first (RED→GREEN): the inherited joiner appears as `Member`; an inherited admin appears as `Admin`; a Restricted subgroup inherits nobody.
- **e2e** (`group-join-via-inheritance.yml`) — after `join_subgroup_inheritance` and before `join_context` (so the joiner provably holds no explicit row), `list_group_members` on the joiner's own node now asserts the joiner is in `members[]`. In-core analogue of mero-drive#32's failing step 5.

## Verification

- `cargo test -p calimero-context --lib group_store::` → 206 passed, 0 failed.
- `cargo build -p calimero-context` → clean.
- The merobox e2e was validated statically (YAML + step schema); it was not run here (needs Docker + `merod:local`), it runs in the scaffolding-e2e CI suite.

## Not included (optional follow-up)

A `via_inheritance` flag on the API entry — the issue marks it optional, and it would touch `context-client` + `server-primitives` wire types. mero-drive's `useMemberCaps` only needs presence, which this delivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes API-visible membership semantics and pagination/count behavior by computing inherited members at query time; risk is moderate due to potential performance impact and edge cases in namespace-chain traversal.
> 
> **Overview**
> Fixes #2371 by making **effective membership** visible via the admin API: `list_group_members` now returns explicit stored members **plus** members who join an `Open` subgroup via inheritance, using new `group_store::enumerate_inherited_members`.
> 
> `get_group_info`’s `member_count` is updated to match the effective member set (stored + inherited) so clients paginating against the count don’t miss inherited members. Adds unit tests around inherited enumeration (member vs admin role, restricted walls, depth overflow/boundary), and extends the `group-join-via-inheritance` e2e workflow to assert the inherited joiner appears in `members[]` before any `join_context` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725215c46715ff02806766a38fb56887e68188cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->