### PR TITLE
fix(ci): wait for release.yml on master push before resolving :edge tag

### DIFF
--- a/scripts/determine-image-tag.sh
+++ b/scripts/determine-image-tag.sh
@@ -180,58 +180,89 @@ elif [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then
     HEAD_SHA="${GITHUB_SHA:-}"
 
     if [ -z "$HEAD_SHA" ]; then
-        echo "WARNING: GITHUB_SHA not set in environment - cannot identify release.yml run for this push"
-        echo "Falling back to :edge${TAG_SUFFIX} without waiting (may be the previous commit's binary)"
+        # GITHUB_SHA is set automatically in every step inside GitHub
+        # Actions, so this branch fires only on local/manual invocation
+        # (e.g. running the script by hand for testing).
+        echo "GITHUB_SHA not set - assuming local invocation, skipping release.yml wait"
+        echo "Falling back to :edge${TAG_SUFFIX} as-is"
         TAG="edge${TAG_SUFFIX}"
     else
-        echo "Master push detected - waiting for release.yml on commit ${HEAD_SHA} to republish :edge${TAG_SUFFIX}"
+        # release.yml only fires on master pushes that touch its `push.paths`
+        # filter (`Cargo.{toml,lock}`, `crates/**`, `.github/workflows/release.yml`,
+        # `.github/workflows/deps/**`, `.github/actions/**`, `scripts/profiling/**`).
+        # A master push that only touches `apps/**`, `docs/**`, other workflows,
+        # `README.md`, etc. won't trigger release.yml at all — in which case
+        # `:edge${TAG_SUFFIX}` doesn't change either (no Rust code rebuilt),
+        # so waiting for a run that will never appear would just stall the
+        # consumer for the full timeout. Skip the wait in that case, matching
+        # the PR-branch's `CRATES_CHANGED` early-exit.
+        CHANGED_FILES=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \
+            --jq '.files[].filename' 2>/dev/null || echo "")
+        RELEASE_TRIGGERING_CHANGED=$(echo "$CHANGED_FILES" | \
+            grep -E '^(Cargo\.toml|Cargo\.lock|crates/|\.github/workflows/release\.yml|\.github/workflows/deps/|\.github/actions/|scripts/profiling/)' || true)
 
-        if [ "$PROFILING_MODE" = "--profiling" ]; then
-            MAX_WAIT=1800  # 30 minutes - profiling container build takes longer
+        if [ -z "$RELEASE_TRIGGERING_CHANGED" ]; then
+            echo "Master push touches no release.yml trigger paths - release.yml will not fire on ${HEAD_SHA}"
+            echo "Resolving :edge${TAG_SUFFIX} immediately (no new image expected)"
+            TAG="edge${TAG_SUFFIX}"
         else
-            MAX_WAIT=1200  # 20 minutes - same budget as the PR-branch path
-        fi
-        WAIT_INTERVAL=10
-        ELAPSED=0
-        TAG=""
+            echo "Master push touches release.yml trigger paths - waiting for release.yml on ${HEAD_SHA} to republish :edge${TAG_SUFFIX}"
 
-        while [ $ELAPSED -lt $MAX_WAIT ]; do
-            # Filter release.yml runs by the exact merge commit SHA. On
-            # master push, this uniquely identifies the run that produces
-            # the new :edge${TAG_SUFFIX} image we want to pull.
-            RUNS=$(gh api "repos/${REPO}/actions/workflows/release.yml/runs?head_sha=${HEAD_SHA}" \
-                --jq '.workflow_runs[0] // {"status":"unknown"}' 2>/dev/null \
-                || echo '{"status":"unknown"}')
-
-            STATUS=$(echo "$RUNS" | jq -r '.status // "unknown"')
-            CONCLUSION=$(echo "$RUNS" | jq -r '.conclusion // "unknown"')
-
-            if [ "$STATUS" = "completed" ]; then
-                if [ "$CONCLUSION" = "success" ]; then
-                    echo "release.yml completed successfully after ${ELAPSED}s - :edge${TAG_SUFFIX} now resolves to ${HEAD_SHA}"
-                else
-                    echo "release.yml completed with conclusion: ${CONCLUSION}"
-                    echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
-                fi
-                TAG="edge${TAG_SUFFIX}"
-                break
-            fi
-
-            if [ "$STATUS" = "queued" ] || [ "$STATUS" = "in_progress" ]; then
-                echo "release.yml ${STATUS}... waiting (${ELAPSED}s/${MAX_WAIT}s)"
-            elif [ "$STATUS" = "unknown" ]; then
-                echo "release.yml run for ${HEAD_SHA} not found yet... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+            if [ "$PROFILING_MODE" = "--profiling" ]; then
+                MAX_WAIT=1800  # 30 minutes - profiling container build takes longer
             else
-                echo "release.yml status: ${STATUS}... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+                MAX_WAIT=1200  # 20 minutes - same budget as the PR-branch path
+            fi
+            WAIT_INTERVAL=10
+            ELAPSED=0
+
+            while [ $ELAPSED -lt $MAX_WAIT ]; do
+                # Filter release.yml runs by the exact merge commit SHA. On
+                # master push, this uniquely identifies the run that produces
+                # the new :edge${TAG_SUFFIX} image we want to pull. `[0]` is
+                # the most recent (the GitHub API sorts workflow_runs by
+                # created_at descending by default), which is correct under
+                # re-runs.
+                RUNS=$(gh api "repos/${REPO}/actions/workflows/release.yml/runs?head_sha=${HEAD_SHA}" \
+                    --jq '.workflow_runs[0] // {"status":"unknown"}' 2>/dev/null \
+                    || echo '{"status":"unknown"}')
+
+                STATUS=$(echo "$RUNS" | jq -r '.status // "unknown"')
+                CONCLUSION=$(echo "$RUNS" | jq -r '.conclusion // "unknown"')
+
+                if [ "$STATUS" = "completed" ]; then
+                    if [ "$CONCLUSION" = "success" ]; then
+                        echo "release.yml completed successfully after ${ELAPSED}s - :edge${TAG_SUFFIX} now resolves to ${HEAD_SHA}"
+                    else
+                        echo "release.yml completed with conclusion: ${CONCLUSION}"
+                        echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
+                    fi
+                    break
+                fi
+
+                if [ "$STATUS" = "queued" ] || [ "$STATUS" = "in_progress" ]; then
+                    echo "release.yml ${STATUS}... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+                elif [ "$STATUS" = "unknown" ]; then
+                    echo "release.yml run for ${HEAD_SHA} not found yet... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+                else
+                    echo "release.yml status: ${STATUS}... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+                fi
+
+                sleep $WAIT_INTERVAL
+                ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+            done
+
+            if [ $ELAPSED -ge $MAX_WAIT ]; then
+                echo "Timeout waiting for release.yml after ${MAX_WAIT}s"
+                echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
             fi
 
-            sleep $WAIT_INTERVAL
-            ELAPSED=$((ELAPSED + WAIT_INTERVAL))
-        done
-
-        if [ -z "$TAG" ]; then
-            echo "Timeout waiting for release.yml after ${MAX_WAIT}s"
-            echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
+            # Same final tag in all three exit paths (success, failure,
+            # timeout). Only the timing and the log message differ — the
+            # caller's `docker pull ghcr.io/.../merod:edge${TAG_SUFFIX}`
+            # works either way because :edge${TAG_SUFFIX} always exists
+            # (it points at the previous master commit's binary if the
+            # current one's release.yml hasn't repointed it yet).
             TAG="edge${TAG_SUFFIX}"
         fi
     fi

--- a/scripts/determine-image-tag.sh
+++ b/scripts/determine-image-tag.sh
@@ -164,6 +164,77 @@ if [ "$EVENT_NAME" == "pull_request" ]; then
             TAG="edge${TAG_SUFFIX}"
         fi
     fi
+elif [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then
+    # Master push: release.yml is triggered in parallel with this caller
+    # workflow (e.g. fuzzy-load-test.yml), and the moving `:edge${TAG_SUFFIX}`
+    # tag in ghcr only gets re-pointed at the just-merged binary once
+    # release.yml's `Release Merod Profiling container` (or its non-profiling
+    # twin) finishes. Until then, `:edge${TAG_SUFFIX}` still points at the
+    # PREVIOUS master commit's binary.
+    #
+    # Without this wait, every master push gets one guaranteed false-positive
+    # cycle on every workflow that pulls `:edge${TAG_SUFFIX}`, because the
+    # test pulls the prior binary and exercises whatever bugs that prior
+    # commit had. Mirror the PR-branch wait loop so the test only proceeds
+    # once the new image is actually live.
+    HEAD_SHA="${GITHUB_SHA:-}"
+
+    if [ -z "$HEAD_SHA" ]; then
+        echo "WARNING: GITHUB_SHA not set in environment - cannot identify release.yml run for this push"
+        echo "Falling back to :edge${TAG_SUFFIX} without waiting (may be the previous commit's binary)"
+        TAG="edge${TAG_SUFFIX}"
+    else
+        echo "Master push detected - waiting for release.yml on commit ${HEAD_SHA} to republish :edge${TAG_SUFFIX}"
+
+        if [ "$PROFILING_MODE" = "--profiling" ]; then
+            MAX_WAIT=1800  # 30 minutes - profiling container build takes longer
+        else
+            MAX_WAIT=1200  # 20 minutes - same budget as the PR-branch path
+        fi
+        WAIT_INTERVAL=10
+        ELAPSED=0
+        TAG=""
+
+        while [ $ELAPSED -lt $MAX_WAIT ]; do
+            # Filter release.yml runs by the exact merge commit SHA. On
+            # master push, this uniquely identifies the run that produces
+            # the new :edge${TAG_SUFFIX} image we want to pull.
+            RUNS=$(gh api "repos/${REPO}/actions/workflows/release.yml/runs?head_sha=${HEAD_SHA}" \
+                --jq '.workflow_runs[0] // {"status":"unknown"}' 2>/dev/null \
+                || echo '{"status":"unknown"}')
+
+            STATUS=$(echo "$RUNS" | jq -r '.status // "unknown"')
+            CONCLUSION=$(echo "$RUNS" | jq -r '.conclusion // "unknown"')
+
+            if [ "$STATUS" = "completed" ]; then
+                if [ "$CONCLUSION" = "success" ]; then
+                    echo "release.yml completed successfully after ${ELAPSED}s - :edge${TAG_SUFFIX} now resolves to ${HEAD_SHA}"
+                else
+                    echo "release.yml completed with conclusion: ${CONCLUSION}"
+                    echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
+                fi
+                TAG="edge${TAG_SUFFIX}"
+                break
+            fi
+
+            if [ "$STATUS" = "queued" ] || [ "$STATUS" = "in_progress" ]; then
+                echo "release.yml ${STATUS}... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+            elif [ "$STATUS" = "unknown" ]; then
+                echo "release.yml run for ${HEAD_SHA} not found yet... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+            else
+                echo "release.yml status: ${STATUS}... waiting (${ELAPSED}s/${MAX_WAIT}s)"
+            fi
+
+            sleep $WAIT_INTERVAL
+            ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+        done
+
+        if [ -z "$TAG" ]; then
+            echo "Timeout waiting for release.yml after ${MAX_WAIT}s"
+            echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
+            TAG="edge${TAG_SUFFIX}"
+        fi
+    fi
 else
     TAG="edge${TAG_SUFFIX}"
 fi


### PR DESCRIPTION
## What

Adds a wait-for-release-workflow branch to `scripts/determine-image-tag.sh`
for `push` events on `master`, mirroring what the script already does on
`pull_request` events for `pr-<N>{-profiling}` tags.

## Why

`:edge` and `:edge-profiling` are moving tags in ghcr. They get re-pointed
to the just-merged binary by `release.yml`'s container-release jobs on
every master push. The catch: a push to master triggers BOTH `release.yml`
AND consumer workflows that pull `:edge{-profiling}` (e.g.
`fuzzy-load-test.yml`) in parallel:

```
T+0    Push to master. release.yml + fuzzy-load-test.yml both start.
T+~3m  fuzzy-load-test resolves :edge-profiling and pulls.
       At this moment the tag still points at the PREVIOUS master
       commit's binary, because release.yml is only a few minutes in.
T+~15m release.yml's "Release Merod Profiling container" job finally
       finishes and re-points :edge-profiling at the new binary.
```

Every master push has a ~10–25 minute window where any consumer workflow
that resolves `:edge{-profiling}` will get the prior commit's binary.
If that prior commit had a bug, the consumer fails on a binary that no
longer exists on master, which is *very* hard to interpret — it looks
like the just-merged commit caused the failure.

A concrete real-world instance from yesterday: PR #2433 (Root LWW fix)
merged into master at `bdea97e8`. The fuzzy-load-test for that push
failed with a HashComparison non-convergence on node-3 — which is
exactly the failure shape the fix addresses. Node logs in the run's
artifacts show the prior `:edge-profiling` binary running. The same
SHA re-ran 25 minutes later (after release.yml finished republishing)
and passed.

## How

The script's `pull_request` branch already does this — when crates
change, it polls `release.yml`'s run for the PR's head_sha and waits
up to 20 min (30 for profiling) before resolving the `pr-<N>{-profiling}`
tag. This change adds a parallel branch for `event=="push" && head_branch=="master"`:

- Read the merge commit SHA from `GITHUB_SHA` (set automatically by GH
  Actions in every step's environment).
- Poll `repos/.../actions/workflows/release.yml/runs?head_sha=${GITHUB_SHA}`
  every 10s.
- On `completed/success`: resolve `:edge${TAG_SUFFIX}`. The tag now
  points at the new binary.
- On `completed/failure` or timeout: fall back to `:edge${TAG_SUFFIX}`
  as-is and log a warning. Same final behaviour as today, but the
  consumer at least gets to see the warning explaining why the image
  is stale.

Other events (`workflow_run`, `schedule`, `workflow_dispatch`, tag
pushes, non-master branch pushes) keep the existing `TAG="edge${TAG_SUFFIX}"`
fallback. `e2e-rust-apps-release.yml` runs via `workflow_run` on Release
completion, so it never had the race and is unaffected.

## Verification

```
$ bash -n scripts/determine-image-tag.sh
$ echo $?
0
```

The behavioural change is gated to a narrow case (`push` on `master`)
and has the same final tag (`:edge{-profiling}`) — only the timing
changes. PR runs and other event types take the identical code path
as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes default group membership behavior (auto-follow now enabled by default) and introduces a breaking sync wire-protocol variant (`StreamMessage::NotMaterialized`), which requires coordinated upgrades and can affect cluster interoperability and sync behavior.
> 
> **Overview**
> **Auto-follow now defaults on for contexts.** `AutoFollowFlags` default changes to `{contexts: true, subgroups: false}`, and group membership apply paths now synthesize an `OpEvent::AutoFollowSet` so new members backfill and auto-join pre-existing contexts without requiring an explicit flag flip.
> 
> **Sync behavior is hardened for non-following peers.** Namespace-fallback peer discovery is filtered to peers subscribed to the context topic, and the sync wire protocol adds `StreamMessage::NotMaterialized` so responders can explicitly signal “valid peer, context not local”; initiators treat this as benign (no failure_count/backoff). New unit/e2e tests and updated docs/workflows (including new auto-follow regression workflows and removal of a manual `join_context` in `group-late-joiner`) lock in the regression coverage, and workspace version bumps to `0.10.1-rc.42`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4876472ea456cefe89b321a8c33e0d87e4ca5dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->