### PR TITLE
ci(#2422): inline assert_log_absent gates for auto-follow regression workflows

### DIFF
--- a/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
@@ -38,19 +38,19 @@ description: >
   Pass/fail policy:
     - Workflow PASSES on the positive overlap (context_b converged,
       both nodes read each other's writes in context_b).
-    - The regression signal is currently MANUAL: the per-node logs
-      uploaded as an artefact must be grepped for three signatures —
+    - The REGRESSION GATE is inline via merobox's
+      `assert_log_absent` step (merobox#244) — a final step at the
+      end of the workflow scans both nodes' docker logs for three
+      signatures and fails the workflow on any hit:
         (a) "context not materialised within join race window"
             on either node (debug-level — our topology's symptom)
         (b) "inbound stream for unknown context, closing cleanly"
             on either node (warn-level — Ronit/Fran shape, kept for
             future workflows that provoke !dialer_verified)
         (c) "no owned identities found for context" on either node
-      An inline gate via `assert_log_absent` is the durable fix;
-      requested in calimero-network/merobox#243. Until then, manual
-      log inspection (or the same grep wired into the matrix runner
-      directly, matching sync-regression.yml's #2356 pattern) is the
-      gate.
+      Same shape as sync-regression.yml's #2356 guards, but now
+      expressed inline in the workflow file rather than as a CI-side
+      grep on the artefact.
     - Local-absence checks (context_a not on node-2, context_c not
       on node-1) and metric checks
       (`sync_failures_total{protocol="HashComparison"}` near zero)
@@ -385,6 +385,23 @@ steps:
     type: wait
     seconds: 30
 
+  # ── Inline regression gate (per merobox#244) ─────────────────────────
+  # During the 30s settle window above, a buggy build's sync manager
+  # would have picked the non-following peer (node-1 ∌ subgroup_c
+  # syncing context_c against node-2, or node-2 ∌ subgroup_a syncing
+  # context_a against node-1) and the receiver-side gate would have
+  # logged at least one of the three signatures below. A healthy
+  # build emits none of them.
+  - name: Regression guard — no rejection spam on either node
+    type: assert_log_absent
+    nodes:
+      - af-asym-node-1
+      - af-asym-node-2
+    patterns:
+      - "context not materialised within join race window"
+      - "inbound stream for unknown context, closing cleanly"
+      - "no owned identities found for context"
+
   # TODO (Phase A follow-up): when merobox grows `assert_context_absent`,
   # close the loop with:
   #   - name: Assert node-1 has no local entry for context_c
@@ -395,5 +412,3 @@ steps:
   #     type: assert_context_absent
   #     node: af-asym-node-2
   #     context_id: "{{ctx_a}}"
-  # Until then, the CI runner's log-grep is the gate on the asymmetric
-  # state being benign (no rejection spam, no failure_count climb).

--- a/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
@@ -392,6 +392,16 @@ steps:
   # context_a against node-1) and the receiver-side gate would have
   # logged at least one of the three signatures below. A healthy
   # build emits none of them.
+  # `assert_log_absent` scans each node's full docker log history (no
+  # time-window scoping in the current API). The three patterns below
+  # are specific failure-mode signatures from the sync responder/
+  # initiator and are NOT emitted during normal bootstrap, namespace
+  # join, governance gossip, or auto-follow setup — verified
+  # empirically on the green-build matrix runs at b694dc03 +
+  # 57fffca6 (zero hits across both nodes for all three patterns on
+  # the full lifetime log). The pattern for shape (b) is the broader
+  # form so it also matches future "...closing with error" suffix
+  # variants, consistent with the spam workflow.
   - name: Regression guard — no rejection spam on either node
     type: assert_log_absent
     nodes:
@@ -399,7 +409,7 @@ steps:
       - af-asym-node-2
     patterns:
       - "context not materialised within join race window"
-      - "inbound stream for unknown context, closing cleanly"
+      - "inbound stream for unknown context"
       - "no owned identities found for context"
 
   # TODO (Phase A follow-up): when merobox grows `assert_context_absent`,

--- a/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
@@ -239,8 +239,18 @@ steps:
   # observation window above. A regression on Options 3 / 4 emits the
   # first (debug-level, our topology's symptom); a regression that also
   # provokes !dialer_verified emits the second (warn-level, Ronit/Fran
-  # shape); the third is the unrelated #2356 owned-identity guard kept
-  # in lockstep with sync-regression.yml.
+  # shape, broad-substring match so future "...closing cleanly" /
+  # "...closing with error" suffix variants are also caught); the
+  # third is the unrelated #2356 owned-identity guard kept in lockstep
+  # with sync-regression.yml.
+  #
+  # `assert_log_absent` scans the full container log history (no
+  # time-window scoping in the current API). The three patterns are
+  # specific failure-mode signatures from the sync responder/initiator
+  # and are NOT emitted during normal bootstrap, namespace join,
+  # governance gossip, or auto-follow setup — verified empirically on
+  # the green-build matrix runs at b694dc03 + 57fffca6 (zero hits
+  # across both nodes for all three patterns on the full lifetime log).
   - name: Regression guard — no rejection spam on either node
     type: assert_log_absent
     nodes:

--- a/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
@@ -33,25 +33,23 @@ description: >
       responder logs the rejection.
 
   Pass/fail policy:
-    - The workflow itself ALWAYS passes (it does no convergence
-      assertion on the asymmetric context — by construction node-2
-      never materialises it). All workflow steps are individually
+    - The convergence side is intentionally empty: by construction
+      node-2 never materialises context-A, so no positive overlap
+      assertion exists. Workflow steps are otherwise individually
       green on a healthy run.
-    - The REGRESSION SIGNAL is currently MANUAL: the workflow's node
-      logs (`auto-follow-no-rejection-spam-af-no-spam-node-*.log`
-      uploaded as an artefact by the matrix runner) must be grepped
-      for the three signatures below, and any hit is the regression:
+    - The REGRESSION GATE is inline via merobox's
+      `assert_log_absent` step (merobox#244) — a final step at the
+      end of the workflow scans both nodes' docker logs for three
+      signatures and fails the workflow on any hit:
         (a) "context not materialised within join race window"
             (debug-level — our topology's symptom)
         (b) "inbound stream for unknown context"
             (warn-level — Ronit/Fran shape, for future workflows
              that provoke !dialer_verified)
         (c) "no owned identities found for context"
-      An inline gate via `assert_log_absent` is the durable fix; the
-      step type is requested in calimero-network/merobox#243. Until
-      then, manual log inspection (or the same grep wired into the
-      matrix runner directly) is the gate. The sync-regression.yml
-      runner uses the same inline-grep pattern today.
+      Same shape as sync-regression.yml's #2356 guards, but now
+      expressed inline in the workflow file rather than as a CI-side
+      grep on the artefact.
     - The metric counterpart
       (`sync_failures_total{protocol="HashComparison"}` on node-1
       should stay near zero for this context) is deferred until
@@ -235,6 +233,24 @@ steps:
       - "is_set({{n1_self_read}})"
       - 'contains({{n1_self_read}}, "from-A")'
 
+  # ── Inline regression gate (per merobox#244) ─────────────────────────
+  # Three log signatures are the symptom of #2422 on this topology. A
+  # healthy build emits none of them across either node during the 30s
+  # observation window above. A regression on Options 3 / 4 emits the
+  # first (debug-level, our topology's symptom); a regression that also
+  # provokes !dialer_verified emits the second (warn-level, Ronit/Fran
+  # shape); the third is the unrelated #2356 owned-identity guard kept
+  # in lockstep with sync-regression.yml.
+  - name: Regression guard — no rejection spam on either node
+    type: assert_log_absent
+    nodes:
+      - af-no-spam-node-1
+      - af-no-spam-node-2
+    patterns:
+      - "context not materialised within join race window"
+      - "inbound stream for unknown context"
+      - "no owned identities found for context"
+
   # TODO (Phase A follow-up): when merobox grows `assert_context_absent`,
   # add the local-absent check on node-2 here:
   #
@@ -242,5 +258,3 @@ steps:
   #     type: assert_context_absent
   #     node: af-no-spam-node-2
   #     context_id: "{{ctx_a}}"
-  #
-  # Until then the CI runner's log grep is the regression gate.


### PR DESCRIPTION
## Summary

Closes the #2422 regression-detection gap that the merged PR #2431 inherited when the dedicated `.github/workflows/auto-follow-regression.yml` runner was removed in favour of the `e2e-rust-apps` matrix. Two of the five auto-follow workflows are log-grep-driven (the symptom is a debug-level line, not a workflow-step failure), and without an inline gate they passed unconditionally — a regression on Options 3/4 would have shipped silently.

[merobox#244](https://github.com/calimero-network/merobox/pull/244) (merged 2026-05-21) adds the `assert_log_absent` step type with the schema designed in [merobox#243](https://github.com/calimero-network/merobox/issues/243). This PR uses it as the final step of both workflows.

## Changes

| File | Change |
|---|---|
| `apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml` | Final `assert_log_absent` step scanning `af-no-spam-node-1` + `af-no-spam-node-2` for 3 signatures + description updated |
| `apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml` | Final `assert_log_absent` step scanning `af-asym-node-1` + `af-asym-node-2` for 3 signatures + description updated |

The three signatures matched are the same ones I previously verified manually by downloading the log artefact and grepping (see PR #2431 review thread evidence):

- `context not materialised within join race window` — debug-level, our topology's symptom
- `inbound stream for unknown context` (or `, closing cleanly` in asymmetric) — warn-level Ronit/Fran shape, kept for future workflows that provoke `!dialer_verified`
- `no owned identities found for context` — unrelated #2356 owned-identity guard kept in lockstep with `sync-regression.yml`

Any hit on any node fails the workflow with the offending node + matched line surfaced in the CI log (no artefact download needed).

## Why DRAFT

The `setup-merobox` composite action installs from the merobox `stable` apt channel with no version pin (`.github/actions/setup-merobox/action.yml`). Once the merobox release containing #244 lands in the stable channel, CI picks it up automatically — at which point this PR can be marked Ready-for-review and the new inline gate runs on every push.

Until then, CI would fail with "unknown step type: assert_log_absent" against the older merobox version. Keeping as Draft so it doesn't churn the bot reviewers.

## Test plan

- [ ] Wait for merobox release to publish to apt `stable`
- [ ] Mark Ready-for-review and re-run CI
- [ ] Confirm both auto-follow workflows pass with the new gate on a healthy build
- [ ] Confirm the `auto-follow-regression-asymmetric` and `auto-follow-no-rejection-spam` jobs ALSO show the new step in their log output (workflow step "Regression guard — no rejection spam on either node")

## Follow-ups (not in this PR)

- Migrate `sync-regression.yml`'s existing inline `run: grep ...` for #2356 to `assert_log_absent` for consistency (separate PR)
- `assert_context_absent` and `assert_metric` step types — required for the deferred local-absence and metric checks marked as TODOs at the end of both workflows
- Unit tests for Options 3+4 in `crates/node/src/sync/peers.rs` and `manager/mod.rs` (queued as tasks #41–#43)

Refs: #2422, #2431, [merobox#244](https://github.com/calimero-network/merobox/pull/244), [merobox#243](https://github.com/calimero-network/merobox/issues/243)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates e2e workflow YAML to fail on known regression log signatures; main risk is CI flakiness if the log patterns are emitted for benign reasons.
> 
> **Overview**
> Adds an **inline regression gate** to the two auto-follow e2e workflows that previously relied on CI-side/manual log greps.
> 
> Both workflows now end with `assert_log_absent` over each node’s docker logs, failing the run if any of three signatures appear: `context not materialised within join race window`, `inbound stream for unknown context`, or `no owned identities found for context` (and updates the workflow descriptions to reflect this).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bd356ebfebcdef758e8800afdcecbea08e19bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->