### PR TITLE
docs(storage): explain Shared upsert sig=causal vs nonce=stored asymmetry

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -808,44 +808,35 @@ impl<S: StorageAdaptor> Interface<S> {
                         // signature verification so replays are O(1)-rejected without
                         // iterating Ed25519 verifies over each writer (matches User arm).
                         //
-                        // P3 keeps the nonce check unchanged. Per the epic exit
-                        // criterion, the nonce check is removed only after weeks
-                        // of zero-divergence telemetry between nonce + DAG-causal.
-                        // Tests that need to validate the v3 target behavior
-                        // (post-nonce-removal) can opt out via the test-only
-                        // [`disable_nonce_check_for_testing`] hook.
+                        // Tests that need to validate behavior under
+                        // out-of-order delivery can opt out via the
+                        // test-only [`disable_nonce_check_for_testing`]
+                        // hook.
                         //
-                        // Source asymmetry: signature verification (above) uses
-                        // `authoritative_writers` — the DAG-causal pre-resolved
-                        // set from `ctx.effective_writers` when available; the
-                        // nonce baseline below reads from `stored_metadata`
-                        // (local) regardless of causal context. This is
-                        // intentional: the two layers answer different
-                        // questions and using different sources is correct.
-                        //
-                        // * Signature verification answers WHO can write at
-                        //   this causal point. The DAG-causal writer set is
-                        //   the authoritative answer per ADR-0001 and #2266.
-                        // * Nonce check answers WHEN this write happened
-                        //   relative to local state. The local stored value
-                        //   is the LWW baseline — same source
-                        //   `save_internal`'s `last_metadata.updated_at >
-                        //   metadata.updated_at` LWW guard reads (defense
-                        //   in depth), so the two layers never disagree.
+                        // Source asymmetry vs the signature check above:
+                        // signature uses `authoritative_writers` (the
+                        // pre-resolved causal writer set when callers
+                        // supply it); the nonce baseline below reads from
+                        // stored metadata regardless of causal context.
+                        // Intentional — the two checks answer different
+                        // questions:
+                        // * Signature: WHO can write at this causal point
+                        //   (authorization boundary).
+                        // * Nonce: WHEN this write happened relative to
+                        //   local state — same baseline `save_internal`
+                        //   reads for its LWW-by-HLC guard, so the two
+                        //   layers never disagree.
                         //
                         // `ApplyContext` deliberately does not carry an
-                        // `effective_last_nonce` — computing one would
-                        // require scanning the DAG for the most-recent
-                        // prior write to this entity at the causal point,
-                        // which is heavier than the design wants. The
-                        // HLC implementation's `max(local, last_seen_remote) + 1`
-                        // monotonicity rule rules out the only theoretical
-                        // failure mode (a post-rotation writer's HLC
-                        // somehow lower than the pre-rotation writer's
-                        // last write): a fresh writer who has observed the
-                        // rotation has also observed all writes ancestral
-                        // to it, so its HLC must exceed the stored
-                        // baseline. See #2402 for the full audit.
+                        // `effective_last_nonce`: computing one would
+                        // require scanning the DAG for this entity's most
+                        // recent prior write at the causal point. The
+                        // HLC's `max(local, last_seen_remote) + 1`
+                        // monotonicity rule means a post-rotation writer
+                        // who has observed the rotation has also observed
+                        // all writes ancestral to it, so its HLC must
+                        // exceed the stored baseline — ruling out the
+                        // "fresh writer at lower HLC than stored" case.
                         let new_nonce = sig_data.nonce;
                         let last_nonce =
                             stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -814,6 +814,38 @@ impl<S: StorageAdaptor> Interface<S> {
                         // Tests that need to validate the v3 target behavior
                         // (post-nonce-removal) can opt out via the test-only
                         // [`disable_nonce_check_for_testing`] hook.
+                        //
+                        // Source asymmetry: signature verification (above) uses
+                        // `authoritative_writers` — the DAG-causal pre-resolved
+                        // set from `ctx.effective_writers` when available; the
+                        // nonce baseline below reads from `stored_metadata`
+                        // (local) regardless of causal context. This is
+                        // intentional: the two layers answer different
+                        // questions and using different sources is correct.
+                        //
+                        // * Signature verification answers WHO can write at
+                        //   this causal point. The DAG-causal writer set is
+                        //   the authoritative answer per ADR-0001 and #2266.
+                        // * Nonce check answers WHEN this write happened
+                        //   relative to local state. The local stored value
+                        //   is the LWW baseline — same source
+                        //   `save_internal`'s `last_metadata.updated_at >
+                        //   metadata.updated_at` LWW guard reads (defense
+                        //   in depth), so the two layers never disagree.
+                        //
+                        // `ApplyContext` deliberately does not carry an
+                        // `effective_last_nonce` — computing one would
+                        // require scanning the DAG for the most-recent
+                        // prior write to this entity at the causal point,
+                        // which is heavier than the design wants. The
+                        // HLC implementation's `max(local, last_seen_remote) + 1`
+                        // monotonicity rule rules out the only theoretical
+                        // failure mode (a post-rotation writer's HLC
+                        // somehow lower than the pre-rotation writer's
+                        // last write): a fresh writer who has observed the
+                        // rotation has also observed all writes ancestral
+                        // to it, so its HLC must exceed the stored
+                        // baseline. See #2402 for the full audit.
                         let new_nonce = sig_data.nonce;
                         let last_nonce =
                             stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);


### PR DESCRIPTION
## Summary

Closes #2402 as documented-as-intended. The Shared upsert arm verifies signatures against `authoritative_writers` (DAG-causal, from `ctx.effective_writers`) but reads the nonce baseline from `stored_metadata.updated_at` (local). #2402 surfaced this asymmetry and asked whether it's safe.

## Audit conclusion

The two sources are **correct** because the two layers answer different questions:

| Layer | Source | Question answered |
|---|---|---|
| Signature verification | `authoritative_writers` (DAG-causal via `ctx.effective_writers`) | WHO can write at this causal point? — ADR-0001 / #2266 boundary |
| Nonce check | `stored_metadata.updated_at` (local) | WHEN did this write happen relative to local state? — LWW baseline |

The nonce check uses the same baseline `save_internal`'s LWW-by-HLC guard (`last_metadata.updated_at > metadata.updated_at` ⇒ returns `Ok(None)`, no write) reads — defense in depth — so the two layers never disagree.

`ApplyContext` deliberately does not carry an `effective_last_nonce`: computing one would require scanning the DAG for the most-recent prior write at the causal point, which is heavier than the design wants. The HLC implementation's `max(local, last_seen_remote) + 1` monotonicity rule rules out the only theoretical failure mode (a post-rotation writer's HLC somehow lower than the pre-rotation writer's last write): a fresh writer who has observed the rotation has also observed all writes ancestral to it, so its HLC must exceed the stored baseline.

## What this PR changes

Adds an inline comment in `crates/storage/src/interface.rs` (Shared upsert arm, right above the nonce check) capturing this design rationale so the asymmetry is no longer review-bait. No behavior change.

## Test plan

- [x] `cargo build -p calimero-storage --lib`
- [x] `cargo fmt --check`
- Comment-only change — no tests to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change documenting why Shared upsert verifies signatures against DAG-causal `authoritative_writers` while nonce replay protection uses locally stored metadata; no runtime behavior is modified.
> 
> **Overview**
> Adds detailed inline documentation in `crates/storage/src/interface.rs` (Shared upsert path) explaining the intentional asymmetry between **signature verification** (uses DAG-causal `authoritative_writers` when provided) and **nonce replay checking** (uses stored `updated_at` as the local baseline), including why `ApplyContext` does not carry an `effective_last_nonce`.
> 
> No functional changes; this PR is purely clarifying commentary for reviewers and test authors (including the existing `disable_nonce_check_for_testing` hook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed623bb1350326e3822cf607efde8ffb29c52585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->