### PR TITLE
chore: bump 0.10.1 rc.41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.40"
+version = "0.10.1-rc.41"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
Bumps the workspace release version `[workspace.metadata.workspaces].version` `0.10.1-rc.40` → `0.10.1-rc.41` to cut RC 41.

Single-line metadata change, same shape as the prior RC-cut PRs (#2388 rc.40, #2380 rc.39, #2364 rc.38) — no `Cargo.lock` or per-crate version changes. RC 41 is the first release candidate that includes the namespace-native Phase 1 namespace-ownership-proof primitive (#2389).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that bumps the workspace RC version; no code, dependency, or lockfile updates.
> 
> **Overview**
> Bumps the workspace release-candidate version in `Cargo.toml` from `0.10.1-rc.40` to `0.10.1-rc.41` to cut the next RC.
> 
> No crate versions, dependencies, or `Cargo.lock` changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5660ac3d1e2da1c1c38dc05fa38e1c81168a3737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->