### PR TITLE
fix(sync): DAG-head divergence catch-up for burst-write convergence

### DIFF
--- a/.github/workflows/burst-write-regression.yml
+++ b/.github/workflows/burst-write-regression.yml
@@ -1,0 +1,151 @@
+name: Burst-write regression
+
+# Regression guard for DAG-delta convergence under burst writes — the
+# mero-drive E2E (main) failure mode. Runs `burst-write-regression.yml`:
+# a 2-node bootstrap, then 20 mutations from one node with NO intermediate
+# `wait_for_sync`, then a single convergence assertion.
+#
+# Core's other sync workflows pace every mutation with `wait_for_sync`,
+# which suppresses the burst-write condition real apps hit. This workflow
+# is the deterministic core guard for it — pre-fix the final
+# `wait_for_sync` times out; post-fix it converges via the DAG-head
+# divergence catch-up in `handle_dag_sync`.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "crates/node/src/sync/**"
+      - "crates/node/src/delta_store.rs"
+      - "crates/dag/**"
+      - "workflows/sync-tests/**"
+      - ".github/workflows/burst-write-regression.yml"
+      - ".github/actions/build-local-merod/**"
+      - ".github/actions/setup-merobox/**"
+
+  pull_request:
+    branches: [master]
+    paths:
+      - "crates/node/src/sync/**"
+      - "crates/node/src/delta_store.rs"
+      - "crates/dag/**"
+      - "workflows/sync-tests/**"
+      - ".github/workflows/burst-write-regression.yml"
+      - ".github/actions/build-local-merod/**"
+      - ".github/actions/setup-merobox/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUST_LOG: info,calimero_=debug
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+jobs:
+  burst-write-regression:
+    name: Burst-write regression
+    # Same runner class as e2e-rust-apps / sync-regression so cold-start
+    # performance is comparable and we share the rust-ci cache.
+    runs-on: ubuntu-24.04-8cpu
+    # 15-min cap is generous: the workflow's own timeout is 60s on the
+    # final `wait_for_sync`, so a regression fails in ~1 min. The cap is
+    # for the cold-build steps (merod image + WASM) plus a safety margin.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          shared-key: burst-write-regression
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build local merod image
+        uses: ./.github/actions/build-local-merod
+        env:
+          CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build kv-store-with-handlers WASM
+        run: |
+          cd apps/kv-store-with-handlers
+          ./build.sh
+
+      - name: Setup merobox
+        uses: ./.github/actions/setup-merobox
+
+      - name: Run burst-write-regression workflow
+        # `merobox bootstrap run` exits non-zero on any failed step
+        # (including a `wait_for_sync` timeout, which is the symptom under
+        # regression). No retry — a flake here is a real bug, same
+        # rationale as `e2e-rust-apps.yml` / `sync-regression.yml`.
+        run: |
+          mkdir -p docker-logs
+
+          # Stream docker logs to per-container files while the run is
+          # live. `merobox bootstrap run` tears the runtime containers
+          # down on its way out, so a post-run `docker logs` pass catches
+          # nothing — capture during the run instead. Same shape as
+          # sync-regression.yml's watcher.
+          LOGDIR="$GITHUB_WORKSPACE/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+              for c in $(docker ps --filter "label=calimero.node=true" \
+                                   --format "{{.Names}}" 2>/dev/null \
+                         | grep -v -- '-init$' || true); do
+                mark="$WATCHER_STATE_DIR/${c}"
+                if [ ! -f "$mark" ]; then
+                  touch "$mark"
+                  echo "[log-watcher] following $c"
+                  docker logs -f --timestamps "$c" \
+                    > "$LOGDIR/${c}.log" 2>&1 &
+                fi
+              done
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
+          set +e
+          set -o pipefail
+          merobox bootstrap run \
+              workflows/sync-tests/burst-write-regression.yml \
+              --image merod:local \
+              --e2e-mode \
+              --verbose 2>&1 | tee docker-logs/merobox-output.log
+          exit_code=$?
+          set +o pipefail
+
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
+
+          exit "$exit_code"
+
+      - name: Upload docker logs
+        # Always upload — green runs still need log evidence (e.g.
+        # confirming the catch-up actually fired, not that the burst
+        # simply never dropped a delta). Matches `sync-regression.yml`.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: burst-write-regression-docker-logs
+          path: docker-logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -2131,6 +2131,15 @@ impl DeltaStore {
         dag.has_delta(id)
     }
 
+    /// Check if a specific delta is applied in the in-memory DAG (not
+    /// merely present-but-pending). Used by the sync manager's DAG-head
+    /// divergence catch-up to decide whether a peer-advertised head has
+    /// actually been integrated into local state.
+    pub async fn is_applied(&self, id: &[u8; 32]) -> bool {
+        let dag = self.dag.read().await;
+        dag.is_applied(id)
+    }
+
     /// Get a specific delta (for sending to peers)
     pub async fn get_delta(&self, id: &[u8; 32]) -> Option<CausalDelta<Vec<Action>>> {
         let dag = self.dag.read().await;

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -2098,6 +2098,19 @@ impl DeltaStore {
         dag.is_applied(delta_id)
     }
 
+    /// Of `delta_ids`, the subset already applied in the in-memory DAG.
+    /// Takes the DAG read lock once for the whole batch — cheaper than a
+    /// per-id `dag_has_delta_applied` loop when several ids are checked
+    /// together (e.g. the sync manager's DAG-head divergence catch-up).
+    pub async fn dag_applied_subset(&self, delta_ids: &[[u8; 32]]) -> HashSet<[u8; 32]> {
+        let dag = self.dag.read().await;
+        delta_ids
+            .iter()
+            .filter(|id| dag.is_applied(id))
+            .copied()
+            .collect()
+    }
+
     /// Get current DAG heads
     pub async fn get_heads(&self) -> Vec<[u8; 32]> {
         let dag = self.dag.read().await;
@@ -2129,15 +2142,6 @@ impl DeltaStore {
     pub async fn has_delta(&self, id: &[u8; 32]) -> bool {
         let dag = self.dag.read().await;
         dag.has_delta(id)
-    }
-
-    /// Check if a specific delta is applied in the in-memory DAG (not
-    /// merely present-but-pending). Used by the sync manager's DAG-head
-    /// divergence catch-up to decide whether a peer-advertised head has
-    /// actually been integrated into local state.
-    pub async fn is_applied(&self, id: &[u8; 32]) -> bool {
-        let dag = self.dag.read().await;
-        dag.is_applied(id)
     }
 
     /// Get a specific delta (for sending to peers)

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3,7 +3,7 @@
 //! **Purpose**: Coordinates periodic syncs, selects peers, and delegates to protocols.
 //! **Strategy**: Try delta sync first, fallback to state sync on failure.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -1567,6 +1567,55 @@ impl SyncManager {
             .await?;
 
         if let Some((peer_root_hash, peer_dag_heads)) = peer_state {
+            // DAG-head divergence catch-up.
+            //
+            // `select_protocol` below only reconciles the entity Merkle
+            // tree — it has no `DeltaSync` arm for two initialized peers,
+            // and the pending-set catch-up above (`get_missing_parents`)
+            // is invisible to a node that missed a *contiguous suffix* of
+            // the delta chain: nothing is pending, so nothing reports a
+            // missing parent. Such a node would never pull the missed
+            // deltas, and its `dag_heads` would stay stale forever (only a
+            // restart, via init-time `load_persisted_deltas`, recovers it).
+            //
+            // If the peer advertises a DAG head we have not applied
+            // locally, route to the recursive parent-pull
+            // (`request_dag_heads_and_sync`): it fetches the peer's heads,
+            // they go pending, `get_missing_parents` then walks the missed
+            // suffix back to a delta we already hold, and the cascade
+            // applies it — advancing `dag_heads` and `root_hash`. This is
+            // divergence-triggered (peer head absent locally) and bounded
+            // (`request_missing_deltas`' fetch limit); it adds no periodic
+            // rescan.
+            if !peer_dag_heads.is_empty()
+                && self
+                    .local_dag_behind_peer_heads(context_id, &peer_dag_heads)
+                    .await
+            {
+                info!(
+                    %context_id,
+                    %chosen_peer,
+                    peer_heads = peer_dag_heads.len(),
+                    "Peer advertises unapplied DAG heads, requesting delta catch-up"
+                );
+                let result = self
+                    .request_dag_heads_and_sync(context_id, chosen_peer, our_identity, stream)
+                    .await
+                    .wrap_err("DAG-head divergence catch-up")?;
+
+                // `None` means the peer served no heads after all — but we
+                // only entered this branch because an earlier
+                // `query_peer_dag_state` saw non-empty heads, so this is a
+                // transient peer hiccup. Bail to try another peer rather
+                // than reuse the now-consumed stream for the entity-tree
+                // path (matches the sibling `request_dag_heads_and_sync`
+                // call sites above and in the `DeltaSync` arm below).
+                if matches!(result, SyncProtocol::None) {
+                    bail!("Peer has no data for this context");
+                }
+                return Ok(Some(result));
+            }
+
             // Build handshakes for protocol selection (CIP §2.3)
             // Uses shared functions from calimero_node_primitives::sync::state_machine
             let local_hs = self.build_local_handshake(context);
@@ -1873,6 +1922,57 @@ impl SyncManager {
                 Ok(None)
             }
         }
+    }
+
+    /// Pure divergence rule behind [`Self::local_dag_behind_peer_heads`].
+    ///
+    /// Returns `true` when `peer_dag_heads` contains a non-genesis head
+    /// absent from `applied_heads`. Genesis sentinels (`[0u8; DIGEST_SIZE]`)
+    /// are skipped — they are never real deltas to fetch. Kept static and
+    /// closure-free so the genesis-skip / any-unapplied logic is
+    /// unit-testable without constructing a `SyncManager`.
+    fn peer_heads_diverge(
+        peer_dag_heads: &[[u8; DIGEST_SIZE]],
+        applied_heads: &HashSet<[u8; DIGEST_SIZE]>,
+    ) -> bool {
+        peer_dag_heads
+            .iter()
+            .any(|head| *head != [0u8; DIGEST_SIZE] && !applied_heads.contains(head))
+    }
+
+    /// True when the peer advertises a DAG head this node has not applied
+    /// locally — the trigger for DAG-head divergence catch-up in
+    /// [`Self::handle_dag_sync`].
+    ///
+    /// A missing delta store (no local DAG materialised for this context)
+    /// counts as behind: `request_dag_heads_and_sync` hydrates a fresh
+    /// store via its bootstrap path. Genesis heads (`[0u8; DIGEST_SIZE]`)
+    /// are skipped — they are never real deltas to fetch.
+    async fn local_dag_behind_peer_heads(
+        &self,
+        context_id: ContextId,
+        peer_dag_heads: &[[u8; DIGEST_SIZE]],
+    ) -> bool {
+        let Some(delta_store) = self
+            .node_state
+            .delta_stores
+            .get(&context_id)
+            .map(|ds| ds.clone())
+        else {
+            return true;
+        };
+
+        // Resolve applied-ness for each non-genesis head up front, then
+        // apply the pure divergence rule. Heads lists are tiny (typically
+        // 1-2), so resolving all of them rather than short-circuiting on
+        // the first miss costs nothing.
+        let mut applied_heads = HashSet::new();
+        for head in peer_dag_heads {
+            if *head != [0u8; DIGEST_SIZE] && delta_store.is_applied(head).await {
+                let _ = applied_heads.insert(*head);
+            }
+        }
+        Self::peer_heads_diverge(peer_dag_heads, &applied_heads)
     }
 
     async fn initiate_sync_inner(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1944,15 +1944,28 @@ impl SyncManager {
     /// locally — the trigger for DAG-head divergence catch-up in
     /// [`Self::handle_dag_sync`].
     ///
-    /// A missing delta store (no local DAG materialised for this context)
-    /// counts as behind: `request_dag_heads_and_sync` hydrates a fresh
-    /// store via its bootstrap path. Genesis heads (`[0u8; DIGEST_SIZE]`)
-    /// are skipped — they are never real deltas to fetch.
+    /// Genesis sentinels (`[0u8; DIGEST_SIZE]`) are never real deltas to
+    /// fetch: if every advertised head is genesis this returns `false`
+    /// regardless of local state, so the catch-up cannot fire a doomed
+    /// `DeltaRequest` for a genesis id. Otherwise a missing delta store
+    /// (no local DAG materialised for this context) counts as behind —
+    /// `request_dag_heads_and_sync` hydrates a fresh store via its
+    /// bootstrap path.
     async fn local_dag_behind_peer_heads(
         &self,
         context_id: ContextId,
         peer_dag_heads: &[[u8; DIGEST_SIZE]],
     ) -> bool {
+        // Nothing real to fetch if every advertised head is a genesis
+        // sentinel — skip before the delta-store lookup so the no-store
+        // branch below cannot trigger a catch-up for a genesis id.
+        if !peer_dag_heads
+            .iter()
+            .any(|head| *head != [0u8; DIGEST_SIZE])
+        {
+            return false;
+        }
+
         let Some(delta_store) = self
             .node_state
             .delta_stores
@@ -1962,16 +1975,9 @@ impl SyncManager {
             return true;
         };
 
-        // Resolve applied-ness for each non-genesis head up front, then
-        // apply the pure divergence rule. Heads lists are tiny (typically
-        // 1-2), so resolving all of them rather than short-circuiting on
-        // the first miss costs nothing.
-        let mut applied_heads = HashSet::new();
-        for head in peer_dag_heads {
-            if *head != [0u8; DIGEST_SIZE] && delta_store.is_applied(head).await {
-                let _ = applied_heads.insert(*head);
-            }
-        }
+        // Resolve applied-ness for every advertised head under a single
+        // DAG read lock, then apply the pure divergence rule.
+        let applied_heads = delta_store.dag_applied_subset(peer_dag_heads).await;
         Self::peer_heads_diverge(peer_dag_heads, &applied_heads)
     }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1603,15 +1603,16 @@ impl SyncManager {
                     .await
                     .wrap_err("DAG-head divergence catch-up")?;
 
-                // `None` means the peer served no heads after all — but we
-                // only entered this branch because an earlier
-                // `query_peer_dag_state` saw non-empty heads, so this is a
-                // transient peer hiccup. Bail to try another peer rather
-                // than reuse the now-consumed stream for the entity-tree
-                // path (matches the sibling `request_dag_heads_and_sync`
-                // call sites above and in the `DeltaSync` arm below).
+                // `None` from `request_dag_heads_and_sync` means the peer
+                // served no usable DAG heads — either genuinely no data
+                // or an unexpected response. This path cannot distinguish
+                // the two, so the message stays cause-neutral. Either way,
+                // bail to try another peer rather than reuse the
+                // now-consumed stream for the entity-tree path (matches
+                // the sibling `request_dag_heads_and_sync` call sites
+                // above and in the `DeltaSync` arm below).
                 if matches!(result, SyncProtocol::None) {
-                    bail!("Peer has no data for this context");
+                    bail!("divergence catch-up yielded no DAG heads from peer; retrying");
                 }
                 return Ok(Some(result));
             }

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -178,6 +178,95 @@ fn test_max_depth_calculation() {
 }
 
 // =========================================================================
+// Tests for the DAG-head divergence rule (`SyncManager::peer_heads_diverge`)
+// backing the divergence catch-up in `handle_dag_sync`.
+//
+// `peer_heads_diverge` is the pure kernel of `local_dag_behind_peer_heads`:
+// the async wrapper resolves each non-genesis peer head against the local
+// DAG's *applied* set (a present-but-pending delta is NOT applied, so it is
+// absent from `applied_heads` and counts as divergent) and a missing delta
+// store short-circuits to "behind" before this rule runs.
+// =========================================================================
+
+#[cfg(test)]
+mod peer_heads_diverge_tests {
+    use std::collections::HashSet;
+
+    use super::SyncManager;
+
+    /// No heads advertised — nothing to catch up on.
+    #[test]
+    fn empty_heads_do_not_diverge() {
+        assert!(!SyncManager::peer_heads_diverge(&[], &HashSet::new()));
+    }
+
+    /// A genesis sentinel head is skipped — it is never a real delta.
+    #[test]
+    fn genesis_only_heads_do_not_diverge() {
+        assert!(!SyncManager::peer_heads_diverge(
+            &[[0u8; 32]],
+            &HashSet::new()
+        ));
+    }
+
+    /// Peer advertises a real head we have not applied — diverge.
+    #[test]
+    fn unapplied_head_diverges() {
+        assert!(SyncManager::peer_heads_diverge(
+            &[[1u8; 32]],
+            &HashSet::new()
+        ));
+    }
+
+    /// Peer's only head is already applied locally — no divergence.
+    #[test]
+    fn applied_head_does_not_diverge() {
+        assert!(!SyncManager::peer_heads_diverge(
+            &[[1u8; 32]],
+            &HashSet::from([[1u8; 32]])
+        ));
+    }
+
+    /// One unapplied head among applied ones still diverges.
+    #[test]
+    fn one_unapplied_among_applied_diverges() {
+        assert!(SyncManager::peer_heads_diverge(
+            &[[1u8; 32], [2u8; 32]],
+            &HashSet::from([[1u8; 32]])
+        ));
+    }
+
+    /// Every advertised head is applied locally — no divergence.
+    #[test]
+    fn all_heads_applied_do_not_diverge() {
+        assert!(!SyncManager::peer_heads_diverge(
+            &[[1u8; 32], [2u8; 32]],
+            &HashSet::from([[1u8; 32], [2u8; 32]])
+        ));
+    }
+
+    /// A genesis sentinel alongside an applied real head — genesis is
+    /// skipped, the real head is applied, so no divergence.
+    #[test]
+    fn genesis_alongside_applied_head_does_not_diverge() {
+        assert!(!SyncManager::peer_heads_diverge(
+            &[[0u8; 32], [1u8; 32]],
+            &HashSet::from([[1u8; 32]])
+        ));
+    }
+
+    /// A genesis sentinel alongside an unapplied real head — genesis is
+    /// skipped, the real head is missing, so it diverges.
+    #[test]
+    fn genesis_alongside_unapplied_head_diverges() {
+        assert!(SyncManager::peer_heads_diverge(
+            &[[0u8; 32], [1u8; 32]],
+            &HashSet::new()
+        ));
+    }
+}
+
+// =========================================================================
 // Tests for the #2319 dispatch-attempt backoff helper
 // =========================================================================
 

--- a/workflows/sync-tests/burst-write-regression.yml
+++ b/workflows/sync-tests/burst-write-regression.yml
@@ -1,0 +1,377 @@
+name: "Burst-write DAG-delta convergence regression"
+description: >
+  2-node bootstrap mirroring mero-drive's failing E2E (main) burst pattern:
+  install app, create a namespace + Registry-style context, the second node
+  joins both, then a burst of 20 mutations from a single node with NO
+  intermediate `wait_for_sync`, followed by one final convergence assertion.
+
+  Core's other sync workflows pace every mutation with `wait_for_sync`, which
+  structurally suppresses the burst-write condition real apps hit (apps fire
+  mutations as fast as the UI produces them — they do not sync between each
+  write). This workflow encodes that real pattern as a permanent regression
+  guard.
+
+  Pre-fix: a node that misses a contiguous suffix of the delta chain has no
+  DAG-delta recovery path. `select_protocol` reconciles only the entity
+  Merkle tree, and the `get_missing_parents` catch-up is invisible to a node
+  with nothing pending — so `dag_heads` stay stale and the final
+  `wait_for_sync` times out (only a restart recovers it).
+
+  Post-fix: the DAG-head divergence catch-up in `handle_dag_sync` notices the
+  peer advertises an unapplied head and pulls the missed deltas via
+  `request_dag_heads_and_sync` within a few interval-sync cycles, so the
+  final `wait_for_sync` converges.
+
+  Total runtime budget: ~4 min. Under regression the failure mode is the
+  final `wait_for_sync` timing out at 60s — fast and unambiguous.
+
+# Test configuration
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 2
+  # The GHA wrapper (`burst-write-regression.yml`) builds `merod:local` from
+  # the PR HEAD and loads it into docker before invoking merobox — that's
+  # the image tag this workflow expects. `--image merod:local` on the
+  # merobox CLI overrides this anyway, but specify it here so a local
+  # `merobox bootstrap run` works without the override.
+  image: merod:local
+  prefix: burst-write-node
+
+steps:
+  # ── Phase 1: Bootstrap mesh + namespace + context ───────────────────
+  - name: Install kv-store-with-handlers on node-1
+    type: install_application
+    node: burst-write-node-1
+    path: apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install kv-store-with-handlers on node-2
+    type: install_application
+    node: burst-write-node-2
+    path: apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: burst-write-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Node-1 creates Registry-style context inside namespace
+    type: create_context
+    node: burst-write-node-1
+    application_id: "{{app_id}}"
+    group_id: "{{namespace_id}}"
+    outputs:
+      ctx_id: contextId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: burst-write-node-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      ns_invite: invitation
+
+  - name: Wait for namespace governance to gossip
+    # Namespace governance DAG needs to propagate to node-2 before the join
+    # op (otherwise `join_namespace` 404s on the invitation). 10s matches
+    # mero-drive's e2e and the opaque-leaf workflow.
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: burst-write-node-2
+    namespace_id: "{{namespace_id}}"
+    invitation: "{{ns_invite}}"
+    outputs:
+      node2_identity: memberIdentity
+
+  - name: Node-2 joins context
+    type: join_context
+    node: burst-write-node-2
+    context_id: "{{ctx_id}}"
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Assert bootstrap shape
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+      - "is_set({{ctx_id}})"
+      - "is_set({{node1_key}})"
+      - "is_set({{node2_identity}})"
+      - "is_set({{node2_key}})"
+
+  # ── Phase 2: Baseline sync (empty Root state) ───────────────────────
+  # Single sanity baseline before the burst — both Roots are still empty,
+  # so a healthy mesh handles this trivially. This is the LAST
+  # `wait_for_sync` before the burst on purpose.
+  - name: Baseline sync after join
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - burst-write-node-1
+      - burst-write-node-2
+    timeout: 30
+    check_interval: 2
+
+  # ── Phase 3: Burst write — 20 mutations from node-1, NO intermediate sync ─
+  # This is the crux. Every mutation extends the Root<KvStore> delta chain
+  # on node-1. With no `wait_for_sync` between writes, node-2 must keep up
+  # purely via gossip + interval sync. If node-2 misses any contiguous run
+  # of these deltas, pre-fix it can never catch up (see the description).
+  - name: Burst 01 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_01"
+      value: "burst-value-01"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 02 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_02"
+      value: "burst-value-02"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 03 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_03"
+      value: "burst-value-03"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 04 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_04"
+      value: "burst-value-04"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 05 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_05"
+      value: "burst-value-05"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 06 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_06"
+      value: "burst-value-06"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 07 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_07"
+      value: "burst-value-07"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 08 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_08"
+      value: "burst-value-08"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 09 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_09"
+      value: "burst-value-09"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 10 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_10"
+      value: "burst-value-10"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 11 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_11"
+      value: "burst-value-11"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 12 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_12"
+      value: "burst-value-12"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 13 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_13"
+      value: "burst-value-13"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 14 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_14"
+      value: "burst-value-14"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 15 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_15"
+      value: "burst-value-15"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 16 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_16"
+      value: "burst-value-16"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 17 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_17"
+      value: "burst-value-17"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 18 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_18"
+      value: "burst-value-18"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 19 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_19"
+      value: "burst-value-19"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 20 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_20"
+      value: "burst-value-20"
+    executor_public_key: "{{node1_key}}"
+
+  # ── Phase 4: Single convergence point ───────────────────────────────
+  # The ONLY sync after the burst. 60s / 6 interval-sync cycles gives the
+  # post-fix DAG-head divergence catch-up room to pull any missed run.
+  # Pre-fix, a node behind on a contiguous suffix never recovers and this
+  # times out.
+  - name: Final sync after burst
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - burst-write-node-1
+      - burst-write-node-2
+    timeout: 60
+    check_interval: 3
+
+  # ── Phase 5: Cross-node read assertion ──────────────────────────────
+  # node-2 reads keys only node-1 ever wrote. The first and last burst keys
+  # bracket the whole chain — if node-2 missed any contiguous run, at least
+  # one of these is absent.
+  - name: Node-2 reads first burst key
+    type: call
+    node: burst-write-node-2
+    context_id: "{{ctx_id}}"
+    method: get
+    args:
+      key: "burst_key_01"
+    executor_public_key: "{{node2_key}}"
+    outputs:
+      node2_read_first: result
+
+  - name: Node-2 reads last burst key
+    type: call
+    node: burst-write-node-2
+    context_id: "{{ctx_id}}"
+    method: get
+    args:
+      key: "burst_key_20"
+    executor_public_key: "{{node2_key}}"
+    outputs:
+      node2_read_last: result
+
+  - name: Assert node-2 converged on node-1's burst
+    type: assert
+    statements:
+      - "is_set({{node2_read_first}})"
+      - "is_set({{node2_read_last}})"
+      - 'contains({{node2_read_first}}, "burst-value-01")'
+      - 'contains({{node2_read_last}}, "burst-value-20")'


### PR DESCRIPTION
## Problem

mero-drive's `E2E (main)` fails: node-2 joins a namespace + Registry-style context, node-1 bursts ~30 mutations with no intermediate `wait_for_sync`, then one final `wait_for_sync` — node-2 never converges, and only a node restart recovers it.

This is a **context state-delta sync** convergence bug (it was previously misattributed to namespace-governance anti-entropy; PR #2374 fixed a different channel and changed nothing here).

## Root cause

A node that missed a **contiguous suffix** of a context's delta chain has no recovery path:

- `select_protocol` (`crates/node/primitives/src/sync/protocol.rs`) only ever selects entity-Merkle-tree protocols (`HashComparison` / `SubtreePrefetch` / `BloomFilter` / `LevelWise`) for two initialized peers — it has no `DeltaSync` arm. None of these touch the DAG (`dag_heads`, the `ContextDagDelta` keyspace).
- The only DAG-delta catch-up in `handle_dag_sync` is gated on `get_missing_parents` returning a non-empty set. `get_missing_parents` walks the in-memory DAG's *pending* map (`crates/dag/src/lib.rs`) — a node behind by a contiguous suffix has **nothing pending**, so it reports nothing missing and the catch-up never fires.

Net effect: such a node's `dag_heads`/`root_hash` stay stale, later deltas referencing the missed run go pending forever, and it stays "stuck" until a restart re-runs init-time `load_persisted_deltas`.

## Fix

`handle_dag_sync` now compares the peer's advertised DAG heads (already carried in the `DagHeadsResponse` it fetches) against the local DAG. If the peer advertises a head we have **not applied locally**, route to the existing recursive parent-pull (`request_dag_heads_and_sync`) instead of the entity-tree path:

1. it fetches the peer's heads → they go *pending* (their parents are the missed run);
2. `get_missing_parents` now sees them → recursive `request_missing_deltas` walks the missed suffix back to a delta we already hold;
3. the cascade applies it — advancing `dag_heads` and `root_hash`.

The trigger is **divergence-triggered** (peer head absent locally) and **bounded** (`request_missing_deltas`' fetch limit). It introduces **no periodic rescan** — #2244's removal stands. It is robust to both candidate framings of the burst failure (gossip non-delivery vs. the pre-persist orphan window): both present identically as "the peer advertises a DAG head we have not applied."

### Changes
- `DeltaStore::is_applied` — thin wrapper over `DagStore::is_applied`.
- `SyncManager::peer_heads_diverge` — pure, closure-free divergence rule (8 unit tests).
- `SyncManager::local_dag_behind_peer_heads` — async wrapper resolving applied-ness against the local DAG.
- The divergence-routing block in `handle_dag_sync`.

## Regression test

`workflows/sync-tests/burst-write-regression.yml` + `.github/workflows/burst-write-regression.yml`: a 2-node bootstrap that bursts 20 mutations from one node with **no intermediate `wait_for_sync`** and a single final convergence assertion — the mero-drive burst shape. Core's other sync workflows pace every mutation with `wait_for_sync`, structurally suppressing this pattern; this encodes it as a permanent core guard.

Pre-fix the final `wait_for_sync` times out; post-fix the divergence catch-up converges it within a few interval-sync cycles.

> [!NOTE]
> The "fails pre-fix" half of the test still needs an empirical run against `master` (locally or a throwaway CI run) to confirm the burst reliably reproduces the wedge in a clean 2-node merobox env. If it does **not** fail pre-fix, the root-cause framing must be re-examined before merge.

## Verification
- `cargo build` / `cargo clippy --all-targets` — clean for `calimero-node`, `calimero-node-primitives`, `calimero-dag`.
- `cargo test -p calimero-node --lib sync::manager` — 38 pass (8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sync decision-making to trigger delta catch-up based on peer DAG-head divergence, which could affect convergence behavior and network load in edge cases. Adds a new CI workflow/regression scenario that may introduce flakiness if timing-sensitive.
> 
> **Overview**
> Fixes a burst-write convergence hole by adding a *DAG-head divergence* check in `SyncManager::handle_dag_sync`: if a peer advertises DAG heads the node hasn’t **applied**, the node now routes into the existing `request_dag_heads_and_sync` catch-up path instead of proceeding with entity-tree protocol selection.
> 
> Adds supporting helpers (`DeltaStore::dag_applied_subset`, `SyncManager::peer_heads_diverge`/`local_dag_behind_peer_heads`) plus unit tests to validate genesis-head skipping and divergence detection.
> 
> Introduces a new merobox-based regression test and GitHub Actions workflow (`workflows/sync-tests/burst-write-regression.yml`, `.github/workflows/burst-write-regression.yml`) that bootstraps two nodes, performs a burst of writes without intermediate sync, and asserts eventual convergence while capturing/uploading docker logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12af03476b89ca8ca3c38f1ec5a704c63e240812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->