### PR TITLE
fix(storage): merkle hash iterates children by id, not (created_at, id)

### DIFF
--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -103,6 +103,20 @@ pub struct ChildInfo {
     pub metadata: Metadata,
 }
 
+// Sort by `(created_at, id)`. This order is load-bearing for
+// collections that preserve insertion semantics — `Vector::get(idx)`
+// iterates children in this order, so each push() must end up after
+// previous pushes. `created_at` is an HLC at write time, which is
+// roughly monotonic per writer, so this gives insertion-order
+// iteration. `id` is the tiebreaker for entries written at the same
+// HLC.
+//
+// The merkle full_hash computation in `Index::calculate_full_hash_for_children`
+// deliberately re-sorts by `id` alone before hashing, so the hash
+// content is independent of this ordering — peers that disagree on
+// `created_at` (e.g. locally-created entities like `Root<T>`) still
+// compute the same parent hash. The two concerns (storage iteration
+// order vs hash content) are intentionally decoupled.
 impl Ord for ChildInfo {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.created_at()

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -373,6 +373,24 @@ impl<S: StorageAdaptor> Index<S> {
     }
 
     /// Calculates full Merkle hash from own hash and children.
+    ///
+    /// **Iteration order is `id`-sorted, not `ChildInfo`'s natural
+    /// `(created_at, id)` Ord.** The merkle hash must be deterministic
+    /// across peers regardless of when each peer first observed each
+    /// child — and `created_at` is a local-clock observation that
+    /// diverges for entities two peers create independently with the
+    /// same content (canonical case: the `Root<T>` opaque-marker
+    /// entity the storage layer creates the first time an app
+    /// touches its state). Sorting by `id` alone before hashing
+    /// makes the parent hash purely content-derived: identical child
+    /// sets at identical merkle hashes produce identical parent
+    /// hashes regardless of when each node first wrote each child.
+    ///
+    /// The stored `ChildInfo` list keeps its `(created_at, id)`
+    /// order — that's load-bearing for `Vector::get(idx)`'s
+    /// insertion-order semantics and other collections that
+    /// depend on iteration order at the storage layer. The hash
+    /// content is decoupled from that layout here.
     pub(crate) fn calculate_full_hash_for_children(
         own_hash: [u8; 32],
         children: &Option<Vec<ChildInfo>>,
@@ -381,7 +399,10 @@ impl<S: StorageAdaptor> Index<S> {
         hasher.update(own_hash);
 
         if let Some(children_vec) = children {
-            for child in children_vec {
+            // Sort by id before hashing — see method-level doc.
+            let mut by_id: Vec<&ChildInfo> = children_vec.iter().collect();
+            by_id.sort_by_key(|c| c.id());
+            for child in by_id {
                 hasher.update(child.merkle_hash());
             }
         }

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -7,7 +7,7 @@
 
 use super::common::{Page, Paragraph};
 use crate::address::Id;
-use crate::entities::{Data, Element};
+use crate::entities::{ChildInfo, Data, Element, Metadata};
 use crate::index::Index;
 use crate::interface::{ApplyContext, Interface};
 use crate::store::{MockedStorage, StorageAdaptor};
@@ -782,4 +782,111 @@ fn stored_full_hash_stays_authoritative_through_ancestor_walks() {
             "full_hash must be set for every node after ops"
         );
     }
+}
+
+// ============================================================
+// `calculate_full_hash_for_children` — hash content is content-
+// derived, decoupled from `(created_at, id)` storage layout.
+// ============================================================
+//
+// These tests pin the invariant fix-issue-#2418 relies on: two
+// peers holding the same set of children at the same merkle
+// hashes must compute identical parent hashes regardless of how
+// their `created_at`s differ. The canonical case the fix
+// addresses is the `Root<T>` opaque-marker entity each peer
+// creates independently at a different local wall-clock time —
+// before the fix, the parent's `full_hash` iterated children in
+// stored `(created_at, id)` order, so the parent hash diverged
+// across peers even though every child's bytes matched.
+
+fn child(id_byte: u8, merkle_byte: u8, created_at: u64) -> ChildInfo {
+    let metadata = Metadata::new(created_at, created_at);
+    ChildInfo::new(Id::new([id_byte; 32]), [merkle_byte; 32], metadata)
+}
+
+#[test]
+fn full_hash_invariant_to_created_at_when_children_match() {
+    // Same ids + same merkle_hashes, different `created_at`s.
+    // This is the exact divergence shape #2418 documents:
+    // peer-1's `Root<T>` was created at T=100, peer-2's at T=105,
+    // but the value bytes (and therefore the merkle hashes) are
+    // identical.
+    let peer1 = vec![
+        child(0x01, 0xAA, 100),
+        child(0x02, 0xBB, 101),
+        child(0x03, 0xCC, 102),
+    ];
+    let peer2 = vec![
+        child(0x01, 0xAA, 200),
+        child(0x02, 0xBB, 201),
+        child(0x03, 0xCC, 202),
+    ];
+
+    let own_hash = [0xDE; 32];
+    let h1 =
+        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(peer1)).unwrap();
+    let h2 =
+        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(peer2)).unwrap();
+
+    assert_eq!(
+        h1, h2,
+        "parent hash must NOT depend on children's `created_at` — \
+         same ids + same merkle_hashes → same parent hash regardless \
+         of local creation times"
+    );
+}
+
+#[test]
+fn full_hash_invariant_to_input_order() {
+    // The function sorts by `id` internally, so the caller's
+    // iteration order should not matter. Catches a regression
+    // where someone removes the sort step expecting "the input
+    // is already sorted by Ord" (true today for stored children
+    // — but the function should defend against unsorted inputs
+    // because the whole point is decoupling the hash from the
+    // stored layout).
+    let in_order = vec![
+        child(0x01, 0xAA, 100),
+        child(0x02, 0xBB, 100),
+        child(0x03, 0xCC, 100),
+    ];
+    let reversed = vec![
+        child(0x03, 0xCC, 100),
+        child(0x02, 0xBB, 100),
+        child(0x01, 0xAA, 100),
+    ];
+
+    let own_hash = [0xDE; 32];
+    let h1 =
+        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(in_order)).unwrap();
+    let h2 =
+        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(reversed)).unwrap();
+
+    assert_eq!(
+        h1, h2,
+        "parent hash must NOT depend on input iteration order"
+    );
+}
+
+#[test]
+fn full_hash_changes_when_a_child_merkle_hash_changes() {
+    // Sanity: the hash MUST still depend on children's merkle
+    // hashes. Swap one child's merkle hash and the parent hash
+    // must change — otherwise the merkle invariant is broken.
+    let before = vec![child(0x01, 0xAA, 100), child(0x02, 0xBB, 100)];
+    let after = vec![
+        child(0x01, 0xAA, 100),
+        child(0x02, 0xBC, 100), // <-- merkle hash differs
+    ];
+
+    let own_hash = [0xDE; 32];
+    let h1 =
+        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(before)).unwrap();
+    let h2 =
+        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(after)).unwrap();
+
+    assert_ne!(
+        h1, h2,
+        "parent hash must change when a child's merkle hash changes"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #2418. Two peers holding the same entity at the same value bytes but different local `created_at` timestamps could not converge their root hashes via HashComparison sync. Canonical case: the `Root<T>` opaque-marker entity the storage layer creates the first time an app touches its state — each node creates its own locally at a different wall-clock time, and Update actions preserve the stored `created_at`, so they never converge.

## Mechanism (from the issue)

1. Leaf merkle hash: `Metadata` is `#[borsh(skip)]` on `Element`, so HLC doesn't feed into the leaf hash. Same value bytes → same leaf hash on both peers.
2. `compare_tree_nodes` returns `Equal` for the leaf → DFS recurses no further.
3. But the **parent's** `full_hash` was computed by iterating `ChildInfo`s in their stored `(created_at, id)` order. Different `created_at` per peer → different child positions → different parent hash → different root hash.

`#2414`'s bidirectional leaf push couldn't fire because its entry condition is `local.hash != remote.hash`, which doesn't hold here.

## Fix

Re-sort the children by `id` alone inside `calculate_full_hash_for_children` before iterating to update the hash. The hash content becomes purely deterministic from child ids and merkle hashes — no local-clock observation in the mix.

The stored `ChildInfo` list keeps its `(created_at, id)` Ord because that's **load-bearing for `Vector::get(idx)`'s insertion-order semantics**. Confirmed empirically — an earlier attempt to change `ChildInfo::Ord` to `id`-only broke `test_merge_vector_of_counters` because `Vector::push(c1)` followed by `push(c2)` no longer gave `get(0)=c1, get(1)=c2` (instead it gave whichever id sorted first). The two concerns — storage iteration layout vs hash content — are now intentionally decoupled.

## Upgrade story

Every parent's stored `full_hash` cache diverges from the new computation on first run after upgrade, until the next write to that entity triggers `recalculate_ancestor_hashes_for_now`. Pre-1.0 + the lazy-recompute mechanism + divergence detection via hash heartbeat + convergence via #2414's bidirectional leaf push makes this tractable — nodes will quickly converge to the new hash space as normal writes flow.

## Test plan

- [x] `cargo test -p calimero-storage` — 445 + 14 + smaller bins pass (the previously-failing `test_merge_vector_of_counters` from the abandoned `Ord` change now passes because we no longer touch the storage layout).
- [x] `cargo test -p calimero-node` — 173 + 308 sync_sim + smaller bins pass.
- [x] `cargo fmt --check`
- [ ] CI on `Sync regression (smoke)` should now consistently pass (it's been flaking precisely on this `Root<T>` divergence post-#2414).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Merkle `full_hash` computation order, which affects sync convergence and will shift stored hashes after upgrade until recomputed on write. Logic is small and well-covered by new invariance tests, but it touches core consistency behavior.
> 
> **Overview**
> Fixes Merkle-tree divergence across peers by making `Index::calculate_full_hash_for_children` hash children in **`id`-sorted order**, rather than relying on the stored `(created_at, id)` ordering of `ChildInfo`.
> 
> Clarifies via docs that **storage iteration/insertion order remains `(created_at, id)`** (to preserve collection semantics), while hash content is now deterministic across peers even when `created_at` differs; adds targeted tests asserting invariance to `created_at` and input ordering, and sensitivity to child hash changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78586472f2c4a09c1f24be6a9bdb8aa9cd0089a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->