### PR TITLE
chore: bump node version to rc39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that updates the workspace release version without affecting runtime logic.
> 
> **Overview**
> Updates `Cargo.toml` workspace metadata to bump the shared public-crate version from `0.10.1-rc.38` to **`0.10.1-rc.39`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4ef9ac7ebbfbed7b335bc11107669dd13744ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->