### PR TITLE
fix(node/sync): make namespace-join stream-open resilient to flaky peers

### DIFF
--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -165,6 +165,13 @@ pub struct SyncConfig {
     /// Wall-clock budget for the cross-peer missing-parent fetch loop.
     /// See [`DEFAULT_PARENT_PULL_BUDGET_MS`].
     pub parent_pull_budget: time::Duration,
+
+    /// Per-attempt timeout for opening a stream to a mesh peer during
+    /// namespace-join discovery. See [`DEFAULT_OPEN_STREAM_TIMEOUT_MS`]
+    /// for the rationale (stale-connection idle-die backoff). Deployment-
+    /// sensitive: shorter for low-latency LANs with aggressive QUIC idle
+    /// timeouts, longer for high-latency WAN.
+    pub open_stream_timeout: time::Duration,
 }
 
 impl Default for SyncConfig {
@@ -180,6 +187,7 @@ impl Default for SyncConfig {
             peer_state_probe_concurrency: DEFAULT_PEER_STATE_PROBE_CONCURRENCY,
             parent_pull_additional_peers: DEFAULT_PARENT_PULL_ADDITIONAL_PEERS,
             parent_pull_budget: time::Duration::from_millis(DEFAULT_PARENT_PULL_BUDGET_MS),
+            open_stream_timeout: time::Duration::from_millis(DEFAULT_OPEN_STREAM_TIMEOUT_MS),
         }
     }
 }

--- a/crates/node/src/sync/config.rs
+++ b/crates/node/src/sync/config.rs
@@ -82,6 +82,14 @@ pub const DEFAULT_MESH_RETRIES_UNINITIALIZED: u32 = 10;
 /// Default mesh discovery retry delay for uninitialized nodes (milliseconds).
 pub const DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED: u64 = 1_000;
 
+/// Per-attempt timeout for opening a stream to a mesh peer (milliseconds).
+/// A peer can be in the gossipsub mesh while its transport connection is
+/// stale, so the substream negotiation can stall until the connection
+/// itself idle-dies (~4s observed on CI). Bounding the open explicitly
+/// lets us fail fast and fail over to the next peer instead of waiting
+/// for connection death.
+pub const DEFAULT_OPEN_STREAM_TIMEOUT_MS: u64 = 3_000;
+
 /// Max concurrent peer probes when looking for a peer with state.
 /// Typical meshes are 2-20 peers; a pool of 4 is enough parallelism
 /// that the tail is bounded by the fastest responder, without racing

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4311,8 +4311,7 @@ impl SyncManager {
         // peer instead of waiting for connection death (~4s observed on
         // CI). Use the uninitialized retry window (10 × 1 s) to stay
         // reliable in slower environments (CI, Docker, mDNS cold-start).
-        let open_timeout =
-            std::time::Duration::from_millis(super::config::DEFAULT_OPEN_STREAM_TIMEOUT_MS);
+        let open_timeout = self.sync_config.open_stream_timeout;
         let mut stream = None;
         'connect: for attempt in 1..=super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED {
             let peers = self.network_client.mesh_peers(topic.clone()).await;

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4302,22 +4302,53 @@ impl SyncManager {
             hex::encode(params.namespace_id)
         ));
 
-        // Retry peer discovery: gossipsub mesh for the namespace topic may
-        // still be forming when this runs (mDNS + GRAFT exchange can take
-        // several seconds). Use the same retry window as uninitialized
-        // context sync (10 × 1 s = 10 s) to ensure we don't give up too
-        // quickly in slower environments (CI, Docker, mDNS cold-start).
-        let mut peers = Vec::new();
-        for attempt in 1..=super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED {
-            peers = self.network_client.mesh_peers(topic.clone()).await;
-            if !peers.is_empty() {
-                break;
+        // Discover a mesh peer and open a namespace-join stream, retrying
+        // both. The gossipsub mesh may still be forming when this runs
+        // (mDNS + GRAFT exchange can take several seconds), and a peer can
+        // be in the mesh while its transport connection is stale — so each
+        // round we try *every* known peer, and the open is bounded by an
+        // explicit timeout so a stalled negotiation fails over to the next
+        // peer instead of waiting for connection death (~4s observed on
+        // CI). Use the uninitialized retry window (10 × 1 s) to stay
+        // reliable in slower environments (CI, Docker, mDNS cold-start).
+        let open_timeout =
+            std::time::Duration::from_millis(super::config::DEFAULT_OPEN_STREAM_TIMEOUT_MS);
+        let mut stream = None;
+        'connect: for attempt in 1..=super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED {
+            let peers = self.network_client.mesh_peers(topic.clone()).await;
+
+            for peer in &peers {
+                match time::timeout(open_timeout, self.network_client.open_stream(*peer)).await {
+                    Ok(Ok(opened)) => {
+                        stream = Some(opened);
+                        break 'connect;
+                    }
+                    Ok(Err(err)) => {
+                        debug!(
+                            namespace_id = %hex::encode(params.namespace_id),
+                            %peer,
+                            attempt,
+                            %err,
+                            "Failed to open namespace-join stream, trying next peer..."
+                        );
+                    }
+                    Err(_) => {
+                        debug!(
+                            namespace_id = %hex::encode(params.namespace_id),
+                            %peer,
+                            attempt,
+                            "Timed out opening namespace-join stream, trying next peer..."
+                        );
+                    }
+                }
             }
+
             if attempt < super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED {
                 debug!(
                     namespace_id = %hex::encode(params.namespace_id),
                     attempt,
-                    "No namespace mesh peers yet, retrying..."
+                    peer_count = peers.len(),
+                    "No reachable namespace mesh peer yet, retrying..."
                 );
                 time::sleep(std::time::Duration::from_millis(
                     super::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
@@ -4326,18 +4357,12 @@ impl SyncManager {
             }
         }
 
-        let peer = peers.first().ok_or_else(|| {
+        let mut stream = stream.ok_or_else(|| {
             eyre::eyre!(
-                "no mesh peers for namespace {}",
+                "could not open a namespace-join stream to any mesh peer for namespace {}",
                 hex::encode(params.namespace_id)
             )
         })?;
-
-        let mut stream = self
-            .network_client
-            .open_stream(*peer)
-            .await
-            .wrap_err("open stream for namespace join")?;
 
         let msg = StreamMessage::Init {
             context_id: calimero_primitives::context::ContextId::from([0u8; 32]),

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4318,19 +4318,21 @@ impl SyncManager {
         //
         // The whole discovery+open loop is bounded by an outer deadline
         // so a worst-case `retries × peers × open_timeout` blow-up
-        // (3-peer mesh + default 3 s open + 10 retries ≈ 100 s) can't
-        // outlast the caller's own timeout and leave the join in an
-        // ambiguous state. The deadline is generous enough to cover a
-        // legitimate cold-start mesh formation
-        // (`mesh_retries × (mesh_retry_delay + open_timeout)`) but caps
-        // pathological cases.
+        // (3-peer mesh × 3 s open × 10 retries ≈ 100 s, plus inter-round
+        // sleeps) can't outlast the caller's own timeout and leave the
+        // join in an ambiguous state. The deadline is `mesh_retries ×
+        // (mesh_retry_delay + DEADLINE_MAX_PEERS_PER_ROUND × open_timeout)` —
+        // sized for a small-to-medium mesh; on very-large meshes the
+        // deadline will fire mid-round and the per-peer loop bails via
+        // its own check (defense in depth, line below).
+        const DEADLINE_MAX_PEERS_PER_ROUND: u32 = 4;
         let open_timeout = self.sync_config.open_stream_timeout;
         let mesh_retries = super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED;
         let mesh_retry_delay = std::time::Duration::from_millis(
             super::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
         );
         let connect_deadline = mesh_retry_delay
-            .saturating_add(open_timeout)
+            .saturating_add(open_timeout.saturating_mul(DEADLINE_MAX_PEERS_PER_ROUND))
             .saturating_mul(mesh_retries);
         let connect_started = std::time::Instant::now();
 
@@ -4356,6 +4358,14 @@ impl SyncManager {
                 .collect();
 
             for peer in &peers {
+                // Per-peer deadline check — bails mid-round if the
+                // outer budget is exhausted, so a very-large mesh
+                // can't sit on `open_timeout` for several peers past
+                // the deadline before the top-of-loop check fires
+                // again.
+                if connect_started.elapsed() >= connect_deadline {
+                    break 'connect;
+                }
                 match time::timeout(open_timeout, self.network_client.open_stream(*peer)).await {
                     Ok(Ok(opened)) => {
                         stream = Some(opened);
@@ -4381,7 +4391,14 @@ impl SyncManager {
                 }
             }
 
-            if attempt < mesh_retries {
+            // Sleep before the next round only if (a) there IS a next
+            // round and (b) we'd still be inside the deadline after
+            // the sleep — otherwise we'd just burn the delay and
+            // immediately hit the deadline check at the top of the
+            // next iteration.
+            if attempt < mesh_retries
+                && connect_started.elapsed().saturating_add(mesh_retry_delay) < connect_deadline
+            {
                 debug!(
                     namespace_id = %hex::encode(params.namespace_id),
                     attempt,
@@ -4392,12 +4409,14 @@ impl SyncManager {
             }
         }
 
+        let elapsed = connect_started.elapsed();
         let mut stream = stream.ok_or_else(|| {
             eyre::eyre!(
                 "could not open a namespace-join stream to any mesh peer for namespace {} \
-                 (deadline {}ms)",
+                 (deadline {}ms, elapsed {}ms)",
                 hex::encode(params.namespace_id),
-                connect_deadline.as_millis()
+                connect_deadline.as_millis(),
+                elapsed.as_millis()
             )
         })?;
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4306,15 +4306,54 @@ impl SyncManager {
         // both. The gossipsub mesh may still be forming when this runs
         // (mDNS + GRAFT exchange can take several seconds), and a peer can
         // be in the mesh while its transport connection is stale — so each
-        // round we try *every* known peer, and the open is bounded by an
-        // explicit timeout so a stalled negotiation fails over to the next
-        // peer instead of waiting for connection death (~4s observed on
-        // CI). Use the uninitialized retry window (10 × 1 s) to stay
-        // reliable in slower environments (CI, Docker, mDNS cold-start).
+        // round we try every known peer (in randomized order so a
+        // consistently-stale peer doesn't get tried first every round and
+        // burn the per-peer timeout budget before falling over to a
+        // healthy one — matches `perform_interval_sync`'s shuffle). The
+        // open is bounded by an explicit timeout so a stalled negotiation
+        // fails over to the next peer instead of waiting for connection
+        // death (~4s observed on CI). Use the uninitialized retry window
+        // (10 × 1 s) to stay reliable in slower environments (CI, Docker,
+        // mDNS cold-start).
+        //
+        // The whole discovery+open loop is bounded by an outer deadline
+        // so a worst-case `retries × peers × open_timeout` blow-up
+        // (3-peer mesh + default 3 s open + 10 retries ≈ 100 s) can't
+        // outlast the caller's own timeout and leave the join in an
+        // ambiguous state. The deadline is generous enough to cover a
+        // legitimate cold-start mesh formation
+        // (`mesh_retries × (mesh_retry_delay + open_timeout)`) but caps
+        // pathological cases.
         let open_timeout = self.sync_config.open_stream_timeout;
+        let mesh_retries = super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED;
+        let mesh_retry_delay = std::time::Duration::from_millis(
+            super::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
+        );
+        let connect_deadline = mesh_retry_delay
+            .saturating_add(open_timeout)
+            .saturating_mul(mesh_retries);
+        let connect_started = std::time::Instant::now();
+
         let mut stream = None;
-        'connect: for attempt in 1..=super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED {
-            let peers = self.network_client.mesh_peers(topic.clone()).await;
+        'connect: for attempt in 1..=mesh_retries {
+            if connect_started.elapsed() >= connect_deadline {
+                debug!(
+                    namespace_id = %hex::encode(params.namespace_id),
+                    attempt,
+                    elapsed_ms = connect_started.elapsed().as_millis() as u64,
+                    "namespace-join connect-loop deadline exceeded, giving up"
+                );
+                break;
+            }
+            let mut peers = self.network_client.mesh_peers(topic.clone()).await;
+            // Randomize peer order so a consistently-stale peer doesn't
+            // get tried first every round. `choose_multiple` of all
+            // peers is the same shuffle pattern used in
+            // `perform_interval_sync`.
+            peers = peers
+                .choose_multiple(&mut rand::thread_rng(), peers.len())
+                .copied()
+                .collect();
 
             for peer in &peers {
                 match time::timeout(open_timeout, self.network_client.open_stream(*peer)).await {
@@ -4342,24 +4381,23 @@ impl SyncManager {
                 }
             }
 
-            if attempt < super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED {
+            if attempt < mesh_retries {
                 debug!(
                     namespace_id = %hex::encode(params.namespace_id),
                     attempt,
                     peer_count = peers.len(),
                     "No reachable namespace mesh peer yet, retrying..."
                 );
-                time::sleep(std::time::Duration::from_millis(
-                    super::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
-                ))
-                .await;
+                time::sleep(mesh_retry_delay).await;
             }
         }
 
         let mut stream = stream.ok_or_else(|| {
             eyre::eyre!(
-                "could not open a namespace-join stream to any mesh peer for namespace {}",
-                hex::encode(params.namespace_id)
+                "could not open a namespace-join stream to any mesh peer for namespace {} \
+                 (deadline {}ms)",
+                hex::encode(params.namespace_id),
+                connect_deadline.as_millis()
             )
         })?;
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4321,10 +4321,24 @@ impl SyncManager {
         // (3-peer mesh × 3 s open × 10 retries ≈ 100 s, plus inter-round
         // sleeps) can't outlast the caller's own timeout and leave the
         // join in an ambiguous state. The deadline is `mesh_retries ×
-        // (mesh_retry_delay + DEADLINE_MAX_PEERS_PER_ROUND × open_timeout)` —
-        // sized for a small-to-medium mesh; on very-large meshes the
-        // deadline will fire mid-round and the per-peer loop bails via
-        // its own check (defense in depth, line below).
+        // (mesh_retry_delay + DEADLINE_MAX_PEERS_PER_ROUND × open_timeout)`.
+        //
+        // `DEADLINE_MAX_PEERS_PER_ROUND` is a worst-case *cap* used for
+        // budgeting, not an exact per-round peer count. It under-counts
+        // the per-round cost on very-large meshes (where the per-peer
+        // deadline check below bails the loop mid-round as a safety net)
+        // and over-counts on small or empty meshes (where the deadline
+        // simply doesn't fire because rounds are cheap — `mesh_retries ×
+        // mesh_retry_delay` ≈ 10 s on the 0-peer floor, well under any
+        // reasonable caller timeout). Either way the loop terminates
+        // inside `mesh_retries` rounds; the deadline is the upper-bound
+        // safety net, not a precise schedule.
+        //
+        // 4 covers the expected mesh size for namespace-join discovery
+        // (typically 1–3 peers in the namespace topic mesh during cold
+        // start). If we ever see meshes consistently above this, the
+        // constant should grow — the per-peer deadline check keeps the
+        // current value sound regardless.
         const DEADLINE_MAX_PEERS_PER_ROUND: u32 = 4;
         let open_timeout = self.sync_config.open_stream_timeout;
         let mesh_retries = super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED;


### PR DESCRIPTION
## Problem

`initiate_namespace_join` (`crates/node/src/sync/manager/mod.rs`) discovered gossipsub mesh peers with a 10×1s retry loop, then took **`peers.first()`** and called **`open_stream` exactly once, unbounded**.

A peer can be in the gossipsub mesh while its transport connection is stale — mesh membership ≠ a live connection. When that happens the `/calimero/stream/0.0.2` substream negotiation stalls and `open_stream` blocks until the QUIC connection itself idle-dies (**~4s observed on CI**), then the join fails:

```
ERROR join_namespace: Failed to join namespace … ApiError { 500, "open stream for namespace join" }
```

No retry, no failover to other mesh peers, no recovery. This is behind a large share of the E2E flake — investigated from run [26085685709](https://github.com/calimero-network/core/actions/runs/26085685709) (`group-governance-peer-down` → "Node-3 joins namespace"; node-3's log shows conn id=7 proposing the stream protocol, then `ConnectionLost(TimedOut)` ~4s later).

## Fix

Restructure into a single discover→open loop. Each round:
- re-discovers mesh peers,
- tries **every** peer, not just `peers.first()`,
- bounds each `open_stream` with an explicit timeout — new `DEFAULT_OPEN_STREAM_TIMEOUT_MS` (3s) in `sync/config.rs` — so a stalled negotiation **fails over to the next peer** instead of waiting for connection death,
- retries the whole cycle within the existing 10×1s uninitialized window.

The `Init`/`send`/`recv` handshake below is unchanged.

## Scope

Targeted at the namespace-join path. The sync path (`scaffolding-e2e` convergence flake) shares the same family — `open_stream` trusting mesh membership without a bounded open — but it already has `match`/fallback handling and is a larger change; left as a follow-up.

## Verification

- `cargo fmt --check` clean
- `cargo check -p calimero-node` passes
- Functional confirmation will come from the E2E suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the namespace-join connection/discovery loop to add per-peer timeouts and multi-peer failover; mistakes could cause join attempts to time out prematurely or increase latency under unusual network conditions.
> 
> **Overview**
> Improves `initiate_namespace_join` so namespace joins no longer depend on `peers.first()` and an unbounded `open_stream`; it now re-discovers mesh peers across retries, shuffles peer order, and attempts *every* peer with a per-attempt timeout to fail over quickly from stale/flaky connections.
> 
> Adds a new `SyncConfig::open_stream_timeout` (default `3s`) plus an outer connect-loop deadline to cap worst-case `retries × peers × timeout`, and enhances debug/error messages to report peer counts, attempts, and deadline/elapsed timing when join stream setup fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa97a209c61645ef044b7d4044be756c87618c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->