### PR TITLE
feat(client): set_member_auto_follow wrapper for PUT auto-follow endpoint

### DIFF
--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -32,6 +32,8 @@ use calimero_server_primitives::admin::ReparentGroupApiResponse;
 use calimero_server_primitives::admin::RetryGroupUpgradeApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiResponse;
+use calimero_server_primitives::admin::SetMemberAutoFollowApiRequest;
+use calimero_server_primitives::admin::SetMemberAutoFollowApiResponse;
 use calimero_server_primitives::admin::SetMemberCapabilitiesApiRequest;
 use calimero_server_primitives::admin::SetMemberCapabilitiesApiResponse;
 use calimero_server_primitives::admin::SetMetadataApiRequest;
@@ -351,6 +353,28 @@ where
             .get(&format!(
                 "admin-api/groups/{group_id}/members/{identity_hex}/capabilities"
             ))
+            .await?;
+        Ok(response)
+    }
+
+    /// Toggle a member's per-group auto-follow flags
+    /// (`auto_follow.contexts` / `auto_follow.subgroups`).
+    ///
+    /// Authorized by group admin (for any `identity_hex`) or by the target
+    /// itself (self-setting). The apply path enforces the admin-or-self rule —
+    /// see `GroupOp::MemberSetAutoFollow`.
+    pub async fn set_member_auto_follow(
+        &self,
+        group_id: &str,
+        identity_hex: &str,
+        request: SetMemberAutoFollowApiRequest,
+    ) -> Result<SetMemberAutoFollowApiResponse> {
+        let response = self
+            .connection
+            .put_json(
+                &format!("admin-api/groups/{group_id}/members/{identity_hex}/auto-follow"),
+                request,
+            )
             .await?;
         Ok(response)
     }


### PR DESCRIPTION
## Summary

Adds the high-level `calimero-client` wrapper for the auto-follow endpoint introduced in #2427.

- **Why this is needed**: #2427 wired `MemberSetAutoFollow` end-to-end on the server side — context-actor handler, server-primitives `SetMemberAutoFollow{Api,Response}` types, and the admin route `PUT /groups/:group_id/members/:identity/auto-follow`. But the high-level `calimero-client` Rust crate (which `calimero-client-py` and other SDKs consume) had no corresponding wrapper, so the route was unreachable from any client in practice.
- **What this adds**: a single `Client::set_member_auto_follow(group_id, identity_hex, request)` method on `crates/client/src/client/group.rs`, shaped identically to the existing `set_member_capabilities` wrapper. No new types — both `SetMemberAutoFollowApiRequest` and `SetMemberAutoFollowApiResponse` already live in `calimero-server-primitives` (added by #2427).

This unblocks:
- A matching Python binding in `calimero-network/calimero-client-py` (`set_member_auto_follow(group_id, member_id, auto_follow_contexts, auto_follow_subgroups, requester=None)`).
- A `set_member_auto_follow` workflow step in `calimero-network/merobox`.
- Phase A test plumbing for #2422.

## Test plan

- [x] `cargo check -p calimero-client` — clean against latest master.
- [x] `cargo fmt -p calimero-client -- --check` — clean.
- [x] Local end-to-end build through `calimero-client-py` with `[patch."https://github.com/calimero-network/core"]` pointed at this branch — Python binding `set_member_auto_follow` compiles and the new method is callable from Python.
- [ ] CI to confirm workspace builds + lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a thin client wrapper around an existing server endpoint without changing underlying auth, storage, or business logic.
> 
> **Overview**
> Adds a new `Client::set_member_auto_follow` method to `crates/client/src/client/group.rs`, exposing the `PUT admin-api/groups/{group_id}/members/{identity_hex}/auto-follow` endpoint via the Rust client.
> 
> Also wires in the existing `SetMemberAutoFollow{ApiRequest,ApiResponse}` primitive types so downstream SDKs can toggle per-member auto-follow flags (contexts/subgroups) through the high-level client API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131ab92ee17ae999950c98c964c4bc55266ff38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->