### PR TITLE
fix(node/sync): HashComparison root-not_found Err + bidirectional leaf push

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -200,6 +200,15 @@ async fn run_initiator_impl<T: SyncTransport>(
     // Stack for DFS traversal
     let mut to_compare: Vec<([u8; 32], bool)> = vec![(remote_root_hash, true)];
 
+    // Leaves the initiator needs to push back to the peer because local
+    // is divergent from what the peer just sent us (see #2407
+    // bidirectional reconciliation below). Collected during the DFS and
+    // flushed in one chunked call after the walk to keep the number of
+    // round-trips O(divergent_leaves / MAX_ENTITIES_PER_PUSH) rather
+    // than O(divergent_leaves), and to keep `stats.requests_sent` well
+    // below `MAX_HASH_COMPARISON_REQUESTS` on heavily-diverged trees.
+    let mut pending_local_leaf_pushes: Vec<TreeLeafData> = Vec::new();
+
     while let Some((node_id, is_root_request)) = to_compare.pop() {
         // DoS protection: limit stack size
         if to_compare.len() > MAX_PENDING_NODES {
@@ -317,25 +326,21 @@ async fn run_initiator_impl<T: SyncTransport>(
                     // re-emit it on every subsequent sync — the sticky
                     // loop documented in #2407 evidence
                     // (`entities_merged=2, entities_pushed=0,
-                    // success_count climbing forever`). Push local's
-                    // leaf back so the peer can converge in the SAME
-                    // session; the peer's own LWW guard skips if its
-                    // version is already newer, so this is a no-op when
-                    // unnecessary.
+                    // success_count climbing forever`). Queue local's
+                    // leaf to push back so the peer can converge in the
+                    // SAME session; the peer's own LWW guard skips if
+                    // its version is already newer, so this is a no-op
+                    // when unnecessary. We accumulate and flush in one
+                    // chunked batch after the DFS so an N-leaf
+                    // divergence is N entities over O(N/batch) round-
+                    // trips, not N round-trips inline.
                     let local_node = with_runtime_env(runtime_env.clone(), || {
                         get_local_tree_node(context_id, &remote_node.id, false)
                     })?;
                     if let Some(local) = local_node {
                         if local.is_leaf() && local.hash != remote_node.hash {
                             if let Some(local_leaf) = local.leaf_data {
-                                push_entities(
-                                    transport,
-                                    context_id,
-                                    identity,
-                                    &[local_leaf],
-                                    &mut stats,
-                                )
-                                .await?;
+                                pending_local_leaf_pushes.push(local_leaf);
                             }
                         }
                     }
@@ -410,6 +415,28 @@ async fn run_initiator_impl<T: SyncTransport>(
         // #2319: yield once per peer round-trip batch too, in case the
         // batch was < 64 nodes but we are walking thousands of them.
         tokio::task::yield_now().await;
+    }
+
+    // Flush bidirectional-reconciliation leaf pushes (#2407). One
+    // chunked `push_entities` call covers all divergent leaves
+    // discovered during the DFS; the helper batches at
+    // `MAX_ENTITIES_PER_PUSH` and a single EntityPushAck is consumed
+    // per batch, so the request budget stays bounded.
+    if !pending_local_leaf_pushes.is_empty() {
+        let pushed = push_entities(
+            transport,
+            context_id,
+            identity,
+            &pending_local_leaf_pushes,
+            &mut stats,
+        )
+        .await?;
+        debug!(
+            %context_id,
+            divergent_leaves = pending_local_leaf_pushes.len(),
+            entities_pushed = pushed,
+            "Flushed bidirectional leaf reconciliation pushes"
+        );
     }
 
     // Close the transport to signal completion to the responder

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -340,7 +340,26 @@ async fn run_initiator_impl<T: SyncTransport>(
                     if let Some(local) = local_node {
                         if local.is_leaf() && local.hash != remote_node.hash {
                             if let Some(local_leaf) = local.leaf_data {
-                                pending_local_leaf_pushes.push(local_leaf);
+                                // Same guard `collect_local_leaves`
+                                // applies on the snapshot-push path:
+                                // an oversized leaf is rejected by
+                                // the peer's `TreeLeafData::is_valid`
+                                // check inside `handle_entity_push`,
+                                // so queuing it here would silently
+                                // fail and re-enter the sticky loop
+                                // this fix exists to eliminate.
+                                if local_leaf.value.len() > MAX_LEAF_VALUE_SIZE {
+                                    warn!(
+                                        %context_id,
+                                        key = %hex::encode(local_leaf.key),
+                                        len = local_leaf.value.len(),
+                                        max = MAX_LEAF_VALUE_SIZE,
+                                        "leaf value exceeds MAX_LEAF_VALUE_SIZE, \
+                                         skipping bidirectional push"
+                                    );
+                                } else {
+                                    pending_local_leaf_pushes.push(local_leaf);
+                                }
                             }
                         }
                     }

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -251,6 +251,22 @@ async fn run_initiator_impl<T: SyncTransport>(
         }
 
         if not_found {
+            if is_root_request {
+                // #2407 root-advance race: the peer's root moved between
+                // handshake (where we captured `remote_root_hash`) and now,
+                // so the peer no longer has that exact internal-node entity
+                // in its index. Without this branch the DFS stack stays
+                // empty, the session closes cleanly, and `Ok(stats)` is
+                // returned with all counters at zero — the manager records
+                // it as a successful sync and the divergent node never
+                // recovers. Bailing here surfaces the failure to the
+                // manager's fallback chain (DAG catchup → snapshot), which
+                // re-handshakes against the peer's current root.
+                bail!(
+                    "HashComparison sync aborted: peer reported root node not_found \
+                     (peer's root advanced after handshake)"
+                );
+            }
             debug!(%context_id, node_id = %hex::encode(node_id), "Node not found on peer");
             continue;
         }
@@ -288,6 +304,41 @@ async fn run_initiator_impl<T: SyncTransport>(
                         apply_leaf_with_crdt_merge(context_id, leaf_data)
                     })?;
                     stats.entities_merged += 1;
+
+                    // #2407 bidirectional leaf reconciliation: a parent's
+                    // `children` list is keyed by entity_id (see
+                    // `get_local_tree_node`: `c.id().as_bytes()`), so a
+                    // same-entity-different-HLC divergence ends up in
+                    // `common_children` and DFS recurses here. We've
+                    // already pulled the peer's version above; the
+                    // storage layer's LWW guard keeps the newer of
+                    // {local, peer}. If local won (silent skip), the
+                    // peer still holds the older version and would
+                    // re-emit it on every subsequent sync — the sticky
+                    // loop documented in #2407 evidence
+                    // (`entities_merged=2, entities_pushed=0,
+                    // success_count climbing forever`). Push local's
+                    // leaf back so the peer can converge in the SAME
+                    // session; the peer's own LWW guard skips if its
+                    // version is already newer, so this is a no-op when
+                    // unnecessary.
+                    let local_node = with_runtime_env(runtime_env.clone(), || {
+                        get_local_tree_node(context_id, &remote_node.id, false)
+                    })?;
+                    if let Some(local) = local_node {
+                        if local.is_leaf() && local.hash != remote_node.hash {
+                            if let Some(local_leaf) = local.leaf_data {
+                                push_entities(
+                                    transport,
+                                    context_id,
+                                    identity,
+                                    &[local_leaf],
+                                    &mut stats,
+                                )
+                                .await?;
+                            }
+                        }
+                    }
                 }
             } else {
                 // Internal node: compare with local version

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -1332,6 +1332,12 @@ mod tests {
         assert_eq!(alice.root_hash(), bob.root_hash(), "must start equal");
 
         // Same entity_id, different HLC values: Bob older, Alice newer.
+        // `Metadata::new(created_at, updated_at)` — see
+        // `crates/storage/src/entities.rs`. LWW compares `updated_at`,
+        // so Bob=100 vs Alice=200 means Alice is the intended LWW
+        // winner; the test fails if these are inverted because then
+        // Bob would already hold the winning value and no push is
+        // needed to converge.
         let entity_id = Id::new([42u8; 32]);
         let mut older_meta = Metadata::new(100, 100);
         older_meta.crdt_type = Some(CrdtType::lww_register("alloc::string::String"));
@@ -1400,17 +1406,14 @@ mod tests {
     /// interval tick — the all-zero shape from #2411 logs.
     #[tokio::test]
     async fn test_root_not_found_surfaces_err() {
-        use calimero_node::sync::{HashComparisonConfig, HashComparisonProtocol};
-        use calimero_node_primitives::sync::SyncProtocolExecutor;
-        use calimero_primitives::identity::PublicKey;
+        use calimero_storage::address::Id;
+        use calimero_storage::entities::Metadata;
 
         let ctx = shared_context();
         let alice = SimNode::new_in_context("alice", ctx);
         let bob = SimNode::new_in_context("bob", ctx);
 
         // Give both peers some state so the protocol has a tree to walk.
-        use calimero_storage::address::Id;
-        use calimero_storage::entities::Metadata;
         let seed_id = Id::new([7u8; 32]);
         for node in [&alice, &bob] {
             node.storage()
@@ -1439,8 +1442,6 @@ mod tests {
         };
 
         let responder_fut = async {
-            use calimero_node::sync::HashComparisonFirstRequest;
-            use calimero_node_primitives::sync::{InitPayload, StreamMessage};
             let first_msg = resp_stream
                 .recv()
                 .await?

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -1296,4 +1296,189 @@ mod tests {
             "root hashes should converge — new child placed at correct Merkle position"
         );
     }
+
+    /// **#2407 regression guard (bidirectional leaf push)**: when the
+    /// initiator holds the *newer* version of an entity the responder
+    /// also has at an older HLC, a SINGLE HashComparison sync must
+    /// converge both peers — the initiator pushes its local leaf after
+    /// pulling the responder's older one.
+    ///
+    /// Pre-fix: the initiator's DFS reached the leaf, called
+    /// `apply_leaf_with_crdt_merge` with the older remote leaf, the
+    /// storage layer's LWW guard silently kept local, `entities_merged`
+    /// incremented but local state never changed, and the loop closed
+    /// `Ok` with no push leg. The responder still held the older value
+    /// and would re-emit it on every subsequent interval sync — the
+    /// "Sync regression (smoke)" sticky-loop signature.
+    #[tokio::test]
+    async fn test_initiator_newer_leaf_pushes_to_peer_in_single_sync() {
+        use calimero_primitives::crdt::CrdtType;
+        use calimero_storage::address::Id;
+        use calimero_storage::entities::Metadata;
+
+        let ctx = shared_context();
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let bob = SimNode::new_in_context("bob", ctx);
+
+        // Shared parent so both peers have non-empty state and the
+        // protocol selects HashComparison over Snapshot.
+        let parent_id = Id::new([1u8; 32]);
+        let mut parent_meta = Metadata::new(50, 50);
+        parent_meta.crdt_type = Some(CrdtType::lww_register("alloc::string::String"));
+        for node in [&alice, &bob] {
+            node.storage()
+                .add_entity(parent_id, b"shared-parent", parent_meta.clone());
+        }
+        assert_eq!(alice.root_hash(), bob.root_hash(), "must start equal");
+
+        // Same entity_id, different HLC values: Bob older, Alice newer.
+        let entity_id = Id::new([42u8; 32]);
+        let mut older_meta = Metadata::new(100, 100);
+        older_meta.crdt_type = Some(CrdtType::lww_register("alloc::string::String"));
+        bob.storage().add_entity_with_parent(
+            entity_id,
+            parent_id,
+            b"older-from-bob",
+            older_meta,
+        );
+        let mut newer_meta = Metadata::new(100, 200);
+        newer_meta.crdt_type = Some(CrdtType::lww_register("alloc::string::String"));
+        alice.storage().add_entity_with_parent(
+            entity_id,
+            parent_id,
+            b"newer-from-alice",
+            newer_meta,
+        );
+
+        assert_ne!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "peers must start divergent"
+        );
+
+        // Alice initiates HashComparison. Without the bidirectional-leaf
+        // fix, this returns Ok but Bob keeps `older-from-bob` and the two
+        // peers stay divergent across arbitrary further sync rounds.
+        let stats = execute_hash_comparison_sync(&mut alice, &bob)
+            .await
+            .expect("sync should succeed");
+
+        // Alice still holds her newer leaf.
+        assert_eq!(
+            alice.storage().get_entity_data(entity_id).as_deref(),
+            Some(b"newer-from-alice".as_slice()),
+            "Alice must keep her newer LWW winner"
+        );
+        // Bob now holds Alice's newer leaf.
+        assert_eq!(
+            bob.storage().get_entity_data(entity_id).as_deref(),
+            Some(b"newer-from-alice".as_slice()),
+            "Bob must have received Alice's newer leaf via push in a single sync"
+        );
+        // Single-session convergence — the load-bearing assertion. Without
+        // the fix, this fails: Alice's root advances on her own LWW skip
+        // (no), her root stays put; Bob's root stays at the older value.
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "roots must converge in a single sync"
+        );
+        assert!(
+            stats.entities_pushed >= 1,
+            "at least one leaf must have been pushed; got entities_pushed={}",
+            stats.entities_pushed
+        );
+    }
+
+    /// **#2407 regression guard (root-not_found Err)**: when the
+    /// responder reports `not_found=true` for the root the initiator
+    /// asked about (the post-handshake "peer advanced" race), the
+    /// initiator must surface an Err so the manager's fallback chain
+    /// (DAG catchup → snapshot) takes over.
+    ///
+    /// Pre-fix: the initiator silently `continue`d on `not_found`, the
+    /// DFS stack stayed empty, the session closed `Ok` with all
+    /// counters at zero, and the manager recorded a successful sync.
+    /// CI evidence: `nodes_compared=0 entities_merged=0 entities_pushed=0
+    /// nodes_skipped=0` with the divergent root re-detected every
+    /// interval tick — the all-zero shape from #2411 logs.
+    #[tokio::test]
+    async fn test_root_not_found_surfaces_err() {
+        use calimero_node::sync::{HashComparisonConfig, HashComparisonProtocol};
+        use calimero_node_primitives::sync::SyncProtocolExecutor;
+        use calimero_primitives::identity::PublicKey;
+
+        let ctx = shared_context();
+        let alice = SimNode::new_in_context("alice", ctx);
+        let bob = SimNode::new_in_context("bob", ctx);
+
+        // Give both peers some state so the protocol has a tree to walk.
+        use calimero_storage::address::Id;
+        use calimero_storage::entities::Metadata;
+        let seed_id = Id::new([7u8; 32]);
+        for node in [&alice, &bob] {
+            node.storage()
+                .add_entity(seed_id, b"shared", Metadata::new(10, 10));
+        }
+
+        // Drive the initiator with a stale `remote_root_hash` Bob doesn't
+        // have in his index — simulates the post-handshake root-advance
+        // race. Bob's responder will look up the entity at this ID and
+        // return `TreeNodeResponse::not_found()`.
+        let (mut init_stream, mut resp_stream) = super::SimStream::pair();
+        let stale_root: [u8; 32] = [0xFF; 32];
+        let identity = PublicKey::from([0u8; 32]);
+
+        let initiator_fut = async {
+            HashComparisonProtocol::run_initiator(
+                &mut init_stream,
+                alice.storage().store(),
+                alice.context_id(),
+                identity,
+                HashComparisonConfig {
+                    remote_root_hash: stale_root,
+                },
+            )
+            .await
+        };
+
+        let responder_fut = async {
+            use calimero_node::sync::HashComparisonFirstRequest;
+            use calimero_node_primitives::sync::{InitPayload, StreamMessage};
+            let first_msg = resp_stream
+                .recv()
+                .await?
+                .ok_or_else(|| eyre::eyre!("stream closed before first message"))?;
+            let first_request = match first_msg {
+                StreamMessage::Init {
+                    payload:
+                        InitPayload::TreeNodeRequest {
+                            node_id, max_depth, ..
+                        },
+                    ..
+                } => HashComparisonFirstRequest { node_id, max_depth },
+                _ => bail!("expected TreeNodeRequest Init"),
+            };
+            HashComparisonProtocol::run_responder(
+                &mut resp_stream,
+                bob.storage().store(),
+                bob.context_id(),
+                identity,
+                first_request,
+            )
+            .await
+        };
+
+        let (init_result, _resp_result) = tokio::join!(initiator_fut, responder_fut);
+
+        let err = init_result.expect_err(
+            "initiator must return Err when peer reports root_node not_found — \
+             surfacing the failure so the manager's fallback chain runs",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not_found"),
+            "error message should mention not_found; got: {msg}"
+        );
+    }
 }

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -1335,12 +1335,8 @@ mod tests {
         let entity_id = Id::new([42u8; 32]);
         let mut older_meta = Metadata::new(100, 100);
         older_meta.crdt_type = Some(CrdtType::lww_register("alloc::string::String"));
-        bob.storage().add_entity_with_parent(
-            entity_id,
-            parent_id,
-            b"older-from-bob",
-            older_meta,
-        );
+        bob.storage()
+            .add_entity_with_parent(entity_id, parent_id, b"older-from-bob", older_meta);
         let mut newer_meta = Metadata::new(100, 200);
         newer_meta.crdt_type = Some(CrdtType::lww_register("alloc::string::String"));
         alice.storage().add_entity_with_parent(
@@ -1469,7 +1465,12 @@ mod tests {
             .await
         };
 
-        let (init_result, _resp_result) = tokio::join!(initiator_fut, responder_fut);
+        // The responder may return an error when the initiator bails
+        // and drops the stream mid-session (broken-pipe on its next
+        // recv). That's expected behaviour for the failure mode we're
+        // exercising — only the initiator's Err is load-bearing.
+        let (init_result, _resp_result_expected_stream_close) =
+            tokio::join!(initiator_fut, responder_fut);
 
         let err = init_result.expect_err(
             "initiator must return Err when peer reports root_node not_found — \


### PR DESCRIPTION
## Summary

Addresses **two specific sub-cases** of #2407 (the HashComparison merge convergence bug that #2411 made *visible* via WARN). **Does not close #2407** — a third sub-case (Root<T> opaque-leaf + parent `created_at` ordering) remains open and is the dominant failure mode in the `Sync regression (smoke)` workflow; tracked in #2407 for follow-up.

### Part 1 — root-`not_found` surfaces as Err

When the initiator's first `TreeNodeRequest` for the remote root (captured at handshake) returns `not_found=true`, the peer's root has advanced between handshake and now. The old code silently `continue`d, the DFS stack stayed empty, and the session closed `Ok` with all-zero counters — the manager logged a successful sync while the node remained divergent. Now we `bail!` so the manager's fallback chain (DAG catchup → snapshot) re-handshakes against the peer's current root.

Matches the all-zero CI evidence from #2411's scaffolding-e2e WARN: `nodes_compared=0 entities_merged=0 entities_pushed=0 nodes_skipped=0`.

### Part 2 — bidirectional leaf push on `common_children` (value-divergence case)

A parent's `children` list is keyed on `entity_id` (`c.id().as_bytes()` in `get_local_tree_node`), not merkle hash. So when two peers have the same entity_id at different **values**, the leaves land in `common_children` and DFS recurses to the leaf. The bug was at the leaf: the initiator applied the peer's leaf via storage CRDT merge but **never pushed its own newer leaf back** when LWW silently kept local. Now we accumulate such leaves into a `pending_local_leaf_pushes` Vec during the DFS and flush in a single chunked call after the walk.

The peer's own LWW guard makes this a no-op when its version is already newer, so there's no risk of ping-pong.

## What this PR does NOT fix

The `Sync regression (smoke)` workflow still flaps after this PR. Diagnosis from the latest failed run:

- The two Round-2 writes update each peer's `Root<T>` opaque-leaf entry ([118;32]) at different HLCs but with the **same value bytes**.
- The leaf's merkle hash does NOT depend on HLC (`Metadata` is `#[borsh(skip)]` in the storage layer), so `local.hash == remote.hash` for the Root<T> leaf.
- `compare_tree_nodes` returns `Equal` for that leaf → DFS skips it.
- But the **parent's** full_hash factors children in `created_at`-sorted order, and the two peers wrote their Root<T> at different times → different `created_at` → different parent ordering → different parent hash → different root hash.
- My Part 2 fix can't fire because `local.hash != remote.hash` is the entry condition, and that condition isn't met for the Root<T> leaf.

Solving this requires either (a) making the leaf merkle hash depend on `created_at`, (b) HashComparison always re-pushing leaves at the same entity_id in `common_children` regardless of merkle-hash equality, or (c) replication of `created_at` on Update actions (currently storage preserves stored `created_at` and ignores the incoming value). All three have ripple effects on existing snapshot/delta paths. Tracking on #2407.

## Test plan

Two new integration tests in `sync_sim::protocol::tests`:

- `test_initiator_newer_leaf_pushes_to_peer_in_single_sync` — same entity_id at different HLC + value. Alice (initiator, newer) syncs to Bob (older). Single sync converges; pre-fix this fails the root-hash equality assertion.
- `test_root_not_found_surfaces_err` — stale `remote_root_hash` Bob's index doesn't have. Initiator must return `Err` matching "not_found"; pre-fix returns `Ok(default stats)`.

Local test status:

- [x] `cargo test -p calimero-node` — 308/308 sync_sim, all other test binaries pass
- [x] `cargo clippy -p calimero-node --lib --tests` — no new warnings in touched files
- [x] `cargo fmt --check`
- [ ] `Sync regression (smoke)` workflow — **flaps** on this PR for the reasons in "What this PR does NOT fix" above. Same commit (`16b5899`) had one success + one failure in CI history. Matches the original #2407 flakiness signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
