### PR TITLE
fix(node/sync): namespace-join iterates peers on protocol-level rejection

### DIFF
--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4451,23 +4451,36 @@ impl SyncManager {
                     continue;
                 }
                 Ok(other) => {
+                    let detail = format!(
+                        "unexpected response variant: {:?}",
+                        other.as_ref().map(|m| std::mem::discriminant(m))
+                    );
                     debug!(
                         namespace_id = %hex::encode(params.namespace_id),
                         %peer,
-                        "namespace join: unexpected response {:?}, marking peer rejected",
-                        other.as_ref().map(|m| std::mem::discriminant(m))
+                        %detail,
+                        "namespace join: unexpected response, marking peer rejected"
                     );
                     rejected_peers.insert(peer);
+                    // Carry the unexpected-response detail into
+                    // `last_rejection` so the exhaustion error keeps
+                    // diagnostic context if every retry hits this arm.
+                    last_rejection = Some(detail);
                     continue;
                 }
                 Err(recv_err) => {
+                    let detail = format!("recv failed: {recv_err}");
                     debug!(
                         namespace_id = %hex::encode(params.namespace_id),
                         %peer,
-                        error = %recv_err,
+                        %detail,
                         "namespace join: recv failed, marking peer rejected, trying next peer"
                     );
                     rejected_peers.insert(peer);
+                    // Same rationale as the `Ok(other)` arm above —
+                    // carry the recv failure into `last_rejection` so
+                    // the exhaustion error remains informative.
+                    last_rejection = Some(detail);
                     continue;
                 }
             }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4328,68 +4328,158 @@ impl SyncManager {
         &self,
         params: NamespaceJoinParams,
     ) -> eyre::Result<JoinBundle> {
-        // Discover a mesh peer and open a namespace-join stream.
         // Connect-loop logic (shuffled-peer retry, per-peer timeout,
         // outer deadline) lives in `namespace_join::open_namespace_join_stream`
         // so it can be unit-tested against `MockSyncNetwork` without
         // standing up a full `SyncManager`. See that module for the
         // design rationale (mesh-formation latency, stale-transport
         // fallback, deadline budgeting under large meshes).
-        let mut stream = namespace_join::open_namespace_join_stream(
-            &*self.sync_network,
-            params.namespace_id,
-            self.sync_config.open_stream_timeout,
-            super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED,
-            std::time::Duration::from_millis(
-                super::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
-            ),
-        )
-        .await?;
+        //
+        // Outer loop retries the entire connect-and-exchange when the
+        // chosen peer returns `NamespaceJoinRejected` or fails the
+        // post-open send/recv. A peer can be in the gossipsub mesh
+        // and reachable on transport but not yet have processed the
+        // namespace governance DAG far enough to serve the join —
+        // rejecting that peer must not fail the whole join when
+        // another mesh peer is in a position to answer. Mirrors the
+        // pattern `initiate_open_subgroup_join` uses for the same
+        // mesh-cold-peer race.
+        //
+        // Rejected peers feed back into `open_namespace_join_stream`
+        // via `excluded_peers` so the next round skips them at the
+        // connect layer rather than re-opening a transport just to
+        // get rejected again.
+        let mut rejected_peers: std::collections::HashSet<libp2p::PeerId> =
+            std::collections::HashSet::new();
+        let mut last_rejection: Option<String> = None;
+        // Cap on protocol-level retries. The connect loop already
+        // handles transport failure across peers; this cap bounds the
+        // total post-open exchanges so a small mesh full of stale
+        // peers can't deadlock the join indefinitely. Sized to cover
+        // typical 1–3 mesh peers plus headroom.
+        const MAX_PROTOCOL_RETRIES: usize = 5;
 
-        let msg = StreamMessage::Init {
-            context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
-            party_id: params.joiner_public_key,
-            payload: InitPayload::NamespaceJoinRequest {
-                namespace_id: params.namespace_id,
-                invitation_bytes: params.invitation_bytes,
-                joiner_public_key: params.joiner_public_key,
-            },
-            next_nonce: rand::thread_rng().gen(),
-        };
+        for protocol_attempt in 1..=MAX_PROTOCOL_RETRIES {
+            let (mut stream, peer) = match namespace_join::open_namespace_join_stream(
+                &*self.sync_network,
+                params.namespace_id,
+                self.sync_config.open_stream_timeout,
+                super::config::DEFAULT_MESH_RETRIES_UNINITIALIZED,
+                std::time::Duration::from_millis(
+                    super::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
+                ),
+                &rejected_peers,
+            )
+            .await
+            {
+                Ok(opened) => opened,
+                Err(open_err) => {
+                    // Connect loop exhausted (no reachable peer left,
+                    // or every remaining mesh peer is in
+                    // `rejected_peers`). Surface the most diagnostic
+                    // error we have — a previous rejection beats the
+                    // generic "could not open" because the rejection
+                    // tells the caller *why* the peer wouldn't serve.
+                    if let Some(reason) = last_rejection {
+                        eyre::bail!(
+                            "namespace join failed after {} attempt(s): last rejection \
+                             \"{}\"; subsequent connect failed: {}",
+                            protocol_attempt - 1,
+                            reason,
+                            open_err
+                        );
+                    }
+                    return Err(open_err);
+                }
+            };
 
-        super::stream::send(&mut stream, &msg, None).await?;
+            let msg = StreamMessage::Init {
+                context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
+                party_id: params.joiner_public_key,
+                payload: InitPayload::NamespaceJoinRequest {
+                    namespace_id: params.namespace_id,
+                    invitation_bytes: params.invitation_bytes.clone(),
+                    joiner_public_key: params.joiner_public_key,
+                },
+                next_nonce: rand::thread_rng().gen(),
+            };
 
-        match super::stream::recv(&mut stream, None, self.sync_config.timeout).await? {
-            Some(StreamMessage::Message {
-                payload:
-                    MessagePayload::NamespaceJoinResponse {
+            if let Err(send_err) = super::stream::send(&mut stream, &msg, None).await {
+                debug!(
+                    namespace_id = %hex::encode(params.namespace_id),
+                    %peer,
+                    error = %send_err,
+                    "namespace join: send failed, marking peer rejected, trying next peer"
+                );
+                rejected_peers.insert(peer);
+                continue;
+            }
+
+            match super::stream::recv(&mut stream, None, self.sync_config.timeout).await {
+                Ok(Some(StreamMessage::Message {
+                    payload:
+                        MessagePayload::NamespaceJoinResponse {
+                            key_envelope_bytes,
+                            context_ids,
+                            application_id,
+                            governance_ops,
+                            default_capabilities,
+                        },
+                    ..
+                })) => {
+                    return Ok(JoinBundle {
                         key_envelope_bytes,
                         context_ids,
-                        application_id,
+                        application_id: application_id.into(),
                         governance_ops,
                         default_capabilities,
-                    },
-                ..
-            }) => Ok(JoinBundle {
-                key_envelope_bytes,
-                context_ids,
-                application_id: application_id.into(),
-                governance_ops,
-                default_capabilities,
-            }),
-            Some(StreamMessage::Message {
-                payload: MessagePayload::NamespaceJoinRejected { reason },
-                ..
-            }) => {
-                eyre::bail!("namespace join rejected: {}", reason)
-            }
-            other => {
-                eyre::bail!(
-                    "unexpected response to namespace join request: {:?}",
-                    other.as_ref().map(|m| std::mem::discriminant(m))
-                )
+                    });
+                }
+                Ok(Some(StreamMessage::Message {
+                    payload: MessagePayload::NamespaceJoinRejected { reason },
+                    ..
+                })) => {
+                    debug!(
+                        namespace_id = %hex::encode(params.namespace_id),
+                        %peer,
+                        %reason,
+                        attempt = protocol_attempt,
+                        "namespace join: peer rejected, trying next peer"
+                    );
+                    rejected_peers.insert(peer);
+                    last_rejection = Some(reason);
+                    continue;
+                }
+                Ok(other) => {
+                    debug!(
+                        namespace_id = %hex::encode(params.namespace_id),
+                        %peer,
+                        "namespace join: unexpected response {:?}, marking peer rejected",
+                        other.as_ref().map(|m| std::mem::discriminant(m))
+                    );
+                    rejected_peers.insert(peer);
+                    continue;
+                }
+                Err(recv_err) => {
+                    debug!(
+                        namespace_id = %hex::encode(params.namespace_id),
+                        %peer,
+                        error = %recv_err,
+                        "namespace join: recv failed, marking peer rejected, trying next peer"
+                    );
+                    rejected_peers.insert(peer);
+                    continue;
+                }
             }
         }
+
+        eyre::bail!(
+            "namespace join exhausted {} protocol attempts (last rejection: {:?}, \
+             {} peer(s) rejected)",
+            MAX_PROTOCOL_RETRIES,
+            last_rejection,
+            rejected_peers.len()
+        )
     }
 
     /// Pull all namespace governance ops from a mesh peer.

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4352,6 +4352,7 @@ impl SyncManager {
         let mut rejected_peers: std::collections::HashSet<libp2p::PeerId> =
             std::collections::HashSet::new();
         let mut last_rejection: Option<String> = None;
+        let mut last_connect_err: Option<String> = None;
         // Cap on protocol-level retries. The connect loop already
         // handles transport failure across peers; this cap bounds the
         // total post-open exchanges so a small mesh full of stale
@@ -4374,22 +4375,31 @@ impl SyncManager {
             {
                 Ok(opened) => opened,
                 Err(open_err) => {
-                    // Connect loop exhausted (no reachable peer left,
-                    // or every remaining mesh peer is in
-                    // `rejected_peers`). Surface the most diagnostic
-                    // error we have — a previous rejection beats the
-                    // generic "could not open" because the rejection
-                    // tells the caller *why* the peer wouldn't serve.
-                    if let Some(reason) = last_rejection {
-                        eyre::bail!(
-                            "namespace join failed after {} attempt(s): last rejection \
-                             \"{}\"; subsequent connect failed: {}",
-                            protocol_attempt - 1,
-                            reason,
-                            open_err
-                        );
+                    if last_rejection.is_none() {
+                        // First attempt's connect loop exhausted with
+                        // no prior protocol-level success. The
+                        // connect loop has its own mesh-retry budget;
+                        // re-running it immediately would repeat the
+                        // same exhaustion with no state change.
+                        // Surface the connect_err directly.
+                        return Err(open_err);
                     }
-                    return Err(open_err);
+                    // Connect failure *after* at least one peer has
+                    // rejected: do not bail. The mesh may surface a
+                    // fresh peer on a later protocol attempt that
+                    // wasn't visible during this one (mesh-formation
+                    // delay, peer just finished processing the
+                    // namespace governance DAG, etc.). Record the err
+                    // for the exhaustion diagnostic and let the loop
+                    // continue.
+                    debug!(
+                        namespace_id = %hex::encode(params.namespace_id),
+                        attempt = protocol_attempt,
+                        error = %open_err,
+                        "namespace join: connect failed after prior rejection, will retry"
+                    );
+                    last_connect_err = Some(open_err.to_string());
+                    continue;
                 }
             };
 
@@ -4488,9 +4498,10 @@ impl SyncManager {
 
         eyre::bail!(
             "namespace join exhausted {} protocol attempts (last rejection: {:?}, \
-             {} peer(s) rejected)",
+             last connect_err: {:?}, {} peer(s) rejected)",
             MAX_PROTOCOL_RETRIES,
             last_rejection,
+            last_connect_err,
             rejected_peers.len()
         )
     }

--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -478,7 +478,11 @@ mod tests {
             &excluded,
         )
         .await;
-        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("excluded 1"),
+            "err should report 1 excluded peer for diagnostic symmetry: {err}"
+        );
         mock.assert_all_consumed();
     }
 }

--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -13,8 +13,11 @@
 //! this module deliberately holds none of it so the comments don't
 //! drift out of sync.
 
+use std::collections::HashSet;
+
 use calimero_network_primitives::stream::Stream;
 use libp2p::gossipsub::TopicHash;
+use libp2p::PeerId;
 use rand::seq::SliceRandom;
 use tokio::time;
 use tracing::debug;
@@ -43,20 +46,27 @@ const DEADLINE_MAX_PEERS_PER_ROUND: u32 = 4;
 /// Open a stream to a namespace mesh peer.
 ///
 /// Iterates `mesh_retries` rounds. Each round: discover mesh peers,
-/// shuffle, try each with a per-peer `open_timeout`. The whole loop
-/// is bounded by an outer deadline computed from the retry/timeout
-/// config so a pathological large-mesh case can't outlast the
-/// caller's own timeout.
+/// shuffle, try each with a per-peer `open_timeout`. Peers in
+/// `excluded_peers` are filtered out before the inner loop —
+/// `initiate_namespace_join` uses this to retry against a different
+/// peer after one returns `NamespaceJoinRejected` without opening
+/// fresh transports to the rejecting peer. The whole loop is bounded
+/// by an outer deadline computed from the retry/timeout config so a
+/// pathological large-mesh case can't outlast the caller's own
+/// timeout.
 ///
-/// Returns `Ok(stream)` on first success or `Err(_)` after the
-/// deadline elapses / all retries exhaust.
+/// Returns `Ok((stream, peer_id))` on first success or `Err(_)` after
+/// the deadline elapses / all retries exhaust. The `peer_id` lets the
+/// caller record a rejection and pass the peer back via
+/// `excluded_peers` on the next call.
 pub(super) async fn open_namespace_join_stream(
     sync_network: &dyn SyncNetwork,
     namespace_id: [u8; 32],
     open_timeout: std::time::Duration,
     mesh_retries: u32,
     mesh_retry_delay: std::time::Duration,
-) -> eyre::Result<Stream> {
+    excluded_peers: &HashSet<PeerId>,
+) -> eyre::Result<(Stream, PeerId)> {
     // Production wiring always passes `DEFAULT_MESH_RETRIES_UNINITIALIZED`
     // (a non-zero compile-time const). A zero here would yield a zero
     // deadline and an empty `1..=0` loop body — the function would
@@ -82,7 +92,7 @@ pub(super) async fn open_namespace_join_stream(
     // `std::time::Instant`.
     let connect_started = tokio::time::Instant::now();
 
-    let mut stream = None;
+    let mut result: Option<(Stream, PeerId)> = None;
     'connect: for attempt in 1..=mesh_retries {
         if connect_started.elapsed() >= connect_deadline {
             debug!(
@@ -94,6 +104,15 @@ pub(super) async fn open_namespace_join_stream(
             break;
         }
         let mut peers = sync_network.mesh_peers(topic.clone()).await;
+        // Filter excluded peers before shuffling so an excluded peer
+        // doesn't get picked first and then `continue`'d — that would
+        // burn a slot in the shuffle order. Filtering up-front also
+        // makes the empty-after-exclusion case observable: if every
+        // mesh peer is excluded, we skip straight to the inter-round
+        // sleep (or, if this is the last attempt, the Err).
+        if !excluded_peers.is_empty() {
+            peers.retain(|p| !excluded_peers.contains(p));
+        }
         // In-place shuffle avoids the second `Vec` allocation that
         // `choose_multiple` would produce. Matches the pattern used
         // in `perform_interval_sync`.
@@ -105,7 +124,7 @@ pub(super) async fn open_namespace_join_stream(
             }
             match time::timeout(open_timeout, sync_network.open_stream(*peer)).await {
                 Ok(Ok(opened)) => {
-                    stream = Some(opened);
+                    result = Some((opened, *peer));
                     break 'connect;
                 }
                 Ok(Err(err)) => {
@@ -142,13 +161,14 @@ pub(super) async fn open_namespace_join_stream(
     }
 
     let elapsed = connect_started.elapsed();
-    stream.ok_or_else(|| {
+    result.ok_or_else(|| {
         eyre::eyre!(
             "could not open a namespace-join stream to any mesh peer for namespace {} \
-             (deadline {}ms, elapsed {}ms)",
+             (deadline {}ms, elapsed {}ms, excluded {})",
             hex::encode(namespace_id),
             connect_deadline.as_millis(),
-            elapsed.as_millis()
+            elapsed.as_millis(),
+            excluded_peers.len()
         )
     })
 }
@@ -173,6 +193,12 @@ mod tests {
         (Duration::from_millis(100), 3, Duration::from_millis(50))
     }
 
+    /// Default-empty exclusion set for tests that don't need to
+    /// exercise the protocol-level-retry rejection path.
+    fn no_excluded() -> HashSet<PeerId> {
+        HashSet::new()
+    }
+
     /// All peers in every round return Err → function returns Err
     /// with the deadline+elapsed signature. We seed exactly the
     /// expected error count (retries × peers = 6) and assert
@@ -193,9 +219,15 @@ mod tests {
             mock.push_open_stream_err(format!("err-{i}"));
         }
 
-        let result =
-            open_namespace_join_stream(&mock, NAMESPACE_ID, open_timeout, retries, retry_delay)
-                .await;
+        let result = open_namespace_join_stream(
+            &mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &no_excluded(),
+        )
+        .await;
 
         let err = result.unwrap_err().to_string();
         assert!(
@@ -234,9 +266,15 @@ mod tests {
             .saturating_add(open_timeout.saturating_mul(DEADLINE_MAX_PEERS_PER_ROUND))
             .saturating_mul(retries);
         let start = time::Instant::now();
-        let result =
-            open_namespace_join_stream(&mock, NAMESPACE_ID, open_timeout, retries, retry_delay)
-                .await;
+        let result = open_namespace_join_stream(
+            &mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &no_excluded(),
+        )
+        .await;
         let elapsed = start.elapsed();
 
         assert!(result.is_err(), "expected Err from hanging peers, got Ok");
@@ -263,9 +301,15 @@ mod tests {
         // mesh hasn't formed yet).
 
         let (open_timeout, retries, retry_delay) = defaults();
-        let result =
-            open_namespace_join_stream(&mock, NAMESPACE_ID, open_timeout, retries, retry_delay)
-                .await;
+        let result = open_namespace_join_stream(
+            &mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &no_excluded(),
+        )
+        .await;
 
         assert!(
             result.is_err(),
@@ -306,6 +350,7 @@ mod tests {
             open_timeout,
             mesh_retries,
             mesh_retry_delay,
+            &no_excluded(),
         )
         .await;
         let elapsed = start.elapsed();
@@ -332,11 +377,102 @@ mod tests {
         let mock: Arc<dyn SyncNetwork> = Arc::new(MockSyncNetwork::default());
 
         let (open_timeout, retries, retry_delay) = defaults();
-        let result =
-            open_namespace_join_stream(&*mock, NAMESPACE_ID, open_timeout, retries, retry_delay)
-                .await;
+        let result = open_namespace_join_stream(
+            &*mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &no_excluded(),
+        )
+        .await;
         // Empty mesh → Err is expected; we're just checking the
         // type coercion compiles and runs.
         assert!(result.is_err());
+    }
+
+    /// Every mesh peer present is in `excluded_peers` → connect loop
+    /// has nothing to try → Err after the full retry budget. Catches
+    /// the protocol-level-retry exhaustion case where every peer has
+    /// already rejected `NamespaceJoinRequest` on a prior attempt and
+    /// the manager re-calls the helper with all of them excluded.
+    #[tokio::test(start_paused = true)]
+    async fn all_peers_excluded_returns_err_without_open_attempts() {
+        let mock = MockSyncNetwork::default();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        mock.push_mesh_peers(vec![p1, p2]);
+        let mut excluded = HashSet::new();
+        excluded.insert(p1);
+        excluded.insert(p2);
+
+        let (open_timeout, retries, retry_delay) = defaults();
+        // Crucially: NO `push_open_stream_*` calls. If the connect
+        // loop tries to open_stream against an excluded peer, the
+        // mock's "no queued response" Err surfaces — but that would
+        // mean the filter failed. With the filter working, the
+        // exhausted-mesh path returns Err without consuming the
+        // open_stream queue.
+        let result = open_namespace_join_stream(
+            &mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &excluded,
+        )
+        .await;
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("could not open a namespace-join stream"),
+            "unexpected err: {err}"
+        );
+        assert!(
+            err.contains("excluded 2"),
+            "err should report the excluded-peer count: {err}"
+        );
+        // The filter dropped both peers before open_stream got a
+        // chance to be called, so the open_stream queue is still
+        // empty (nothing seeded, nothing consumed). The mesh_peers
+        // entry consumed-or-sticky-last; either way no panic.
+        mock.assert_all_consumed();
+    }
+
+    /// Only the excluded peer is filtered; non-excluded peers in the
+    /// same mesh still get tried. The mock seeds *only* one
+    /// open_stream Err — if the filter also blocked the non-excluded
+    /// peer, we'd see "no queued response" instead.
+    #[tokio::test(start_paused = true)]
+    async fn excluded_peer_skipped_other_mesh_peer_still_attempted() {
+        let mock = MockSyncNetwork::default();
+        let kept = PeerId::random();
+        let blocked = PeerId::random();
+        mock.push_mesh_peers(vec![kept, blocked]);
+        let mut excluded = HashSet::new();
+        excluded.insert(blocked);
+
+        // Per-round one peer remains → one open_stream attempt per
+        // round → `retries` attempts total. Seed exactly that many
+        // errors and assert_all_consumed below catches both
+        // "filter let the blocked peer through" (would consume more
+        // than seeded → error on exhaust) and "filter blocked the
+        // kept peer too" (would consume fewer → unconsumed Errs).
+        let (open_timeout, retries, retry_delay) = defaults();
+        for i in 0..(retries as usize) {
+            mock.push_open_stream_err(format!("kept-err-{i}"));
+        }
+
+        let result = open_namespace_join_stream(
+            &mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &excluded,
+        )
+        .await;
+        assert!(result.is_err());
+        mock.assert_all_consumed();
     }
 }

--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -448,6 +448,12 @@ mod tests {
         let mock = MockSyncNetwork::default();
         let kept = PeerId::random();
         let blocked = PeerId::random();
+        // `mesh_peers` is sticky-last in the mock (see module doc): a
+        // single `push_mesh_peers` call seeds the same list for every
+        // round. The test budget below (`retries` open_stream Errs)
+        // depends on that — if sticky-last ever changes to return an
+        // empty list after the first read, the assertion below would
+        // pass vacuously instead of guarding the filter behaviour.
         mock.push_mesh_peers(vec![kept, blocked]);
         let mut excluded = HashSet::new();
         excluded.insert(blocked);


### PR DESCRIPTION
## Summary

Closes #2405. `initiate_namespace_join` now iterates mesh peers on protocol-level rejection, not just stream-open failure. Mirrors the pattern `initiate_open_subgroup_join` already uses for the same mesh-cold-peer race.

## Why

#2398 added retry/timeout to the **stream-open** phase. Once a stream opened, `initiate_namespace_join` committed to that one peer — the post-open `NamespaceJoinRequest` exchange was single-shot, and any `NamespaceJoinRejected` propagated as a terminal error.

The race this enables: a peer can be in the gossipsub `ns/<hex>` topic mesh (so `open_stream` succeeds) but not yet have processed the namespace governance DAG far enough to verify the invitation. That peer legitimately responds `NamespaceJoinRejected`, and pre-fix the whole join fails — even though another mesh peer might be in a position to answer.

## What changed

- `open_namespace_join_stream` now accepts `excluded_peers: &HashSet<PeerId>` and returns `(Stream, PeerId)`. Peers in the exclusion set are filtered up-front (before shuffle) so they don't burn a slot in the shuffle order.
- `initiate_namespace_join` wraps open-and-exchange in a bounded retry loop (`MAX_PROTOCOL_RETRIES = 5`):
  - on `NamespaceJoinRejected` → mark peer rejected, record reason, retry against a different peer
  - on send/recv failure or unexpected payload → mark peer rejected, retry
  - on exhaustion → surface the most diagnostic available error (last rejection reason beats the generic connect-loop Err)
- Existing connect-loop semantics (mesh-retry, per-peer timeout, outer deadline) are preserved — the protocol-retry loop just wraps it.

## Test plan

| Test | What it guards |
|---|---|
| `all_peers_excluded_returns_err_without_open_attempts` | Every mesh peer in `excluded_peers` → connect loop has nothing to try → Err with `excluded N` in the message. Assert no `open_stream` attempts seeded/consumed. |
| `excluded_peer_skipped_other_mesh_peer_still_attempted` | Exactly one of two mesh peers excluded → only the other gets `open_stream` attempts. `assert_all_consumed` catches both filter regressions (let blocked through / blocked kept). |
| 5 existing helper tests | Updated to pass `&no_excluded()`; behaviours unchanged. |

Local test status:

- [x] `cargo test -p calimero-node --lib namespace_join` — 7/7 pass
- [x] `cargo test -p calimero-node` — all bins pass (306 sync_sim incl.)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p calimero-node --lib --tests` — no new warnings in touched files

## Out of scope (existing follow-ups)

- Stream-level mocking for an end-to-end protocol-retry integration test (would need `Stream::test_pair()` infrastructure that doesn't exist yet). The new helper tests cover the connect-layer exclusion behaviour deterministically; the protocol-retry loop in `initiate_namespace_join` is exercised via the existing e2e workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace-join control flow to add protocol-level retries and peer exclusion, which can affect join latency and error handling under partial mesh formation. Risk is moderate because it touches P2P stream/retry logic but is bounded and covered by updated/new unit tests.
> 
> **Overview**
> Improves namespace join robustness by retrying the full `NamespaceJoinRequest` exchange across different mesh peers when a peer rejects the request or the post-open send/recv fails, rather than treating a single rejection as terminal.
> 
> Extends `namespace_join::open_namespace_join_stream` to return `(Stream, PeerId)` and accept an `excluded_peers` set, enabling the manager to skip previously rejecting peers and produce more diagnostic exhaustion errors; updates and adds unit tests to cover excluded-peer filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5c7f5c41e28f9e42febd814ea1921954cba671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->