### PR TITLE
fix: replace deprecated --node-name flag with --node

### DIFF
--- a/architecture/config-reference.html
+++ b/architecture/config-reference.html
@@ -73,11 +73,11 @@ details.config-section .detail-body { padding: 18px; }
 
 <div class="cli-box">
 <span class="cc"># Generate default config</span>
-merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span class="cf">--node-name</span> <span class="cv">my-node</span> init
+merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span class="cf">--node</span> <span class="cv">my-node</span> init
 
 <span class="cc"># All flags and their defaults:</span>
   <span class="cf">--home</span>            <span class="cv">~/.calimero</span>          <span class="cc"># base directory for data + config</span>
-  <span class="cf">--node-name</span>       <span class="cv">(required)</span>           <span class="cc"># human-readable node name</span>
+  <span class="cf">--node</span>       <span class="cv">(required)</span>           <span class="cc"># human-readable node name</span>
   <span class="cf">--swarm-port</span>      <span class="cv">2428</span>                 <span class="cc"># libp2p swarm listen port</span>
   <span class="cf">--server-port</span>    <span class="cv">2528</span>                 <span class="cc"># HTTP API listen port</span>
   <span class="cf">--server-host</span>    <span class="cv">127.0.0.1</span>            <span class="cc"># HTTP API listen host</span>


### PR DESCRIPTION
## Summary
- Replace deprecated `--node-name` flag with `--node` in architecture config reference docs

## Files changed
- `architecture/config-reference.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating the CLI flag name in an example and defaults list; no runtime behavior is modified.
> 
> **Overview**
> Updates `architecture/config-reference.html` to replace the deprecated `--node-name` flag with `--node` in the `merod init` example command and the documented list of CLI defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0e7dfc78a3ed0c07a1646ef07a20d9633d962f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->