### PR TITLE
fix(node/sync): warn when SyncSessionResult arrives for unknown context (closes #2445)

### DIFF
--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -261,9 +261,30 @@ impl SessionTracker {
     /// updates `SyncState`. Logs preserved verbatim from the
     /// pre-extraction `apply_session_result` body so log-grep-based
     /// regression detection still works.
+    ///
+    /// Defensive: emits a `warn!` if no `SyncState` entry exists for
+    /// the result's `context_id`. This should never happen in
+    /// practice — `record_dispatch_succeeded` always inserts an
+    /// in-progress entry before a session can produce a result — so
+    /// a hit here indicates one of (a) the dispatch-tracking path
+    /// skipped `record_dispatch_succeeded`, (b) cross-actor routing
+    /// delivered a result for the wrong `context_id`, or (c)
+    /// external code cleared the state map mid-session. Without the
+    /// warn, those bugs are silently swallowed by `and_modify`'s
+    /// no-op-on-missing-entry behaviour.
     pub(super) fn apply_result(&mut self, result: SyncSessionResult) {
         let _removed = self.last_dispatch_attempt.remove(&result.context_id);
         let _removed = self.initiator_dispatched_at.remove(&result.context_id);
+
+        if !self.state.contains_key(&result.context_id) {
+            warn!(
+                context_id = %result.context_id,
+                peer_id = %result.peer_id,
+                took = ?result.took,
+                "SyncSessionResult arrived for context with no tracked SyncState — \
+                 dispatch-tracking inconsistency or external state mutation (logic bug, #2445)"
+            );
+        }
 
         let SyncSessionResult {
             context_id,
@@ -707,6 +728,37 @@ mod tests {
             0,
             "PeerNotMaterialized must not count as failure"
         );
+    }
+
+    #[test]
+    fn apply_result_with_missing_state_does_not_panic_or_create_entry() {
+        // #2445 defensive-warn invariant: a `SyncSessionResult`
+        // arriving for a context with no tracked `SyncState` must
+        // (a) not panic, (b) not silently create a state entry, and
+        // (c) clear any backoff / wedge timers that may exist for
+        // the context (they shouldn't either, but the clears are
+        // idempotent on absent keys).
+        //
+        // The accompanying `warn!` log fires inside `apply_result`
+        // and is the operator-visible signal that the dispatch-
+        // tracking invariant was violated; this test exercises the
+        // state side-effects.
+        let mut t = tracker();
+        assert!(
+            !t.state.contains_key(&ctx(1)),
+            "precondition: no state entry for ctx(1)"
+        );
+
+        t.apply_result(ok_result(ctx(1)));
+
+        assert!(
+            !t.state.contains_key(&ctx(1)),
+            "apply_result must NOT create a state entry on missing-state path \
+             (and_modify's behaviour must be preserved)"
+        );
+        // Timers are removed unconditionally; verify they're still absent.
+        assert!(!t.last_dispatch_attempt.contains_key(&ctx(1)));
+        assert!(!t.initiator_dispatched_at.contains_key(&ctx(1)));
     }
 
     // -----------------------------------------------------------------

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -278,8 +278,8 @@ impl SessionTracker {
     /// logged on this path — backtraces and peer-internal error
     /// text don't belong in a defensive observability surface.
     pub(super) fn apply_result(&mut self, result: SyncSessionResult) {
-        let _removed = self.last_dispatch_attempt.remove(&result.context_id);
-        let _removed = self.initiator_dispatched_at.remove(&result.context_id);
+        let _dispatch_attempt_removed = self.last_dispatch_attempt.remove(&result.context_id);
+        let _wedge_timer_removed = self.initiator_dispatched_at.remove(&result.context_id);
 
         let SyncSessionResult {
             context_id,
@@ -290,22 +290,25 @@ impl SessionTracker {
 
         match self.state.get_mut(&context_id) {
             None => {
-                // Log only the result discriminant — not the inner
-                // `eyre::Report` debug, which can carry backtraces /
-                // peer-internal error text and would leak into log
-                // aggregators on a path that's purely defensive. The
-                // three buckets are enough to triage which kind of
-                // inconsistency fired.
-                let result_variant = match &result {
-                    Ok(Ok(_)) => "success",
-                    Ok(Err(_)) => "sync_error",
-                    Err(_) => "timeout",
+                // Log the result discriminant + Display-only error
+                // summary — never the `eyre::Report` Debug, which
+                // can carry backtraces (`RUST_BACKTRACE=1`) and would
+                // leak into log aggregators on a path that's purely
+                // defensive. The discriminant tells the operator
+                // which arm fired; the Display string gives the
+                // top-level error message for the failure arms
+                // without dragging in the source chain.
+                let (result_variant, error_summary) = match &result {
+                    Ok(Ok(_)) => ("success", None),
+                    Ok(Err(err)) => ("sync_error", Some(err.to_string())),
+                    Err(timeout_err) => ("timeout", Some(timeout_err.to_string())),
                 };
                 warn!(
                     %context_id,
                     %peer_id,
                     ?took,
                     result_variant,
+                    error_summary = error_summary.as_deref(),
                     "SyncSessionResult arrived for context with no tracked SyncState — \
                      dispatch-tracking inconsistency or external state mutation (logic bug)"
                 );

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -258,33 +258,26 @@ impl SessionTracker {
 
     /// Apply a `SyncSessionResult` from the result channel. Clears
     /// the dispatch-attempt + wedge timers for the context, then
-    /// updates `SyncState`. Logs preserved verbatim from the
-    /// pre-extraction `apply_session_result` body so log-grep-based
-    /// regression detection still works.
+    /// updates `SyncState`. The per-arm `info!` / `warn!` / `debug!`
+    /// calls inside the `Some(s)` branch are the operator-visible
+    /// signals for sync outcomes; their fields and wording have
+    /// stayed stable across the run-loop extractions so log-grep
+    /// filters keep matching.
     ///
-    /// Defensive: emits a `warn!` if no `SyncState` entry exists for
-    /// the result's `context_id`. This should never happen in
-    /// practice — `record_dispatch_succeeded` always inserts an
-    /// in-progress entry before a session can produce a result — so
-    /// a hit here indicates one of (a) the dispatch-tracking path
-    /// skipped `record_dispatch_succeeded`, (b) cross-actor routing
+    /// The `None` branch is defensive: `record_dispatch_succeeded`
+    /// always inserts an in-progress entry before a session can
+    /// produce a result, so a result for an untracked context
+    /// indicates one of (a) the dispatch-tracking path skipped
+    /// `record_dispatch_succeeded`, (b) cross-actor routing
     /// delivered a result for the wrong `context_id`, or (c)
-    /// external code cleared the state map mid-session. Without the
-    /// warn, those bugs are silently swallowed by `and_modify`'s
-    /// no-op-on-missing-entry behaviour.
+    /// external code cleared the state map mid-session. Without
+    /// the warn, those bugs would be silently swallowed; with it,
+    /// operators see the inconsistency and the inner result variant
+    /// is included so they can correlate it back to the originating
+    /// dispatch.
     pub(super) fn apply_result(&mut self, result: SyncSessionResult) {
         let _removed = self.last_dispatch_attempt.remove(&result.context_id);
         let _removed = self.initiator_dispatched_at.remove(&result.context_id);
-
-        if !self.state.contains_key(&result.context_id) {
-            warn!(
-                context_id = %result.context_id,
-                peer_id = %result.peer_id,
-                took = ?result.took,
-                "SyncSessionResult arrived for context with no tracked SyncState — \
-                 dispatch-tracking inconsistency or external state mutation (logic bug, #2445)"
-            );
-        }
 
         let SyncSessionResult {
             context_id,
@@ -293,59 +286,71 @@ impl SessionTracker {
             result,
         } = result;
 
-        let _ignored = self.state.entry(context_id).and_modify(|s| match result {
-            Ok(Ok(ref protocol)) => {
-                s.on_success(peer_id, TrackingSyncProtocol::from(protocol));
-                info!(
+        match self.state.get_mut(&context_id) {
+            None => {
+                warn!(
                     %context_id,
+                    %peer_id,
                     ?took,
-                    ?protocol,
-                    success_count = s.success_count,
-                    "Sync finished successfully"
+                    ?result,
+                    "SyncSessionResult arrived for context with no tracked SyncState — \
+                     dispatch-tracking inconsistency or external state mutation (logic bug)"
                 );
             }
-            Ok(Err(ref err)) => {
-                // #2422 Option 4: PeerNotMaterialized is benign — the
-                // responder told us they're a valid namespace peer
-                // that simply hasn't joined this context. Do not
-                // increment failure_count or apply backoff — doing so
-                // starves legitimate sync against other peers behind
-                // 256s exponential delays. The peer-selection filter
-                // in peers.rs::namespace-fallback already excludes
-                // non-followers up-front; this arm catches the
-                // residual race (peer in flight of materialising,
-                // mixed-version cluster, etc.).
-                if err.downcast_ref::<PeerNotMaterialized>().is_some() {
-                    debug!(
+            Some(s) => match result {
+                Ok(Ok(ref protocol)) => {
+                    s.on_success(peer_id, TrackingSyncProtocol::from(protocol));
+                    info!(
                         %context_id,
                         ?took,
-                        %peer_id,
-                        "peer has not materialised this context — \
-                         dropping for this round, not a failure"
+                        ?protocol,
+                        success_count = s.success_count,
+                        "Sync finished successfully"
                     );
-                    return;
                 }
-                s.on_failure(err.to_string());
-                warn!(
-                    %context_id,
-                    ?took,
-                    error = %err,
-                    failure_count = s.failure_count(),
-                    backoff_secs = s.backoff_delay().as_secs(),
-                    "Sync failed, applying exponential backoff"
-                );
-            }
-            Err(ref timeout_err) => {
-                s.on_failure(timeout_err.to_string());
-                warn!(
-                    %context_id,
-                    ?took,
-                    failure_count = s.failure_count(),
-                    backoff_secs = s.backoff_delay().as_secs(),
-                    "Sync timed out, applying exponential backoff"
-                );
-            }
-        });
+                Ok(Err(ref err)) => {
+                    // #2422 Option 4: PeerNotMaterialized is benign —
+                    // the responder told us they're a valid namespace
+                    // peer that simply hasn't joined this context. Do
+                    // not increment failure_count or apply backoff —
+                    // doing so starves legitimate sync against other
+                    // peers behind 256s exponential delays. The peer-
+                    // selection filter in peers.rs::namespace-fallback
+                    // already excludes non-followers up-front; this
+                    // arm catches the residual race (peer in flight
+                    // of materialising, mixed-version cluster, etc.).
+                    if err.downcast_ref::<PeerNotMaterialized>().is_some() {
+                        debug!(
+                            %context_id,
+                            ?took,
+                            %peer_id,
+                            "peer has not materialised this context — \
+                             dropping for this round, not a failure"
+                        );
+                        return;
+                    }
+                    s.on_failure(err.to_string());
+                    warn!(
+                        %context_id,
+                        ?took,
+                        error = %err,
+                        failure_count = s.failure_count(),
+                        backoff_secs = s.backoff_delay().as_secs(),
+                        "Sync failed, applying exponential backoff"
+                    );
+                }
+                Err(ref timeout_err) => {
+                    s.on_failure(timeout_err.to_string());
+                    warn!(
+                        %context_id,
+                        ?took,
+                        failure_count = s.failure_count(),
+                        backoff_secs = s.backoff_delay().as_secs(),
+                        "Sync timed out, applying exponential backoff"
+                    );
+                }
+            },
+        }
     }
 
     /// Wedge-watchdog tick. Returns contexts whose initiator was
@@ -732,17 +737,13 @@ mod tests {
 
     #[test]
     fn apply_result_with_missing_state_does_not_panic_or_create_entry() {
-        // #2445 defensive-warn invariant: a `SyncSessionResult`
-        // arriving for a context with no tracked `SyncState` must
-        // (a) not panic, (b) not silently create a state entry, and
-        // (c) clear any backoff / wedge timers that may exist for
-        // the context (they shouldn't either, but the clears are
-        // idempotent on absent keys).
-        //
-        // The accompanying `warn!` log fires inside `apply_result`
-        // and is the operator-visible signal that the dispatch-
-        // tracking invariant was violated; this test exercises the
-        // state side-effects.
+        // A `SyncSessionResult` arriving for a context with no tracked
+        // `SyncState` must (a) not panic, (b) not silently create a
+        // state entry (the `None` branch is observation-only), and (c)
+        // the unconditional dispatch / wedge timer clears at the top
+        // of `apply_result` must still run. The accompanying `warn!`
+        // is the operator-visible signal; this test covers the state
+        // side-effects.
         let mut t = tracker();
         assert!(
             !t.state.contains_key(&ctx(1)),
@@ -753,12 +754,40 @@ mod tests {
 
         assert!(
             !t.state.contains_key(&ctx(1)),
-            "apply_result must NOT create a state entry on missing-state path \
-             (and_modify's behaviour must be preserved)"
+            "apply_result must NOT create a state entry on missing-state path"
         );
         // Timers are removed unconditionally; verify they're still absent.
         assert!(!t.last_dispatch_attempt.contains_key(&ctx(1)));
         assert!(!t.initiator_dispatched_at.contains_key(&ctx(1)));
+    }
+
+    #[test]
+    fn apply_result_clears_stale_timers_on_missing_state_path() {
+        // Same anomalous path as the test above, but with
+        // pre-existing entries in both timer maps. Exercises the
+        // unconditional `remove` at the top of `apply_result`: even
+        // when state is gone, the dispatch / wedge timers for the
+        // context must be cleared (otherwise they'd persist
+        // unboundedly across the inconsistency).
+        let mut t = tracker();
+        let _ = t.last_dispatch_attempt.insert(ctx(1), Instant::now());
+        let _ = t.initiator_dispatched_at.insert(ctx(1), Instant::now());
+        assert!(!t.state.contains_key(&ctx(1)));
+
+        t.apply_result(ok_result(ctx(1)));
+
+        assert!(
+            !t.last_dispatch_attempt.contains_key(&ctx(1)),
+            "dispatch-attempt timer must be cleared even on missing-state path"
+        );
+        assert!(
+            !t.initiator_dispatched_at.contains_key(&ctx(1)),
+            "wedge timer must be cleared even on missing-state path"
+        );
+        assert!(
+            !t.state.contains_key(&ctx(1)),
+            "missing-state path must not create a state entry"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -272,9 +272,11 @@ impl SessionTracker {
     /// delivered a result for the wrong `context_id`, or (c)
     /// external code cleared the state map mid-session. Without
     /// the warn, those bugs would be silently swallowed; with it,
-    /// operators see the inconsistency and the inner result variant
-    /// is included so they can correlate it back to the originating
-    /// dispatch.
+    /// operators see the inconsistency and a short discriminant
+    /// (`success` / `sync_error` / `timeout`) tells them which
+    /// arm fired. The inner `eyre::Report` is deliberately NOT
+    /// logged on this path — backtraces and peer-internal error
+    /// text don't belong in a defensive observability surface.
     pub(super) fn apply_result(&mut self, result: SyncSessionResult) {
         let _removed = self.last_dispatch_attempt.remove(&result.context_id);
         let _removed = self.initiator_dispatched_at.remove(&result.context_id);
@@ -288,11 +290,22 @@ impl SessionTracker {
 
         match self.state.get_mut(&context_id) {
             None => {
+                // Log only the result discriminant — not the inner
+                // `eyre::Report` debug, which can carry backtraces /
+                // peer-internal error text and would leak into log
+                // aggregators on a path that's purely defensive. The
+                // three buckets are enough to triage which kind of
+                // inconsistency fired.
+                let result_variant = match &result {
+                    Ok(Ok(_)) => "success",
+                    Ok(Err(_)) => "sync_error",
+                    Err(_) => "timeout",
+                };
                 warn!(
                     %context_id,
                     %peer_id,
                     ?took,
-                    ?result,
+                    result_variant,
                     "SyncSessionResult arrived for context with no tracked SyncState — \
                      dispatch-tracking inconsistency or external state mutation (logic bug)"
                 );


### PR DESCRIPTION
Closes #2445.

## What

\`SessionTracker::apply_result\` uses \`self.state.entry(context_id).and_modify(...)\`, which silently no-ops if no state entry exists for the result's \`context_id\`. That should never happen — \`record_dispatch_succeeded\` always inserts an in-progress state entry before a session can produce a result — so a hit on the missing-state path indicates one of:

1. Dispatch-tracking bug (\`record_dispatch_succeeded\` was skipped for a dispatched session).
2. Cross-actor routing bug (\`SyncSessionActor\` sent a result on a mismatched \`context_id\`).
3. External state mutation (something cleared \`self.state\` between dispatch and result).

All three are real bugs that were being silently swallowed by \`and_modify\`'s no-op-on-missing-entry behaviour.

## Fix

Defensive \`warn!\` before the \`and_modify\` call with \`context_id\`, \`peer_id\`, and \`took\` for operator correlation. Fires only on the never-should-happen path; normal flow is unchanged.

## Out of scope (not needed)

The same review thread on #2443 also flagged \`tick_wedge_watchdog\`'s \`if let Some(s) = self.state.get_mut(ctx)\` arm. After reading the code more carefully, that arm is genuinely dead-defensive: \`session_dispatch_wedged\`'s predicate requires \`state.get(ctx).is_some_and(|s| s.last_sync().is_none())\`, so the wedged list can only contain contexts whose state entry exists. No warn needed there.

## Tests

- New unit test \`apply_result_with_missing_state_does_not_panic_or_create_entry\` asserts the state-side invariants on the missing-entry path: no panic, no silent state insertion (preserving \`and_modify\`'s no-op behaviour), and the dispatch / wedge timer clears stay idempotent on absent keys.
- \`cargo test -p calimero-node --lib\`: 198 passed (197 pre-PR + 1 new).
- The accompanying \`warn!\` log itself is exercised on the missing-entry path; the test doesn't assert log emission (would require pulling in \`tracing-test\` as a workspace dev-dep just for this one assertion). The operator-visible value lives in production logs; the test covers the state-side invariants.

## Behaviour preservation

The normal path (state entry exists) is byte-identical to before. The only new code is the \`if !contains_key { warn!(...) }\` guard above the \`and_modify\`. No tracing fields, severities, or message wording in existing logs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior on the normal sync path is unchanged; this only adds defensive handling and tests for an unexpected missing-state result case.
> 
> **Overview**
> Adds defensive handling in `SessionTracker::apply_result` to detect when a `SyncSessionResult` arrives for a `context_id` with no tracked `SyncState`, emitting a structured `warn!` (with a `success`/`sync_error`/`timeout` discriminant and a Display-only error summary) instead of silently no-oping.
> 
> Keeps existing success/error/timeout and `PeerNotMaterialized` behavior for tracked contexts, while adding unit tests to ensure the missing-state path does not panic, does not create state, and still clears dispatch/wedge timer entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a91bf1e544eefad0cec0374983457015419e9cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->