### PR TITLE
feat(governance): namespace-level cascade for application upgrades

### DIFF
--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -59,7 +59,16 @@ pub use ack_router::AckRouter;
 ///
 /// v1 was internal to feature branch development and never deployed to any
 /// persistent network. No backward-compatible deserialization is needed.
-pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 5;
+///
+/// Schema v6: adds `CascadeTargetApplicationSet` and
+/// `CascadeGroupMigrationSet` variants at the END of the `GroupOp` enum
+/// for namespace-level application-upgrade cascade. Variant ordinals for
+/// every prior variant are preserved (Borsh tags variants by source
+/// order). Older peers cannot deserialize these new variants -- the
+/// rollout posture is operator-discipline: deploy v6 to every peer
+/// before triggering a cascade. See
+/// docs/superpowers/specs/2026-05-22-namespace-cascade-app-upgrade-design.md.
+pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 6;
 
 /// Domain separation prefix for Ed25519 signatures over group ops.
 pub const GROUP_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.group.v1";
@@ -252,6 +261,39 @@ pub enum GroupOp {
     /// regular admin (no automatic role change beyond the owner field).
     /// See `architecture/membership-and-leave.html` § 7.
     TransferOwnership { new_owner: PublicKey },
+    /// Cascade variant of [`Self::TargetApplicationSet`]: update the
+    /// target application on the signed group AND on every descendant
+    /// subgroup whose current `app_key` equals `from_app_key`. Walked at
+    /// apply time against the receiver's local tree state, depth-bounded
+    /// by `MAX_NAMESPACE_DEPTH`. Same `manage_application` permission as
+    /// the non-cascade variant on the signed group. Descendants that
+    /// run a different application (different `app_key`) are skipped --
+    /// heterogeneous deployments stay untouched.
+    ///
+    /// `from_app_key` is the matching predicate, snapshotted at the
+    /// emission peer's RPC-handling time. Carried in the op itself so
+    /// every receiver applies the same filter against its own tree
+    /// state -- ensures cross-peer convergence even when local stores
+    /// have diverged between the emission peer's snapshot and a remote
+    /// peer's apply time.
+    ///
+    /// Operationally invoked by an `upgrade_group` RPC with `cascade:
+    /// true`. See `docs/superpowers/specs/2026-05-22-namespace-cascade-app-upgrade-design.md`.
+    CascadeTargetApplicationSet {
+        from_app_key: [u8; 32],
+        app_key: [u8; 32],
+        target_application_id: ApplicationId,
+    },
+    /// Cascade variant of [`Self::GroupMigrationSet`]: emitted alongside
+    /// [`Self::CascadeTargetApplicationSet`] when the operator requested
+    /// cascade-with-migration. Updates the migration bytes on the signed
+    /// group AND on every descendant subgroup whose current `app_key`
+    /// equals `from_app_key`. Same matching-predicate semantics as the
+    /// target variant.
+    CascadeGroupMigrationSet {
+        from_app_key: [u8; 32],
+        migration: Option<Vec<u8>>,
+    },
 }
 
 impl GroupOp {
@@ -287,6 +329,8 @@ impl GroupOp {
             GroupOp::TeeAdmissionPolicySet { .. } => "tee_admission_policy_set",
             GroupOp::MemberJoinedViaTeeAttestation { .. } => "member_joined_via_tee",
             GroupOp::MemberSetAutoFollow { .. } => "member_set_auto_follow",
+            GroupOp::CascadeTargetApplicationSet { .. } => "cascade_target_application_set",
+            GroupOp::CascadeGroupMigrationSet { .. } => "cascade_group_migration_set",
         }
     }
 }

--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -264,11 +264,12 @@ pub enum GroupOp {
     /// Cascade variant of [`Self::TargetApplicationSet`]: update the
     /// target application on the signed group AND on every descendant
     /// subgroup whose current `app_key` equals `from_app_key`. Walked at
-    /// apply time against the receiver's local tree state, depth-bounded
-    /// by `MAX_NAMESPACE_DEPTH`. Same `manage_application` permission as
-    /// the non-cascade variant on the signed group. Descendants that
-    /// run a different application (different `app_key`) are skipped --
-    /// heterogeneous deployments stay untouched.
+    /// apply time against the receiver's local tree state, bounded by
+    /// the namespace tree's maximum nesting depth (enforced in the
+    /// apply handler in `calimero-context`). Same `manage_application`
+    /// permission as the non-cascade variant on the signed group.
+    /// Descendants that run a different application (different
+    /// `app_key`) are skipped -- heterogeneous deployments stay untouched.
     ///
     /// `from_app_key` is the matching predicate, snapshotted at the
     /// emission peer's RPC-handling time. Carried in the op itself so

--- a/crates/context/primitives/src/local_governance/tests.rs
+++ b/crates/context/primitives/src/local_governance/tests.rs
@@ -283,3 +283,109 @@ fn namespace_signable_bytes_deterministic() {
     assert_eq!(a, b);
     assert!(a.starts_with(NAMESPACE_GOVERNANCE_SIGN_DOMAIN));
 }
+
+// --- Cascade op variants (Option C in cascade design doc) ---
+
+fn sample_application_id(seed: u8) -> ApplicationId {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[31] = !seed;
+    ApplicationId::from(bytes)
+}
+
+#[test]
+fn cascade_target_application_set_sign_verify() {
+    let mut rng = OsRng;
+    let sk = PrivateKey::random(&mut rng);
+
+    let op = SignedGroupOp::sign(
+        &sk,
+        sample_group_id(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::CascadeTargetApplicationSet {
+            from_app_key: [9u8; 32],
+            app_key: [10u8; 32],
+            target_application_id: sample_application_id(0x42),
+        },
+    )
+    .expect("sign");
+
+    op.verify_signature().expect("verify");
+    assert_eq!(
+        op.op.op_kind_label(),
+        "cascade_target_application_set",
+        "op_kind_label must distinguish cascade variant for metrics"
+    );
+}
+
+#[test]
+fn cascade_group_migration_set_sign_verify() {
+    let mut rng = OsRng;
+    let sk = PrivateKey::random(&mut rng);
+
+    let op = SignedGroupOp::sign(
+        &sk,
+        sample_group_id(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::CascadeGroupMigrationSet {
+            from_app_key: [9u8; 32],
+            migration: Some(b"migrate_v1_to_v2".to_vec()),
+        },
+    )
+    .expect("sign");
+
+    op.verify_signature().expect("verify");
+    assert_eq!(
+        op.op.op_kind_label(),
+        "cascade_group_migration_set",
+        "op_kind_label must distinguish cascade migration variant for metrics"
+    );
+}
+
+#[test]
+fn cascade_target_distinct_from_single_group_target() {
+    // A cascade op and a non-cascade op with the same new app_key/target
+    // must produce DIFFERENT content hashes -- otherwise replay/dedup
+    // would conflate the two distinct governance intents.
+    let mut rng = OsRng;
+    let sk = PrivateKey::random(&mut rng);
+    let new_app_key = [11u8; 32];
+    let target = sample_application_id(0x77);
+
+    let single = SignedGroupOp::sign(
+        &sk,
+        sample_group_id(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::TargetApplicationSet {
+            app_key: new_app_key,
+            target_application_id: target,
+        },
+    )
+    .expect("sign");
+
+    let cascade = SignedGroupOp::sign(
+        &sk,
+        sample_group_id(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::CascadeTargetApplicationSet {
+            from_app_key: [9u8; 32],
+            app_key: new_app_key,
+            target_application_id: target,
+        },
+    )
+    .expect("sign");
+
+    assert_ne!(
+        single.content_hash().expect("hash single"),
+        cascade.content_hash().expect("hash cascade"),
+        "cascade and single-group target ops must hash distinctly"
+    );
+}

--- a/crates/context/primitives/src/local_governance/tests.rs
+++ b/crates/context/primitives/src/local_governance/tests.rs
@@ -504,7 +504,13 @@ fn cascade_group_migration_set_borsh_round_trip() {
     let bytes_none = borsh::to_vec(&original_none).expect("serialize none");
     let decoded_none: GroupOp = borsh::from_slice(&bytes_none).expect("deserialize none");
     match decoded_none {
-        GroupOp::CascadeGroupMigrationSet { migration, .. } => assert!(migration.is_none()),
+        GroupOp::CascadeGroupMigrationSet {
+            from_app_key,
+            migration,
+        } => {
+            assert_eq!(from_app_key, [0u8; 32]);
+            assert!(migration.is_none());
+        }
         other => panic!("expected CascadeGroupMigrationSet, got {:?}", other),
     }
 }

--- a/crates/context/primitives/src/local_governance/tests.rs
+++ b/crates/context/primitives/src/local_governance/tests.rs
@@ -389,3 +389,122 @@ fn cascade_target_distinct_from_single_group_target() {
         "cascade and single-group target ops must hash distinctly"
     );
 }
+
+#[test]
+fn cascade_target_from_app_key_changes_hash() {
+    // The Borsh-discriminant guarantees distinctness from the
+    // single-group variant (covered by
+    // `cascade_target_distinct_from_single_group_target`). This test
+    // covers the stronger invariant: `from_app_key` is itself part of
+    // the signed bytes, so two cascade ops that agree on every field
+    // EXCEPT `from_app_key` must still hash differently. Otherwise a
+    // refactor that accidentally collapses `from_app_key` (e.g. by
+    // defaulting it or excluding it from signable bytes) would silently
+    // break dedup of intent-different cascades.
+    let mut rng = OsRng;
+    let sk = PrivateKey::random(&mut rng);
+    let new_app_key = [11u8; 32];
+    let target = sample_application_id(0x77);
+
+    let a = SignedGroupOp::sign(
+        &sk,
+        sample_group_id(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::CascadeTargetApplicationSet {
+            from_app_key: [9u8; 32],
+            app_key: new_app_key,
+            target_application_id: target,
+        },
+    )
+    .expect("sign");
+
+    let b = SignedGroupOp::sign(
+        &sk,
+        sample_group_id(),
+        vec![],
+        [0u8; 32],
+        1,
+        GroupOp::CascadeTargetApplicationSet {
+            from_app_key: [8u8; 32], // only this differs
+            app_key: new_app_key,
+            target_application_id: target,
+        },
+    )
+    .expect("sign");
+
+    assert_ne!(
+        a.content_hash().expect("hash a"),
+        b.content_hash().expect("hash b"),
+        "from_app_key must be covered by the signed content hash"
+    );
+}
+
+#[test]
+fn cascade_target_application_set_borsh_round_trip() {
+    // Explicit wire-format round-trip for the new variant. The
+    // sign/verify tests above implicitly exercise serialization (sign
+    // hashes the Borsh bytes; verify rebuilds them) but do not assert
+    // that field values survive a standalone serialize -> deserialize
+    // round trip on the GroupOp itself. A future enum reordering that
+    // shifts variant tags would silently change which variant a stored
+    // op decodes as; this guards against that by asserting field
+    // equality after a round trip.
+    let original = GroupOp::CascadeTargetApplicationSet {
+        from_app_key: [9u8; 32],
+        app_key: [10u8; 32],
+        target_application_id: sample_application_id(0x42),
+    };
+
+    let bytes = borsh::to_vec(&original).expect("serialize");
+    let decoded: GroupOp = borsh::from_slice(&bytes).expect("deserialize");
+
+    match decoded {
+        GroupOp::CascadeTargetApplicationSet {
+            from_app_key,
+            app_key,
+            target_application_id,
+        } => {
+            assert_eq!(from_app_key, [9u8; 32]);
+            assert_eq!(app_key, [10u8; 32]);
+            assert_eq!(target_application_id, sample_application_id(0x42));
+        }
+        other => panic!("expected CascadeTargetApplicationSet, got {:?}", other),
+    }
+}
+
+#[test]
+fn cascade_group_migration_set_borsh_round_trip() {
+    // Symmetric round-trip guard for the migration variant.
+    let original = GroupOp::CascadeGroupMigrationSet {
+        from_app_key: [9u8; 32],
+        migration: Some(b"migrate_v1_to_v2".to_vec()),
+    };
+
+    let bytes = borsh::to_vec(&original).expect("serialize");
+    let decoded: GroupOp = borsh::from_slice(&bytes).expect("deserialize");
+
+    match decoded {
+        GroupOp::CascadeGroupMigrationSet {
+            from_app_key,
+            migration,
+        } => {
+            assert_eq!(from_app_key, [9u8; 32]);
+            assert_eq!(migration.as_deref(), Some(b"migrate_v1_to_v2".as_ref()));
+        }
+        other => panic!("expected CascadeGroupMigrationSet, got {:?}", other),
+    }
+
+    // Also cover migration = None.
+    let original_none = GroupOp::CascadeGroupMigrationSet {
+        from_app_key: [0u8; 32],
+        migration: None,
+    };
+    let bytes_none = borsh::to_vec(&original_none).expect("serialize none");
+    let decoded_none: GroupOp = borsh::from_slice(&bytes_none).expect("deserialize none");
+    match decoded_none {
+        GroupOp::CascadeGroupMigrationSet { migration, .. } => assert!(migration.is_none()),
+        other => panic!("expected CascadeGroupMigrationSet, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

Adds namespace-level cascade for application upgrades. An operator can run **one** upgrade command at a namespace and have it propagate to every descendant subgroup running the same application, on every peer. Without this, operators must call `upgrade_group` once per subgroup, which doesn't scale for apps that partition data by subgroup (drive/folders, chat/channels, etc.).

Unblocks PR #2449 (app-migration e2e workflows), which is parked because it can't exercise the realistic deployment shape — namespace + subgroups + multi-peer — without this cascade.

## Design

Two new `GroupOp` variants record the cascade intent explicitly in the governance DAG:

- `CascadeTargetApplicationSet { from_app_key, app_key, target_application_id }`
- `CascadeGroupMigrationSet { from_app_key, migration }`

`from_app_key` is the matching predicate, snapshotted at the emitting peer's RPC-handling time. The apply handler walks the receiver's local descendant tree (DAG-ordered), filters by `meta.app_key == from_app_key`, and updates matching descendants' metadata in place. Descendants running a different application (different `app_key`) are skipped — heterogeneous deployments stay untouched.

Why this shape:

- **Explicit operator intent in the DAG.** Cascade is its own op type, so an auditor reading the op stream can tell "this was a cascade" without re-deriving from tree state.
- **Existing `TargetApplicationSet` semantics preserved.** The single-group variant keeps its single-group behaviour. Code paths that today reason about `TargetApplicationSet` don't change meaning.
- **Cross-peer convergence is deterministic.** Because every receiver applies the same op against its DAG-ordered local tree state and filters by the same carried `from_app_key`, the descendant set is identical on every peer regardless of when they apply.
- **Authorization is clean.** Same `manage_application` permission on the parent group as the non-cascade variant; the cascade scope is the matching-`app_key` predicate, not arbitrary descendant selection.

## Locked design choices

- Cascade only to descendants whose current `app_key` matches `from_app_key` — skip heterogeneous subgroups.
- `GroupMigrationSet` cascades the same migration method name to matching descendants.
- Recurse the full subtree, depth-bounded by `MAX_NAMESPACE_DEPTH = 16`.
- No per-subgroup opt-out in this PR (future flag).

## What's in this PR so far

- [x] New `GroupOp` variants (at the END of the variant list to preserve every existing variant's Borsh ordinal). Schema version bumped 5→6. `op_kind_label` updated. Sign/verify + content-hash unit tests.

## What's remaining (WIP, expect more commits)

- [ ] Apply handler for `CascadeTargetApplicationSet` — descendant walk + matching-`app_key` filter + in-place `save_group_meta`. Unit tests: empty subtree, single-level, multi-level, mixed-app skip, max-depth, idempotency.
- [ ] Symmetric apply handler for `CascadeGroupMigrationSet`.
- [ ] Delete the now-unreferenced `cascade_target_application` stub (currently `Ok(())` at `crates/context/src/group_store/mod.rs:2018`).
- [ ] `cascade: bool` field on `UpgradeGroupRequest`; conditional emission of cascade vs single-group variants.
- [ ] Propagator at `upgrade_group.rs:484` extended to walk cascaded descendants' contexts when `cascade: true` was used (Automatic/Coordinated policies).
- [ ] Multi-node convergence test extending `crates/context/tests/local_group_governance_convergence.rs` — assert two peers converge on identical descendant state after one peer emits a cascade.

## Rollout posture

Operator-discipline: the new variants are wire-format additions, so peers without v6 cannot deserialize them. Deploy v6 to every peer in a swarm before any peer triggers a cascade. Same rollout pattern as `MemberJoinedOpen` (#2351) and `MemberSetAutoFollow` (#2427). The `cascade` RPC flag defaults to `false` for the first roll — explicit opt-in.

## Test plan

- [ ] All unit tests in `calimero-context-client` and `calimero-context` pass
- [ ] Multi-node convergence test passes
- [ ] Workspace clippy stays green
- [ ] No regression in existing sync-regression / e2e-rust-apps CI jobs
- [ ] Follow-up #2449's e2e workflows (rebased on this branch) exercise namespace + subgroups + node2-joins + cascade-upgrade end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the signed group-op wire schema and extends the `GroupOp` enum, which is backwards-incompatible for older peers and could impact on-disk/gossip deserialization if rollout is not coordinated.
> 
> **Overview**
> Introduces two new `GroupOp` variants, `CascadeTargetApplicationSet` and `CascadeGroupMigrationSet`, to explicitly encode *cascade* application upgrade intent (filtered by `from_app_key`) across a group’s descendant subgroups.
> 
> Bumps `SIGNED_GROUP_OP_SCHEMA_VERSION` from **5 → 6**, updates `op_kind_label()` to emit distinct metric labels for the new variants, and adds unit tests covering sign/verify, content-hash distinctness (vs non-cascade and vs differing `from_app_key`), and Borsh round-trip stability for the new wire variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7c3a1ed1941aae9a1b6560edbeb157a21ca440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->