### PR TITLE
docs: auto-update for PR #2393 — TESTING AI REVIEWER DOCS feat(merod): add --log-level flag

### DIFF
--- a/architecture/config-reference.html
+++ b/architecture/config-reference.html
@@ -387,14 +387,21 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 <div class="config-field">
   <div class="cf-key">frequency_ms</div>
   <div class="cf-type">u64</div>
-  <div class="cf-default">10000</div>
+  <div class="cf-default">15000</div>
   <div class="cf-desc">Minimum ms between consecutive sync attempts for the same context.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">max_concurrent</div>
+  <div class="cf-type">usize</div>
+  <div class="cf-default">30</div>
+  <div class="cf-desc">Maximum number of concurrent sync operations across all contexts.</div>
 </div>
 
 <div class="toml-example"><span class="ts">[sync]</span>
 <span class="tk">timeout_ms</span> = <span class="tv">30000</span>
 <span class="tk">interval_ms</span> = <span class="tv">5000</span>
-<span class="tk">frequency_ms</span> = <span class="tv">10000</span></div>
+<span class="tk">frequency_ms</span> = <span class="tv">15000</span>
+<span class="tk">max_concurrent</span> = <span class="tv">30</span></div>
 </div>
 </details>
 
@@ -552,7 +559,8 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 <span class="ts">[sync]</span>
 <span class="tk">timeout_ms</span> = <span class="tv">30000</span>
 <span class="tk">interval_ms</span> = <span class="tv">5000</span>
-<span class="tk">frequency_ms</span> = <span class="tv">10000</span>
+<span class="tk">frequency_ms</span> = <span class="tv">15000</span>
+<span class="tk">max_concurrent</span> = <span class="tv">30</span>
 
 <span class="ts">[datastore]</span>
 <span class="tk">path</span> = <span class="tv">"data"</span>

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -280,6 +280,13 @@ pub struct SyncConfig {
     pub interval: Duration,
     #[serde(rename = "frequency_ms", with = "serde_duration")]
     pub frequency: Duration,
+    /// Maximum number of concurrent sync operations (default: 30).
+    #[serde(default = "default_max_concurrent_syncs")]
+    pub max_concurrent: usize,
+}
+
+fn default_max_concurrent_syncs() -> usize {
+    30
 }
 
 fn default_sync_session_deadline() -> Duration {

--- a/crates/merod/src/cli.rs
+++ b/crates/merod/src/cli.rs
@@ -86,6 +86,10 @@ pub struct RootArgs {
     /// Name of node
     #[arg(short = 'n', long = "node", value_name = "NAME")]
     pub node_name: Utf8PathBuf,
+
+    /// Override the log level (e.g. debug, info, warn, error). Overrides RUST_LOG.
+    #[arg(long, value_name = "LEVEL")]
+    pub log_level: Option<String>,
 }
 
 impl RootCommand {

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -155,7 +155,8 @@ impl RunCommand {
                 session_deadline: config.sync.session_deadline,
                 interval: config.sync.interval,
                 frequency: config.sync.frequency,
-                ..Default::default() // Use defaults for new fields
+                max_concurrent: config.sync.max_concurrent,
+                ..Default::default()
             },
             datastore: datastore_config,
             blobstore: BlobStoreConfig::new(path.join(config.blobstore.path)),

--- a/crates/merod/src/main.rs
+++ b/crates/merod/src/main.rs
@@ -22,30 +22,34 @@ async fn main() -> EyreResult<()> {
     // Used by integration tests to verify panic hook logs structured info without panicking in-process.
     match std::env::var("MEROD_TEST_PANIC").as_deref() {
         Ok("1") => {
-            setup()?;
+            setup(None)?;
             panic!("test panic message");
         }
         Ok("string") => {
-            setup()?;
+            setup(None)?;
             std::panic::panic_any(String::from("string payload panic"));
         }
         _ => {}
     }
 
-    setup()?;
-
     let command = RootCommand::parse();
+
+    setup(command.args.log_level.as_deref())?;
 
     version::check_for_update();
 
     command.run().await
 }
 
-fn setup() -> EyreResult<()> {
-    let directives = match var("RUST_LOG") {
-        Ok(value) if !value.trim().is_empty() => value,
-        _ => "merod=info,calimero_=info".to_owned(),
-    };
+fn setup(log_level: Option<&str>) -> EyreResult<()> {
+    let directives = log_level
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| format!("merod={s},calimero_={s}"))
+        .or_else(|| match var("RUST_LOG") {
+            Ok(value) if !value.trim().is_empty() => Some(value),
+            _ => None,
+        })
+        .unwrap_or_else(|| "merod=info,calimero_=info".to_owned());
 
     registry()
         .with(EnvFilter::builder().parse(directives)?)

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -56,9 +56,9 @@ pub const DEFAULT_SYNC_SESSION_DEADLINE_SECS: u64 = DEFAULT_SYNC_TIMEOUT_SECS;
 /// This allows rapid re-sync if broadcasts fail, ensuring fast CRDT convergence
 pub const DEFAULT_SYNC_INTERVAL_SECS: u64 = 5;
 
-/// Default frequency of periodic sync checks (10 seconds)
+/// Default frequency of periodic sync checks (15 seconds)
 /// Aggressive fallback for when gossipsub broadcasts fail or are delayed
-pub const DEFAULT_SYNC_FREQUENCY_SECS: u64 = 10;
+pub const DEFAULT_SYNC_FREQUENCY_SECS: u64 = 15;
 
 /// Default maximum concurrent sync operations
 pub const DEFAULT_MAX_CONCURRENT_SYNCS: usize = 30;


### PR DESCRIPTION
## Automatic Documentation Update

This PR was opened automatically by the AI Code Reviewer after [PR #2393](https://github.com/calimero-network/core/pull/2393) was merged.

### Updated files

- `architecture/config-reference.html`

### What changed

**architecture/config-reference.html**: Static HTML page in `architecture/config-reference.html` — scanning for updates triggered by architecture-impacting changes in this PR.

---
*Generated by `ai-reviewer update-docs`. Review the changes and merge if correct — nothing was auto-merged.*