### PR TITLE
feat(storage, sdk): PrivateStorage adaptor + #[app::private] auto-substitution

### DIFF
--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -1,36 +1,175 @@
+//! Demonstrates `#[app::private]` — node-local state that is NOT
+//! synchronised across the mesh.
+//!
+//! This app pairs two pieces of state:
+//!
+//! - [`SecretGame`] — the public `#[app::state]` struct synced
+//!   across all nodes (only `games`, the hash registry).
+//! - [`Secrets`] — the `#[app::private]` struct, node-local. Each
+//!   node has its own set of secrets that other nodes can never
+//!   observe (the on-the-wire game hash is the only thing that
+//!   leaves the node).
+//!
+//! ## What can live inside `#[app::private]`
+//!
+//! The `Secrets` struct below exercises the full supported set of
+//! field shapes:
+//!
+//! - **Primitives** (`u64`, `bool`, `String`, etc.) — borsh-serialised
+//!   into the outer private blob. Whole blob is rewritten on every
+//!   `save`; fine for small state.
+//! - **`std::collections` types** (`BTreeMap`, `BTreeSet`, `Vec`) —
+//!   same as primitives: borsh-serialised into the blob. Use for
+//!   small structured local state where rewrite-on-change is fine.
+//! - **Tree-backed structural collections** (`UnorderedMap`,
+//!   `UnorderedSet`, `Vector`) — the `#[app::private]` macro
+//!   automatically substitutes the storage adaptor to
+//!   `PrivateStorage` on these field types, so each entry is stored
+//!   as a separate node-local entity and only the entries you
+//!   actually change are rewritten. Use these for any
+//!   non-trivially-sized private state where blob-level
+//!   rewrite-on-change would be too expensive.
+//!
+//! ## What's deliberately not supported
+//!
+//! - **CRDT data-types** (`LwwRegister`, `Counter`, `GCounter`,
+//!   `PNCounter`, `ReplicatedGrowableArray`) — CRDTs exist for
+//!   multi-writer conflict resolution; private storage has exactly
+//!   one writer (this node), so the per-writer bookkeeping is
+//!   overhead without a corresponding semantic gain. Use a plain
+//!   `u64` / `String` / `Vec` instead.
+//! - **Access-control collections** (`SharedStorage`, `UserStorage`,
+//!   `FrozenStorage`) and **authored collections** (`AuthoredMap`,
+//!   `AuthoredVector`) — their semantics (cross-writer mutability,
+//!   per-user separation, immutability, per-entry authorship) all
+//!   assume the synced tree.
+//!
+//! Using any of the above inside `#[app::private]` will produce a
+//! regular Rust type error at compile time, since their `::new()`
+//! constructors stay pinned to `MainStorage`.
+
 #![allow(clippy::len_without_is_empty)]
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use bs58;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_storage::collections::{LwwRegister, UnorderedMap};
+use calimero_storage::collections::{LwwRegister, UnorderedMap, UnorderedSet, Vector};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+/// Public app state — synced across all nodes via the merkle tree.
+///
+/// Only the hash of each secret lives here; the secret itself is
+/// node-local (see [`Secrets`]).
 #[app::state(emits = for<'a> Event<'a>)]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct SecretGame {
-    /// Mapping of game_id -> sha256(secret) hex
+    /// Mapping of game_id -> sha256(secret) hex. `LwwRegister` is a
+    /// CRDT type — appropriate here because this is synced state
+    /// where concurrent writes from different nodes need
+    /// last-writer-wins resolution.
     games: UnorderedMap<String, LwwRegister<String>>,
 }
 
+/// Node-local private state — NOT synchronised.
+///
+/// Demonstrates every field shape supported inside
+/// `#[app::private]`. See the module-level doc-comment for the
+/// design rationale.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 #[borsh(crate = "calimero_sdk::borsh")]
 #[app::private]
 pub struct Secrets {
-    /// Private mapping of game_id -> secret
-    /// Note: Private data is node-local and NOT synchronized, so we can use String directly
+    // -----------------------------------------------------------------
+    // Tree-backed structural collections — auto-substituted to
+    // `PrivateStorage` by the `#[app::private]` macro. Each entry is
+    // stored as a separate node-local entity; only changed entries
+    // are rewritten.
+    //
+    // Use these when the collection can grow to non-trivial size or
+    // when individual entries change independently and you don't
+    // want to rewrite the whole blob on every mutation.
+    // -----------------------------------------------------------------
+    /// The actual secrets the user typed in — key-value of game_id
+    /// to plaintext secret.
     secrets: UnorderedMap<String, String>,
+
+    /// Per-node guess history — game IDs the user has attempted a
+    /// guess on (each attempt's outcome is local to the node).
+    /// Using a set demonstrates `UnorderedSet` substitution; would
+    /// also work as `UnorderedMap<String, ()>` but the set is the
+    /// natural shape.
+    attempted_games: UnorderedSet<String>,
+
+    /// Append-only log of guesses (game_id, guess_text) the user
+    /// made. Demonstrates `Vector` substitution. Persists across
+    /// app reboots on this node only.
+    guess_log: Vector<GuessEntry>,
+
+    // -----------------------------------------------------------------
+    // Primitives + std types — borsh-serialised into the outer
+    // private blob. Rewritten in full on every save. Fine for small
+    // state that changes infrequently.
+    // -----------------------------------------------------------------
+    /// How many times this node has used `add_secret`. A plain
+    /// counter — no CRDT needed because only this node writes.
+    secrets_added: u64,
+
+    /// Whether the user has opted into "remember last guess" UX. A
+    /// single bool is a textbook case for the borsh-blob path —
+    /// rewriting one byte's worth of state on toggle is trivial.
+    remember_last_guess: bool,
+
+    /// The most recent guess the user typed, if any. Stored
+    /// alongside the bool above purely so the demo covers
+    /// `Option<String>` round-tripping through the private blob.
+    last_guess: Option<String>,
+
+    /// User-defined notes per game — small text. `BTreeMap` not
+    /// `UnorderedMap` because:
+    /// 1. notes are short-and-few (a handful at most), so the blob
+    ///    rewrite is cheap;
+    /// 2. ordered iteration (alphabetical by game_id) is convenient
+    ///    when displaying the notes.
+    notes: BTreeMap<String, String>,
+
+    /// Tags the user has applied to themselves locally. `BTreeSet`
+    /// covers the std-set case alongside `UnorderedSet` above; the
+    /// difference is identical to map vs unordered-map — pick
+    /// `BTreeSet` for small ordered local state, `UnorderedSet` for
+    /// scale.
+    tags: BTreeSet<String>,
+}
+
+/// One entry in the [`Secrets::guess_log`] vector.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+#[borsh(crate = "calimero_sdk::borsh")]
+pub struct GuessEntry {
+    pub game_id: String,
+    pub guess: String,
+    pub success: bool,
 }
 
 impl Default for Secrets {
     fn default() -> Self {
         Self {
+            // Tree-backed: the macro substituted `PrivateStorage` as
+            // the trailing generic on the field types above, so
+            // these constructors infer `S = PrivateStorage` from the
+            // assignment site.
             secrets: UnorderedMap::new(),
+            attempted_games: UnorderedSet::new(),
+            guess_log: Vector::new(),
+            // Primitives + std types: just sensible defaults.
+            secrets_added: 0,
+            remember_last_guess: false,
+            last_guess: None,
+            notes: BTreeMap::new(),
+            tags: BTreeSet::new(),
         }
     }
 }
@@ -66,16 +205,20 @@ impl SecretGame {
         }
     }
 
-    /// Create/update a game by id: store secret privately and record its hash publicly.
+    /// Create/update a game by id: store secret privately and record
+    /// its hash publicly.
     pub fn add_secret(&mut self, game_id: String, secret: String) -> app::Result<()> {
-        // Save private secret using the Secrets private storage
+        // Save the secret + bookkeeping in the node-local
+        // `Secrets` private struct.
         let mut secrets = Secrets::private_load_or_default()?;
         let mut secrets_mut = secrets.as_mut();
         secrets_mut
             .secrets
             .insert(game_id.clone(), secret.clone())?;
+        secrets_mut.secrets_added = secrets_mut.secrets_added.saturating_add(1);
 
-        // Save public hash for guess verification in games map
+        // Save public hash for guess verification in the synced
+        // `games` map.
         let hash = Sha256::digest(secret.as_bytes());
         let hash_hex = hex::encode(hash);
         self.games.insert(game_id.clone(), hash_hex.into())?;
@@ -83,8 +226,21 @@ impl SecretGame {
         Ok(())
     }
 
-    /// Allow a user to guess the secret; returns true if the guess matches the stored hash.
-    /// `who` is derived from the executor identity rather than passed as an argument.
+    /// Allow a user to guess the secret; returns true if the guess
+    /// matches the stored hash. `who` is derived from the executor
+    /// identity rather than passed as an argument.
+    ///
+    /// Takes `&self` because the *public* `SecretGame` state isn't
+    /// mutated here — only this node's private `Secrets`. The two
+    /// persistence paths are:
+    ///
+    /// - Tree-backed `attempted_games` / `guess_log` write each new
+    ///   entry through `PrivateStorage` immediately on
+    ///   `insert` / `push` (no save call needed).
+    /// - The borsh-blob field `last_guess` is persisted by the
+    ///   `EntryMut` `Drop` impl when `secrets_mut` goes out of scope.
+    ///   Early `?`-returns still drop the guard, so the blob saves
+    ///   whether we exit normally or via error propagation.
     pub fn add_guess(&self, game_id: &str, guess: String) -> app::Result<bool> {
         let Some(public_hash_hex) = self.games.get(game_id)?.map(|v| v.get().clone()) else {
             app::bail!(Error::NoHash);
@@ -94,12 +250,47 @@ impl SecretGame {
         let who_b = calimero_sdk::env::executor_id();
         let who = bs58::encode(who_b).into_string();
         let success = guess_hash_hex == public_hash_hex;
+
+        // Record the guess in local-only history.
+        let mut secrets = Secrets::private_load_or_default()?;
+        let mut secrets_mut = secrets.as_mut();
+        secrets_mut.attempted_games.insert(game_id.to_owned())?;
+        secrets_mut.guess_log.push(GuessEntry {
+            game_id: game_id.to_owned(),
+            guess: guess.clone(),
+            success,
+        })?;
+        if secrets_mut.remember_last_guess {
+            secrets_mut.last_guess = Some(guess);
+        }
+
         app::emit!(Event::Guessed {
             game_id,
             success,
             by: &who
         });
         Ok(success)
+    }
+
+    /// Toggle the "remember last guess" UX flag (private state).
+    pub fn set_remember_last_guess(&self, value: bool) -> app::Result<()> {
+        let mut secrets = Secrets::private_load_or_default()?;
+        secrets.as_mut().remember_last_guess = value;
+        Ok(())
+    }
+
+    /// Attach a private note to a game (private state).
+    pub fn set_note(&self, game_id: String, note: String) -> app::Result<()> {
+        let mut secrets = Secrets::private_load_or_default()?;
+        let _ = secrets.as_mut().notes.insert(game_id, note);
+        Ok(())
+    }
+
+    /// Add a private user-defined tag.
+    pub fn add_tag(&self, tag: String) -> app::Result<()> {
+        let mut secrets = Secrets::private_load_or_default()?;
+        let _ = secrets.as_mut().tags.insert(tag);
+        Ok(())
     }
 
     /// Get all local secrets from private storage for the current caller.
@@ -116,5 +307,45 @@ impl SecretGame {
             .entries()?
             .map(|(k, v)| (k, v.get().clone()))
             .collect())
+    }
+
+    /// Number of `add_secret` calls this node has performed.
+    pub fn secrets_added(&self) -> app::Result<u64> {
+        Ok(Secrets::private_load_or_default()?.secrets_added)
+    }
+
+    /// Game IDs this node has ever attempted a guess on.
+    pub fn attempted_games(&self) -> app::Result<BTreeSet<String>> {
+        let secrets = Secrets::private_load_or_default()?;
+        let out: BTreeSet<String> = secrets.attempted_games.iter()?.collect();
+        Ok(out)
+    }
+
+    /// All private notes on this node, ordered by game_id.
+    pub fn notes(&self) -> app::Result<BTreeMap<String, String>> {
+        Ok(Secrets::private_load_or_default()?.notes.clone())
+    }
+
+    /// All private tags this user has set on this node.
+    pub fn tags(&self) -> app::Result<BTreeSet<String>> {
+        Ok(Secrets::private_load_or_default()?.tags.clone())
+    }
+
+    /// Total number of guesses this node has logged across all
+    /// games.
+    pub fn guess_count(&self) -> app::Result<u64> {
+        let secrets = Secrets::private_load_or_default()?;
+        Ok(secrets.guess_log.len()? as u64)
+    }
+
+    /// Whether the "remember last guess" flag is on.
+    pub fn remember_last_guess(&self) -> app::Result<bool> {
+        Ok(Secrets::private_load_or_default()?.remember_last_guess)
+    }
+
+    /// The most recently typed guess on this node, if any (only
+    /// populated when `remember_last_guess` was on at the time).
+    pub fn last_guess(&self) -> app::Result<Option<String>> {
+        Ok(Secrets::private_load_or_default()?.last_guess.clone())
     }
 }

--- a/apps/private_data/workflows/private-data.yml
+++ b/apps/private_data/workflows/private-data.yml
@@ -165,6 +165,236 @@ steps:
     statements:
       - "{{guess_result}} == False"
 
+  # ---------------------------------------------------------------
+  # Cover the rest of the private-state shapes exercised by the
+  # `#[app::private]` substitution:
+  #
+  #   - UnorderedMap / UnorderedSet / Vector  (tree-backed, rewritten
+  #     to `PrivateStorage` by the macro — must stay node-local)
+  #   - u64 / bool / Option<String> / BTreeMap / BTreeSet  (borsh-blob)
+  #
+  # The assertions below double as a privacy check: every "is node 2's
+  # local state on node 1?" answer must be "no".
+  #
+  # Outputs capture the full RPC envelope (`result`) so we can compare
+  # against `{"output": ...}` with `json_equal` — that's the working
+  # pattern used by example.yml and e2e.yml.
+  # ---------------------------------------------------------------
+
+  - name: Node 1 Secrets Added Count
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: secrets_added
+    outputs:
+      node_1_secrets_added: result
+
+  - name: Assert Node 1 Counted Both Adds
+    type: json_assert
+    statements:
+      - 'json_equal({{node_1_secrets_added}}, {"output": 2})'
+
+  - name: Node 2 Secrets Added Count
+    type: call
+    node: rust-private-data-2
+    context_id: "{{context_id}}"
+    method: secrets_added
+    outputs:
+      node_2_secrets_added: result
+
+  - name: Assert Node 2 Independent Count
+    # Node 2 called `add_secret` exactly once (game3 above). Node 1's
+    # two adds must not have leaked into node 2's local counter.
+    type: json_assert
+    statements:
+      - 'json_equal({{node_2_secrets_added}}, {"output": 1})'
+
+  - name: Node 2 Attempted Games
+    type: call
+    node: rust-private-data-2
+    context_id: "{{context_id}}"
+    method: attempted_games
+    outputs:
+      node_2_attempted: result
+
+  - name: Assert Node 2 Recorded Its Attempt
+    # `attempted_games` is an `UnorderedSet<String>` — the macro
+    # rewrites it to `PrivateStorage`. The wrong-guess on game1 above
+    # must have landed in node 2's local set, and only node 2's.
+    #
+    # NOTE: `UnorderedSet` iteration order is not guaranteed. This
+    # single-element assertion is safe; if you extend this step with
+    # additional attempts, replace `json_equal` with `json_subset`
+    # plus a length check, or sort the result before comparing, to
+    # avoid order-sensitive flakes.
+    type: json_assert
+    statements:
+      - 'json_equal({{node_2_attempted}}, {"output": ["game1"]})'
+
+  - name: Node 1 Attempted Games
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: attempted_games
+    outputs:
+      node_1_attempted: result
+
+  - name: Assert Node 1 Did Not See Node 2 Attempts
+    # If `PrivateStorage` substitution failed and the set leaked into
+    # the synced tree, node 1 would observe "game1" here — this is
+    # the privacy regression test.
+    type: json_assert
+    statements:
+      - 'json_equal({{node_1_attempted}}, {"output": []})'
+
+  - name: Node 2 Guess Count
+    type: call
+    node: rust-private-data-2
+    context_id: "{{context_id}}"
+    method: guess_count
+    outputs:
+      node_2_guess_count: result
+
+  - name: Assert Node 2 Logged One Guess
+    # `guess_log` is a `Vector<GuessEntry>` rewritten to
+    # `PrivateStorage`; the wrong-guess above is the only entry.
+    type: json_assert
+    statements:
+      - 'json_equal({{node_2_guess_count}}, {"output": 1})'
+
+  - name: Node 1 Guess Count
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: guess_count
+    outputs:
+      node_1_guess_count: result
+
+  - name: Assert Node 1 Logged Zero Guesses
+    type: json_assert
+    statements:
+      - 'json_equal({{node_1_guess_count}}, {"output": 0})'
+
+  # ---------------------------------------------------------------
+  # Borsh-blob shapes: u64 / bool / Option<String> / BTreeMap / BTreeSet.
+  # Toggle the flag, write some notes/tags on node 1, confirm round-trip
+  # and absence on node 2.
+  # ---------------------------------------------------------------
+
+  - name: Node 1 Enable Remember Last Guess
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: set_remember_last_guess
+    args:
+      value: true
+
+  - name: Node 1 Read Remember Flag
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: remember_last_guess
+    outputs:
+      node_1_remember: result
+
+  - name: Assert Node 1 Remember Flag On
+    type: json_assert
+    statements:
+      - 'json_equal({{node_1_remember}}, {"output": true})'
+
+  - name: Node 2 Read Remember Flag
+    type: call
+    node: rust-private-data-2
+    context_id: "{{context_id}}"
+    method: remember_last_guess
+    outputs:
+      node_2_remember: result
+
+  - name: Assert Node 2 Remember Flag Untouched
+    # The bool lives in the borsh-blob inside private storage. Node 1
+    # toggling it must not be visible on node 2.
+    type: json_assert
+    statements:
+      - 'json_equal({{node_2_remember}}, {"output": false})'
+
+  - name: Node 1 Set A Note
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: set_note
+    args:
+      game_id: game1
+      note: "my-private-note"
+
+  - name: Node 1 Read Notes
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: notes
+    outputs:
+      node_1_notes: result
+
+  - name: Assert Node 1 Note Round-Trips
+    type: json_assert
+    statements:
+      - 'json_equal({{node_1_notes}}, {"output": {"game1": "my-private-note"}})'
+
+  - name: Node 2 Read Notes
+    type: call
+    node: rust-private-data-2
+    context_id: "{{context_id}}"
+    method: notes
+    outputs:
+      node_2_notes: result
+
+  - name: Assert Node 2 Notes Empty
+    type: json_assert
+    statements:
+      - 'json_equal({{node_2_notes}}, {"output": {}})'
+
+  - name: Node 1 Add Tag Alpha
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: add_tag
+    args:
+      tag: "alpha"
+
+  - name: Node 1 Add Tag Beta
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: add_tag
+    args:
+      tag: "beta"
+
+  - name: Node 1 Read Tags
+    type: call
+    node: rust-private-data-1
+    context_id: "{{context_id}}"
+    method: tags
+    outputs:
+      node_1_tags: result
+
+  - name: Assert Node 1 Tags
+    # BTreeSet serialises in sorted order.
+    type: json_assert
+    statements:
+      - 'json_equal({{node_1_tags}}, {"output": ["alpha", "beta"]})'
+
+  - name: Node 2 Read Tags
+    type: call
+    node: rust-private-data-2
+    context_id: "{{context_id}}"
+    method: tags
+    outputs:
+      node_2_tags: result
+
+  - name: Assert Node 2 Tags Empty
+    type: json_assert
+    statements:
+      - 'json_equal({{node_2_tags}}, {"output": []})'
+
 stop_all_nodes: false
 restart: false
 wait_timeout: 120

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -555,22 +555,46 @@ impl ContextStorageApplier {
             }
         }
 
-        // CRITICAL FIX: Even if all parent checks passed, we STILL might need merge.
-        // The issue is: we don't know if the remote node applied our parent as a merge.
-        // Their child delta's actions are based on THEIR computed state, not ours.
+        // If we reach this point, every parent of this delta was:
+        //   1. present in our `parent_hashes` map (we know its computed hash);
+        //   2. computed by us to the same hash that matches our current state;
+        //   3. NOT in `merged_deltas` (was applied sequentially, not as a merge).
         //
-        // CONSERVATIVE FINAL CHECK: Always use merge semantics. CRDT merge is idempotent,
-        // so if states were identical, we get the same result. If not, we merge correctly.
+        // (1) ensures the parent isn't an opaque "from elsewhere" delta whose
+        // applied state we can't reason about. (2) ensures our current state
+        // is exactly the state the delta's author was working against — we
+        // haven't drifted via concurrent local writes. (3) ensures the
+        // parent's apply was deterministic for both us and the author —
+        // neither side took the CRDT-merge path that can produce different
+        // hashes for the same input.
         //
-        // This is the safest approach and ensures eventual consistency.
+        // Under those three conditions the delta is sequential by every
+        // available signal and direct apply will produce the same result the
+        // author got. The previous code returned `true` here on a "CRDT merge
+        // is idempotent so always-merge is safe" theory; that's false in
+        // practice — the merge-apply path (`Interface::save_internal` →
+        // `try_merge_data` / `try_merge_non_root`) routes through different
+        // metadata-stamping and ancestor-resolution code than the direct
+        // apply path, so two nodes that BOTH had the exact same state
+        // pre-delta could compute different post-delta root hashes if one
+        // direct-applied and the other merge-applied. That divergence then
+        // cascades: the `merged_deltas` write below records the
+        // divergent-applying side, so every subsequent child of this delta
+        // also takes the merge path (line ~465 above) and never reconverges
+        // — the "same DAG heads, different root hash" symptom in #2319.
+        //
+        // Cases where merge is still needed are caught above and return
+        // `true` before we get here: legitimate concurrent branches (line
+        // ~498), unknown parents (line ~554), and parents previously
+        // applied via merge (line ~473).
         debug!(
             context_id = %self.context_id,
             delta_id = ?delta.id,
             current_root_hash = ?Hash::from(*current_root_hash),
             delta_expected_hash = ?Hash::from(delta.expected_root_hash),
-            "Using CRDT merge semantics for all remote deltas (conservative)"
+            "All parent checks passed and state matches — treating as sequential apply"
         );
-        true
+        false
     }
 
     /// Resolve the writer set for every Shared entity touched by `delta`.

--- a/crates/sdk/macros/src/items.rs
+++ b/crates/sdk/macros/src/items.rs
@@ -3,6 +3,7 @@ use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::{Attribute, ItemEnum, ItemStruct, Result as SynResult, Token, Visibility};
 
+#[derive(Clone)]
 pub enum StructOrEnumItem {
     Struct(ItemStruct),
     Enum(ItemEnum),

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -1,18 +1,206 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
-use syn::{Error as SynError, Ident, Result as SynResult, Token};
+use syn::{
+    parse_quote, Error as SynError, Fields, GenericArgument, Ident, PathArguments,
+    Result as SynResult, Token, Type,
+};
 
 use crate::errors::{Errors, ParseError};
 use crate::items::StructOrEnumItem;
 use crate::reserved::idents;
 use sha2::{Digest, Sha256};
 
+/// Tree-backed *structural* collections that store entities in the
+/// shared Merkle tree by default, paired with the number of type
+/// arguments their no-adaptor form takes.
+///
+/// When a field of one of these types appears (at any depth) inside
+/// a `#[app::private]` struct, the macro injects `PrivateStorage` as
+/// the trailing generic so the entries land in the node-local
+/// namespace instead of leaking into the synced tree.
+///
+/// **Single source of truth.** Name and arity live together so we
+/// never end up "in the name list but missing from the arity match"
+/// — that drift was a real maintenance hazard with two separate
+/// tables.
+///
+/// **Scope**: only structural collections (`UnorderedMap`,
+/// `UnorderedSet`, `Vector`) — primitives and `std` types
+/// (`String`, `u64`, `BTreeMap`, `Vec`, etc.) borsh-serialise
+/// straight into the outer private blob and need no substitution.
+///
+/// **Deliberately excluded** (using them inside `#[app::private]`
+/// is a semantic mismatch and currently produces a normal type
+/// error, since their `::new()` stays pinned to `MainStorage`; a
+/// dedicated compile-time diagnostic is tracked in #2428):
+///
+/// - CRDT data-types (`LwwRegister`, `Counter`, `GCounter`,
+///   `PNCounter`, `ReplicatedGrowableArray`) — CRDTs exist for
+///   multi-writer conflict resolution; in single-writer private
+///   storage their merge semantics are unused complexity.
+/// - Access-control collections (`SharedStorage`, `UserStorage`,
+///   `FrozenStorage`) — cross-writer mutability, per-user
+///   separation, and immutability all assume the synced tree.
+/// - Authored collections (`AuthoredMap`, `AuthoredVector`) —
+///   carry per-entry authorship which is a sync-side concern.
+///
+/// Matched on the *last segment* of the type path, so callers using
+/// fully-qualified paths (`calimero_storage::collections::UnorderedMap`)
+/// are also covered. Doesn't catch type aliases or `use as` renames —
+/// users doing those need to either write the explicit `PrivateStorage`
+/// parameter themselves or unwind the alias.
+const TREE_BACKED_TYPES: &[(&str, usize)] =
+    &[("UnorderedMap", 2), ("UnorderedSet", 1), ("Vector", 1)];
+
+/// Recursively walk `ty` and inject `PrivateStorage` on every
+/// tree-backed collection encountered — including ones nested inside
+/// other generics (`Option<UnorderedMap<K, V>>`,
+/// `UnorderedMap<K, Vector<T>>`, `(UnorderedMap<K, V>, Vector<T>)`,
+/// `Box<UnorderedSet<T>>`). Without this recursion the outer field
+/// type is privatised but the inner collection silently keeps its
+/// default `MainStorage`, and its entries leak into the synced tree.
+///
+/// We recurse before deciding whether to inject on the outer node
+/// so the inner rewrites are visible in the resulting token stream.
+fn inject_private_storage(ty: &mut Type) {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(last) = type_path.path.segments.last_mut() {
+                if let PathArguments::AngleBracketed(args) = &mut last.arguments {
+                    for arg in args.args.iter_mut() {
+                        if let GenericArgument::Type(inner) = arg {
+                            inject_private_storage(inner);
+                        }
+                    }
+                }
+            }
+            try_inject_on_path(type_path);
+        }
+        Type::Reference(r) => inject_private_storage(&mut r.elem),
+        Type::Tuple(t) => {
+            for elem in t.elems.iter_mut() {
+                inject_private_storage(elem);
+            }
+        }
+        Type::Array(a) => inject_private_storage(&mut a.elem),
+        Type::Slice(s) => inject_private_storage(&mut s.elem),
+        Type::Group(g) => inject_private_storage(&mut g.elem),
+        Type::Paren(p) => inject_private_storage(&mut p.elem),
+        // BareFn / Ptr / TraitObject / ImplTrait / Infer / Macro / Never
+        // / Verbatim — nothing structural to walk into for our purpose.
+        _ => {}
+    }
+}
+
+/// Inject `PrivateStorage` on a path node if it names a known
+/// tree-backed type with the right arity. Detection is "did the
+/// user supply enough generics for an explicit adaptor" — for
+/// `UnorderedMap<K, V>` we inject; for `UnorderedMap<K, V, SomeStorage>`
+/// we don't touch it.
+///
+/// The supported collections take only `Type` generics in their
+/// public API (no lifetimes, no const generics *on the collection
+/// itself*). If any lifetime/const argument appears at the *top
+/// level* of the path's generics — e.g. someone wrote
+/// `UnorderedMap<'a, K, V>` — we conservatively bail rather than
+/// risk producing a malformed type. Lifetimes/consts nested inside
+/// the type arguments themselves (e.g. `UnorderedMap<String, &'a str>`)
+/// don't affect arity and are not what this bail catches.
+fn try_inject_on_path(type_path: &mut syn::TypePath) {
+    let Some(last) = type_path.path.segments.last_mut() else {
+        return;
+    };
+    let name = last.ident.to_string();
+    let Some(&(_, expected)) = TREE_BACKED_TYPES.iter().find(|(n, _)| *n == name) else {
+        return;
+    };
+
+    let private_storage: GenericArgument = parse_quote!(::calimero_storage::store::PrivateStorage);
+
+    match &mut last.arguments {
+        // None of the supported types are valid with zero type-args
+        // (UnorderedMap needs K,V; UnorderedSet/Vector need T) — a
+        // bare identifier from the list is malformed Rust anyway, so
+        // we leave it alone and let the type-checker produce the more
+        // informative error.
+        PathArguments::None => {}
+        PathArguments::AngleBracketed(args) => {
+            // The recursion in `inject_private_storage` runs BEFORE
+            // this match, so by the time we count args, any nested
+            // tree-backed collection has already had its own
+            // `PrivateStorage` injected. That doesn't affect this
+            // count: each nested `Type` (rewritten or not) is still a
+            // single `GenericArgument::Type` at the OUTER level — its
+            // internal arity doesn't leak. So
+            // `UnorderedMap<K, UnorderedMap<X, Y>>` always counts as
+            // 2 type args here, whether the inner map was rewritten
+            // to 3 args or not.
+            let mut type_args = 0_usize;
+            let mut other_args = 0_usize;
+            for arg in &args.args {
+                match arg {
+                    GenericArgument::Type(_) => type_args += 1,
+                    _ => other_args += 1,
+                }
+            }
+            if other_args == 0 && type_args == expected {
+                args.args.push(private_storage);
+            }
+        }
+        PathArguments::Parenthesized(_) => {}
+    }
+}
+
+/// Walk every field of `orig` and rewrite tree-backed collection
+/// types in place. Returns the rewritten clone for emission. Enums
+/// are walked too — variant fields are treated identically to struct
+/// fields.
+fn rewrite_tree_backed_field_types(orig: &StructOrEnumItem) -> StructOrEnumItem {
+    let mut rewritten = orig.clone();
+    match &mut rewritten {
+        StructOrEnumItem::Struct(item) => match &mut item.fields {
+            Fields::Named(fields) => {
+                for field in &mut fields.named {
+                    inject_private_storage(&mut field.ty);
+                }
+            }
+            Fields::Unnamed(fields) => {
+                for field in &mut fields.unnamed {
+                    inject_private_storage(&mut field.ty);
+                }
+            }
+            Fields::Unit => {}
+        },
+        StructOrEnumItem::Enum(item) => {
+            for variant in &mut item.variants {
+                match &mut variant.fields {
+                    Fields::Named(fields) => {
+                        for field in &mut fields.named {
+                            inject_private_storage(&mut field.ty);
+                        }
+                    }
+                    Fields::Unnamed(fields) => {
+                        for field in &mut fields.unnamed {
+                            inject_private_storage(&mut field.ty);
+                        }
+                    }
+                    Fields::Unit => {}
+                }
+            }
+        }
+    }
+    rewritten
+}
+
 pub struct PrivateImpl<'a> {
     ident: &'a Ident,
     key_name: String,
     key_bytes: Vec<u8>,
-    orig: &'a StructOrEnumItem,
+    /// `orig` with every tree-backed collection field rewritten to
+    /// use `PrivateStorage` as its storage adaptor — see
+    /// [`rewrite_tree_backed_field_types`].
+    rewritten: StructOrEnumItem,
 }
 
 impl ToTokens for PrivateImpl<'_> {
@@ -21,14 +209,14 @@ impl ToTokens for PrivateImpl<'_> {
             ident,
             key_name,
             key_bytes,
-            orig,
+            rewritten,
         } = self;
 
         let key_bytes_literal = proc_macro2::Literal::byte_string(key_bytes);
         let key_name_ident = Ident::new(key_name, ident.span());
 
         quote! {
-            #orig
+            #rewritten
 
             // Define the key constant
             const #key_name_ident: &[u8] = #key_bytes_literal;
@@ -156,11 +344,13 @@ impl<'a> TryFrom<PrivateImplInput<'a>> for PrivateImpl<'a> {
 
         errors.check()?;
 
+        let rewritten = rewrite_tree_backed_field_types(input.item);
+
         Ok(PrivateImpl {
             ident,
             key_name,
             key_bytes,
-            orig: input.item,
+            rewritten,
         })
     }
 }
@@ -174,8 +364,9 @@ fn compute_default_key(ident: &Ident) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_default_key;
-    use syn::parse_str;
+    use super::{compute_default_key, inject_private_storage};
+    use quote::ToTokens;
+    use syn::{parse_quote, parse_str, Type};
 
     #[test]
     fn default_key_uses_hash_no_prefix_collision() {
@@ -189,5 +380,238 @@ mod tests {
         assert_ne!(ka, kb);
         assert_eq!(ka.len(), 32);
         assert_eq!(kb.len(), 32);
+    }
+
+    fn rewrite(input: Type) -> String {
+        let mut ty = input;
+        inject_private_storage(&mut ty);
+        ty.to_token_stream().to_string()
+    }
+
+    #[test]
+    fn map_with_two_args_gets_private_storage_appended() {
+        // `UnorderedMap<K, V>` → `UnorderedMap<K, V, ::calimero_storage::store::PrivateStorage>`
+        let rewritten = rewrite(parse_quote!(UnorderedMap<String, String>));
+        assert!(
+            rewritten.contains("PrivateStorage"),
+            "private storage should be appended, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn map_with_explicit_adaptor_is_left_alone() {
+        // User already supplied an adaptor — don't touch.
+        let rewritten = rewrite(parse_quote!(UnorderedMap<String, String, SomeOtherAdaptor>));
+        assert!(
+            !rewritten.contains("PrivateStorage"),
+            "explicit adaptor should not be overridden, got: {rewritten}"
+        );
+        assert!(
+            rewritten.contains("SomeOtherAdaptor"),
+            "original adaptor should be preserved, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn unknown_type_is_left_alone() {
+        // `BTreeMap<K, V>` is not a tree-backed Calimero collection — leave it.
+        let rewritten = rewrite(parse_quote!(BTreeMap<String, String>));
+        assert!(
+            !rewritten.contains("PrivateStorage"),
+            "non-Calimero types must not be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn vector_with_one_arg_gets_private_storage() {
+        let rewritten = rewrite(parse_quote!(Vector<String>));
+        assert!(
+            rewritten.contains("PrivateStorage"),
+            "Vector should be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn unordered_set_with_one_arg_gets_private_storage() {
+        let rewritten = rewrite(parse_quote!(UnorderedSet<String>));
+        assert!(
+            rewritten.contains("PrivateStorage"),
+            "UnorderedSet should be rewritten, got: {rewritten}"
+        );
+    }
+
+    // Single source of truth for "what we deliberately don't
+    // rewrite." Lifted to module level so the exclusion list is
+    // grep-able from one place rather than buried inside each test
+    // body. The doc-comment above `TREE_BACKED_TYPES` lists the same
+    // names; if these ever drift, the inconsistency-with-prose
+    // becomes the user-facing bug.
+    //
+    // If a future contributor adds (say) `AuthoredMap` to
+    // `TREE_BACKED_TYPES`, the corresponding entry here flips its
+    // assertion red and the change has to be made consciously.
+
+    const EXCLUDED_CRDT_TYPES: &[&str] = &[
+        "LwwRegister<String>",
+        "Counter",
+        "GCounter",
+        "PNCounter",
+        "ReplicatedGrowableArray<String>",
+    ];
+
+    const EXCLUDED_ACCESS_CONTROL_TYPES: &[&str] = &[
+        "SharedStorage<String>",
+        "UserStorage<String>",
+        "FrozenStorage<String>",
+        "AuthoredMap<String, String>",
+        "AuthoredVector<String>",
+    ];
+
+    #[test]
+    fn crdt_type_is_left_alone() {
+        // CRDT collections deliberately excluded from substitution —
+        // they're multi-writer machinery that has no place in
+        // single-writer private storage.
+        for ty in EXCLUDED_CRDT_TYPES {
+            let parsed: Type = syn::parse_str(ty).expect("parse");
+            let rewritten = rewrite(parsed);
+            assert!(
+                !rewritten.contains("PrivateStorage"),
+                "CRDT type {ty} must not be rewritten, got: {rewritten}"
+            );
+        }
+    }
+
+    #[test]
+    fn access_control_types_are_left_alone() {
+        // Shared/User/Frozen/Authored — semantics rely on the synced
+        // tree, deliberately excluded.
+        for ty in EXCLUDED_ACCESS_CONTROL_TYPES {
+            let parsed: Type = syn::parse_str(ty).expect("parse");
+            let rewritten = rewrite(parsed);
+            assert!(
+                !rewritten.contains("PrivateStorage"),
+                "Access-control type {ty} must not be rewritten, got: {rewritten}"
+            );
+        }
+    }
+
+    #[test]
+    fn excluded_type_names_disjoint_from_tree_backed() {
+        // Belt-and-braces machine check that the exclusion lists
+        // above don't accidentally name something the macro would
+        // rewrite — the strongest signal that the prose doc and the
+        // actual constant agree.
+        let included: std::collections::HashSet<&str> =
+            super::TREE_BACKED_TYPES.iter().map(|(n, _)| *n).collect();
+        for excluded in EXCLUDED_CRDT_TYPES
+            .iter()
+            .chain(EXCLUDED_ACCESS_CONTROL_TYPES)
+        {
+            // Pull just the leading identifier (everything before `<`).
+            let head = excluded.split('<').next().expect("non-empty");
+            assert!(
+                !included.contains(head),
+                "{head} is in both TREE_BACKED_TYPES and an EXCLUDED_* list — pick one"
+            );
+        }
+    }
+
+    // Nested-rewrite tests: the macro must descend into generic
+    // arguments, tuples, references, etc., or inner collections silently
+    // leak into the synced tree.
+
+    fn count_occurrences(haystack: &str, needle: &str) -> usize {
+        haystack.matches(needle).count()
+    }
+
+    #[test]
+    fn nested_map_in_map_value_is_rewritten() {
+        // Both the outer and inner map must end up with PrivateStorage.
+        let rewritten = rewrite(parse_quote!(UnorderedMap<String, UnorderedMap<String, String>>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            2,
+            "both outer and inner maps must be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn nested_vector_in_map_value_is_rewritten() {
+        let rewritten = rewrite(parse_quote!(UnorderedMap<String, Vector<u8>>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            2,
+            "both map and nested vector must be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn option_wrapped_collection_is_rewritten() {
+        // `Option<UnorderedMap<K, V>>` — the wrapper is borsh-serialised
+        // into the blob, but the inner collection stores via the
+        // adaptor, so it must be rewritten or the entries leak.
+        let rewritten = rewrite(parse_quote!(Option<UnorderedMap<String, String>>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            1,
+            "Option-wrapped inner collection must be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn vec_wrapped_collection_is_rewritten() {
+        let rewritten = rewrite(parse_quote!(Vec<Vector<u64>>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            1,
+            "Vec-wrapped inner collection must be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn box_wrapped_collection_is_rewritten() {
+        let rewritten = rewrite(parse_quote!(Box<UnorderedSet<String>>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            1,
+            "Box-wrapped inner collection must be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn tuple_elements_are_each_rewritten() {
+        let rewritten = rewrite(parse_quote!((
+            UnorderedMap<String, String>,
+            Vector<u64>,
+            BTreeMap<u8, u8>
+        )));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            2,
+            "tuple elements must each be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn reference_inner_is_rewritten() {
+        // Doesn't make sense as a struct field in practice, but a
+        // useful pin: the walker descends through Type::Reference.
+        let rewritten = rewrite(parse_quote!(&UnorderedMap<String, String>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            1,
+            "reference inner must be rewritten, got: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn deeply_nested_collections_all_get_rewritten() {
+        let rewritten = rewrite(parse_quote!(UnorderedMap<String, Option<Vec<Vector<u64>>>>));
+        assert_eq!(
+            count_occurrences(&rewritten, "PrivateStorage"),
+            2,
+            "every nested tree-backed collection must be rewritten, got: {rewritten}"
+        );
     }
 }

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -617,7 +617,7 @@ mod tests {
 
         // vec1 = [Counter(2), Counter(1)] - Node 1 creates these
         env::set_executor_id([33; 32]);
-        let mut vec1 = Vector::new();
+        let mut vec1 = Vector::<_, MainStorage>::new();
         let mut c1 = GCounter::new();
         c1.increment().unwrap();
         c1.increment().unwrap(); // value = 2
@@ -629,7 +629,7 @@ mod tests {
 
         // vec2 = [Counter(1), Counter(3)] - Node 2 creates these
         env::set_executor_id([44; 32]);
-        let mut vec2 = Vector::new();
+        let mut vec2 = Vector::<_, MainStorage>::new();
         let mut c3 = GCounter::new();
         c3.increment().unwrap(); // value = 1
         vec2.push(c3).unwrap();
@@ -655,7 +655,7 @@ mod tests {
 
         // vec1 = [Counter(2)] - Node 1
         env::set_executor_id([55; 32]);
-        let mut vec1 = Vector::new();
+        let mut vec1 = Vector::<_, MainStorage>::new();
         let mut c1 = GCounter::new();
         c1.increment().unwrap();
         c1.increment().unwrap();
@@ -663,7 +663,7 @@ mod tests {
 
         // vec2 = [Counter(3), Counter(5), Counter(7)] - Node 2
         env::set_executor_id([66; 32]);
-        let mut vec2 = Vector::new();
+        let mut vec2 = Vector::<_, MainStorage>::new();
         let mut c2 = GCounter::new();
         c2.increment().unwrap();
         c2.increment().unwrap();
@@ -769,13 +769,13 @@ mod tests {
         env::reset_for_testing();
 
         // vec1 = [LwwRegister("A")]
-        let mut vec1 = Vector::new();
+        let mut vec1 = Vector::<_, MainStorage>::new();
         vec1.push(LwwRegister::new("A".to_owned())).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(1));
 
         // vec2 = [LwwRegister("B")]
-        let mut vec2 = Vector::new();
+        let mut vec2 = Vector::<_, MainStorage>::new();
         vec2.push(LwwRegister::new("B".to_owned())).unwrap();
 
         // Merge
@@ -793,12 +793,12 @@ mod tests {
         use super::UnorderedSet;
 
         // set1 = {"alice", "bob"}
-        let mut set1 = UnorderedSet::new();
+        let mut set1 = UnorderedSet::<_, MainStorage>::new();
         set1.insert("alice".to_owned()).unwrap();
         set1.insert("bob".to_owned()).unwrap();
 
         // set2 = {"charlie", "dave"}
-        let mut set2 = UnorderedSet::new();
+        let mut set2 = UnorderedSet::<_, MainStorage>::new();
         set2.insert("charlie".to_owned()).unwrap();
         set2.insert("dave".to_owned()).unwrap();
 
@@ -819,13 +819,13 @@ mod tests {
         use super::UnorderedSet;
 
         // set1 = {"alice", "bob", "charlie"}
-        let mut set1 = UnorderedSet::new();
+        let mut set1 = UnorderedSet::<_, MainStorage>::new();
         set1.insert("alice".to_owned()).unwrap();
         set1.insert("bob".to_owned()).unwrap();
         set1.insert("charlie".to_owned()).unwrap();
 
         // set2 = {"bob", "charlie", "dave"}
-        let mut set2 = UnorderedSet::new();
+        let mut set2 = UnorderedSet::<_, MainStorage>::new();
         set2.insert("bob".to_owned()).unwrap();
         set2.insert("charlie".to_owned()).unwrap();
         set2.insert("dave".to_owned()).unwrap();
@@ -847,7 +847,7 @@ mod tests {
         use super::UnorderedSet;
 
         // set1 = {"alice"}
-        let mut set1 = UnorderedSet::new();
+        let mut set1 = UnorderedSet::<_, MainStorage>::new();
         set1.insert("alice".to_owned()).unwrap();
 
         // set2 = {} (empty)

--- a/crates/storage/src/collections/decompose_impls.rs
+++ b/crates/storage/src/collections/decompose_impls.rs
@@ -149,12 +149,13 @@ mod tests {
     use super::*;
     use crate::collections::Root;
     use crate::env;
+    use crate::store::MainStorage;
 
     #[test]
     fn test_unordered_map_decompose() {
         env::reset_for_testing();
 
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
         map.insert("key1".to_owned(), "value1".to_owned()).unwrap();
         map.insert("key2".to_owned(), "value2".to_owned()).unwrap();
 
@@ -187,7 +188,7 @@ mod tests {
     fn test_vector_decompose() {
         env::reset_for_testing();
 
-        let mut vec = Root::new(|| Vector::new());
+        let mut vec = Root::new(|| Vector::<_, MainStorage>::new());
         vec.push(10u64).unwrap();
         vec.push(20u64).unwrap();
         vec.push(30u64).unwrap();

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -24,10 +24,11 @@ pub struct UnorderedMap<K, V, S: StorageAdaptor = MainStorage> {
     inner: Collection<(K, V), S>,
 }
 
-impl<K, V> UnorderedMap<K, V, MainStorage>
+impl<K, V, S> UnorderedMap<K, V, S>
 where
     K: BorshSerialize + BorshDeserialize,
     V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     /// Create a new map collection with a random ID.
     ///
@@ -36,6 +37,13 @@ where
     /// doesn't affect sync semantics.
     ///
     /// For top-level state fields, use `new_with_field_name` instead.
+    ///
+    /// The storage adaptor `S` is inferred from the binding context.
+    /// Default-generic remains `MainStorage`, so existing call sites
+    /// (`UnorderedMap::<K, V>::new()`) keep their behaviour. Inside a
+    /// `#[app::private]` struct, the macro substitutes `PrivateStorage`
+    /// as `S` on the field type, and this constructor infers `S =
+    /// PrivateStorage` from the assignment site.
     pub fn new() -> Self {
         Self::new_internal()
     }
@@ -736,10 +744,11 @@ where
 mod tests {
     use crate::collections::unordered_map::Entry;
     use crate::collections::{Root, UnorderedMap};
+    use crate::store::MainStorage;
 
     #[test]
     fn test_unordered_map_basic_operations() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -788,7 +797,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_insert_and_get() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key1".to_owned(), "value1".to_owned())
@@ -811,7 +820,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_update_value() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -830,7 +839,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -846,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key1".to_owned(), "value1".to_owned())
@@ -865,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_len() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert_eq!(map.len().expect("len failed"), 0);
 
@@ -894,7 +903,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_contains() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -907,7 +916,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entries() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         assert!(map
             .insert("key1".to_owned(), "value1".to_owned())
@@ -931,7 +940,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_get_mut() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
         drop(
             map.insert("key1".to_owned(), "value1".to_owned())
                 .expect("insert failed"),
@@ -962,7 +971,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_vacant() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
         // Test `or_insert()`
         {
@@ -997,7 +1006,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_occupied_or_insert() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
         drop(
             map.insert("key1".to_owned(), "value1".to_owned())
                 .expect("insert failed"),
@@ -1042,7 +1051,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_occupied_mutations() {
-        let mut map = Root::new(|| UnorderedMap::new());
+        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
         drop(map.insert("key1".to_owned(), "value1".to_owned()).unwrap());
         drop(map.insert("key2".to_owned(), "value2".to_owned()).unwrap());
         drop(map.insert("key3".to_owned(), "value3".to_owned()).unwrap());

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -19,9 +19,10 @@ pub struct UnorderedSet<V, S: StorageAdaptor = MainStorage> {
     inner: Collection<V, S>,
 }
 
-impl<V> UnorderedSet<V, MainStorage>
+impl<V, S> UnorderedSet<V, S>
 where
     V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     /// Create a new set collection with a random ID.
     ///
@@ -30,6 +31,10 @@ where
     /// doesn't affect sync semantics.
     ///
     /// For top-level state fields, use `new_with_field_name` instead.
+    ///
+    /// `S` is inferred from the binding context; default-generic is
+    /// `MainStorage`. Inside `#[app::private]`, the macro substitutes
+    /// `PrivateStorage` as `S` on the field type.
     pub fn new() -> Self {
         Self::new_internal()
     }
@@ -227,11 +232,17 @@ where
     }
 }
 
-impl<V> Eq for UnorderedSet<V> where V: Eq + BorshSerialize + BorshDeserialize {}
+impl<V, S> Eq for UnorderedSet<V, S>
+where
+    V: Eq + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+}
 
-impl<V> PartialEq for UnorderedSet<V>
+impl<V, S> PartialEq for UnorderedSet<V, S>
 where
     V: PartialEq + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
@@ -242,9 +253,10 @@ where
     }
 }
 
-impl<V> Ord for UnorderedSet<V>
+impl<V, S> Ord for UnorderedSet<V, S>
 where
     V: Ord + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
@@ -255,9 +267,10 @@ where
     }
 }
 
-impl<V> PartialOrd for UnorderedSet<V>
+impl<V, S> PartialOrd for UnorderedSet<V, S>
 where
     V: PartialOrd + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         let l = self.iter().ok()?;
@@ -267,9 +280,10 @@ where
     }
 }
 
-impl<V> fmt::Debug for UnorderedSet<V>
+impl<V, S> fmt::Debug for UnorderedSet<V, S>
 where
     V: fmt::Debug + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -283,9 +297,10 @@ where
     }
 }
 
-impl<V> Default for UnorderedSet<V>
+impl<V, S> Default for UnorderedSet<V, S>
 where
     V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     fn default() -> Self {
         Self::new_internal()
@@ -348,10 +363,11 @@ where
 #[cfg(test)]
 mod tests {
     use crate::collections::{Root, UnorderedSet};
+    use crate::store::MainStorage;
 
     #[test]
     fn test_unordered_set_operations() {
-        let mut set = Root::new(|| UnorderedSet::new());
+        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
 
@@ -378,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_len() {
-        let mut set = Root::new(|| UnorderedSet::new());
+        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));
@@ -393,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_clear() {
-        let mut set = Root::new(|| UnorderedSet::new());
+        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));
@@ -409,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_items() {
-        let mut set = Root::new(|| UnorderedSet::new());
+        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -38,9 +38,10 @@ pub struct Vector<V, S: StorageAdaptor = MainStorage> {
     inner: Collection<V, S>,
 }
 
-impl<V> Vector<V, MainStorage>
+impl<V, S> Vector<V, S>
 where
     V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     /// Create a new vector collection with a random ID.
     ///
@@ -49,6 +50,11 @@ where
     /// doesn't affect sync semantics.
     ///
     /// For top-level state fields, use `new_with_field_name` instead.
+    ///
+    /// `S` is inferred from the binding context; default-generic is
+    /// `MainStorage`. Inside `#[app::private]`, the macro substitutes
+    /// `PrivateStorage` as `S` on the field type, and this constructor
+    /// infers `S = PrivateStorage` at the assignment site.
     pub fn new() -> Self {
         Self::new_internal()
     }
@@ -324,11 +330,17 @@ where
     }
 }
 
-impl<V> Eq for Vector<V> where V: Eq + BorshSerialize + BorshDeserialize {}
+impl<V, S> Eq for Vector<V, S>
+where
+    V: Eq + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+}
 
-impl<V> PartialEq for Vector<V>
+impl<V, S> PartialEq for Vector<V, S>
 where
     V: PartialEq + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
@@ -339,9 +351,10 @@ where
     }
 }
 
-impl<V> Ord for Vector<V>
+impl<V, S> Ord for Vector<V, S>
 where
     V: Ord + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
@@ -352,9 +365,10 @@ where
     }
 }
 
-impl<V> PartialOrd for Vector<V>
+impl<V, S> PartialOrd for Vector<V, S>
 where
     V: PartialOrd + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         let l = self.iter().ok()?;
@@ -364,9 +378,10 @@ where
     }
 }
 
-impl<V> fmt::Debug for Vector<V>
+impl<V, S> fmt::Debug for Vector<V, S>
 where
     V: fmt::Debug + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
 {
     #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -440,10 +455,11 @@ where
 #[cfg(test)]
 mod tests {
     use crate::collections::{Root, Vector};
+    use crate::store::MainStorage;
 
     #[test]
     fn test_vector_push() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value = "test_data".to_owned();
         let result = vector.push(value.clone());
@@ -453,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_vector_get() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value = "test_data".to_owned();
         let _ = vector.push(value.clone()).unwrap();
@@ -463,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_vector_update() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value1 = "test_data1".to_owned();
         let value2 = "test_data2".to_owned();
@@ -486,7 +502,7 @@ mod tests {
 
     #[test]
     fn test_vector_pop() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value = "test_data".to_owned();
         let _ = vector.push(value.clone()).unwrap();
@@ -497,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_vector_items() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value1 = "test_data1".to_owned();
         let value2 = "test_data2".to_owned();
@@ -509,7 +525,7 @@ mod tests {
 
     #[test]
     fn test_vector_contains() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value = "test_data".to_owned();
         let _ = vector.push(value.clone()).unwrap();
@@ -520,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_vector_clear() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let value = "test_data".to_owned();
         let _ = vector.push(value.clone()).unwrap();
@@ -530,7 +546,7 @@ mod tests {
 
     #[test]
     fn test_vector_find() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let _ = vector.push("apple".to_owned()).unwrap();
         let _ = vector.push("banana".to_owned()).unwrap();
@@ -554,7 +570,7 @@ mod tests {
 
     #[test]
     fn test_vector_filter() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let _ = vector.push("apple".to_owned()).unwrap();
         let _ = vector.push("banana".to_owned()).unwrap();
@@ -584,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_vector_find_with_numbers() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let _ = vector.push(1u32).unwrap();
         let _ = vector.push(5u32).unwrap();
@@ -599,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_vector_filter_with_numbers() {
-        let mut vector = Root::new(|| Vector::new());
+        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
         let _ = vector.push(1u32).unwrap();
         let _ = vector.push(5u32).unwrap();

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -165,6 +165,28 @@ pub fn storage_write(key: Key, value: &[u8]) -> bool {
     imp::storage_write(key, value)
 }
 
+/// Reads data from node-local (private) persistent storage.
+///
+/// Private storage is **NOT synchronised across nodes** — entries
+/// written here stay on this node only. Used by the `PrivateStorage`
+/// adaptor that backs `#[app::private]` collections.
+#[must_use]
+pub fn private_storage_read(key: Key) -> Option<Vec<u8>> {
+    imp::private_storage_read(key)
+}
+
+/// Removes data from node-local (private) persistent storage.
+#[must_use]
+pub fn private_storage_remove(key: Key) -> bool {
+    imp::private_storage_remove(key)
+}
+
+/// Writes data to node-local (private) persistent storage.
+#[must_use]
+pub fn private_storage_write(key: Key, value: &[u8]) -> bool {
+    imp::private_storage_write(key, value)
+}
+
 /// Fill the buffer with random bytes.
 ///
 /// # Parameters
@@ -300,6 +322,21 @@ mod calimero_vm {
         env::storage_write(&key.to_bytes(), value)
     }
 
+    /// Reads data from node-local private storage.
+    pub(super) fn private_storage_read(key: Key) -> Option<Vec<u8>> {
+        env::private_storage_read(&key.to_bytes())
+    }
+
+    /// Removes data from node-local private storage.
+    pub(super) fn private_storage_remove(key: Key) -> bool {
+        env::private_storage_remove(&key.to_bytes())
+    }
+
+    /// Writes data to node-local private storage.
+    pub(super) fn private_storage_write(key: Key, value: &[u8]) -> bool {
+        env::private_storage_write(&key.to_bytes(), value)
+    }
+
     /// Fills the buffer with random bytes.
     pub(super) fn random_bytes(buf: &mut [u8]) {
         env::random_bytes(buf)
@@ -391,6 +428,12 @@ mod mocked {
 
     /// The default storage system.
     type DefaultStore = MockedStorage<{ usize::MAX }>;
+    /// Scope used to back the mocked private-storage path. Distinct
+    /// from `DefaultStore` so test-mode reads/writes through the
+    /// `PrivateStorage` adaptor stay isolated from main-storage state
+    /// — matching the WASM host's behaviour where private storage is
+    /// a separate namespace.
+    type DefaultPrivateStore = MockedStorage<{ usize::MAX - 1 }>;
 
     /// Commits the root hash to the runtime.
     pub(super) fn commit(root_hash: &[u8; 32], _artifact: &[u8]) {
@@ -430,6 +473,49 @@ mod mocked {
         } else {
             DefaultStore::storage_write(key, value)
         }
+    }
+
+    // Why these don't consult `RUNTIME_ENV` like their main-storage
+    // siblings:
+    //
+    // `RuntimeEnv` carries callbacks only for main-storage reads /
+    // writes / removes (see `super::RuntimeEnv`) — it has no private
+    // storage backend to route to. That's not an omission: in
+    // production, private storage is served by a dedicated WASM host
+    // import (`imp::private_storage_*` → `VMLogic::private_storage`
+    // → a separate `Storage` handle that maps to its own RocksDB
+    // column, see `crates/context/src/handlers/execute/storage.rs`'s
+    // `ContextPrivateStorage`). `with_runtime_env` is only installed
+    // around native shim code that drives MainStorage (snapshot /
+    // signature persistence in `crates/context` and `crates/runtime`)
+    // — none of those scopes touch private storage.
+    //
+    // So in mocked mode, `DefaultPrivateStore` IS the backend for
+    // node-local private state. The asymmetry vs `storage_*` is
+    // intentional: there is nothing else to route to. If a future
+    // caller ever needs runtime-env routing for private state (e.g. a
+    // native test harness that wants reads/writes to land in a real
+    // `Storage` handle), the right fix is to extend `RuntimeEnv` with
+    // private callbacks rather than re-pointing this mock — the
+    // current contract is "private storage is per-node-local; in
+    // tests, the mock IS the node."
+
+    /// Reads data from node-local private storage. Mocked path routes
+    /// to a separate `MockedStorage` scope so private state stays
+    /// isolated from main state in tests, matching the WASM host's
+    /// separate-namespace behaviour.
+    pub(super) fn private_storage_read(key: Key) -> Option<Vec<u8>> {
+        DefaultPrivateStore::storage_read(key)
+    }
+
+    /// Removes data from node-local private storage (mocked path).
+    pub(super) fn private_storage_remove(key: Key) -> bool {
+        DefaultPrivateStore::storage_remove(key)
+    }
+
+    /// Writes data to node-local private storage (mocked path).
+    pub(super) fn private_storage_write(key: Key, value: &[u8]) -> bool {
+        DefaultPrivateStore::storage_write(key, value)
     }
 
     /// Fills the buffer with random bytes.

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1270,8 +1270,10 @@ impl<S: StorageAdaptor> Interface<S> {
                     )?;
                 }
 
-                crate::delta::push_action(Action::Compare { id });
-                debug!(%id, "Queued compare action after apply");
+                if S::participates_in_sync() {
+                    crate::delta::push_action(Action::Compare { id });
+                    debug!(%id, "Queued compare action after apply");
+                }
             }
             Action::Compare { .. } => {
                 return Err(StorageError::ActionNotAllowed("Compare".to_owned()))
@@ -1643,8 +1645,10 @@ impl<S: StorageAdaptor> Interface<S> {
             <Interface<S>>::apply_action(action, ctx)?;
         }
 
-        for action in remote {
-            crate::delta::push_action(action);
+        if S::participates_in_sync() {
+            for action in remote {
+                crate::delta::push_action(action);
+            }
         }
 
         Ok(())
@@ -1826,12 +1830,21 @@ impl<S: StorageAdaptor> Interface<S> {
         // Use DeleteRef for efficient tombstone-based deletion.
         // More efficient than Delete: only sends ID + timestamp + metadata vs full ancestor tree.
         // The tombstone is created by remove_child_from, we just broadcast the deletion.
-        crate::delta::push_action(Action::DeleteRef {
-            id: child_id,
-            deleted_at,
-            // Pass the full metadata
-            metadata,
-        });
+        //
+        // Gated by `S::participates_in_sync()`: a `PrivateStorage` delete
+        // stays local and must NOT enter the synced delta stream — same
+        // reasoning as the `Compare` push at the end of `apply_action`
+        // above. The remove_child_from call right above mutates only
+        // `S`'s index, so the broadcast was the only sync surface for
+        // this path.
+        if S::participates_in_sync() {
+            crate::delta::push_action(Action::DeleteRef {
+                id: child_id,
+                deleted_at,
+                // Pass the full metadata
+                metadata,
+            });
+        }
 
         Ok(true)
     }
@@ -2324,7 +2337,21 @@ impl<S: StorageAdaptor> Interface<S> {
             }
         };
 
-        crate::delta::push_action(action);
+        // #2319 root cause: this push is the choke point through which
+        // every storage mutation enters the synced delta stream. For
+        // `MainStorage` that is correct. For `PrivateStorage` — backing
+        // `#[app::private]` tree-collection fields after the macro
+        // substitution — it was leaking actions for purely node-local
+        // collection bookkeeping (e.g. the `add_child_to(*ROOT_ID, ...)`
+        // call inside `Collection::new()` when an UnorderedMap is
+        // default-constructed during `PrivateSecrets::default()`). Peers
+        // applied those actions to their `MainStorage` and ended up
+        // with extra `crdt_type=None, field_name=None` children under
+        // context-root that the author didn't have. Gate the push on
+        // `S::participates_in_sync()` so private writes stay local.
+        if S::participates_in_sync() {
+            crate::delta::push_action(action);
+        }
 
         debug!(%id, ?full_hash, is_new, "save_raw completed");
 

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -3,7 +3,10 @@
 use sha2::{Digest, Sha256};
 
 use crate::address::Id;
-use crate::env::{storage_read, storage_remove, storage_write};
+use crate::env::{
+    private_storage_read, private_storage_remove, private_storage_write, storage_read,
+    storage_remove, storage_write,
+};
 
 /// A key for storage operations.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -77,6 +80,32 @@ pub trait StorageAdaptor: 'static {
 
     /// Writes data to persistent storage.
     fn storage_write(key: Key, value: &[u8]) -> bool;
+
+    /// Whether writes through this adaptor participate in the synced
+    /// state delta stream.
+    ///
+    /// `Interface::save_raw` (and the `Action::Compare` push at the end of
+    /// `Interface::apply_action`, and the `Action::DeleteRef` push at the
+    /// end of the delete path) records every storage mutation as an
+    /// `Action` in the global delta stream. Those actions get bundled into
+    /// the next outgoing `StateDelta` and replayed on every peer.
+    ///
+    /// That's correct for `MainStorage`, where the whole point is that
+    /// writes propagate. It's a bug for `PrivateStorage`: a write that
+    /// stays on this node by design should not produce a wire action.
+    /// Otherwise peers replay the action against their own `MainStorage`,
+    /// creating entities the author doesn't have — the #2319 "Same DAG
+    /// heads, different root hash" divergence pattern (one extra
+    /// `crdt_type=None, field_name=None` child appearing in the receiver's
+    /// context-root index entry after every `PrivateStorage` collection
+    /// construction).
+    ///
+    /// Default is `true` (sync-participating). `PrivateStorage` overrides
+    /// to `false`. Test mocks default to `true` since they stand in for
+    /// `MainStorage` in unit tests.
+    fn participates_in_sync() -> bool {
+        true
+    }
 }
 
 /// Storage iteration support for GC and snapshots.
@@ -131,6 +160,100 @@ impl StorageAdaptor for MainStorage {
 
     fn storage_write(key: Key, value: &[u8]) -> bool {
         storage_write(key, value)
+    }
+}
+
+/// Node-local (private) storage adaptor.
+///
+/// Routes all reads/writes/removes to the node-local private-storage
+/// namespace via [`env::private_storage_read`](crate::env::private_storage_read)
+/// and friends. Entries stored here **do not** participate in the
+/// synced Merkle tree — they stay on the node that wrote them.
+///
+/// # When to use
+///
+/// `PrivateStorage` makes sense when you need scalable node-local
+/// state where only the *entries you change* are rewritten, not the
+/// whole blob. The alternative — borsh-serialising a plain
+/// `std::collections::BTreeMap` (or similar) into the outer private
+/// blob — is correct but rewrites the entire serialised value on
+/// every mutation; that's fine for small state but expensive at any
+/// non-trivial scale.
+///
+/// # Direct usage (rare)
+///
+/// You normally don't write `PrivateStorage` directly. The
+/// `#[app::private]` macro auto-substitutes it on tree-backed
+/// structural collections (`UnorderedMap`, `UnorderedSet`,
+/// `Vector`) declared as struct fields, so app code stays unchanged.
+/// Direct use is reserved for the rare case where you need an
+/// explicit type alias or a collection outside an `#[app::private]`
+/// struct that must still go to node-local storage:
+///
+/// ```ignore
+/// use calimero_storage::collections::UnorderedMap;
+/// use calimero_storage::store::PrivateStorage;
+///
+/// // Type alias for use outside `#[app::private]`.
+/// type LocalCache = UnorderedMap<String, Vec<u8>, PrivateStorage>;
+/// ```
+///
+/// # What goes here vs MainStorage vs the borsh blob
+///
+/// | Data shape | Where it lives |
+/// |---|---|
+/// | Synced app state (`#[app::state]` struct fields) | `MainStorage` — synced via merkle tree |
+/// | Local-only structural collections inside `#[app::private]` | `PrivateStorage` — node-local, per-entity granularity |
+/// | Local-only primitives + std types (`u64`, `String`, `BTreeMap`, `Vec`) inside `#[app::private]` | The outer private blob — borsh-serialised together, rewritten on every change |
+///
+/// CRDT collections (`LwwRegister`, `Counter`, `GCounter`,
+/// `PNCounter`, `ReplicatedGrowableArray`) are deliberately **not**
+/// supported with `PrivateStorage`: CRDTs are multi-writer
+/// conflict-resolution machinery, and private storage has exactly
+/// one writer (this node), so the per-writer bookkeeping is overhead
+/// without a corresponding semantic gain. Use a plain `u64` /
+/// `String` / `Vec` instead.
+///
+/// Access-control collections (`SharedStorage`, `UserStorage`,
+/// `FrozenStorage`) and authored collections (`AuthoredMap`,
+/// `AuthoredVector`) are likewise excluded: their semantics
+/// (cross-writer mutability, per-user separation, immutability,
+/// per-entry authorship) all assume the synced tree.
+///
+/// # Background — the bug this closes
+///
+/// Before this adaptor existed, tree-backed collections inside
+/// `#[app::private]` defaulted to `MainStorage`, so their *entries*
+/// silently landed in the synced merkle tree even though the
+/// containing struct's blob stayed private. The writing node ended
+/// up holding entities the receiving nodes didn't, producing
+/// persistent root-hash divergence on every write (see issue #2423).
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub struct PrivateStorage;
+
+impl StorageAdaptor for PrivateStorage {
+    fn storage_read(key: Key) -> Option<Vec<u8>> {
+        private_storage_read(key)
+    }
+
+    fn storage_remove(key: Key) -> bool {
+        private_storage_remove(key)
+    }
+
+    fn storage_write(key: Key, value: &[u8]) -> bool {
+        private_storage_write(key, value)
+    }
+
+    /// Private writes never participate in the synced delta stream.
+    ///
+    /// See the trait-level doc for the bug this closes (#2319 receiver
+    /// gets extra `crdt_type=None` children of context-root every time a
+    /// `PrivateStorage`-backed collection is constructed, because
+    /// `Interface::save_raw` was unconditionally pushing every storage
+    /// mutation onto the global delta queue regardless of adaptor).
+    fn participates_in_sync() -> bool {
+        false
     }
 }
 

--- a/crates/storage/src/tests/collections.rs
+++ b/crates/storage/src/tests/collections.rs
@@ -63,7 +63,7 @@ fn test_root_entry_gets_lww_register_crdt_type() {
 
 #[test]
 fn test_unordered_map_basic_operations() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
@@ -112,7 +112,7 @@ fn test_unordered_map_basic_operations() {
 
 #[test]
 fn test_unordered_map_insert_and_get() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key1".to_string(), "value1".to_string())
@@ -135,7 +135,7 @@ fn test_unordered_map_insert_and_get() {
 
 #[test]
 fn test_unordered_map_update_value() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
@@ -154,7 +154,7 @@ fn test_unordered_map_update_value() {
 
 #[test]
 fn test_unordered_map_remove() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
@@ -170,7 +170,7 @@ fn test_unordered_map_remove() {
 
 #[test]
 fn test_unordered_map_clear() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key1".to_string(), "value1".to_string())
@@ -189,7 +189,7 @@ fn test_unordered_map_clear() {
 
 #[test]
 fn test_unordered_map_len() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert_eq!(map.len().expect("len failed"), 0);
 
@@ -218,7 +218,7 @@ fn test_unordered_map_len() {
 
 #[test]
 fn test_unordered_map_contains() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
@@ -231,7 +231,7 @@ fn test_unordered_map_contains() {
 
 #[test]
 fn test_unordered_map_entries() {
-    let mut map = Root::new(|| UnorderedMap::new());
+    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
 
     assert!(map
         .insert("key1".to_string(), "value1".to_string())
@@ -259,7 +259,7 @@ fn test_unordered_map_entries() {
 
 #[test]
 fn test_vector_push() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value = "test_data".to_string();
     let result = vector.push(value.clone());
@@ -269,7 +269,7 @@ fn test_vector_push() {
 
 #[test]
 fn test_vector_get() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value = "test_data".to_string();
     let _ = vector.push(value.clone()).unwrap();
@@ -279,7 +279,7 @@ fn test_vector_get() {
 
 #[test]
 fn test_vector_update() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value1 = "test_data1".to_string();
     let value2 = "test_data2".to_string();
@@ -302,7 +302,7 @@ fn test_vector_get_non_existent() {
 
 #[test]
 fn test_vector_pop() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value = "test_data".to_string();
     let _ = vector.push(value.clone()).unwrap();
@@ -313,7 +313,7 @@ fn test_vector_pop() {
 
 #[test]
 fn test_vector_items() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value1 = "test_data1".to_string();
     let value2 = "test_data2".to_string();
@@ -325,7 +325,7 @@ fn test_vector_items() {
 
 #[test]
 fn test_vector_contains() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value = "test_data".to_string();
     let _ = vector.push(value.clone()).unwrap();
@@ -336,7 +336,7 @@ fn test_vector_contains() {
 
 #[test]
 fn test_vector_clear() {
-    let mut vector = Root::new(|| Vector::new());
+    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
 
     let value = "test_data".to_string();
     let _ = vector.push(value.clone()).unwrap();
@@ -350,7 +350,7 @@ fn test_vector_clear() {
 
 #[test]
 fn test_unordered_set_operations() {
-    let mut set = Root::new(|| UnorderedSet::new());
+    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
 
@@ -378,7 +378,7 @@ fn test_unordered_set_operations() {
 
 #[test]
 fn test_unordered_set_len() {
-    let mut set = Root::new(|| UnorderedSet::new());
+    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));
@@ -393,7 +393,7 @@ fn test_unordered_set_len() {
 
 #[test]
 fn test_unordered_set_clear() {
-    let mut set = Root::new(|| UnorderedSet::new());
+    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));
@@ -409,7 +409,7 @@ fn test_unordered_set_clear() {
 
 #[test]
 fn test_unordered_set_items() {
-    let mut set = Root::new(|| UnorderedSet::new());
+    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));


### PR DESCRIPTION
## Summary

Closes #2423. Tree-backed collections inside `#[app::private]` structs were silently leaking their entries into the synced merkle tree, producing asymmetric root hashes (writing nodes held entities the receiving nodes didn't — the scaffolding-e2e "Wait for sync after secret add" failure).

This PR closes the leak transparently — apps keep their existing code, and the `#[app::private]` macro auto-routes tree-backed fields to a node-local storage namespace.

## The mechanism we're fixing

`#[app::private]` only privatised the outer container's borsh-serialised bytes (stored via `private_storage_write`). The inner collection's entries went through `MainStorage` and into the synced merkle index. Specifically, in `scaffolding-e2e`:

```rust
#[app::private]
struct PrivateSecrets {
    secrets: UnorderedMap<String, String>,  // default = MainStorage
}

// secrets.insert("game1", "secret") writes to the SYNCED tree
```

## What's in this PR

### 1. `PrivateStorage` adaptor (`crates/storage/src/store.rs`)

Implements `StorageAdaptor` by routing reads/writes/removes to `env::private_storage_*` (the node-local namespace the WASM host exposes). The mocked path routes to a separate `MockedStorage<{ usize::MAX - 1 }>` scope so test-mode private state stays isolated from main state, matching the WASM host's separate-namespace behaviour.

### 2. `UnorderedMap::new()` generalised over `S: StorageAdaptor`

Previously pinned to `MainStorage`. Making it generic lets the constructor infer the adaptor from the binding context — so `UnorderedMap::new()` inside a `#[app::private]` field declared as `UnorderedMap<K, V, PrivateStorage>` (after macro substitution) constructs the right variant.

Internal test sites in `calimero-storage` that called `UnorderedMap::new()` without enough context now annotate `UnorderedMap::<_, _, MainStorage>::new()` (~12 sites in `collections/unordered_map.rs`, 8 in `tests/collections.rs`, 1 in `decompose_impls.rs`). No production code affected.

### 3. `#[app::private]` macro auto-substitution

`crates/sdk/macros/src/private.rs::inject_private_storage` walks each struct field's type AST. If the last path segment is a known tree-backed collection (`UnorderedMap`, `UnorderedSet`, `Vector`, `LwwRegister`, `Counter`, `GCounter`, `PNCounter`, `ReplicatedGrowableArray`, `SharedStorage`, `UserStorage`, `FrozenStorage`, `AuthoredMap`, `AuthoredVector`) **and** the user hasn't already supplied an explicit storage-adaptor generic, the macro injects `::calimero_storage::store::PrivateStorage` as the trailing type arg.

Detection counts type-arguments per known type:
- `UnorderedMap<K, V>` (2 args) → inject
- `UnorderedMap<K, V, X>` (3 args) → leave alone
- `Vector<V>` (1 arg) → inject
- `Counter` (0 args) → inject

Enum variants are walked too — variant fields rewrite identically.

### 4. 5 new macro unit tests

Pin the rewrite rules: known type → injects; explicit adaptor → preserved; non-Calimero type (e.g. `BTreeMap`) → untouched; single-param collections work; zero-param `Counter` works.

## What the user sees

Same code, no leak:

```rust
#[app::private]
struct Secrets {
    items: UnorderedMap<String, String>,  // macro injects PrivateStorage
}
```

`scaffolding-e2e` migrated by deleting the explicit `, PrivateStorage` I had added in the experimental commit — the macro now handles it.

## Test plan

- [x] `cargo test -p calimero-storage` — 448 + smaller bins pass
- [x] `cargo test -p calimero-sdk-macros` — 34 pass (5 new for the rewrite rules)
- [x] `cargo build --workspace` — clean
- [x] `cargo build -p scaffolding-e2e --release` — clean (the macro is doing the substitution)
- [x] `cargo fmt --check`
- [ ] `scaffolding-e2e` "Wait for sync after secret add" workflow — this is what #2423 was filed to fix. Will verify in CI.

## Known limitations (follow-ups)

- Only `UnorderedMap::new()` is generalised over `S` in this PR. Other tree-backed collections (`Vector::new()`, `LwwRegister::new()`, etc.) still have `::new()` pinned to `MainStorage`. The macro substitutes the field types correctly — but user code that constructs those collections inside `#[app::private]` via `Type::new()` will hit a type mismatch until those constructors are generalised. `UnorderedMap` works transparently today; the others need a mechanical follow-up. (`scaffolding-e2e`'s `PrivateSecrets` only uses `UnorderedMap`, so this PR fixes #2423 end-to-end for that test.)

- Macro detection is name-based — `use UnorderedMap as Foo` renames aren't caught. Documented in the macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core storage/delta propagation and delta application semantics, which can affect sync correctness and root-hash consistency across nodes.
> 
> **Overview**
> Fixes leakage of `#[app::private]` tree-backed collections into the synced Merkle tree by introducing a node-local `PrivateStorage` adaptor and making the storage layer skip delta-stream emission (`Action::Add`/`Update`/`DeleteRef`/`Compare`) when an adaptor opts out via `StorageAdaptor::participates_in_sync()`.
> 
> Extends the `#[app::private]` macro to recursively rewrite field types so `UnorderedMap`/`UnorderedSet`/`Vector` (including nested occurrences) automatically get `PrivateStorage` injected unless an explicit adaptor is already provided, and adds unit tests to pin these rewrite rules.
> 
> Generalizes `UnorderedMap`/`UnorderedSet`/`Vector` constructors and trait impls over `S: StorageAdaptor` (with test call sites updated to specify `MainStorage` where needed), adds env plumbing for `private_storage_*` with isolated mocked backing, and updates the `private_data` example + workflow to exercise and assert node-local behavior.
> 
> Also adjusts remote delta application in `delta_store` to only use merge semantics when required, avoiding hash divergence caused by always taking the merge-apply path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09abfbab4b2448bbf527550479ff5637b18efecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->