### PR TITLE
fix(node/sync): deprioritise timed-out peers across rounds in namespace-join

### DIFF
--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -13,8 +13,11 @@
 //! this module deliberately holds none of it so the comments don't
 //! drift out of sync.
 
+use std::collections::HashSet;
+
 use calimero_network_primitives::stream::Stream;
 use libp2p::gossipsub::TopicHash;
+use libp2p::PeerId;
 use rand::seq::SliceRandom;
 use tokio::time;
 use tracing::debug;
@@ -82,6 +85,16 @@ pub(super) async fn open_namespace_join_stream(
     // `std::time::Instant`.
     let connect_started = tokio::time::Instant::now();
 
+    // Peers that hit `time::timeout` on `open_stream` earlier in
+    // this discovery sequence — i.e., we've already spent
+    // `open_timeout` waiting on them once. Subsequent rounds
+    // deprioritise (don't exclude) them so a consistently-stale
+    // peer doesn't keep burning the per-peer budget ahead of
+    // healthy ones. Plain `Err` (no timeout) does NOT add to this
+    // set — those failures might be transient and the peer is
+    // still worth trying first.
+    let mut timed_out_peers: HashSet<PeerId> = HashSet::new();
+
     let mut stream = None;
     'connect: for attempt in 1..=mesh_retries {
         if connect_started.elapsed() >= connect_deadline {
@@ -98,6 +111,14 @@ pub(super) async fn open_namespace_join_stream(
         // `choose_multiple` would produce. Matches the pattern used
         // in `perform_interval_sync`.
         peers.shuffle(&mut rand::thread_rng());
+        // Partition shuffled list: peers we haven't timed out on
+        // come first, timed-out peers last. Stable-by-construction
+        // (sort_by_key with a bool maps false=0/true=1, preserving
+        // the random-relative order within each partition). This
+        // means peers that briefly errored last round still get
+        // tried before the chronically-timing-out peer; only
+        // *prior-timeout* peers get pushed to the tail.
+        peers.sort_by_key(|p| timed_out_peers.contains(p));
 
         for peer in &peers {
             if connect_started.elapsed() >= connect_deadline {
@@ -118,11 +139,17 @@ pub(super) async fn open_namespace_join_stream(
                     );
                 }
                 Err(_) => {
+                    // Record the peer for deprioritisation in
+                    // subsequent rounds. Insertion is idempotent
+                    // (HashSet); a peer that times out repeatedly
+                    // stays at the tail without further bookkeeping.
+                    timed_out_peers.insert(*peer);
                     debug!(
                         namespace_id = %hex::encode(namespace_id),
                         %peer,
                         attempt,
-                        "Timed out opening namespace-join stream, trying next peer..."
+                        "Timed out opening namespace-join stream, trying next peer \
+                         (peer will be deprioritised in subsequent rounds)"
                     );
                 }
             }
@@ -338,5 +365,73 @@ mod tests {
         // Empty mesh → Err is expected; we're just checking the
         // type coercion compiles and runs.
         assert!(result.is_err());
+    }
+
+    /// Peers that timed out in earlier rounds are deprioritised in
+    /// subsequent rounds — they go to the tail of the (shuffled)
+    /// peer list, so non-timed-out peers are tried first.
+    ///
+    /// Two peers `slow` and `fast`: `slow` always hangs (timeout
+    /// every time tried); `fast` always errors quickly. Both fail,
+    /// so the loop runs the full retry budget. The expectation is
+    /// that across rounds we see `fast` tried before `slow` *more*
+    /// often in later rounds than in round 1 (where the shuffle is
+    /// 50/50). Concretely: after `slow` times out at least once,
+    /// every later round must try `fast` before `slow`.
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_peers_are_deprioritised_in_subsequent_rounds() {
+        let mock = MockSyncNetwork::default();
+        let slow = PeerId::random();
+        let fast = PeerId::random();
+        mock.push_mesh_peers(vec![slow, fast]);
+        let (open_timeout, retries, retry_delay) = defaults();
+        // Per-peer scripting: `slow` always hangs (triggers
+        // `tokio::time::timeout` to fire and adds it to the
+        // timed-out set), `fast` always errors quickly without
+        // timing out. Queue enough for the full retry budget
+        // (`retries` attempts per peer).
+        for _ in 0..retries {
+            mock.push_open_stream_hang_for_peer(slow, Duration::from_secs(10), "slow-hang");
+            mock.push_open_stream_err_for_peer(fast, "fast-err");
+        }
+
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, open_timeout, retries, retry_delay)
+                .await;
+        assert!(result.is_err(), "expected Err when all peers fail");
+
+        // Inspect the order peers were tried. Round 1's shuffle is
+        // random (slow may be first or second); but once `slow`
+        // times out, every later round must put `fast` first.
+        //
+        // The mock records the peer-id arg of each `open_stream`
+        // call in call order. We slice off round 1 and verify the
+        // remaining calls put `fast` strictly before `slow` within
+        // each round.
+        let call_log = mock.open_stream_call_peers();
+        assert!(
+            call_log.len() >= 4,
+            "expected at least 2 rounds × 2 peers in call log, got {}",
+            call_log.len()
+        );
+
+        // From round 2 onward (call_log[2..]), every pair of
+        // consecutive calls should be (fast, slow) — never
+        // (slow, fast) and never (slow, slow) — because the
+        // partition puts non-timed-out peers (fast) first.
+        let later_rounds = &call_log[2..];
+        for chunk in later_rounds.chunks(2) {
+            if chunk.len() != 2 {
+                break; // partial round at the deadline
+            }
+            assert_eq!(
+                chunk[0], fast,
+                "round-N first call must be fast (deprioritised slow), got chunk={chunk:?}"
+            );
+            assert_eq!(
+                chunk[1], slow,
+                "round-N second call must be slow, got chunk={chunk:?}"
+            );
+        }
     }
 }

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -28,7 +28,7 @@
 //! against either method should use [`MockSyncNetwork::assert_all_consumed`]
 //! after running the code under test.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -57,6 +57,13 @@ pub(crate) enum OpenStreamResponse {
 #[derive(Default)]
 pub(crate) struct MockSyncNetwork {
     mesh_peers_responses: Mutex<VecDeque<Vec<PeerId>>>,
+    /// Per-peer `open_stream` response queues. Consulted *before*
+    /// the global queue — lets tests script different behaviour
+    /// for specific peers (e.g. one peer always hangs, another
+    /// always errors quickly), which is needed for any test that
+    /// asserts peer-ordering behaviour. If a peer has no per-peer
+    /// queue (or its queue is empty), the global queue is used.
+    open_stream_responses_per_peer: Mutex<HashMap<PeerId, VecDeque<OpenStreamResponse>>>,
     open_stream_responses: Mutex<VecDeque<OpenStreamResponse>>,
     /// `mesh_peers` call count — needed to distinguish "queued 1
     /// sticky-last entry and the code under test called mesh_peers
@@ -68,6 +75,12 @@ pub(crate) struct MockSyncNetwork {
     /// fails `assert_all_consumed`'s `open_stream_remaining > 0`
     /// check without needing a separate guard.
     mesh_peers_calls: Mutex<u32>,
+    /// `open_stream` peer-id call log — captures the `PeerId` of
+    /// every `open_stream` call in order. Used by tests that need
+    /// to assert the order peers were tried in (e.g. timed-out
+    /// peer deprioritisation in `namespace_join`). Cheap; bounded
+    /// by the number of attempts in a single discovery loop.
+    open_stream_call_log: Mutex<Vec<PeerId>>,
 }
 
 impl MockSyncNetwork {
@@ -99,6 +112,39 @@ impl MockSyncNetwork {
         self
     }
 
+    /// Queue an error response routed to a specific peer. Used by
+    /// tests that need different behaviour per peer (e.g. one peer
+    /// always hangs to trigger timeout, another always errors
+    /// quickly). Per-peer queues are consulted before the global
+    /// queue.
+    pub(crate) fn push_open_stream_err_for_peer(
+        &self,
+        peer: PeerId,
+        msg: impl Into<String>,
+    ) -> &Self {
+        self.open_stream_responses_per_peer
+            .lock()
+            .entry(peer)
+            .or_default()
+            .push_back(OpenStreamResponse::Err(msg.into()));
+        self
+    }
+
+    /// Queue a hang-then-error routed to a specific peer.
+    pub(crate) fn push_open_stream_hang_for_peer(
+        &self,
+        peer: PeerId,
+        sleep_for: Duration,
+        then_msg: impl Into<String>,
+    ) -> &Self {
+        self.open_stream_responses_per_peer
+            .lock()
+            .entry(peer)
+            .or_default()
+            .push_back(OpenStreamResponse::SleepThenErr(sleep_for, then_msg.into()));
+        self
+    }
+
     /// Panic if a queued response wasn't consumed by the code
     /// under test, or if a non-empty queue was never read from.
     ///
@@ -113,6 +159,13 @@ impl MockSyncNetwork {
     ///   the discovery path at all" — without the call-count
     ///   guard the assertion would pass silently in that case.
     ///
+    /// Return the peer-id arg of every `open_stream` call so far,
+    /// in call order. Used by tests that need to assert ordering
+    /// (e.g. timed-out peer deprioritisation).
+    pub(crate) fn open_stream_call_peers(&self) -> Vec<PeerId> {
+        self.open_stream_call_log.lock().clone()
+    }
+
     /// `#[track_caller]` so panics point at the test's call
     /// site, not inside this helper.
     ///
@@ -199,9 +252,16 @@ impl SyncNetwork for MockSyncNetwork {
 
     async fn open_stream(
         &self,
-        _peer_id: PeerId,
+        peer_id: PeerId,
     ) -> eyre::Result<calimero_network_primitives::stream::Stream> {
-        let response = self.open_stream_responses.lock().pop_front();
+        self.open_stream_call_log.lock().push(peer_id);
+        // Per-peer queue first, then fall back to global queue.
+        let response = self
+            .open_stream_responses_per_peer
+            .lock()
+            .get_mut(&peer_id)
+            .and_then(|q| q.pop_front())
+            .or_else(|| self.open_stream_responses.lock().pop_front());
         match response {
             None => Err(eyre::eyre!(
                 "MockSyncNetwork: open_stream called with no queued response"


### PR DESCRIPTION
Addresses #2403 (follow-up to #2398 / review-4321393426 suggestion #4).

## Summary

`open_namespace_join_stream` (from #2410) shuffles peers per round, but a consistently-stale peer can still get tried first 50/50 of the time, burning the full `open_timeout` each round. This PR tracks peers that hit `tokio::time::timeout` on `open_stream` and deprioritises them — stable partition: non-timed-out peers first, timed-out last — in subsequent rounds.

Plain `Err` from `open_stream` does NOT add a peer to the set: those failures might be transient and the peer is still worth trying ahead of one that ate the full timeout budget. Excluded peers can still be retried (they just go to the tail), matching the \"degraded but not excluded\" pattern the issue suggested.

## Mock extension

The existing `MockSyncNetwork` has a flat `open_stream` queue — every call consumes the head regardless of which peer was asked, which can't model \"this specific peer hangs while others error fast\". Added per-peer queues:

- `push_open_stream_err_for_peer(peer, msg)`
- `push_open_stream_hang_for_peer(peer, sleep, msg)`

The `open_stream` impl consults the per-peer queue first, falls back to the global queue. Mirrors the layered-fallback shape from the existing `mesh_peers` sticky-last logic.

## Test

`timed_out_peers_are_deprioritised_in_subsequent_rounds`: two peers `slow` and `fast`, scripted per-peer; slow always hangs, fast always errors quickly. Asserts that from round 2 onward every pair of consecutive `open_stream` calls is `(fast, slow)` — fast first because slow landed in the timed-out set after round 1.

## Test plan

- [x] `cargo test -p calimero-node --lib sync::manager::namespace_join` — 6 passing
- [x] `cargo test -p calimero-node --lib` — 169 passing
- [x] `cargo fmt --check`, `cargo clippy` — clean
- [ ] CI green

Closes #2403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts retry peer-selection logic in namespace-join discovery, which can affect connection behavior and timing under failure conditions; changes are covered by new targeted unit tests and mock enhancements.
> 
> **Overview**
> Improves `open_namespace_join_stream` retry behavior by tracking peers that hit the per-peer `tokio::time::timeout` and **deprioritising them in subsequent rounds** (stable partition: non-timed-out peers first, timed-out peers last) while still allowing retries.
> 
> Extends `MockSyncNetwork` to support **per-peer scripted `open_stream` responses** plus an `open_stream` call-order log, and adds a unit test asserting that once a peer times out, later rounds try healthier peers before it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c9a841d6165de3a2c326b0c43670ec80bd6c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->