### PR TITLE
fix(network): track relay reservations by ListenerId for ListenerClosed recovery

### DIFF
--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -309,7 +309,15 @@ impl NetworkManager {
             }
         };
 
-        let _ = self.swarm.listen_on(relayed_addr)?;
+        let listener_id = self.swarm.listen_on(relayed_addr)?;
+
+        // Record the listener id so the ListenerClosed handler can route
+        // recovery back to this relay peer even if the close event comes
+        // with an empty `addresses` list (the quota-denied-before-address-
+        // allocation case).
+        self.discovery
+            .state
+            .record_relay_listener(listener_id, *relay_peer);
 
         self.discovery
             .state

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -7,13 +7,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Instant;
 
-/// Consecutive-failure threshold at which an address is evicted from a
-/// peer's address book. Three is chosen as a small magic number that
-/// tolerates transient flakiness (one bad TCP retransmit, one identify
-/// race) without keeping a permanently broken address around long enough
-/// to waste many rendezvous-tick dial attempts.
-pub(crate) const DIAL_FAILURE_EVICTION_THRESHOLD: u8 = 3;
-
+use libp2p::core::transport::ListenerId;
 use libp2p::relay::HOP_PROTOCOL_NAME;
 use libp2p::rendezvous::Cookie;
 use libp2p::{Multiaddr, PeerId, StreamProtocol};
@@ -23,6 +17,13 @@ use tracing::info;
 // The rendezvous protocol name is not public in libp2p, so we have to define it here.
 // source: https://github.com/libp2p/rust-libp2p/blob/a8888a7978f08ec9b8762207bf166193bf312b94/protocols/rendezvous/src/lib.rs#L50C12-L50C92
 const RENDEZVOUS_PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/rendezvous/1.0.0");
+
+/// Consecutive-failure threshold at which an address is evicted from a
+/// peer's address book. Three is chosen as a small magic number that
+/// tolerates transient flakiness (one bad TCP retransmit, one identify
+/// race) without keeping a permanently broken address around long enough
+/// to waste many rendezvous-tick dial attempts.
+pub(crate) const DIAL_FAILURE_EVICTION_THRESHOLD: u8 = 3;
 
 /// DiscoveryState is a struct that holds the state of the disovered peers.
 /// It holds the relay and rendezvous indexes to quickly check if a peer is a relay or rendezvous.
@@ -34,6 +35,14 @@ pub struct DiscoveryState {
     rendezvous_index: BTreeSet<PeerId>,
     autonat_index: BTreeSet<PeerId>,
     confirmed_external_addresses: HashSet<Multiaddr>,
+    /// Maps each libp2p relayed listener back to the relay peer it was
+    /// opened against. Populated by `create_relay_reservation` when it
+    /// calls `listen_on(<relay>/p2p-circuit/<self>)` and gets back a
+    /// `ListenerId`. Looked up by the `ListenerClosed` swarm handler so
+    /// it can route the recovery action even when the closed listener's
+    /// `addresses` list is empty (e.g. quota denial before address
+    /// allocation).
+    relay_listeners: HashMap<ListenerId, PeerId>,
     reachability_state: ReachabilityState,
 }
 
@@ -52,6 +61,7 @@ impl Default for DiscoveryState {
             rendezvous_index: BTreeSet::new(),
             autonat_index: BTreeSet::new(),
             confirmed_external_addresses: HashSet::new(),
+            relay_listeners: HashMap::new(),
             reachability_state: ReachabilityState::Unknown,
         }
     }
@@ -256,6 +266,30 @@ impl DiscoveryState {
             .peers
             .entry(*rendezvous_peer)
             .and_modify(|info| info.update_rendezvous_cookie(cookie.clone()));
+    }
+
+    /// Remember that `listener_id` was opened against `relay_peer` as a
+    /// relayed listener. The ListenerClosed handler uses this to route
+    /// recovery for the quota-denied case where libp2p tears the listener
+    /// down before any external address is ever attached — leaving
+    /// `addresses` empty in the event and the address-iteration fallback
+    /// with nothing to act on.
+    pub(crate) fn record_relay_listener(&mut self, listener_id: ListenerId, relay_peer: PeerId) {
+        let _ = self.relay_listeners.insert(listener_id, relay_peer);
+    }
+
+    /// Look up the relay peer associated with a libp2p listener id.
+    /// Returns `None` if the listener wasn't registered by
+    /// `record_relay_listener` (e.g. a non-relay TCP/QUIC listener).
+    pub(crate) fn relay_peer_for_listener(&self, listener_id: &ListenerId) -> Option<PeerId> {
+        self.relay_listeners.get(listener_id).copied()
+    }
+
+    /// Drop the listener-id → relay-peer mapping. Called from
+    /// `ListenerClosed` once the recovery action has been queued, so the
+    /// map doesn't grow unbounded across many reservation cycles.
+    pub(crate) fn forget_relay_listener(&mut self, listener_id: &ListenerId) {
+        let _ = self.relay_listeners.remove(listener_id);
     }
 
     pub(crate) fn update_relay_reservation_status(

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -278,18 +278,20 @@ impl DiscoveryState {
         let _ = self.relay_listeners.insert(listener_id, relay_peer);
     }
 
-    /// Look up the relay peer associated with a libp2p listener id.
-    /// Returns `None` if the listener wasn't registered by
-    /// `record_relay_listener` (e.g. a non-relay TCP/QUIC listener).
-    pub(crate) fn relay_peer_for_listener(&self, listener_id: &ListenerId) -> Option<PeerId> {
-        self.relay_listeners.get(listener_id).copied()
-    }
-
-    /// Drop the listener-id → relay-peer mapping. Called from
-    /// `ListenerClosed` once the recovery action has been queued, so the
-    /// map doesn't grow unbounded across many reservation cycles.
-    pub(crate) fn forget_relay_listener(&mut self, listener_id: &ListenerId) {
-        let _ = self.relay_listeners.remove(listener_id);
+    /// Remove and return the relay peer associated with a libp2p listener
+    /// id. Returns `None` if the listener wasn't registered (a non-relay
+    /// TCP/QUIC listener, or a relayed listener opened outside
+    /// `create_relay_reservation`).
+    ///
+    /// Combines lookup and cleanup in one call so the caller cannot
+    /// accidentally leave a stale entry behind on any code path. This
+    /// matters because the `ListenerClosed` handler falls through to an
+    /// addresses-iteration fallback when the lookup misses; a
+    /// lookup-then-conditional-forget shape would leak entries for
+    /// listeners that were registered but somehow took the fallback
+    /// path. With `take_relay_listener`, the map mutation always happens.
+    pub(crate) fn take_relay_listener(&mut self, listener_id: &ListenerId) -> Option<PeerId> {
+        self.relay_listeners.remove(listener_id)
     }
 
     pub(crate) fn update_relay_reservation_status(

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -551,15 +551,16 @@ fn test_independent_addresses_track_failures_separately() {
 }
 
 #[test]
-fn test_record_and_lookup_relay_listener() {
+fn test_take_relay_listener_returns_recorded_peer_and_removes_entry() {
     let mut state = DiscoveryState::default();
     let relay = PeerId::random();
     let listener = ListenerId::next();
 
-    assert_eq!(state.relay_peer_for_listener(&listener), None);
-
     state.record_relay_listener(listener, relay);
-    assert_eq!(state.relay_peer_for_listener(&listener), Some(relay));
+    assert_eq!(state.take_relay_listener(&listener), Some(relay));
+
+    // Second take returns None — the entry was removed.
+    assert_eq!(state.take_relay_listener(&listener), None);
 }
 
 #[test]
@@ -570,35 +571,20 @@ fn test_record_relay_listener_overwrites_existing_entry() {
     let listener = ListenerId::next();
 
     state.record_relay_listener(listener, relay_a);
-    // Same listener id reused (would be unusual in practice but the API
-    // must be consistent): the latest registration wins.
+    // Same listener id reused (unusual but the API must be consistent):
+    // the latest registration wins.
     state.record_relay_listener(listener, relay_b);
 
-    assert_eq!(state.relay_peer_for_listener(&listener), Some(relay_b));
+    assert_eq!(state.take_relay_listener(&listener), Some(relay_b));
 }
 
 #[test]
-fn test_forget_relay_listener_removes_entry() {
-    let mut state = DiscoveryState::default();
-    let relay = PeerId::random();
-    let listener = ListenerId::next();
-
-    state.record_relay_listener(listener, relay);
-    assert_eq!(state.relay_peer_for_listener(&listener), Some(relay));
-
-    state.forget_relay_listener(&listener);
-    assert_eq!(state.relay_peer_for_listener(&listener), None);
-}
-
-#[test]
-fn test_forget_relay_listener_is_noop_for_unknown_id() {
+fn test_take_relay_listener_is_noop_for_unknown_id() {
     let mut state = DiscoveryState::default();
     let unknown = ListenerId::next();
 
-    // Forgetting an id we never recorded must not panic and must leave
-    // the state unchanged.
-    state.forget_relay_listener(&unknown);
-    assert_eq!(state.relay_peer_for_listener(&unknown), None);
+    // Taking an id we never recorded must not panic and must return None.
+    assert_eq!(state.take_relay_listener(&unknown), None);
 }
 
 #[test]
@@ -612,11 +598,8 @@ fn test_multiple_listeners_map_to_distinct_relays() {
     state.record_relay_listener(listener_a, relay_a);
     state.record_relay_listener(listener_b, relay_b);
 
-    assert_eq!(state.relay_peer_for_listener(&listener_a), Some(relay_a));
-    assert_eq!(state.relay_peer_for_listener(&listener_b), Some(relay_b));
-
-    // Forgetting one leaves the other intact.
-    state.forget_relay_listener(&listener_a);
-    assert_eq!(state.relay_peer_for_listener(&listener_a), None);
-    assert_eq!(state.relay_peer_for_listener(&listener_b), Some(relay_b));
+    // Taking one leaves the other intact.
+    assert_eq!(state.take_relay_listener(&listener_a), Some(relay_a));
+    assert_eq!(state.take_relay_listener(&listener_a), None);
+    assert_eq!(state.take_relay_listener(&listener_b), Some(relay_b));
 }

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -549,3 +549,74 @@ fn test_independent_addresses_track_failures_separately() {
     assert!(state.peers[&peer].addrs.contains_key(&addr_b));
     assert_eq!(state.peers[&peer].addrs[&addr_b], 0);
 }
+
+#[test]
+fn test_record_and_lookup_relay_listener() {
+    let mut state = DiscoveryState::default();
+    let relay = PeerId::random();
+    let listener = ListenerId::next();
+
+    assert_eq!(state.relay_peer_for_listener(&listener), None);
+
+    state.record_relay_listener(listener, relay);
+    assert_eq!(state.relay_peer_for_listener(&listener), Some(relay));
+}
+
+#[test]
+fn test_record_relay_listener_overwrites_existing_entry() {
+    let mut state = DiscoveryState::default();
+    let relay_a = PeerId::random();
+    let relay_b = PeerId::random();
+    let listener = ListenerId::next();
+
+    state.record_relay_listener(listener, relay_a);
+    // Same listener id reused (would be unusual in practice but the API
+    // must be consistent): the latest registration wins.
+    state.record_relay_listener(listener, relay_b);
+
+    assert_eq!(state.relay_peer_for_listener(&listener), Some(relay_b));
+}
+
+#[test]
+fn test_forget_relay_listener_removes_entry() {
+    let mut state = DiscoveryState::default();
+    let relay = PeerId::random();
+    let listener = ListenerId::next();
+
+    state.record_relay_listener(listener, relay);
+    assert_eq!(state.relay_peer_for_listener(&listener), Some(relay));
+
+    state.forget_relay_listener(&listener);
+    assert_eq!(state.relay_peer_for_listener(&listener), None);
+}
+
+#[test]
+fn test_forget_relay_listener_is_noop_for_unknown_id() {
+    let mut state = DiscoveryState::default();
+    let unknown = ListenerId::next();
+
+    // Forgetting an id we never recorded must not panic and must leave
+    // the state unchanged.
+    state.forget_relay_listener(&unknown);
+    assert_eq!(state.relay_peer_for_listener(&unknown), None);
+}
+
+#[test]
+fn test_multiple_listeners_map_to_distinct_relays() {
+    let mut state = DiscoveryState::default();
+    let relay_a = PeerId::random();
+    let relay_b = PeerId::random();
+    let listener_a = ListenerId::next();
+    let listener_b = ListenerId::next();
+
+    state.record_relay_listener(listener_a, relay_a);
+    state.record_relay_listener(listener_b, relay_b);
+
+    assert_eq!(state.relay_peer_for_listener(&listener_a), Some(relay_a));
+    assert_eq!(state.relay_peer_for_listener(&listener_b), Some(relay_b));
+
+    // Forgetting one leaves the other intact.
+    state.forget_relay_listener(&listener_a);
+    assert_eq!(state.relay_peer_for_listener(&listener_a), None);
+    assert_eq!(state.relay_peer_for_listener(&listener_b), Some(relay_b));
+}

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -219,18 +219,23 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                 // The addresses-iteration fallback below would silently
                 // miss that case.
                 //
-                // Fall back to iterating addresses for listeners we did
+                // `take_relay_listener` removes the entry as it returns
+                // the peer, so the map cannot leak entries across
+                // reservation cycles regardless of which branch handles
+                // the close event.
+                //
+                // The fallback iterates addresses for listeners we did
                 // not register ourselves (defensive — covers any future
                 // code path that calls listen_on with a relayed multiaddr
-                // outside create_relay_reservation).
+                // outside create_relay_reservation). It does not need to
+                // clean the map: by definition the map had no entry to
+                // clean.
                 //
                 // The swarm typically also emits ExternalAddrExpired for
                 // the same address, so the second call into
                 // on_relay_reservation_lost will be a no-op (status
                 // already Expired).
-                if let Some(relay_peer) = self.discovery.state.relay_peer_for_listener(&listener_id)
-                {
-                    self.discovery.state.forget_relay_listener(&listener_id);
+                if let Some(relay_peer) = self.discovery.state.take_relay_listener(&listener_id) {
                     let actions = self.discovery.state.on_relay_reservation_lost(&relay_peer);
                     self.execute_reachability_actions(actions);
                 } else {

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -197,22 +197,51 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                 trace!("Expired listen address: {}", address);
             }
             SwarmEvent::ListenerClosed {
-                addresses, reason, ..
+                listener_id,
+                addresses,
+                reason,
+                ..
             } => {
-                trace!("Listener closed: {:?} {:?}", addresses, reason.err());
+                trace!(
+                    ?listener_id,
+                    ?addresses,
+                    error = ?reason.err(),
+                    "Listener closed"
+                );
 
-                // If a relayed listener closed, trigger recovery once per
-                // distinct relay peer. The swarm typically also emits an
-                // ExternalAddrExpired for the same address, so the second
-                // call into on_relay_reservation_lost will be a no-op
-                // (status already Expired).
-                for address in &addresses {
-                    if let Ok(relayed_addr) = RelayedMultiaddr::try_from(address) {
-                        let actions = self
-                            .discovery
-                            .state
-                            .on_relay_reservation_lost(relayed_addr.relay_peer_id());
-                        self.execute_reachability_actions(actions);
+                // Prefer the registered listener-id mapping: when
+                // create_relay_reservation calls listen_on, we record the
+                // returned ListenerId against the relay peer. This routes
+                // recovery correctly even when libp2p emits
+                // ListenerClosed with `addresses: []` — which it does when
+                // the relay denies a reservation before any external
+                // address gets allocated (e.g. quota wall, rate limit).
+                // The addresses-iteration fallback below would silently
+                // miss that case.
+                //
+                // Fall back to iterating addresses for listeners we did
+                // not register ourselves (defensive — covers any future
+                // code path that calls listen_on with a relayed multiaddr
+                // outside create_relay_reservation).
+                //
+                // The swarm typically also emits ExternalAddrExpired for
+                // the same address, so the second call into
+                // on_relay_reservation_lost will be a no-op (status
+                // already Expired).
+                if let Some(relay_peer) = self.discovery.state.relay_peer_for_listener(&listener_id)
+                {
+                    self.discovery.state.forget_relay_listener(&listener_id);
+                    let actions = self.discovery.state.on_relay_reservation_lost(&relay_peer);
+                    self.execute_reachability_actions(actions);
+                } else {
+                    for address in &addresses {
+                        if let Ok(relayed_addr) = RelayedMultiaddr::try_from(address) {
+                            let actions = self
+                                .discovery
+                                .state
+                                .on_relay_reservation_lost(relayed_addr.relay_peer_id());
+                            self.execute_reachability_actions(actions);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What

Closes #2456. Tracks relay reservations by `ListenerId` so the `ListenerClosed` handler can route recovery even when the closed listener's `addresses` field is empty.

## The bug

In `handlers/stream/swarm.rs`, the `ListenerClosed` handler iterates over the closed listener's `addresses`:

```rust
for address in &addresses {
    if let Ok(relayed_addr) = RelayedMultiaddr::try_from(address) {
        let actions = self.discovery.state.on_relay_reservation_lost(...);
        self.execute_reachability_actions(actions);
    }
}
```

When the relay denies a reservation **before** an external address is allocated — most commonly at renewal time when the quota is full, but also rate-limit hits and validation rejections — libp2p emits `ListenerClosed { addresses: [], reason: Err(...) }`. The for-loop runs zero times. `on_relay_reservation_lost` never fires. The peer's reservation status stays `Requested` in `DiscoveryState`. `is_relay_reservation_required` keeps counting it as active. The system never retries until process restart.

Surfaced by [meroreviewer finding `4c2d83ee`](https://github.com/calimero-network/core/pull/2454#pullrequestreview-...) during #2454 review, filed as #2456.

## The fix

Three new `pub(crate)` methods on `DiscoveryState`:

- `record_relay_listener(ListenerId, PeerId)` — called by `create_relay_reservation` after a successful `listen_on`
- `relay_peer_for_listener(&ListenerId) -> Option<PeerId>` — called by the `ListenerClosed` handler
- `forget_relay_listener(&ListenerId)` — called once the recovery action has been queued, so the map doesn't grow

Backed by a new `relay_listeners: HashMap<ListenerId, PeerId>` field in `DiscoveryState` (using `HashMap` because libp2p's `ListenerId` does not implement `Ord`).

`create_relay_reservation` records the listener id immediately after `listen_on`:

```rust
let listener_id = self.swarm.listen_on(relayed_addr)?;
self.discovery.state.record_relay_listener(listener_id, *relay_peer);
self.discovery.state.update_relay_reservation_status(relay_peer, RelayReservationStatus::Requested);
```

The `ListenerClosed` handler prefers the new lookup; falls back to the existing addresses-iteration path for listeners opened outside `create_relay_reservation` (defensive — covers any future code path that opens a relayed listener elsewhere):

```rust
if let Some(relay_peer) = self.discovery.state.relay_peer_for_listener(&listener_id) {
    self.discovery.state.forget_relay_listener(&listener_id);
    let actions = self.discovery.state.on_relay_reservation_lost(&relay_peer);
    self.execute_reachability_actions(actions);
} else {
    // existing addresses-iteration fallback
}
```

## Tests

Five new unit tests in `crates/network/src/discovery/state_tests.rs`:

- `test_record_and_lookup_relay_listener` — happy path
- `test_record_relay_listener_overwrites_existing_entry` — re-registering the same id wins-latest
- `test_forget_relay_listener_removes_entry` — forget + re-lookup returns None
- `test_forget_relay_listener_is_noop_for_unknown_id` — defensive
- `test_multiple_listeners_map_to_distinct_relays` — independent tracking

```
test result: ok. 23 passed; 0 failed (network unit)
test result: ok. 1 passed; 0 failed (gossipsub_group_topic)
test result: ok. 1 passed; 0 failed (kad_modes)
test result: ok. 3 passed; 0 failed (relay_recovery)
```

`cargo fmt --check` clean. `cargo clippy -p calimero-network --tests` clean.

## Drive-by tidy

Moves the `DIAL_FAILURE_EVICTION_THRESHOLD` const (added in #2459) below the libp2p imports to match the placement of `RENDEZVOUS_PROTOCOL_NAME`. The previous placement was between two `use` groups, which is inconsistent with how the file otherwise orders items.

## Why no integration test in this PR

A genuine integration test for this path would need the `MockRelay` testkit to spawn a relay configured to deny a reservation before any external address is allocated (i.e. set `max_reservations: 0` or trigger a rate limiter immediately), then drive the production `NetworkManager` actor and assert on its state. That requires the `NetworkManager` actor harness that was deferred during #2454, plus a `MockRelay` extension. Both are out of scope here.

The unit tests cover the new state-machine surface. The handler wiring is a single match arm + method call — the same shape the rest of the recovery code uses, all of which is exercised by the existing `MockRelay` integration tests.

## Related

- #2446 — relay reservation recovery (this PR closes a gap in its `ListenerClosed` branch)
- #2454 — MockRelay testkit (where the gap was surfaced)
- #2456 — this issue
- #2459 — address-book hygiene (previous follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay reservation recovery in the libp2p swarm event handler; mis-tracking `ListenerId`→relay mappings could cause missed retries or unnecessary re-reservations, but the change is localized and unit-tested.
> 
> **Overview**
> Fixes a relay-reservation recovery gap by **tracking relayed listeners by `ListenerId`** so `SwarmEvent::ListenerClosed` can trigger `on_relay_reservation_lost` even when libp2p reports `addresses: []` (e.g. reservation denied before any external address is allocated).
> 
> `create_relay_reservation` now records the `ListenerId` returned by `listen_on`, `DiscoveryState` gains a `relay_listeners` map with `record_relay_listener`/`take_relay_listener`, and the `ListenerClosed` handler prefers this mapping with an addresses-based fallback; new unit tests cover the listener mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc57ecfc86af0562793975667195e24562aa71fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->