### PR TITLE
fix(storage): drop speculative nonce-check bypass from Shared DeleteRef

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1092,18 +1092,19 @@ impl<S: StorageAdaptor> Interface<S> {
 
                                 // Replay protection (per-entity monotonic nonce).
                                 //
-                                // Mirrors the upsert arm's
-                                // [`disable_nonce_check_for_testing`]
-                                // bypass so DAG-causal P5 tests that
-                                // exercise out-of-order delivery of
-                                // Shared deletes can opt into the v3
-                                // target behavior. Production
-                                // codepath unchanged — the const fn
-                                // returns false outside cfg(test).
+                                // Strict `<=` Err, symmetric with the
+                                // User DeleteRef arm above and matching
+                                // the rationale documented there: stale
+                                // delete semantics differ from upsert
+                                // silent-skip, and DeleteRef tests do
+                                // not opt into the test-only bypass.
+                                // Removing the previously-speculative
+                                // `nonce_check_disabled_for_testing`
+                                // guard here so the two delete arms
+                                // behave identically.
                                 let new_nonce = sig_data.nonce;
                                 let last_nonce = *existing_metadata.updated_at;
-                                let skip_nonce = nonce_check_disabled_for_testing();
-                                if !skip_nonce && new_nonce <= last_nonce {
+                                if new_nonce <= last_nonce {
                                     let placeholder = existing_writers
                                         .iter()
                                         .copied()


### PR DESCRIPTION
## Summary

Closes #2401. Removes the `nonce_check_disabled_for_testing` guard from the Shared DeleteRef arm so both delete arms (User + Shared) behave identically — strict `<=` Err on stale nonce.

## Why

The bypass was added speculatively when #2400 ported the same guard to the upsert arms, on the theory that DAG-causal P5 tests exercising out-of-order delivery might also need it for Shared deletes. **No such test exists today**:

- `crates/node/src/sync/p5_partition_scenarios_tests.rs` — 4 usages of `disable_nonce_check_for_testing()`, all in upsert paths
- `crates/node/tests/dag_causal_shared_e2e.rs` — 3 usages, all in upsert paths
- Only one DeleteRef reference in the test files, and it's a match-arm destructure, not an action creation

So the bypass in Shared DeleteRef was unreachable test-only code creating the asymmetry #2401 flags.

Aligned with the deliberate User-arm choice documented in the surrounding code:

> DeleteRef keeps the strict `Err` on `<=` (unlike upsert's silent skip) because a stale delete being silently accepted vs dropped carries different semantics than a stale upsert, and rare-by-design deletes don't drive the post-divergence convergence problem upsert silent-skip fixes.

Production codepath unchanged — the `const fn` bypass returns false outside `cfg(test)` regardless of what's guarded by it.

## Test plan

- [x] `cargo test -p calimero-storage` — 445 + 1 + 4 + 1 + 1 + 4 pass, no regressions
- [x] `cargo test -p calimero-node --test dag_causal_shared_e2e` — 3 pass (the upsert-side P5 tests)
- [x] `cargo test -p calimero-node --lib p5_partition` — 4 pass
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change that only affects replay-protection behavior for `Shared` `Action::DeleteRef` during sync apply; it may cause previously-bypassed test scenarios to fail if they relied on skipping nonce checks for deletes.
> 
> **Overview**
> Removes the test-only `nonce_check_disabled_for_testing()` bypass from the `Shared` `Action::DeleteRef` path so **stale-or-equal delete nonces (`<=`) always error** with `StorageError::NonceReplay`.
> 
> This makes `Shared` deletes behave identically to `User` deletes (strict rejection instead of conditional skip), while leaving the upsert paths’ test bypass behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b24a084712f34de7e637fb43fee68925ba1dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->