### PR TITLE
fix(server): expose X-Auth-Error via CORS so JS clients can refresh

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -47,6 +47,7 @@ mero-auth.workspace = true
 [dev-dependencies]
 color-eyre.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower = { workspace = true, features = ["util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [build-dependencies]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -146,19 +146,7 @@ pub async fn start(
         .layer(axum::middleware::from_fn(crate::metrics::track_request))
         .layer(Extension(http_metrics));
 
-    app = app.layer(
-        CorsLayer::new()
-            .allow_origin(Any)
-            .allow_headers(Any)
-            .allow_methods([
-                Method::POST,
-                Method::GET,
-                Method::DELETE,
-                Method::PUT,
-                Method::OPTIONS,
-            ])
-            .allow_private_network(true),
-    );
+    app = app.layer(build_cors_layer());
 
     let mut set = JoinSet::new();
 
@@ -174,7 +162,174 @@ pub async fn start(
     Ok(())
 }
 
+/// CORS layer applied to every mounted route.
+///
+/// **Critical:** `expose_headers` MUST include `x-auth-error`. Cross-origin
+/// clients (Tauri webview, browser SPAs) cannot read response headers that
+/// aren't on this list. The auth middleware signals refreshable expiry via
+/// `X-Auth-Error: token_expired`; mero-js's automatic refresh-on-401 flow
+/// reads that header to decide whether to refresh. If the header is hidden
+/// by CORS, every access-token expiry surfaces as a hard logout for the user
+/// instead of a transparent refresh. See `cors_tests` for the regression
+/// guard.
+fn build_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(Any)
+        .allow_headers(Any)
+        .allow_methods([
+            Method::POST,
+            Method::GET,
+            Method::DELETE,
+            Method::PUT,
+            Method::OPTIONS,
+        ])
+        .expose_headers([
+            axum::http::HeaderName::from_static("x-auth-error"),
+            axum::http::HeaderName::from_static("x-auth-user"),
+            axum::http::HeaderName::from_static("x-auth-permissions"),
+        ])
+        .allow_private_network(true)
+}
+
 #[cfg(test)]
 mod integration_tests_package_usage {
     use {color_eyre as _, tracing_subscriber as _};
+}
+
+#[cfg(test)]
+mod cors_tests {
+    //! Regression tests for the CORS layer.
+    //!
+    //! These exist because of a real prod incident: without `expose_headers`
+    //! listing `x-auth-error`, the Tauri webview (cross-origin to the local
+    //! merod) could not read the `X-Auth-Error: token_expired` response
+    //! header, so mero-js never triggered its refresh-on-401 flow and users
+    //! were logged out roughly once per access-token TTL (~1h).
+    //!
+    //! Do not delete `expose_headers` without also breaking these tests.
+
+    use axum::body::Body;
+    use axum::http::{header, HeaderValue, Request, StatusCode};
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    use super::build_cors_layer;
+
+    /// Origin header the Tauri desktop webview presents in production.
+    const TAURI_ORIGIN: &str = "http://tauri.localhost";
+
+    async fn ok_handler() -> Response {
+        Response::new(Body::from("ok"))
+    }
+
+    async fn token_expired_401_handler() -> Response {
+        let mut resp = Response::new(Body::from("unauthorized"));
+        *resp.status_mut() = StatusCode::UNAUTHORIZED;
+        resp.headers_mut().insert(
+            axum::http::HeaderName::from_static("x-auth-error"),
+            HeaderValue::from_static("token_expired"),
+        );
+        resp
+    }
+
+    fn cors_only_router<F, Fut>(handler: F) -> Router
+    where
+        F: Fn() -> Fut + Clone + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Response> + Send + 'static,
+    {
+        Router::new()
+            .route("/x", get(handler))
+            .layer(build_cors_layer())
+    }
+
+    /// Direct guard against the original CORS misconfiguration: a
+    /// cross-origin request must come back with `Access-Control-Expose-
+    /// Headers` listing `x-auth-error`, otherwise no JS-based client can see
+    /// the header even when the server sets it.
+    #[tokio::test]
+    async fn cors_layer_exposes_x_auth_error_to_cross_origin_clients() {
+        let app = cors_only_router(ok_handler);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/x")
+                    .header(header::ORIGIN, TAURI_ORIGIN)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router service call should not fail");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let exposed = resp
+            .headers()
+            .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing Access-Control-Expose-Headers — JS cross-origin clients \
+                     will not see X-Auth-Error: token_expired, breaking automatic \
+                     token refresh in the Tauri desktop app"
+                )
+            })
+            .to_str()
+            .expect("header value must be ASCII")
+            .to_ascii_lowercase();
+
+        assert!(
+            exposed.contains("x-auth-error"),
+            "Access-Control-Expose-Headers must include `x-auth-error`; got: {exposed}"
+        );
+    }
+
+    /// Full pipeline check: when the upstream handler returns a 401 with
+    /// `X-Auth-Error: token_expired` (mimicking what the auth middleware
+    /// emits when a JWT has expired), the CORS layer must not strip the
+    /// header from the response AND must expose it to JS via
+    /// `Access-Control-Expose-Headers`. This is the assertion mero-js's
+    /// `web-client.ts` automatic-refresh logic depends on.
+    #[tokio::test]
+    async fn cors_preserves_and_exposes_token_expired_signal_on_401() {
+        let app = cors_only_router(token_expired_401_handler);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/x")
+                    .header(header::ORIGIN, TAURI_ORIGIN)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router service call should not fail");
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // The header itself must survive the CORS layer.
+        assert_eq!(
+            resp.headers()
+                .get("x-auth-error")
+                .map(|v| v.to_str().unwrap()),
+            Some("token_expired"),
+            "CORS layer must not strip X-Auth-Error from upstream responses"
+        );
+
+        // And it must be in the expose list so cross-origin JS can read it.
+        let exposed = resp
+            .headers()
+            .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+            .expect("Access-Control-Expose-Headers must be set on 401 too")
+            .to_str()
+            .unwrap()
+            .to_ascii_lowercase();
+        assert!(
+            exposed.contains("x-auth-error"),
+            "X-Auth-Error must be exposed to JS even on error responses; got: {exposed}"
+        );
+    }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -172,6 +172,12 @@ pub async fn start(
 /// by CORS, every access-token expiry surfaces as a hard logout for the user
 /// instead of a transparent refresh. See `cors_tests` for the regression
 /// guard.
+///
+/// **`allow_credentials` is intentionally not set.** It is incompatible with
+/// `allow_origin(Any)` per the CORS spec, so adding it here would be a no-op
+/// for browsers in the current configuration. If credentialed requests
+/// (cookies, TLS client certs) ever become required, `allow_origin(Any)`
+/// must first be replaced with an explicit allow-list of trusted origins.
 fn build_cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_origin(Any)


### PR DESCRIPTION
## Summary

- Add `Access-Control-Expose-Headers: x-auth-error, x-auth-user, x-auth-permissions` to the server's top-level CORS layer so cross-origin JS clients can actually read the auth signaling headers the middleware already emits.
- Extract the CORS layer into `fn build_cors_layer() -> CorsLayer` to give the configuration a single named seam.
- Add `cors_tests` with two regression guards (red on master, green with the fix).

## The bug

`crates/auth/src/auth/middleware.rs` sets `X-Auth-Error: token_expired` on 401 responses when a JWT has expired (see `jwt.rs:329` → `middleware.rs:99`). mero-js's `WebHttpClient` reads that header to decide whether to invoke its automatic refresh-on-401 flow. Without `expose_headers` listing it, browsers and Tauri's webview strip the header from JS visibility on cross-origin responses — mero-js sees a plain 401, never refreshes, and `tauri-app`'s `App.tsx` shows the login screen.

End-user symptom: the desktop app logs users out roughly once per access-token TTL (~1h, including while idle in the background via the `setInterval(checkConnection, 10000)` health poll), even though the refresh token is valid for ~30 days. This was the root cause of the auto-logout in the deployed `tauri-app`.

## Why exposing three headers, not just one

`X-Auth-User` and `X-Auth-Permissions` are also set by the auth middleware on successful responses (`middleware.rs:78,82`). They were invisible to JS for the same CORS reason. Exposing them now removes a footgun for any future client logic that wants to read them — equally cheap, equally safe.

## Test plan

- [x] `cargo test -p calimero-server --lib cors_tests` — both tests **fail** on master (verified by deleting `expose_headers` and re-running: both panic with the exact "missing Access-Control-Expose-Headers" diagnostic the tests were designed to surface).
- [x] `cargo test -p calimero-server --lib cors_tests` — both tests **pass** with the fix applied.
- [x] `cargo test -p calimero-server` — full crate suite passes (12 unit + 1 doctest).
- [ ] (manual, optional) Rebuild merod, launch `tauri-app`, lower `access_token_expiry` in merod's auth config to ~60s, leave app idle 70s, confirm the next request silently refreshes (DevTools Network: a 401 with visible `X-Auth-Error: token_expired` immediately followed by a successful `POST /auth/refresh`, then the original request retried).

## Risk

Very low. `expose_headers` only widens what JS can read on cross-origin responses; it cannot block existing requests. The refactor into `build_cors_layer()` is a no-op behavior change covered by the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CORS configuration change that only increases which response headers are visible to cross-origin JS clients; behavior is guarded by new regression tests.
> 
> **Overview**
> Fixes a CORS misconfiguration so cross-origin JS clients can read auth signaling headers by adding `Access-Control-Expose-Headers` for `x-auth-error`, `x-auth-user`, and `x-auth-permissions`.
> 
> Refactors the server’s CORS setup into `build_cors_layer()` and adds targeted regression tests to ensure `x-auth-error` is preserved/exposed (including on `401` responses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5849ab31b3e213335708def72281bec9666e9ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->