### PR TITLE
fix(node): receiver-side anti-entropy for missed namespace governance ops (#2367)

### DIFF
--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -14,17 +14,53 @@
 //!   `BEACON_INTERVAL / 2` — see
 //!   [`Handler<EmitOutOfCycleBeacon>`](crate::readiness::ReadinessManager).
 
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use actix::{AsyncContext, WrapFuture};
 use calimero_context::governance_broadcast::verify_readiness_beacon;
 use calimero_context_client::local_governance::{ReadinessProbe, SignedReadinessBeacon};
 use libp2p::PeerId;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::readiness::{ApplyBeaconLocal, EmitOutOfCycleBeacon};
 use crate::NodeManager;
 
+/// Per-namespace debounce window for beacon-triggered governance syncs.
+/// One beacon interval (~5s): a Ready peer beacons every ~5s, so without
+/// this a behind-node would fire one sync per beacon per peer.
+const NS_BEACON_SYNC_DEBOUNCE: Duration = Duration::from_secs(5);
+
+/// True if the beacon's advertised DAG head names a namespace governance
+/// op this node has not applied locally — i.e. the beaconing peer is
+/// ahead and we should pull the namespace governance DAG from it.
+///
+/// A zero head (`[0u8; 32]`) means the peer has applied nothing yet;
+/// never sync towards an empty DAG.
+fn beacon_indicates_divergence(dag_head: [u8; 32], head_op_present_locally: bool) -> bool {
+    dag_head != [0u8; 32] && !head_op_present_locally
+}
+
+/// Per-namespace debounce gate. Returns `true` (and records `now`) when
+/// no beacon-triggered sync fired for `namespace_id` within
+/// [`NS_BEACON_SYNC_DEBOUNCE`]; returns `false` otherwise.
+fn debounce_allows_sync(
+    debounce: &mut HashMap<[u8; 32], Instant>,
+    namespace_id: [u8; 32],
+    now: Instant,
+) -> bool {
+    match debounce.get(&namespace_id) {
+        Some(last) if now.duration_since(*last) < NS_BEACON_SYNC_DEBOUNCE => false,
+        _ => {
+            let _ = debounce.insert(namespace_id, now);
+            true
+        }
+    }
+}
+
 pub(super) fn handle_readiness_beacon(
     manager: &mut NodeManager,
-    _ctx: &mut actix::Context<NodeManager>,
+    ctx: &mut actix::Context<NodeManager>,
     _peer_id: PeerId,
     beacon: SignedReadinessBeacon,
 ) {
@@ -51,6 +87,61 @@ pub(super) fn handle_readiness_beacon(
         strong,
         "readiness beacon received"
     );
+
+    // #2367 — receiver-side anti-entropy. The beacon advertises the
+    // peer's namespace governance DAG head; if that head names an op we
+    // have not applied, the peer is ahead and we pull the namespace DAG
+    // from it via the real governance sync protocol (ops applied in DAG
+    // order, side-effects run). A spurious sync is only wasted work,
+    // never wrong state. Debounced to one sync per namespace per beacon
+    // interval — see `NS_BEACON_SYNC_DEBOUNCE`.
+    let dag_head = beacon.dag_head;
+    if debounce_allows_sync(
+        &mut manager.ns_beacon_sync_debounce,
+        namespace_id,
+        Instant::now(),
+    ) {
+        let datastore = manager.datastore.clone();
+        let node_client = manager.clients.node.clone();
+        let _ignored = ctx.spawn(
+            async move {
+                let head_op_present = {
+                    let handle = datastore.handle();
+                    let op_key = calimero_store::key::NamespaceGovOp::new(namespace_id, dag_head);
+                    match handle.get(&op_key) {
+                        Ok(present) => present.is_some(),
+                        Err(err) => {
+                            // Unknown local state — do NOT trigger a sync
+                            // on a failed read. The next beacon (~5s) retries.
+                            debug!(
+                                ?err,
+                                namespace_id = %hex::encode(namespace_id),
+                                "beacon-divergence: local DAG read failed; skipping sync"
+                            );
+                            return;
+                        }
+                    }
+                };
+                if beacon_indicates_divergence(dag_head, head_op_present) {
+                    info!(
+                        namespace_id = %hex::encode(namespace_id),
+                        dag_head = %hex::encode(dag_head),
+                        "beacon advertises an unknown namespace DAG head; \
+                         triggering governance sync"
+                    );
+                    if let Err(err) = node_client.sync_namespace(namespace_id).await {
+                        warn!(
+                            ?err,
+                            namespace_id = %hex::encode(namespace_id),
+                            "beacon-triggered namespace governance sync failed"
+                        );
+                    }
+                }
+            }
+            .into_actor(manager),
+        );
+    }
+
     if let Some(addr) = &manager.readiness_addr {
         addr.do_send(ApplyBeaconLocal { namespace_id });
     }
@@ -72,5 +163,61 @@ pub(super) fn handle_readiness_probe(
             namespace_id: probe.namespace_id,
             requesting_peer: peer_id,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn divergence_true_when_head_op_absent() {
+        assert!(beacon_indicates_divergence([7u8; 32], false));
+    }
+
+    #[test]
+    fn divergence_false_when_head_op_present() {
+        assert!(!beacon_indicates_divergence([7u8; 32], true));
+    }
+
+    #[test]
+    fn divergence_false_for_zero_head() {
+        // A peer that has applied nothing advertises a zero head; never
+        // sync towards an empty DAG even though the op is "absent".
+        assert!(!beacon_indicates_divergence([0u8; 32], false));
+    }
+
+    #[test]
+    fn debounce_allows_first_then_blocks_within_window() {
+        let mut d: HashMap<[u8; 32], Instant> = HashMap::new();
+        let t0 = Instant::now();
+        assert!(debounce_allows_sync(&mut d, [1u8; 32], t0));
+        // Second beacon 1s later — inside the 5s window — is blocked.
+        assert!(!debounce_allows_sync(
+            &mut d,
+            [1u8; 32],
+            t0 + Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn debounce_reallows_after_window() {
+        let mut d: HashMap<[u8; 32], Instant> = HashMap::new();
+        let t0 = Instant::now();
+        assert!(debounce_allows_sync(&mut d, [1u8; 32], t0));
+        assert!(debounce_allows_sync(
+            &mut d,
+            [1u8; 32],
+            t0 + NS_BEACON_SYNC_DEBOUNCE + Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn debounce_is_per_namespace() {
+        let mut d: HashMap<[u8; 32], Instant> = HashMap::new();
+        let t0 = Instant::now();
+        assert!(debounce_allows_sync(&mut d, [1u8; 32], t0));
+        // Different namespace — independent budget, still allowed.
+        assert!(debounce_allows_sync(&mut d, [2u8; 32], t0));
     }
 }

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -31,14 +31,27 @@ use crate::NodeManager;
 /// this a behind-node would fire one sync per beacon per peer.
 const NS_BEACON_SYNC_DEBOUNCE: Duration = Duration::from_secs(5);
 
-/// True if the beacon's advertised DAG head names a namespace governance
-/// op this node has not applied locally — i.e. the beaconing peer is
-/// ahead and we should pull the namespace governance DAG from it.
+/// True when a beacon shows the peer is ahead AND this node should act on
+/// it — i.e. trigger a namespace governance sync.
 ///
-/// A zero head (`[0u8; 32]`) means the peer has applied nothing yet;
-/// never sync towards an empty DAG.
-fn beacon_indicates_divergence(dag_head: [u8; 32], head_op_present_locally: bool) -> bool {
-    dag_head != [0u8; 32] && !head_op_present_locally
+/// - `local_has_state` — this node holds a non-empty local namespace
+///   governance DAG head. When false the node is still bootstrapping or
+///   mid-join: the join flow owns the initial governance sync, and firing
+///   one here races the join handshake — it pulls governance ops before
+///   the namespace key is delivered, leaving them as undecryptable opaque
+///   skeletons that the post-key join sync then skips as duplicates. An
+///   established member (the scenario this anti-entropy targets) always
+///   has a non-empty head.
+/// - `dag_head == [0u8; 32]` — the peer has applied nothing yet; never
+///   sync towards an empty DAG.
+/// - `head_op_present_locally` — the peer's advertised head op is already
+///   in our DAG; we are caught up (or ahead).
+fn beacon_indicates_divergence(
+    local_has_state: bool,
+    dag_head: [u8; 32],
+    head_op_present_locally: bool,
+) -> bool {
+    local_has_state && dag_head != [0u8; 32] && !head_op_present_locally
 }
 
 /// Per-namespace debounce gate. Returns `true` (and records `now`) when
@@ -106,24 +119,42 @@ pub(super) fn handle_readiness_beacon(
     let debounce = manager.ns_beacon_sync_debounce.clone();
     let _ignored = ctx.spawn(
         async move {
-            let head_op_present = {
-                let handle = datastore.handle();
-                let op_key = calimero_store::key::NamespaceGovOp::new(namespace_id, dag_head);
-                match handle.get(&op_key) {
-                    Ok(present) => present.is_some(),
+            let handle = datastore.handle();
+            // Local namespace governance state. An empty/absent head means
+            // we are still bootstrapping or mid-join — skip (see
+            // `beacon_indicates_divergence`): the join flow owns the
+            // initial sync, and firing here races the join handshake.
+            let local_has_state =
+                match handle.get(&calimero_store::key::NamespaceGovHead::new(namespace_id)) {
+                    Ok(Some(head)) => !head.dag_heads.is_empty(),
+                    Ok(None) => false,
                     Err(err) => {
-                        // Unknown local state — do NOT trigger a sync
-                        // on a failed read. The next beacon (~5s) retries.
                         debug!(
                             ?err,
                             namespace_id = %hex::encode(namespace_id),
-                            "beacon-divergence: local DAG read failed; skipping sync"
+                            "beacon-divergence: namespace head read failed; skipping sync"
                         );
                         return;
                     }
+                };
+            let head_op_present = match handle.get(&calimero_store::key::NamespaceGovOp::new(
+                namespace_id,
+                dag_head,
+            )) {
+                Ok(present) => present.is_some(),
+                Err(err) => {
+                    // Unknown local state — do NOT trigger a sync
+                    // on a failed read. The next beacon (~5s) retries.
+                    debug!(
+                        ?err,
+                        namespace_id = %hex::encode(namespace_id),
+                        "beacon-divergence: local DAG read failed; skipping sync"
+                    );
+                    return;
                 }
             };
-            if !beacon_indicates_divergence(dag_head, head_op_present) {
+            drop(handle);
+            if !beacon_indicates_divergence(local_has_state, dag_head, head_op_present) {
                 return;
             }
             // Divergence confirmed. Claim the debounce slot atomically;
@@ -186,19 +217,28 @@ mod tests {
 
     #[test]
     fn divergence_true_when_head_op_absent() {
-        assert!(beacon_indicates_divergence([7u8; 32], false));
+        // Established member (has local state), peer's head op missing.
+        assert!(beacon_indicates_divergence(true, [7u8; 32], false));
     }
 
     #[test]
     fn divergence_false_when_head_op_present() {
-        assert!(!beacon_indicates_divergence([7u8; 32], true));
+        assert!(!beacon_indicates_divergence(true, [7u8; 32], true));
     }
 
     #[test]
     fn divergence_false_for_zero_head() {
         // A peer that has applied nothing advertises a zero head; never
         // sync towards an empty DAG even though the op is "absent".
-        assert!(!beacon_indicates_divergence([0u8; 32], false));
+        assert!(!beacon_indicates_divergence(true, [0u8; 32], false));
+    }
+
+    #[test]
+    fn divergence_false_when_no_local_state() {
+        // No local namespace governance head: the node is still
+        // bootstrapping / mid-join. The join flow owns the initial sync;
+        // firing here races the join handshake. Never trigger.
+        assert!(!beacon_indicates_divergence(false, [7u8; 32], false));
     }
 
     #[test]

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -120,16 +120,18 @@ pub(super) fn handle_readiness_beacon(
     let _ignored = ctx.spawn(
         async move {
             let handle = datastore.handle();
-            // Local namespace governance state. An empty/absent head means
-            // we are still bootstrapping or mid-join — skip (see
-            // `beacon_indicates_divergence`): the join flow owns the
-            // initial sync, and firing here races the join handshake.
+            // Local namespace governance state — at least one non-zero
+            // DAG head. An empty/absent head (or only the `[0u8; 32]`
+            // sentinel) means we are still bootstrapping or mid-join —
+            // skip (see `beacon_indicates_divergence`): the join flow owns
+            // the initial sync, and firing here races the join handshake.
             let local_has_state =
                 match handle.get(&calimero_store::key::NamespaceGovHead::new(namespace_id)) {
-                    Ok(Some(head)) => !head.dag_heads.is_empty(),
+                    Ok(Some(head)) => head.dag_heads.iter().any(|h| *h != [0u8; 32]),
                     Ok(None) => false,
                     Err(err) => {
-                        debug!(
+                        // A failed read is datastore-level and unexpected.
+                        warn!(
                             ?err,
                             namespace_id = %hex::encode(namespace_id),
                             "beacon-divergence: namespace head read failed; skipping sync"
@@ -137,15 +139,20 @@ pub(super) fn handle_readiness_beacon(
                         return;
                     }
                 };
+            // `dag_head` is the beacon peer's namespace governance DAG
+            // head — an op `delta_id`, which is exactly the second
+            // component of the `NamespaceGovOp` store key. A point `get`
+            // therefore tests whether we have applied that op locally.
             let head_op_present = match handle.get(&calimero_store::key::NamespaceGovOp::new(
                 namespace_id,
                 dag_head,
             )) {
                 Ok(present) => present.is_some(),
                 Err(err) => {
-                    // Unknown local state — do NOT trigger a sync
-                    // on a failed read. The next beacon (~5s) retries.
-                    debug!(
+                    // A failed read is datastore-level and unexpected — do
+                    // NOT trigger a sync on unknown state. The next beacon
+                    // (~5s) retries.
+                    warn!(
                         ?err,
                         namespace_id = %hex::encode(namespace_id),
                         "beacon-divergence: local DAG read failed; skipping sync"

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -93,54 +93,68 @@ pub(super) fn handle_readiness_beacon(
     // have not applied, the peer is ahead and we pull the namespace DAG
     // from it via the real governance sync protocol (ops applied in DAG
     // order, side-effects run). A spurious sync is only wasted work,
-    // never wrong state. Debounced to one sync per namespace per beacon
-    // interval — see `NS_BEACON_SYNC_DEBOUNCE`.
+    // never wrong state.
+    //
+    // The debounce slot is stamped *inside* the spawned future, after
+    // the DAG read confirms divergence — never at receive time. A beacon
+    // from an already-caught-up peer must not burn the per-namespace
+    // budget and suppress a genuinely-divergent beacon from another peer
+    // for the next `NS_BEACON_SYNC_DEBOUNCE` window.
     let dag_head = beacon.dag_head;
-    if debounce_allows_sync(
-        &mut manager.ns_beacon_sync_debounce,
-        namespace_id,
-        Instant::now(),
-    ) {
-        let datastore = manager.datastore.clone();
-        let node_client = manager.clients.node.clone();
-        let _ignored = ctx.spawn(
-            async move {
-                let head_op_present = {
-                    let handle = datastore.handle();
-                    let op_key = calimero_store::key::NamespaceGovOp::new(namespace_id, dag_head);
-                    match handle.get(&op_key) {
-                        Ok(present) => present.is_some(),
-                        Err(err) => {
-                            // Unknown local state — do NOT trigger a sync
-                            // on a failed read. The next beacon (~5s) retries.
-                            debug!(
-                                ?err,
-                                namespace_id = %hex::encode(namespace_id),
-                                "beacon-divergence: local DAG read failed; skipping sync"
-                            );
-                            return;
-                        }
-                    }
-                };
-                if beacon_indicates_divergence(dag_head, head_op_present) {
-                    info!(
-                        namespace_id = %hex::encode(namespace_id),
-                        dag_head = %hex::encode(dag_head),
-                        "beacon advertises an unknown namespace DAG head; \
-                         triggering governance sync"
-                    );
-                    if let Err(err) = node_client.sync_namespace(namespace_id).await {
-                        warn!(
+    let datastore = manager.datastore.clone();
+    let node_client = manager.clients.node.clone();
+    let debounce = manager.ns_beacon_sync_debounce.clone();
+    let _ignored = ctx.spawn(
+        async move {
+            let head_op_present = {
+                let handle = datastore.handle();
+                let op_key = calimero_store::key::NamespaceGovOp::new(namespace_id, dag_head);
+                match handle.get(&op_key) {
+                    Ok(present) => present.is_some(),
+                    Err(err) => {
+                        // Unknown local state — do NOT trigger a sync
+                        // on a failed read. The next beacon (~5s) retries.
+                        debug!(
                             ?err,
                             namespace_id = %hex::encode(namespace_id),
-                            "beacon-triggered namespace governance sync failed"
+                            "beacon-divergence: local DAG read failed; skipping sync"
                         );
+                        return;
                     }
                 }
+            };
+            if !beacon_indicates_divergence(dag_head, head_op_present) {
+                return;
             }
-            .into_actor(manager),
-        );
-    }
+            // Divergence confirmed. Claim the debounce slot atomically;
+            // if another beacon already triggered a sync for this
+            // namespace within the window, skip. The guard is dropped
+            // before the `.await` below — the lock is never held across
+            // an await point.
+            {
+                let mut guard = debounce
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !debounce_allows_sync(&mut guard, namespace_id, Instant::now()) {
+                    return;
+                }
+            }
+            info!(
+                namespace_id = %hex::encode(namespace_id),
+                dag_head = %hex::encode(dag_head),
+                "beacon advertises an unknown namespace DAG head; \
+                 triggering governance sync"
+            );
+            if let Err(err) = node_client.sync_namespace(namespace_id).await {
+                warn!(
+                    ?err,
+                    namespace_id = %hex::encode(namespace_id),
+                    "beacon-triggered namespace governance sync failed"
+                );
+            }
+        }
+        .into_actor(manager),
+    );
 
     if let Some(addr) = &manager.readiness_addr {
         addr.do_send(ApplyBeaconLocal { namespace_id });

--- a/crates/node/src/handlers/network_event/subscriptions.rs
+++ b/crates/node/src/handlers/network_event/subscriptions.rs
@@ -62,6 +62,51 @@ pub(super) fn handle_subscribed(
         return;
     }
 
+    // #2367 — namespace governance topic. A peer just subscribed to
+    // `ns/<hex>`; emit an out-of-cycle readiness beacon so the new
+    // subscriber sees our namespace DAG head within ~1s instead of
+    // waiting up to a full ~5s periodic interval. The
+    // `EmitOutOfCycleBeacon` handler no-ops unless we are *Ready in
+    // this namespace and rate-limits per (peer, namespace), so this is
+    // safe even when the subscribing peer is in a namespace we don't
+    // belong to.
+    if let Some(hex) = topic_str.strip_prefix("ns/") {
+        let mut bytes = [0u8; 32];
+        if hex::decode_to_slice(hex, &mut bytes).is_err() {
+            debug!(
+                %peer_id,
+                topic = %topic_str,
+                "ns/ topic with malformed namespace id; ignoring subscription"
+            );
+            return;
+        }
+        match &manager.readiness_addr {
+            Some(addr) => {
+                info!(
+                    %peer_id,
+                    namespace_id = %hex,
+                    "Peer subscribed to namespace topic, emitting out-of-cycle beacon"
+                );
+                addr.do_send(crate::readiness::EmitOutOfCycleBeacon {
+                    namespace_id: bytes,
+                    requesting_peer: peer_id,
+                });
+            }
+            None => {
+                // Readiness actor not yet mounted (early-startup race).
+                // The ~5s periodic beacon still covers this subscriber;
+                // only the ~1s cold-start speedup is lost.
+                debug!(
+                    %peer_id,
+                    namespace_id = %hex,
+                    "ns/ subscription observed before readiness actor mounted; \
+                     out-of-cycle beacon skipped"
+                );
+            }
+        }
+        return;
+    }
+
     let Ok(context_id): Result<ContextId, _> = topic_str.parse() else {
         return;
     };

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -68,6 +68,13 @@ pub struct NodeManager {
     /// alert on divergence rate without grepping logs; with the #2319
     /// determinism fixes this should stay near zero.
     pub(crate) divergence_detected: Counter,
+    /// Per-namespace timestamp of the last beacon-triggered governance
+    /// sync (#2367). Caps beacon-divergence syncs to one per namespace
+    /// per `NS_BEACON_SYNC_DEBOUNCE` window — beacons arrive every ~5s
+    /// from every Ready peer, so an un-debounced behind-node would fire
+    /// a sync per beacon per peer. Written/read only by
+    /// `handlers::network_event::readiness::handle_readiness_beacon`.
+    pub(crate) ns_beacon_sync_debounce: std::collections::HashMap<[u8; 32], std::time::Instant>,
 }
 
 impl NodeManager {
@@ -100,6 +107,7 @@ impl NodeManager {
             state_delta_tx,
             sync_session_tx,
             divergence_detected,
+            ns_beacon_sync_debounce: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -1,4 +1,6 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use actix::{Actor, Addr};
 use calimero_blobstore::BlobManager as BlobStore;
@@ -81,8 +83,7 @@ pub struct NodeManager {
     /// genuinely-divergent one. The lock is never held across an await.
     /// Touched only by
     /// `handlers::network_event::readiness::handle_readiness_beacon`.
-    pub(crate) ns_beacon_sync_debounce:
-        Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
+    pub(crate) ns_beacon_sync_debounce: Arc<Mutex<HashMap<[u8; 32], Instant>>>,
 }
 
 impl NodeManager {
@@ -115,9 +116,7 @@ impl NodeManager {
             state_delta_tx,
             sync_session_tx,
             divergence_detected,
-            ns_beacon_sync_debounce: Arc::new(std::sync::Mutex::new(
-                std::collections::HashMap::new(),
-            )),
+            ns_beacon_sync_debounce: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -68,13 +68,21 @@ pub struct NodeManager {
     /// alert on divergence rate without grepping logs; with the #2319
     /// determinism fixes this should stay near zero.
     pub(crate) divergence_detected: Counter,
-    /// Per-namespace timestamp of the last beacon-triggered governance
+    /// Per-namespace timestamp of the last beacon-*triggered* governance
     /// sync (#2367). Caps beacon-divergence syncs to one per namespace
     /// per `NS_BEACON_SYNC_DEBOUNCE` window — beacons arrive every ~5s
     /// from every Ready peer, so an un-debounced behind-node would fire
-    /// a sync per beacon per peer. Written/read only by
+    /// a sync per beacon per peer.
+    ///
+    /// Shared (`Arc<Mutex<_>>`) because the slot is stamped from inside
+    /// the spawned divergence-check future, *after* the async DAG read
+    /// confirms a sync is genuinely needed — a beacon from an
+    /// already-caught-up peer must not burn the budget for a
+    /// genuinely-divergent one. The lock is never held across an await.
+    /// Touched only by
     /// `handlers::network_event::readiness::handle_readiness_beacon`.
-    pub(crate) ns_beacon_sync_debounce: std::collections::HashMap<[u8; 32], std::time::Instant>,
+    pub(crate) ns_beacon_sync_debounce:
+        Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
 }
 
 impl NodeManager {
@@ -107,7 +115,9 @@ impl NodeManager {
             state_delta_tx,
             sync_session_tx,
             divergence_detected,
-            ns_beacon_sync_debounce: std::collections::HashMap::new(),
+            ns_beacon_sync_debounce: Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
         }
     }
 }

--- a/docs/superpowers/plans/2026-05-17-namespace-governance-anti-entropy.md
+++ b/docs/superpowers/plans/2026-05-17-namespace-governance-anti-entropy.md
@@ -1,0 +1,428 @@
+# Namespace Governance Anti-Entropy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a node that missed a namespace governance op recover it by acting on the `ReadinessBeacon` divergence signal it already receives.
+
+**Architecture:** Receiver-side anti-entropy. Patch 1: the `ReadinessBeacon` receive handler compares the beacon's advertised DAG head against the local namespace governance DAG; on divergence it triggers `sync_namespace`, debounced per-namespace. Patch 2: the `Subscribed` event handler emits an out-of-cycle beacon when a peer subscribes to a `ns/<hex>` topic, shaving cold-start recovery from ~5s to ~1s.
+
+**Tech Stack:** Rust, actix actors, libp2p gossipsub, calimero-store (RocksDB), merobox e2e workflows.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-namespace-governance-anti-entropy-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `crates/node/src/manager.rs` | Add `ns_beacon_sync_debounce: HashMap<[u8;32], Instant>` field to `NodeManager` + init in `new()` |
+| `crates/node/src/handlers/network_event/readiness.rs` | Add two pure helpers (`beacon_indicates_divergence`, `debounce_allows_sync`) + `#[cfg(test)]` unit tests; wire Patch 1 into `handle_readiness_beacon` |
+| `crates/node/src/handlers/network_event/subscriptions.rs` | Add `ns/<hex>` arm to `handle_subscribed` (Patch 2) |
+| `workflows/sync-tests/opaque-leaf-regression.yml` | Add Phase 6: node-2 joins + `wait_for_sync` the second context (regression sentinel) |
+
+No GHA workflow change — Phase 6 runs inside the already-wired `opaque-leaf-regression.yml` job. No wire-format change. No publisher change.
+
+---
+
+## Task 1: Pure helpers + unit tests (readiness.rs)
+
+**Files:**
+- Modify: `crates/node/src/handlers/network_event/readiness.rs`
+
+- [ ] **Step 1: Add the helpers and tests**
+
+At the top of `readiness.rs`, after the existing `use` block, add:
+
+```rust
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+```
+
+Before `pub(super) fn handle_readiness_beacon`, add:
+
+```rust
+/// Per-namespace debounce window for beacon-triggered governance syncs.
+/// One beacon interval (~5s): a Ready peer beacons every ~5s, so without
+/// this a behind-node would fire one sync per beacon per peer.
+const NS_BEACON_SYNC_DEBOUNCE: Duration = Duration::from_secs(5);
+
+/// True if the beacon's advertised DAG head names a namespace governance
+/// op this node has not applied locally — i.e. the beaconing peer is
+/// ahead and we should pull the namespace governance DAG from it.
+///
+/// A zero head (`[0u8; 32]`) means the peer has applied nothing yet;
+/// never sync towards an empty DAG.
+fn beacon_indicates_divergence(dag_head: [u8; 32], head_op_present_locally: bool) -> bool {
+    dag_head != [0u8; 32] && !head_op_present_locally
+}
+
+/// Per-namespace debounce gate. Returns `true` (and records `now`) when
+/// no beacon-triggered sync fired for `namespace_id` within
+/// `NS_BEACON_SYNC_DEBOUNCE`; returns `false` otherwise.
+fn debounce_allows_sync(
+    debounce: &mut HashMap<[u8; 32], Instant>,
+    namespace_id: [u8; 32],
+    now: Instant,
+) -> bool {
+    match debounce.get(&namespace_id) {
+        Some(last) if now.duration_since(*last) < NS_BEACON_SYNC_DEBOUNCE => false,
+        _ => {
+            let _ = debounce.insert(namespace_id, now);
+            true
+        }
+    }
+}
+```
+
+At the end of `readiness.rs`, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn divergence_true_when_head_op_absent() {
+        assert!(beacon_indicates_divergence([7u8; 32], false));
+    }
+
+    #[test]
+    fn divergence_false_when_head_op_present() {
+        assert!(!beacon_indicates_divergence([7u8; 32], false) == false || true);
+        assert!(!beacon_indicates_divergence([7u8; 32], true));
+    }
+
+    #[test]
+    fn divergence_false_for_zero_head() {
+        // A peer that has applied nothing advertises a zero head; never
+        // sync towards an empty DAG even though the op is "absent".
+        assert!(!beacon_indicates_divergence([0u8; 32], false));
+    }
+
+    #[test]
+    fn debounce_allows_first_then_blocks_within_window() {
+        let mut d: HashMap<[u8; 32], Instant> = HashMap::new();
+        let t0 = Instant::now();
+        assert!(debounce_allows_sync(&mut d, [1u8; 32], t0));
+        // Second beacon 1s later — inside the 5s window — is blocked.
+        assert!(!debounce_allows_sync(&mut d, [1u8; 32], t0 + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn debounce_reallows_after_window() {
+        let mut d: HashMap<[u8; 32], Instant> = HashMap::new();
+        let t0 = Instant::now();
+        assert!(debounce_allows_sync(&mut d, [1u8; 32], t0));
+        assert!(debounce_allows_sync(
+            &mut d,
+            [1u8; 32],
+            t0 + NS_BEACON_SYNC_DEBOUNCE + Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn debounce_is_per_namespace() {
+        let mut d: HashMap<[u8; 32], Instant> = HashMap::new();
+        let t0 = Instant::now();
+        assert!(debounce_allows_sync(&mut d, [1u8; 32], t0));
+        // Different namespace — independent budget, still allowed.
+        assert!(debounce_allows_sync(&mut d, [2u8; 32], t0));
+    }
+}
+```
+
+(Remove the redundant first assert in `divergence_false_when_head_op_present` — keep only `assert!(!beacon_indicates_divergence([7u8; 32], true));`.)
+
+- [ ] **Step 2: Run tests — expect FAIL (helpers compile-only; field not yet added, handler not wired — tests should already PASS since helpers are self-contained)**
+
+Run: `cargo test -p calimero-node --lib network_event::readiness::tests`
+Expected: PASS (these helpers are pure; they pass immediately). This task is the TDD anchor for the predicate logic.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/node/src/handlers/network_event/readiness.rs
+git commit -m "test(node): beacon-divergence + debounce helpers for namespace anti-entropy"
+```
+
+---
+
+## Task 2: NodeManager debounce field
+
+**Files:**
+- Modify: `crates/node/src/manager.rs`
+
+- [ ] **Step 1: Add the field**
+
+In `crates/node/src/manager.rs`, add to the `NodeManager` struct (after `divergence_detected: Counter,`):
+
+```rust
+    /// Per-namespace timestamp of the last beacon-triggered governance
+    /// sync (#2367). Caps beacon-divergence syncs to one per namespace
+    /// per `NS_BEACON_SYNC_DEBOUNCE` window — beacons arrive every ~5s
+    /// from every Ready peer, so an un-debounced behind-node would fire
+    /// a sync per beacon per peer.
+    pub(crate) ns_beacon_sync_debounce:
+        std::collections::HashMap<[u8; 32], std::time::Instant>,
+```
+
+In `NodeManager::new()`, add to the `Self { ... }` initializer (after `divergence_detected,`):
+
+```rust
+            ns_beacon_sync_debounce: std::collections::HashMap::new(),
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo build -p calimero-node`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/node/src/manager.rs
+git commit -m "feat(node): NodeManager per-namespace beacon-sync debounce map"
+```
+
+---
+
+## Task 3: Wire Patch 1 into the beacon handler
+
+**Files:**
+- Modify: `crates/node/src/handlers/network_event/readiness.rs`
+
+- [ ] **Step 1: Extend imports**
+
+Change the `tracing` import to include `warn`:
+
+```rust
+use tracing::{debug, info, warn};
+```
+
+Add (with the other `use` lines):
+
+```rust
+use actix::{AsyncContext, WrapFuture};
+```
+
+- [ ] **Step 2: Rename `_ctx` → `ctx` and append the divergence trigger**
+
+In `handle_readiness_beacon`, rename the parameter `_ctx: &mut actix::Context<NodeManager>` to `ctx: &mut actix::Context<NodeManager>`.
+
+After the existing `info!( ... "readiness beacon received");` block and before the `if let Some(addr) = &manager.readiness_addr` block, insert:
+
+```rust
+    // #2367 — receiver-side anti-entropy. The beacon advertises the
+    // peer's namespace governance DAG head; if that head names an op we
+    // have not applied, the peer is ahead and we pull the namespace DAG
+    // from it via the real governance sync protocol (ops applied in DAG
+    // order, side-effects run). A spurious sync is only wasted work,
+    // never wrong state. Debounced to one sync per namespace per beacon
+    // interval — see `NS_BEACON_SYNC_DEBOUNCE`.
+    let dag_head = beacon.dag_head;
+    if debounce_allows_sync(
+        &mut manager.ns_beacon_sync_debounce,
+        namespace_id,
+        Instant::now(),
+    ) {
+        let datastore = manager.datastore.clone();
+        let node_client = manager.clients.node.clone();
+        let _ignored = ctx.spawn(
+            async move {
+                let head_op_present = {
+                    let handle = datastore.handle();
+                    let op_key =
+                        calimero_store::key::NamespaceGovOp::new(namespace_id, dag_head);
+                    match handle.get(&op_key) {
+                        Ok(present) => present.is_some(),
+                        Err(err) => {
+                            // Unknown local state — do NOT trigger a sync
+                            // on a failed read. The next beacon (~5s) retries.
+                            debug!(
+                                ?err,
+                                namespace_id = %hex::encode(namespace_id),
+                                "beacon-divergence: local DAG read failed; skipping sync"
+                            );
+                            return;
+                        }
+                    }
+                };
+                if beacon_indicates_divergence(dag_head, head_op_present) {
+                    info!(
+                        namespace_id = %hex::encode(namespace_id),
+                        dag_head = %hex::encode(dag_head),
+                        "beacon advertises an unknown namespace DAG head; \
+                         triggering governance sync"
+                    );
+                    if let Err(err) = node_client.sync_namespace(namespace_id).await {
+                        warn!(
+                            ?err,
+                            namespace_id = %hex::encode(namespace_id),
+                            "beacon-triggered namespace governance sync failed"
+                        );
+                    }
+                }
+            }
+            .into_actor(manager),
+        );
+    }
+```
+
+- [ ] **Step 3: Build + test**
+
+Run: `cargo build -p calimero-node && cargo test -p calimero-node --lib network_event::readiness`
+Expected: builds clean, tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/node/src/handlers/network_event/readiness.rs
+git commit -m "feat(node): trigger namespace governance sync on beacon divergence (#2367)"
+```
+
+---
+
+## Task 4: Patch 2 — on-subscribe out-of-cycle beacon
+
+**Files:**
+- Modify: `crates/node/src/handlers/network_event/subscriptions.rs`
+
+- [ ] **Step 1: Add the `ns/` arm**
+
+In `handle_subscribed`, immediately after the `group/` block's closing `return;` (line ~63) and before `let Ok(context_id): Result<ContextId, _> = topic_str.parse()`, insert:
+
+```rust
+    // #2367 — namespace governance topic. A peer just subscribed to
+    // `ns/<hex>`; emit an out-of-cycle readiness beacon so the new
+    // subscriber sees our namespace DAG head within ~1s instead of
+    // waiting up to a full ~5s periodic interval. The
+    // `EmitOutOfCycleBeacon` handler no-ops unless we are *Ready in
+    // this namespace and rate-limits per (peer, namespace), so this is
+    // safe even when the subscribing peer is in a namespace we don't
+    // belong to.
+    if let Some(hex) = topic_str.strip_prefix("ns/") {
+        let mut bytes = [0u8; 32];
+        if hex::decode_to_slice(hex, &mut bytes).is_ok() {
+            if let Some(addr) = &manager.readiness_addr {
+                info!(
+                    %peer_id,
+                    namespace_id = %hex,
+                    "Peer subscribed to namespace topic, emitting out-of-cycle beacon"
+                );
+                addr.do_send(crate::readiness::EmitOutOfCycleBeacon {
+                    namespace_id: bytes,
+                    requesting_peer: peer_id,
+                });
+            }
+        }
+        return;
+    }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p calimero-node`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/node/src/handlers/network_event/subscriptions.rs
+git commit -m "feat(node): emit out-of-cycle beacon on ns/ topic subscribe (#2367)"
+```
+
+---
+
+## Task 5: e2e regression sentinel — Phase 6
+
+**Files:**
+- Modify: `workflows/sync-tests/opaque-leaf-regression.yml`
+
+- [ ] **Step 1: Append Phase 6 after the existing Phase 5 `wait 12s` step**
+
+At the end of `opaque-leaf-regression.yml`, after the `Phase 5 — let materialisation race play out` step, add:
+
+```yaml
+
+  # ── Phase 6: receiver-side anti-entropy (#2367) ─────────────────────
+  # Pre-fix: node-2 missed node-1's `ContextRegistered` gossip for the
+  # second context on the cold per-namespace mesh and had no recovery
+  # trigger — its namespace governance DAG never learns ctx2 exists, so
+  # the steps below time out.
+  # Post-fix: node-1's periodic `ReadinessBeacon` advertises the new DAG
+  # head; node-2's beacon-divergence handler pulls the namespace
+  # governance DAG and applies `ContextRegistered`, so node-2 can join
+  # the second context and converge.
+  - name: Phase 6 — node-2 joins the second context
+    type: join_context
+    node: sync-regression-node-2
+    context_id: "{{ctx2_id}}"
+    outputs:
+      node2_ctx2_key: memberPublicKey
+
+  - name: Phase 6 — second context converges across both nodes
+    type: wait_for_sync
+    context_id: "{{ctx2_id}}"
+    nodes:
+      - sync-regression-node-1
+      - sync-regression-node-2
+    timeout: 40
+    check_interval: 2
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('workflows/sync-tests/opaque-leaf-regression.yml'))" && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add workflows/sync-tests/opaque-leaf-regression.yml
+git commit -m "test(e2e): Phase 6 second-context anti-entropy sentinel (#2367)"
+```
+
+---
+
+## Task 6: Workspace verification
+
+- [ ] **Step 1: Build + clippy + test**
+
+Run:
+```bash
+cargo build -p calimero-node -p calimero-context
+cargo clippy -p calimero-node --all-targets
+cargo test -p calimero-node --lib network_event
+```
+Expected: clean build, no new clippy warnings, tests PASS.
+
+- [ ] **Step 2: Code review**
+
+Run `/code-review:code-review` over the diff (`git diff origin/master`). Address findings inline; re-run build/clippy/test after fixes.
+
+---
+
+## Task 7: PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin fix/2367-namespace-governance-anti-entropy
+```
+
+- [ ] **Step 2: Open PR**
+
+Title: `fix(node): receiver-side anti-entropy for missed namespace governance ops (#2367)`
+Body: link #2367; explain the cold-start gap; summarize Patch 1 (beacon-divergence sync trigger) + Patch 2 (on-subscribe out-of-cycle beacon); note it supersedes the closed PR #2369 outbox; point at PR #2368 "Bug 3" and mero-drive PR #32 as post-merge verification targets.
+
+- [ ] **Step 3: Monitor CI** — confirm `opaque-leaf-regression` (incl. new Phase 6) and the existing #2356 guards stay green; address bot review threads.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Patch 1 → Tasks 1-3. Patch 2 → Task 4. Testing item 1 (Rust unit test) → Task 1. Testing item 2 (merobox) → Task 5. Testing items 3-4 (#2368 / mero-drive re-trigger) → post-merge, noted in PR body (Task 7). Out-of-scope items (publisher retry, `NamespaceStateHeartbeat`, `ReadinessProbe`) — untouched. ✔
+- **Predicate note:** the spec mentioned an `applied_through > local` secondary check. Op-membership of `beacon.dag_head` subsumes it: if the peer's head op is absent locally the peer is strictly ahead; if present we are equal-or-ahead. Dropping the separate `applied_through` comparison removes ambiguity over whether `NamespaceGovHeadValue.sequence == beacon.applied_through`. This is an intentional, documented simplification.
+- **Type consistency:** `NS_BEACON_SYNC_DEBOUNCE` / `beacon_indicates_divergence` / `debounce_allows_sync` / `ns_beacon_sync_debounce` named identically across Tasks 1-3. `NamespaceGovOp::new(namespace_id, delta_id)` and `NodeClient::sync_namespace` signatures verified against source. ✔
+- **Placeholder scan:** none.

--- a/docs/superpowers/specs/2026-05-16-namespace-governance-anti-entropy-design.md
+++ b/docs/superpowers/specs/2026-05-16-namespace-governance-anti-entropy-design.md
@@ -164,19 +164,37 @@ shaves the cold-start case to ~1s.
 
 ## Testing
 
-1. **Rust unit test** — the divergence predicate: `beacon.dag_head ∉ local` →
-   trigger; `∈ local` → no trigger; `applied_through` comparison; the debounce window is
-   respected (second beacon within the window does not re-trigger).
-2. **merobox e2e** — graduate Phase 5 of `workflows/sync-tests/opaque-leaf-regression.yml`:
-   node-2 joins the namespace **first**, then node-1 creates a second context, then
-   `wait_for_sync` on the second context with a tight timeout (~15s — covers the ~5s
-   beacon interval plus sync). Pre-fix: node-2 never learns the second context. Post-fix:
-   the beacon-divergence trigger syncs it. This is the deterministic regression sentinel.
+1. **Rust unit tests** — the divergence predicate: peer-ahead (`dag_head ∉ local`) →
+   trigger; `∈ local` → no trigger; zero head → no trigger; **no local namespace state
+   (still bootstrapping / mid-join) → no trigger** (the join flow owns the initial sync;
+   firing here races the join handshake — see "join-race gate" below). Plus the debounce
+   window: a second beacon inside the window does not re-trigger, re-allowed after it,
+   per-namespace isolation.
+2. **`group-metadata` e2e** (existing `e2e-rust-apps` matrix) — exercises the
+   namespace-governance join + `GroupMetadataSet` path end-to-end. This is the e2e proof:
+   a draft of this change regressed it (the beacon-divergence sync raced the join
+   handshake, pulling governance ops before key delivery → opaque skeletons), and the
+   join-race gate turns it green again.
+   *Note:* an earlier draft added a Phase 6 to `opaque-leaf-regression.yml` as a
+   dedicated sentinel; that was dropped — the workflow's Round-2 interleaved-write step
+   is a pre-existing #2293 mesh-starvation flake, so coupling a sentinel behind it is
+   unreliable. This change does not touch the sync crate, so `sync-regression.yml` does
+   not apply to it.
 3. **PR #2368** — re-trigger its CI on top of this change; the `MemberJoined` /
    `MemberJoinedOpen` ordering scenario should pass without a #2368-specific patch.
 4. **mero-drive PR #32** — post-merge, once `merod:edge` rebuilds, re-trigger its
    `E2E (main)` workflow; the "Sync Registry after nested-folder registration" step
    should stop flaking.
+
+### Join-race gate
+
+`beacon_indicates_divergence` requires the node to already hold a non-empty local
+namespace governance DAG head before triggering a sync. A node still bootstrapping or
+mid-join has no head: the join flow owns the initial governance sync, and a
+beacon-triggered sync firing concurrently races the join handshake — it can pull
+governance ops before the namespace key is delivered, leaving them as undecryptable
+opaque skeletons that the post-key join sync then skips as duplicates. An established
+member (the scenario this anti-entropy targets) always has a non-empty head.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-05-16-namespace-governance-anti-entropy-design.md
+++ b/docs/superpowers/specs/2026-05-16-namespace-governance-anti-entropy-design.md
@@ -1,0 +1,197 @@
+# Namespace Governance Anti-Entropy — Design
+
+**Date:** 2026-05-16
+**Status:** Approved (brainstorming complete, ready for implementation plan)
+**Supersedes:** PR #2369 (publisher-side outbox — abandoned, see "Why not the outbox" below)
+**Tracks:** #2367 scope item 1 · unblocks mero-drive PR #32 · resolves PR #2368 "Bug 3"
+
+## Context
+
+A node that misses a namespace governance op broadcast never recovers. Concretely:
+
+- A node creates a context (or any governance op) and broadcasts `ContextRegistered`
+  (etc.) on the `ns/<hex>` gossipsub topic. When the per-namespace mesh is cold or
+  still forming, the broadcast reaches zero subscribers.
+- `publish_and_await_ack_namespace` with `min_acks == 0` (the publisher has no known
+  subscribers) returns `Ok` immediately — the op is delivered to no one and is **never
+  retried**. It lives only on the creator's local governance DAG.
+- A peer that is **already a member** of the namespace has no recovery trigger: the
+  join flow does not re-run for it, so it stays permanently unaware of the op.
+
+This produces two observed failures:
+
+1. **mero-drive PR #32 CI** — node-2 is already in the namespace; node-1 creates a
+   context; the `ContextRegistered` broadcast is dropped on the cold per-context mesh;
+   node-2 never learns the context exists, so the `auto_follow` handler never fires.
+2. **PR #2368 "Bug 3"** — node-2's `MemberJoined` op does not reach node-3 before
+   `MemberJoinedOpen` arrives. node-3 buffers `MemberJoinedOpen` (missing parent) and
+   never receives `MemberJoined`, so the buffer never drains.
+
+Both are the same root cause: a governance op dropped on a cold mesh, with no
+receiver-side anti-entropy to detect and repair the gap.
+
+### Why not the outbox (PR #2369)
+
+PR #2369 attempted a network-layer publish outbox: queue a publish that hits
+`NoPeersSubscribedToTopic`, replay it on the next `Subscribed` event. It failed CI four
+times, each with a new failure mode (stale state-delta replay → `Cannot change
+StorageType`; API-signature ripple; topic-scoping; governance-snapshot race that drops
+`ContextRegistered` apply side-effects, losing `service_name`).
+
+Root cause of the outbox's unfixability: it re-publishes governance ops as **delayed
+raw gossip**, decoupled from their DAG context. Governance ops are DAG-ordered and have
+apply-time side-effects; blind re-broadcast races the governance DAG sync protocol and
+corrupts derived state. The outbox is the wrong abstraction. PR #2369 is closed.
+
+## Approach
+
+Close the gap on the **receiver side**, working with the existing #2237 readiness
+system rather than against it.
+
+The recovery signal **already exists and already flows**: `ReadinessBeacon` is emitted
+by every Ready node every ~5s (`crates/node/src/readiness.rs`, `emit_periodic_beacons`,
+`beacon_interval` default 5s) and carries `applied_through` + `dag_head`. It is already
+received and verified (`crates/node/src/handlers/network_event/readiness.rs`). The
+receiver simply inserts it into `ReadinessCache` and does **not act on divergence**.
+
+The fix is two targeted patches that make the receiver act on a signal it already gets.
+
+### Why this is correct where the outbox was not
+
+- **Receiver-pull, not publisher-replay.** A spurious sync is wasted work, never wrong
+  state. The outbox's failure mode (corrupting state by replaying stale ops) is
+  structurally impossible here.
+- **Syncs through the real governance DAG sync protocol** (`sync_namespace_from_peer`)
+  — ops applied in DAG order with their side-effects (`set_context_service_name`,
+  `OpEvent::ContextRegistered`). No snapshot-path corruption.
+- **No wire-format change** — the beacon already carries `applied_through` + `dag_head`.
+- **No publisher change** — the op lives on the creator's DAG; the beacon advertises it;
+  peers pull. `publish_and_await_ack(min_acks=0)` is left untouched.
+- **Aligned with #2237.** The `NamespaceStateHeartbeat` was *deliberately* made
+  liveness-only (Phase 11.2) because the readiness beacon was meant to be the divergence
+  signal. This change finishes that intent — it does not revert it.
+
+## Components
+
+### Patch 1 — beacon-divergence sync trigger
+
+**File:** `crates/node/src/handlers/network_event/readiness.rs` — the `ReadinessBeacon`
+receive handler (currently ~lines 25–56).
+
+After the existing `readiness_cache.insert(&beacon)` + `readiness_notify.notify(...)`:
+
+1. Read the local namespace governance head for `beacon.namespace_id` via the
+   `calimero_store::key::NamespaceGovHead` store key (the same accessor
+   `handle_namespace_state_heartbeat` uses), or `NamespaceGovernance::read_head`.
+2. Compute "peer ahead": `beacon.dag_head` is not present in the local namespace DAG
+   (we are missing the peer's head) **or** `beacon.applied_through` exceeds the local
+   applied-through sequence.
+3. If peer-ahead, enqueue `beacon.namespace_id` into the existing `ns_sync_rx` channel
+   (the same channel the join flow uses) → `sync_namespace_from_peer`.
+4. **Debounce:** a per-namespace `HashMap<[u8; 32], Instant>` on the `NodeManager` /
+   `ReadinessManager`. Skip the trigger if a sync for this namespace was already
+   triggered within the debounce window (~5s, i.e. one beacon interval). Beacons arrive
+   every ~5s from every peer; without the debounce a behind-node would fire one sync per
+   beacon per peer.
+
+Sync peer: `sync_namespace_from_peer` already selects a mesh peer. The beacon's `source`
+peer is demonstrably ahead and in the mesh; if `sync_namespace_from_peer` accepts a peer
+hint, pass `source`. If not, the existing peer-pick is acceptable (the implementation
+plan will confirm and decide).
+
+### Patch 2 — on-subscribe out-of-cycle beacon
+
+**File:** `crates/node/src/handlers/network_event/subscriptions.rs` — the
+`NetworkEvent::Subscribed` handler.
+
+The handler already special-cases `group/<hex>` topics (triggers `sync_group` +
+`broadcast_group_local_state`) and context topics. Add an `ns/<hex>` arm:
+
+- Decode `namespace_id` from the topic hash (`ns/` + hex).
+- Send the existing `EmitOutOfCycleBeacon` actor message to the `ReadinessManager` for
+  that namespace — the same path the `ReadinessProbe` receive handler already uses
+  (`readiness.rs`, the `EmitOutOfCycleBeacon` message, rate-limited to `BEACON_INTERVAL/2`).
+
+Effect: a newly-subscribed peer receives a beacon within ~1s instead of waiting up to
+the full ~5s periodic interval. Patch 1 alone already bounds recovery at ~5s; Patch 2
+shaves the cold-start case to ~1s.
+
+## Data flow
+
+**mero-drive cold-start**
+
+1. node-2 is already in the namespace. node-1 creates a context → `ContextRegistered`
+   op. Broadcast on `ns/<hex>`; cold mesh → node-2 misses it.
+2. node-1 is Ready → emits a `ReadinessBeacon` every ~5s; `dag_head` now includes the
+   `ContextRegistered` op.
+3. node-2 receives node-1's beacon → Patch 1: `beacon.dag_head` is absent from node-2's
+   local namespace DAG → trigger `sync_namespace_from_peer`.
+4. node-2 syncs the namespace governance DAG from node-1 → applies `ContextRegistered`
+   in DAG order; side-effects run (context registered in the group tree,
+   `set_context_service_name`, `OpEvent::ContextRegistered` notified).
+5. The `auto_follow` handler fires on `OpEvent::ContextRegistered` and joins the context.
+
+**PR #2368 "Bug 3"**
+
+1. node-3 misses node-2's `MemberJoined` op on the cold mesh.
+2. `MemberJoinedOpen` arrives at node-3 → buffered in the governance pending buffer
+   (missing parent).
+3. node-2 emits a `ReadinessBeacon` → node-3 receives it → `dag_head`/`applied_through`
+   ahead of local → node-3 triggers a namespace sync → applies `MemberJoined`.
+4. The buffered `MemberJoinedOpen` drains once its parent is present.
+
+**On-subscribe fast path**
+
+1. A new peer subscribes to `ns/<hex>`.
+2. Existing members observe `NetworkEvent::Subscribed` → Patch 2 → emit an out-of-cycle
+   beacon.
+3. The new peer receives a beacon within ~1s → Patch 1 → fast sync.
+
+## Error handling
+
+- **`read_head` failure** — log and skip the divergence check (do not trigger a sync on
+  unknown local state). The next beacon (~5s) retries.
+- **`sync_namespace_from_peer` failure** — handled by the existing namespace-sync error
+  path (exponential backoff). The next beacon re-triggers regardless.
+- **Concurrent heads** (peer and local each hold an op the other lacks) — the
+  "peer-ahead" predicate still fires; triggering a sync is correct (the sync converges
+  both DAGs). Harmless.
+- **Peer actually behind us** — the predicate is strictly "peer ahead"; no trigger fires.
+- **Sync storm** — the per-namespace debounce caps the trigger rate to ~1 sync per
+  namespace per beacon interval.
+- **Untrusted input** — the beacon is already signature-verified and size-bounded in the
+  existing receive handler; Patch 1 runs after that verification.
+
+## Testing
+
+1. **Rust unit test** — the divergence predicate: `beacon.dag_head ∉ local` →
+   trigger; `∈ local` → no trigger; `applied_through` comparison; the debounce window is
+   respected (second beacon within the window does not re-trigger).
+2. **merobox e2e** — graduate Phase 5 of `workflows/sync-tests/opaque-leaf-regression.yml`:
+   node-2 joins the namespace **first**, then node-1 creates a second context, then
+   `wait_for_sync` on the second context with a tight timeout (~15s — covers the ~5s
+   beacon interval plus sync). Pre-fix: node-2 never learns the second context. Post-fix:
+   the beacon-divergence trigger syncs it. This is the deterministic regression sentinel.
+3. **PR #2368** — re-trigger its CI on top of this change; the `MemberJoined` /
+   `MemberJoinedOpen` ordering scenario should pass without a #2368-specific patch.
+4. **mero-drive PR #32** — post-merge, once `merod:edge` rebuilds, re-trigger its
+   `E2E (main)` workflow; the "Sync Registry after nested-folder registration" step
+   should stop flaking.
+
+## Out of scope
+
+- **`publish_and_await_ack_namespace(min_acks == 0)` retry** — not needed. The op
+  persists on the creator's DAG; the beacon advertises it; receivers pull. The publisher
+  is left untouched.
+- **`NamespaceStateHeartbeat`** — stays liveness-only, preserving the #2237 Phase 11.2
+  intent.
+- **`ReadinessProbe` join-path** — unchanged.
+- **The PR #2369 outbox** — fully reverted; PR #2369 closed with a comment documenting
+  the four-failure diagnosis so the dead end is recorded.
+
+## Disposition of PR #2369
+
+Close PR #2369. Post a closing comment summarizing the outbox diagnosis (four CI
+failures, each a distinct failure mode, root cause = re-publishing governance ops as
+delayed raw gossip races the DAG sync protocol). Implementation of this design proceeds
+on a new branch `fix/2367-namespace-governance-anti-entropy`.

--- a/workflows/sync-tests/opaque-leaf-regression.yml
+++ b/workflows/sync-tests/opaque-leaf-regression.yml
@@ -294,3 +294,28 @@ steps:
     # didn't short-circuit.
     type: wait
     seconds: 12
+
+  # ── Phase 6: receiver-side anti-entropy (#2367) ─────────────────────
+  # Pre-fix: node-2 missed node-1's `ContextRegistered` gossip for the
+  # second context on the cold per-namespace mesh and had no recovery
+  # trigger — its namespace governance DAG never learns ctx2 exists, so
+  # the steps below time out.
+  # Post-fix: node-1's periodic `ReadinessBeacon` advertises the new DAG
+  # head; node-2's beacon-divergence handler pulls the namespace
+  # governance DAG and applies `ContextRegistered`, so node-2 can join
+  # the second context and converge.
+  - name: Phase 6 — node-2 joins the second context
+    type: join_context
+    node: sync-regression-node-2
+    context_id: "{{ctx2_id}}"
+    outputs:
+      node2_ctx2_key: memberPublicKey
+
+  - name: Phase 6 — second context converges across both nodes
+    type: wait_for_sync
+    context_id: "{{ctx2_id}}"
+    nodes:
+      - sync-regression-node-1
+      - sync-regression-node-2
+    timeout: 40
+    check_interval: 2

--- a/workflows/sync-tests/opaque-leaf-regression.yml
+++ b/workflows/sync-tests/opaque-leaf-regression.yml
@@ -294,28 +294,3 @@ steps:
     # didn't short-circuit.
     type: wait
     seconds: 12
-
-  # ── Phase 6: receiver-side anti-entropy (#2367) ─────────────────────
-  # Pre-fix: node-2 missed node-1's `ContextRegistered` gossip for the
-  # second context on the cold per-namespace mesh and had no recovery
-  # trigger — its namespace governance DAG never learns ctx2 exists, so
-  # the steps below time out.
-  # Post-fix: node-1's periodic `ReadinessBeacon` advertises the new DAG
-  # head; node-2's beacon-divergence handler pulls the namespace
-  # governance DAG and applies `ContextRegistered`, so node-2 can join
-  # the second context and converge.
-  - name: Phase 6 — node-2 joins the second context
-    type: join_context
-    node: sync-regression-node-2
-    context_id: "{{ctx2_id}}"
-    outputs:
-      node2_ctx2_key: memberPublicKey
-
-  - name: Phase 6 — second context converges across both nodes
-    type: wait_for_sync
-    context_id: "{{ctx2_id}}"
-    nodes:
-      - sync-regression-node-1
-      - sync-regression-node-2
-    timeout: 40
-    check_interval: 2


### PR DESCRIPTION
## Problem

A node that misses a namespace governance op broadcast on a cold per-namespace mesh never recovers:

- The creator broadcasts `ContextRegistered` (etc.) on `ns/<hex>`. When the mesh is cold or still forming, the broadcast reaches zero subscribers.
- `publish_and_await_ack_namespace` with `min_acks == 0` returns `Ok` immediately — delivered to no one, **never retried**. The op lives only on the creator's local governance DAG.
- A peer that is **already a member** has no recovery trigger: the join flow does not re-run, so it stays permanently unaware.

This breaks two observed scenarios: mero-drive PR #32 CI (node-2 never learns of a new context) and PR #2368 "Bug 3" (`MemberJoined` not reaching node-3 before `MemberJoinedOpen`).

## Fix

Receiver-side anti-entropy, working *with* the #2237 readiness system. `ReadinessBeacon` already flows every ~5s carrying `dag_head`; the receiver simply did not act on divergence.

**Patch 1 — beacon-divergence sync trigger** (`handlers/network_event/readiness.rs`)
`handle_readiness_beacon` checks whether `beacon.dag_head` names a `NamespaceGovOp` present in the local DAG. If absent, the peer is ahead → trigger `sync_namespace()`. Ops are pulled through the real governance sync protocol (DAG order, side-effects). Debounced per-namespace; the debounce slot is stamped only when a sync actually fires.

**Join-race gate:** the trigger requires the node to already hold a non-empty local namespace governance DAG head. A node mid-join has no head — the join flow owns the initial sync; firing concurrently races the join handshake (pulls ops before key delivery → opaque skeletons). Established members (the target scenario) always have a head.

**Patch 2 — on-subscribe out-of-cycle beacon** (`handlers/network_event/subscriptions.rs`)
`handle_subscribed` emits an out-of-cycle `ReadinessBeacon` when a peer subscribes to a `ns/<hex>` topic, shaving cold-start recovery from ~5s to ~1s.

No wire-format change, no publisher change. Supersedes the closed publisher-side outbox PR #2369.

## Testing

- **Rust unit tests** — the divergence predicate (peer-ahead, caught-up, zero-head, and the no-local-state join-race gate) and the per-namespace debounce.
- **`group-metadata` e2e** (`e2e-rust-apps` matrix) exercises the namespace-governance join + `GroupMetadataSet` path end-to-end. A draft of this change regressed it (beacon sync racing the join handshake); the join-race gate makes it green.
- An earlier draft added a Phase 6 to `opaque-leaf-regression.yml`; dropped — that workflow's Round-2 step is a pre-existing #2293 mesh-starvation flake, unreliable to couple a sentinel behind. This change touches no sync-crate path, so `sync-regression.yml` does not apply.
- Cross-repo verification (post-merge): re-trigger PR #2368 CI and mero-drive PR #32 `E2E (main)`.

Closes the cold-start governance-delivery gap from #2367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new receiver-side sync triggers based on network beacons and subscription events, which could increase sync traffic or surface edge cases around partial/bootstrapping state despite debounce and join-state gating.
> 
> **Overview**
> Adds receiver-side anti-entropy for namespace governance by having `handle_readiness_beacon` detect when a peer advertises a namespace DAG head op missing locally and then trigger `node_client.sync_namespace`, guarded by a *"has local state"* join-race gate and a per-namespace debounce.
> 
> Also emits an out-of-cycle readiness beacon when a peer subscribes to an `ns/<hex>` topic to speed up cold-start convergence, and introduces the `NodeManager.ns_beacon_sync_debounce` shared map plus unit tests for the divergence/debounce helpers. Includes new design/spec and implementation-plan docs for #2367.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4424fe60d31d686259fd4f79a8f37d14eb643f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->