### PR TITLE
test(network): MockRelay testkit + integration tests for reservation recovery

### DIFF
--- a/crates/network/tests/common/mock_relay.rs
+++ b/crates/network/tests/common/mock_relay.rs
@@ -241,17 +241,21 @@ impl MockRelay {
 
     /// Forcibly close any active connections to `peer`. Returns true if at
     /// least one connection was found.
+    ///
+    /// Panics if the relay task is no longer running — a test that calls
+    /// this expects the relay to be alive, and an Err on the command
+    /// channel or a dropped ack would otherwise be conflated with the
+    /// semantic "peer not connected" return, producing misleading
+    /// assertion messages at call sites.
     pub async fn disconnect_peer(&self, peer: PeerId) -> bool {
         let (ack_tx, ack_rx) = oneshot::channel();
-        if self
-            .cmd_tx
+        self.cmd_tx
             .send(Command::DisconnectPeer { peer, ack: ack_tx })
             .await
-            .is_err()
-        {
-            return false;
-        }
-        ack_rx.await.unwrap_or(false)
+            .expect("mock relay task is not running (cmd channel closed)");
+        ack_rx
+            .await
+            .expect("mock relay task dropped the disconnect ack (likely panicked)")
     }
 
     /// Snapshot of what the relay has observed since spawn. Reads shared

--- a/crates/network/tests/common/mock_relay.rs
+++ b/crates/network/tests/common/mock_relay.rs
@@ -1,0 +1,326 @@
+//! In-process libp2p relay server with controllable configuration and
+//! fault-injection hooks. Used by integration tests to exercise the
+//! reservation lifecycle (request, accept, expire, renew, deny) without
+//! depending on a deployed boot-node.
+//!
+//! The mock runs a real `libp2p::relay::Behaviour` (server side) plus
+//! `identify` so a client speaking the production [`calimero_network`]
+//! behaviour will discover the hop protocol and request a reservation
+//! exactly as it would against the real boot-node.
+//!
+//! ## Fault injection
+//!
+//! - [`MockRelay::disconnect_peer`] forcibly closes any active connection to
+//!   a client. From the client's perspective, this looks the same as the
+//!   relay process crashing or its host going down (the symptom behind the
+//!   "node disconnects, can't reconnect without restart" report).
+//!
+//! - [`MockRelayConfig::max_reservations`] and
+//!   [`MockRelayConfig::max_reservations_per_peer`] cap how many concurrent
+//!   reservations the server will accept. Used to exercise the "relay quota
+//!   exhausted" failure shape — additional clients see `ListenerClosed`
+//!   with a `RESOURCE_LIMIT_EXCEEDED`-flavoured reason.
+//!
+//! - [`MockRelayConfig::reservation_duration`] makes the relay server expire
+//!   each reservation after the given duration. Mostly useful for future
+//!   tests that need to observe natural expiry; the libp2p relay client
+//!   auto-renews aggressively so this alone is not enough to drive a client
+//!   into the `ExternalAddrExpired` path — the relay would also need to
+//!   actively refuse renewal, which requires more infrastructure than this
+//!   mock currently provides.
+
+use core::time::Duration;
+use std::sync::Arc;
+
+use eyre::{eyre, Result};
+use futures_util::StreamExt;
+use libp2p::core::transport::ListenerId;
+use libp2p::identity::Keypair;
+use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
+use libp2p::{identify, noise, relay, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
+use multiaddr::Protocol;
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+/// Identify protocol version advertised by the mock. Distinct from the real
+/// boot-node string so logs make the source obvious.
+const MOCK_IDENTIFY_PROTOCOL_VERSION: &str = "/calimero/mock-relay/1.0.0";
+const MOCK_IDENTIFY_AGENT_VERSION: &str = "calimero-mock-relay/test";
+
+#[derive(NetworkBehaviour)]
+struct MockBehaviour {
+    relay: relay::Behaviour,
+    identify: identify::Behaviour,
+}
+
+/// Tunable parameters for the mock. Defaults track the libp2p-relay 0.21
+/// defaults.
+#[derive(Clone, Debug)]
+pub struct MockRelayConfig {
+    pub max_reservations: usize,
+    pub max_reservations_per_peer: usize,
+    /// How long each reservation lasts before the server expires it.
+    /// Production boot-node uses 1 hour; tests typically want hundreds of
+    /// milliseconds so they don't have to wait.
+    pub reservation_duration: Duration,
+    pub max_circuits: usize,
+    pub max_circuits_per_peer: usize,
+    pub max_circuit_duration: Duration,
+    pub max_circuit_bytes: u64,
+}
+
+impl Default for MockRelayConfig {
+    fn default() -> Self {
+        Self {
+            max_reservations: 128,
+            max_reservations_per_peer: 4,
+            reservation_duration: Duration::from_secs(3600),
+            max_circuits: 1024,
+            max_circuits_per_peer: 16,
+            max_circuit_duration: Duration::from_secs(3600),
+            max_circuit_bytes: 1 << 30,
+        }
+    }
+}
+
+impl MockRelayConfig {
+    fn into_relay_config(self) -> relay::Config {
+        relay::Config {
+            max_reservations: self.max_reservations,
+            max_reservations_per_peer: self.max_reservations_per_peer,
+            reservation_duration: self.reservation_duration,
+            reservation_rate_limiters: vec![],
+            max_circuits: self.max_circuits,
+            max_circuits_per_peer: self.max_circuits_per_peer,
+            max_circuit_duration: self.max_circuit_duration,
+            max_circuit_bytes: self.max_circuit_bytes,
+            circuit_src_rate_limiters: vec![],
+        }
+    }
+}
+
+/// Snapshot of events the mock observed. Useful for assertions about what
+/// the relay actually saw the client do (independent of what the client
+/// thinks happened).
+#[derive(Clone, Debug, Default)]
+pub struct MockRelayObservations {
+    pub reservations_accepted: usize,
+    pub reservations_denied: usize,
+    pub circuits_opened: usize,
+}
+
+/// Commands the mock task accepts on its control channel.
+enum Command {
+    DisconnectPeer {
+        peer: PeerId,
+        ack: oneshot::Sender<bool>,
+    },
+    Observations {
+        ack: oneshot::Sender<MockRelayObservations>,
+    },
+    Shutdown {
+        ack: oneshot::Sender<()>,
+    },
+}
+
+/// Handle to a running mock relay server. Drop or call [`Self::shutdown`]
+/// to stop it.
+pub struct MockRelay {
+    peer_id: PeerId,
+    listen_addr: Multiaddr,
+    cmd_tx: mpsc::Sender<Command>,
+    join: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl MockRelay {
+    /// Spawn a mock relay with default config, listening on a random local
+    /// TCP port. Returns once the listener has reported a concrete address.
+    pub async fn spawn() -> Result<Self> {
+        Self::spawn_with(MockRelayConfig::default(), Keypair::generate_ed25519()).await
+    }
+
+    /// Spawn with a custom config and identity. Tests that need to "restart"
+    /// the relay should keep the keypair around and reuse it.
+    pub async fn spawn_with(config: MockRelayConfig, keypair: Keypair) -> Result<Self> {
+        let peer_id = PeerId::from(keypair.public());
+        let relay_config = config.into_relay_config();
+
+        let mut swarm = SwarmBuilder::with_existing_identity(keypair)
+            .with_tokio()
+            .with_tcp(
+                tcp::Config::default(),
+                noise::Config::new,
+                yamux::Config::default,
+            )?
+            .with_behaviour(|key| MockBehaviour {
+                relay: relay::Behaviour::new(peer_id, relay_config),
+                identify: identify::Behaviour::new(
+                    identify::Config::new(MOCK_IDENTIFY_PROTOCOL_VERSION.to_owned(), key.public())
+                        .with_agent_version(MOCK_IDENTIFY_AGENT_VERSION.to_owned()),
+                ),
+            })
+            .map_err(|err| eyre!("failed to build mock relay behaviour: {err}"))?
+            .build();
+
+        let _listener: ListenerId = swarm.listen_on("/ip4/127.0.0.1/tcp/0".parse()?)?;
+
+        // Wait for the listener to report a concrete bound address.
+        let listen_addr = loop {
+            match swarm.next().await {
+                Some(SwarmEvent::NewListenAddr { address, .. }) => {
+                    break address;
+                }
+                Some(_) => continue,
+                None => return Err(eyre!("mock relay swarm closed before listening")),
+            }
+        };
+
+        // libp2p's relay::Behaviour fills the reservation response with the
+        // SERVER's external addresses, not the client's listen addresses, so
+        // the client can build a `<relay>/p2p-circuit/<self>` multiaddr.
+        // For a server bound only to a loopback TCP port, swarm.external_addresses()
+        // is empty by default — AutoNAT would normally populate it, but we
+        // don't run AutoNAT here. Tell the relay explicitly that its bound
+        // address is its external address. Without this, every reservation
+        // attempt returns NoAddressesInReservation and the client's listener
+        // is torn down before it can be used.
+        swarm.add_external_address(listen_addr.clone());
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<Command>(16);
+        let observations = Arc::new(Mutex::new(MockRelayObservations::default()));
+
+        let observations_for_task = Arc::clone(&observations);
+        let join = tokio::spawn(async move {
+            run_swarm(swarm, &mut cmd_rx, observations_for_task).await;
+        });
+
+        Ok(Self {
+            peer_id,
+            listen_addr,
+            cmd_tx,
+            join: Mutex::new(Some(join)),
+        })
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    /// The relay's address in the form a client would put in its bootstrap
+    /// config: `/ip4/.../tcp/<port>/p2p/<peer_id>`.
+    pub fn bootstrap_addr(&self) -> Multiaddr {
+        self.listen_addr.clone().with(Protocol::P2p(self.peer_id))
+    }
+
+    /// Forcibly close any active connections to `peer`. Returns true if at
+    /// least one connection was found.
+    pub async fn disconnect_peer(&self, peer: PeerId) -> bool {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(Command::DisconnectPeer { peer, ack: ack_tx })
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        ack_rx.await.unwrap_or(false)
+    }
+
+    /// Snapshot of what the relay has observed since spawn.
+    pub async fn observations(&self) -> MockRelayObservations {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(Command::Observations { ack: ack_tx })
+            .await
+            .is_err()
+        {
+            return MockRelayObservations::default();
+        }
+        ack_rx.await.unwrap_or_default()
+    }
+
+    /// Stop the relay. Idempotent; subsequent calls are no-ops.
+    pub async fn shutdown(&self) {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let _ = self.cmd_tx.send(Command::Shutdown { ack: ack_tx }).await;
+        let _ = ack_rx.await;
+
+        let mut guard = self.join.lock().await;
+        if let Some(handle) = guard.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for MockRelay {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.join.try_lock() {
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
+        }
+    }
+}
+
+async fn run_swarm(
+    mut swarm: Swarm<MockBehaviour>,
+    cmd_rx: &mut mpsc::Receiver<Command>,
+    observations: Arc<Mutex<MockRelayObservations>>,
+) {
+    loop {
+        // `biased;` gives control commands priority over swarm events. Without
+        // it, under high-frequency swarm traffic (e.g. many incoming
+        // connections during a quota test) the cmd branch could be starved,
+        // delaying Shutdown long enough that callers time out.
+        tokio::select! {
+            biased;
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(Command::DisconnectPeer { peer, ack }) => {
+                        let result = swarm.disconnect_peer_id(peer).is_ok();
+                        let _ = ack.send(result);
+                    }
+                    Some(Command::Observations { ack }) => {
+                        let snapshot = observations.lock().await.clone();
+                        let _ = ack.send(snapshot);
+                    }
+                    Some(Command::Shutdown { ack }) => {
+                        let _ = ack.send(());
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            event = swarm.next() => {
+                let Some(event) = event else { break; };
+                match event {
+                    SwarmEvent::Behaviour(MockBehaviourEvent::Relay(relay_event)) => {
+                        debug!(?relay_event, "mock relay: relay event");
+                        let mut obs = observations.lock().await;
+                        match relay_event {
+                            relay::Event::ReservationReqAccepted { .. } => {
+                                obs.reservations_accepted += 1;
+                            }
+                            relay::Event::ReservationReqDenied { .. } => {
+                                obs.reservations_denied += 1;
+                            }
+                            relay::Event::CircuitReqAccepted { .. } => {
+                                obs.circuits_opened += 1;
+                            }
+                            _ => {}
+                        }
+                    }
+                    SwarmEvent::Behaviour(MockBehaviourEvent::Identify(_)) => {}
+                    SwarmEvent::IncomingConnectionError { error, .. } => {
+                        warn!(%error, "mock relay: incoming connection error");
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    debug!("mock relay shutting down");
+}

--- a/crates/network/tests/common/mock_relay.rs
+++ b/crates/network/tests/common/mock_relay.rs
@@ -32,6 +32,8 @@
 use core::time::Duration;
 use std::sync::Arc;
 
+use std::sync::Mutex as StdMutex;
+
 use eyre::{eyre, Result};
 use futures_util::StreamExt;
 use libp2p::core::transport::ListenerId;
@@ -116,9 +118,6 @@ enum Command {
         peer: PeerId,
         ack: oneshot::Sender<bool>,
     },
-    Observations {
-        ack: oneshot::Sender<MockRelayObservations>,
-    },
     Shutdown {
         ack: oneshot::Sender<()>,
     },
@@ -130,12 +129,21 @@ enum Command {
 /// `abort` is kept separately from the join handle (without a lock) so
 /// [`Drop`] can always cancel the background task even if [`Self::shutdown`]
 /// is concurrently holding the join-handle mutex.
+///
+/// `observations` is a [`std::sync::Mutex`] shared with the swarm task. The
+/// critical section is just an increment-or-clone, never held across an
+/// await, so the synchronous mutex is correct here and avoids the lock-
+/// across-await footgun an async `tokio::sync::Mutex` would introduce
+/// inside the swarm's `select!`. It also means `observations()` is
+/// infallible — it reads shared state directly rather than racing a
+/// command roundtrip against task shutdown.
 pub struct MockRelay {
     peer_id: PeerId,
     listen_addr: Multiaddr,
     cmd_tx: mpsc::Sender<Command>,
     abort: AbortHandle,
     join: Mutex<Option<JoinHandle<()>>>,
+    observations: Arc<StdMutex<MockRelayObservations>>,
 }
 
 impl MockRelay {
@@ -203,7 +211,7 @@ impl MockRelay {
         swarm.add_external_address(listen_addr.clone());
 
         let (cmd_tx, mut cmd_rx) = mpsc::channel::<Command>(16);
-        let observations = Arc::new(Mutex::new(MockRelayObservations::default()));
+        let observations = Arc::new(StdMutex::new(MockRelayObservations::default()));
 
         let observations_for_task = Arc::clone(&observations);
         let join = tokio::spawn(async move {
@@ -217,6 +225,7 @@ impl MockRelay {
             cmd_tx,
             abort,
             join: Mutex::new(Some(join)),
+            observations,
         })
     }
 
@@ -245,21 +254,19 @@ impl MockRelay {
         ack_rx.await.unwrap_or(false)
     }
 
-    /// Snapshot of what the relay has observed since spawn.
-    pub async fn observations(&self) -> MockRelayObservations {
-        let (ack_tx, ack_rx) = oneshot::channel();
-        if self
-            .cmd_tx
-            .send(Command::Observations { ack: ack_tx })
-            .await
-            .is_err()
-        {
-            return MockRelayObservations::default();
-        }
-        ack_rx.await.unwrap_or_default()
+    /// Snapshot of what the relay has observed since spawn. Reads shared
+    /// state directly, so it's infallible — there is no task-roundtrip that
+    /// could race with shutdown.
+    pub fn observations(&self) -> MockRelayObservations {
+        self.observations
+            .lock()
+            .expect("observations mutex poisoned")
+            .clone()
     }
 
-    /// Stop the relay. Idempotent; subsequent calls are no-ops.
+    /// Stop the relay. Idempotent; subsequent calls are no-ops. Logs
+    /// (rather than swallows) a JoinError so a panic inside the swarm task
+    /// is visible in test output.
     pub async fn shutdown(&self) {
         let (ack_tx, ack_rx) = oneshot::channel();
         let _ = self.cmd_tx.send(Command::Shutdown { ack: ack_tx }).await;
@@ -267,7 +274,9 @@ impl MockRelay {
 
         let mut guard = self.join.lock().await;
         if let Some(handle) = guard.take() {
-            let _ = handle.await;
+            if let Err(err) = handle.await {
+                eprintln!("mock relay task did not exit cleanly: {err:?}");
+            }
         }
     }
 }
@@ -287,7 +296,7 @@ impl Drop for MockRelay {
 async fn run_swarm(
     mut swarm: Swarm<MockBehaviour>,
     cmd_rx: &mut mpsc::Receiver<Command>,
-    observations: Arc<Mutex<MockRelayObservations>>,
+    observations: Arc<StdMutex<MockRelayObservations>>,
 ) {
     loop {
         // `biased;` gives control commands priority over swarm events. Without
@@ -302,10 +311,6 @@ async fn run_swarm(
                         let result = swarm.disconnect_peer_id(peer).is_ok();
                         let _ = ack.send(result);
                     }
-                    Some(Command::Observations { ack }) => {
-                        let snapshot = observations.lock().await.clone();
-                        let _ = ack.send(snapshot);
-                    }
                     Some(Command::Shutdown { ack }) => {
                         let _ = ack.send(());
                         break;
@@ -318,7 +323,11 @@ async fn run_swarm(
                 match event {
                     SwarmEvent::Behaviour(MockBehaviourEvent::Relay(relay_event)) => {
                         debug!(?relay_event, "mock relay: relay event");
-                        let mut obs = observations.lock().await;
+                        // Synchronous std::sync::Mutex — the critical section
+                        // is a single integer increment, never held across an
+                        // await. No async-lock-in-select! footgun.
+                        let mut obs =
+                            observations.lock().expect("observations mutex poisoned");
                         match relay_event {
                             relay::Event::ReservationReqAccepted { .. } => {
                                 obs.reservations_accepted += 1;

--- a/crates/network/tests/common/mock_relay.rs
+++ b/crates/network/tests/common/mock_relay.rs
@@ -40,7 +40,7 @@ use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
 use libp2p::{identify, noise, relay, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
 use multiaddr::Protocol;
 use tokio::sync::{mpsc, oneshot, Mutex};
-use tokio::task::JoinHandle;
+use tokio::task::{AbortHandle, JoinHandle};
 use tracing::{debug, warn};
 
 /// Identify protocol version advertised by the mock. Distinct from the real
@@ -126,10 +126,15 @@ enum Command {
 
 /// Handle to a running mock relay server. Drop or call [`Self::shutdown`]
 /// to stop it.
+///
+/// `abort` is kept separately from the join handle (without a lock) so
+/// [`Drop`] can always cancel the background task even if [`Self::shutdown`]
+/// is concurrently holding the join-handle mutex.
 pub struct MockRelay {
     peer_id: PeerId,
     listen_addr: Multiaddr,
     cmd_tx: mpsc::Sender<Command>,
+    abort: AbortHandle,
     join: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -165,11 +170,21 @@ impl MockRelay {
 
         let _listener: ListenerId = swarm.listen_on("/ip4/127.0.0.1/tcp/0".parse()?)?;
 
-        // Wait for the listener to report a concrete bound address.
+        // Wait for the listener to report a concrete bound address. If the
+        // listener fails to bind (e.g. on a constrained CI environment) the
+        // swarm emits ListenerError / ListenerClosed before NewListenAddr;
+        // surface those explicitly instead of spinning until the stream
+        // closes with a generic message.
         let listen_addr = loop {
             match swarm.next().await {
-                Some(SwarmEvent::NewListenAddr { address, .. }) => {
-                    break address;
+                Some(SwarmEvent::NewListenAddr { address, .. }) => break address,
+                Some(SwarmEvent::ListenerError { error, .. }) => {
+                    return Err(eyre!("mock relay listener error during bind: {error}"));
+                }
+                Some(SwarmEvent::ListenerClosed {
+                    reason: Err(error), ..
+                }) => {
+                    return Err(eyre!("mock relay listener closed during bind: {error}"));
                 }
                 Some(_) => continue,
                 None => return Err(eyre!("mock relay swarm closed before listening")),
@@ -194,11 +209,13 @@ impl MockRelay {
         let join = tokio::spawn(async move {
             run_swarm(swarm, &mut cmd_rx, observations_for_task).await;
         });
+        let abort = join.abort_handle();
 
         Ok(Self {
             peer_id,
             listen_addr,
             cmd_tx,
+            abort,
             join: Mutex::new(Some(join)),
         })
     }
@@ -257,11 +274,13 @@ impl MockRelay {
 
 impl Drop for MockRelay {
     fn drop(&mut self) {
-        if let Ok(mut guard) = self.join.try_lock() {
-            if let Some(handle) = guard.take() {
-                handle.abort();
-            }
-        }
+        // Abort unconditionally. AbortHandle::abort is a no-op if the task
+        // has already finished (e.g. shutdown() already ran), so this is
+        // safe to call whether or not the task is still active. We
+        // deliberately do not lock self.join here — if shutdown() is
+        // concurrently holding it, we must still guarantee the task is
+        // cancelled.
+        self.abort.abort();
     }
 }
 

--- a/crates/network/tests/common/mock_relay.rs
+++ b/crates/network/tests/common/mock_relay.rs
@@ -30,9 +30,7 @@
 //!   mock currently provides.
 
 use core::time::Duration;
-use std::sync::Arc;
-
-use std::sync::Mutex as StdMutex;
+use std::sync::{Arc, Mutex as StdMutex};
 
 use eyre::{eyre, Result};
 use futures_util::StreamExt;
@@ -43,7 +41,10 @@ use libp2p::{identify, noise, relay, tcp, yamux, Multiaddr, PeerId, Swarm, Swarm
 use multiaddr::Protocol;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::{AbortHandle, JoinHandle};
+use tokio::time::timeout;
 use tracing::{debug, warn};
+
+const BIND_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Identify protocol version advertised by the mock. Distinct from the real
 /// boot-node string so logs make the source obvious.
@@ -182,22 +183,32 @@ impl MockRelay {
         // listener fails to bind (e.g. on a constrained CI environment) the
         // swarm emits ListenerError / ListenerClosed before NewListenAddr;
         // surface those explicitly instead of spinning until the stream
-        // closes with a generic message.
-        let listen_addr = loop {
-            match swarm.next().await {
-                Some(SwarmEvent::NewListenAddr { address, .. }) => break address,
-                Some(SwarmEvent::ListenerError { error, .. }) => {
-                    return Err(eyre!("mock relay listener error during bind: {error}"));
+        // closes with a generic message. A hard timeout caps the wait so a
+        // wedged kernel can't hang the entire test runner.
+        let listen_addr = timeout(BIND_TIMEOUT, async {
+            loop {
+                match swarm.next().await {
+                    Some(SwarmEvent::NewListenAddr { address, .. }) => return Ok(address),
+                    Some(SwarmEvent::ListenerError { error, .. }) => {
+                        return Err(eyre!("mock relay listener error during bind: {error}"));
+                    }
+                    Some(SwarmEvent::ListenerClosed {
+                        reason: Err(error), ..
+                    }) => {
+                        return Err(eyre!("mock relay listener closed during bind: {error}"));
+                    }
+                    Some(_) => continue,
+                    None => return Err(eyre!("mock relay swarm closed before listening")),
                 }
-                Some(SwarmEvent::ListenerClosed {
-                    reason: Err(error), ..
-                }) => {
-                    return Err(eyre!("mock relay listener closed during bind: {error}"));
-                }
-                Some(_) => continue,
-                None => return Err(eyre!("mock relay swarm closed before listening")),
             }
-        };
+        })
+        .await
+        .map_err(|_| {
+            eyre!(
+                "mock relay did not bind within {:?} — likely a kernel or libp2p hang",
+                BIND_TIMEOUT
+            )
+        })??;
 
         // libp2p's relay::Behaviour fills the reservation response with the
         // SERVER's external addresses, not the client's listen addresses, so
@@ -268,9 +279,14 @@ impl MockRelay {
             .clone()
     }
 
-    /// Stop the relay. Idempotent; subsequent calls are no-ops. Logs
-    /// (rather than swallows) a JoinError so a panic inside the swarm task
-    /// is visible in test output.
+    /// Stop the relay. Idempotent; subsequent calls are no-ops.
+    ///
+    /// The cmd-channel send and ack receive are best-effort — if the task
+    /// has already exited cleanly they fail silently, which is fine. But
+    /// the final `handle.await` is the authoritative liveness check: a
+    /// panic inside the swarm task surfaces as `JoinError::is_panic()`
+    /// here and we propagate it via `panic!` so the test fails loudly
+    /// rather than letting the panic disappear into stderr.
     pub async fn shutdown(&self) {
         let (ack_tx, ack_rx) = oneshot::channel();
         let _ = self.cmd_tx.send(Command::Shutdown { ack: ack_tx }).await;
@@ -278,8 +294,15 @@ impl MockRelay {
 
         let mut guard = self.join.lock().await;
         if let Some(handle) = guard.take() {
-            if let Err(err) = handle.await {
-                eprintln!("mock relay task did not exit cleanly: {err:?}");
+            match handle.await {
+                Ok(()) => {}
+                Err(err) if err.is_cancelled() => {
+                    // Drop fired and aborted the task before we got here.
+                    // Not a panic — accept silently.
+                }
+                Err(err) => {
+                    panic!("mock relay task panicked: {err:?}");
+                }
             }
         }
     }
@@ -293,6 +316,11 @@ impl Drop for MockRelay {
         // deliberately do not lock self.join here — if shutdown() is
         // concurrently holding it, we must still guarantee the task is
         // cancelled.
+        //
+        // Best-effort by design: Drop cannot await the JoinHandle, so a
+        // panic inside the swarm task that happens *after* abort is silently
+        // lost. shutdown() is the authoritative stop path and propagates
+        // task panics; Drop is the fallback for unjoined leaks.
         self.abort.abort();
     }
 }

--- a/crates/network/tests/common/mod.rs
+++ b/crates/network/tests/common/mod.rs
@@ -1,0 +1,7 @@
+//! Shared helpers for `calimero-network` integration tests.
+//!
+//! The pieces here let a test stand up a controllable libp2p relay server in
+//! the same process, so the relay-reservation lifecycle can be exercised
+//! deterministically without depending on a deployed boot-node.
+
+pub mod mock_relay;

--- a/crates/network/tests/relay_recovery.rs
+++ b/crates/network/tests/relay_recovery.rs
@@ -1,0 +1,399 @@
+//! Integration tests for the relay-reservation recovery code paths in
+//! `calimero-network`.
+//!
+//! These tests use [`common::mock_relay::MockRelay`] to stand up a
+//! controllable libp2p relay server in the same process and drive the
+//! production [`calimero_network::behaviour::Behaviour`] against it.
+//!
+//! ## What is tested here vs elsewhere
+//!
+//! These tests verify the **libp2p mechanics** that the recovery code
+//! depends on:
+//!   - that a real reservation can be set up against the mock relay
+//!     (happy path),
+//!   - that disconnecting the relay produces `SwarmEvent::ConnectionClosed`
+//!     on the client with `num_established == 0` (the trigger condition for
+//!     our `ConnectionClosed` recovery branch),
+//!   - that a relay over its reservation quota produces `ListenerClosed`
+//!     on the additional client (the trigger for the `ListenerClosed`
+//!     recovery branch).
+//!
+//! The **state-machine handling** of those events (mark Expired, queue
+//! recovery action, idempotency) is covered by the
+//! `test_on_relay_reservation_lost_*` unit tests in
+//! `crates/network/src/discovery/state_tests.rs`.
+//!
+//! Tests here intentionally do not spawn the `NetworkManager` actor, so they
+//! don't directly verify the event router glue. That glue is mechanical
+//! (single match arm + method call) and adding an actor harness here would
+//! roughly double the size of this PR. Unit tests on the state machine plus
+//! integration tests on the libp2p events give strong coverage of the bug;
+//! a NetworkManager-actor harness can come as a follow-up if richer
+//! end-to-end assertions are needed.
+//!
+//! ## Scenarios from the disconnect analysis
+//!
+//! - **Covered here**: relay control-connection drop (boot-node restart,
+//!   sleep/wake, App Nap freeze, abrupt TCP reset), relay quota exhaustion
+//!   (S6), happy-path reservation.
+//!
+//! - **Not covered here**: long-session renewal blip (S5) — the libp2p
+//!   relay client auto-renews aggressively so a short server-side
+//!   `reservation_duration` alone does not drive the client into
+//!   `ExternalAddrExpired`; would need the relay to actively refuse a
+//!   renewal, which is more MockRelay infrastructure than this PR adds.
+//!   Client IP change mid-session (network switch, VPN toggle) and true
+//!   symmetric NAT — hard to simulate inside a single kernel without root
+//!   or multiple loopback interfaces. All of these are tracked in
+//!   issue #2447 for future container- or netns-based tests.
+
+mod common;
+
+use core::time::Duration;
+use std::sync::Arc;
+
+use calimero_network::behaviour::{Behaviour, BehaviourEvent};
+use calimero_network_primitives::config::{
+    AutonatConfig, BootstrapConfig, BootstrapNodes, DiscoveryConfig, NetworkConfig, RelayConfig,
+    RendezvousConfig, SwarmConfig,
+};
+use common::mock_relay::{MockRelay, MockRelayConfig};
+use futures_util::StreamExt;
+use libp2p::identity::Keypair;
+use libp2p::swarm::SwarmEvent;
+use libp2p::{Multiaddr, Swarm};
+use multiaddr::Protocol;
+use tokio::time::timeout;
+
+/// Build a NetworkConfig for a client node that will use the supplied
+/// bootstrap addresses (typically a MockRelay).
+fn client_config(keypair: Keypair, listen: Multiaddr, bootstrap: Vec<Multiaddr>) -> NetworkConfig {
+    NetworkConfig::new(
+        keypair,
+        SwarmConfig::new(vec![listen]),
+        BootstrapConfig::new(BootstrapNodes::new(bootstrap)),
+        DiscoveryConfig::new(
+            false,
+            false,
+            RendezvousConfig::default(),
+            RelayConfig::default(),
+            AutonatConfig::new(5, Duration::from_secs(10)),
+        ),
+    )
+}
+
+/// Loopback multiaddr with port 0. libp2p picks the actual port at bind
+/// time, which avoids the TOCTOU race of pre-binding a TcpListener to find
+/// a free port and then handing the address to libp2p (another process
+/// could claim it in the gap, especially under parallel test execution).
+fn ephemeral_listen_addr() -> Multiaddr {
+    "/ip4/127.0.0.1/tcp/0".parse().unwrap()
+}
+
+/// Drive a client swarm until a predicate over its SwarmEvent stream returns
+/// Some(T), or the timeout elapses.
+async fn wait_for<F, T>(
+    swarm: &mut Swarm<Behaviour>,
+    label: &str,
+    deadline: Duration,
+    mut predicate: F,
+) -> T
+where
+    F: FnMut(&SwarmEvent<BehaviourEvent>) -> Option<T>,
+{
+    let result = timeout(deadline, async {
+        loop {
+            let event = swarm.next().await.expect("swarm stream closed");
+            if let Some(value) = predicate(&event) {
+                return value;
+            }
+        }
+    })
+    .await;
+
+    result.unwrap_or_else(|_| panic!("timed out waiting for: {label}"))
+}
+
+/// True if `addr` is a relayed multiaddr (contains the p2p-circuit protocol).
+fn is_relayed(addr: &Multiaddr) -> bool {
+    addr.iter().any(|p| matches!(p, Protocol::P2pCircuit))
+}
+
+/// Drive a client swarm against the relay until a relayed listen address is
+/// confirmed externally. Returns the local PeerId. Encapsulates the boring
+/// dial-then-listen-on-circuit dance every scenario test needs.
+async fn establish_reservation(
+    client_swarm: &mut Swarm<Behaviour>,
+    relay: &MockRelay,
+) -> libp2p::PeerId {
+    let local_peer_id = *client_swarm.local_peer_id();
+
+    client_swarm
+        .dial(relay.bootstrap_addr())
+        .expect("dial mock relay");
+
+    // Wait for the connection to the relay to be established. We don't need
+    // to wait for identify to complete — the relay's reservation response
+    // uses its OWN external addresses (which MockRelay sets at spawn time),
+    // not anything we send via identify.
+    wait_for(
+        client_swarm,
+        "ConnectionEstablished to mock relay",
+        Duration::from_secs(10),
+        |event| match event {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } if *peer_id == relay.peer_id() => {
+                Some(())
+            }
+            _ => None,
+        },
+    )
+    .await;
+
+    let relayed_addr = relay
+        .bootstrap_addr()
+        .with(Protocol::P2pCircuit)
+        .with(Protocol::P2p(local_peer_id));
+    client_swarm
+        .listen_on(relayed_addr)
+        .expect("listen on relayed addr");
+
+    wait_for(
+        client_swarm,
+        "ExternalAddrConfirmed with /p2p-circuit",
+        Duration::from_secs(15),
+        |event| match event {
+            SwarmEvent::ExternalAddrConfirmed { address } if is_relayed(address) => Some(()),
+            _ => None,
+        },
+    )
+    .await;
+
+    local_peer_id
+}
+
+/// End-to-end: a client with the production Behaviour, pointed at a fresh
+/// MockRelay as its sole bootstrap, successfully reserves a relayed circuit.
+///
+/// Baseline test for the suite — if this doesn't pass, no scenario test that
+/// depends on observing the reservation lifecycle can.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_can_reserve_circuit_against_mock_relay() {
+    let relay = Arc::new(MockRelay::spawn().await.expect("spawn mock relay"));
+
+    let client_keypair = Keypair::generate_ed25519();
+    let client_listen = ephemeral_listen_addr();
+    let mut client_swarm = Behaviour::build_swarm(&client_config(
+        client_keypair,
+        client_listen,
+        vec![relay.bootstrap_addr()],
+    ))
+    .expect("build client swarm");
+
+    let _ = establish_reservation(&mut client_swarm, &relay).await;
+
+    let obs = relay.observations().await;
+    assert!(
+        obs.reservations_accepted >= 1,
+        "relay should have accepted at least one reservation; got {obs:?}"
+    );
+
+    relay.shutdown().await;
+}
+
+/// Scenario: relay process restarts (or any other event that drops the
+/// control connection — sleep/wake, App Nap freeze, abrupt TCP reset).
+///
+/// Mocked by [`MockRelay::disconnect_peer`], which closes the control
+/// connection from the relay side. The client's libp2p stack reports
+/// SwarmEvent::ConnectionClosed for the relay peer, which is the trigger
+/// our recovery code in `handlers/stream/swarm.rs` reacts to.
+///
+/// **What this test asserts**: ConnectionClosed actually fires for the
+/// relay peer when the relay disconnects, with no remaining connections.
+/// The state-machine handling of that event is covered by the
+/// `test_on_relay_reservation_lost_*` unit tests; this verifies that the
+/// libp2p event our handler is wired to fires in the situation we care about.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_disconnect_triggers_client_connection_closed() {
+    let relay = Arc::new(MockRelay::spawn().await.expect("spawn mock relay"));
+    let relay_peer_id = relay.peer_id();
+
+    let client_keypair = Keypair::generate_ed25519();
+    let client_listen = ephemeral_listen_addr();
+    let mut client_swarm = Behaviour::build_swarm(&client_config(
+        client_keypair,
+        client_listen,
+        vec![relay.bootstrap_addr()],
+    ))
+    .expect("build client swarm");
+
+    let local_peer_id = establish_reservation(&mut client_swarm, &relay).await;
+
+    // Cause the relay to disconnect the client. Mirrors a boot-node going down.
+    let disconnected = relay.disconnect_peer(local_peer_id).await;
+    assert!(
+        disconnected,
+        "mock relay should have had a live connection to the client to disconnect"
+    );
+
+    // The client must observe ConnectionClosed for the relay peer with
+    // num_established == 0. This is the signal our ConnectionClosed handler
+    // in handlers/stream/swarm.rs uses to call on_relay_reservation_lost.
+    wait_for(
+        &mut client_swarm,
+        "ConnectionClosed for relay peer",
+        Duration::from_secs(10),
+        |event| match event {
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                num_established,
+                ..
+            } if *peer_id == relay_peer_id && *num_established == 0 => Some(()),
+            _ => None,
+        },
+    )
+    .await;
+
+    relay.shutdown().await;
+}
+
+/// Scenario: relay refuses a reservation request because the per-peer quota
+/// is already full. Real-world trigger: a burst of new clients hits the
+/// boot-node at the same time and one of them loses the race for the last
+/// open slot, or a client's existing reservation has counted toward the
+/// per-peer limit when it tries to take a second one.
+///
+/// Mocked by setting `max_reservations_per_peer = 1` and having the client
+/// try to take a second reservation on the same relay. The relay's
+/// `relay::Behaviour` responds with `RESOURCE_LIMIT_EXCEEDED`, which the
+/// libp2p relay client surfaces by tearing down the listener.
+///
+/// **What this test asserts**: `ListenerClosed` fires on the client with a
+/// relayed address in the closed listener's addresses (or an empty
+/// `addresses` list, depending on whether the reservation got an address
+/// allocated before denial). This is the trigger for the `ListenerClosed`
+/// branch of recovery in `handlers/stream/swarm.rs`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_quota_exhaustion_denies_second_client() {
+    // Total quota = 1. First client succeeds; second client must be denied
+    // and observe a ListenerClosed (or never see ExternalAddrConfirmed
+    // within the deadline). The denial is the path that, in production, our
+    // ListenerClosed branch in handlers/stream/swarm.rs would react to.
+    let relay_keypair = Keypair::generate_ed25519();
+    let relay = Arc::new(
+        MockRelay::spawn_with(
+            MockRelayConfig {
+                max_reservations: 1,
+                max_reservations_per_peer: 1,
+                ..MockRelayConfig::default()
+            },
+            relay_keypair,
+        )
+        .await
+        .expect("spawn mock relay"),
+    );
+
+    // Client A: takes the only available slot.
+    let mut client_a = Behaviour::build_swarm(&client_config(
+        Keypair::generate_ed25519(),
+        ephemeral_listen_addr(),
+        vec![relay.bootstrap_addr()],
+    ))
+    .expect("build client A");
+    let _ = establish_reservation(&mut client_a, &relay).await;
+
+    // Client B: tries to reserve, must be denied.
+    let mut client_b = Behaviour::build_swarm(&client_config(
+        Keypair::generate_ed25519(),
+        ephemeral_listen_addr(),
+        vec![relay.bootstrap_addr()],
+    ))
+    .expect("build client B");
+    let client_b_local = *client_b.local_peer_id();
+
+    client_b
+        .dial(relay.bootstrap_addr())
+        .expect("client B dial");
+
+    // Wait for client B's connection to the relay before requesting.
+    wait_for(
+        &mut client_b,
+        "client B ConnectionEstablished",
+        Duration::from_secs(10),
+        |event| match event {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } if *peer_id == relay.peer_id() => {
+                Some(())
+            }
+            _ => None,
+        },
+    )
+    .await;
+
+    let relayed_for_b = relay
+        .bootstrap_addr()
+        .with(Protocol::P2pCircuit)
+        .with(Protocol::P2p(client_b_local));
+    let b_listener = client_b
+        .listen_on(relayed_for_b)
+        .expect("client B listen_on");
+
+    // Client B must observe ListenerClosed (not ExternalAddrConfirmed) for
+    // the rejected reservation. Drive client A in the background so its
+    // connection stays alive and holds the quota.
+    //
+    // The matched ListenerClosed must be for client B's freshly created
+    // listener AND must carry an error reason. We don't pattern-match the
+    // specific libp2p error type because relay-client wraps its protocol
+    // errors several Either layers deep, and matching against the stringified
+    // form would be brittle. Instead we narrow on listener_id + reason.is_err()
+    // and assert that the only plausible failure here is the relay denial:
+    // the listener was created moments ago, the transport is healthy (client
+    // A is connected over the same TCP path), and ExternalAddrConfirmed has
+    // not fired for it. A spurious ListenerError unrelated to the quota
+    // denial would imply a different bug, which would surface as a separate
+    // test failure rather than a false positive on this one.
+    let mut saw_close = false;
+    let result = timeout(Duration::from_secs(15), async {
+        loop {
+            tokio::select! {
+                _ = client_a.next() => {}
+                event = client_b.next() => {
+                    match event.expect("client B stream") {
+                        SwarmEvent::ListenerClosed { listener_id, reason, .. }
+                            if listener_id == b_listener && reason.is_err() =>
+                        {
+                            // Log the actual error for triage when this test
+                            // does fail; the wrapped form is too noisy for an
+                            // assertion message but useful in the output.
+                            eprintln!(
+                                "client B ListenerClosed reason: {:?}",
+                                reason.err()
+                            );
+                            saw_close = true;
+                            return;
+                        }
+                        SwarmEvent::ExternalAddrConfirmed { address } if is_relayed(&address) => {
+                            panic!("client B should not have got a reservation; quota was 1");
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for quota denial on client B"
+    );
+    assert!(saw_close, "client B should have seen ListenerClosed");
+
+    let obs = relay.observations().await;
+    assert!(
+        obs.reservations_accepted >= 1,
+        "at least one reservation accepted (client A); got {obs:?}"
+    );
+
+    relay.shutdown().await;
+}

--- a/crates/network/tests/relay_recovery.rs
+++ b/crates/network/tests/relay_recovery.rs
@@ -194,7 +194,7 @@ async fn client_can_reserve_circuit_against_mock_relay() {
 
     let _ = establish_reservation(&mut client_swarm, &relay).await;
 
-    let obs = relay.observations().await;
+    let obs = relay.observations();
     assert!(
         obs.reservations_accepted >= 1,
         "relay should have accepted at least one reservation; got {obs:?}"
@@ -312,17 +312,16 @@ async fn relay_quota_exhaustion_denies_second_client() {
     // loop, which can let a yamux ping or identify exchange time out and
     // free the quota slot — letting client B succeed and producing a
     // confusing false positive.
+    //
+    // The driver exits silently on stream close (returns `None`). Panicking
+    // there would only be observable if the test joins the task, which we
+    // don't reliably do (the task is aborted, and abort then join would add
+    // ordering complications). If client A's swarm dies, the test loses
+    // its quota-holder and the assertion `obs.reservations_denied >= 1`
+    // below will fail with a clear message anyway.
     let client_a_driver = tokio::spawn(async move {
-        // Loop until cancelled by the test's abort. Panic on stream
-        // closure so we surface a real environment break rather than
-        // hanging.
-        loop {
-            let event = client_a
-                .next()
-                .await
-                .expect("client A swarm closed unexpectedly");
-            // Don't act on A's events — we only need to keep it polled.
-            let _ = event;
+        while client_a.next().await.is_some() {
+            // Only purpose is to keep the swarm polled.
         }
     });
 
@@ -394,13 +393,20 @@ async fn relay_quota_exhaustion_denies_second_client() {
     .await;
 
     client_a_driver.abort();
+    // Await the driver after abort so any panic inside it surfaces here
+    // (JoinError::is_cancelled() distinguishes abort from a real panic).
+    if let Err(err) = client_a_driver.await {
+        if !err.is_cancelled() {
+            panic!("client A driver task panicked: {err:?}");
+        }
+    }
 
     assert!(
         result.is_ok(),
         "timed out waiting for ListenerClosed on client B's relayed listener"
     );
 
-    let obs = relay.observations().await;
+    let obs = relay.observations();
     assert!(
         obs.reservations_accepted >= 1,
         "client A's reservation must have been accepted; got {obs:?}"

--- a/crates/network/tests/relay_recovery.rs
+++ b/crates/network/tests/relay_recovery.rs
@@ -376,13 +376,22 @@ async fn relay_quota_exhaustion_denies_second_client() {
                     listener_id,
                     reason,
                     ..
-                } if listener_id == b_listener && reason.is_err() => {
-                    // Log the actual error for triage when this test does
-                    // fail; the wrapped form is too noisy for an assertion
-                    // message but useful in the output.
-                    eprintln!("client B ListenerClosed reason: {:?}", reason.err());
-                    return;
-                }
+                } if listener_id == b_listener => match reason {
+                    Err(err) => {
+                        // Log the actual error for triage when this test
+                        // does fail; the wrapped form is too noisy for an
+                        // assertion message but useful in the output.
+                        eprintln!("client B ListenerClosed reason: {err:?}");
+                        return;
+                    }
+                    Ok(()) => {
+                        panic!(
+                            "client B's relayed listener closed gracefully, but this test \
+                             expected an error reason (relay quota denial). A graceful close \
+                             here indicates a different failure mode than quota exhaustion."
+                        );
+                    }
+                },
                 SwarmEvent::ExternalAddrConfirmed { address } if is_relayed(&address) => {
                     panic!("client B should not have got a reservation; quota was 1");
                 }
@@ -392,19 +401,24 @@ async fn relay_quota_exhaustion_denies_second_client() {
     })
     .await;
 
+    // Assert the timeout outcome before unwinding client A's driver — the
+    // timeout result is already computed, and surfacing it first means a
+    // CI-side timeout failure is more diagnosable than a driver panic that
+    // happens during cleanup.
+    assert!(
+        result.is_ok(),
+        "timed out waiting for ListenerClosed on client B's relayed listener"
+    );
+
+    // Now cleanly stop client A's driver. If the driver itself panicked
+    // (rather than being aborted), surface that too — it would explain
+    // why a quota slot might have been freed early.
     client_a_driver.abort();
-    // Await the driver after abort so any panic inside it surfaces here
-    // (JoinError::is_cancelled() distinguishes abort from a real panic).
     if let Err(err) = client_a_driver.await {
         if !err.is_cancelled() {
             panic!("client A driver task panicked: {err:?}");
         }
     }
-
-    assert!(
-        result.is_ok(),
-        "timed out waiting for ListenerClosed on client B's relayed listener"
-    );
 
     let obs = relay.observations();
     assert!(

--- a/crates/network/tests/relay_recovery.rs
+++ b/crates/network/tests/relay_recovery.rs
@@ -103,7 +103,10 @@ where
 {
     let result = timeout(deadline, async {
         loop {
-            let event = swarm.next().await.expect("swarm stream closed");
+            let event = swarm
+                .next()
+                .await
+                .unwrap_or_else(|| panic!("swarm stream closed while waiting for: {label}"));
             if let Some(value) = predicate(&event) {
                 return value;
             }
@@ -302,6 +305,27 @@ async fn relay_quota_exhaustion_denies_second_client() {
     .expect("build client A");
     let _ = establish_reservation(&mut client_a, &relay).await;
 
+    // Drive client A's swarm continuously in a background task so its
+    // libp2p connection (and therefore its reservation) stays alive while
+    // we test client B. Without this, A's swarm goes unpolled between
+    // the end of establish_reservation and the start of the assertion
+    // loop, which can let a yamux ping or identify exchange time out and
+    // free the quota slot — letting client B succeed and producing a
+    // confusing false positive.
+    let client_a_driver = tokio::spawn(async move {
+        // Loop until cancelled by the test's abort. Panic on stream
+        // closure so we surface a real environment break rather than
+        // hanging.
+        loop {
+            let event = client_a
+                .next()
+                .await
+                .expect("client A swarm closed unexpectedly");
+            // Don't act on A's events — we only need to keep it polled.
+            let _ = event;
+        }
+    });
+
     // Client B: tries to reserve, must be denied.
     let mut client_b = Behaviour::build_swarm(&client_config(
         Keypair::generate_ed25519(),
@@ -338,61 +362,55 @@ async fn relay_quota_exhaustion_denies_second_client() {
         .expect("client B listen_on");
 
     // Client B must observe ListenerClosed (not ExternalAddrConfirmed) for
-    // the rejected reservation. Drive client A in the background so its
-    // connection stays alive and holds the quota.
-    //
-    // The matched ListenerClosed must be for client B's freshly created
-    // listener AND must carry an error reason. We don't pattern-match the
-    // specific libp2p error type because relay-client wraps its protocol
-    // errors several Either layers deep, and matching against the stringified
-    // form would be brittle. Instead we narrow on listener_id + reason.is_err()
-    // and assert that the only plausible failure here is the relay denial:
-    // the listener was created moments ago, the transport is healthy (client
-    // A is connected over the same TCP path), and ExternalAddrConfirmed has
-    // not fired for it. A spurious ListenerError unrelated to the quota
-    // denial would imply a different bug, which would surface as a separate
-    // test failure rather than a false positive on this one.
-    let mut saw_close = false;
+    // the rejected reservation. The matched ListenerClosed must be for
+    // client B's freshly created listener AND must carry an error reason.
+    // We don't pattern-match the specific libp2p error variant because the
+    // relay-client wraps its protocol errors several Either layers deep
+    // and matching against the stringified form would be brittle. Instead
+    // we narrow on listener_id + reason.is_err() and corroborate via the
+    // relay-side observations.reservations_denied counter below, which
+    // gives us a positive signal from the relay's own state machine.
     let result = timeout(Duration::from_secs(15), async {
         loop {
-            tokio::select! {
-                _ = client_a.next() => {}
-                event = client_b.next() => {
-                    match event.expect("client B stream") {
-                        SwarmEvent::ListenerClosed { listener_id, reason, .. }
-                            if listener_id == b_listener && reason.is_err() =>
-                        {
-                            // Log the actual error for triage when this test
-                            // does fail; the wrapped form is too noisy for an
-                            // assertion message but useful in the output.
-                            eprintln!(
-                                "client B ListenerClosed reason: {:?}",
-                                reason.err()
-                            );
-                            saw_close = true;
-                            return;
-                        }
-                        SwarmEvent::ExternalAddrConfirmed { address } if is_relayed(&address) => {
-                            panic!("client B should not have got a reservation; quota was 1");
-                        }
-                        _ => {}
-                    }
+            match client_b.next().await.expect("client B stream") {
+                SwarmEvent::ListenerClosed {
+                    listener_id,
+                    reason,
+                    ..
+                } if listener_id == b_listener && reason.is_err() => {
+                    // Log the actual error for triage when this test does
+                    // fail; the wrapped form is too noisy for an assertion
+                    // message but useful in the output.
+                    eprintln!("client B ListenerClosed reason: {:?}", reason.err());
+                    return;
                 }
+                SwarmEvent::ExternalAddrConfirmed { address } if is_relayed(&address) => {
+                    panic!("client B should not have got a reservation; quota was 1");
+                }
+                _ => {}
             }
         }
     })
     .await;
 
+    client_a_driver.abort();
+
     assert!(
         result.is_ok(),
-        "timed out waiting for quota denial on client B"
+        "timed out waiting for ListenerClosed on client B's relayed listener"
     );
-    assert!(saw_close, "client B should have seen ListenerClosed");
 
     let obs = relay.observations().await;
     assert!(
         obs.reservations_accepted >= 1,
-        "at least one reservation accepted (client A); got {obs:?}"
+        "client A's reservation must have been accepted; got {obs:?}"
+    );
+    assert!(
+        obs.reservations_denied >= 1,
+        "relay must have denied at least one reservation request from client B; got {obs:?}. \
+         Without a denial counter increment, the client-side ListenerClosed could be triggered \
+         by a different failure mode (e.g. transport teardown) that doesn't exercise the quota \
+         path we mean to test."
     );
 
     relay.shutdown().await;


### PR DESCRIPTION
## What

Adds a `MockRelay` testkit in `crates/network/tests/common/` and three integration tests in `crates/network/tests/relay_recovery.rs` that exercise the libp2p events the state-machine recovery in [#2446](https://github.com/calimero-network/core/pull/2446) reacts to.

Stacked on top of [#2446](https://github.com/calimero-network/core/pull/2446). Targets `master`.

## Why

The recovery code in [#2446](https://github.com/calimero-network/core/pull/2446) is unit-tested at the `DiscoveryState` level. What is not yet tested is the wiring between libp2p's `SwarmEvent`s and the recovery method — and more importantly, that those events actually fire under the conditions we expect. This PR fills that gap with an in-process relay server we can fully control, so the bug fixed in #2446 (and any future regression) is detectable from `cargo test`, not just from a user complaining in Slack.

## What's in it

### `MockRelay` — in-process libp2p relay server (~320 LoC)

`tests/common/mock_relay.rs`. Wraps real `libp2p::relay::Behaviour` (server side) + `identify` in a swarm task. Exposes:

- `MockRelay::spawn()` / `spawn_with(config, keypair)`
- `peer_id()`, `bootstrap_addr()` — what a client puts in its bootstrap config
- `disconnect_peer(peer)` — forcibly close active connections; the fault injection
- `observations()` — snapshot of accepted/denied reservations and circuits
- `shutdown()` — stop the swarm task

Tunable via `MockRelayConfig`: `max_reservations`, `max_reservations_per_peer`, `reservation_duration`, `max_circuit_*` knobs.

One non-obvious detail documented inline: `libp2p::relay::Behaviour` builds reservation responses from the **server's** external addresses (so the client can construct `<relay>/p2p-circuit/<self>`). On a loopback-only mock these are empty by default since we don't run AutoNAT — the mock explicitly adds its bound listen address as external. Without that line every reservation request comes back with `NoAddressesInReservation` and the client's listener is torn down before any test can observe anything useful.

### Three integration tests (~380 LoC)

`tests/relay_recovery.rs`:

| Test | What it asserts | Scenario from #2446 analysis |
|---|---|---|
| `client_can_reserve_circuit_against_mock_relay` | A reservation can be set up against the mock. Baseline. | — |
| `relay_disconnect_triggers_client_connection_closed` | `ConnectionClosed` fires for the relay peer with `num_established == 0` after `disconnect_peer`. | S1 (boot-node restart), S2 (sleep/wake), S8 (App Nap freeze), abrupt TCP reset |
| `relay_quota_exhaustion_denies_second_client` | With `max_reservations = 1`, a second client's `listen_on(/p2p-circuit/)` produces `ListenerClosed` with an error reason. | S6 (relay quota exhausted) |

These verify that the libp2p events our recovery code is wired to actually fire in the conditions we care about. The state-machine handling of those events (mark Expired, queue recovery, idempotency under repeated events) is already covered by the `test_on_relay_reservation_lost_*` unit tests in `discovery/state_tests.rs` from #2446.

## What is not covered, and why

- **Long-session renewal blip (S5)**. The libp2p relay client auto-renews aggressively while the control connection is alive, so a short server-side `reservation_duration` alone doesn't drive the client into `ExternalAddrExpired`. Would need the relay to actively refuse a renewal — more `MockRelay` infrastructure than is in scope here. Tracked in [#2447](https://github.com/calimero-network/core/issues/2447).
- **Client IP rotation (S3, S4) and true symmetric NAT (S7)**. Hard to simulate inside a single kernel without root or extra interfaces. Needs container-based testing via the primitives proposed in [merobox#246](https://github.com/calimero-network/merobox/issues/246) and the multi-network topology work in [#2453](https://github.com/calimero-network/core/issues/2453).
- **End-to-end `NetworkManager` actor tests**. Would roughly double the size of this PR (actix System setup, recording dispatcher, introspection accessors). The current tests verify the libp2p mechanics; the state-machine unit tests verify the state transitions; the glue between them is a single match arm + method call per event. Filed as a future enhancement on [#2447](https://github.com/calimero-network/core/issues/2447).

## Running

```bash
cargo test -p calimero-network --test relay_recovery
```

Three tests, all passing, ~40ms total.

## Verification on master

The whole suite:

```
test result: ok. 12 passed; 0 failed; 0 ignored (discovery/state_tests + request_blob)
test result: ok. 1 passed; 0 failed (gossipsub_group_topic)
test result: ok. 1 passed; 0 failed (kad_modes)
test result: ok. 3 passed; 0 failed (relay_recovery)
```

`cargo fmt --check` clean. `cargo clippy -p calimero-network --tests` clean (the pre-existing `clippy::no_effect` in `calimero-utils-actix` is unrelated and was on master before this change).

## Related

- [#2446](https://github.com/calimero-network/core/pull/2446) — relay-reservation recovery (this PR sits on top of)
- [#2447](https://github.com/calimero-network/core/issues/2447) — network resilience test plan
- [merobox#246](https://github.com/calimero-network/merobox/issues/246) — fault-injection primitives for the scenarios not testable here
- [boot-node#37](https://github.com/calimero-network/boot-node/issues/37) — long-term: fold boot-node into core so we can drop the mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to `crates/network` test code, adding an in-process libp2p relay and new integration tests without touching production networking logic.
> 
> **Overview**
> Adds a reusable `MockRelay` testkit that runs an in-process libp2p relay server with configurable quotas/durations, a `disconnect_peer` fault-injection hook, and observable counters for accepted/denied reservations.
> 
> Introduces `relay_recovery` integration tests that drive the production `Behaviour` against the mock relay to assert the key libp2p event triggers used by reservation recovery: successful reservation (`ExternalAddrConfirmed`), relay-side disconnect causing client `ConnectionClosed` with `num_established == 0`, and quota exhaustion causing a client `ListenerClosed` with an error reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e4ac1a2d47808c45c70c700aa2d12a2499202e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->