### PR TITLE
test(e2e): add app-migration e2e workflows + CI job

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -1,0 +1,170 @@
+name: App migration e2e
+
+# End-to-end coverage for the per-context application migration pipeline
+# introduced in #1911. Runs the workflows under workflows/app-upgrade/
+# against a locally built merod image, exercising every fixture under
+# apps/migrations/migration-suite-v{1..5}.
+#
+# The Rust unit layer for migration is well-covered
+# (crates/context/src/handlers/update_application/mod.rs has 16
+# verify_appkey_continuity tests). What this job adds is end-to-end
+# proof that install -> upgrade_group -> migrate_method -> state in the
+# new shape actually works. Pre-#1911 this was deferred ("blocked
+# pending update_context_application step type support in merobox") --
+# that step now exists as merobox's `upgrade_group` step.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "crates/context/src/handlers/update_application/**"
+      - "crates/context/src/handlers/upgrade_group.rs"
+      - "crates/context/primitives/src/messages.rs"
+      - "crates/sdk/macros/**"
+      - "crates/storage/src/**"
+      - "apps/migrations/**"
+      - "workflows/app-upgrade/**"
+      - ".github/workflows/app-migration-e2e.yml"
+      - ".github/actions/build-local-merod/**"
+      - ".github/actions/setup-merobox/**"
+
+  pull_request:
+    branches: [master]
+    paths:
+      - "crates/context/src/handlers/update_application/**"
+      - "crates/context/src/handlers/upgrade_group.rs"
+      - "crates/context/primitives/src/messages.rs"
+      - "crates/sdk/macros/**"
+      - "crates/storage/src/**"
+      - "apps/migrations/**"
+      - "workflows/app-upgrade/**"
+      - ".github/workflows/app-migration-e2e.yml"
+      - ".github/actions/build-local-merod/**"
+      - ".github/actions/setup-merobox/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUST_LOG: info,calimero_=debug
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+jobs:
+  app-migration-e2e:
+    name: App migration e2e
+    # Same runner class as sync-regression / e2e-rust-apps so cold-start
+    # performance is comparable and we share the rust-ci cache.
+    runs-on: ubuntu-24.04-8cpu
+    # The chain workflow has 4 sequential upgrades x ~6s wait each plus
+    # WASM build + image build overhead. 20 min cap gives generous
+    # headroom; a regression typically fails inside the first migration.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          shared-key: app-migration-e2e
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build local merod image
+        uses: ./.github/actions/build-local-merod
+        env:
+          CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build migration-suite WASM fixtures
+        # Convenience wrapper around each suite's build.sh -- see
+        # workflows/app-upgrade/build-wasms.sh.
+        run: bash workflows/app-upgrade/build-wasms.sh
+
+      - name: Setup merobox
+        uses: ./.github/actions/setup-merobox
+
+      - name: Run app-migration workflows
+        # Iterates every workflow in workflows/app-upgrade/, running each
+        # against the locally built merod:local image. Captures docker
+        # logs per node during each run so a failure leaves diagnosable
+        # artefacts. Same log-watcher pattern as sync-regression.yml --
+        # the init containers exit quickly and merobox tears the runtime
+        # containers down on exit, so `docker logs` after the fact catches
+        # nothing.
+        run: |
+          mkdir -p docker-logs
+          LOGDIR="$GITHUB_WORKSPACE/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          (
+            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+              for c in $(docker ps --filter "label=calimero.node=true" \
+                                   --format "{{.Names}}" 2>/dev/null \
+                         | grep -v -- '-init$' || true); do
+                mark="$WATCHER_STATE_DIR/${c}"
+                if [ ! -f "$mark" ]; then
+                  touch "$mark"
+                  echo "[log-watcher] following $c"
+                  docker logs -f --timestamps "$c" \
+                    > "$LOGDIR/${c}.log" 2>&1 &
+                fi
+              done
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
+          set +e
+          set -o pipefail
+          overall_exit=0
+          # Sequential rather than parallel: each workflow nukes docker
+          # state on start (nuke_on_start: true), so running concurrently
+          # would have them stomp on each other's containers. Sequential
+          # also makes failures easier to triage from log artefacts.
+          for wf in workflows/app-upgrade/*.yml; do
+              name=$(basename "$wf" .yml)
+              echo "::group::Running $name"
+              merobox bootstrap run "$wf" \
+                  --image merod:local \
+                  --e2e-mode \
+                  --verbose 2>&1 | tee "docker-logs/merobox-${name}.log"
+              wf_exit=$?
+              echo "::endgroup::"
+              if [ "$wf_exit" -ne 0 ]; then
+                  echo "::error::Workflow $name failed with exit $wf_exit"
+                  overall_exit=$wf_exit
+              fi
+          done
+          set +o pipefail
+
+          touch "$WATCHER_STATE_DIR/stop"
+          sleep 2
+          kill "$WATCHER_PID" 2>/dev/null || true
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          wait 2>/dev/null || true
+
+          exit "$overall_exit"
+
+      - name: Upload docker logs
+        # Always upload -- even green runs benefit from log evidence
+        # (e.g. confirming the Migrated event was actually emitted, not
+        # just present in node output by coincidence). Same pattern as
+        # sync-regression.yml.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-migration-e2e-docker-logs
+          path: docker-logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -133,13 +133,24 @@ jobs:
           # would have them stomp on each other's containers. Sequential
           # also makes failures easier to triage from log artefacts.
           for wf in workflows/app-upgrade/*.yml; do
-              name=$(basename "$wf" .yml)
+              # Sanitise the derived log-filename component. The glob itself
+              # is hardcoded, but defence in depth: a future workflow whose
+              # filename includes shell-metacharacter-like bytes (or path
+              # separators if someone ever symlinks into the directory)
+              # would otherwise be interpolated into the log path. Strip to
+              # the safe set used by every existing workflow filename.
+              name=$(basename "$wf" .yml | tr -cd 'A-Za-z0-9_-')
               echo "::group::Running $name"
+              # Pipe merobox stdout/stderr through tee to capture it as a
+              # build artefact. ${PIPESTATUS[0]} captures merobox's exit
+              # explicitly -- more legible than relying on `pipefail` to
+              # surface merobox's failure as the pipeline's `$?`, and
+              # robust even if a future edit drops `pipefail`.
               merobox bootstrap run "$wf" \
                   --image merod:local \
                   --e2e-mode \
                   --verbose 2>&1 | tee "docker-logs/merobox-${name}.log"
-              wf_exit=$?
+              wf_exit=${PIPESTATUS[0]}
               echo "::endgroup::"
               if [ "$wf_exit" -ne 0 ]; then
                   echo "::error::Workflow $name failed with exit $wf_exit"

--- a/workflows/app-upgrade/01-empty-upgrade-rejected.yml
+++ b/workflows/app-upgrade/01-empty-upgrade-rejected.yml
@@ -1,0 +1,115 @@
+name: Empty upgrade rejected (target == current, no migration)
+description: >
+  Server-side guard test: an `upgrade_group` call targeting the group's
+  current application with no `migrate_method` must be rejected. The
+  guard lives in crates/context/src/handlers/upgrade_group.rs:480 and
+  exists to prevent operationally-empty upgrade ops from churning the
+  governance DAG.
+
+  Asserts:
+    1. The upgrade_group RPC fails (expected_failure: true).
+    2. The server log carries the canonical error text from
+       upgrade_group.rs:480 — "group is already targeting this
+       application and no migration was requested".
+
+  Tiny + fast — runs in well under a minute.
+
+# Test configuration
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 1
+  image: merod:local
+  prefix: app-migration-reject-node
+  base_port: 9230
+  base_rpc_port: 9330
+
+steps:
+  - name: Install migration-suite-v1
+    type: install_application
+    node: app-migration-reject-node-1
+    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    dev: true
+    outputs:
+      app_v1: applicationId
+
+  - name: Create namespace
+    type: create_namespace
+    node: app-migration-reject-node-1
+    application_id: "{{app_v1}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Capture admin key
+    type: get_namespace_identity
+    node: app-migration-reject-node-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      admin_key: publicKey
+
+  - name: Create subgroup
+    type: create_group_in_namespace
+    node: app-migration-reject-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: "empty-upgrade-test"
+    outputs:
+      group_id: groupId
+
+  - name: Create context on v1
+    type: create_context
+    node: app-migration-reject-node-1
+    application_id: "{{app_v1}}"
+    group_id: "{{group_id}}"
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for context propagation
+    type: wait
+    seconds: 3
+
+  # Trigger the rejected path: target == current && no migration.
+  - name: Attempt empty upgrade (expected to fail)
+    type: upgrade_group
+    node: app-migration-reject-node-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v1}}"
+    expected_failure: true
+
+  # Verify the failure path is the documented one, not some unrelated error
+  # (auth failure, missing group, etc.). The exact bail! text is from
+  # crates/context/src/handlers/upgrade_group.rs:480.
+  - name: Assert canonical rejection message in logs
+    type: assert_log_present
+    nodes:
+      - app-migration-reject-node-1
+    patterns:
+      - "group is already targeting this application and no migration was requested"
+    min_matches: 1
+
+  # ── Teardown ─────────────────────────────────────────────────────────
+  - name: Delete context
+    type: delete_context
+    node: app-migration-reject-node-1
+    context_id: "{{ctx_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete subgroup
+    type: delete_group
+    node: app-migration-reject-node-1
+    group_id: "{{group_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete namespace
+    type: delete_namespace
+    node: app-migration-reject-node-1
+    namespace_id: "{{namespace_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Uninstall v1
+    type: uninstall_application
+    node: app-migration-reject-node-1
+    application_id: "{{app_v1}}"
+
+stop_all_nodes: false

--- a/workflows/app-upgrade/03-single-migration-v1-to-v2.yml
+++ b/workflows/app-upgrade/03-single-migration-v1-to-v2.yml
@@ -1,0 +1,221 @@
+name: Application migration v1 → v2 (single node)
+description: >
+  End-to-end smoke test for the per-context migration pipeline introduced
+  in #1911. Installs migration-suite-v1, creates a context, writes state
+  through the v1 API, installs migration-suite-v2-add-field, then triggers
+  `upgrade_group` with `migrate_method=migrate_v1_to_v2`. Asserts:
+
+    1. The migrate function ran (Event::Migrated { v1 -> v2 } log line).
+    2. schema_info() now reports v2 ("schema_version": "2.0.0") with the
+       new `notes` field populated by the migration ("added in v2").
+    3. Pre-migration writes survived (description + counter readable via
+       v2's API).
+
+  This is the headline e2e gap from PR #1911 — see
+  workflows/app-upgrade/README.md.
+
+# Test configuration
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 1
+  # GHA wrapper builds merod:local from PR HEAD and loads it before invoking
+  # merobox. Same pattern as workflows/sync-tests/opaque-leaf-regression.yml.
+  image: merod:local
+  prefix: app-migration-node
+  base_port: 9210
+  base_rpc_port: 9310
+
+steps:
+  # ── Phase 1: Install both binaries on the single node ─────────────────
+  - name: Install migration-suite-v1
+    type: install_application
+    node: app-migration-node-1
+    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    dev: true
+    outputs:
+      app_v1: applicationId
+
+  - name: Install migration-suite-v2-add-field
+    type: install_application
+    node: app-migration-node-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  # ── Phase 2: Namespace + subgroup + context on v1 ─────────────────────
+  - name: Create namespace
+    type: create_namespace
+    node: app-migration-node-1
+    application_id: "{{app_v1}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Capture admin key (for teardown)
+    type: get_namespace_identity
+    node: app-migration-node-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      admin_key: publicKey
+
+  - name: Create subgroup
+    type: create_group_in_namespace
+    node: app-migration-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: "migration-test"
+    outputs:
+      group_id: groupId
+
+  - name: Create context in subgroup (on v1)
+    type: create_context
+    node: app-migration-node-1
+    application_id: "{{app_v1}}"
+    group_id: "{{group_id}}"
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for context propagation
+    type: wait
+    seconds: 3
+
+  # ── Phase 3: Write v1 state ───────────────────────────────────────────
+  - name: Set description (v1)
+    type: call
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    method: set_description
+    args:
+      description: "set-before-migration"
+
+  - name: Increment counter (v1)
+    type: call
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    method: increment_counter
+
+  - name: Read v1 schema_info (sanity)
+    type: call
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v1_schema: result
+
+  - name: Assert v1 schema before migration
+    type: json_assert
+    statements:
+      - 'json_subset({{v1_schema}}, {"output": {"schema_version": "1.0.0", "description": "set-before-migration", "counter": "1"}})'
+
+  # ── Phase 4: Set upgrade policy + trigger migration ───────────────────
+  - name: Set upgrade policy to coordinated
+    type: update_group_settings
+    node: app-migration-node-1
+    group_id: "{{group_id}}"
+    upgrade_policy: coordinated
+
+  - name: Upgrade with migrate_v1_to_v2
+    type: upgrade_group
+    node: app-migration-node-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v2}}"
+    migrate_method: migrate_v1_to_v2
+
+  - name: Wait for upgrade + migration to apply
+    type: wait
+    seconds: 8
+
+  - name: Read upgrade status
+    type: get_group_upgrade_status
+    node: app-migration-node-1
+    group_id: "{{group_id}}"
+
+  # ── Phase 5: Verify migration actually executed ───────────────────────
+  # Assert #1: Migrate function emitted the Migrated event.
+  # The #[app::emit!] macro on `Event::Migrated { v1 -> v2 }` writes a
+  # structured event into node logs visible to assert_log_present.
+  - name: Assert Migrated event observed (v1 → v2)
+    type: assert_log_present
+    nodes:
+      - app-migration-node-1
+    patterns:
+      - "Migrated"
+      - "1.0.0"
+      - "2.0.0"
+    min_matches: 1
+
+  # Assert #2: schema_info() now returns v2 shape + preserved data.
+  - name: Read post-migration schema_info
+    type: call
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v2_schema: result
+
+  - name: Assert v2 schema after migration
+    type: json_assert
+    statements:
+      # schema_version flipped to 2.0.0
+      - 'json_subset({{v2_schema}}, {"output": {"schema_version": "2.0.0"}})'
+      # pre-migration writes preserved
+      - 'json_subset({{v2_schema}}, {"output": {"description": "set-before-migration", "counter": "1"}})'
+      # the new v2-only `notes` field is present + populated by migration
+      - 'json_subset({{v2_schema}}, {"output": {"notes": "added in v2"}})'
+
+  # Assert #3: v2-only setters/getters work post-migration (i.e. we are
+  # really executing on the v2 binary, not the v1 binary that happens to
+  # silently tolerate the new shape).
+  - name: Call v2-only setter `set_notes`
+    type: call
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    method: set_notes
+    args:
+      notes: "written-post-migration"
+
+  - name: Read notes via v2 getter
+    type: call
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    method: get_notes
+    outputs:
+      notes_after: result
+
+  - name: Assert v2 setter/getter round-tripped
+    type: json_assert
+    statements:
+      - 'json_equal({{notes_after}}, {"output": "written-post-migration"})'
+
+  # ── Phase 6: Teardown ─────────────────────────────────────────────────
+  - name: Delete context
+    type: delete_context
+    node: app-migration-node-1
+    context_id: "{{ctx_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete subgroup
+    type: delete_group
+    node: app-migration-node-1
+    group_id: "{{group_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete namespace
+    type: delete_namespace
+    node: app-migration-node-1
+    namespace_id: "{{namespace_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Uninstall v1
+    type: uninstall_application
+    node: app-migration-node-1
+    application_id: "{{app_v1}}"
+
+  - name: Uninstall v2
+    type: uninstall_application
+    node: app-migration-node-1
+    application_id: "{{app_v2}}"
+
+stop_all_nodes: false

--- a/workflows/app-upgrade/20-chain-v1-to-v5.yml
+++ b/workflows/app-upgrade/20-chain-v1-to-v5.yml
@@ -1,0 +1,393 @@
+name: Application migration chain v1 → v5 (single node)
+description: >
+  Stress test for the per-context migration pipeline: walks one context
+  through four consecutive schema migrations (v1 → v2 → v3 → v4 → v5),
+  asserting after every step that:
+
+    a) the corresponding migrate_vX_to_vY function actually ran (via the
+       Event::Migrated log emitted from #[app::migrate]),
+    b) schema_info() reports the expected new schema_version,
+    c) field-level changes apply correctly:
+         v1 → v2:  notes field added (populated by migration)
+         v2 → v3:  notes field removed (silently dropped)
+         v3 → v4:  description renamed to details
+         v4 → v5:  counter type changed from u64 to String
+    d) data written through v(N-1)'s API survives into vN and is readable
+       through vN's API, *and* writes done at intermediate versions persist
+       through subsequent migrations.
+
+  Exercises every fixture under apps/migrations/. If any single migration
+  step breaks, the chain fails at that step with the exact schema delta
+  that broke.
+
+# Test configuration
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 1
+  image: merod:local
+  prefix: app-migration-chain-node
+  base_port: 9220
+  base_rpc_port: 9320
+
+steps:
+  # ── Phase 1: Install all five binaries ────────────────────────────────
+  - name: Install migration-suite-v1
+    type: install_application
+    node: app-migration-chain-node-1
+    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    dev: true
+    outputs:
+      app_v1: applicationId
+
+  - name: Install migration-suite-v2-add-field
+    type: install_application
+    node: app-migration-chain-node-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  - name: Install migration-suite-v3-remove-field
+    type: install_application
+    node: app-migration-chain-node-1
+    path: apps/migrations/migration-suite-v3-remove-field/res/migration_suite_v3_remove_field.wasm
+    dev: true
+    outputs:
+      app_v3: applicationId
+
+  - name: Install migration-suite-v4-rename-field
+    type: install_application
+    node: app-migration-chain-node-1
+    path: apps/migrations/migration-suite-v4-rename-field/res/migration_suite_v4_rename_field.wasm
+    dev: true
+    outputs:
+      app_v4: applicationId
+
+  - name: Install migration-suite-v5-change-type
+    type: install_application
+    node: app-migration-chain-node-1
+    path: apps/migrations/migration-suite-v5-change-type/res/migration_suite_v5_change_type.wasm
+    dev: true
+    outputs:
+      app_v5: applicationId
+
+  # ── Phase 2: Namespace + subgroup + context on v1 ─────────────────────
+  - name: Create namespace
+    type: create_namespace
+    node: app-migration-chain-node-1
+    application_id: "{{app_v1}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Capture admin key
+    type: get_namespace_identity
+    node: app-migration-chain-node-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      admin_key: publicKey
+
+  - name: Create subgroup
+    type: create_group_in_namespace
+    node: app-migration-chain-node-1
+    namespace_id: "{{namespace_id}}"
+    group_name: "chain-test"
+    outputs:
+      group_id: groupId
+
+  - name: Create context on v1
+    type: create_context
+    node: app-migration-chain-node-1
+    application_id: "{{app_v1}}"
+    group_id: "{{group_id}}"
+    outputs:
+      ctx_id: contextId
+
+  - name: Wait for context propagation
+    type: wait
+    seconds: 3
+
+  - name: Set upgrade policy to coordinated
+    type: update_group_settings
+    node: app-migration-chain-node-1
+    group_id: "{{group_id}}"
+    upgrade_policy: coordinated
+
+  # ── Phase 3: Write initial v1 state ───────────────────────────────────
+  - name: v1 — set description
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: set_description
+    args:
+      description: "written-at-v1"
+
+  - name: v1 — increment counter (→ 1)
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: increment_counter
+
+  # ── Phase 4: v1 → v2 (add field `notes`) ──────────────────────────────
+  - name: Upgrade v1 → v2
+    type: upgrade_group
+    node: app-migration-chain-node-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v2}}"
+    migrate_method: migrate_v1_to_v2
+
+  - name: Wait for v1 → v2 to apply
+    type: wait
+    seconds: 6
+
+  - name: Assert Migrated event (v1 → v2)
+    type: assert_log_present
+    nodes:
+      - app-migration-chain-node-1
+    patterns:
+      - "Migrated"
+      - "1.0.0"
+      - "2.0.0"
+    min_matches: 1
+
+  - name: v2 — read schema_info
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v2_schema: result
+
+  - name: Assert v2 shape (notes populated, prior data preserved)
+    type: json_assert
+    statements:
+      - 'json_subset({{v2_schema}}, {"output": {"schema_version": "2.0.0"}})'
+      - 'json_subset({{v2_schema}}, {"output": {"description": "written-at-v1", "counter": "1"}})'
+      - 'json_subset({{v2_schema}}, {"output": {"notes": "added in v2"}})'
+
+  - name: v2 — overwrite notes (proves v2 binary is live)
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: set_notes
+    args:
+      notes: "written-at-v2"
+
+  # ── Phase 5: v2 → v3 (drop field `notes`) ─────────────────────────────
+  - name: Upgrade v2 → v3
+    type: upgrade_group
+    node: app-migration-chain-node-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v3}}"
+    migrate_method: migrate_v2_to_v3
+
+  - name: Wait for v2 → v3 to apply
+    type: wait
+    seconds: 6
+
+  - name: Assert Migrated event (v2 → v3)
+    type: assert_log_present
+    nodes:
+      - app-migration-chain-node-1
+    patterns:
+      - "Migrated"
+      - "2.0.0"
+      - "3.0.0"
+    min_matches: 1
+
+  - name: v3 — read schema_info
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v3_schema: result
+
+  - name: Assert v3 shape (notes dropped, description still readable)
+    type: json_assert
+    statements:
+      - 'json_subset({{v3_schema}}, {"output": {"schema_version": "3.0.0"}})'
+      - 'json_subset({{v3_schema}}, {"output": {"description": "written-at-v1", "counter": "1"}})'
+      # `notes` no longer present in SchemaInfo — json_subset is permissive
+      # about extra fields, so the assertion above is sufficient. If a
+      # phantom notes field appeared, that itself wouldn't be caught — but
+      # the next migration's deserialiser would fail loudly.
+
+  - name: v3 — overwrite description (test write at v3)
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: set_description
+    args:
+      description: "written-at-v3"
+
+  - name: v3 — increment counter (→ 2)
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: increment_counter
+
+  # ── Phase 6: v3 → v4 (rename description → details) ───────────────────
+  - name: Upgrade v3 → v4
+    type: upgrade_group
+    node: app-migration-chain-node-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v4}}"
+    migrate_method: migrate_v3_to_v4
+
+  - name: Wait for v3 → v4 to apply
+    type: wait
+    seconds: 6
+
+  - name: Assert Migrated event (v3 → v4)
+    type: assert_log_present
+    nodes:
+      - app-migration-chain-node-1
+    patterns:
+      - "Migrated"
+      - "3.0.0"
+      - "4.0.0"
+    min_matches: 1
+
+  - name: v4 — read schema_info
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v4_schema: result
+
+  - name: Assert v4 shape (description renamed to details, value preserved)
+    type: json_assert
+    statements:
+      - 'json_subset({{v4_schema}}, {"output": {"schema_version": "4.0.0"}})'
+      # v3's `description = "written-at-v3"` moved into v4's `details` field
+      - 'json_subset({{v4_schema}}, {"output": {"details": "written-at-v3", "counter": "2"}})'
+
+  - name: v4 — overwrite details (test v4-only setter)
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: set_details
+    args:
+      details: "written-at-v4"
+
+  # ── Phase 7: v4 → v5 (counter type u64 → String) ──────────────────────
+  - name: Upgrade v4 → v5
+    type: upgrade_group
+    node: app-migration-chain-node-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v5}}"
+    migrate_method: migrate_v4_to_v5
+
+  - name: Wait for v4 → v5 to apply
+    type: wait
+    seconds: 6
+
+  - name: Assert Migrated event (v4 → v5)
+    type: assert_log_present
+    nodes:
+      - app-migration-chain-node-1
+    patterns:
+      - "Migrated"
+      - "4.0.0"
+      - "5.0.0"
+    min_matches: 1
+
+  - name: v5 — read schema_info
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v5_schema: result
+
+  - name: Assert v5 shape (details preserved, counter stringified)
+    type: json_assert
+    statements:
+      - 'json_subset({{v5_schema}}, {"output": {"schema_version": "5.0.0"}})'
+      - 'json_subset({{v5_schema}}, {"output": {"details": "written-at-v4"}})'
+      # counter went u64(2) → String("2") via migrate_v4_to_v5
+      - 'json_subset({{v5_schema}}, {"output": {"counter": "2"}})'
+
+  - name: v5 — set string counter (proves new type works)
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: set_counter
+    args:
+      counter: "v5-string-counter"
+
+  - name: v5 — read counter back
+    type: call
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    method: get_counter
+    outputs:
+      v5_counter: result
+
+  - name: Assert v5 counter accepts string
+    type: json_assert
+    statements:
+      - 'json_equal({{v5_counter}}, {"output": "v5-string-counter"})'
+
+  # ── Phase 8: Final sanity — four distinct Migrated transitions logged ─
+  # The aggregate count of "Migrated" event lines should be exactly 4
+  # across the run (one per upgrade step). assert_log_present's
+  # min_matches gives us a floor; a stricter equality check would need
+  # an aggregate-count step which doesn't currently exist in merobox.
+  - name: Assert aggregate Migrated event count (>= 4)
+    type: assert_log_present
+    nodes:
+      - app-migration-chain-node-1
+    patterns:
+      - "Migrated"
+    min_matches: 4
+
+  # ── Phase 9: Teardown ─────────────────────────────────────────────────
+  - name: Delete context
+    type: delete_context
+    node: app-migration-chain-node-1
+    context_id: "{{ctx_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete subgroup
+    type: delete_group
+    node: app-migration-chain-node-1
+    group_id: "{{group_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete namespace
+    type: delete_namespace
+    node: app-migration-chain-node-1
+    namespace_id: "{{namespace_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Uninstall v1
+    type: uninstall_application
+    node: app-migration-chain-node-1
+    application_id: "{{app_v1}}"
+
+  - name: Uninstall v2
+    type: uninstall_application
+    node: app-migration-chain-node-1
+    application_id: "{{app_v2}}"
+
+  - name: Uninstall v3
+    type: uninstall_application
+    node: app-migration-chain-node-1
+    application_id: "{{app_v3}}"
+
+  - name: Uninstall v4
+    type: uninstall_application
+    node: app-migration-chain-node-1
+    application_id: "{{app_v4}}"
+
+  - name: Uninstall v5
+    type: uninstall_application
+    node: app-migration-chain-node-1
+    application_id: "{{app_v5}}"
+
+stop_all_nodes: false

--- a/workflows/app-upgrade/README.md
+++ b/workflows/app-upgrade/README.md
@@ -1,0 +1,89 @@
+# `workflows/app-upgrade/` — application upgrade & migration e2e
+
+End-to-end merobox workflows that exercise the per-context application
+upgrade + state-migration engine introduced in
+[#1911](https://github.com/calimero-network/core/pull/1911).
+
+The Rust unit layer is already well-covered — see the 16
+`verify_appkey_continuity` tests in
+`crates/context/src/handlers/update_application/mod.rs` (signer mismatch,
+hijacking, downgrades, case/whitespace edge cases, prefix attacks). These
+workflows add the missing **end-to-end** coverage: install a new WASM,
+run `upgrade_group` with a `migrate_method`, prove on every peer that the
+migration function actually executed and that post-migration state is in
+the new schema's shape.
+
+## Fixtures
+
+The workflows reuse the [`apps/migrations/migration-suite-v{1..5}`](../../apps/migrations)
+fixtures (also introduced in #1911):
+
+| Suite | Schema change vs prior | Migration function |
+|---|---|---|
+| `migration-suite-v1` | initial | — |
+| `migration-suite-v2-add-field` | + `notes: LwwRegister<String>` | `migrate_v1_to_v2` |
+| `migration-suite-v3-remove-field` | − `notes` | `migrate_v2_to_v3` |
+| `migration-suite-v4-rename-field` | `description` → `details` | `migrate_v3_to_v4` |
+| `migration-suite-v5-change-type` | `counter: u64` → `counter: String` | `migrate_v4_to_v5` |
+
+Each suite exposes a `schema_info()` view returning the current
+`schema_version` and the live field shape, which the workflows pipe
+through `json_assertion` for post-upgrade verification. Each `#[app::migrate]`
+also emits a `Migrated { from_version, to_version }` event, which the
+workflows assert on via `assert_log_present`.
+
+## Workflows in this folder
+
+| File | What it proves |
+|---|---|
+| `01-empty-upgrade-rejected.yml` | Server rejects an `upgrade_group` whose target equals the current application and carries no migration (the bail at `upgrade_group.rs:480`). Asserts both the failed RPC and the canonical error message in logs. |
+| `03-single-migration-v1-to-v2.yml` | Install v1, write state, install v2, `upgrade_group` with `migrate_method=migrate_v1_to_v2`. Asserts the `Event::Migrated { v1 -> v2 }` log line, that `schema_info()` reports v2's shape with `notes` populated by the migration, that pre-migration writes survived, and that v2-only setters/getters now work. |
+| `20-chain-v1-to-v5.yml` | Sequentially migrates one context through all four migrations (v1 → v2 → v3 → v4 → v5). Writes new data at intermediate versions and asserts after each step that schema_version flipped, field-level changes applied (add/drop/rename/retype), and inherited data survived. Aggregate `Migrated` count must be ≥ 4. |
+
+(Numbering reserves gaps for follow-up workflows. `02-binary-swap-without-migration.yml`
+would require a same-schema v1/v2 pair that does not exist in the migration-suite,
+and is omitted from this PR — the `update_application_id` no-migration path is
+already covered by the unit suite at `update_application/mod.rs`.)
+
+## Building the fixtures
+
+Convenience wrapper:
+
+```bash
+bash workflows/app-upgrade/build-wasms.sh
+```
+
+Or build individually:
+
+```bash
+bash apps/migrations/migration-suite-v1/build.sh
+# ...
+```
+
+CI builds them inline in `.github/workflows/app-migration-e2e.yml`.
+
+## Running locally
+
+Requires `merobox >= 0.6.16` and Docker. Use the published
+`merod:edge` image, or build a local `merod:local` per the pattern in
+`workflows/sync-tests/`:
+
+```bash
+# Build fixtures
+bash workflows/app-upgrade/build-wasms.sh
+
+# Run one workflow against the published edge image
+merobox bootstrap run workflows/app-upgrade/03-single-migration-v1-to-v2.yml --verbose
+
+# Or against a locally built merod
+merobox bootstrap run workflows/app-upgrade/03-single-migration-v1-to-v2.yml \
+    --image merod:local --e2e-mode --verbose
+```
+
+## Relationship to other test layers
+
+| Layer | Lives in | Covers |
+|---|---|---|
+| Unit | `crates/context/src/handlers/update_application/mod.rs` (16 tests) | `verify_appkey_continuity`: signer/hijack/downgrade/encoding |
+| Governance convergence | `crates/context/tests/local_group_governance_convergence.rs` | `TargetApplicationSet` + `GroupMigrationSet` DAG-replicate cleanly |
+| **This folder** | `workflows/app-upgrade/` | Full pipeline: install → publish governance op → per-context apply → migration runs → state in new shape |

--- a/workflows/app-upgrade/build-wasms.sh
+++ b/workflows/app-upgrade/build-wasms.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Build all migration-suite WASM fixtures consumed by the app-upgrade workflows.
+#
+# Convenience wrapper around each apps/migrations/migration-suite-*/build.sh.
+# Each fixture writes its .wasm into its own apps/migrations/.../res/ — the
+# workflows reference those paths directly, matching the pattern used by
+# workflows/sync-tests/ (which builds apps/kv-store-with-handlers/ directly).
+#
+# Usage:
+#   bash workflows/app-upgrade/build-wasms.sh
+#
+# CI runs the equivalent inline; this is for local dev iteration.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+for build in apps/migrations/migration-suite-*/build.sh; do
+    suite_dir="$(dirname "$build")"
+    suite_name="$(basename "$suite_dir")"
+    echo "==> Building ${suite_name}"
+    bash "$build"
+done
+
+echo
+echo "Built fixtures:"
+for wasm in apps/migrations/migration-suite-*/res/*.wasm; do
+    printf "  %-72s %s\n" "$wasm" "$(ls -lh "$wasm" | awk '{print $5}')"
+done


### PR DESCRIPTION
## Summary

End-to-end coverage for the per-context application migration pipeline introduced in #1911. At #1911's merge the merobox e2e was deferred (*"blocked pending update_context_application step type support"*); that step now exists as merobox's `upgrade_group` with `migrate_method`, unblocking this work.

This is **PR-1 of a planned sequence** of small follow-up PRs against the same gap (see findings doc `docs/superpowers/specs/2026-05-22-app-update-flow-findings.md`). PR-1 contains only test scaffolding — no core code changes, no new merobox steps, no new fixtures.

## What's in this PR

Three merobox workflows under `workflows/app-upgrade/`:

| File | Asserts |
|---|---|
| `01-empty-upgrade-rejected.yml` | Server-side guard at `upgrade_group.rs:480` — same-target + no-migration is rejected. Asserts both the failed RPC (`expected_failure: true`) and the canonical bail message in node logs. |
| `03-single-migration-v1-to-v2.yml` | Install v1, write state, install v2, `upgrade_group` with `migrate_method=migrate_v1_to_v2`. Asserts `Event::Migrated` log line, schema_info() returns v2 shape with `notes` populated, pre-migration writes survived, and v2-only setters/getters work. |
| `20-chain-v1-to-v5.yml` | Sequentially migrates one context through all four migrations (v1→v2→v3→v4→v5), writing fresh data at intermediate versions. Asserts after each step that `schema_version` flipped, field-level changes applied (add / drop / rename / retype), and inherited data survived. Aggregate `Migrated` count ≥ 4. |

Plus:

- `workflows/app-upgrade/build-wasms.sh` — convenience wrapper around each fixture's `build.sh`
- `workflows/app-upgrade/README.md` — what each test asserts + how it relates to existing Rust unit and convergence layers
- `.github/workflows/app-migration-e2e.yml` — new CI job modeled on `sync-regression.yml`. Builds `merod:local` from PR HEAD, builds the five migration-suite WASMs, iterates every workflow sequentially against `merod:local`, streams docker logs per node, uploads artefacts on success and failure.

All three workflows pass `merobox bootstrap validate` against merobox 0.6.16.

## Why draft

The workflows have been schema-validated locally but not yet run against a live `merod` image — the new CI job in this PR is the first real run. Once CI is green I'll flip to ready-for-review.

## What's intentionally NOT in this PR

Deferred to follow-up PRs to keep this one reviewable:

- **PR-2**: Multi-peer migration workflows (2-node propagation, offline-peer catch-up, multi-missed-upgrade catch-up).
- **PR-3**: Per-handler Rust integration tests (`update_application_handler.rs`, `upgrade_group_handler.rs`).
- **PR-4**: Multi-node convergence Rust tests (extends `local_group_governance_convergence.rs`).
- **PR-5**: Negative-path fixtures (wrong-signer, panic-migrate, bad-state) + workflows.
- **PR-6–9**: New core APIs (stuck-upgrade recovery RPC, upgrade NodeEvents, `cascade_target_application` decision, failure-injection harness).
- **PR-10**: Concurrent upgrade test.
- **`02-binary-swap-without-migration.yml`**: would need a same-schema v1/v2 pair that does not exist in `apps/migrations/`. The `update_application_id` no-migration code path is already covered by the unit suite at `update_application/mod.rs`.

Findings + gap analysis is in `docs/superpowers/specs/2026-05-22-app-update-flow-findings.md` (in my local checkout; will land alongside PR-2 if useful as reference).

## Test plan

- [ ] CI job `app-migration-e2e` runs green against this branch
- [ ] Each of the three workflows reports `✅ Workflow execution completed successfully`
- [ ] `Migrated` events visible in uploaded docker logs for workflow #03 (1 event) and #20 (≥4 events)
- [ ] Local merobox bootstrap `validate` passes (verified pre-push)
- [ ] No regression in existing CI jobs (sync-regression, e2e-rust-apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)