### PR TITLE
feat(node/sync): SyncStateAccess trait + dependency inversion

### DIFF
--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -611,10 +611,15 @@ impl crate::sync::state_access::SyncStateAccess for NodeState {
         context_id: ContextId,
         factory: Box<dyn FnOnce() -> DeltaStore + Send>,
     ) -> (DeltaStore, bool) {
-        // DashMap's entry API gives us the atomicity we need — no
-        // TOCTOU window between "is there a store?" and "register
-        // one." Track creation via a flag captured by the factory
-        // wrapper so we can report it back to the caller.
+        // DashMap's `entry().or_insert_with()` runs the factory at most
+        // once per `context_id`, under the shard write-lock. The
+        // `was_newly_created` flag is updated inside that critical
+        // section, so the value the caller sees reflects whether
+        // *this thread* won the create race. Under contention exactly
+        // one thread sees `true`; every other thread sees `false`. The
+        // one-time setup at call sites (`load_persisted_deltas` after
+        // a fresh store) is therefore guaranteed to run exactly once
+        // per context across threads.
         let mut was_newly_created = false;
         let store = self
             .delta_stores

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -596,3 +596,61 @@ impl NodeState {
         }
     }
 }
+
+// Production implementation of the `SyncStateAccess` trait. Inverts the
+// dependency: `sync/` consumes `&dyn SyncStateAccess` rather than
+// reaching into `NodeState`'s fields/methods directly, which lets unit
+// tests substitute a recording fake.
+impl crate::sync::state_access::SyncStateAccess for NodeState {
+    fn delta_store(&self, context_id: &ContextId) -> Option<DeltaStore> {
+        self.delta_stores.get(context_id).map(|entry| entry.clone())
+    }
+
+    fn register_delta_store(&self, context_id: ContextId, store: DeltaStore) {
+        let _ = self.delta_stores.insert(context_id, store);
+    }
+
+    fn end_sync_session(
+        &self,
+        context_id: &ContextId,
+    ) -> Option<Vec<calimero_node_primitives::delta_buffer::BufferedDelta>> {
+        Self::end_sync_session(self, context_id)
+    }
+
+    fn cancel_sync_session(&self, context_id: &ContextId) {
+        Self::cancel_sync_session(self, context_id)
+    }
+
+    fn peer_identities(&self, peer_id: &PeerId) -> Option<BTreeSet<PublicKey>> {
+        self.peer_identities.get(peer_id).map(|entry| entry.clone())
+    }
+
+    fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
+        let entry = self.reconcile_attempts.get(context_id)?;
+        let cooldown = crate::sync::reconcile_cooldown(entry.consecutive_failures);
+        let elapsed = entry.last_attempt_at.elapsed();
+        let remaining = cooldown.checked_sub(elapsed)?;
+        if remaining.is_zero() {
+            None
+        } else {
+            Some((remaining, entry.consecutive_failures))
+        }
+    }
+
+    fn record_reconcile_success(&self, context_id: &ContextId) {
+        let _ = self.reconcile_attempts.remove(context_id);
+    }
+
+    fn record_reconcile_failure(&self, context_id: ContextId) -> u32 {
+        let mut entry = self
+            .reconcile_attempts
+            .entry(context_id)
+            .or_insert_with(|| ReconcileAttempt {
+                last_attempt_at: Instant::now(),
+                consecutive_failures: 0,
+            });
+        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+        entry.last_attempt_at = Instant::now();
+        entry.consecutive_failures
+    }
+}

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -606,8 +606,25 @@ impl crate::sync::state_access::SyncStateAccess for NodeState {
         self.delta_stores.get(context_id).map(|entry| entry.clone())
     }
 
-    fn register_delta_store(&self, context_id: ContextId, store: DeltaStore) {
-        let _ = self.delta_stores.insert(context_id, store);
+    fn get_or_register_delta_store(
+        &self,
+        context_id: ContextId,
+        factory: Box<dyn FnOnce() -> DeltaStore + Send>,
+    ) -> (DeltaStore, bool) {
+        // DashMap's entry API gives us the atomicity we need — no
+        // TOCTOU window between "is there a store?" and "register
+        // one." Track creation via a flag captured by the factory
+        // wrapper so we can report it back to the caller.
+        let mut was_newly_created = false;
+        let store = self
+            .delta_stores
+            .entry(context_id)
+            .or_insert_with(|| {
+                was_newly_created = true;
+                factory()
+            })
+            .clone();
+        (store, was_newly_created)
     }
 
     fn end_sync_session(
@@ -626,31 +643,14 @@ impl crate::sync::state_access::SyncStateAccess for NodeState {
     }
 
     fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
-        let entry = self.reconcile_attempts.get(context_id)?;
-        let cooldown = crate::sync::reconcile_cooldown(entry.consecutive_failures);
-        let elapsed = entry.last_attempt_at.elapsed();
-        let remaining = cooldown.checked_sub(elapsed)?;
-        if remaining.is_zero() {
-            None
-        } else {
-            Some((remaining, entry.consecutive_failures))
-        }
+        crate::sync::reconcile_remaining_cooldown(&self.reconcile_attempts, context_id)
     }
 
     fn record_reconcile_success(&self, context_id: &ContextId) {
-        let _ = self.reconcile_attempts.remove(context_id);
+        crate::sync::record_reconcile_success(&self.reconcile_attempts, context_id);
     }
 
     fn record_reconcile_failure(&self, context_id: ContextId) -> u32 {
-        let mut entry = self
-            .reconcile_attempts
-            .entry(context_id)
-            .or_insert_with(|| ReconcileAttempt {
-                last_attempt_at: Instant::now(),
-                consecutive_failures: 0,
-            });
-        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
-        entry.last_attempt_at = Instant::now();
-        entry.consecutive_failures
+        crate::sync::record_reconcile_failure(&self.reconcile_attempts, context_id)
     }
 }

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -286,7 +286,7 @@ impl SyncManager {
             MessagePayload::DeltaResponse {
                 delta: serialized.into(),
             }
-        } else if let Some(delta_store) = self.node_state.delta_stores.get(&context_id) {
+        } else if let Some(delta_store) = self.state_access.delta_store(&context_id) {
             // Not in RocksDB yet (race condition after broadcast), try DeltaStore
             if let Some(dag_delta) = delta_store.get_delta(&delta_id).await {
                 // dag::CausalDelta now includes HLC, so we can directly convert

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -68,12 +68,25 @@ pub struct SyncManager {
     /// — the two fields hold the same underlying handle. See
     /// [`crate::sync::network::SyncNetwork`] for the contract.
     ///
-    /// This split is the minimum-viable mockability for #2406:
-    /// external callers keep talking to the concrete `NetworkClient`
-    /// (no ripple), while sync's own methods read through the trait
-    /// (mockable). After #2312 (SyncDeps inversion) lands, only the
-    /// trait field will remain.
+    /// This split is the minimum-viable mockability: external callers
+    /// keep talking to the concrete `NetworkClient` (no ripple), while
+    /// sync's own methods read through the trait (mockable).
     pub(crate) sync_network: Arc<dyn super::network::SyncNetwork>,
+    /// Sync's view of the node's mutable runtime state. Trait-mediated
+    /// (`Arc<dyn SyncStateAccess>`) so tests can substitute a recording
+    /// fake without spinning up a full `NodeManager`. In production
+    /// this is always `Arc::new(node_state)` — the same `NodeState`
+    /// the rest of the node holds.
+    pub(super) state_access: Arc<dyn super::state_access::SyncStateAccess>,
+    /// Concrete `NodeState` kept solely to hand off to the cross-actor
+    /// `crate::handlers::state_delta::replay_buffered_delta` call,
+    /// which uses a richer surface than `SyncStateAccess` exposes
+    /// (governance-pending drain, delta-buffer operations, etc.). The
+    /// rest of sync goes through `state_access`. Folding this last
+    /// dependency requires either expanding `SyncStateAccess` to
+    /// match `replay_buffered_delta`'s needs or restructuring the
+    /// cross-actor call — both deferred per the spike that landed
+    /// this trait.
     pub(super) node_state: crate::NodeState,
 
     pub(super) ctx_sync_rx: Option<mpsc::Receiver<(Option<ContextId>, Option<PeerId>)>>,
@@ -132,6 +145,7 @@ impl Clone for SyncManager {
             context_client: self.context_client.clone(),
             network_client: self.network_client.clone(),
             sync_network: Arc::clone(&self.sync_network),
+            state_access: Arc::clone(&self.state_access),
             node_state: self.node_state.clone(),
             ctx_sync_rx: None,
             ns_sync_rx: None,
@@ -214,12 +228,19 @@ impl SyncManager {
         )>,
     ) -> Self {
         let sync_network: Arc<dyn super::network::SyncNetwork> = Arc::new(network_client.clone());
+        // Wrap the concrete `NodeState` once here. The trait field is
+        // sync's primary state surface; the concrete `node_state`
+        // field is retained ONLY for the cross-actor
+        // `replay_buffered_delta` handoff (see field doc).
+        let state_access: Arc<dyn super::state_access::SyncStateAccess> =
+            Arc::new(node_state.clone());
         Self {
             sync_config,
             node_client,
             context_client,
             network_client,
             sync_network,
+            state_access,
             node_state,
             ctx_sync_rx: Some(ctx_sync_rx),
             ns_sync_rx: Some(ns_sync_rx),
@@ -920,7 +941,7 @@ impl SyncManager {
             .collect();
         let anchor_count = partition_peers_anchor_first(
             &mut shuffled,
-            &self.node_state.peer_identities,
+            &*self.state_access,
             &self.anchor_identities_for_context(&context_id),
         );
         if anchor_count > 0 {
@@ -1440,19 +1461,19 @@ impl SyncManager {
                             // This ensures that when new deltas arrive referencing the
                             // snapshot boundary heads as parents, the DAG accepts them.
                             if !result.dag_heads.is_empty() {
-                                let delta_store = self
-                                    .node_state
-                                    .delta_stores
-                                    .entry(context_id)
-                                    .or_insert_with(|| {
-                                        crate::delta_store::DeltaStore::new(
-                                            [0u8; 32],
-                                            self.context_client.clone(),
-                                            context_id,
-                                            our_identity,
-                                        )
-                                    })
-                                    .clone();
+                                let context_client = self.context_client.clone();
+                                let (delta_store, _was_newly_created) =
+                                    self.state_access.get_or_register_delta_store(
+                                        context_id,
+                                        Box::new(move || {
+                                            crate::delta_store::DeltaStore::new(
+                                                [0u8; 32],
+                                                context_client,
+                                                context_id,
+                                                our_identity,
+                                            )
+                                        }),
+                                    );
 
                                 let checkpoints_added = delta_store
                                     .add_snapshot_checkpoints(
@@ -1500,7 +1521,7 @@ impl SyncManager {
                             // Replay any buffered deltas (from uninitialized context period)
                             // This ensures handlers execute for deltas that arrived before sync completed
                             if let Some(buffered_deltas) =
-                                self.node_state.end_sync_session(&context_id)
+                                self.state_access.end_sync_session(&context_id)
                             {
                                 let buffered_count = buffered_deltas.len();
                                 if buffered_count > 0 {
@@ -1549,7 +1570,7 @@ impl SyncManager {
 
         // Check if we have pending deltas (incomplete DAG)
         // Even if node has some state, it might be missing parent deltas
-        if let Some(delta_store) = self.node_state.delta_stores.get(&context_id) {
+        if let Some(delta_store) = self.state_access.delta_store(&context_id) {
             // NOTE: previously called `load_persisted_deltas()` here to
             // catch locally-created deltas from execute.rs that are in
             // the DB but not in the in-memory DAG. That rescan was
@@ -2106,22 +2127,18 @@ impl SyncManager {
 
                 // Get or create DeltaStore for this context (do this once before the loop)
                 let (delta_store_ref, is_new) = {
-                    let mut is_new = false;
-                    let delta_store = self
-                        .node_state
-                        .delta_stores
-                        .entry(context_id)
-                        .or_insert_with(|| {
-                            is_new = true;
+                    let context_client = self.context_client.clone();
+                    self.state_access.get_or_register_delta_store(
+                        context_id,
+                        Box::new(move || {
                             crate::delta_store::DeltaStore::new(
                                 [0u8; 32],
-                                self.context_client.clone(),
+                                context_client,
                                 context_id,
                                 our_identity,
                             )
-                        });
-
-                    (delta_store.clone(), is_new)
+                        }),
+                    )
                 };
 
                 // The previous revision ran `load_persisted_deltas`
@@ -2420,14 +2437,14 @@ impl SyncManager {
             Err(e) => {
                 // Cancel sync session on failure - discard buffered deltas
                 // since the context state is inconsistent
-                self.node_state.cancel_sync_session(&context_id);
+                self.state_access.cancel_sync_session(&context_id);
                 return Err(e);
             }
         };
         info!(%context_id, records = result.applied_records, "Snapshot sync completed");
 
         // End buffering and get any deltas that arrived during sync
-        let buffered_deltas = self.node_state.end_sync_session(&context_id);
+        let buffered_deltas = self.state_access.end_sync_session(&context_id);
         let buffered_count = buffered_deltas.as_ref().map_or(0, Vec::len);
 
         if buffered_count > 0 {
@@ -2501,21 +2518,18 @@ impl SyncManager {
         // warm-store case, but a fresh store here would otherwise miss
         // everything on disk and we'd later fail to match checkpoints.
         let (delta_store, is_new) = {
-            let mut is_new = false;
-            let entry = self
-                .node_state
-                .delta_stores
-                .entry(context_id)
-                .or_insert_with(|| {
-                    is_new = true;
+            let context_client = self.context_client.clone();
+            self.state_access.get_or_register_delta_store(
+                context_id,
+                Box::new(move || {
                     crate::delta_store::DeltaStore::new(
                         [0u8; 32],
-                        self.context_client.clone(),
+                        context_client,
                         context_id,
                         our_identity,
                     )
-                });
-            (entry.clone(), is_new)
+                }),
+            )
         };
         if is_new {
             if let Err(e) = delta_store.load_persisted_deltas().await {
@@ -2643,21 +2657,18 @@ impl SyncManager {
         // warm stores are kept current by execute-side incremental
         // notifications.
         let (delta_store, is_new) = {
-            let mut is_new = false;
-            let entry = self
-                .node_state
-                .delta_stores
-                .entry(context_id)
-                .or_insert_with(|| {
-                    is_new = true;
+            let context_client = self.context_client.clone();
+            self.state_access.get_or_register_delta_store(
+                context_id,
+                Box::new(move || {
                     crate::delta_store::DeltaStore::new(
                         [0u8; 32],
-                        self.context_client.clone(),
+                        context_client,
                         context_id,
                         our_identity,
                     )
-                });
-            (entry.clone(), is_new)
+                }),
+            )
         };
         if is_new {
             if let Err(e) = delta_store.load_persisted_deltas().await {
@@ -3245,7 +3256,7 @@ impl SyncManager {
         op_kind: &'static str,
     ) {
         if let Some((remaining, failures)) =
-            reconcile_remaining_cooldown(&self.node_state.reconcile_attempts, &context_id)
+            self.state_access.reconcile_remaining_cooldown(&context_id)
         {
             tracing::debug!(
                 %context_id,
@@ -3303,30 +3314,32 @@ impl SyncManager {
         // but cache hasn't warmed yet" in the no-anchor warn below.
         let mut peers_missing_cache_entry: usize = 0;
         let mut peers_known_not_anchor: usize = 0;
-        let anchor_peer = mesh_peers.iter().copied().find(|peer| {
-            match self.node_state.peer_identities.get(peer) {
-                Some(ids) => {
-                    if ids.iter().any(|id| anchors.contains(id)) {
-                        true
-                    } else {
-                        peers_known_not_anchor += 1;
+        let anchor_peer =
+            mesh_peers
+                .iter()
+                .copied()
+                .find(|peer| match self.state_access.peer_identities(peer) {
+                    Some(ids) => {
+                        if ids.iter().any(|id| anchors.contains(id)) {
+                            true
+                        } else {
+                            peers_known_not_anchor += 1;
+                            false
+                        }
+                    }
+                    None => {
+                        peers_missing_cache_entry += 1;
+                        tracing::debug!(
+                            %context_id,
+                            %peer,
+                            op_kind,
+                            "reconcile-after-divergence: mesh peer skipped — no peer_identities \
+                             cache entry yet (peer has not been observed signing a verified \
+                             message); cache warms as the peer's signed traffic is processed"
+                        );
                         false
                     }
-                }
-                None => {
-                    peers_missing_cache_entry += 1;
-                    tracing::debug!(
-                        %context_id,
-                        %peer,
-                        op_kind,
-                        "reconcile-after-divergence: mesh peer skipped — no peer_identities \
-                         cache entry yet (peer has not been observed signing a verified \
-                         message); cache warms as the peer's signed traffic is processed"
-                    );
-                    false
-                }
-            }
-        });
+                });
         let Some(anchor_peer) = anchor_peer else {
             tracing::warn!(
                 %context_id,
@@ -3370,10 +3383,9 @@ impl SyncManager {
                     op_kind,
                 );
                 if converged {
-                    record_reconcile_success(&self.node_state.reconcile_attempts, &context_id);
+                    self.state_access.record_reconcile_success(&context_id);
                 } else {
-                    let failures =
-                        record_reconcile_failure(&self.node_state.reconcile_attempts, context_id);
+                    let failures = self.state_access.record_reconcile_failure(context_id);
                     tracing::warn!(
                         %context_id,
                         op_kind,
@@ -3385,8 +3397,7 @@ impl SyncManager {
                 }
             }
             Err(err) => {
-                let failures =
-                    record_reconcile_failure(&self.node_state.reconcile_attempts, context_id);
+                let failures = self.state_access.record_reconcile_failure(context_id);
                 tracing::warn!(
                     %context_id,
                     %anchor_peer,
@@ -3481,7 +3492,7 @@ pub(crate) fn reconcile_cooldown(consecutive_failures: u32) -> std::time::Durati
 /// its cooldown window, return `Some((remaining_cooldown,
 /// consecutive_failures))`. Otherwise — no entry, or the cooldown has
 /// elapsed — return `None`.
-fn reconcile_remaining_cooldown(
+pub(crate) fn reconcile_remaining_cooldown(
     attempts: &dashmap::DashMap<ContextId, crate::state::ReconcileAttempt>,
     context_id: &ContextId,
 ) -> Option<(std::time::Duration, u32)> {
@@ -3500,7 +3511,7 @@ fn reconcile_remaining_cooldown(
 /// `consecutive_failures` and stamp `last_attempt_at = now`. Returns
 /// the new failure count so the caller can log the next cooldown
 /// directly.
-fn record_reconcile_failure(
+pub(crate) fn record_reconcile_failure(
     attempts: &dashmap::DashMap<ContextId, crate::state::ReconcileAttempt>,
     context_id: ContextId,
 ) -> u32 {
@@ -3517,7 +3528,7 @@ fn record_reconcile_failure(
 
 /// Clear backoff state for `context_id` after a successful reconcile.
 /// Subsequent divergences are treated as fresh — no inherited cooldown.
-fn record_reconcile_success(
+pub(crate) fn record_reconcile_success(
     attempts: &dashmap::DashMap<ContextId, crate::state::ReconcileAttempt>,
     context_id: &ContextId,
 ) {
@@ -3546,10 +3557,7 @@ fn record_reconcile_success(
 /// synthetic inputs without spinning up a sync manager.
 fn partition_peers_anchor_first(
     peers: &mut [libp2p::PeerId],
-    peer_identities: &dashmap::DashMap<
-        libp2p::PeerId,
-        std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
-    >,
+    state_access: &dyn super::state_access::SyncStateAccess,
     anchors: &std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
 ) -> usize {
     if anchors.is_empty() {
@@ -3558,8 +3566,8 @@ fn partition_peers_anchor_first(
     let anchor_flags: Vec<bool> = peers
         .iter()
         .map(|peer| {
-            peer_identities
-                .get(peer)
+            state_access
+                .peer_identities(peer)
                 .map(|ids| ids.iter().any(|id| anchors.contains(id)))
                 .unwrap_or(false)
         })

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3469,7 +3469,7 @@ impl SyncManager {
 /// - 7+ failures → 30m (cap)
 ///
 /// Free function so backoff math can be unit-tested independently.
-fn reconcile_cooldown(consecutive_failures: u32) -> std::time::Duration {
+pub(crate) fn reconcile_cooldown(consecutive_failures: u32) -> std::time::Duration {
     const BASE_SECS: u64 = 30;
     const MAX: std::time::Duration = std::time::Duration::from_secs(30 * 60);
     let exp = consecutive_failures.saturating_sub(1).min(8);

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -357,6 +357,23 @@ use libp2p::PeerId;
 
 use super::partition_peers_anchor_first;
 
+/// Build a `NodeState` populated with the given `(peer, identities)`
+/// pairs in its `peer_identities` cache and nothing else, so the
+/// `SyncStateAccess` impl on `NodeState` can serve the partition
+/// tests without standing up the full node. The remaining trait
+/// methods are unreachable from `partition_peers_anchor_first` —
+/// it only calls `peer_identities` — so leaving them at their
+/// default (empty) state is safe.
+fn node_state_with_peer_identities(
+    entries: impl IntoIterator<Item = (PeerId, BTreeSet<PublicKey>)>,
+) -> crate::state::NodeState {
+    let node_state = crate::state::NodeState::new(false, crate::run::NodeMode::Standard);
+    for (peer, ids) in entries {
+        let _replaced = node_state.peer_identities.insert(peer, ids);
+    }
+    node_state
+}
+
 fn dummy_peer(n: u8) -> PeerId {
     // Deterministic peer-id keyed by a single byte — only equality
     // matters here, not the byte structure.
@@ -373,10 +390,10 @@ fn dummy_pk(n: u8) -> PublicKey {
 fn partition_empty_anchors_set_returns_zero() {
     // No anchor set defined → no preference; every peer is non-anchor.
     let mut peers = vec![dummy_peer(1), dummy_peer(2), dummy_peer(3)];
-    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let node_state = node_state_with_peer_identities([]);
     let anchors: BTreeSet<PublicKey> = BTreeSet::new();
 
-    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    let count = partition_peers_anchor_first(&mut peers, &node_state, &anchors);
     assert_eq!(count, 0);
 }
 
@@ -386,10 +403,10 @@ fn partition_empty_cache_no_anchors_found() {
     // non-anchor; relative order preserved.
     let mut peers = vec![dummy_peer(1), dummy_peer(2)];
     let original = peers.clone();
-    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
+    let node_state = node_state_with_peer_identities([]);
     let anchors: BTreeSet<PublicKey> = [dummy_pk(0xAA)].into_iter().collect();
 
-    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    let count = partition_peers_anchor_first(&mut peers, &node_state, &anchors);
     assert_eq!(count, 0);
     assert_eq!(peers, original);
 }
@@ -399,13 +416,14 @@ fn partition_all_peers_are_anchors() {
     let peer1 = dummy_peer(1);
     let peer2 = dummy_peer(2);
     let pk_admin = dummy_pk(0xAA);
-    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
-    let _replaced = cache.insert(peer1, [pk_admin].into_iter().collect());
-    let _replaced = cache.insert(peer2, [pk_admin].into_iter().collect());
+    let node_state = node_state_with_peer_identities([
+        (peer1, [pk_admin].into_iter().collect()),
+        (peer2, [pk_admin].into_iter().collect()),
+    ]);
     let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
 
     let mut peers = vec![peer1, peer2];
-    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    let count = partition_peers_anchor_first(&mut peers, &node_state, &anchors);
     assert_eq!(count, 2);
     assert_eq!(peers, vec![peer1, peer2]);
 }
@@ -418,15 +436,16 @@ fn partition_mixed_anchor_and_non_anchor_preserves_relative_order() {
     let plain_b = dummy_peer(4);
     let pk_admin = dummy_pk(0xAA);
 
-    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
-    let _replaced = cache.insert(anchor_a, [pk_admin].into_iter().collect());
-    let _replaced = cache.insert(anchor_b, [pk_admin].into_iter().collect());
+    let node_state = node_state_with_peer_identities([
+        (anchor_a, [pk_admin].into_iter().collect()),
+        (anchor_b, [pk_admin].into_iter().collect()),
+    ]);
 
     let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
 
     // Pre-shuffled order interleaves the two partitions.
     let mut peers = vec![plain_a, anchor_a, plain_b, anchor_b];
-    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    let count = partition_peers_anchor_first(&mut peers, &node_state, &anchors);
     assert_eq!(count, 2);
     // Anchors first (anchor_a before anchor_b, preserved from input),
     // then non-anchors (plain_a before plain_b, preserved).
@@ -441,13 +460,15 @@ fn partition_peer_with_one_anchor_identity_among_many_qualifies() {
     let pk_admin = dummy_pk(0xAA);
     let pk_other_context = dummy_pk(0xBB);
 
-    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
-    let _replaced = cache.insert(peer, [pk_admin, pk_other_context].into_iter().collect());
+    let node_state = node_state_with_peer_identities([(
+        peer,
+        [pk_admin, pk_other_context].into_iter().collect(),
+    )]);
 
     let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
 
     let mut peers = vec![peer];
-    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    let count = partition_peers_anchor_first(&mut peers, &node_state, &anchors);
     assert_eq!(count, 1);
 }
 
@@ -457,13 +478,12 @@ fn partition_peer_with_only_non_anchor_identities_does_not_qualify() {
     let pk_member = dummy_pk(0xCC);
     let pk_admin = dummy_pk(0xAA);
 
-    let cache: DashMap<PeerId, BTreeSet<PublicKey>> = DashMap::new();
-    let _replaced = cache.insert(peer, [pk_member].into_iter().collect());
+    let node_state = node_state_with_peer_identities([(peer, [pk_member].into_iter().collect())]);
 
     let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
 
     let mut peers = vec![peer];
-    let count = partition_peers_anchor_first(&mut peers, &cache, &anchors);
+    let count = partition_peers_anchor_first(&mut peers, &node_state, &anchors);
     assert_eq!(count, 0);
 }
 

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -487,6 +487,50 @@ fn partition_peer_with_only_non_anchor_identities_does_not_qualify() {
     assert_eq!(count, 0);
 }
 
+/// `partition_peers_anchor_first` works against any
+/// `SyncStateAccess` impl, not just `NodeState`. This test exercises
+/// the same partition behaviour using the `MockSyncStateAccess`
+/// fixture — a pure unit test surface for the partition helper that
+/// could be extended to higher-level sync code as more dependencies
+/// become mockable.
+///
+/// Pinning this demonstrates the test surface promised in the
+/// trait's doc: `sync/` code that goes through `SyncStateAccess`
+/// can be exercised without a `NodeState` at all.
+#[test]
+fn partition_works_against_mock_sync_state_access() {
+    use crate::sync::state_access_mock::{MockSyncStateAccess, SyncStateAccessCall};
+
+    let anchor_peer = dummy_peer(1);
+    let plain_peer = dummy_peer(2);
+    let pk_admin = dummy_pk(0xAA);
+
+    let mock = MockSyncStateAccess::default();
+    mock.insert_peer_identities(anchor_peer, [pk_admin].into_iter().collect());
+
+    let anchors: BTreeSet<PublicKey> = [pk_admin].into_iter().collect();
+
+    let mut peers = vec![plain_peer, anchor_peer];
+    let count = partition_peers_anchor_first(&mut peers, &mock, &anchors);
+    assert_eq!(count, 1, "exactly one anchor in the input");
+    assert_eq!(
+        peers,
+        vec![anchor_peer, plain_peer],
+        "anchor should come first"
+    );
+
+    // Both peer-identity lookups should have been observed in order.
+    let calls = mock.calls();
+    assert_eq!(
+        calls,
+        vec![
+            SyncStateAccessCall::PeerIdentities(plain_peer),
+            SyncStateAccessCall::PeerIdentities(anchor_peer),
+        ],
+        "partition should query peer_identities exactly once per input peer, in order"
+    );
+}
+
 // =========================================================================
 // `reconcile_cooldown` / `record_reconcile_*` — backoff for the
 // reconcile-after-divergence path

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -47,6 +47,8 @@ pub mod prometheus_metrics;
 pub mod rotation_log_reader;
 mod snapshot;
 pub(crate) mod state_access;
+#[cfg(test)]
+pub(crate) mod state_access_mock;
 pub(crate) mod stream;
 mod tracking;
 

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -46,6 +46,7 @@ pub(crate) mod parent_pull;
 pub mod prometheus_metrics;
 pub mod rotation_log_reader;
 mod snapshot;
+pub(crate) mod state_access;
 pub(crate) mod stream;
 mod tracking;
 
@@ -66,6 +67,7 @@ pub use hash_comparison_protocol::{
     HashComparisonConfig, HashComparisonFirstRequest, HashComparisonProtocol, HashComparisonStats,
 };
 pub use level_sync::{LevelWiseConfig, LevelWiseFirstRequest, LevelWiseProtocol, LevelWiseStats};
+pub(crate) use manager::reconcile_cooldown;
 pub use manager::SyncManager;
 pub use metrics::{no_op_metrics, NoOpMetrics, PhaseTimer, SharedMetrics, SyncMetricsCollector};
 pub use prometheus_metrics::PrometheusSyncMetrics;

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -70,6 +70,14 @@ pub use hash_comparison_protocol::{
 };
 pub use level_sync::{LevelWiseConfig, LevelWiseFirstRequest, LevelWiseProtocol, LevelWiseStats};
 pub use manager::SyncManager;
+// `mod manager` is private to `sync/`; these `pub(crate)` re-exports
+// are the *only* way for `crate::state` to reach the reconcile-attempt
+// helpers from its `SyncStateAccess` impl on `NodeState`. The helpers
+// can't be inlined into `state.rs` without duplicating the logic that
+// the dedicated tests in `sync/manager/tests.rs` already cover
+// against synthetic `DashMap` inputs. Keeping the helpers as
+// implementation details of `sync::manager` and exposing them via
+// these narrow re-exports preserves both surfaces.
 pub(crate) use manager::{
     reconcile_cooldown, reconcile_remaining_cooldown, record_reconcile_failure,
     record_reconcile_success,

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -67,7 +67,10 @@ pub use hash_comparison_protocol::{
     HashComparisonConfig, HashComparisonFirstRequest, HashComparisonProtocol, HashComparisonStats,
 };
 pub use level_sync::{LevelWiseConfig, LevelWiseFirstRequest, LevelWiseProtocol, LevelWiseStats};
-pub(crate) use manager::reconcile_cooldown;
 pub use manager::SyncManager;
+pub(crate) use manager::{
+    reconcile_cooldown, reconcile_remaining_cooldown, record_reconcile_failure,
+    record_reconcile_success,
+};
 pub use metrics::{no_op_metrics, NoOpMetrics, PhaseTimer, SharedMetrics, SyncMetricsCollector};
 pub use prometheus_metrics::PrometheusSyncMetrics;

--- a/crates/node/src/sync/state_access.rs
+++ b/crates/node/src/sync/state_access.rs
@@ -1,0 +1,92 @@
+//! Trait abstraction for the subset of `NodeState` that `sync/` reads
+//! and mutates.
+//!
+//! Why this exists: `sync/` used to reach directly into `NodeState`'s
+//! fields (`delta_stores`, `peer_identities`, `reconcile_attempts`)
+//! and call its methods (`end_sync_session`, `cancel_sync_session`).
+//! That coupling made the sync module impossible to unit-test without
+//! standing up a full `NodeManager` — every interesting failure mode
+//! had to be engineered as an integration test against the real actor
+//! stack. The trait inverts the dependency: `sync/` knows only this
+//! interface, and `NodeState` implements it. Tests can substitute a
+//! recording fake (`MockSyncStateAccess`) and exercise sync paths in
+//! isolation.
+//!
+//! Scope: data access only. Behavioural concerns that already have a
+//! trait (network in [`crate::sync::network::SyncNetwork`], storage in
+//! [`calimero_storage::store`]) stay in their own traits. Cross-actor
+//! function calls (the lone `crate::handlers::state_delta::replay_buffered_delta`
+//! call site) are out of scope here — pass a closure to that call site
+//! or convert it to an actor message in a follow-up.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use calimero_node_primitives::delta_buffer::BufferedDelta;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use libp2p::PeerId;
+
+use crate::delta_store::DeltaStore;
+
+/// Access surface from `sync/` into `NodeState`.
+///
+/// The methods here are the entire set of `NodeState` touchpoints
+/// the sync module needs. Every call to `self.node_state.<field>` or
+/// `self.node_state.<method>` inside `sync/` goes through this
+/// trait; that's enforced by `sync/` only depending on `&dyn
+/// SyncStateAccess`, never on the concrete `NodeState`.
+pub(crate) trait SyncStateAccess: Send + Sync {
+    /// Look up the [`DeltaStore`] registered for `context_id`.
+    ///
+    /// Returns `None` if no sync has been initiated for that context
+    /// yet — the store is lazily created on first sync.
+    fn delta_store(&self, context_id: &ContextId) -> Option<DeltaStore>;
+
+    /// Register a freshly-constructed [`DeltaStore`] for `context_id`.
+    ///
+    /// Overwrites any prior registration. Called from sync paths that
+    /// realise a context is new (first interval sync, first reconcile,
+    /// first DAG catchup).
+    fn register_delta_store(&self, context_id: ContextId, store: DeltaStore);
+
+    /// End the active sync session for `context_id` and return any
+    /// deltas the session buffered.
+    ///
+    /// Returns `None` if no session was active (caller already handled
+    /// session end or it was never started). See
+    /// `NodeState::end_sync_session` for the buffer-drop diagnostics
+    /// the production impl emits on session end with leftover deltas.
+    fn end_sync_session(&self, context_id: &ContextId) -> Option<Vec<BufferedDelta>>;
+
+    /// Cancel the active sync session for `context_id` and discard
+    /// buffered deltas without surfacing them. Called on sync failure
+    /// where the in-flight deltas can't be replayed safely.
+    fn cancel_sync_session(&self, context_id: &ContextId);
+
+    /// Identities `peer_id` has been observed signing applied messages
+    /// with.
+    ///
+    /// Returns `None` if the peer has never been observed. The
+    /// returned set is a clone — callers iterate it without holding
+    /// the underlying `DashMap` shard lock.
+    fn peer_identities(&self, peer_id: &PeerId) -> Option<BTreeSet<PublicKey>>;
+
+    /// Remaining cooldown for the reconcile-after-divergence path on
+    /// `context_id`, plus the current `consecutive_failures` count.
+    ///
+    /// Returns `None` if either no failure has been recorded or the
+    /// cooldown has elapsed — both interpreted as "reconcile is
+    /// allowed right now."
+    fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)>;
+
+    /// Clear backoff state for `context_id` after a successful
+    /// reconcile. The next divergence is treated as a fresh attempt.
+    fn record_reconcile_success(&self, context_id: &ContextId);
+
+    /// Record a reconcile failure for `context_id`: bump
+    /// `consecutive_failures`, stamp `last_attempt_at = now`. Returns
+    /// the new failure count so the caller can compute the next
+    /// cooldown directly.
+    fn record_reconcile_failure(&self, context_id: ContextId) -> u32;
+}

--- a/crates/node/src/sync/state_access.rs
+++ b/crates/node/src/sync/state_access.rs
@@ -43,12 +43,23 @@ pub(crate) trait SyncStateAccess: Send + Sync {
     /// yet — the store is lazily created on first sync.
     fn delta_store(&self, context_id: &ContextId) -> Option<DeltaStore>;
 
-    /// Register a freshly-constructed [`DeltaStore`] for `context_id`.
+    /// Atomic get-or-insert: return the [`DeltaStore`] for
+    /// `context_id` paired with a flag that's `true` iff this call
+    /// created the entry. The factory closure runs only on the
+    /// create path, atomic under the storage's internal lock — so
+    /// the `was_newly_created` bool is reliable for one-time setup
+    /// (e.g. hydrating the freshly-created store from disk).
     ///
-    /// Overwrites any prior registration. Called from sync paths that
-    /// realise a context is new (first interval sync, first reconcile,
-    /// first DAG catchup).
-    fn register_delta_store(&self, context_id: ContextId, store: DeltaStore);
+    /// The factory is `Box<dyn FnOnce ... + Send>` because trait
+    /// methods on a `dyn`-compatible trait can't be generic over the
+    /// closure type; the heap allocation runs at most once per
+    /// context per process lifetime (only on first sync for a
+    /// context).
+    fn get_or_register_delta_store(
+        &self,
+        context_id: ContextId,
+        factory: Box<dyn FnOnce() -> DeltaStore + Send>,
+    ) -> (DeltaStore, bool);
 
     /// End the active sync session for `context_id` and return any
     /// deltas the session buffered.

--- a/crates/node/src/sync/state_access_mock.rs
+++ b/crates/node/src/sync/state_access_mock.rs
@@ -1,0 +1,241 @@
+//! Scriptable mock for [`super::state_access::SyncStateAccess`].
+//!
+//! Records every trait-method call and lets tests inject specific
+//! return values per-context or per-peer. Drop-in for `Arc<dyn
+//! SyncStateAccess>` in sync's `SyncManager.state_access` field, so
+//! tests can drive `SyncManager` paths without standing up a full
+//! `NodeManager` + `NodeState`.
+//!
+//! Counterpart to [`crate::sync::network::mock::MockSyncNetwork`] —
+//! same `parking_lot::Mutex` choice (never poisons on panic), same
+//! drop-in pattern. Together they cover the two non-storage,
+//! non-protocol surfaces a `SyncManager` reaches into.
+
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::time::Duration;
+
+use calimero_node_primitives::delta_buffer::BufferedDelta;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use libp2p::PeerId;
+use parking_lot::Mutex;
+
+use super::state_access::SyncStateAccess;
+use crate::delta_store::DeltaStore;
+
+/// Record of a single trait-method call. Useful for asserting
+/// what the code under test asked for, in what order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SyncStateAccessCall {
+    DeltaStore(ContextId),
+    GetOrRegisterDeltaStore {
+        context_id: ContextId,
+        created: bool,
+    },
+    EndSyncSession(ContextId),
+    CancelSyncSession(ContextId),
+    PeerIdentities(PeerId),
+    ReconcileRemainingCooldown(ContextId),
+    RecordReconcileSuccess(ContextId),
+    RecordReconcileFailure(ContextId),
+}
+
+/// Scriptable `SyncStateAccess` fixture. All getters return `None`
+/// (or `0` for the reconcile-failure counter) by default; tests
+/// override per-key behaviour via the `set_*` / `push_*` helpers
+/// below.
+#[derive(Default)]
+pub(crate) struct MockSyncStateAccess {
+    delta_stores: Mutex<HashMap<ContextId, DeltaStore>>,
+    peer_identities: Mutex<HashMap<PeerId, BTreeSet<PublicKey>>>,
+    end_sync_session_responses: Mutex<HashMap<ContextId, VecDeque<Option<Vec<BufferedDelta>>>>>,
+    reconcile_cooldowns: Mutex<HashMap<ContextId, (Duration, u32)>>,
+    failure_counts: Mutex<HashMap<ContextId, u32>>,
+    calls: Mutex<Vec<SyncStateAccessCall>>,
+}
+
+impl MockSyncStateAccess {
+    /// Register a `DeltaStore` so subsequent `delta_store(ctx)` calls
+    /// return it (rather than `None`) and `get_or_register_delta_store`
+    /// reports `created=false`.
+    pub(crate) fn insert_delta_store(&self, context_id: ContextId, store: DeltaStore) {
+        let _replaced = self.delta_stores.lock().insert(context_id, store);
+    }
+
+    /// Inject a `peer_identities` response for `peer`.
+    pub(crate) fn insert_peer_identities(&self, peer: PeerId, ids: BTreeSet<PublicKey>) {
+        let _replaced = self.peer_identities.lock().insert(peer, ids);
+    }
+
+    /// Queue a response for the next `end_sync_session(ctx)` call.
+    /// Returns are popped FIFO per `context_id`; once exhausted the
+    /// method returns `None`.
+    pub(crate) fn push_end_sync_session_response(
+        &self,
+        context_id: ContextId,
+        response: Option<Vec<BufferedDelta>>,
+    ) {
+        self.end_sync_session_responses
+            .lock()
+            .entry(context_id)
+            .or_default()
+            .push_back(response);
+    }
+
+    /// Pre-set the cooldown that `reconcile_remaining_cooldown(ctx)`
+    /// returns. The mock does not advance time; the test owns the
+    /// observed value end-to-end.
+    pub(crate) fn set_reconcile_cooldown(
+        &self,
+        context_id: ContextId,
+        cooldown: Duration,
+        consecutive_failures: u32,
+    ) {
+        let _replaced = self
+            .reconcile_cooldowns
+            .lock()
+            .insert(context_id, (cooldown, consecutive_failures));
+    }
+
+    /// Snapshot of every trait-method call observed so far, in order.
+    /// Tests can assert on this directly.
+    pub(crate) fn calls(&self) -> Vec<SyncStateAccessCall> {
+        self.calls.lock().clone()
+    }
+}
+
+impl SyncStateAccess for MockSyncStateAccess {
+    fn delta_store(&self, context_id: &ContextId) -> Option<DeltaStore> {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::DeltaStore(*context_id));
+        self.delta_stores.lock().get(context_id).cloned()
+    }
+
+    fn get_or_register_delta_store(
+        &self,
+        context_id: ContextId,
+        factory: Box<dyn FnOnce() -> DeltaStore + Send>,
+    ) -> (DeltaStore, bool) {
+        let mut stores = self.delta_stores.lock();
+        match stores.get(&context_id) {
+            Some(existing) => {
+                let store = existing.clone();
+                drop(stores);
+                self.calls
+                    .lock()
+                    .push(SyncStateAccessCall::GetOrRegisterDeltaStore {
+                        context_id,
+                        created: false,
+                    });
+                (store, false)
+            }
+            None => {
+                let store = factory();
+                let _replaced = stores.insert(context_id, store.clone());
+                drop(stores);
+                self.calls
+                    .lock()
+                    .push(SyncStateAccessCall::GetOrRegisterDeltaStore {
+                        context_id,
+                        created: true,
+                    });
+                (store, true)
+            }
+        }
+    }
+
+    fn end_sync_session(&self, context_id: &ContextId) -> Option<Vec<BufferedDelta>> {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::EndSyncSession(*context_id));
+        self.end_sync_session_responses
+            .lock()
+            .get_mut(context_id)
+            .and_then(|q| q.pop_front())
+            .unwrap_or(None)
+    }
+
+    fn cancel_sync_session(&self, context_id: &ContextId) {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::CancelSyncSession(*context_id));
+    }
+
+    fn peer_identities(&self, peer_id: &PeerId) -> Option<BTreeSet<PublicKey>> {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::PeerIdentities(*peer_id));
+        self.peer_identities.lock().get(peer_id).cloned()
+    }
+
+    fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::ReconcileRemainingCooldown(*context_id));
+        self.reconcile_cooldowns.lock().get(context_id).copied()
+    }
+
+    fn record_reconcile_success(&self, context_id: &ContextId) {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::RecordReconcileSuccess(*context_id));
+        let _ = self.reconcile_cooldowns.lock().remove(context_id);
+        let _ = self.failure_counts.lock().remove(context_id);
+    }
+
+    fn record_reconcile_failure(&self, context_id: ContextId) -> u32 {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::RecordReconcileFailure(context_id));
+        let mut counts = self.failure_counts.lock();
+        let entry = counts.entry(context_id).or_insert(0);
+        *entry = entry.saturating_add(1);
+        *entry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(byte: u8) -> ContextId {
+        ContextId::from([byte; 32])
+    }
+
+    #[test]
+    fn defaults_return_none_or_zero_and_calls_are_recorded() {
+        let mock = MockSyncStateAccess::default();
+        assert!(mock.delta_store(&ctx(1)).is_none());
+        assert!(mock.end_sync_session(&ctx(1)).is_none());
+        assert!(mock.peer_identities(&PeerId::random()).is_none());
+        assert!(mock.reconcile_remaining_cooldown(&ctx(2)).is_none());
+        assert_eq!(mock.record_reconcile_failure(ctx(2)), 1);
+        assert_eq!(mock.record_reconcile_failure(ctx(2)), 2);
+        assert_eq!(mock.record_reconcile_failure(ctx(3)), 1);
+        // record_reconcile_success clears the count.
+        mock.record_reconcile_success(&ctx(2));
+        assert_eq!(mock.record_reconcile_failure(ctx(2)), 1);
+
+        let calls = mock.calls();
+        assert!(matches!(
+            calls.first(),
+            Some(SyncStateAccessCall::DeltaStore(_))
+        ));
+        // Order preserved.
+        assert!(calls.windows(2).all(|w| w[0] != w[1] || true));
+    }
+
+    #[test]
+    fn end_sync_session_responses_pop_per_context_fifo() {
+        let mock = MockSyncStateAccess::default();
+        mock.push_end_sync_session_response(ctx(1), Some(vec![]));
+        mock.push_end_sync_session_response(ctx(1), None);
+        // First call returns the queued Some.
+        assert!(mock.end_sync_session(&ctx(1)).is_some());
+        // Second call returns the queued None.
+        assert!(mock.end_sync_session(&ctx(1)).is_none());
+        // Third call (exhausted) returns None by default.
+        assert!(mock.end_sync_session(&ctx(1)).is_none());
+    }
+}

--- a/crates/node/src/sync/state_access_mock.rs
+++ b/crates/node/src/sync/state_access_mock.rs
@@ -22,6 +22,7 @@ use parking_lot::Mutex;
 
 use super::state_access::SyncStateAccess;
 use crate::delta_store::DeltaStore;
+use crate::sync::reconcile_cooldown;
 
 /// Record of a single trait-method call. Useful for asserting
 /// what the code under test asked for, in what order.
@@ -69,7 +70,10 @@ impl MockSyncStateAccess {
 
     /// Queue a response for the next `end_sync_session(ctx)` call.
     /// Returns are popped FIFO per `context_id`; once exhausted the
-    /// method returns `None`.
+    /// method returns `None`. **Note**: a queued `None` and the
+    /// exhausted-queue case both return `None` from `end_sync_session`
+    /// — tests that need to distinguish the two should also assert
+    /// on `calls()` length, not just the return value.
     pub(crate) fn push_end_sync_session_response(
         &self,
         context_id: ContextId,
@@ -84,7 +88,12 @@ impl MockSyncStateAccess {
 
     /// Pre-set the cooldown that `reconcile_remaining_cooldown(ctx)`
     /// returns. The mock does not advance time; the test owns the
-    /// observed value end-to-end.
+    /// observed value end-to-end. Useful when a test wants to start
+    /// in a pre-existing-cooldown state without driving N failures
+    /// to get there; otherwise prefer calling `record_reconcile_failure`
+    /// directly — that path now installs a cooldown the same way the
+    /// production impl does (see [`SyncStateAccess::record_reconcile_failure`]'s
+    /// mock body).
     pub(crate) fn set_reconcile_cooldown(
         &self,
         context_id: ContextId,
@@ -117,29 +126,33 @@ impl SyncStateAccess for MockSyncStateAccess {
         context_id: ContextId,
         factory: Box<dyn FnOnce() -> DeltaStore + Send>,
     ) -> (DeltaStore, bool) {
+        // Record the call *before* releasing the stores lock so a
+        // concurrent reader of `calls()` can never observe an inserted
+        // store without the matching log entry. Matches the call-then-
+        // return ordering of every other trait method in this impl.
         let mut stores = self.delta_stores.lock();
         match stores.get(&context_id) {
             Some(existing) => {
                 let store = existing.clone();
-                drop(stores);
                 self.calls
                     .lock()
                     .push(SyncStateAccessCall::GetOrRegisterDeltaStore {
                         context_id,
                         created: false,
                     });
+                drop(stores);
                 (store, false)
             }
             None => {
                 let store = factory();
                 let _replaced = stores.insert(context_id, store.clone());
-                drop(stores);
                 self.calls
                     .lock()
                     .push(SyncStateAccessCall::GetOrRegisterDeltaStore {
                         context_id,
                         created: true,
                     });
+                drop(stores);
                 (store, true)
             }
         }
@@ -191,7 +204,21 @@ impl SyncStateAccess for MockSyncStateAccess {
         let mut counts = self.failure_counts.lock();
         let entry = counts.entry(context_id).or_insert(0);
         *entry = entry.saturating_add(1);
-        *entry
+        let failures = *entry;
+        drop(counts);
+        // Mirror production: a failure also installs a cooldown
+        // computed from the new `consecutive_failures`. Without this,
+        // `reconcile_remaining_cooldown` would return `None` after a
+        // failure (because the cooldowns map is only populated via
+        // explicit `set_reconcile_cooldown`), which diverges from the
+        // real `NodeState` impl where one DashMap holds both fields
+        // of `ReconcileAttempt` together.
+        let cooldown = reconcile_cooldown(failures);
+        let _replaced = self
+            .reconcile_cooldowns
+            .lock()
+            .insert(context_id, (cooldown, failures));
+        failures
     }
 }
 
@@ -209,21 +236,29 @@ mod tests {
         assert!(mock.delta_store(&ctx(1)).is_none());
         assert!(mock.end_sync_session(&ctx(1)).is_none());
         assert!(mock.peer_identities(&PeerId::random()).is_none());
+        // Cooldown is None until a failure (or explicit
+        // `set_reconcile_cooldown`) installs one.
         assert!(mock.reconcile_remaining_cooldown(&ctx(2)).is_none());
         assert_eq!(mock.record_reconcile_failure(ctx(2)), 1);
+        // The first failure installs a cooldown — `reconcile_remaining_cooldown`
+        // returns Some, mirroring production behaviour.
+        assert!(mock.reconcile_remaining_cooldown(&ctx(2)).is_some());
         assert_eq!(mock.record_reconcile_failure(ctx(2)), 2);
         assert_eq!(mock.record_reconcile_failure(ctx(3)), 1);
-        // record_reconcile_success clears the count.
+        // record_reconcile_success clears the count and the cooldown.
         mock.record_reconcile_success(&ctx(2));
+        assert!(mock.reconcile_remaining_cooldown(&ctx(2)).is_none());
         assert_eq!(mock.record_reconcile_failure(ctx(2)), 1);
 
+        // `calls()` records every trait-method invocation in order;
+        // tests can pattern-match the full sequence to assert
+        // ordering. Sanity-check the first entry; assertion shapes
+        // for specific sequences belong in higher-level tests.
         let calls = mock.calls();
         assert!(matches!(
             calls.first(),
             Some(SyncStateAccessCall::DeltaStore(_))
         ));
-        // Order preserved.
-        assert!(calls.windows(2).all(|w| w[0] != w[1] || true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2312. Defines a `SyncStateAccess` trait (named per design discussion — alternative to the issue's "SyncDeps" proposal) that captures every interaction `sync/` has with `NodeState`, routes every call site through the trait, and adds a `MockSyncStateAccess` test fixture so sync paths can be exercised without a full `NodeManager`.

## Commit sequence

1. **C1** `feat(node/sync): define SyncStateAccess trait + impl on NodeState` — scaffolding only, no use sites changed.
2. **C2** `feat(node/sync): route sync's NodeState access through SyncStateAccess` — migrates every `self.node_state.<field/method>` call inside `sync/` to go through the trait. Adds `state_access: Arc<dyn SyncStateAccess>` to `SyncManager` alongside the existing concrete `node_state` field; the concrete one is kept ONLY for the cross-actor `replay_buffered_delta` handoff (which uses a richer surface than the trait exposes; carved out per the spike on #2311).
3. **C3** `test(node/sync): scriptable MockSyncStateAccess fixture` — recording fake implementing the trait, drop-in for `Arc<dyn SyncStateAccess>`. Behind `#[cfg(test)]`. Mirrors `MockSyncNetwork`'s style.
4. **C4** `test(node/sync): demonstrate MockSyncStateAccess substitutability` — one partition test exercised against the mock instead of `NodeState`, proves the test surface works end-to-end.

## Trait shape (final)

```rust
pub(crate) trait SyncStateAccess: Send + Sync {
    fn delta_store(&self, ctx: &ContextId) -> Option<DeltaStore>;
    fn get_or_register_delta_store(
        &self,
        ctx: ContextId,
        factory: Box<dyn FnOnce() -> DeltaStore + Send>,
    ) -> (DeltaStore, bool); // (store, was_newly_created)
    fn end_sync_session(&self, ctx: &ContextId) -> Option<Vec<BufferedDelta>>;
    fn cancel_sync_session(&self, ctx: &ContextId);
    fn peer_identities(&self, peer: &PeerId) -> Option<BTreeSet<PublicKey>>;
    fn reconcile_remaining_cooldown(&self, ctx: &ContextId) -> Option<(Duration, u32)>;
    fn record_reconcile_success(&self, ctx: &ContextId);
    fn record_reconcile_failure(&self, ctx: ContextId) -> u32;
}
```

8 methods covering: delta-store lookup & atomic create, sync-session lifecycle, peer-identities cache read, reconcile-attempt state machine.

## What changed in `sync/`

- `self.node_state.end_sync_session(...)` → `self.state_access.end_sync_session(...)` (2 sites)
- `self.node_state.cancel_sync_session(...)` → `self.state_access.cancel_sync_session(...)` (1 site)
- `self.node_state.peer_identities.get(...)` → `self.state_access.peer_identities(...)` (1 site)
- `self.node_state.delta_stores.get(...)` → `self.state_access.delta_store(...)` (2 sites including `delta_request.rs`)
- `self.node_state.delta_stores.entry().or_insert_with()` → `self.state_access.get_or_register_delta_store(ctx, Box::new(...))` (4 sites)
- 3× reconcile_* free-function calls → equivalent trait methods (3 sites)
- `partition_peers_anchor_first(&mut peers, &DashMap<...>, &anchors)` → `partition_peers_anchor_first(&mut peers, &dyn SyncStateAccess, &anchors)`

After this PR `sync/` no longer directly reads any `NodeState` field. The lone `self.node_state.clone()` (for the cross-actor `replay_buffered_delta` handoff) is documented as a deliberate carve-out.

## Done-when criteria from #2312

- [x] All `crate::state::*` / `crate::delta_store::*` references inside `sync/` go through `SyncStateAccess` (except the carved-out cross-actor call, documented)
- [x] `NodeState` implements `SyncStateAccess`
- [x] Test infrastructure has a mock `SyncStateAccess` impl (`MockSyncStateAccess`)
- [x] `cargo test -p calimero-node` green
- [x] One unit test converted to use the mock (`partition_works_against_mock_sync_state_access`)

## Test plan

- [x] `cargo test -p calimero-node` — 172 + 308 + smaller bins all pass
- [x] `cargo fmt --check`
- [x] `cargo build -p calimero-node --lib`
- [x] New tests: 2 mock self-tests + 1 partition-against-mock test

## Out of scope (follow-ups)

- Cross-actor `replay_buffered_delta`: kept as `self.node_state.clone()` handoff. Folding it into `SyncStateAccess` requires either expanding the trait to match the richer surface (governance-pending drain, delta-buffer ops, ~6 more methods) or restructuring the call to flow through an actor message. The spike on #2311 explicitly carved this out.
- Broader integration-test conversion: `p3_dag_causal_tests` / `p5_partition_scenarios_tests` touch more of `SyncManager`'s dependency surface (network, store) than just `SyncStateAccess`. Converting them to pure unit tests requires mocks for those layers too. The infrastructure to do this incrementally now exists.
- Physical extraction (#2314): the spike recommended **wontfix**. Once #2312 lands, the cost of extracting `sync/` to a separate crate exceeds the testability gain since the trait already unblocks the test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors sync’s access to mutable node state behind a new trait and updates several hot-path sync operations (delta-store creation, session buffering, reconcile backoff); behavior should be equivalent but regressions could affect sync correctness under contention.
> 
> **Overview**
> Introduces a `SyncStateAccess` trait (plus `NodeState` production impl) so `sync/` no longer reaches directly into `NodeState`’s fields/methods, enabling unit tests to substitute a fake state surface.
> 
> `SyncManager` now holds `state_access: Arc<dyn SyncStateAccess>` and routes delta-store lookup/atomic creation, sync-session end/cancel, peer-identity reads, and reconcile backoff bookkeeping through the trait (including updating `partition_peers_anchor_first` to depend on `&dyn SyncStateAccess`).
> 
> Adds `MockSyncStateAccess` (recording/scriptable) and updates tests to build minimal `NodeState` fixtures and to exercise partitioning against the mock; reconcile helper functions are made `pub(crate)` and re-exported from `sync/mod.rs` for use by the `NodeState` impl.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17373a038ded62300b931c3f2f52a2005038bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->