### PR TITLE
docs: auto-update for PR #2393 — TESTING AI REVIEWER DOCS feat(merod): add --log-level flag

### DIFF
--- a/architecture/config-reference.html
+++ b/architecture/config-reference.html
@@ -84,6 +84,7 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
   <span class="cf">--mdns</span>            <span class="cv">true</span>                 <span class="cc"># enable mDNS discovery</span>
   <span class="cf">--protocol</span>       <span class="cv">/calimero/devnet/global</span>  <span class="cc"># rendezvous namespace</span>
   <span class="cf">--boot-nodes</span>      <span class="cv">[]</span>                   <span class="cc"># bootstrap multiaddrs</span>
+  <span class="cf">--log-level</span>      <span class="cv">(optional)</span>         <span class="cc"># override log level (debug, info, warn, error)</span>
 </div>
 </div>
 
@@ -387,14 +388,21 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 <div class="config-field">
   <div class="cf-key">frequency_ms</div>
   <div class="cf-type">u64</div>
-  <div class="cf-default">10000</div>
+  <div class="cf-default">15000</div>
   <div class="cf-desc">Minimum ms between consecutive sync attempts for the same context.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">max_concurrent</div>
+  <div class="cf-type">usize</div>
+  <div class="cf-default">30</div>
+  <div class="cf-desc">Maximum number of concurrent sync operations.</div>
 </div>
 
 <div class="toml-example"><span class="ts">[sync]</span>
 <span class="tk">timeout_ms</span> = <span class="tv">30000</span>
 <span class="tk">interval_ms</span> = <span class="tv">5000</span>
-<span class="tk">frequency_ms</span> = <span class="tv">10000</span></div>
+<span class="tk">frequency_ms</span> = <span class="tv">15000</span>
+<span class="tk">max_concurrent</span> = <span class="tv">30</span></div>
 </div>
 </details>
 
@@ -443,155 +451,4 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 <summary><span class="code" style="color:var(--green)">[context]</span> &mdash; Context Client</summary>
 <div class="detail-body">
 <p style="margin-bottom:12px;">Configuration for the context management subsystem.</p>
-<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/context/src/config.rs" target="_blank" rel="noopener">ContextConfig</a></div>
-
-<div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
-<div class="config-field">
-  <div class="cf-key">client</div>
-  <div class="cf-type">ContextClientConfig</div>
-  <div class="cf-default">(default)</div>
-  <div class="cf-desc">Context client connection and retry settings.</div>
-</div>
-
-<div class="toml-example"><span class="ts">[context]</span>
-<span class="tc"># Uses defaults — typically no manual configuration needed</span></div>
-</div>
-</details>
-
-<!-- ── [tee] ── -->
-<details class="config-section">
-<summary><span class="code" style="color:var(--green)">[tee]</span> &mdash; TEE / KMS</summary>
-<div class="detail-body">
-<p style="margin-bottom:12px;">Optional Trusted Execution Environment and Key Management Service configuration. Only relevant for nodes running in secure enclaves.</p>
-<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/node/src/config.rs" target="_blank" rel="noopener">TeeConfig</a></div>
-
-<div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
-<div class="config-field">
-  <div class="cf-key">enabled</div>
-  <div class="cf-type">bool</div>
-  <div class="cf-default">false</div>
-  <div class="cf-desc">Enable TEE attestation and sealed storage.</div>
-</div>
-<div class="config-field">
-  <div class="cf-key">kms_url</div>
-  <div class="cf-type">Option&lt;String&gt;</div>
-  <div class="cf-default">None</div>
-  <div class="cf-desc">URL of the Key Management Service for key provisioning.</div>
-</div>
-
-<div class="toml-example"><span class="ts">[tee]</span>
-<span class="tk">enabled</span> = <span class="tv">false</span>
-<span class="tc"># kms_url = "https://kms.example.com"</span></div>
-</div>
-</details>
-
-<!-- ── [specialized_node] ── -->
-<details class="config-section">
-<summary><span class="code" style="color:var(--green)">[specialized_node]</span> &mdash; Specialized Node</summary>
-<div class="detail-body">
-<p style="margin-bottom:12px;">Settings for specialized node roles (e.g., TEE nodes that handle key shares).</p>
-<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/node/src/config.rs" target="_blank" rel="noopener">SpecializedNodeConfig</a></div>
-
-<div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
-<div class="config-field">
-  <div class="cf-key">invite_topic</div>
-  <div class="cf-type">String</div>
-  <div class="cf-default">"mero_specialized_node_invites"</div>
-  <div class="cf-desc">Gossipsub topic for receiving specialized node invitations.</div>
-</div>
-<div class="config-field">
-  <div class="cf-key">accept_mock_tee</div>
-  <div class="cf-type">bool</div>
-  <div class="cf-default">false</div>
-  <div class="cf-desc">Accept mock TEE attestations (for development/testing only).</div>
-</div>
-
-<div class="toml-example"><span class="ts">[specialized_node]</span>
-<span class="tk">invite_topic</span> = <span class="tv">"mero_specialized_node_invites"</span>
-<span class="tk">accept_mock_tee</span> = <span class="tv">false</span></div>
-</div>
-</details>
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     Full example
-     ═══════════════════════════════════════════════════════════════════ -->
-<div class="card gc" style="margin-top:36px;">
-<h2>Complete Example</h2>
-<p style="margin-bottom:14px;">A typical production <span class="code">config.toml</span> with commonly customized fields:</p>
-<div class="toml-example"><span class="ts">[identity]</span>
-<span class="tk">mode</span> = <span class="tv">"Standard"</span>
-
-<span class="ts">[swarm]</span>
-<span class="tk">listen</span> = [
-  <span class="tv">"/ip4/0.0.0.0/tcp/2428"</span>,
-  <span class="tv">"/ip4/0.0.0.0/udp/2428/quic-v1"</span>
-]
-
-<span class="ts">[bootstrap]</span>
-<span class="tk">nodes</span> = []
-
-<span class="ts">[discovery]</span>
-<span class="tk">mdns</span> = <span class="tv">true</span>
-<span class="tk">advertise_address</span> = <span class="tv">false</span>
-
-<span class="ts">[discovery.rendezvous]</span>
-<span class="tk">namespace</span> = <span class="tv">"/calimero/devnet/global"</span>
-<span class="tk">registrations_limit</span> = <span class="tv">3</span>
-
-<span class="ts">[discovery.relay]</span>
-<span class="tk">registrations_limit</span> = <span class="tv">3</span>
-
-<span class="ts">[discovery.autonat]</span>
-<span class="tk">probe_interval</span> = <span class="tv">"10s"</span>
-<span class="tk">max_candidates</span> = <span class="tv">5</span>
-
-<span class="ts">[server]</span>
-<span class="tk">listen</span> = [<span class="tv">"/ip4/127.0.0.1/tcp/2528"</span>]
-<span class="tk">auth_mode</span> = <span class="tv">"Proxy"</span>
-
-<span class="ts">[sync]</span>
-<span class="tk">timeout_ms</span> = <span class="tv">30000</span>
-<span class="tk">interval_ms</span> = <span class="tv">5000</span>
-<span class="tk">frequency_ms</span> = <span class="tv">10000</span>
-
-<span class="ts">[datastore]</span>
-<span class="tk">path</span> = <span class="tv">"data"</span>
-
-<span class="ts">[blobstore]</span>
-<span class="tk">path</span> = <span class="tv">"blobs"</span>
-
-<span class="ts">[specialized_node]</span>
-<span class="tk">invite_topic</span> = <span class="tv">"mero_specialized_node_invites"</span>
-<span class="tk">accept_mock_tee</span> = <span class="tv">false</span></div>
-</div>
-
-<h2 id="governance-migration">Governance Migration</h2>
-<p>Guide for migrating between group governance modes.</p>
-
-<div class="card ga">
-<h3>Default Configuration</h3>
-<div class="typedef">
-merod init --group-governance local
-</div>
-<p>Local governance is the default (and only) governance mode. Group operations are signed locally and propagated via gossip.</p>
-</div>
-
-<div class="card gb">
-<h3>Backup</h3>
-<p>Back up the node data directory (RocksDB store path in <span class="code">config.toml</span>) regularly. The <span class="code">group_store</span> contains all governance state and can be rebuilt from the persistent op log, but a backup provides faster recovery.</p>
-</div>
-
-</div>
-</div>
-
-<script src="nav.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  arch.buildBreadcrumb([
-    { label: 'Home', href: 'index.html' },
-    { label: 'Config Reference' }
-  ]);
-});
-</script>
-</body>
-</html>
+<div class="section-source">Rust type: <a href="

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -280,6 +280,13 @@ pub struct SyncConfig {
     pub interval: Duration,
     #[serde(rename = "frequency_ms", with = "serde_duration")]
     pub frequency: Duration,
+    /// Maximum number of concurrent sync operations (default: 30).
+    #[serde(default = "default_max_concurrent_syncs")]
+    pub max_concurrent: usize,
+}
+
+fn default_max_concurrent_syncs() -> usize {
+    30
 }
 
 fn default_sync_session_deadline() -> Duration {

--- a/crates/merod/src/cli.rs
+++ b/crates/merod/src/cli.rs
@@ -86,6 +86,10 @@ pub struct RootArgs {
     /// Name of node
     #[arg(short = 'n', long = "node", value_name = "NAME")]
     pub node_name: Utf8PathBuf,
+
+    /// Override the log level (e.g. debug, info, warn, error). Overrides RUST_LOG.
+    #[arg(long, value_name = "LEVEL")]
+    pub log_level: Option<String>,
 }
 
 impl RootCommand {

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -155,7 +155,8 @@ impl RunCommand {
                 session_deadline: config.sync.session_deadline,
                 interval: config.sync.interval,
                 frequency: config.sync.frequency,
-                ..Default::default() // Use defaults for new fields
+                max_concurrent: config.sync.max_concurrent,
+                ..Default::default()
             },
             datastore: datastore_config,
             blobstore: BlobStoreConfig::new(path.join(config.blobstore.path)),

--- a/crates/merod/src/main.rs
+++ b/crates/merod/src/main.rs
@@ -22,30 +22,34 @@ async fn main() -> EyreResult<()> {
     // Used by integration tests to verify panic hook logs structured info without panicking in-process.
     match std::env::var("MEROD_TEST_PANIC").as_deref() {
         Ok("1") => {
-            setup()?;
+            setup(None)?;
             panic!("test panic message");
         }
         Ok("string") => {
-            setup()?;
+            setup(None)?;
             std::panic::panic_any(String::from("string payload panic"));
         }
         _ => {}
     }
 
-    setup()?;
-
     let command = RootCommand::parse();
+
+    setup(command.args.log_level.as_deref())?;
 
     version::check_for_update();
 
     command.run().await
 }
 
-fn setup() -> EyreResult<()> {
-    let directives = match var("RUST_LOG") {
-        Ok(value) if !value.trim().is_empty() => value,
-        _ => "merod=info,calimero_=info".to_owned(),
-    };
+fn setup(log_level: Option<&str>) -> EyreResult<()> {
+    let directives = log_level
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| format!("merod={s},calimero_={s}"))
+        .or_else(|| match var("RUST_LOG") {
+            Ok(value) if !value.trim().is_empty() => Some(value),
+            _ => None,
+        })
+        .unwrap_or_else(|| "merod=info,calimero_=info".to_owned());
 
     registry()
         .with(EnvFilter::builder().parse(directives)?)

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -56,9 +56,9 @@ pub const DEFAULT_SYNC_SESSION_DEADLINE_SECS: u64 = DEFAULT_SYNC_TIMEOUT_SECS;
 /// This allows rapid re-sync if broadcasts fail, ensuring fast CRDT convergence
 pub const DEFAULT_SYNC_INTERVAL_SECS: u64 = 5;
 
-/// Default frequency of periodic sync checks (10 seconds)
+/// Default frequency of periodic sync checks (15 seconds)
 /// Aggressive fallback for when gossipsub broadcasts fail or are delayed
-pub const DEFAULT_SYNC_FREQUENCY_SECS: u64 = 10;
+pub const DEFAULT_SYNC_FREQUENCY_SECS: u64 = 15;
 
 /// Default maximum concurrent sync operations
 pub const DEFAULT_MAX_CONCURRENT_SYNCS: usize = 30;


### PR DESCRIPTION
## Automatic Documentation Update

This PR was opened automatically by the AI Code Reviewer after [PR #2393](https://github.com/calimero-network/core/pull/2393) was merged.

### Updated files

- `architecture/config-reference.html`

### What changed

**architecture/config-reference.html**: Static HTML page in `architecture/config-reference.html` — scanning for updates triggered by architecture-impacting changes in this PR.

---
*Generated by `ai-reviewer update-docs`. Review the changes and merge if correct — nothing was auto-merged.*