### PR TITLE
feat(context): B3 — local-execute membership check for state ops

### DIFF
--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -105,10 +105,11 @@ pub use self::namespace::{
     collect_descendant_groups, collect_subtree_for_cascade, collect_visible_descendant_groups,
     create_recursive_invitations, get_namespace_identity, get_namespace_identity_record,
     get_or_create_namespace_identity, get_or_create_namespace_identity_bundle, get_parent_group,
-    is_descendant_of, is_read_only_for_context, list_child_groups, nest_group,
-    recursive_remove_member, reparent_group, resolve_namespace, resolve_namespace_identity,
-    resolve_namespace_identity_record, store_namespace_identity, unnest_group, CascadePayload,
-    NamespaceIdentityRecord, ReparentOutcome, ResolvedNamespaceIdentity,
+    is_authorized_for_context_state_op, is_descendant_of, is_read_only_for_context,
+    list_child_groups, nest_group, recursive_remove_member, reparent_group, resolve_namespace,
+    resolve_namespace_identity, resolve_namespace_identity_record, store_namespace_identity,
+    unnest_group, CascadePayload, NamespaceIdentityRecord, ReparentOutcome,
+    ResolvedNamespaceIdentity,
 };
 pub use self::namespace_dag::{NamespaceDagService, NamespaceHead};
 pub use self::namespace_governance::{

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -52,6 +52,67 @@ pub fn is_read_only_for_context(
     }
 }
 
+/// Returns `true` if `executor` is currently authorized to author state
+/// mutations on `context_id` — i.e., is a current Admin or Member of the
+/// context's owning group.
+///
+/// Returns `false` for:
+/// * Read-only roles (`ReadOnly`, `ReadOnlyTee`) — they can read but not write.
+/// * Members that have been removed from the group.
+/// * Identities that were never a member of the group.
+///
+/// Returns `true` for contexts that aren't owned by any group — there's no
+/// group membership concept to enforce.
+///
+/// **Live-state check, not historical.** The receive path's cross-DAG check
+/// (`membership_status_at`) is forward-only at the delta's *signed* governance
+/// cut, which is the right semantic for replicated authoring: a pre-removal
+/// delta stays valid forever. This function is the local-execute mirror, and
+/// uses **current** membership because at execute time there is no signed
+/// cut — the WASM call happens "now," not against any historical snapshot.
+/// The two checks complement each other: the receive-path check decides
+/// whether a delta from a peer is honored; this one decides whether the
+/// local WASM may produce a delta in the first place. Without this check, a
+/// removed member's WASM could still mutate local state (including User-
+/// storage entries) — the mutation would never propagate (peers reject via
+/// the receive-path check), but would accumulate as silent divergence from
+/// the canonical view until the next sync round repaired it.
+///
+/// The namespace creator / root admin is recognised via
+/// [`super::membership::is_group_admin`] (their membership lives in
+/// `GroupMeta::admin_identity`, not in a `GroupMember` row).
+pub fn is_authorized_for_context_state_op(
+    store: &Store,
+    context_id: &ContextId,
+    executor: &PublicKey,
+) -> EyreResult<bool> {
+    let Some(group_id) = get_group_for_context(store, context_id)? else {
+        // Non-group context — no membership concept to enforce.
+        return Ok(true);
+    };
+
+    // Namespace creator / root admin carve-out — they don't emit a self-
+    // `MemberJoined` op at genesis, so their membership is stored in
+    // `GroupMeta::admin_identity` and `get_group_member_role` returns
+    // `None`. Mirror the same carve-out `membership_status_at` and
+    // `namespace_member_pubkeys` apply, so admin authority is consistent
+    // across the receive-side and local-execute-side authorization
+    // checks.
+    if super::membership::is_group_admin(store, &group_id, executor)? {
+        return Ok(true);
+    }
+
+    match get_group_member_role(store, &group_id, executor)? {
+        Some(
+            calimero_primitives::context::GroupMemberRole::Admin
+            | calimero_primitives::context::GroupMemberRole::Member,
+        ) => Ok(true),
+        // ReadOnly / ReadOnlyTee → readable but not writeable. Removed /
+        // never-member → no authorization at all. Both fall through here.
+        Some(_) | None => Ok(false),
+    }
+}
+
 /// Read the parent group for a given group (legacy, used by `resolve_namespace`).
 pub fn get_parent_group(
     store: &Store,

--- a/crates/context/src/group_store/namespace.rs
+++ b/crates/context/src/group_store/namespace.rs
@@ -54,12 +54,15 @@ pub fn is_read_only_for_context(
 
 /// Returns `true` if `executor` is currently authorized to author state
 /// mutations on `context_id` — i.e., is a current Admin or Member of the
-/// context's owning group.
+/// context's owning group, either by direct row or by Open-subgroup
+/// inheritance.
 ///
 /// Returns `false` for:
-/// * Read-only roles (`ReadOnly`, `ReadOnlyTee`) — they can read but not write.
+/// * Direct members with read-only roles (`ReadOnly`, `ReadOnlyTee`) — they
+///   can read but not write.
 /// * Members that have been removed from the group.
-/// * Identities that were never a member of the group.
+/// * Identities that were never a member of the group and don't reach it
+///   via Open-subgroup inheritance.
 ///
 /// Returns `true` for contexts that aren't owned by any group — there's no
 /// group membership concept to enforce.
@@ -78,9 +81,29 @@ pub fn is_read_only_for_context(
 /// the receive-path check), but would accumulate as silent divergence from
 /// the canonical view until the next sync round repaired it.
 ///
+/// **Inherited membership.** Members of an Open subgroup may not have a
+/// stored `GroupMember` row at the subgroup level — they reach it via the
+/// parent-walk with `CAN_JOIN_OPEN_SUBGROUPS` at the anchor (see
+/// [`super::membership::check_group_membership_path`]). The receive-side
+/// `membership_status_at` folds `Inherited → Member(Member)`; this function
+/// does the same so the two checks agree on inherited members. Without
+/// this, a perfectly legitimate inherited member's local state ops would be
+/// dropped by this check, but the receive-side would accept their deltas —
+/// internally inconsistent and breaks Open-subgroup workflows.
+///
 /// The namespace creator / root admin is recognised via
 /// [`super::membership::is_group_admin`] (their membership lives in
 /// `GroupMeta::admin_identity`, not in a `GroupMember` row).
+///
+/// **Deny-list is a separate layer.** This function checks live membership
+/// state only. The receive path layers an additional `is_author_denied_for_context`
+/// pre-filter that runs in front of the cross-DAG check (an O(1) fast-
+/// rejection for identities the local node explicitly denied). The local-
+/// execute path doesn't need that fast-path: removed identities are caught
+/// here by the absence of a `GroupMember` row (admin removal also clears
+/// the row), and there is no high-volume traffic to short-circuit. If a
+/// future kick path ever marks an identity denied *without* removing its
+/// `GroupMember` row, add an `is_denied` consultation here.
 pub fn is_authorized_for_context_state_op(
     store: &Store,
     context_id: &ContextId,
@@ -102,14 +125,32 @@ pub fn is_authorized_for_context_state_op(
         return Ok(true);
     }
 
-    match get_group_member_role(store, &group_id, executor)? {
-        Some(
+    // Direct membership: check the stored `GroupMember` row's role.
+    if let Some(role) = get_group_member_role(store, &group_id, executor)? {
+        return Ok(matches!(
+            role,
             calimero_primitives::context::GroupMemberRole::Admin
-            | calimero_primitives::context::GroupMemberRole::Member,
-        ) => Ok(true),
-        // ReadOnly / ReadOnlyTee → readable but not writeable. Removed /
-        // never-member → no authorization at all. Both fall through here.
-        Some(_) | None => Ok(false),
+                | calimero_primitives::context::GroupMemberRole::Member,
+        ));
+    }
+
+    // No direct row — fall through to the inherited-membership walk.
+    // `check_group_membership_path` returns `Inherited { .. }` when the
+    // executor reaches this group through an Open-subgroup chain anchored
+    // at an ancestor where they hold a row (and `CAN_JOIN_OPEN_SUBGROUPS`,
+    // for non-admin anchors). Mirrors what the receive-side
+    // `membership_status_at` does, so the two checks agree on who is
+    // authorized to author state ops.
+    match super::membership::check_group_membership_path(store, &group_id, executor)? {
+        super::membership::MembershipPath::Direct => {
+            // Practically unreachable: the direct lookup above already
+            // returned `Some(role)` if a row existed. Treat a race here
+            // (concurrent `MemberAdded`) as `Member` — same fallback the
+            // receive-side check uses at the equivalent boundary.
+            Ok(true)
+        }
+        super::membership::MembershipPath::Inherited { .. } => Ok(true),
+        super::membership::MembershipPath::None => Ok(false),
     }
 }
 

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3409,6 +3409,51 @@ fn authorized_for_state_op_allows_non_group_context() {
 }
 
 #[test]
+fn authorized_for_state_op_admits_inherited_members_via_open_subgroup() {
+    use calimero_context_config::{MemberCapabilities, VisibilityMode};
+
+    use super::is_authorized_for_context_state_op;
+
+    // Members of an Open subgroup don't necessarily have a stored
+    // `GroupMember` row at the subgroup level — they reach the subgroup
+    // via the parent-walk with `CAN_JOIN_OPEN_SUBGROUPS` at the anchor.
+    // The receive-side `membership_status_at` folds Inherited →
+    // Member(Member); this check has to agree or the two checks
+    // disagree on the same identity (receive accepts their deltas
+    // while local-execute drops their state ops). That divergence
+    // broke `group-subgroup-visibility-inheritance` and adjacent
+    // workflows on an earlier draft of this PR.
+    let store = test_store();
+    let ns = ContextGroupId::from([0xC0; 32]);
+    let child = ContextGroupId::from([0xC1; 32]);
+    let context = ContextId::from([0xC2; 32]);
+    let admin = PublicKey::from([0xC3; 32]);
+    let inherited = PublicKey::from([0xC4; 32]);
+
+    nest_for_test(&store, &ns, &child);
+    set_subgroup_visibility(&store, &child, VisibilityMode::Open).unwrap();
+
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    meta.owner_identity = admin;
+    save_group_meta(&store, &ns, &meta).unwrap();
+    save_group_meta(&store, &child, &meta).unwrap();
+
+    set_default_capabilities(&store, &ns, MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS).unwrap();
+    add_group_member(&store, &ns, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &ns, &inherited, GroupMemberRole::Member).unwrap();
+
+    // Register the context under the (Open) child — `inherited` has
+    // no row in `child`, only in `ns`.
+    register_context_in_group(&store, &child, &context).unwrap();
+
+    assert!(
+        is_authorized_for_context_state_op(&store, &context, &inherited).unwrap(),
+        "Inherited member of an Open subgroup must be authorized to author state ops"
+    );
+}
+
+#[test]
 fn local_state_join_tracking_and_delete_group_rows_cleanup() {
     let store = test_store();
     let gid = ContextGroupId::from([0xC1; 32]);

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3285,6 +3285,130 @@ fn namespace_nesting_resolve_and_read_only_checks() {
 }
 
 #[test]
+fn authorized_for_state_op_admits_admin_and_member_only() {
+    use super::is_authorized_for_context_state_op;
+
+    let store = test_store();
+    let gid = ContextGroupId::from([0xC0; 32]);
+    let context = ContextId::from([0xC1; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let member = PublicKey::from([0x02; 32]);
+    let ro = PublicKey::from([0x03; 32]);
+    let ro_tee = PublicKey::from([0x04; 32]);
+    let outsider = PublicKey::from([0x05; 32]);
+
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    meta.owner_identity = admin;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    register_context_in_group(&store, &gid, &context).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &member, GroupMemberRole::Member).unwrap();
+    add_group_member(&store, &gid, &ro, GroupMemberRole::ReadOnly).unwrap();
+    add_group_member(&store, &gid, &ro_tee, GroupMemberRole::ReadOnlyTee).unwrap();
+
+    assert!(
+        is_authorized_for_context_state_op(&store, &context, &admin).unwrap(),
+        "Admin must be authorized to author state ops"
+    );
+    assert!(
+        is_authorized_for_context_state_op(&store, &context, &member).unwrap(),
+        "Member must be authorized to author state ops"
+    );
+    assert!(
+        !is_authorized_for_context_state_op(&store, &context, &ro).unwrap(),
+        "ReadOnly must NOT be authorized to author state ops"
+    );
+    assert!(
+        !is_authorized_for_context_state_op(&store, &context, &ro_tee).unwrap(),
+        "ReadOnlyTee must NOT be authorized to author state ops"
+    );
+    assert!(
+        !is_authorized_for_context_state_op(&store, &context, &outsider).unwrap(),
+        "Non-member must NOT be authorized to author state ops"
+    );
+}
+
+#[test]
+fn authorized_for_state_op_rejects_removed_member() {
+    use super::is_authorized_for_context_state_op;
+
+    let store = test_store();
+    let gid = ContextGroupId::from([0xD0; 32]);
+    let context = ContextId::from([0xD1; 32]);
+    let admin = PublicKey::from([0x01; 32]);
+    let target = PublicKey::from([0xDD; 32]);
+
+    let mut meta = test_meta();
+    meta.admin_identity = admin;
+    meta.owner_identity = admin;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    register_context_in_group(&store, &gid, &context).unwrap();
+    add_group_member(&store, &gid, &admin, GroupMemberRole::Admin).unwrap();
+    add_group_member(&store, &gid, &target, GroupMemberRole::Member).unwrap();
+
+    // Member is authorized while in the group.
+    assert!(is_authorized_for_context_state_op(&store, &context, &target).unwrap());
+
+    // After removal: the GroupMember row is gone (apply path deletes it),
+    // and the deny-list flags the identity as denied — both ways the
+    // check must return `false`. The B3 receive path rejects deltas
+    // from this identity at the cut; this check rejects local state ops
+    // by the same identity at the WASM-execute path.
+    remove_group_member(&store, &gid, &target).unwrap();
+
+    assert!(
+        !is_authorized_for_context_state_op(&store, &context, &target).unwrap(),
+        "Removed member must NOT be authorized to author state ops locally"
+    );
+}
+
+#[test]
+fn authorized_for_state_op_recognises_namespace_creator() {
+    use super::is_authorized_for_context_state_op;
+
+    // Namespace creator does not have a `GroupMember` row at namespace
+    // genesis — their admin authority lives in `GroupMeta::admin_identity`.
+    // The check must use the same `is_group_admin` carve-out as the
+    // receive-side `membership_status_at`, or the creator's local state
+    // ops on a fresh namespace would be wrongly rejected.
+    let store = test_store();
+    let gid = ContextGroupId::from([0xE0; 32]);
+    let context = ContextId::from([0xE1; 32]);
+    let creator = PublicKey::from([0xEE; 32]);
+
+    let mut meta = test_meta();
+    meta.admin_identity = creator;
+    meta.owner_identity = creator;
+    save_group_meta(&store, &gid, &meta).unwrap();
+    register_context_in_group(&store, &gid, &context).unwrap();
+    // No `GroupMember` row for the creator — relies on the
+    // `is_group_admin` carve-out.
+
+    assert!(
+        is_authorized_for_context_state_op(&store, &context, &creator).unwrap(),
+        "Namespace creator must be authorized via the admin-identity carve-out"
+    );
+}
+
+#[test]
+fn authorized_for_state_op_allows_non_group_context() {
+    use super::is_authorized_for_context_state_op;
+
+    // A context that isn't registered under any group has no
+    // group-membership concept to enforce. The check returns `true`
+    // (no enforcement) so legacy / non-group contexts keep working.
+    let store = test_store();
+    let context = ContextId::from([0xF1; 32]);
+    let executor = PublicKey::from([0xF2; 32]);
+
+    assert!(
+        is_authorized_for_context_state_op(&store, &context, &executor).unwrap(),
+        "Non-group context must allow any executor (nothing to enforce)"
+    );
+}
+
+#[test]
 fn local_state_join_tracking_and_delete_group_rows_cleanup() {
     let store = test_store();
     let gid = ContextGroupId::from([0xC1; 32]);

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1216,6 +1216,36 @@ async fn internal_execute(
         && crate::group_store::is_read_only_for_context(&datastore, &context.id, &executor)
             .unwrap_or(false);
 
+    // B3 user-storage extension: a state op authored by a non-member of
+    // the context's owning group is dropped after WASM execution, mirroring
+    // the ReadOnly handling below. The receive-path cross-DAG check
+    // (`membership_status_at`) already rejects deltas from non-members on
+    // peers; without this companion check at the local-execute path, a
+    // removed member's WASM would still mutate local state (including
+    // their own User-storage entries). Those mutations never propagate —
+    // peers reject them — but they accumulate as silent divergence from
+    // the canonical view until a sync round repairs the local state.
+    // Discarding the outcome here closes that gap.
+    //
+    // Read-only calls (`is_state_op == false`) are unaffected — reads of
+    // a context's state are allowed for anyone with local access; if the
+    // method genuinely mutates storage despite being read-typed, the
+    // ReadOnly discard below clears it on the same path.
+    //
+    // Live-state check vs. the receive path's forward-only check: at
+    // execute time there is no signed governance cut to evaluate
+    // membership against, so this consults current membership. The two
+    // checks complement each other rather than duplicate — receive-path
+    // governs whether a remote delta is accepted; this governs whether
+    // local WASM may produce one.
+    let executor_not_authorized_for_state_op = is_state_op
+        && !crate::group_store::is_authorized_for_context_state_op(
+            &datastore,
+            &context.id,
+            &executor,
+        )
+        .unwrap_or(true);
+
     let storage = ContextStorage::from(datastore.clone(), context.id);
     let private_storage = ContextPrivateStorage::from(datastore, context.id);
     let (mut outcome, storage, private_storage) = execute(
@@ -1278,6 +1308,19 @@ async fn internal_execute(
             %executor,
             method = %method,
             "ReadOnly member attempted state mutation — discarding changes"
+        );
+        outcome.root_hash = None;
+        outcome.artifact.clear();
+        outcome.xcalls.clear();
+        return Ok((outcome, None));
+    }
+
+    if executor_not_authorized_for_state_op && outcome.root_hash.is_some() {
+        info!(
+            context_id = %context.id,
+            %executor,
+            method = %method,
+            "Non-member attempted state mutation — discarding changes (B3 user-storage extension)"
         );
         outcome.root_hash = None;
         outcome.artifact.clear();

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1238,13 +1238,24 @@ async fn internal_execute(
     // checks complement each other rather than duplicate — receive-path
     // governs whether a remote delta is accepted; this governs whether
     // local WASM may produce one.
+    // Fail-closed on store error: an authorization gate that fails open
+    // on transient store errors silently grants permission exactly when
+    // the check is most needed (storage degradation). The non-group-
+    // context happy-path already returns `Ok(true)` inside the helper,
+    // so this fail-closed only affects genuine error cases — and there
+    // the safer answer is "drop the state op." Asymmetry with the
+    // `is_read_only_for_context` call above (`.unwrap_or(false)` reads
+    // as fail-open for that check because `false` means "not
+    // read-only" → allow) is deliberate: the ReadOnly check is a
+    // defense-in-depth post-discard, while this is a primary
+    // authorization gate.
     let executor_not_authorized_for_state_op = is_state_op
         && !crate::group_store::is_authorized_for_context_state_op(
             &datastore,
             &context.id,
             &executor,
         )
-        .unwrap_or(true);
+        .unwrap_or(false);
 
     let storage = ContextStorage::from(datastore.clone(), context.id);
     let private_storage = ContextPrivateStorage::from(datastore, context.id);


### PR DESCRIPTION
## Summary

Close the local-execute side of the cross-DAG authorization check. The receive-path enforcement was already in place (peers reject deltas from non-members at apply time); this adds the companion check so a removed member's WASM cannot mutate local state in the first place.

**Net +233 LOC** (most of it tests). One new helper + one new call site mirroring the existing ReadOnly discard pattern.

## The gap this closes

The cross-DAG authorization story has two sides:

| Side | Question | Status before this PR |
|---|---|---|
| **Receive path** | Is the delta's signer a current member at the delta's signed cut? | ✅ Enforced by `membership_status_at` |
| **Local execute** | Is the local executor a current member of the context's group? | ❌ Not enforced |

A removed member's WASM could still call mutation methods on a context they no longer belong to. The mutations:
- Never propagate (every peer rejects the resulting delta via the receive-path check)
- BUT accumulate as silent local-only divergence from the canonical view

The principle of least surprise — \"a removed member's WASM can't write to anything in this group anymore\" — was documented in the cross-DAG RFC's \"as-shipped notes\" as a follow-up. This PR finishes that.

## What changed

### `crates/context/src/group_store/namespace.rs` — new helper

```rust
pub fn is_authorized_for_context_state_op(
    store: &Store,
    context_id: &ContextId,
    executor: &PublicKey,
) -> EyreResult<bool>
```

Returns `true` for:
- Current Admin or Member role in the context's owning group
- Namespace creator (via `is_group_admin` carve-out — `admin_identity` membership without a `GroupMember` row)
- Contexts not owned by any group (no membership concept to enforce)

Returns `false` for:
- ReadOnly / ReadOnlyTee — covered by existing `is_read_only_for_context` too, but explicit here
- Removed members — `GroupMember` row deleted at removal time
- Never-members — never had a row

### `crates/context/src/handlers/execute/mod.rs` — new discard branch

Mirrors the existing ReadOnly discard at line ~1275. Runs after WASM execution; if the executor isn't a current authorized member and the outcome carries state changes (`root_hash.is_some()`), the state effects (`root_hash`, `artifact`, `xcalls`) are cleared and an info log records the rejection. Read-only methods are unaffected.

Post-WASM discard (matching the existing pattern) rather than pre-WASM rejection: keeps the user-visible behavior identical to the ReadOnly case and lets read-side execution complete normally even when state effects are dropped.

## Live-state vs. forward-only

The receive path's `membership_status_at` is **forward-only at the delta's signed cut**: pre-removal writes stay valid forever, regardless of when the receiver observes the removal. That's correct for replicated authoring — two peers that observe ops in different orders must converge.

The local check is **live-state**: at execute time there's no signed cut to evaluate against; the WASM call happens *now*. The two checks complement rather than duplicate:

- **Receive path** governs whether a remote delta is honored on this peer.
- **Local execute** governs whether the local WASM may produce a delta in the first place.

A removed member's pre-removal writes that were already in flight before the removal still apply (forward-only, receive-side). Their new writes after the removal are stopped at the local-execute path before they ever become a delta.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p calimero-context --lib` — 282 passed (4 new)
- [x] `cargo test -p calimero-context --test local_group_governance_convergence` — 23 passed
- [ ] CI green on push

New unit tests:
1. `authorized_for_state_op_admits_admin_and_member_only` — Admin/Member yes; ReadOnly/ReadOnlyTee/outsider no.
2. `authorized_for_state_op_rejects_removed_member` — author authorized before removal; rejected after.
3. `authorized_for_state_op_recognises_namespace_creator` — admin-identity carve-out works (no `GroupMember` row).
4. `authorized_for_state_op_allows_non_group_context` — contexts without an owning group bypass the check.

## Not in this PR

- **Storage-layer enforcement.** `apply_action` in `crates/storage/src/interface.rs` could also gate User-storage updates on membership, which would catch any code path that bypasses the execute handler. Doing it there is a layering violation (storage doesn't depend on context/group_store today); the right boundary is at the call site, which is what this PR does. If a future caller of `apply_action` opens a new path that bypasses `internal_execute`, that path needs its own check — the comment at the call site documents this contract.
- **WASM-side error path.** Currently the rejection is silent to the WASM module (state cleared post-execution, like ReadOnly). A future PR could surface an `ExecuteError::NotMember` to the caller; that's a UX call, not a security one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new authorization gate that discards local WASM state mutations when the executor is no longer a permitted group member, which can change write behavior and prevent previously-allowed mutations if the membership logic is wrong. Touches state-execution and authorization paths, so mistakes could cause unexpected write drops or divergence issues.
> 
> **Overview**
> Closes a local-execute gap by adding `is_authorized_for_context_state_op` to decide whether an identity may author **state mutations** for a group-owned context (Admin/Member, namespace creator, and inherited members via Open subgroups allowed; read-only/outsiders/removed members rejected; non-group contexts bypass).
> 
> `internal_execute` now uses this check for `is_state_op` calls and, after WASM execution, discards state effects (`root_hash`, `artifact`, `xcalls`) and logs when a non-authorized executor attempted a mutation, mirroring the existing ReadOnly discard behavior.
> 
> Adds focused unit tests covering allowed roles, removed members, namespace-creator carve-out, non-group contexts, and Open-subgroup inherited membership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7567ed846da5ee4901e2bd992971d07ada8ae443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->