### PR TITLE
fix(node): route TeeAttestationAnnounce on ns/ topic into admission

### DIFF
--- a/crates/node/src/handlers/network_event/specialized.rs
+++ b/crates/node/src/handlers/network_event/specialized.rs
@@ -8,6 +8,35 @@ use crate::handlers::{specialized_node_invite, tee_attestation_admission};
 use crate::run::NodeMode;
 use crate::NodeManager;
 
+/// Why a gossipsub topic was rejected as a `TeeAttestationAnnounce`
+/// namespace-governance topic.
+#[derive(Debug, PartialEq, Eq)]
+enum NamespaceTopicError {
+    /// Topic did not carry the `ns/` namespace-governance prefix. Fleet
+    /// TEE nodes publish on `ns/<hex(namespace_id)>` via
+    /// `NodeClient::publish_on_namespace`, so anything else is not an
+    /// admission announce.
+    NotNamespaceTopic,
+    /// Topic had the `ns/` prefix but the suffix was not a 32-byte hex id.
+    MalformedHex,
+}
+
+/// Parse a `TeeAttestationAnnounce` gossipsub topic into its namespace id.
+///
+/// Fleet TEE nodes announce on `ns/<hex(namespace_id)>` (the namespace
+/// governance topic — see `NodeClient::publish_on_namespace`,
+/// `governance_broadcast::ns_topic`, and the `ns/` handling in
+/// `subscriptions.rs`). The namespace IS its root group, so the returned
+/// 32-byte id is used directly as the admission group id.
+fn parse_namespace_announce_topic(topic_str: &str) -> Result<[u8; 32], NamespaceTopicError> {
+    let hex = topic_str
+        .strip_prefix("ns/")
+        .ok_or(NamespaceTopicError::NotNamespaceTopic)?;
+    let mut bytes = [0u8; 32];
+    hex::decode_to_slice(hex, &mut bytes).map_err(|_| NamespaceTopicError::MalformedHex)?;
+    Ok(bytes)
+}
+
 pub(super) fn handle_specialized_broadcast(
     this: &mut NodeManager,
     ctx: &mut actix::Context<NodeManager>,
@@ -81,24 +110,26 @@ pub(super) fn handle_specialized_broadcast(
             node_type: _,
         } => {
             let topic_str = topic.as_str();
-            let group_id_bytes = match topic_str.strip_prefix("group/") {
-                Some(hex) => {
-                    let mut bytes = [0u8; 32];
-                    if hex::decode_to_slice(hex, &mut bytes).is_err() {
-                        warn!(
-                            %source,
-                            topic = %topic_str,
-                            "Invalid group topic hex in TeeAttestationAnnounce"
-                        );
-                        return true;
-                    }
-                    bytes
-                }
-                None => {
+            // Fleet TEE nodes announce on the namespace governance topic
+            // `ns/<hex(namespace_id)>` (see `NodeClient::publish_on_namespace`
+            // and the `ns/` convention in `subscriptions.rs` /
+            // `governance_broadcast::ns_topic`). The namespace IS its root
+            // group, so the parsed namespace id is the admission group id.
+            let namespace_id_bytes = match parse_namespace_announce_topic(topic_str) {
+                Ok(bytes) => bytes,
+                Err(NamespaceTopicError::MalformedHex) => {
                     warn!(
                         %source,
                         topic = %topic_str,
-                        "TeeAttestationAnnounce received on non-group topic"
+                        "Invalid namespace topic hex in TeeAttestationAnnounce"
+                    );
+                    return true;
+                }
+                Err(NamespaceTopicError::NotNamespaceTopic) => {
+                    warn!(
+                        %source,
+                        topic = %topic_str,
+                        "TeeAttestationAnnounce received on non-namespace topic"
                     );
                     return true;
                 }
@@ -108,8 +139,8 @@ pub(super) fn handle_specialized_broadcast(
                 %source,
                 %public_key,
                 nonce = %hex::encode(*nonce),
-                group_id = %hex::encode(group_id_bytes),
-                "Received TEE attestation announce on group topic"
+                namespace_id = %hex::encode(namespace_id_bytes),
+                "Received TEE attestation announce on namespace topic"
             );
 
             let context_client = this.clients.context.clone();
@@ -124,7 +155,7 @@ pub(super) fn handle_specialized_broadcast(
                         quote_bytes,
                         public_key,
                         nonce,
-                        group_id_bytes,
+                        namespace_id_bytes,
                     )
                     .await
                     {
@@ -274,5 +305,71 @@ pub(super) fn handle_specialized_network_event(
             true
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_namespace_announce_topic, NamespaceTopicError};
+
+    /// Regression test for the `ns/` vs `group/` topic mismatch (PR #2096):
+    /// fleet TEE nodes announce `TeeAttestationAnnounce` on
+    /// `ns/<hex(namespace_id)>`, but the dispatcher used to strip
+    /// `group/`, so the announce fell into the "non-namespace topic" arm
+    /// and was dropped — `handle_tee_attestation_announce` / `admit_tee_node`
+    /// never ran, and fleet TEE nodes were never admitted to the namespace
+    /// group. The dispatcher must resolve an `ns/` topic to its namespace id
+    /// and route it into the admission path.
+    #[test]
+    fn ns_announce_topic_resolves_to_namespace_id_for_admission() {
+        let namespace_id = [0x42u8; 32];
+        let topic = format!("ns/{}", hex::encode(namespace_id));
+
+        let parsed = parse_namespace_announce_topic(&topic)
+            .expect("ns/<hex> announce topic must route into the admission path, not be dropped");
+
+        // The resolved id is what gets handed to
+        // `handle_tee_attestation_announce` → `admit_tee_node` as the
+        // admission group id (the namespace is its own root group).
+        assert_eq!(parsed, namespace_id);
+    }
+
+    /// The old (buggy) `group/<hex>` topic must NOT match this path anymore.
+    /// `group/` is not how TEE announces are published (publish uses
+    /// `publish_on_namespace` → `ns/`), so a `group/` topic here is a
+    /// non-namespace topic and is correctly rejected rather than admitted.
+    #[test]
+    fn legacy_group_topic_is_not_a_namespace_announce_topic() {
+        let topic = format!("group/{}", hex::encode([0x42u8; 32]));
+        assert_eq!(
+            parse_namespace_announce_topic(&topic),
+            Err(NamespaceTopicError::NotNamespaceTopic),
+        );
+    }
+
+    /// A non-prefixed topic (e.g. a raw context id) is not a namespace
+    /// announce topic.
+    #[test]
+    fn unprefixed_topic_is_not_a_namespace_announce_topic() {
+        assert_eq!(
+            parse_namespace_announce_topic("some-context-id"),
+            Err(NamespaceTopicError::NotNamespaceTopic),
+        );
+    }
+
+    /// An `ns/` topic with a malformed (non-hex / wrong-length) suffix is
+    /// reported distinctly so the dispatcher can warn precisely instead of
+    /// silently treating it as the wrong kind of topic.
+    #[test]
+    fn ns_topic_with_malformed_hex_is_rejected_as_malformed() {
+        assert_eq!(
+            parse_namespace_announce_topic("ns/not-hex"),
+            Err(NamespaceTopicError::MalformedHex),
+        );
+        // Right prefix, valid hex, wrong length (16 bytes, not 32).
+        assert_eq!(
+            parse_namespace_announce_topic(&format!("ns/{}", hex::encode([0u8; 16]))),
+            Err(NamespaceTopicError::MalformedHex),
+        );
     }
 }

--- a/crates/node/src/handlers/tee_attestation_admission.rs
+++ b/crates/node/src/handlers/tee_attestation_admission.rs
@@ -1,6 +1,7 @@
 //! TEE attestation-based admission handler.
 //!
-//! When a fleet TEE node broadcasts `TeeAttestationAnnounce` on a group topic,
+//! When a fleet TEE node broadcasts `TeeAttestationAnnounce` on the namespace
+//! governance topic (`ns/<hex>`; the namespace is its own root group),
 //! existing peers verify the TDX quote against the group's `TeeAdmissionPolicy`
 //! and, if valid, admit the node via a `MemberJoinedViaTeeAttestation` governance op.
 //!
@@ -13,7 +14,7 @@ use calimero_tee_attestation::{is_mock_quote, verify_attestation, verify_mock_at
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
-/// Handle a `TeeAttestationAnnounce` broadcast on a group gossip topic.
+/// Handle a `TeeAttestationAnnounce` broadcast on a namespace gossip topic.
 ///
 /// Verifies the TDX quote, checks measurements against the group's TEE admission
 /// policy, and publishes a `MemberJoinedViaTeeAttestation` governance op if valid.

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -9,8 +9,9 @@ use actix::Actor;
 use calimero_blobstore::config::BlobStoreConfig;
 use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
 use calimero_context::group_store::{
-    add_group_member, check_group_membership, get_group_member_value, get_local_gov_nonce,
-    save_group_meta, store_group_signing_key,
+    add_group_member, apply_local_signed_group_op, check_group_membership, count_group_members,
+    get_group_member_value, get_local_gov_nonce, save_group_meta, store_group_signing_key,
+    store_namespace_identity,
 };
 use calimero_context::ContextManager;
 use calimero_context_client::client::ContextClient;
@@ -18,8 +19,11 @@ use calimero_context_client::group::SetMemberAutoFollowRequest;
 use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
 use calimero_context_config::types::ContextGroupId;
 use calimero_network_primitives::client::NetworkClient;
+use calimero_network_primitives::messages::{IdentTopic, Message, MessageId, NetworkEvent};
+use calimero_network_primitives::specialized_node_invite::SpecializedNodeType;
 use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
 use calimero_node_primitives::messages::NodeMessage;
+use calimero_node_primitives::sync::BroadcastMessage;
 use calimero_node_primitives::NodeMode;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{GroupMemberRole, UpgradePolicy};
@@ -30,6 +34,7 @@ use calimero_store::Store;
 use calimero_utils_actix::LazyRecipient;
 use prometheus_client::registry::Registry;
 use rand::rngs::OsRng;
+use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
@@ -37,6 +42,60 @@ use tokio::time::sleep;
 use crate::arbiter_pool::ArbiterPool;
 use crate::sync::{SyncConfig, SyncManager};
 use crate::{NodeManager, NodeState};
+
+/// Minimal stand-in for the real network actor. The governance publish path
+/// (`group_store::sign_apply_and_publish`) samples mesh peer count and best-
+/// effort-publishes before/after the local store apply; both go through the
+/// `LazyRecipient<NetworkMessage>`. Left uninitialised, a `send().await` on
+/// that recipient queues and never resolves, deadlocking the admission task.
+///
+/// This stub answers every `NetworkMessage` variant with a benign default
+/// (no mesh peers, no connected peers, publish "succeeds" with a dummy id) so
+/// the publish path returns promptly and the local apply — the part this test
+/// asserts on — actually runs. It sends nothing on the wire: there is no peer.
+struct StubNetworkActor;
+
+impl actix::Actor for StubNetworkActor {
+    type Context = actix::Context<Self>;
+}
+
+impl actix::Handler<calimero_network_primitives::messages::NetworkMessage> for StubNetworkActor {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        msg: calimero_network_primitives::messages::NetworkMessage,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        // `MessageId` is already in scope from the module-level import; only
+        // `NetworkMessage` needs bringing in here for the match arms below.
+        use calimero_network_primitives::messages::NetworkMessage;
+        // The admission publish path only samples mesh/peer state and
+        // best-effort-publishes. Resolve those `outcome` oneshots with a
+        // benign default so the awaiting client future completes; drop every
+        // other variant (none are reached by the paths under test, and a
+        // dropped receiver simply surfaces `MailboxError::Closed`). `let _ =`
+        // tolerates a caller that already stopped awaiting.
+        match msg {
+            NetworkMessage::MeshPeerCount { outcome, .. } => {
+                let _ = outcome.send(0);
+            }
+            NetworkMessage::MeshPeers { outcome, .. } => {
+                let _ = outcome.send(Vec::new());
+            }
+            NetworkMessage::MeshStats { outcome, .. } => {
+                let _ = outcome.send(Vec::new());
+            }
+            NetworkMessage::PeerCount { outcome, .. } => {
+                let _ = outcome.send(0);
+            }
+            NetworkMessage::Publish { outcome, .. } => {
+                let _ = outcome.send(Ok(MessageId(b"stub".to_vec())));
+            }
+            _ => {}
+        }
+    }
+}
 
 fn sample_meta(admin: PublicKey) -> GroupMetaValue {
     GroupMetaValue {
@@ -59,6 +118,12 @@ struct TestNode {
     _tmp: TempDir,
     store: Store,
     context_client: ContextClient,
+    /// Address of the running `NodeManager` actor. Lets a test deliver a
+    /// synthesized `NetworkEvent` straight to the production
+    /// `Handler<NetworkEvent>` dispatch (the same entrypoint a real
+    /// gossipsub message takes), exercising the network-event → admission
+    /// path without standing up a libp2p transport.
+    node_addr: actix::Addr<NodeManager>,
 }
 
 /// Boots a `ContextManager` + `NodeManager` against an in-memory store and
@@ -169,9 +234,18 @@ async fn boot_test_node() -> TestNode {
     });
 
     let arb2 = pool.get().await.expect("arbiter 2");
-    let _node_addr = Actor::start_in_arbiter(&arb2, move |ctx| {
+    let node_addr = Actor::start_in_arbiter(&arb2, move |ctx| {
         assert!(node_recipient.init(ctx), "node recipient");
         node_manager
+    });
+
+    // Wire the network recipient to a stub so the governance publish path
+    // (mesh sampling + best-effort publish) resolves instead of deadlocking
+    // on an uninitialised `LazyRecipient`. See `StubNetworkActor`.
+    let arb3 = pool.get().await.expect("arbiter 3");
+    let _network_addr = Actor::start_in_arbiter(&arb3, move |ctx| {
+        assert!(network_recipient.init(ctx), "network recipient");
+        StubNetworkActor
     });
 
     sleep(Duration::from_millis(50)).await;
@@ -181,6 +255,7 @@ async fn boot_test_node() -> TestNode {
         _tmp: tmp,
         store,
         context_client,
+        node_addr,
     }
 }
 
@@ -332,4 +407,280 @@ async fn set_member_auto_follow_handler_error_paths() {
         .expect("alice row");
     assert!(alice_row.auto_follow.contexts);
     assert!(!alice_row.auto_follow.subgroups);
+}
+
+// ---------------------------------------------------------------------------
+// TEE attestation announce → admission, end-to-end regression for #2441.
+//
+// PR #2096 published fleet `TeeAttestationAnnounce` messages on the namespace
+// governance topic `ns/<hex(namespace_id)>`, but the network-event dispatcher
+// stripped `group/` and so dropped every announce — `admit_tee_node` never ran
+// and fleet TEE nodes were never admitted. #2441 fixed the dispatcher to
+// resolve `ns/` topics. The unit tests in
+// `handlers/network_event/specialized.rs` cover topic *parsing*; the tests
+// below close the loop: a real `NetworkEvent::Message` carrying a borsh-encoded
+// mock-attestation `TeeAttestationAnnounce` is delivered to the production
+// `Handler<NetworkEvent>` (the exact entrypoint a gossipsub message takes), and
+// we assert the owner admits the announcer as a `ReadOnlyTee` group member.
+//
+// The libp2p transport itself is the only thing not exercised here; real
+// two-swarm gossipsub delivery over a live connection is covered by
+// `calimero-network/tests/gossipsub_group_topic.rs`. Stubbing the wire keeps
+// this test deterministic in CI while still driving announce → verify → admit
+// through real actors and the real store.
+
+/// `MOCK_TDX_QUOTE_V1` — the marker prefix that
+/// `calimero_tee_attestation::is_mock_quote` matches on. Kept in lock-step
+/// with `crates/tee-attestation/src/generate.rs::MOCK_QUOTE_HEADER`, which is
+/// `pub` at the item level but deliberately NOT re-exported from the crate
+/// root, so it is not reachable from here. Exposing it would widen a published
+/// crate's public surface (consumed by mero-tee at a pinned rev), so this test
+/// keeps a local copy instead. The report-data half of the quote IS built via
+/// the crate's public `build_report_data`, so only the header marker is
+/// duplicated. Building the mock quote bytes by hand (rather than via
+/// `generate_attestation`) keeps the test platform-independent: on Linux,
+/// `generate_attestation` would attempt a real TDX quote.
+const MOCK_QUOTE_HEADER: &[u8] = b"MOCK_TDX_QUOTE_V1";
+
+/// The all-zero 48-byte measurement (96 hex chars) that `create_mock_quote`
+/// reports for `mrtd`/`rtmr*`. The owner's `TeeAdmissionPolicy` must allow this
+/// MRTD for the mock announcer to be admitted.
+const MOCK_MEASUREMENT_48_HEX: &str =
+    "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+/// Build mock TDX quote bytes that bind `nonce` and `pk_hash` into the report
+/// data, matching the layout `verify_mock_attestation` expects:
+/// `MOCK_QUOTE_HEADER || report_data[64] || zero-pad to 256`, where
+/// `report_data = nonce[32] || pk_hash[32]`. The admission handler computes
+/// `pk_hash = Sha256(public_key)` and verifies the report data against it, so
+/// the caller must pass `Sha256(public_key)` here.
+fn mock_quote_bytes(nonce: &[u8; 32], pk_hash: &[u8; 32]) -> Vec<u8> {
+    // `nonce[32] || pk_hash[32]`, built via the crate's public helper so the
+    // report-data layout stays in sync with production rather than hand-rolled.
+    let report_data = calimero_tee_attestation::build_report_data(nonce, Some(pk_hash));
+
+    let mut quote_bytes = Vec::with_capacity(256);
+    quote_bytes.extend_from_slice(MOCK_QUOTE_HEADER);
+    quote_bytes.extend_from_slice(&report_data);
+    quote_bytes.resize(256, 0);
+    quote_bytes
+}
+
+/// Borsh-encode a `TeeAttestationAnnounce` broadcast and wrap it in a
+/// `NetworkEvent::Message` on `topic`, exactly as the gossipsub layer would
+/// hand it to the node actor.
+fn announce_network_event(
+    source: libp2p::PeerId,
+    topic: &str,
+    quote_bytes: Vec<u8>,
+    public_key: PublicKey,
+    nonce: [u8; 32],
+) -> NetworkEvent {
+    let payload = BroadcastMessage::TeeAttestationAnnounce {
+        quote_bytes,
+        public_key,
+        nonce,
+        node_type: SpecializedNodeType::ReadOnly,
+    };
+    let data = borsh::to_vec(&payload).expect("borsh encode TeeAttestationAnnounce");
+
+    NetworkEvent::Message {
+        id: MessageId(b"test-announce".to_vec()),
+        message: Message {
+            source: Some(source),
+            data,
+            sequence_number: Some(1),
+            topic: IdentTopic::new(topic.to_owned()).hash(),
+        },
+    }
+}
+
+/// Provision an owner node so it can act as a TEE-attestation verifier for the
+/// namespace `gid`: store its namespace identity (so `node_namespace_identity`
+/// resolves and a signing key is available), seed it as group admin, and apply
+/// a mock-accepting `TeeAdmissionPolicySet` op that allowlists the mock MRTD.
+/// Returns the owner's namespace public key (the admission op's signer).
+fn provision_tee_owner(node: &TestNode, gid: &ContextGroupId, rng: &mut OsRng) -> PublicKey {
+    let owner_sk = PrivateKey::random(rng);
+    let owner_pk = owner_sk.public_key();
+
+    save_group_meta(&node.store, gid, &sample_meta(owner_pk)).expect("save_group_meta");
+    add_group_member(&node.store, gid, &owner_pk, GroupMemberRole::Admin).expect("add owner admin");
+
+    // The namespace identity is what `admit_tee_node` uses as the verifier
+    // identity AND signing key. Without it the handler bails with
+    // "node has no configured group identity for TEE admission".
+    store_namespace_identity(&node.store, gid, &owner_pk, &owner_sk, &[0u8; 32])
+        .expect("store_namespace_identity");
+
+    // Policy lives on the namespace governance op log; admin-signed.
+    let policy_op = SignedGroupOp::sign(
+        &owner_sk,
+        gid.to_bytes(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::TeeAdmissionPolicySet {
+            allowed_mrtd: vec![MOCK_MEASUREMENT_48_HEX.to_owned()],
+            allowed_rtmr0: vec![],
+            allowed_rtmr1: vec![],
+            allowed_rtmr2: vec![],
+            allowed_rtmr3: vec![],
+            allowed_tcb_statuses: vec![],
+            accept_mock: true,
+        },
+    )
+    .expect("sign TeeAdmissionPolicySet");
+    apply_local_signed_group_op(&node.store, &policy_op).expect("apply policy op");
+
+    owner_pk
+}
+
+/// Poll `cond` until it returns true or the deadline elapses. The admission
+/// path is spawned onto the actor's context and crosses an actor boundary
+/// (`NodeManager` → `ContextManager`), so the store write lands asynchronously.
+async fn wait_until<F: Fn() -> bool>(cond: F) -> bool {
+    for _ in 0..100 {
+        if cond() {
+            return true;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    cond()
+}
+
+/// End-to-end #2441 regression: a `TeeAttestationAnnounce` (mock quote)
+/// delivered on the `ns/<hex(namespace_id)>` topic, through the production
+/// `Handler<NetworkEvent>`, drives the owner to admit the announcer as a
+/// `ReadOnlyTee` group member — exactly what the `group/` vs `ns/` prefix bug
+/// silently prevented. Before the fix the dispatcher dropped the announce on
+/// the `ns/` topic, so `count_group_members` would stay at 1 and no
+/// `ReadOnlyTee` row would ever appear; this test would time out.
+#[tokio::test]
+async fn ns_announce_admits_announcer_as_read_only_tee_member() {
+    let node = boot_test_node().await;
+    let mut rng = OsRng;
+
+    let gid = ContextGroupId::from([0x91u8; 32]);
+    let owner_pk = provision_tee_owner(&node, &gid, &mut rng);
+
+    // Sanity: only the owner is a member before the announce.
+    assert_eq!(count_group_members(&node.store, &gid).expect("count"), 1);
+    assert!(
+        check_group_membership(&node.store, &gid, &owner_pk).expect("owner membership"),
+        "owner must be the sole member before the announce"
+    );
+
+    // The announcing fleet TEE node.
+    let announcer_pk = PrivateKey::random(&mut rng).public_key();
+    let nonce = [0x7Au8; 32];
+    let pk_hash: [u8; 32] = Sha256::digest(*announcer_pk).into();
+    let quote_bytes = mock_quote_bytes(&nonce, &pk_hash);
+
+    // Publish on the namespace governance topic, exactly as
+    // `NodeClient::publish_on_namespace` does: `ns/<hex(namespace_id)>`.
+    let topic = format!("ns/{}", hex::encode(gid.to_bytes()));
+    let event = announce_network_event(
+        libp2p::PeerId::random(),
+        &topic,
+        quote_bytes,
+        announcer_pk,
+        nonce,
+    );
+
+    node.node_addr
+        .send(event)
+        .await
+        .expect("deliver NetworkEvent to node actor");
+
+    let admitted = wait_until(|| {
+        get_group_member_value(&node.store, &gid, &announcer_pk)
+            .ok()
+            .flatten()
+            .map(|v| v.role == GroupMemberRole::ReadOnlyTee)
+            .unwrap_or(false)
+    })
+    .await;
+
+    assert!(
+        admitted,
+        "announcer must be admitted as a ReadOnlyTee member after a TeeAttestationAnnounce on the ns/ topic"
+    );
+    assert_eq!(
+        count_group_members(&node.store, &gid).expect("count after admit"),
+        2,
+        "member_count must increment to 2 (owner + admitted TEE node)"
+    );
+}
+
+/// Negative guard locking in the fix: a `TeeAttestationAnnounce` arriving on a
+/// legacy `group/<hex>` topic must NOT be routed into namespace admission. This
+/// is the precise shape of the #2096 bug — if the dispatcher ever resurrects
+/// `group/` handling for announces, the announcer would be admitted here and
+/// this assertion would fail. The announce is otherwise identical (valid mock
+/// quote, allowlisted MRTD), so the ONLY thing keeping the announcer out is the
+/// topic-prefix routing decision under test.
+#[tokio::test]
+async fn group_topic_announce_is_not_routed_as_namespace_admission() {
+    let node = boot_test_node().await;
+    let mut rng = OsRng;
+
+    let gid = ContextGroupId::from([0x92u8; 32]);
+    let _owner_pk = provision_tee_owner(&node, &gid, &mut rng);
+
+    let announcer_pk = PrivateKey::random(&mut rng).public_key();
+    let nonce = [0x7Bu8; 32];
+    let pk_hash: [u8; 32] = Sha256::digest(*announcer_pk).into();
+    let quote_bytes = mock_quote_bytes(&nonce, &pk_hash);
+
+    // Legacy `group/<hex>` topic — the buggy prefix. Same namespace id suffix.
+    let topic = format!("group/{}", hex::encode(gid.to_bytes()));
+    let event = announce_network_event(
+        libp2p::PeerId::random(),
+        &topic,
+        quote_bytes,
+        announcer_pk,
+        nonce,
+    );
+
+    node.node_addr
+        .send(event)
+        .await
+        .expect("deliver NetworkEvent to node actor");
+
+    // Deterministic signal: `send().await` resolves only after the actor's
+    // synchronous `Handler<NetworkEvent>` returns, and the dispatcher rejects a
+    // `group/` topic *synchronously* (`parse_namespace_announce_topic` →
+    // `NotNamespaceTopic`) without ever reaching the `ctx.spawn` admission path.
+    // So the moment we get here, the #2096-shape regression (synchronous
+    // mis-routing) is already decided — no member row can exist.
+    assert!(
+        get_group_member_value(&node.store, &gid, &announcer_pk)
+            .ok()
+            .flatten()
+            .is_none(),
+        "a group/ announce was routed into admission synchronously (the #2096 bug shape)"
+    );
+
+    // Secondary guard for a regression that instead spawned an *async*
+    // admission task off this event: give any such task ample time to land a
+    // row, then assert none did. (There is no positive signal to await for a
+    // correctly-ignored announce without adding a test hook to production code.)
+    let leaked = wait_until(|| {
+        get_group_member_value(&node.store, &gid, &announcer_pk)
+            .ok()
+            .flatten()
+            .is_some()
+    })
+    .await;
+
+    assert!(
+        !leaked,
+        "a TeeAttestationAnnounce on a group/ topic must not be routed into namespace admission"
+    );
+    assert_eq!(
+        count_group_members(&node.store, &gid).expect("count"),
+        1,
+        "no member should be admitted from a group/ topic announce (owner only)"
+    );
 }


### PR DESCRIPTION
## Summary

Fleet TEE nodes broadcast `TeeAttestationAnnounce` on the **namespace governance topic** `ns/<hex(namespace_id)>` (via `NodeClient::publish_on_namespace`), and the namespace owner subscribes on that same `ns/<hex>` topic at startup. But the owner's receiver dispatcher stripped the **wrong** prefix — `group/` — when parsing the announce topic in `crates/node/src/handlers/network_event/specialized.rs`.

Because the `ns/...` topic never matched `strip_prefix("group/")`, every announce fell into the `None`/else arm (logged "TeeAttestationAnnounce received on non-group topic", returned `true` = handled/discarded). So `handle_tee_attestation_announce` → quote verify → `admit_tee_node` was **never invoked**, the owner never authored `MemberJoinedViaTeeAttestation`, and **fleet TEE nodes were never actually admitted to the namespace group**.

Confirmed in prod: an owner node shows 1 member despite an active, heartbeating fleet assignment. The publish/receiver prefix mismatch shipped together in PR #2096 — existing tests only exercise `group/` topics, so it was never caught.

## Fix

One-line routing fix plus cleanup, all internal to the node handler:

- `specialized.rs`: parse the `TeeAttestationAnnounce` topic with `strip_prefix("ns/")` instead of `strip_prefix("group/")`, matching the publish side (`publish_on_namespace`) and the rest of namespace governance (`subscriptions.rs`, `governance_broadcast::ns_topic`). The namespace is its own root group, so the parsed namespace id is the admission group id.
- Renamed the local id (`group_id_bytes` → `namespace_id_bytes`) and updated the now-stale warning/log strings ("non-group topic" → "non-namespace topic", etc.).
- Extracted the topic parse into a small pure helper (`parse_namespace_announce_topic`) so the routing decision is unit-testable.
- Updated stale "group topic" doc comments in `tee_attestation_admission.rs`.

The **publish side was already correct** and is left unchanged.

## Regression test

Added unit tests in `specialized.rs` around the topic parse:

- `ns_announce_topic_resolves_to_namespace_id_for_admission` — an `ns/<hex>` announce resolves to the namespace id and is routed into the admission path (the id handed to `handle_tee_attestation_announce` / `admit_tee_node`), i.e. is NOT dropped as a non-namespace topic. This is the regression that PR #2096 introduced.
- `legacy_group_topic_is_not_a_namespace_announce_topic` — the old `group/<hex>` topic no longer matches this path (it is not how TEE announces are published).
- `unprefixed_topic_is_not_a_namespace_announce_topic` and `ns_topic_with_malformed_hex_is_rejected_as_malformed` — cover the rejection arms.

## Verification

- `cargo check -p calimero-node` — clean (pre-existing unrelated `node_metrics` dead-code warning only).
- `cargo test -p calimero-node --lib specialized` — 4 passed.
- `cargo fmt --check` — clean. `cargo clippy -p calimero-node --all-targets -- -A warnings` — clean.
- `cargo check --workspace` — clean.

## Cross-repo / published surface

No published surfaces touched. The change is entirely inside the internal node handler (`calimero-node`); `calimero-server-primitives` and `calimero-tee-attestation` are unchanged, so **no mero-tee rev bump is needed**.

## Follow-ups (not in this PR)

- Announce retry: the fleet node should re-announce until admitted, to survive a missed delivery / mesh-not-yet-formed window.
- mdma confirm-gating: gate fleet "joined" confirmation on actual `admitted` state rather than a successful announce publish.

Relates to the namespace-native HA work (namespace is its own root group; HA is per-namespace).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb5589230c4484c570b4fc31e65fc23f7f6b653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->