### PR TITLE
DO NOT MERGE — burst-write regression pre-fix verification probe

### DIFF
--- a/.github/workflows/burst-write-regression.yml
+++ b/.github/workflows/burst-write-regression.yml
@@ -1,0 +1,151 @@
+name: Burst-write regression
+
+# Regression guard for DAG-delta convergence under burst writes — the
+# mero-drive E2E (main) failure mode. Runs `burst-write-regression.yml`:
+# a 2-node bootstrap, then 20 mutations from one node with NO intermediate
+# `wait_for_sync`, then a single convergence assertion.
+#
+# Core's other sync workflows pace every mutation with `wait_for_sync`,
+# which suppresses the burst-write condition real apps hit. This workflow
+# is the deterministic core guard for it — pre-fix the final
+# `wait_for_sync` times out; post-fix it converges via the DAG-head
+# divergence catch-up in `handle_dag_sync`.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "crates/node/src/sync/**"
+      - "crates/node/src/delta_store.rs"
+      - "crates/dag/**"
+      - "workflows/sync-tests/**"
+      - ".github/workflows/burst-write-regression.yml"
+      - ".github/actions/build-local-merod/**"
+      - ".github/actions/setup-merobox/**"
+
+  pull_request:
+    branches: [master]
+    paths:
+      - "crates/node/src/sync/**"
+      - "crates/node/src/delta_store.rs"
+      - "crates/dag/**"
+      - "workflows/sync-tests/**"
+      - ".github/workflows/burst-write-regression.yml"
+      - ".github/actions/build-local-merod/**"
+      - ".github/actions/setup-merobox/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUST_LOG: info,calimero_=debug
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+jobs:
+  burst-write-regression:
+    name: Burst-write regression
+    # Same runner class as e2e-rust-apps / sync-regression so cold-start
+    # performance is comparable and we share the rust-ci cache.
+    runs-on: ubuntu-24.04-8cpu
+    # 15-min cap is generous: the workflow's own timeout is 60s on the
+    # final `wait_for_sync`, so a regression fails in ~1 min. The cap is
+    # for the cold-build steps (merod image + WASM) plus a safety margin.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          shared-key: burst-write-regression
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build local merod image
+        uses: ./.github/actions/build-local-merod
+        env:
+          CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build kv-store-with-handlers WASM
+        run: |
+          cd apps/kv-store-with-handlers
+          ./build.sh
+
+      - name: Setup merobox
+        uses: ./.github/actions/setup-merobox
+
+      - name: Run burst-write-regression workflow
+        # `merobox bootstrap run` exits non-zero on any failed step
+        # (including a `wait_for_sync` timeout, which is the symptom under
+        # regression). No retry — a flake here is a real bug, same
+        # rationale as `e2e-rust-apps.yml` / `sync-regression.yml`.
+        run: |
+          mkdir -p docker-logs
+
+          # Stream docker logs to per-container files while the run is
+          # live. `merobox bootstrap run` tears the runtime containers
+          # down on its way out, so a post-run `docker logs` pass catches
+          # nothing — capture during the run instead. Same shape as
+          # sync-regression.yml's watcher.
+          LOGDIR="$GITHUB_WORKSPACE/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+              for c in $(docker ps --filter "label=calimero.node=true" \
+                                   --format "{{.Names}}" 2>/dev/null \
+                         | grep -v -- '-init$' || true); do
+                mark="$WATCHER_STATE_DIR/${c}"
+                if [ ! -f "$mark" ]; then
+                  touch "$mark"
+                  echo "[log-watcher] following $c"
+                  docker logs -f --timestamps "$c" \
+                    > "$LOGDIR/${c}.log" 2>&1 &
+                fi
+              done
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
+          set +e
+          set -o pipefail
+          merobox bootstrap run \
+              workflows/sync-tests/burst-write-regression.yml \
+              --image merod:local \
+              --e2e-mode \
+              --verbose 2>&1 | tee docker-logs/merobox-output.log
+          exit_code=$?
+          set +o pipefail
+
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
+
+          exit "$exit_code"
+
+      - name: Upload docker logs
+        # Always upload — green runs still need log evidence (e.g.
+        # confirming the catch-up actually fired, not that the burst
+        # simply never dropped a delta). Matches `sync-regression.yml`.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: burst-write-regression-docker-logs
+          path: docker-logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/workflows/sync-tests/burst-write-regression.yml
+++ b/workflows/sync-tests/burst-write-regression.yml
@@ -1,0 +1,377 @@
+name: "Burst-write DAG-delta convergence regression"
+description: >
+  2-node bootstrap mirroring mero-drive's failing E2E (main) burst pattern:
+  install app, create a namespace + Registry-style context, the second node
+  joins both, then a burst of 20 mutations from a single node with NO
+  intermediate `wait_for_sync`, followed by one final convergence assertion.
+
+  Core's other sync workflows pace every mutation with `wait_for_sync`, which
+  structurally suppresses the burst-write condition real apps hit (apps fire
+  mutations as fast as the UI produces them — they do not sync between each
+  write). This workflow encodes that real pattern as a permanent regression
+  guard.
+
+  Pre-fix: a node that misses a contiguous suffix of the delta chain has no
+  DAG-delta recovery path. `select_protocol` reconciles only the entity
+  Merkle tree, and the `get_missing_parents` catch-up is invisible to a node
+  with nothing pending — so `dag_heads` stay stale and the final
+  `wait_for_sync` times out (only a restart recovers it).
+
+  Post-fix: the DAG-head divergence catch-up in `handle_dag_sync` notices the
+  peer advertises an unapplied head and pulls the missed deltas via
+  `request_dag_heads_and_sync` within a few interval-sync cycles, so the
+  final `wait_for_sync` converges.
+
+  Total runtime budget: ~4 min. Under regression the failure mode is the
+  final `wait_for_sync` timing out at 60s — fast and unambiguous.
+
+# Test configuration
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 2
+  # The GHA wrapper (`burst-write-regression.yml`) builds `merod:local` from
+  # the PR HEAD and loads it into docker before invoking merobox — that's
+  # the image tag this workflow expects. `--image merod:local` on the
+  # merobox CLI overrides this anyway, but specify it here so a local
+  # `merobox bootstrap run` works without the override.
+  image: merod:local
+  prefix: burst-write-node
+
+steps:
+  # ── Phase 1: Bootstrap mesh + namespace + context ───────────────────
+  - name: Install kv-store-with-handlers on node-1
+    type: install_application
+    node: burst-write-node-1
+    path: apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install kv-store-with-handlers on node-2
+    type: install_application
+    node: burst-write-node-2
+    path: apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
+    dev: true
+
+  - name: Node-1 creates namespace
+    type: create_namespace
+    node: burst-write-node-1
+    application_id: "{{app_id}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Node-1 creates Registry-style context inside namespace
+    type: create_context
+    node: burst-write-node-1
+    application_id: "{{app_id}}"
+    group_id: "{{namespace_id}}"
+    outputs:
+      ctx_id: contextId
+      node1_key: memberPublicKey
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: burst-write-node-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      ns_invite: invitation
+
+  - name: Wait for namespace governance to gossip
+    # Namespace governance DAG needs to propagate to node-2 before the join
+    # op (otherwise `join_namespace` 404s on the invitation). 10s matches
+    # mero-drive's e2e and the opaque-leaf workflow.
+    type: wait
+    seconds: 10
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: burst-write-node-2
+    namespace_id: "{{namespace_id}}"
+    invitation: "{{ns_invite}}"
+    outputs:
+      node2_identity: memberIdentity
+
+  - name: Node-2 joins context
+    type: join_context
+    node: burst-write-node-2
+    context_id: "{{ctx_id}}"
+    outputs:
+      node2_key: memberPublicKey
+
+  - name: Assert bootstrap shape
+    type: assert
+    statements:
+      - "is_set({{namespace_id}})"
+      - "is_set({{ctx_id}})"
+      - "is_set({{node1_key}})"
+      - "is_set({{node2_identity}})"
+      - "is_set({{node2_key}})"
+
+  # ── Phase 2: Baseline sync (empty Root state) ───────────────────────
+  # Single sanity baseline before the burst — both Roots are still empty,
+  # so a healthy mesh handles this trivially. This is the LAST
+  # `wait_for_sync` before the burst on purpose.
+  - name: Baseline sync after join
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - burst-write-node-1
+      - burst-write-node-2
+    timeout: 30
+    check_interval: 2
+
+  # ── Phase 3: Burst write — 20 mutations from node-1, NO intermediate sync ─
+  # This is the crux. Every mutation extends the Root<KvStore> delta chain
+  # on node-1. With no `wait_for_sync` between writes, node-2 must keep up
+  # purely via gossip + interval sync. If node-2 misses any contiguous run
+  # of these deltas, pre-fix it can never catch up (see the description).
+  - name: Burst 01 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_01"
+      value: "burst-value-01"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 02 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_02"
+      value: "burst-value-02"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 03 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_03"
+      value: "burst-value-03"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 04 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_04"
+      value: "burst-value-04"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 05 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_05"
+      value: "burst-value-05"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 06 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_06"
+      value: "burst-value-06"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 07 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_07"
+      value: "burst-value-07"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 08 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_08"
+      value: "burst-value-08"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 09 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_09"
+      value: "burst-value-09"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 10 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_10"
+      value: "burst-value-10"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 11 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_11"
+      value: "burst-value-11"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 12 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_12"
+      value: "burst-value-12"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 13 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_13"
+      value: "burst-value-13"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 14 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_14"
+      value: "burst-value-14"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 15 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_15"
+      value: "burst-value-15"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 16 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_16"
+      value: "burst-value-16"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 17 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_17"
+      value: "burst-value-17"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 18 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_18"
+      value: "burst-value-18"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 19 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_19"
+      value: "burst-value-19"
+    executor_public_key: "{{node1_key}}"
+
+  - name: Burst 20 — node-1 writes
+    type: call
+    node: burst-write-node-1
+    context_id: "{{ctx_id}}"
+    method: set
+    args:
+      key: "burst_key_20"
+      value: "burst-value-20"
+    executor_public_key: "{{node1_key}}"
+
+  # ── Phase 4: Single convergence point ───────────────────────────────
+  # The ONLY sync after the burst. 60s / 6 interval-sync cycles gives the
+  # post-fix DAG-head divergence catch-up room to pull any missed run.
+  # Pre-fix, a node behind on a contiguous suffix never recovers and this
+  # times out.
+  - name: Final sync after burst
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - burst-write-node-1
+      - burst-write-node-2
+    timeout: 60
+    check_interval: 3
+
+  # ── Phase 5: Cross-node read assertion ──────────────────────────────
+  # node-2 reads keys only node-1 ever wrote. The first and last burst keys
+  # bracket the whole chain — if node-2 missed any contiguous run, at least
+  # one of these is absent.
+  - name: Node-2 reads first burst key
+    type: call
+    node: burst-write-node-2
+    context_id: "{{ctx_id}}"
+    method: get
+    args:
+      key: "burst_key_01"
+    executor_public_key: "{{node2_key}}"
+    outputs:
+      node2_read_first: result
+
+  - name: Node-2 reads last burst key
+    type: call
+    node: burst-write-node-2
+    context_id: "{{ctx_id}}"
+    method: get
+    args:
+      key: "burst_key_20"
+    executor_public_key: "{{node2_key}}"
+    outputs:
+      node2_read_last: result
+
+  - name: Assert node-2 converged on node-1's burst
+    type: assert
+    statements:
+      - "is_set({{node2_read_first}})"
+      - "is_set({{node2_read_last}})"
+      - 'contains({{node2_read_first}}, "burst-value-01")'
+      - 'contains({{node2_read_last}}, "burst-value-20")'


### PR DESCRIPTION
## Do not merge / do not review — throwaway verification probe

This branch is **`master` + only the two `burst-write-regression` workflow files** from PR #2376 — **the fix is deliberately absent.**

Purpose: confirm the new `Burst-write regression` workflow actually **fails pre-fix** (the "test must fail without the fix" half of PR #2376's verification). The job runs the merobox burst workflow against an unfixed `merod:local` built from `master`.

- **Expected:** the `Burst-write regression` check **fails** (final `wait_for_sync` times out — a suffix-behind node never recovers).
- If it **passes**, the burst pattern does not reproduce the wedge in a clean 2-node merobox env and PR #2376's root-cause framing must be re-examined before merge.

This PR will be closed once the `Burst-write regression` result is observed. Ignore all other checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new GitHub Actions and merobox workflow definitions, with no production code changes. Main impact is additional CI runtime and potential for flaky failures if the underlying sync behavior or environment is unstable.
> 
> **Overview**
> Adds a new CI check, **`Burst-write regression`**, that runs a deterministic 2-node `merobox` scenario designed to reproduce DAG-delta convergence failures under burst writes (20 rapid mutations with no intermediate `wait_for_sync`).
> 
> Introduces the corresponding `workflows/sync-tests/burst-write-regression.yml` bootstrap script and updates the GitHub Action to build `merod:local`, run the scenario, stream per-container docker logs during execution, and always upload those logs as an artifact for debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d062950374380608db18ed33f4baa1f0a0841ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->