### PR TITLE
fix(storage): silent-skip stale upsert nonce instead of fatal NonceReplay

### DIFF
--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -174,6 +174,15 @@ impl ToTokens for PublicLogicMethod<'_> {
                 #[cfg(target_arch = "wasm32")]
                 #[no_mangle]
                 pub extern "C" fn __calimero_sync_next() {
+                    // Route panic location + message through the host so a
+                    // WASM trap during apply surfaces the actual Rust
+                    // panic in node logs instead of a bare "unreachable".
+                    // Other exported methods install this hook already
+                    // (see the regular-method branch below); sync-next
+                    // didn't, which is why upstream sync failures were
+                    // hard to diagnose.
+                    ::calimero_sdk::env::setup_panic_hook();
+
                     let Some(args) = ::calimero_sdk::env::input() else {
                         ::calimero_sdk::env::panic_str("Expected payload to sync method.")
                     };

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -140,9 +140,17 @@ where
     }
 
     /// Commits the root collection without an instance of the root state.
-    #[expect(clippy::unwrap_used, reason = "fatal error if it happens")]
     pub fn commit_headless() {
-        <Interface<S>>::commit_root::<Collection<T>>(None).unwrap();
+        if let Err(e) = <Interface<S>>::commit_root::<Collection<T>>(None) {
+            tracing::error!(
+                target: "storage::root",
+                error = %e,
+                debug_error = ?e,
+                "commit_headless: Interface::commit_root returned Err — about to panic via unwrap"
+            );
+            #[expect(clippy::unwrap_used, reason = "fatal error if it happens")]
+            Err::<(), _>(e).unwrap();
+        }
     }
 
     /// Syncs the root collection.
@@ -162,42 +170,63 @@ where
         let artifact =
             from_slice::<StorageDelta>(args).map_err(StorageError::DeserializationError)?;
 
-        match artifact {
-            StorageDelta::Actions(actions) => {
-                Self::apply_actions(actions, |_| ctx.clone())?;
-            }
-            StorageDelta::CausalActions {
-                actions,
-                delta_id,
-                delta_hlc,
-                effective_writers,
-            } => {
-                Self::apply_actions(actions, |action| crate::interface::ApplyContext {
-                    effective_writers: effective_writers.get(&action.id()).cloned(),
-                    delta_id: Some(delta_id),
-                    delta_hlc: Some(delta_hlc),
-                })?;
-            }
-            StorageDelta::Comparisons(comparisons) => {
-                if comparisons.is_empty() {
-                    push_comparison(Comparison {
-                        data: <Interface<S>>::find_by_id_raw(Id::root()),
-                        comparison_data: <Interface<S>>::generate_comparison_data(None)?,
-                    });
-                }
+        let variant = match &artifact {
+            StorageDelta::Actions(_) => "Actions",
+            StorageDelta::CausalActions { .. } => "CausalActions",
+            StorageDelta::Comparisons(_) => "Comparisons",
+        };
 
-                for Comparison {
-                    data,
-                    comparison_data,
-                } in comparisons
-                {
-                    <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
+        let result: Result<(), StorageError> = (|| {
+            match artifact {
+                StorageDelta::Actions(actions) => {
+                    Self::apply_actions(actions, |_| ctx.clone())?;
+                }
+                StorageDelta::CausalActions {
+                    actions,
+                    delta_id,
+                    delta_hlc,
+                    effective_writers,
+                } => {
+                    Self::apply_actions(actions, |action| crate::interface::ApplyContext {
+                        effective_writers: effective_writers.get(&action.id()).cloned(),
+                        delta_id: Some(delta_id),
+                        delta_hlc: Some(delta_hlc),
+                    })?;
+                }
+                StorageDelta::Comparisons(comparisons) => {
+                    if comparisons.is_empty() {
+                        push_comparison(Comparison {
+                            data: <Interface<S>>::find_by_id_raw(Id::root()),
+                            comparison_data: <Interface<S>>::generate_comparison_data(None)?,
+                        });
+                    }
+
+                    for Comparison {
+                        data,
+                        comparison_data,
+                    } in comparisons
+                    {
+                        <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
+                    }
                 }
             }
+            Ok(())
+        })();
+
+        if let Err(ref e) = result {
+            tracing::error!(
+                target: "storage::root",
+                variant,
+                error = %e,
+                debug_error = ?e,
+                "Root::sync apply_actions/branch returned Err — about to bubble up to __calimero_sync_next's .expect()"
+            );
+            return result;
         }
 
         info!(
             target: "storage::root",
+            variant,
             "committing root after delta replay"
         );
         Self::commit_headless();

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -140,6 +140,12 @@ where
     }
 
     /// Commits the root collection without an instance of the root state.
+    #[expect(
+        clippy::panic,
+        reason = "fatal error if it happens; tracing::error first so node logs \
+                  carry the cause before the WASM abort, then panic with the \
+                  Display form in the message for any panic-hook consumer"
+    )]
     pub fn commit_headless() {
         <Interface<S>>::commit_root::<Collection<T>>(None).unwrap_or_else(|e| {
             tracing::error!(
@@ -191,22 +197,12 @@ where
                 delta_id: Some(delta_id),
                 delta_hlc: Some(delta_hlc),
             }),
-            StorageDelta::Comparisons(comparisons) => {
-                if comparisons.is_empty() {
-                    push_comparison(Comparison {
-                        data: <Interface<S>>::find_by_id_raw(Id::root()),
-                        comparison_data: <Interface<S>>::generate_comparison_data(None)?,
-                    });
-                }
-                for Comparison {
-                    data,
-                    comparison_data,
-                } in comparisons
-                {
-                    <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
-                }
-                Ok(())
-            }
+            // Extracted to a helper so the `?` operators inside
+            // propagate to a Result that the match arm returns,
+            // which then flows through the `.inspect_err()` below.
+            // Inlining the body here would let the inner `?`
+            // return from `sync` directly, bypassing the trace.
+            StorageDelta::Comparisons(comparisons) => Self::apply_comparisons(comparisons, ctx),
         }
         .inspect_err(|e| {
             tracing::error!(
@@ -224,6 +220,33 @@ where
         );
         Self::commit_headless();
 
+        Ok(())
+    }
+
+    /// Apply a batch of `Comparison` entries from a sync delta.
+    ///
+    /// Extracted to a helper so the inner `?` operators propagate to
+    /// this function's `Result`, which the caller (`Self::sync`) returns
+    /// from its match expression and then runs through `.inspect_err`.
+    /// Inlining the body in the match arm would let `?` skip over the
+    /// trace.
+    fn apply_comparisons(
+        comparisons: Vec<Comparison>,
+        ctx: &crate::interface::ApplyContext,
+    ) -> Result<(), StorageError> {
+        if comparisons.is_empty() {
+            push_comparison(Comparison {
+                data: <Interface<S>>::find_by_id_raw(Id::root()),
+                comparison_data: <Interface<S>>::generate_comparison_data(None)?,
+            });
+        }
+        for Comparison {
+            data,
+            comparison_data,
+        } in comparisons
+        {
+            <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
+        }
         Ok(())
     }
 

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -141,16 +141,14 @@ where
 
     /// Commits the root collection without an instance of the root state.
     pub fn commit_headless() {
-        if let Err(e) = <Interface<S>>::commit_root::<Collection<T>>(None) {
+        <Interface<S>>::commit_root::<Collection<T>>(None).unwrap_or_else(|e| {
             tracing::error!(
                 target: "storage::root",
                 error = %e,
-                debug_error = ?e,
-                "commit_headless: Interface::commit_root returned Err — about to panic via unwrap"
+                "commit_headless: Interface::commit_root failed — panicking"
             );
-            #[expect(clippy::unwrap_used, reason = "fatal error if it happens")]
-            Err::<(), _>(e).unwrap();
-        }
+            panic!("commit_headless: fatal: {e}");
+        });
     }
 
     /// Syncs the root collection.
@@ -176,53 +174,48 @@ where
             StorageDelta::Comparisons(_) => "Comparisons",
         };
 
-        let result: Result<(), StorageError> = (|| {
-            match artifact {
-                StorageDelta::Actions(actions) => {
-                    Self::apply_actions(actions, |_| ctx.clone())?;
+        // `match` is an expression — assign directly. `inspect_err` then
+        // logs without rewriting the Result; `?` propagates the Err to
+        // the caller (the SDK macro's `.expect("fatal: sync failed")`).
+        // Without this trace, a `Result::Err` from apply_actions surfaces
+        // as a bare WASM `unreachable` trap with no clue what failed.
+        match artifact {
+            StorageDelta::Actions(actions) => Self::apply_actions(actions, |_| ctx.clone()),
+            StorageDelta::CausalActions {
+                actions,
+                delta_id,
+                delta_hlc,
+                effective_writers,
+            } => Self::apply_actions(actions, |action| crate::interface::ApplyContext {
+                effective_writers: effective_writers.get(&action.id()).cloned(),
+                delta_id: Some(delta_id),
+                delta_hlc: Some(delta_hlc),
+            }),
+            StorageDelta::Comparisons(comparisons) => {
+                if comparisons.is_empty() {
+                    push_comparison(Comparison {
+                        data: <Interface<S>>::find_by_id_raw(Id::root()),
+                        comparison_data: <Interface<S>>::generate_comparison_data(None)?,
+                    });
                 }
-                StorageDelta::CausalActions {
-                    actions,
-                    delta_id,
-                    delta_hlc,
-                    effective_writers,
-                } => {
-                    Self::apply_actions(actions, |action| crate::interface::ApplyContext {
-                        effective_writers: effective_writers.get(&action.id()).cloned(),
-                        delta_id: Some(delta_id),
-                        delta_hlc: Some(delta_hlc),
-                    })?;
+                for Comparison {
+                    data,
+                    comparison_data,
+                } in comparisons
+                {
+                    <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
                 }
-                StorageDelta::Comparisons(comparisons) => {
-                    if comparisons.is_empty() {
-                        push_comparison(Comparison {
-                            data: <Interface<S>>::find_by_id_raw(Id::root()),
-                            comparison_data: <Interface<S>>::generate_comparison_data(None)?,
-                        });
-                    }
-
-                    for Comparison {
-                        data,
-                        comparison_data,
-                    } in comparisons
-                    {
-                        <Interface<S>>::compare_affective(data, comparison_data, ctx)?;
-                    }
-                }
+                Ok(())
             }
-            Ok(())
-        })();
-
-        if let Err(ref e) = result {
+        }
+        .inspect_err(|e| {
             tracing::error!(
                 target: "storage::root",
                 variant,
                 error = %e,
-                debug_error = ?e,
-                "Root::sync apply_actions/branch returned Err — about to bubble up to __calimero_sync_next's .expect()"
+                "Root::sync returned Err — will bubble up to __calimero_sync_next's .expect()"
             );
-            return result;
-        }
+        })?;
 
         info!(
             target: "storage::root",

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -721,10 +721,26 @@ impl<S: StorageAdaptor> Interface<S> {
                         // Gated by the same `nonce_check_disabled_for_testing`
                         // bypass as the Shared arm so DAG-causal P5 tests
                         // exercising out-of-order delivery see consistent
-                        // behaviour across User/Shared entities.
+                        // behaviour across User/Shared entities. When the
+                        // bypass is active (`skip_nonce = true`), the stale
+                        // action falls through to `save_internal`, which
+                        // has its own LWW-by-HLC guard
+                        // (`last_metadata.updated_at > metadata.updated_at`
+                        // ⇒ returns `Ok(None)`, no write). Storage state
+                        // is never downgraded regardless of which path
+                        // executes.
+                        //
+                        // Logged at WARN, not DEBUG: silent-skip on a
+                        // signature-verified-but-stale action is an
+                        // audit-relevant event (could be a captured-
+                        // signature replay attempt, or just a benign
+                        // sync redelivery). Surface enough information
+                        // for downstream monitoring to distinguish the
+                        // two.
                         if !skip_nonce && new_nonce <= last_nonce {
-                            debug!(
+                            tracing::warn!(
                                 %id,
+                                %owner,
                                 new_nonce,
                                 last_nonce,
                                 "User upsert: stale-or-equal nonce, signature verified \
@@ -853,7 +869,10 @@ impl<S: StorageAdaptor> Interface<S> {
                             // a HashComparison or DAG-catchup delivers
                             // a stale-but-authentic leaf whose newer
                             // twin already landed via gossipsub.
-                            debug!(
+                            //
+                            // Logged at WARN — same audit rationale
+                            // as the User arm.
+                            tracing::warn!(
                                 %id,
                                 new_nonce,
                                 last_nonce,
@@ -865,14 +884,20 @@ impl<S: StorageAdaptor> Interface<S> {
 
                         // P3 of #2233: rotation-log write hook.
                         //
-                        // Fires here — right after signature verification, BEFORE
-                        // the apply branch — so the log captures every
-                        // signature-verified Shared rotation regardless of
-                        // whether `save_internal` later chooses to skip the
-                        // write under v2's LWW-by-HLC. Cross-node convergence
-                        // (P5) depends on this: the rotation log must reflect
-                        // *received causal facts*, not the local node's
-                        // storage-merge decisions.
+                        // Fires here — right after signature verification AND
+                        // after the stale-nonce silent-skip guard above — so
+                        // the log captures every fresh signature-verified
+                        // Shared rotation that will reach the apply branch.
+                        // Stale-but-authentic actions short-circuit before
+                        // this point (silent-skip Ok), so they do NOT append
+                        // a rotation entry — that's the right call: the log
+                        // tracks rotations that influence storage state, and
+                        // a stale rotation is a no-op (its newer counterpart
+                        // already landed and was logged on its own apply).
+                        //
+                        // Cross-node convergence (P5) still works because
+                        // peers see the same set of *causally-newer*
+                        // rotations, just possibly in different orders.
                         //
                         // Idempotent: `rotation_log::append` dedups on
                         // `delta_id`, so a replayed delta produces no extra

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -686,6 +686,7 @@ impl<S: StorageAdaptor> Interface<S> {
                         let last_nonce = <Index<S>>::get_metadata(*id)?
                             .map(|m| *m.updated_at)
                             .unwrap_or(0);
+                        let skip_nonce = nonce_check_disabled_for_testing();
 
                         // Verify signature FIRST, before deciding whether
                         // to skip. We need to know the action is
@@ -716,7 +717,12 @@ impl<S: StorageAdaptor> Interface<S> {
                         // through `Root::sync().expect("fatal: sync
                         // failed")` and aborts the whole sync batch,
                         // blocking convergence.
-                        if new_nonce <= last_nonce {
+                        //
+                        // Gated by the same `nonce_check_disabled_for_testing`
+                        // bypass as the Shared arm so DAG-causal P5 tests
+                        // exercising out-of-order delivery see consistent
+                        // behaviour across User/Shared entities.
+                        if !skip_nonce && new_nonce <= last_nonce {
                             debug!(
                                 %id,
                                 new_nonce,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -954,28 +954,44 @@ impl<S: StorageAdaptor> Interface<S> {
                                         "Remote User delete must be signed".to_owned(),
                                     ))?;
 
-                                // TODO: refactor to a separate function.
-                                // Replay protection check
-                                let new_nonce = sig_data.nonce;
-                                // The nonce is the `deleted_at` time. We check it against the
-                                // last `updated_at` time stored in the index.
-                                let last_nonce = *existing_metadata.updated_at;
-
-                                if new_nonce <= last_nonce {
-                                    return Err(StorageError::NonceReplay(Box::new((
-                                        *owner, new_nonce,
-                                    ))));
-                                }
-
+                                // Verify signature FIRST, then check nonce.
+                                // Consistent with the upsert arms:
+                                // an unauthenticated stale delete
+                                // should reject as `InvalidSignature`
+                                // (the more informative error)
+                                // rather than `NonceReplay` (which
+                                // leaks current-nonce state to
+                                // unauthenticated probers).
+                                //
+                                // DeleteRef keeps the strict `Err` on
+                                // `<=` (unlike upsert's silent skip)
+                                // because a stale delete being
+                                // silently accepted vs dropped
+                                // carries different semantics than
+                                // a stale upsert, and rare-by-design
+                                // deletes don't drive the
+                                // post-divergence convergence problem
+                                // upsert silent-skip fixes.
                                 let payload = action.payload_for_signing();
                                 let verification_result = crate::env::ed25519_verify(
                                     &sig_data.signature,
                                     owner.digest(),
                                     &payload,
                                 );
-
                                 if !verification_result {
                                     return Err(StorageError::InvalidSignature);
+                                }
+
+                                // Replay protection: nonce is the
+                                // `deleted_at` time, checked against
+                                // the last `updated_at` stored in
+                                // the index.
+                                let new_nonce = sig_data.nonce;
+                                let last_nonce = *existing_metadata.updated_at;
+                                if new_nonce <= last_nonce {
+                                    return Err(StorageError::NonceReplay(Box::new((
+                                        *owner, new_nonce,
+                                    ))));
                                 }
                             }
                             _ => {
@@ -1006,30 +1022,20 @@ impl<S: StorageAdaptor> Interface<S> {
                                         "Remote Shared delete must be signed".to_owned(),
                                     ))?;
 
-                                // Replay protection (per-entity monotonic nonce).
-                                // Done BEFORE per-writer Ed25519 scan so replays are
-                                // O(1)-rejected (matches User arm + upsert arm).
+                                // Verify signature FIRST, then check
+                                // nonce — consistent with the upsert
+                                // arms and the User DeleteRef arm
+                                // above. An unauthenticated stale
+                                // delete now rejects as
+                                // `InvalidSignature` rather than
+                                // `NonceReplay` (which leaks
+                                // current-nonce state).
                                 //
-                                // Mirrors the upsert arm's [`disable_nonce_check_for_testing`]
-                                // bypass so DAG-causal P5 tests that exercise out-of-order
-                                // delivery of Shared deletes can opt into the v3 target
-                                // behavior. Production codepath unchanged — the const fn
-                                // returns false outside cfg(test).
-                                let new_nonce = sig_data.nonce;
-                                let last_nonce = *existing_metadata.updated_at;
-                                let skip_nonce = nonce_check_disabled_for_testing();
-                                if !skip_nonce && new_nonce <= last_nonce {
-                                    let placeholder = existing_writers
-                                        .iter()
-                                        .copied()
-                                        .next()
-                                        .unwrap_or_else(|| [0u8; 32].into());
-                                    return Err(StorageError::NonceReplay(Box::new((
-                                        placeholder,
-                                        new_nonce,
-                                    ))));
-                                }
-
+                                // DeleteRef keeps the strict `Err` on
+                                // `<=` (unlike upsert's silent skip)
+                                // — see the User DeleteRef arm for
+                                // rationale.
+                                //
                                 // Identify the signer.
                                 // Fast path: if the action carries a `signer` hint and that
                                 // signer is in the authoritative set, do exactly one verify.
@@ -1057,6 +1063,31 @@ impl<S: StorageAdaptor> Interface<S> {
                                 };
                                 if signer.is_none() {
                                     return Err(StorageError::InvalidSignature);
+                                }
+
+                                // Replay protection (per-entity monotonic nonce).
+                                //
+                                // Mirrors the upsert arm's
+                                // [`disable_nonce_check_for_testing`]
+                                // bypass so DAG-causal P5 tests that
+                                // exercise out-of-order delivery of
+                                // Shared deletes can opt into the v3
+                                // target behavior. Production
+                                // codepath unchanged — the const fn
+                                // returns false outside cfg(test).
+                                let new_nonce = sig_data.nonce;
+                                let last_nonce = *existing_metadata.updated_at;
+                                let skip_nonce = nonce_check_disabled_for_testing();
+                                if !skip_nonce && new_nonce <= last_nonce {
+                                    let placeholder = existing_writers
+                                        .iter()
+                                        .copied()
+                                        .next()
+                                        .unwrap_or_else(|| [0u8; 32].into());
+                                    return Err(StorageError::NonceReplay(Box::new((
+                                        placeholder,
+                                        new_nonce,
+                                    ))));
                                 }
                             }
                             _ => {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -687,10 +687,12 @@ impl<S: StorageAdaptor> Interface<S> {
                             .map(|m| *m.updated_at)
                             .unwrap_or(0);
 
-                        if new_nonce < last_nonce {
-                            return Err(StorageError::NonceReplay(Box::new((*owner, new_nonce))));
-                        }
-
+                        // Verify signature FIRST, before deciding whether
+                        // to skip. We need to know the action is
+                        // authentic before we drop it as stale — an
+                        // unauthenticated stale action should still
+                        // reject as `InvalidSignature`, not silently
+                        // disappear.
                         let verification_result = crate::env::ed25519_verify(
                             &sig_data.signature,
                             owner.digest(),
@@ -701,13 +703,26 @@ impl<S: StorageAdaptor> Interface<S> {
                             return Err(StorageError::InvalidSignature);
                         }
 
-                        if new_nonce == last_nonce {
-                            // Idempotent re-apply — no-op.
+                        // Stale-or-equal: signature verified, but our
+                        // local state is already at or ahead of this
+                        // nonce. Drop silently — the action is
+                        // authentic, just older than what we already
+                        // have, which is the normal post-divergence
+                        // sync case (HashComparison can re-deliver
+                        // leaves whose newer twin already landed via
+                        // gossipsub; DAG-causal catchup can hand us an
+                        // older delta after a newer one). Treating
+                        // this as a hard `NonceReplay` Err propagates
+                        // through `Root::sync().expect("fatal: sync
+                        // failed")` and aborts the whole sync batch,
+                        // blocking convergence.
+                        if new_nonce <= last_nonce {
                             debug!(
                                 %id,
-                                nonce = new_nonce,
-                                "User upsert: idempotent re-apply (same nonce, signature \
-                                 verified) — skipping save_internal"
+                                new_nonce,
+                                last_nonce,
+                                "User upsert: stale-or-equal nonce, signature verified \
+                                 — skipping save_internal (authentic but no-op)"
                             );
                             return Ok(());
                         }
@@ -781,38 +796,25 @@ impl<S: StorageAdaptor> Interface<S> {
                         let last_nonce =
                             stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);
                         let skip_nonce = nonce_check_disabled_for_testing();
-                        // Strict-less-than: equal nonce + valid
-                        // signature is byte-identical re-apply (see
-                        // the User arm above for the full
-                        // rationale). HashComparison can deliver
-                        // common-children leaves redundantly when
-                        // parent hashes diverge — accepting
-                        // idempotent re-apply prevents a hard
-                        // NonceReplay rejection from blocking
-                        // post-divergence convergence.
-                        if !skip_nonce && new_nonce < last_nonce {
-                            // Use the first authoritative writer as a placeholder identity
-                            // for the error since the signer hasn't been identified yet.
-                            let placeholder = authoritative_writers
-                                .iter()
-                                .copied()
-                                .next()
-                                .unwrap_or_else(|| [0u8; 32].into());
-                            return Err(StorageError::NonceReplay(Box::new((
-                                placeholder,
-                                new_nonce,
-                            ))));
-                        }
 
-                        // Identify the signer.
-                        // Fast path: if the action carries a `signer` hint and that
-                        // signer is in the authoritative set, do exactly one verify.
-                        // Slow path (no hint): linear scan over authoritative writers.
+                        // Verify signature first — see the User arm
+                        // above for the full "verify-before-skip"
+                        // rationale: an authentic stale action is a
+                        // no-op; an unauthenticated stale action must
+                        // still reject as InvalidSignature.
                         //
-                        // Per the #2233 epic compatibility rule, the signer hint is
-                        // validated against the *causal* writer set above, not stored —
-                        // that's already how it works here since `authoritative_writers`
-                        // is now the DAG-causal answer when available.
+                        // Identify the signer. Fast path: if the
+                        // action carries a `signer` hint and that
+                        // signer is in the authoritative set, do
+                        // exactly one verify. Slow path (no hint):
+                        // linear scan over authoritative writers.
+                        //
+                        // Per the #2233 epic compatibility rule, the
+                        // signer hint is validated against the
+                        // *causal* writer set above, not stored —
+                        // that's already how it works here since
+                        // `authoritative_writers` is now the
+                        // DAG-causal answer when available.
                         let payload = action.payload_for_signing();
                         let verified = match sig_data.signer {
                             Some(hint) if authoritative_writers.contains(&hint) => {
@@ -834,20 +836,23 @@ impl<S: StorageAdaptor> Interface<S> {
                             return Err(StorageError::InvalidSignature);
                         }
 
-                        if !skip_nonce && new_nonce == last_nonce {
-                            // Idempotent re-apply (same nonce + valid
-                            // signature ⇒ same payload). Skip the
-                            // save_internal path which would hit the
-                            // equal-updated_at CRDT-merge branch
-                            // (would fail for non-CRDT Shared
-                            // entities). Mirrors the User upsert
-                            // arm above; see that comment for the
-                            // full HashComparison-induced rationale.
+                        if !skip_nonce && new_nonce <= last_nonce {
+                            // Stale-or-equal: signature verified, but
+                            // our local state is already at or ahead
+                            // of this nonce. Drop silently. See the
+                            // User arm above for full rationale —
+                            // hard NonceReplay propagates through
+                            // `Root::sync().expect()` and aborts the
+                            // sync batch, blocking convergence after
+                            // a HashComparison or DAG-catchup delivers
+                            // a stale-but-authentic leaf whose newer
+                            // twin already landed via gossipsub.
                             debug!(
                                 %id,
-                                nonce = new_nonce,
-                                "Shared upsert: idempotent re-apply (same nonce, signature \
-                                 verified) — skipping save_internal"
+                                new_nonce,
+                                last_nonce,
+                                "Shared upsert: stale-or-equal nonce, signature verified \
+                                 — skipping save_internal (authentic but no-op)"
                             );
                             return Ok(());
                         }

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -283,6 +283,21 @@ pub fn pubkey_of(sk: &SigningKey) -> PublicKey {
     PublicKey::from(*sk.verifying_key().as_bytes())
 }
 
+/// Register the root node in `MainStorage` and return a `ChildInfo`
+/// referencing it. Mirrors `setup_root::<MockedStorage<N>>` from
+/// `write_hook_stale_writers.rs` for tests that use the `MainInterface`
+/// alias.
+pub fn setup_root_for_main() -> ChildInfo {
+    use crate::index::Index;
+    use crate::store::MainStorage;
+
+    let root_id = Id::root();
+    let root_meta = Metadata::default();
+    Index::<MainStorage>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
+    let (full_hash, _) = Index::<MainStorage>::get_hashes_for(root_id).unwrap().unwrap();
+    ChildInfo::new(root_id, full_hash, root_meta)
+}
+
 /// Build a signed `Shared` storage action (Add or Update).
 ///
 /// `hlc_ns` populates BOTH the action's `updated_at` and the signature's

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -294,7 +294,9 @@ pub fn setup_root_for_main() -> ChildInfo {
     let root_id = Id::root();
     let root_meta = Metadata::default();
     Index::<MainStorage>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
-    let (full_hash, _) = Index::<MainStorage>::get_hashes_for(root_id).unwrap().unwrap();
+    let (full_hash, _) = Index::<MainStorage>::get_hashes_for(root_id)
+        .unwrap()
+        .unwrap();
     ChildInfo::new(root_id, full_hash, root_meta)
 }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -998,7 +998,29 @@ mod user_storage_replay_protection {
     }
 
     #[test]
-    fn replay_with_lower_nonce_fails() {
+    fn replay_with_lower_nonce_is_silent_noop_for_upsert() {
+        // Upsert (Add/Update) used to reject lower-nonce actions as
+        // `NonceReplay`. That rejection bubbles through
+        // `Root::sync().expect("fatal: sync failed")` in the SDK
+        // macro and aborts the entire WASM sync batch, which blocks
+        // post-divergence convergence: a HashComparison or DAG
+        // catchup that re-delivers a now-stale-but-authentic leaf
+        // (the newer twin already arrived via gossipsub) would kill
+        // the whole sync.
+        //
+        // The new contract: verify the signature first (an
+        // unauthenticated stale action still rejects as
+        // `InvalidSignature`), then on `new_nonce <= last_nonce`
+        // silently skip with Ok(()). The state isn't downgraded —
+        // we just no-op on the stale action, leaving the newer
+        // local state intact. The owner-signature-replay test
+        // below (`replay_signature_with_different_data_rejected`)
+        // covers the security property: forged data can't slip
+        // through because the signature commits to `(id, data,
+        // nonce)` and verify still runs.
+        //
+        // The DeleteRef path keeps the strict `Err(NonceReplay)` on
+        // `<=` — see `tombstone_replay_with_lower_nonce_fails`.
         env::reset_for_testing();
 
         let (signing_key, owner) = create_test_keypair();
@@ -1021,23 +1043,21 @@ mod user_storage_replay_protection {
 
         sleep(Duration::from_millis(2));
 
-        // Action with LOWER nonce should fail
         let nonce2 = nonce1 - 1000;
         let action2 = create_signed_user_update_action(
             &signing_key,
             owner,
             page.id(),
             serialized,
-            nonce2, // Lower nonce!
+            nonce2, // Lower nonce
             page.element().created_at(),
         );
 
         let result = MainInterface::apply_action(action2, &ApplyContext::empty());
-        assert!(result.is_err());
-        match result {
-            Err(StorageError::NonceReplay(_)) => {}
-            other => panic!("Expected NonceReplay error, got {:?}", other),
-        }
+        assert!(
+            result.is_ok(),
+            "stale-but-signed upsert must be silently skipped, got {result:?}"
+        );
     }
 
     #[test]
@@ -1109,8 +1129,13 @@ mod user_storage_replay_protection {
 
         sleep(Duration::from_millis(10));
 
-        // Try action with nonce OLDER than stored updated_at - should fail
-        // The replay protection compares nonce against stored updated_at
+        // Try action with nonce OLDER than stored updated_at — upsert
+        // now silently skips (returns Ok(())) rather than rejecting
+        // with `NonceReplay`. See the rationale on
+        // `replay_with_lower_nonce_is_silent_noop_for_upsert` above
+        // and the apply_action User arm comment. State must NOT be
+        // downgraded — the stale action is dropped without
+        // overwriting the newer stored value.
         let old_nonce = first_nonce - 1_000_000_000; // 1 second before first action
         let action_old = create_signed_user_update_action(
             &signing_key,
@@ -1122,11 +1147,28 @@ mod user_storage_replay_protection {
         );
 
         let result = MainInterface::apply_action(action_old, &ApplyContext::empty());
-        assert!(result.is_err());
-        match result {
-            Err(StorageError::NonceReplay(_)) => {}
-            other => panic!("Expected NonceReplay error, got {:?}", other),
-        }
+        assert!(
+            result.is_ok(),
+            "stale-but-signed upsert must be silently skipped, got {result:?}"
+        );
+
+        // Confirm the stored state was NOT downgraded by the stale
+        // upsert. Stored nonce should still be at or above the
+        // first action's nonce, not the stale `old_nonce`.
+        let stored_nonce = <Index<MainStorage>>::get_metadata(page.id())
+            .unwrap()
+            .map(|m| *m.updated_at)
+            .unwrap_or(0);
+        assert!(
+            stored_nonce >= first_nonce,
+            "stale upsert must not downgrade stored nonce; stored={stored_nonce} \
+             first={first_nonce} stale_attempt={old_nonce}"
+        );
+        assert!(
+            stored_nonce > old_nonce,
+            "stale upsert must not downgrade stored nonce; stored={stored_nonce} \
+             stale_attempt={old_nonce}"
+        );
     }
 }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1061,6 +1061,55 @@ mod user_storage_replay_protection {
     }
 
     #[test]
+    fn stale_upsert_with_invalid_signature_still_rejects() {
+        // Security invariant: silent-skip on stale nonce applies
+        // ONLY after the signature verifies. A stale upsert signed
+        // by the wrong key must still reject as
+        // `InvalidSignature` — without this, a future refactor that
+        // moves the signature check after the nonce check would
+        // silently accept unauthenticated stale traffic.
+        env::reset_for_testing();
+
+        let (signing_key, owner) = create_test_keypair();
+        let (wrong_signing_key, _) = create_test_keypair();
+
+        let mut element = Element::root();
+        element.set_user_domain(owner);
+        let page = Page::new_from_element("Page", element);
+        let serialized = to_vec(&page).unwrap();
+
+        let nonce1 = env::time_now();
+        let action1 = create_signed_user_add_action(
+            &signing_key,
+            owner,
+            page.id(),
+            serialized.clone(),
+            nonce1,
+        );
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+
+        sleep(Duration::from_millis(2));
+
+        // Stale nonce + signed by WRONG key → InvalidSignature, not
+        // silent-skip.
+        let nonce2 = nonce1 - 1000;
+        let action2 = create_signed_user_update_action(
+            &wrong_signing_key,
+            owner,
+            page.id(),
+            serialized,
+            nonce2,
+            page.element().created_at(),
+        );
+
+        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
+        assert!(
+            matches!(result, Err(StorageError::InvalidSignature)),
+            "stale upsert with invalid signature must reject as InvalidSignature, got {result:?}"
+        );
+    }
+
+    #[test]
     fn sequential_updates_with_increasing_nonces_succeed() {
         crate::tests::common::register_test_merge_functions();
         env::reset_for_testing();
@@ -1106,7 +1155,7 @@ mod user_storage_replay_protection {
     }
 
     #[test]
-    fn out_of_order_nonces_are_rejected() {
+    fn out_of_order_nonces_are_silently_skipped_for_upsert() {
         env::reset_for_testing();
 
         let (signing_key, owner) = create_test_keypair();

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1221,6 +1221,94 @@ mod user_storage_replay_protection {
     }
 }
 
+/// Tests for Shared storage replay protection.
+///
+/// Mirrors the User-arm tests in `user_storage_replay_protection` so the
+/// silent-skip-on-stale contract is enforced consistently across both
+/// signed storage types.
+#[cfg(test)]
+mod shared_storage_replay_protection {
+    use std::collections::BTreeSet;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use ed25519_dalek::SigningKey;
+
+    use crate::address::Id;
+    use crate::env;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, MainInterface};
+    use crate::store::MainStorage;
+    use crate::tests::common::{build_signed_shared_action, pubkey_of, setup_root_for_main};
+
+    fn make_signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    #[test]
+    fn stale_shared_upsert_does_not_downgrade_state() {
+        // Mirror of `out_of_order_nonces_are_silently_skipped_for_upsert`
+        // for the Shared arm. A signature-verified action whose nonce
+        // is below the locally stored nonce must return Ok(()) (silent
+        // skip) AND must not downgrade the stored nonce.
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+        let id = Id::new([0x5E; 32]);
+
+        // Bootstrap with a fresh nonce.
+        let nonce1 = env::time_now();
+        let bootstrap = build_signed_shared_action(
+            true,
+            id,
+            b"v0".to_vec(),
+            writers.clone(),
+            nonce1,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+
+        sleep(Duration::from_millis(2));
+
+        // Stale-but-signed update (nonce < stored). Must Ok(()) without
+        // downgrading state.
+        let nonce_stale = nonce1.saturating_sub(1_000_000);
+        let stale = build_signed_shared_action(
+            false,
+            id,
+            b"v1".to_vec(),
+            writers,
+            nonce_stale,
+            &alice_sk,
+            vec![],
+        );
+        let result = MainInterface::apply_action(stale, &ApplyContext::empty());
+        assert!(
+            result.is_ok(),
+            "stale-but-signed Shared upsert must be silently skipped, got {result:?}"
+        );
+
+        let stored_nonce = <Index<MainStorage>>::get_metadata(id)
+            .unwrap()
+            .map(|m| *m.updated_at)
+            .unwrap_or(0);
+        assert!(
+            stored_nonce >= nonce1,
+            "stale Shared upsert must not downgrade stored nonce; stored={stored_nonce} \
+             bootstrap_nonce={nonce1} stale_attempt={nonce_stale}"
+        );
+        assert!(
+            stored_nonce > nonce_stale,
+            "stale Shared upsert must not downgrade stored nonce; stored={stored_nonce} \
+             stale_attempt={nonce_stale}"
+        );
+    }
+}
+
 /// Tests for Frozen storage verification.
 ///
 /// Frozen storage is immutable and content-addressed:


### PR DESCRIPTION
## Summary

Fixes the post-merge e2e flake on master (commit 4c9405a1, PR #2386): `hashcomparison-shared-user-reconcile`, `group-governance-peer-down`, KV-store fuzzy tests, and sync-regression all surface the same shape — node-2's WASM aborts with \"unreachable\" during `__calimero_sync_next`, blocking convergence.

**Root cause** (captured via the diagnostic panic hook below):

```
Guest panic captured fatal: sync failed: NonceReplay((PublicKey(...), 1779203342655547589))
  file=apps/scaffolding-e2e/src/lib.rs line=382
```

`apply_action` for User/Shared Add/Update rejected any `new_nonce < last_nonce` with `Err(StorageError::NonceReplay)`. That `Err` propagates through `Root::sync(...).expect(\"fatal: sync failed\")` in the SDK macro → WASM `unreachable` trap → whole sync batch aborted. Subsequent retries hit the same wall — no convergence.

But this case is *expected* in normal sync: HashComparison can re-deliver a leaf whose newer twin already landed via gossipsub, and DAG-causal catchup can hand us an older delta after a newer one. Both legitimate, both were fatal under the old rule.

**The fix** (commit `cc6baa70`): verify the signature first (an unauthenticated stale action still rejects as `InvalidSignature` — security property preserved), then on `new_nonce <= last_nonce` silently `Ok(())`. State isn't downgraded; the authentic-but-stale action is dropped. Collapses the previous separate `<` (Err) and `==` (Ok) branches into one consistent `<=` (Ok).

DeleteRef keeps strict `Err(NonceReplay)` on `<=` — delete replays are rare and a stale delete being silently dropped vs accepted carries different semantics than a stale upsert. Revisit if needed.

## Commits in this PR

1. `dfd1030f` — **debug** logging on `Root::sync` Err path. Now redundant since the fix prevents that Err. Plan: drop before merge once CI confirms green.
2. `dd510fd0` — install `setup_panic_hook` in `__calimero_sync_next`. Durably useful: any future WASM sync panic will print message + Rust file:line in node logs instead of a bare \"unreachable\". Keep.
3. `cc6baa70` — the actual fix.

## Test plan

- [x] All 443 storage unit tests pass locally
- [x] `replay_with_lower_nonce_fails` → `replay_with_lower_nonce_is_silent_noop_for_upsert` updated to reflect new contract
- [x] `out_of_order_nonces_are_rejected` updated; new assertion that stored nonce doesn't downgrade on stale-action attempt
- [ ] e2e in CI — should turn `hashcomparison-shared-user-reconcile`, `group-governance-peer-down`, fuzzy tests, sync-regression green
- [ ] Drop `dfd1030f` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay-protection and signature-verification ordering for signed `User`/`Shared` actions during sync; incorrect behavior could weaken anti-replay guarantees or affect convergence. Also adjusts WASM panic/logging paths, but overall scope is contained to storage apply/sync behavior and tests.
> 
> **Overview**
> Prevents WASM sync batches from aborting on stale-but-authentic `User`/`Shared` *upserts* by verifying signatures first and then **silently no-oping** when `new_nonce <= last_nonce` (instead of returning fatal `NonceReplay`). *DeleteRef* keeps strict `NonceReplay`, but now verifies the signature before nonce checks to avoid leaking nonce state and to surface `InvalidSignature` correctly.
> 
> Improves diagnosability of sync failures by installing `setup_panic_hook()` in the generated `__calimero_sync_next`, adding structured error logging in `Root::sync` (including delta variant), and making `commit_headless` log then panic with a clearer message. Updates/adds unit tests to lock in the new stale-upsert contract (including “doesn’t downgrade state” assertions) and adds a `setup_root_for_main` helper for Shared-action tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ce0f030996944b67a52013f57fb6fa692512da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->