### PR TITLE
feat(context): namespace-scoped ownership proof (namespace-native Phase 1)

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -29,20 +29,21 @@ use crate::group::{
     GetGroupForContextRequest, GetGroupInfoRequest, GetGroupMetadataRequest,
     GetGroupUpgradeStatusRequest, GetMemberCapabilitiesRequest, GetMemberCapabilitiesResponse,
     GetMemberMetadataRequest, GetNamespaceIdentityRequest, GroupContextEntry, GroupInfoResponse,
-    GroupSummary, GroupUpgradeInfo, IssueOwnershipProofRequest, IssueOwnershipProofResponse,
-    JoinContextRequest, JoinContextResponse, JoinGroupRequest, JoinGroupResponse,
-    JoinSubgroupInheritanceRequest, JoinSubgroupInheritanceResponse, LeaveContextRequest,
-    LeaveContextResponse, LeaveGroupRequest, LeaveGroupResponse, LeaveNamespaceRequest,
-    LeaveNamespaceResponse, ListAllGroupsRequest, ListGroupContextsRequest,
-    ListGroupMembersRequest, ListGroupMembersResponse, ListNamespacesForApplicationRequest,
-    ListNamespacesRequest, NamespaceSummary, RemoveGroupMembersRequest, RetryGroupUpgradeRequest,
-    SetContextMetadataRequest, SetDefaultCapabilitiesRequest, SetGroupMetadataRequest,
-    SetMemberCapabilitiesRequest, SetMemberMetadataRequest, SetSubgroupVisibilityRequest,
-    SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest,
-    StoreGroupContextRequest, StoreGroupMetaRequest, StoreGroupMetadataRequest,
-    StoreMemberCapabilityRequest, StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest,
-    SyncGroupRequest, SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest,
-    UpgradeGroupRequest, UpgradeGroupResponse,
+    GroupSummary, GroupUpgradeInfo, IssueNamespaceOwnershipProofRequest,
+    IssueOwnershipProofRequest, IssueOwnershipProofResponse, JoinContextRequest,
+    JoinContextResponse, JoinGroupRequest, JoinGroupResponse, JoinSubgroupInheritanceRequest,
+    JoinSubgroupInheritanceResponse, LeaveContextRequest, LeaveContextResponse, LeaveGroupRequest,
+    LeaveGroupResponse, LeaveNamespaceRequest, LeaveNamespaceResponse, ListAllGroupsRequest,
+    ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
+    ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
+    RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetContextMetadataRequest,
+    SetDefaultCapabilitiesRequest, SetGroupMetadataRequest, SetMemberCapabilitiesRequest,
+    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
+    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
+    UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1296,6 +1297,12 @@ impl ContextClient {
         issue_ownership_proof,
         IssueOwnershipProof,
         IssueOwnershipProofRequest,
+        eyre::Result<IssueOwnershipProofResponse>
+    );
+    forward_to_actor!(
+        issue_namespace_ownership_proof,
+        IssueNamespaceOwnershipProof,
+        IssueNamespaceOwnershipProofRequest,
         eyre::Result<IssueOwnershipProofResponse>
     );
     forward_to_actor!(

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -549,6 +549,30 @@ impl Message for IssueOwnershipProofRequest {
     type Result = eyre::Result<IssueOwnershipProofResponse>;
 }
 
+/// Namespace-scoped sibling of [`IssueOwnershipProofRequest`].
+///
+/// Identical wire/signing contract MINUS the `context_id`: the signed payload
+/// carries `context_id == ""` and the handler skips the context lookup +
+/// containment walk. The authorization root is the namespace-root `group_id`
+/// (direct-admin gate), and the response type is reused verbatim.
+///
+/// See the issue-ownership-proof handler for the locked wire format.
+#[derive(Debug)]
+pub struct IssueNamespaceOwnershipProofRequest {
+    pub group_id: ContextGroupId,
+    pub audience: String,
+    pub subject: String,
+    /// Hex string, validated by the API layer to be 32..=128 chars.
+    pub nonce: String,
+    /// Caller-requested expiry in unix ms. Clamped server-side to
+    /// `min(expires_at_ms, issued_at_ms + 5*60*1000)`.
+    pub expires_at_ms: u64,
+}
+
+impl Message for IssueNamespaceOwnershipProofRequest {
+    type Result = eyre::Result<IssueOwnershipProofResponse>;
+}
+
 #[derive(Clone, Debug)]
 pub struct IssueOwnershipProofResponse {
     /// Ed25519 public key of the signer (the node's group signing identity).

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -15,9 +15,9 @@ use crate::group::{
     DetachContextFromGroupRequest, GetContextMetadataRequest, GetGroupForContextRequest,
     GetGroupInfoRequest, GetGroupMetadataRequest, GetGroupUpgradeStatusRequest,
     GetMemberCapabilitiesRequest, GetMemberMetadataRequest, GetNamespaceIdentityRequest,
-    IssueOwnershipProofRequest, JoinContextRequest, JoinGroupRequest,
-    JoinSubgroupInheritanceRequest, LeaveContextRequest, LeaveGroupRequest, LeaveNamespaceRequest,
-    ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
+    IssueNamespaceOwnershipProofRequest, IssueOwnershipProofRequest, JoinContextRequest,
+    JoinGroupRequest, JoinSubgroupInheritanceRequest, LeaveContextRequest, LeaveGroupRequest,
+    LeaveNamespaceRequest, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
     ListNamespacesForApplicationRequest, ListNamespacesRequest, RemoveGroupMembersRequest,
     RetryGroupUpgradeRequest, SetContextMetadataRequest, SetDefaultCapabilitiesRequest,
     SetGroupMetadataRequest, SetMemberCapabilitiesRequest, SetMemberMetadataRequest,
@@ -476,5 +476,9 @@ pub enum ContextMessage {
     IssueOwnershipProof {
         request: IssueOwnershipProofRequest,
         outcome: oneshot::Sender<<IssueOwnershipProofRequest as Message>::Result>,
+    },
+    IssueNamespaceOwnershipProof {
+        request: IssueNamespaceOwnershipProofRequest,
+        outcome: oneshot::Sender<<IssueNamespaceOwnershipProofRequest as Message>::Result>,
     },
 }

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -238,6 +238,9 @@ impl Handler<ContextMessage> for ContextManager {
             ContextMessage::IssueOwnershipProof { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
+            ContextMessage::IssueNamespaceOwnershipProof { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
         }
     }
 }

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -1,7 +1,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use actix::{ActorResponse, Handler, Message};
-use calimero_context_client::group::{IssueOwnershipProofRequest, IssueOwnershipProofResponse};
+use calimero_context_client::group::{
+    IssueNamespaceOwnershipProofRequest, IssueOwnershipProofRequest, IssueOwnershipProofResponse,
+};
 use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -142,6 +144,78 @@ pub(crate) fn build_ownership_proof(
     })
 }
 
+/// Namespace-scoped variant of [`build_ownership_proof`].
+///
+/// This is [`build_ownership_proof`] MINUS the context lookup + containment
+/// walk, with `context_id` set to the empty string `""` in the signed
+/// payload. The authorization root is unchanged: `is_direct_group_admin` on
+/// the namespace-root `group_id`, signing key resolved by `group_id` via
+/// `resolve_group_signing_key`, signer derived from the private key, expiry
+/// clamp to `now_ms + MAX_PROOF_LIFETIME_MS`. The signed `OwnershipClaimPayload`
+/// struct (and therefore its field order / signature input) is reused
+/// verbatim; the ONLY delta vs a context proof is `context_id == ""`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_namespace_ownership_proof(
+    store: &Store,
+    node_identity: PublicKey,
+    group_id: ContextGroupId,
+    audience: &str,
+    subject: &str,
+    nonce: &str,
+    requested_expires_at_ms: u64,
+    now_ms: u64,
+) -> eyre::Result<OwnershipProofBuildOutput> {
+    if !group_store::is_direct_group_admin(store, &group_id, &node_identity)? {
+        bail!("node is not a direct admin of this group");
+    }
+
+    let Some(signing_key_bytes) =
+        group_store::resolve_group_signing_key(store, &group_id, &node_identity)?
+    else {
+        bail!("no signing key registered for self-identity in this group");
+    };
+
+    let max_exp = now_ms.saturating_add(MAX_PROOF_LIFETIME_MS);
+    let expires_at_ms = requested_expires_at_ms.min(max_exp);
+    if expires_at_ms <= now_ms {
+        bail!("expires_at_ms must be in the future");
+    }
+
+    // Derive the signer identity from the resolved signing key itself rather
+    // than trusting `node_identity` — identical rationale to
+    // `build_ownership_proof`; mdma cross-checks
+    // `payload.issuer_identity == response.signer_public_key`.
+    let private_key = PrivateKey::from(signing_key_bytes);
+    let signer_public_key = private_key.public_key();
+
+    let payload = OwnershipClaimPayload {
+        v: 1,
+        audience,
+        group_id: hex::encode(group_id.to_bytes()),
+        issuer_identity: signer_public_key.to_string(),
+        // The single, deliberate delta vs a context-scoped proof.
+        context_id: String::new(),
+        subject,
+        nonce,
+        issued_at_ms: now_ms,
+        expires_at_ms,
+    };
+    let signed_payload = serde_json::to_vec(&payload)?;
+
+    let mut sign_input = Vec::with_capacity(OWNERSHIP_PROOF_DOMAIN.len() + signed_payload.len());
+    sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
+    sign_input.extend_from_slice(&signed_payload);
+
+    let signature = private_key.sign(&sign_input)?;
+    let signature_bytes: [u8; 64] = signature.to_bytes();
+
+    Ok(OwnershipProofBuildOutput {
+        signer_public_key,
+        signed_payload,
+        signature: signature_bytes,
+    })
+}
+
 impl Handler<IssueOwnershipProofRequest> for ContextManager {
     type Result = ActorResponse<Self, <IssueOwnershipProofRequest as Message>::Result>;
 
@@ -181,6 +255,44 @@ impl Handler<IssueOwnershipProofRequest> for ContextManager {
     }
 }
 
+impl Handler<IssueNamespaceOwnershipProofRequest> for ContextManager {
+    type Result = ActorResponse<Self, <IssueNamespaceOwnershipProofRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        req: IssueNamespaceOwnershipProofRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let result = (|| {
+            let Some((node_identity, _)) = self.node_namespace_identity(&req.group_id) else {
+                bail!("node has no group identity configured");
+            };
+
+            let now_ms = u64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())
+                .map_err(|_| eyre::eyre!("system clock out of u64 millisecond range"))?;
+
+            let built = build_namespace_ownership_proof(
+                &self.datastore,
+                node_identity,
+                req.group_id,
+                &req.audience,
+                &req.subject,
+                &req.nonce,
+                req.expires_at_ms,
+                now_ms,
+            )?;
+
+            Ok(IssueOwnershipProofResponse {
+                signer_public_key: built.signer_public_key,
+                signed_payload: built.signed_payload,
+                signature: built.signature,
+            })
+        })();
+
+        ActorResponse::reply(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -192,7 +304,7 @@ mod tests {
     use calimero_store::Store;
     use serde_json::Value;
 
-    use super::{build_ownership_proof, OWNERSHIP_PROOF_DOMAIN};
+    use super::{build_namespace_ownership_proof, build_ownership_proof, OWNERSHIP_PROOF_DOMAIN};
     use crate::group_store;
 
     const NOW_MS: u64 = 1_700_000_000_000;
@@ -491,5 +603,76 @@ mod tests {
             serde_json::from_slice(&out.signed_payload).expect("payload must be valid JSON");
         assert_eq!(json["issuer_identity"], out.signer_public_key.to_string());
         assert_eq!(json["issuer_identity"], real_pub.to_string());
+    }
+
+    #[test]
+    fn namespace_proof_no_context_succeeds() {
+        // Admin + signing key registered at the namespace-root group, but NO
+        // context is registered anywhere. A context-scoped proof would bail on
+        // the containment walk; the namespace primitive must succeed.
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+
+        let signing_priv = PrivateKey::from([0x33; 32]);
+        let signing_pub = signing_priv.public_key();
+
+        group_store::add_group_member(&store, &group_id, &signing_pub, GroupMemberRole::Admin)
+            .expect("add admin");
+        group_store::store_group_signing_key(&store, &group_id, &signing_pub, &signing_priv)
+            .expect("store signing key");
+
+        let out = build_namespace_ownership_proof(
+            &store,
+            signing_pub,
+            group_id,
+            "mdma:enable-ha-namespace",
+            "subject-xyz",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect("namespace proof with no context must succeed");
+
+        // Signature verifies over DOMAIN || signed_payload.
+        let mut sign_input =
+            Vec::with_capacity(OWNERSHIP_PROOF_DOMAIN.len() + out.signed_payload.len());
+        sign_input.extend_from_slice(OWNERSHIP_PROOF_DOMAIN);
+        sign_input.extend_from_slice(&out.signed_payload);
+        out.signer_public_key
+            .verify_raw_signature(&sign_input, &out.signature)
+            .expect("signature must verify");
+
+        let json: Value =
+            serde_json::from_slice(&out.signed_payload).expect("payload must be valid JSON");
+        assert_eq!(json["v"], 1);
+        // The only delta vs a context proof: context_id is the empty string.
+        assert_eq!(json["context_id"], "");
+        // Audience is passed through unchanged; core hardcodes nothing.
+        assert_eq!(json["audience"], "mdma:enable-ha-namespace");
+        assert_eq!(json["subject"], "subject-xyz");
+        assert_eq!(json["group_id"], hex::encode([0xAAu8; 32]));
+        assert_eq!(json["issuer_identity"], signing_pub.to_string());
+        assert_eq!(out.signer_public_key, signing_pub);
+    }
+
+    #[test]
+    fn non_admin_namespace_proof_bails() {
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+        let identity = PublicKey::from([0x44; 32]);
+
+        // Identity is not a member at all — not a direct admin.
+        let err = build_namespace_ownership_proof(
+            &store,
+            identity,
+            group_id,
+            "mdma:enable-ha-namespace",
+            "sub",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect_err("expected not-direct-admin error");
+        assert!(err.to_string().contains("direct admin"));
     }
 }

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -169,6 +169,17 @@ pub(crate) fn build_namespace_ownership_proof(
         bail!("node is not a direct admin of this group");
     }
 
+    // A namespace proof is scoped to a whole namespace, and a namespace IS its
+    // root group. Unlike the context path (`build_ownership_proof`), which
+    // legitimately accepts a subgroup context via the containment walk, the
+    // namespace primitive must reject any non-root `group_id` — admin on a
+    // subgroup must not yield a namespace-wide claim. Same check & API as the
+    // server-side precedent in
+    // `crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs`.
+    if group_store::get_parent_group(store, &group_id)?.is_some() {
+        bail!("group_id must reference a namespace root group");
+    }
+
     let Some(signing_key_bytes) =
         group_store::resolve_group_signing_key(store, &group_id, &node_identity)?
     else {
@@ -674,5 +685,47 @@ mod tests {
         )
         .expect_err("expected not-direct-admin error");
         assert!(err.to_string().contains("direct admin"));
+    }
+
+    #[test]
+    fn subgroup_namespace_proof_bails() {
+        // A namespace proof must be scoped to a namespace ROOT (a group with
+        // no parent). Being a direct admin of a subgroup nested under a root
+        // must NOT yield a namespace-wide claim: the builder must bail.
+        let store = test_store();
+        let root = ContextGroupId::from([0xAA; 32]);
+        let child = ContextGroupId::from([0xCC; 32]);
+
+        let signing_priv = PrivateKey::from([0x33; 32]);
+        let signing_pub = signing_priv.public_key();
+
+        // Admin + signing key registered directly at the child subgroup, so
+        // the `is_direct_group_admin` gate passes for `child` — the only
+        // thing standing between the caller and a namespace proof is the
+        // namespace-root check.
+        group_store::add_group_member(&store, &child, &signing_pub, GroupMemberRole::Admin)
+            .expect("add admin at child");
+        group_store::store_group_signing_key(&store, &child, &signing_pub, &signing_priv)
+            .expect("store signing key at child");
+
+        // `child` is nested under the namespace root `root`, so
+        // `get_parent_group(child)` is `Some(root)`.
+        group_store::nest_group(&store, &root, &child).expect("nest child under root");
+
+        let err = build_namespace_ownership_proof(
+            &store,
+            signing_pub,
+            child,
+            "mdma:enable-ha-namespace",
+            "subject-xyz",
+            "deadbeefcafebabe1122334455667788",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect_err("namespace proof on a subgroup must bail");
+        assert!(
+            err.to_string().contains("root"),
+            "error must mention namespace root, got: {err}"
+        );
     }
 }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2372,6 +2372,70 @@ impl Validate for IssueOwnershipProofApiRequest {
     }
 }
 
+/// Namespace-scoped sibling of [`IssueOwnershipProofApiRequest`].
+///
+/// Wire-identical MINUS the `contextId` field: the proof is scoped to the
+/// namespace-root group only. The response reuses
+/// [`IssueOwnershipProofApiResponse`] verbatim. Purely additive to
+/// `calimero-server-primitives`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueNamespaceOwnershipProofApiRequest {
+    pub audience: String,
+    pub subject: String,
+    /// Hex string, 32–128 chars inclusive (16–64 raw bytes).
+    pub nonce: String,
+    /// Caller-requested expiry in unix milliseconds. Server clamps to
+    /// `min(expires_at_ms, issued_at_ms + 5*60*1000)`.
+    pub expires_at_ms: u64,
+}
+
+impl Validate for IssueNamespaceOwnershipProofApiRequest {
+    fn validate(&self) -> Vec<ValidationError> {
+        let mut errors = Vec::new();
+
+        // audience: non-empty, <= 256 chars.
+        if self.audience.is_empty() {
+            errors.push(ValidationError::EmptyField { field: "audience" });
+        } else if let Some(e) = validate_string_length(&self.audience, "audience", 256) {
+            errors.push(e);
+        }
+
+        // subject: non-empty, <= 512 chars.
+        if self.subject.is_empty() {
+            errors.push(ValidationError::EmptyField { field: "subject" });
+        } else if let Some(e) = validate_string_length(&self.subject, "subject", 512) {
+            errors.push(e);
+        }
+
+        // nonce: hex string, 32..=128 chars inclusive (16..=64 raw bytes).
+        let n = self.nonce.len();
+        if !(32..=128).contains(&n) {
+            errors.push(ValidationError::InvalidFormat {
+                field: "nonce",
+                reason: "nonce must be hex-encoded, 32..=128 characters".into(),
+            });
+        } else if !self.nonce.chars().all(|c| c.is_ascii_hexdigit()) {
+            errors.push(ValidationError::InvalidHexEncoding {
+                field: "nonce",
+                reason: "nonce must be valid hex".into(),
+            });
+        } else if n % 2 != 0 {
+            // An odd-length hex string can't decode to whole bytes, which is
+            // inconsistent with the documented "16..=64 raw bytes" contract.
+            errors.push(ValidationError::InvalidFormat {
+                field: "nonce",
+                reason: "nonce hex string must have even length".into(),
+            });
+        }
+
+        // expires_at_ms is validated in the handler (it requires comparing
+        // against the current wall-clock).
+
+        errors
+    }
+}
+
 // ---- Leave Namespace (cascading self-leave) ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -7,6 +7,7 @@ pub mod get_group_info;
 pub mod get_group_upgrade_status;
 pub mod get_member_capabilities;
 pub mod get_tee_admission_policy;
+pub mod issue_namespace_ownership_proof;
 pub mod issue_ownership_proof;
 pub mod join_group;
 pub mod join_subgroup_inheritance;

--- a/crates/server/src/admin/handlers/groups/issue_namespace_ownership_proof.rs
+++ b/crates/server/src/admin/handlers/groups/issue_namespace_ownership_proof.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
+use calimero_context_client::group::IssueNamespaceOwnershipProofRequest;
+use calimero_server_primitives::admin::{
+    IssueNamespaceOwnershipProofApiRequest, IssueOwnershipProofApiResponse,
+};
+use tracing::{error, info};
+
+use super::parse_group_id;
+use crate::admin::handlers::validation::ValidatedJson;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(group_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+    ValidatedJson(req): ValidatedJson<IssueNamespaceOwnershipProofApiRequest>,
+) -> impl IntoResponse {
+    let group_id = match parse_group_id(&group_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(
+        group_id=%group_id_str,
+        audience=%req.audience,
+        "Issuing namespace ownership proof"
+    );
+
+    let result = state
+        .ctx_client
+        .issue_namespace_ownership_proof(IssueNamespaceOwnershipProofRequest {
+            group_id,
+            audience: req.audience,
+            subject: req.subject,
+            nonce: req.nonce,
+            expires_at_ms: req.expires_at_ms,
+        })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(resp) => {
+            info!(
+                group_id=%group_id_str,
+                signer=%resp.signer_public_key,
+                "Namespace ownership proof issued"
+            );
+            ApiResponse {
+                payload: IssueOwnershipProofApiResponse {
+                    // `PublicKey: Display` produces base58 (see calimero-primitives::identity).
+                    signer_public_key: resp.signer_public_key.to_string(),
+                    signed_payload: base64_engine.encode(&resp.signed_payload),
+                    signature: base64_engine.encode(resp.signature),
+                },
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(group_id=%group_id_str, error=?err, "Failed to issue namespace ownership proof");
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -237,6 +237,10 @@ pub(crate) fn setup(
             post(groups::issue_ownership_proof::handler),
         )
         .route(
+            "/groups/:group_id/issue-namespace-ownership-proof",
+            post(groups::issue_namespace_ownership_proof::handler),
+        )
+        .route(
             "/groups/:group_id/sync",
             post(groups::sync_group::handler),
         )


### PR DESCRIPTION
## What

Additive, wire-compatible namespace-scoped ownership proof, alongside the **untouched** context-scoped proof.

- `build_namespace_ownership_proof` — no `context_id`; authz gate is `is_direct_group_admin` on the namespace-root group; signing key resolved by `group_id`; payload `context_id == ""`. No containment walk.
- `IssueNamespaceOwnershipProofRequest` actor message + handler, ctx_client forward, `IssueNamespaceOwnershipProofApiRequest`, admin route `POST /admin-api/groups/{group_id}/issue-namespace-ownership-proof` (response shape identical to the existing proof endpoint).
- New unit tests `namespace_proof_no_context_succeeds`, `non_admin_namespace_proof_bails`; all 8 pre-existing context-path tests pass unchanged (byte-shape regression).

## Why

Closes the cross-tenant IDOR the reverted mdma spike (#115) opened: enabling HA on a namespace with zero contexts had no authorization signal. This is the missing core primitive — a proof scoped to the namespace root with no context.

## Wire contract

Signed payload is the existing `OwnershipClaimPayload` struct, field order unchanged; the only delta vs a context proof is `context_id` is the empty string. Domain, expiry clamp, and signature input unchanged.

## Cross-repo

Phase 1 spans core + **mdma** (verifier + route) + **tauri-app** (proof client) — sibling PRs on the same branch name. Spec: `HA_NAMESPACE_PROOF_FIX_PLAN.md` §A. No mero-tee rev bump (build-verified, purely additive).

## Verify

`(cd core && cargo test -p calimero-context && cargo check --workspace)` — green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new signed-claim issuance path and admin API route; while additive, it touches authorization/signing logic where subtle scoping mistakes could lead to over-broad claims.
> 
> **Overview**
> Adds a **namespace-scoped ownership proof** alongside the existing context-scoped proof: new `IssueNamespaceOwnershipProofRequest`/`ContextMessage` variant, `ContextClient::issue_namespace_ownership_proof` forwarder, and a new builder/actor handler that signs the same payload format but with `context_id == ""`.
> 
> Extends the admin API with `POST /groups/:group_id/issue-namespace-ownership-proof`, including request validation (audience/subject length + nonce hex/length) and response reuse of `IssueOwnershipProofApiResponse`. Adds unit tests covering namespace proof success with no contexts and failure cases for non-admin callers and non-root (subgroup) `group_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c059b1daa4b1f643abe56f443e63daa504e640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->