### PR TITLE
fix(network): address-book hygiene (eviction, inbound recording, identify mirror)

### DIFF
--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -4,8 +4,15 @@ mod tests;
 
 use core::time::Duration;
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Instant;
+
+/// Consecutive-failure threshold at which an address is evicted from a
+/// peer's address book. Three is chosen as a small magic number that
+/// tolerates transient flakiness (one bad TCP retransmit, one identify
+/// race) without keeping a permanently broken address around long enough
+/// to waste many rendezvous-tick dial attempts.
+pub(crate) const DIAL_FAILURE_EVICTION_THRESHOLD: u8 = 3;
 
 use libp2p::relay::HOP_PROTOCOL_NAME;
 use libp2p::rendezvous::Cookie;
@@ -147,13 +154,44 @@ impl DiscoveryState {
         }
     }
 
+    /// Record an address for a peer, or reset its failure counter to zero if
+    /// it already exists. Called from successful connection events (the
+    /// address obviously works), from identify (the peer told us it
+    /// listens there), and from the rendezvous discovery path.
+    ///
+    /// Addresses are stored as supplied, without normalization. The caller
+    /// is responsible for filtering out forms we don't want to dial
+    /// directly — most notably relayed multiaddrs (`/p2p-circuit/`) for
+    /// inbound connection records.
     pub(crate) fn add_peer_addr(&mut self, peer_id: PeerId, addr: &Multiaddr) {
         let _ = self
             .peers
             .entry(peer_id)
             .or_default()
             .addrs
-            .insert(addr.clone());
+            .insert(addr.clone(), 0);
+    }
+
+    /// Mark a dial failure for `addr` under `peer_id`. Increments the
+    /// per-address counter; if it reaches
+    /// [`DIAL_FAILURE_EVICTION_THRESHOLD`], evicts the address and returns
+    /// true. No-op if the peer or address is not in the book (we don't
+    /// add entries for addresses we never planned to keep).
+    pub(crate) fn record_dial_failure(&mut self, peer_id: &PeerId, addr: &Multiaddr) -> bool {
+        let Some(peer_info) = self.peers.get_mut(peer_id) else {
+            return false;
+        };
+        let Some(count) = peer_info.addrs.get_mut(addr) else {
+            return false;
+        };
+
+        *count = count.saturating_add(1);
+        if *count >= DIAL_FAILURE_EVICTION_THRESHOLD {
+            let _ = peer_info.addrs.remove(addr);
+            true
+        } else {
+            false
+        }
     }
 
     pub(crate) fn remove_peer(&mut self, peer_id: &PeerId) {
@@ -204,7 +242,7 @@ impl DiscoveryState {
                 let _ = discoveries.insert(mechanism);
 
                 let _ = entry.insert(PeerInfo {
-                    addrs: HashSet::default(),
+                    addrs: HashMap::default(),
                     discoveries,
                     relay: None,
                     rendezvous: None,
@@ -375,9 +413,18 @@ impl DiscoveryState {
 
 /// PeerInfo is a struct that holds information about a peer.
 /// It offers immutable methods for accessing the information.
+///
+/// `addrs` maps each known address to the number of consecutive dial
+/// failures observed for it. The counter is reset on every successful
+/// connection (or on a fresh identify push that re-introduces the
+/// address) and incremented on `OutgoingConnectionError`. An address is
+/// evicted entirely once the count reaches
+/// [`DIAL_FAILURE_EVICTION_THRESHOLD`]. This bounds growth without
+/// penalising stable long-online peers — a working address keeps its
+/// counter at zero indefinitely.
 #[derive(Clone, Debug, Default)]
 pub struct PeerInfo {
-    addrs: HashSet<Multiaddr>,
+    addrs: HashMap<Multiaddr, u8>,
     discoveries: HashSet<PeerDiscoveryMechanism>,
     relay: Option<PeerRelayInfo>,
     rendezvous: Option<PeerRendezvousInfo>,
@@ -385,18 +432,18 @@ pub struct PeerInfo {
 
 impl PeerInfo {
     pub(crate) fn addrs(&self) -> impl Iterator<Item = &Multiaddr> {
-        self.addrs.iter()
+        self.addrs.keys()
     }
 
     pub(crate) fn get_preferred_addr(&self) -> Option<&Multiaddr> {
         let udp_addrs: Vec<&Multiaddr> = self
             .addrs
-            .iter()
+            .keys()
             .filter(|addr| addr.iter().any(|p| matches!(p, Protocol::Udp(_))))
             .collect();
 
         match udp_addrs.len() {
-            0 => self.addrs.iter().next(),
+            0 => self.addrs.keys().next(),
             _ => Some(udp_addrs[0]),
         }
     }

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -11,7 +11,7 @@ fn test_get_preferred_addr() {
 
     assert_eq!(peer_info.get_preferred_addr(), None);
 
-    let _ = peer_info.addrs.insert(tcp_addr_1);
+    let _ = peer_info.addrs.insert(tcp_addr_1, 0);
     assert_eq!(
         peer_info
             .get_preferred_addr()
@@ -22,7 +22,7 @@ fn test_get_preferred_addr() {
         Protocol::Tcp(4001)
     );
 
-    let _ = peer_info.addrs.insert(quic_addr);
+    let _ = peer_info.addrs.insert(quic_addr, 0);
     assert_eq!(
         peer_info
             .get_preferred_addr()
@@ -33,7 +33,7 @@ fn test_get_preferred_addr() {
         Protocol::Udp(4001)
     );
 
-    let _ = peer_info.addrs.insert(tcp_addr_2);
+    let _ = peer_info.addrs.insert(tcp_addr_2, 0);
     assert_eq!(
         peer_info
             .get_preferred_addr()
@@ -242,8 +242,8 @@ fn test_state_mutations() {
     state.add_peer_addr(peer_id, &tcp_addr);
     assert_eq!(state.peers.len(), 1);
     assert_eq!(state.peers[&peer_id].addrs.len(), 2);
-    assert!(state.peers[&peer_id].addrs.contains(&tcp_addr));
-    assert!(state.peers[&peer_id].addrs.contains(&quic_addr));
+    assert!(state.peers[&peer_id].addrs.contains_key(&tcp_addr));
+    assert!(state.peers[&peer_id].addrs.contains_key(&quic_addr));
 
     state.add_peer_discovery_mechanism(&peer_id, mdns_discovery);
     state.add_peer_discovery_mechanism(&peer_id, rendezvous_discovery);
@@ -439,4 +439,113 @@ fn test_on_relay_reservation_lost_multiple_relays_queue_independently() {
     // though the first is already Expired. Each relay is tracked independently.
     let actions_b = state.on_relay_reservation_lost(&relay_b);
     assert_eq!(actions_b.relay_reservations, vec![relay_b]);
+}
+
+#[test]
+fn test_add_peer_addr_initialises_failure_counter_to_zero() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+
+    state.add_peer_addr(peer, &addr);
+    assert_eq!(state.peers[&peer].addrs[&addr], 0);
+}
+
+#[test]
+fn test_add_peer_addr_resets_failure_counter_when_address_already_present() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+
+    state.add_peer_addr(peer, &addr);
+    let _ = state.record_dial_failure(&peer, &addr);
+    let _ = state.record_dial_failure(&peer, &addr);
+    assert_eq!(state.peers[&peer].addrs[&addr], 2);
+
+    // A re-addition (successful identify push, fresh dial, etc.) treats
+    // the address as healthy again and resets the counter.
+    state.add_peer_addr(peer, &addr);
+    assert_eq!(state.peers[&peer].addrs[&addr], 0);
+}
+
+#[test]
+fn test_record_dial_failure_evicts_at_threshold() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+
+    state.add_peer_addr(peer, &addr);
+    for _ in 0..(DIAL_FAILURE_EVICTION_THRESHOLD - 1) {
+        assert!(
+            !state.record_dial_failure(&peer, &addr),
+            "address must not evict before reaching the threshold"
+        );
+    }
+    assert!(state.peers[&peer].addrs.contains_key(&addr));
+
+    // The threshold-th failure evicts.
+    let evicted = state.record_dial_failure(&peer, &addr);
+    assert!(evicted, "reaching the threshold must evict");
+    assert!(!state.peers[&peer].addrs.contains_key(&addr));
+}
+
+#[test]
+fn test_record_dial_failure_is_noop_for_unknown_peer_or_address() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+    let other_addr: Multiaddr = "/ip4/127.0.0.1/tcp/4002".parse().unwrap();
+
+    // Unknown peer: no-op.
+    assert!(!state.record_dial_failure(&peer, &addr));
+    assert!(!state.peers.contains_key(&peer));
+
+    // Known peer, unknown address: no-op (don't speculatively insert an
+    // address we never planned to keep).
+    state.add_peer_addr(peer, &addr);
+    assert!(!state.record_dial_failure(&peer, &other_addr));
+    assert!(!state.peers[&peer].addrs.contains_key(&other_addr));
+}
+
+#[test]
+fn test_dial_success_after_failures_resets_counter() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+
+    state.add_peer_addr(peer, &addr);
+    let _ = state.record_dial_failure(&peer, &addr);
+    let _ = state.record_dial_failure(&peer, &addr);
+    assert_eq!(state.peers[&peer].addrs[&addr], 2);
+
+    // ConnectionEstablished re-records the address, resetting the counter.
+    // The address now needs another full threshold of consecutive
+    // failures before eviction.
+    state.add_peer_addr(peer, &addr);
+    assert_eq!(state.peers[&peer].addrs[&addr], 0);
+
+    for _ in 0..(DIAL_FAILURE_EVICTION_THRESHOLD - 1) {
+        assert!(!state.record_dial_failure(&peer, &addr));
+    }
+    assert!(state.peers[&peer].addrs.contains_key(&addr));
+}
+
+#[test]
+fn test_independent_addresses_track_failures_separately() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let addr_a: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+    let addr_b: Multiaddr = "/ip4/127.0.0.1/tcp/4002".parse().unwrap();
+
+    state.add_peer_addr(peer, &addr_a);
+    state.add_peer_addr(peer, &addr_b);
+
+    // Fail addr_a to the threshold; addr_b is untouched.
+    for _ in 0..DIAL_FAILURE_EVICTION_THRESHOLD {
+        let _ = state.record_dial_failure(&peer, &addr_a);
+    }
+
+    assert!(!state.peers[&peer].addrs.contains_key(&addr_a));
+    assert!(state.peers[&peer].addrs.contains_key(&addr_b));
+    assert_eq!(state.peers[&peer].addrs[&addr_b], 0);
 }

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -2,7 +2,7 @@ use actix::StreamHandler;
 use calimero_network_primitives::messages::NetworkEvent;
 use eyre::eyre;
 use libp2p::core::ConnectedPoint;
-use libp2p::swarm::SwarmEvent;
+use libp2p::swarm::{DialError, SwarmEvent};
 use libp2p::PeerId;
 use multiaddr::{Multiaddr, Protocol};
 use tracing::{debug, info, trace, warn};
@@ -83,11 +83,26 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                 peer_id, endpoint, ..
             } => {
                 debug!(%peer_id, ?endpoint, "Connection established");
-                if let ConnectedPoint::Dialer { .. } = endpoint {
-                    self.discovery
-                        .state
-                        .add_peer_addr(peer_id, endpoint.get_remote_address());
 
+                // Record the remote address for both inbound and outbound
+                // connections. The previous version only recorded for the
+                // Dialer endpoint, which meant a peer that dialed us first
+                // never made it into our address book until rendezvous
+                // happened to surface them later. That left the rendezvous-
+                // tick re-dial loop with nothing to iterate on
+                // ConnectionClosed.
+                //
+                // Skip relayed multiaddrs (`/p2p-circuit/`) — those aren't
+                // useful as direct-dial entries for the peer, and storing
+                // them would pollute the book with addresses that always
+                // fail to dial directly.
+                let remote = endpoint.get_remote_address();
+                let is_relayed = remote.iter().any(|p| matches!(p, Protocol::P2pCircuit));
+                if !is_relayed {
+                    self.discovery.state.add_peer_addr(peer_id, remote);
+                }
+
+                if let ConnectedPoint::Dialer { .. } = endpoint {
                     if let Some(sender) = self.pending_dial.remove(&peer_id) {
                         let _ignored = sender.send(Ok(()));
                     }
@@ -136,7 +151,32 @@ impl StreamHandler<FromSwarm> for NetworkManager {
             }
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 debug!(?peer_id, %error, "Outgoing connection error");
+
+                // Attribute the failure to specific addresses where DialError
+                // gives us that detail. Three variants carry addresses:
+                //   - LocalPeerId { address }: we dialed our own peer id at
+                //     that address; whoever advertised it for this peer was
+                //     wrong, so evict.
+                //   - WrongPeerId { address, .. }: the peer at that address
+                //     turned out to have a different identity; same idea.
+                //   - Transport(Vec<(addr, err)>): each address we tried in
+                //     this dial, with the transport-level error per attempt.
+                // Other variants (NoAddresses, Aborted, Denied, DialPeer
+                // ConditionFalse) don't pin the failure to an address, so
+                // there's nothing to attribute.
                 if let Some(peer_id) = peer_id {
+                    let failed_addrs: Vec<&Multiaddr> = match &error {
+                        DialError::LocalPeerId { address }
+                        | DialError::WrongPeerId { address, .. } => vec![address],
+                        DialError::Transport(attempts) => {
+                            attempts.iter().map(|(addr, _)| addr).collect()
+                        }
+                        _ => vec![],
+                    };
+                    for addr in failed_addrs {
+                        let _ = self.discovery.state.record_dial_failure(&peer_id, addr);
+                    }
+
                     if let Some(sender) = self.pending_dial.remove(&peer_id) {
                         let _ignored = sender.send(Err(eyre!(error)));
                     }

--- a/crates/network/src/handlers/stream/swarm/identify.rs
+++ b/crates/network/src/handlers/stream/swarm/identify.rs
@@ -16,6 +16,7 @@ impl EventHandler<Event> for NetworkManager {
             peer_id,
             info:
                 Info {
+                    listen_addrs,
                     observed_addr,
                     protocols,
                     ..
@@ -26,6 +27,25 @@ impl EventHandler<Event> for NetworkManager {
             self.discovery
                 .state
                 .update_peer_protocols(&peer_id, &protocols);
+
+            // Mirror the peer's declared listen addresses into our local
+            // address book. Without this, we only ever learn an address
+            // when a dial to it succeeds and ConnectionEstablished fires —
+            // so a peer that advertises three addresses but only one
+            // happens to work first would shrink to one entry in our
+            // book, leaving us no fallback when that address dies.
+            //
+            // Filter out relayed addresses (`/p2p-circuit/`); they aren't
+            // useful as direct-dial entries and the rendezvous-tick redial
+            // loop would just waste attempts on them. Filter out our own
+            // observed address (sometimes echoed back); it's about us, not
+            // the peer.
+            for addr in &listen_addrs {
+                let is_relayed = addr.iter().any(|p| matches!(p, Protocol::P2pCircuit));
+                if !is_relayed && addr != &observed_addr {
+                    self.discovery.state.add_peer_addr(peer_id, addr);
+                }
+            }
 
             if let Some(advertise_address) = &self.discovery.advertise {
                 let is_external_addr = observed_addr


### PR DESCRIPTION
## What

Three independent fixes to `DiscoveryState`'s per-peer address tracking, all of which directly improve the quality of relay-reservation recovery (which landed in #2446). Closes #2448.

The `RendezvousTick` handler iterates `peer_info.addrs()` and re-dials every entry to reach disconnected peers. Without these fixes, the book accumulates stale addresses that waste dial attempts, misses addresses for inbound peers entirely, and ignores most of what the network actually tells us via identify.

## The three fixes

### 1. Address eviction (`HashMap<Multiaddr, u8>`)

`PeerInfo.addrs` was a `HashSet<Multiaddr>` with no removal path except whole-peer eviction in `ConnectionClosed` — which is gated to skip relay, rendezvous, and mDNS peers, the three categories most likely to have rotating addresses. So a peer that rotated its IP five times left five entries in the book, four dead; every rendezvous tick re-dialed all five and paid a TCP timeout per dead one.

Switched to `HashMap<Multiaddr, u8>`, where the value is consecutive dial failures.

- `add_peer_addr` inserts or resets to zero (fresh identify push, successful connection, etc.)
- New `record_dial_failure` increments and evicts at `DIAL_FAILURE_EVICTION_THRESHOLD = 3`
- Called from `OutgoingConnectionError`, which extracts per-address detail from `DialError` (`LocalPeerId`, `WrongPeerId`, `Transport`)

Threshold of 3 chosen to absorb one or two transient flakes without dragging permanently broken addresses through many tick cycles.

**Design alternative considered**: TTL-based eviction (`Instant` per address, prune after N hours). Rejected because a healthy long-online peer (Fran's stable home IP) would get evicted from quiet peers' books even though it's working fine. Failure-count keeps "addresses that work" forever and removes "addresses that don't" promptly — exactly the right semantics.

### 2. Inbound peer addresses now recorded

Before:
```rust
if let ConnectedPoint::Dialer { .. } = endpoint {
    self.discovery.state.add_peer_addr(peer_id, endpoint.get_remote_address());
}
```

If a remote peer dialed us first, their `send_back_addr` was logged but never stored. The `RendezvousTick` re-dial loop had nothing to iterate when that connection closed.

After: `add_peer_addr` moved out of the `Dialer`-only guard. Skip relayed multiaddrs (`/p2p-circuit/...`) so we don't pollute the book with addresses that can't be dialed directly.

### 3. Identify-reported listen addresses now mirrored

`identify::Event::Received` carries the peer's own `listen_addrs`. The handler used `protocols` and `observed_addr` (for our own external-address detection) but threw away `listen_addrs`. libp2p's internal Kademlia store ingested them; core's `discovery.state` didn't — and the `RendezvousTick` consumer reads `discovery.state`.

After: iterate `info.listen_addrs` in the identify handler and call `add_peer_addr` for each. Same `/p2p-circuit/` filter. Also skip `observed_addr` (the peer echoed back our own external address; that's about us, not them).

## Why this matters for #2446's recovery

The relay-recovery code in #2446 calls `swarm.dial(addr)` for the recovered relay's stored address. If that address is stale (rotated by ISP, no longer routable), the dial fails and recovery can't complete. Without these fixes:

- A new IP that the peer advertised via identify isn't in our book → no fallback.
- A new IP that we observed via an inbound dial isn't in our book → no fallback.
- A dead old IP that we last connected to a week ago is still in our book → wasted dial attempts.

After these fixes, the rendezvous-tick re-dial cycles efficiently through a current, bounded set of addresses for each peer.

## Tests

Six new unit tests in `crates/network/src/discovery/state_tests.rs`:

- `add_peer_addr` initialises counter at zero
- `add_peer_addr` resets counter on re-insert
- `record_dial_failure` evicts at threshold
- `record_dial_failure` is no-op for unknown peer / address
- Successful dial after failures resets the counter
- Per-address failure counts are independent

Existing tests touching `PeerInfo.addrs` updated for the `HashMap` shape.

```
test result: ok. 18 passed; 0 failed (network unit)
test result: ok. 1 passed; 0 failed (gossipsub_group_topic)
test result: ok. 1 passed; 0 failed (kad_modes)
test result: ok. 3 passed; 0 failed (relay_recovery)
```

`cargo fmt --check` clean. `cargo clippy -p calimero-network --tests` clean.

## Out of scope

- **Integration test for the eviction path** end-to-end (via MockRelay or merobox). MockRelay only tests relay-side behaviour; a multi-client mock could verify eviction in practice but doesn't exist yet. Acceptable here because the unit tests cover the state machine and the event-handler wiring is mechanical (single match arm + method call per event).
- **`ListenerClosed` with empty addresses** — tracked separately in #2456. Needs `ListenerId → relay_peer` tracking in `DiscoveryState`, a different change.

## Related

- #2446 — relay reservation recovery (this PR improves its dial success rate)
- #2447 — network resilience test plan
- #2448 — this issue
- #2456 — `ListenerClosed` empty-addresses production gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer address tracking and dial failure handling in the libp2p swarm event loop, which can affect connectivity and recovery behavior if the new eviction/filters misclassify addresses. Scope is contained to discovery state and event handlers with added unit coverage.
> 
> **Overview**
> Improves peer address-book quality used for re-dial/recovery by **tracking per-address dial failures and evicting stale entries**. `PeerInfo.addrs` is changed from `HashSet<Multiaddr>` to `HashMap<Multiaddr, u8>`, `add_peer_addr` now (re)inserts with a zeroed counter, and new `record_dial_failure` increments/evicts at `DIAL_FAILURE_EVICTION_THRESHOLD`.
> 
> Updates swarm handlers to **populate and maintain the address book more reliably**: `ConnectionEstablished` now records remote addresses for inbound and outbound connections (excluding `/p2p-circuit/` relayed addrs), `OutgoingConnectionError` attributes `DialError` failures to specific attempted addresses and records them for eviction, and the identify handler mirrors peers’ `listen_addrs` into the book (filtering relayed addrs and `observed_addr`). Adds/updates unit tests covering counter reset, eviction threshold, no-op cases, and per-address independence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70f3c6355c921eaa7b7593f8cda22aabe60f929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->