### PR TITLE
feat(server/admin): expose MemberSetAutoFollow as a public HTTP endpoint

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -37,13 +37,13 @@ use crate::group::{
     ListGroupContextsRequest, ListGroupMembersRequest, ListGroupMembersResponse,
     ListNamespacesForApplicationRequest, ListNamespacesRequest, NamespaceSummary,
     RemoveGroupMembersRequest, RetryGroupUpgradeRequest, SetContextMetadataRequest,
-    SetDefaultCapabilitiesRequest, SetGroupMetadataRequest, SetMemberCapabilitiesRequest,
-    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
-    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
-    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
-    SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
-    UpgradeGroupResponse,
+    SetDefaultCapabilitiesRequest, SetGroupMetadataRequest, SetMemberAutoFollowRequest,
+    SetMemberCapabilitiesRequest, SetMemberMetadataRequest, SetSubgroupVisibilityRequest,
+    SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest,
+    StoreGroupContextRequest, StoreGroupMetaRequest, StoreGroupMetadataRequest,
+    StoreMemberCapabilityRequest, StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest,
+    SyncGroupRequest, SyncGroupResponse, UpdateGroupSettingsRequest, UpdateMemberRoleRequest,
+    UpgradeGroupRequest, UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1315,6 +1315,12 @@ impl ContextClient {
         set_member_capabilities,
         SetMemberCapabilities,
         SetMemberCapabilitiesRequest,
+        eyre::Result<()>
+    );
+    forward_to_actor!(
+        set_member_auto_follow,
+        SetMemberAutoFollow,
+        SetMemberAutoFollowRequest,
         eyre::Result<()>
     );
     forward_to_actor!(

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -598,6 +598,24 @@ impl Message for SetMemberCapabilitiesRequest {
     type Result = eyre::Result<()>;
 }
 
+/// Set per-member auto-follow flags on a group.
+///
+/// Authorized by group admin (for any `target`) or by the `target` itself
+/// (self-setting). The apply path enforces the admin-or-self rule —
+/// see `GroupOp::MemberSetAutoFollow` and the auto-follow architecture doc.
+#[derive(Debug)]
+pub struct SetMemberAutoFollowRequest {
+    pub group_id: ContextGroupId,
+    pub target: PublicKey,
+    pub auto_follow_contexts: bool,
+    pub auto_follow_subgroups: bool,
+    pub requester: Option<PublicKey>,
+}
+
+impl Message for SetMemberAutoFollowRequest {
+    type Result = eyre::Result<()>;
+}
+
 #[derive(Debug)]
 pub struct GetMemberCapabilitiesRequest {
     pub group_id: ContextGroupId,

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -20,12 +20,12 @@ use crate::group::{
     LeaveNamespaceRequest, ListAllGroupsRequest, ListGroupContextsRequest, ListGroupMembersRequest,
     ListNamespacesForApplicationRequest, ListNamespacesRequest, RemoveGroupMembersRequest,
     RetryGroupUpgradeRequest, SetContextMetadataRequest, SetDefaultCapabilitiesRequest,
-    SetGroupMetadataRequest, SetMemberCapabilitiesRequest, SetMemberMetadataRequest,
-    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest,
-    StoreDefaultCapabilitiesRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
-    StoreGroupMetadataRequest, StoreMemberCapabilityRequest, StoreMemberMetadataRequest,
-    StoreSubgroupVisibilityRequest, SyncGroupRequest, UpdateGroupSettingsRequest,
-    UpdateMemberRoleRequest, UpgradeGroupRequest,
+    SetGroupMetadataRequest, SetMemberAutoFollowRequest, SetMemberCapabilitiesRequest,
+    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
+    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    UpdateGroupSettingsRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -380,6 +380,10 @@ pub enum ContextMessage {
     SetMemberCapabilities {
         request: SetMemberCapabilitiesRequest,
         outcome: oneshot::Sender<<SetMemberCapabilitiesRequest as Message>::Result>,
+    },
+    SetMemberAutoFollow {
+        request: SetMemberAutoFollowRequest,
+        outcome: oneshot::Sender<<SetMemberAutoFollowRequest as Message>::Result>,
     },
     GetMemberCapabilities {
         request: GetMemberCapabilitiesRequest,

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -43,6 +43,7 @@ pub mod retry_group_upgrade;
 pub mod set_context_metadata;
 pub mod set_default_capabilities;
 pub mod set_group_metadata;
+pub mod set_member_auto_follow;
 pub mod set_member_capabilities;
 pub mod set_member_metadata;
 pub mod set_subgroup_visibility;
@@ -164,6 +165,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::SetMemberCapabilities { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::SetMemberAutoFollow { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::GetMemberCapabilities { request, outcome } => {

--- a/crates/context/src/handlers/set_member_auto_follow.rs
+++ b/crates/context/src/handlers/set_member_auto_follow.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::group::SetMemberAutoFollowRequest;
+use calimero_context_client::local_governance::GroupOp;
+
+use crate::governance_broadcast::ObserveDelivery;
+use crate::{group_store, ContextManager};
+
+impl Handler<SetMemberAutoFollowRequest> for ContextManager {
+    type Result = ActorResponse<Self, <SetMemberAutoFollowRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        SetMemberAutoFollowRequest {
+            group_id,
+            target,
+            auto_follow_contexts,
+            auto_follow_subgroups,
+            requester,
+        }: SetMemberAutoFollowRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        // Admin-or-self is enforced inside the apply path
+        // (`GroupOp::MemberSetAutoFollow`), so don't require admin here —
+        // a non-admin self-setter must be allowed through preflight.
+        let preflight = match self.governance_preflight(&group_id, requester, false) {
+            Ok(p) => p,
+            Err(err) => return ActorResponse::reply(Err(err)),
+        };
+
+        // Surface the membership check up-front for a clearer error than the
+        // generic apply-path "target is not a member" bail.
+        if group_store::get_group_member_role(&self.datastore, &group_id, &target)
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            return ActorResponse::reply(Err(eyre::eyre!(
+                "target is not a member of group '{group_id:?}'"
+            )));
+        }
+
+        let datastore = preflight.datastore.clone();
+        let node_client = preflight.node_client.clone();
+        let ack_router = Arc::clone(&self.ack_router);
+        let sk = preflight.signer_sk();
+
+        ActorResponse::r#async(
+            async move {
+                let report = group_store::sign_apply_and_publish(
+                    &datastore,
+                    &node_client,
+                    &ack_router,
+                    &group_id,
+                    &sk,
+                    GroupOp::MemberSetAutoFollow {
+                        target,
+                        auto_follow_contexts,
+                        auto_follow_subgroups,
+                    },
+                )
+                .await?;
+                report.observe("set_member_auto_follow", "MemberSetAutoFollow");
+                tracing::info!(
+                    ?group_id,
+                    %target,
+                    auto_follow_contexts,
+                    auto_follow_subgroups,
+                    "member auto-follow flags updated"
+                );
+                Ok(())
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -9,10 +9,12 @@ use actix::Actor;
 use calimero_blobstore::config::BlobStoreConfig;
 use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
 use calimero_context::group_store::{
-    add_group_member, check_group_membership, get_local_gov_nonce, save_group_meta,
+    add_group_member, check_group_membership, get_group_member_value, get_local_gov_nonce,
+    save_group_meta, store_group_signing_key,
 };
 use calimero_context::ContextManager;
 use calimero_context_client::client::ContextClient;
+use calimero_context_client::group::SetMemberAutoFollowRequest;
 use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
 use calimero_context_config::types::ContextGroupId;
 use calimero_network_primitives::client::NetworkClient;
@@ -28,6 +30,7 @@ use calimero_store::Store;
 use calimero_utils_actix::LazyRecipient;
 use prometheus_client::registry::Registry;
 use rand::rngs::OsRng;
+use tempfile::TempDir;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
@@ -48,8 +51,22 @@ fn sample_meta(admin: PublicKey) -> GroupMetaValue {
     }
 }
 
-#[tokio::test]
-async fn apply_signed_group_op_via_context_client() {
+/// Bundle of resources kept alive for the duration of a test — dropping
+/// `_tmp` or `_pool` would tear down the blobstore / arbiters underneath
+/// the running actors.
+struct TestNode {
+    _pool: ArbiterPool,
+    _tmp: TempDir,
+    store: Store,
+    context_client: ContextClient,
+}
+
+/// Boots a `ContextManager` + `NodeManager` against an in-memory store and
+/// a tempdir-backed blobstore, with no peer wired up (the network client's
+/// recipient is a never-initialised `LazyRecipient`, so any outbound op
+/// publish becomes a local-only apply). Sufficient for governance handlers
+/// that just need the actor mailbox and the datastore.
+async fn boot_test_node() -> TestNode {
     let mut pool = ArbiterPool::new().await.expect("arbiter pool");
     let tmp = tempfile::tempdir().expect("tempdir");
 
@@ -159,6 +176,18 @@ async fn apply_signed_group_op_via_context_client() {
 
     sleep(Duration::from_millis(50)).await;
 
+    TestNode {
+        _pool: pool,
+        _tmp: tmp,
+        store,
+        context_client,
+    }
+}
+
+#[tokio::test]
+async fn apply_signed_group_op_via_context_client() {
+    let node = boot_test_node().await;
+
     let mut rng = OsRng;
     let gid = ContextGroupId::from([0x77u8; 32]);
     let gid_bytes = gid.to_bytes();
@@ -166,8 +195,8 @@ async fn apply_signed_group_op_via_context_client() {
     let admin_sk = PrivateKey::random(&mut rng);
     let admin_pk = admin_sk.public_key();
 
-    save_group_meta(&store, &gid, &sample_meta(admin_pk)).expect("save_group_meta");
-    add_group_member(&store, &gid, &admin_pk, GroupMemberRole::Admin).expect("add_group_member");
+    save_group_meta(&node.store, &gid, &sample_meta(admin_pk)).expect("save_group_meta");
+    add_group_member(&node.store, &gid, &admin_pk, GroupMemberRole::Admin).expect("add admin");
 
     let new_member = PrivateKey::random(&mut rng).public_key();
 
@@ -184,7 +213,8 @@ async fn apply_signed_group_op_via_context_client() {
     )
     .expect("sign op");
 
-    match context_client
+    match node
+        .context_client
         .apply_signed_group_op(op)
         .await
         .expect("apply")
@@ -194,13 +224,110 @@ async fn apply_signed_group_op_via_context_client() {
     }
 
     assert!(
-        check_group_membership(&store, &gid, &new_member).expect("check_group_membership"),
+        check_group_membership(&node.store, &gid, &new_member).expect("check_group_membership"),
         "member should be present after apply_signed_group_op"
     );
     assert_eq!(
-        get_local_gov_nonce(&store, &gid, &admin_pk)
+        get_local_gov_nonce(&node.store, &gid, &admin_pk)
             .expect("get_local_gov_nonce")
             .expect("nonce row"),
         1
     );
+}
+
+/// Plumbing test for the synchronous-error paths in the
+/// `set_member_auto_follow` actor handler. Both cases short-circuit
+/// before the async `sign_apply_and_publish` block, so they don't
+/// require a wired-up network actor — `ActorResponse::reply(Err(...))`
+/// returns immediately:
+///
+/// 1. Unknown group — preflight bails with `"not found"` before any
+///    signing or apply. Exercises that the request actually reaches the
+///    handler and that preflight runs against the requester's view.
+/// 2. Non-member target — surfaced by the handler's up-front
+///    `get_group_member_role` check (`"not a member"`), giving a
+///    clearer error than the apply-path bail.
+///
+/// The non-admin-non-self and happy-path cases are intentionally not
+/// tested here: both reach the async block which awaits the network
+/// actor (`mesh_peer_count_for_namespace`) — the apply-path admin-or-self
+/// bail and the apply itself live inside that block. Happy-path apply
+/// semantics and the admin-or-self rule are exhaustively covered by
+/// `group_store::tests::auto_follow_tests` (12 cases including admin-set,
+/// self-set, non-admin-rejected, and non-member-target variants).
+#[tokio::test]
+async fn set_member_auto_follow_handler_error_paths() {
+    let node = boot_test_node().await;
+
+    let mut rng = OsRng;
+    let gid = ContextGroupId::from([0x55u8; 32]);
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let alice_sk = PrivateKey::random(&mut rng);
+    let stranger = PrivateKey::random(&mut rng).public_key();
+
+    save_group_meta(&node.store, &gid, &sample_meta(admin_sk.public_key())).unwrap();
+    add_group_member(
+        &node.store,
+        &gid,
+        &admin_sk.public_key(),
+        GroupMemberRole::Admin,
+    )
+    .unwrap();
+    add_group_member(
+        &node.store,
+        &gid,
+        &alice_sk.public_key(),
+        GroupMemberRole::Member,
+    )
+    .unwrap();
+
+    // Admin needs a signing key registered so preflight can resolve one
+    // when admin acts as requester.
+    store_group_signing_key(&node.store, &gid, &admin_sk.public_key(), &admin_sk).unwrap();
+
+    // Case 1: unknown group — preflight bails before the membership
+    // check, before signing, before any async work.
+    let unknown_gid = ContextGroupId::from([0xEE; 32]);
+    let err = node
+        .context_client
+        .set_member_auto_follow(SetMemberAutoFollowRequest {
+            group_id: unknown_gid,
+            target: alice_sk.public_key(),
+            auto_follow_contexts: true,
+            auto_follow_subgroups: false,
+            requester: Some(admin_sk.public_key()),
+        })
+        .await
+        .expect_err("unknown group should fail preflight");
+    assert!(
+        err.to_string().contains("not found"),
+        "unexpected error: {err}"
+    );
+
+    // Case 2: non-member target — handler's up-front check rejects after
+    // preflight but before signing. The clearer error is the whole reason
+    // the handler does this ahead of the apply path's bail.
+    let err = node
+        .context_client
+        .set_member_auto_follow(SetMemberAutoFollowRequest {
+            group_id: gid,
+            target: stranger,
+            auto_follow_contexts: true,
+            auto_follow_subgroups: false,
+            requester: Some(admin_sk.public_key()),
+        })
+        .await
+        .expect_err("stranger is not a member");
+    assert!(
+        err.to_string().contains("not a member"),
+        "unexpected error: {err}"
+    );
+
+    // Alice's flags remain at default — nothing was applied.
+    let alice_row = get_group_member_value(&node.store, &gid, &alice_sk.public_key())
+        .unwrap()
+        .expect("alice row");
+    assert!(!alice_row.auto_follow.contexts);
+    assert!(!alice_row.auto_follow.subgroups);
 }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2478,6 +2478,26 @@ impl Validate for SetMemberCapabilitiesApiRequest {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct SetMemberCapabilitiesApiResponse {}
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetMemberAutoFollowApiRequest {
+    /// When true, the target auto-joins new contexts registered in this group.
+    pub auto_follow_contexts: bool,
+    /// When true, the target self-admits into subgroups nested under this group.
+    pub auto_follow_subgroups: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester: Option<PublicKey>,
+}
+
+impl Validate for SetMemberAutoFollowApiRequest {
+    fn validate(&self) -> Vec<ValidationError> {
+        Vec::new()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct SetMemberAutoFollowApiResponse {}
+
 // ---- Set Metadata (group / member / context) ----
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -23,6 +23,7 @@ pub mod retry_group_upgrade;
 pub mod set_context_metadata;
 pub mod set_default_capabilities;
 pub mod set_group_metadata;
+pub mod set_member_auto_follow;
 pub mod set_member_capabilities;
 pub mod set_member_metadata;
 pub mod set_subgroup_visibility;

--- a/crates/server/src/admin/handlers/groups/set_member_auto_follow.rs
+++ b/crates/server/src/admin/handlers/groups/set_member_auto_follow.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_client::group::SetMemberAutoFollowRequest;
+use calimero_server_primitives::admin::{
+    SetMemberAutoFollowApiRequest, SetMemberAutoFollowApiResponse,
+};
+use tracing::{error, info};
+
+use super::{parse_group_id, parse_identity};
+use crate::admin::handlers::validation::ValidatedJson;
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::auth::AuthenticatedKey;
+use crate::AdminState;
+
+pub async fn handler(
+    Path((group_id_str, identity_str)): Path<(String, String)>,
+    Extension(state): Extension<Arc<AdminState>>,
+    auth_key: Option<Extension<AuthenticatedKey>>,
+    ValidatedJson(req): ValidatedJson<SetMemberAutoFollowApiRequest>,
+) -> impl IntoResponse {
+    let group_id = match parse_group_id(&group_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    let target = match parse_identity(&identity_str) {
+        Ok(pk) => pk,
+        Err(err) => return err.into_response(),
+    };
+
+    info!(
+        group_id=%group_id_str,
+        identity=%identity_str,
+        contexts=req.auto_follow_contexts,
+        subgroups=req.auto_follow_subgroups,
+        "Setting member auto-follow flags"
+    );
+
+    let result = state
+        .ctx_client
+        .set_member_auto_follow(SetMemberAutoFollowRequest {
+            group_id,
+            target,
+            auto_follow_contexts: req.auto_follow_contexts,
+            auto_follow_subgroups: req.auto_follow_subgroups,
+            requester: auth_key.map(|Extension(k)| k.0).or(req.requester),
+        })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(()) => {
+            info!(
+                group_id=%group_id_str,
+                identity=%identity_str,
+                "Member auto-follow flags updated"
+            );
+            ApiResponse {
+                payload: SetMemberAutoFollowApiResponse {},
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(
+                group_id=%group_id_str,
+                identity=%identity_str,
+                error=?err,
+                "Failed to set member auto-follow flags"
+            );
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -262,6 +262,10 @@ pub(crate) fn setup(
                 .put(groups::set_member_capabilities::handler),
         )
         .route(
+            "/groups/:group_id/members/:identity/auto-follow",
+            put(groups::set_member_auto_follow::handler),
+        )
+        .route(
             "/groups/:group_id/settings/default-capabilities",
             put(groups::set_default_capabilities::handler),
         )


### PR DESCRIPTION
## Summary

Adds end-to-end plumbing so the `MemberSetAutoFollow` governance op has a public HTTP surface, mirroring the existing `set_member_capabilities` path. Until now the op was only published from `crates/server/src/admin/handlers/tee/fleet_join.rs` with both flags hard-coded to `true` — tests, tooling, and SDKs had no way to toggle a member's `auto_follow.contexts` / `auto_follow.subgroups` flags.

This unblocks **Phase A of the #2422 test plan** ([comment](https://github.com/calimero-network/core/issues/2422#issuecomment-4499886343)), which needs a deterministic way for merobox workflows to flip auto-follow flags. The downstream `merobox` `set_member_auto_follow` step + e2e workflows will follow in separate repos once this lands.

Note: this PR does **not** fix #2422 itself — it only adds the infrastructure required to write the failing tests that will gate the actual fix.

## What's wired up

- `SetMemberAutoFollowRequest { group_id, target, auto_follow_contexts, auto_follow_subgroups, requester }` in `crates/context/primitives/src/group.rs`.
- `ContextMessage::SetMemberAutoFollow` actor variant + `ctx_client.set_member_auto_follow(...)` forwarder.
- Context actor handler at `crates/context/src/handlers/set_member_auto_follow.rs`:
  - Runs `governance_preflight(require_admin=false)` — admin-or-self is enforced inside the apply path at `crates/context/src/group_store/mod.rs:1529`, so non-admin self-setters must pass preflight.
  - Surfaces a clearer "target is not a member" error up-front instead of relying on the generic apply-path bail.
  - Publishes `GroupOp::MemberSetAutoFollow` via `sign_apply_and_publish`.
- `SetMemberAutoFollowApiRequest` + empty response in `crates/server/primitives/src/admin/mod.rs`.
- `PUT /groups/:group_id/members/:identity/auto-follow` route registered in `crates/server/src/admin/service.rs`.

### HTTP shape

```
PUT /admin/groups/:group_id/members/:identity/auto-follow
{ "autoFollowContexts": true, "autoFollowSubgroups": false }
```

The auth-key requester is threaded through to the context handler, matching `set_member_capabilities`. A member can call the endpoint for themselves; a group admin can call it for any member.

## Tests

Added in `c339ac99` (`crates/node/src/local_governance_node_e2e.rs`):

- Extracted shared `boot_test_node()` helper from the existing `apply_signed_group_op_via_context_client` setup (boots a `ContextManager` + `NodeManager` actor pair against an in-memory store).
- New `set_member_auto_follow_handler_error_paths` test covering the two synchronous error paths the new handler adds on top of the apply layer:
  - **Unknown group** → `governance_preflight` bails with `"not found"` before any signing.
  - **Non-member target** → handler's up-front `get_group_member_role` check returns `"not a member"` before the apply-path bail (the clearer error is the reason the handler does this check ahead of publish).

Both paths return synchronously via `ActorResponse::reply(Err(...))` and don't require a wired-up network actor. Total runtime: ~0.06s after build.

#### What's intentionally not tested at this layer

- **Happy path** and **non-admin-non-self rejection** both live inside the async `sign_apply_and_publish` block past `mesh_peer_count_for_namespace.await`, which would block on the never-initialised network actor in this harness. Stubbing the network actor for one test was out of scope.
- These cases are already exhaustively covered by the **12 apply-path tests in `group_store::tests::auto_follow_tests`** (admin-set, self-set, non-admin-rejected, non-member-target, default-flags-preserved, etc.), which exercise the same `GroupOp::MemberSetAutoFollow` op directly via `apply_local_signed_group_op`.

## Test plan

- [x] `cargo check -p calimero-context-client -p calimero-context -p calimero-server-primitives -p calimero-server` — clean.
- [x] `cargo clippy --no-deps` on the same four crates — zero new warnings on added code.
- [x] `cargo fmt` — pre-commit hook passing.
- [x] `cargo test -p calimero-node --lib local_governance_node_e2e` — 2 passed (existing + new).
- [ ] Manual end-to-end via the merobox step (to land in a follow-up `merobox` PR once this endpoint is published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admin HTTP surface that triggers a governance op affecting group membership behavior; mistakes could allow unintended toggling or introduce regressions in governance request routing.
> 
> **Overview**
> Exposes the existing `GroupOp::MemberSetAutoFollow` governance operation end-to-end, adding a new `PUT /admin/groups/:group_id/members/:identity/auto-follow` endpoint that lets admins (or a member for themselves) toggle `autoFollowContexts` / `autoFollowSubgroups`.
> 
> Wires the request through `calimero-context-client` (`SetMemberAutoFollowRequest`, `ContextMessage::SetMemberAutoFollow`, and `ContextClient::set_member_auto_follow`) into a new `calimero-context` actor handler that runs preflight without requiring admin, performs an explicit target-membership check for clearer errors, and then `sign_apply_and_publish`es the op.
> 
> Updates node e2e tests by extracting a reusable `boot_test_node()` harness and adding coverage for the new handler’s synchronous error paths (unknown group and non-member target).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee66aacd0b62ecb3902919483714e788150e1f9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->