### PR TITLE
fix(node, sync, storage, sdk): close HC fallback + WASM-owns-merges architecture + envelope signing (closes #2457, addresses #2469)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "calimero-network-primitives",
  "calimero-node-primitives",
  "calimero-primitives",
+ "calimero-storage",
  "calimero-store",
  "calimero-utils-actix",
  "ed25519-dalek",

--- a/crates/context/primitives/Cargo.toml
+++ b/crates/context/primitives/Cargo.toml
@@ -29,6 +29,7 @@ calimero-context-config.workspace = true
 calimero-primitives = { workspace = true, features = ["borsh", "rand"] }
 calimero-node-primitives.workspace = true
 calimero-store = { workspace = true, features = ["datatypes"] }
+calimero-storage.workspace = true
 calimero-utils-actix.workspace = true
 
 [dev-dependencies]

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -994,6 +994,93 @@ impl ContextClient {
         receiver.await.expect("Mailbox not to be dropped")
     }
 
+    /// Invoke the app's typed root-state CRDT merge inside WASM and return
+    /// the merged bytes.
+    ///
+    /// The host can't deserialize the app's root state (it doesn't have
+    /// the type at compile time), so any sync path that needs to merge
+    /// two root-state byte blobs sends them into the WASM module via the
+    /// macro-generated `__calimero_merge_root_state` export, which knows
+    /// the type and dispatches `Mergeable::merge`. This is the
+    /// receive-side counterpart to per-action signature verification:
+    /// where signatures verify "did this writer authorize this byte
+    /// blob," `merge_root_state` answers "what does the app's CRDT say
+    /// these two byte blobs combine to."
+    ///
+    /// Returns the merged bytes on success. Returns
+    /// `ExecuteError::InternalError` if the WASM merge function returned
+    /// an error variant, the payload didn't round-trip through the wire
+    /// format, or the WASM module doesn't export the entry point (which
+    /// means the app didn't use `#[app::state]` — an upgrade gate
+    /// concern, not a runtime sync concern).
+    pub async fn merge_root_state(
+        &self,
+        context_id: &ContextId,
+        executor: &PublicKey,
+        request: calimero_storage::merge::MergeRootStateRequest,
+    ) -> Result<Vec<u8>, ExecuteError> {
+        let payload = borsh::to_vec(&request).map_err(|err| {
+            tracing::error!(
+                %context_id,
+                %err,
+                "merge_root_state: failed to serialize MergeRootStateRequest"
+            );
+            ExecuteError::InternalError
+        })?;
+
+        let response = self
+            .execute(
+                context_id,
+                executor,
+                "__calimero_merge_root_state".to_owned(),
+                payload,
+                vec![],
+                None,
+            )
+            .await?;
+
+        let return_bytes = match response.returns {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => {
+                tracing::error!(
+                    %context_id,
+                    "merge_root_state: WASM export returned no bytes"
+                );
+                return Err(ExecuteError::InternalError);
+            }
+            Err(err) => {
+                tracing::error!(
+                    %context_id,
+                    ?err,
+                    "merge_root_state: WASM export reported a function-call error"
+                );
+                return Err(ExecuteError::InternalError);
+            }
+        };
+
+        let response: calimero_storage::merge::MergeRootStateResponse =
+            borsh::from_slice(&return_bytes).map_err(|err| {
+                tracing::error!(
+                    %context_id,
+                    %err,
+                    "merge_root_state: failed to deserialize MergeRootStateResponse"
+                );
+                ExecuteError::InternalError
+            })?;
+
+        match response {
+            calimero_storage::merge::MergeRootStateResponse::Ok(bytes) => Ok(bytes),
+            calimero_storage::merge::MergeRootStateResponse::Err(msg) => {
+                tracing::error!(
+                    %context_id,
+                    error = %msg,
+                    "merge_root_state: WASM Mergeable::merge returned an error"
+                );
+                Err(ExecuteError::InternalError)
+            }
+        }
+    }
+
     /// Sends a request to update the application for a given context.
     /// This is an asynchronous operation handled by the `ContextManager` actor.
     ///

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -29,22 +29,62 @@ pub fn get_group_for_context(
     ContextTreeService::new(store, ContextGroupId::from([0u8; 32])).group_for_context(context_id)
 }
 
-/// Returns `true` if `author` is currently an authorized member of
+/// Returns `true` if `author` is currently an authorized **writer** for
 /// `context_id`'s owning group, or if `context_id` is not registered to any
 /// group (no group-membership constraint applies). The check includes the
 /// namespace-creator admin-identity carve-out, mirroring `membership_status_at`.
 ///
-/// Used by sync apply paths (HashComparison EntityPush, snapshot apply) that
-/// can't carry a per-leaf governance position on the wire — the check is
-/// against the receiver's *current* group state, not the author's signed
-/// cut. Trade-off: this is strictly coarser than the gossip path's
-/// `membership_status_at(author, sender_position)` — legitimate pre-removal
-/// writes from a now-removed author that propagate via HC will be dropped on
-/// receivers that have already applied the removal. The strict alternative
-/// (per-leaf governance position on the HC wire) is tracked separately; this
-/// helper is the practical fix for the HC authorization-bypass back door
-/// where an unverified merge accepted writes the gossip path correctly
-/// rejected.
+/// Read-only roles (`ReadOnly`, `ReadOnlyTee`) are rejected here for parity
+/// with the gossip path's `is_read_only_for_context` filter in
+/// `state_delta::handle_state_delta` — without that filter, a read-only
+/// identity could route a state mutation through HashComparison / LevelWise /
+/// EntityPush (which call this helper) and have it merged on the receiver,
+/// bypassing the role boundary that gossip enforces. The asymmetry between
+/// "gossip rejects read-only writes" and "HC accepts read-only writes" was
+/// a privilege-escalation surface; the read-only check below removes it.
+///
+/// ## Why current state, not membership-at-author-time
+///
+/// Used by sync apply paths (HashComparison EntityPush, snapshot apply,
+/// LevelWise reconcile) that operate on per-leaf entities, not on the
+/// signed delta envelope. The envelope carries `governance_position` —
+/// the cited cut for `membership_status_at` — and we use it in the gossip
+/// and DAG-catchup paths. Per-leaf HC entities are NOT signed individually
+/// and the wire format deliberately does NOT attach a per-leaf governance
+/// position (would balloon the per-entity overhead by an order of
+/// magnitude for typical sync sessions). With no per-leaf cut to cite,
+/// the only governance state the receiver can check against is its own
+/// *current* view — there is no historical anchor on the wire to pin to.
+///
+/// This is a **defensible design choice**, not a known limitation:
+///
+/// * It mirrors the local-execute check in `is_authorized_for_context` —
+///   both are "does this identity have current write permission?" at the
+///   point the receiver makes a decision. The two checks (local write,
+///   remote HC merge) use the same membership snapshot, so a node never
+///   contradicts itself between "I wrote this" and "I'd accept this from
+///   a peer."
+/// * It's strict in the right direction: a removed-then-re-added author's
+///   intermediate-history entities replay successfully on HC; a removed-
+///   and-still-removed author's leaves do not. The gossip path's
+///   `membership_status_at` is a *richer* signal — it can distinguish
+///   "removed today but valid at sign time" from "never a member" — but
+///   that richness depends on per-delta envelope metadata that doesn't
+///   exist for HC leaves. We use what we have.
+/// * The TOCTOU window between this check and the actual entity write is
+///   the same window the local-execute path uses; if a member is removed
+///   mid-merge, both paths converge on the post-removal view on the next
+///   tick. Per-leaf signature replay isn't on the table — those leaves
+///   are already authenticated against the per-entity `signature_data`
+///   covered by `Interface::apply_action`.
+///
+/// Two nodes with identical DAG state but divergent local governance state
+/// CAN reject different HC leaves — this is a real behaviour. But that's
+/// the same behaviour the local-write path has (which is what HC is the
+/// "receive mirror" of), and divergent governance state is itself
+/// converged through gossip (governance ops use the same delivery
+/// machinery as state deltas). The window is bounded by the same heartbeat
+/// that bounds every other gossip-converged invariant.
 pub fn is_currently_authorized_for_context(
     store: &Store,
     context_id: &ContextId,
@@ -60,6 +100,15 @@ pub fn is_currently_authorized_for_context(
     // creator and HC would drop their legitimately-authored entities.
     if super::membership::is_group_admin(store, &group_id, author)? {
         return Ok(true);
+    }
+    // Reject read-only roles up-front — `check_group_membership` returns
+    // true for any `GroupMember` row regardless of role, so without this
+    // gate a ReadOnly / ReadOnlyTee identity would author-launder a
+    // state mutation through HC/LevelWise/EntityPush. The gossip path's
+    // `is_read_only_for_context` filter (in `handle_state_delta`) is what
+    // we're mirroring here.
+    if super::namespace::is_read_only_for_context(store, context_id, author)? {
+        return Ok(false);
     }
     super::membership::check_group_membership(store, &group_id, author)
 }

--- a/crates/context/src/group_store/contexts.rs
+++ b/crates/context/src/group_store/contexts.rs
@@ -29,6 +29,41 @@ pub fn get_group_for_context(
     ContextTreeService::new(store, ContextGroupId::from([0u8; 32])).group_for_context(context_id)
 }
 
+/// Returns `true` if `author` is currently an authorized member of
+/// `context_id`'s owning group, or if `context_id` is not registered to any
+/// group (no group-membership constraint applies). The check includes the
+/// namespace-creator admin-identity carve-out, mirroring `membership_status_at`.
+///
+/// Used by sync apply paths (HashComparison EntityPush, snapshot apply) that
+/// can't carry a per-leaf governance position on the wire — the check is
+/// against the receiver's *current* group state, not the author's signed
+/// cut. Trade-off: this is strictly coarser than the gossip path's
+/// `membership_status_at(author, sender_position)` — legitimate pre-removal
+/// writes from a now-removed author that propagate via HC will be dropped on
+/// receivers that have already applied the removal. The strict alternative
+/// (per-leaf governance position on the HC wire) is tracked separately; this
+/// helper is the practical fix for the HC authorization-bypass back door
+/// where an unverified merge accepted writes the gossip path correctly
+/// rejected.
+pub fn is_currently_authorized_for_context(
+    store: &Store,
+    context_id: &ContextId,
+    author: &PublicKey,
+) -> EyreResult<bool> {
+    let Some(group_id) = get_group_for_context(store, context_id)? else {
+        return Ok(true);
+    };
+    // Namespace creator carve-out: the creator does not emit a self-
+    // `MemberJoined` op at namespace genesis, so their membership lives in
+    // `GroupMeta::admin_identity` rather than a `GroupMember` row. Without
+    // this short-circuit, `check_group_membership` returns false for the
+    // creator and HC would drop their legitimately-authored entities.
+    if super::membership::is_group_admin(store, &group_id, author)? {
+        return Ok(true);
+    }
+    super::membership::check_group_membership(store, &group_id, author)
+}
+
 pub fn enumerate_group_contexts(
     store: &Store,
     group_id: &ContextGroupId,

--- a/crates/context/src/group_store/mod.rs
+++ b/crates/context/src/group_store/mod.rs
@@ -54,8 +54,8 @@ pub use self::context_registration::ContextRegistrationService;
 pub use self::context_tree::ContextTreeService;
 pub use self::contexts::{
     cascade_remove_member_from_group_tree, enumerate_group_contexts, find_local_signing_identity,
-    get_group_for_context, register_context_in_group, restore_member_context_identities,
-    unregister_context_from_group,
+    get_group_for_context, is_currently_authorized_for_context, register_context_in_group,
+    restore_member_context_identities, unregister_context_from_group,
 };
 pub use self::deny_list::{
     clear_all_denied, clear_denied, is_author_denied_for_context, is_denied, mark_denied,

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -431,6 +431,10 @@ async fn create_context(
             expected_root_hash: root_hash,
             // Genesis delta has no events
             events: None,
+            // Genesis predates any governance op; no author claim to
+            // verify on the DAG-catchup path.
+            author_id: None,
+            governance_position_blob: None,
         };
 
         debug!(

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -435,6 +435,8 @@ async fn create_context(
             // verify on the DAG-catchup path.
             author_id: None,
             governance_position_blob: None,
+            // Genesis has no author signature to record.
+            delta_signature: None,
         };
 
         debug!(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1551,8 +1551,7 @@ async fn internal_execute(
                     executor,
                     governance_position.as_ref(),
                 )?;
-            let delta_signature =
-                Some(identity_private_key.sign(&signature_payload)?.to_bytes());
+            let delta_signature = Some(identity_private_key.sign(&signature_payload)?.to_bytes());
             delta_signature_for_broadcast = delta_signature;
 
             handle.put(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1518,8 +1518,7 @@ async fn internal_execute(
             // peers that pull this delta via `request_dag_heads_and_sync`
             // can run the same `membership_status_at` check the gossip
             // path runs.
-            let governance_position =
-                compute_governance_position_for_context(&store, &context.id);
+            let governance_position = compute_governance_position_for_context(&store, &context.id);
             let governance_position_blob = governance_position
                 .as_ref()
                 .and_then(|gp| borsh::to_vec(gp).ok());

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -496,20 +496,21 @@ impl Handler<ExecuteRequest> for ContextManager {
 
                 let start = Instant::now();
 
-                let (outcome, causal_delta, delta_signature) = internal_execute(
-                    datastore,
-                    &node_client,
-                    &context_client,
-                    module,
-                    &guard,
-                    &mut context,
-                    executor,
-                    method.clone().into(),
-                    payload.into(),
-                    is_state_op,
-                    &private_key,
-                )
-                .await?;
+                let (outcome, causal_delta, delta_signature, signing_governance_position) =
+                    internal_execute(
+                        datastore,
+                        &node_client,
+                        &context_client,
+                        module,
+                        &guard,
+                        &mut context,
+                        executor,
+                        method.clone().into(),
+                        payload.into(),
+                        is_state_op,
+                        &private_key,
+                    )
+                    .await?;
 
                 let duration = start.elapsed().as_secs_f64();
                 let status = outcome
@@ -562,13 +563,20 @@ impl Handler<ExecuteRequest> for ContextManager {
                     "Execution outcome details"
                 );
 
-                Ok((guard, context, outcome, causal_delta, delta_signature))
+                Ok((
+                    guard,
+                    context,
+                    outcome,
+                    causal_delta,
+                    delta_signature,
+                    signing_governance_position,
+                ))
             }
             .into_actor(act)
         });
 
         let external_task =
-            execute_task.and_then(move |(guard, context, outcome, causal_delta, delta_signature), act, _ctx| {
+            execute_task.and_then(move |(guard, context, outcome, causal_delta, delta_signature, signing_governance_position), act, _ctx| {
                 if let Some(cached_context) = act.contexts.get_mut(&context_id) {
                     debug!(
                         %context_id,
@@ -584,7 +592,13 @@ impl Handler<ExecuteRequest> for ContextManager {
 
                 let node_client = act.node_client.clone();
                 let context_client = act.context_client.clone();
-                let datastore_for_broadcast = act.datastore.clone();
+                // `datastore_for_broadcast` used to recompute the
+                // governance position at broadcast time — that recompute
+                // produced the persist-vs-broadcast signature mismatch
+                // documented on `governance_position_for_broadcast`.
+                // The threaded value from `internal_execute` is the
+                // single source of truth now, so no fresh store
+                // snapshot is needed here.
 
                 async move {
                     if outcome.returns.is_err() {
@@ -739,15 +753,18 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 Some(serialized)
                             };
 
-                            // Cross-DAG reference: names the governance cut
-                            // this delta was signed against. `None` for legacy
-                            // non-group contexts. Read failures are logged but
-                            // not fatal — the receiver-side membership check
-                            // will reject if the position is missing or stale.
-                            let governance_position = compute_governance_position_for_context(
-                                &datastore_for_broadcast,
-                                &context.id,
-                            );
+                            // Cross-DAG reference: the EXACT governance cut
+                            // `delta_signature` was bound to inside
+                            // `internal_execute`. We reuse that captured
+                            // value (`signing_governance_position`) instead
+                            // of recomputing from `datastore_for_broadcast`
+                            // because the local governance state can advance
+                            // between the persist and broadcast points
+                            // (member added/removed, namespace op landed).
+                            // A fresh computation would silently diverge
+                            // from the signed payload and receivers would
+                            // reject the delta on signature mismatch.
+                            let governance_position = signing_governance_position.clone();
 
                             node_client
                                 .broadcast(
@@ -761,12 +778,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                                     events_data,
                                     governance_position,
                                     broadcast_key_id,
-                                    // Per-delta envelope signature computed
-                                    // inside `internal_execute` against the
-                                    // same `governance_position` used here
-                                    // (both helpers compute from the same
-                                    // store snapshot, see the persist site
-                                    // comment).
+                                    // Pre-signed envelope bytes — paired with
+                                    // the exact `signing_governance_position`
+                                    // above, see the comment there.
                                     delta_signature,
                                 )
                                 .await?;
@@ -1221,7 +1235,12 @@ async fn internal_execute(
     input: Cow<'static, [u8]>,
     is_state_op: bool,
     identity_private_key: &PrivateKey,
-) -> eyre::Result<(Outcome, Option<CausalDelta>, Option<[u8; 64]>)> {
+) -> eyre::Result<(
+    Outcome,
+    Option<CausalDelta>,
+    Option<[u8; 64]>,
+    Option<GovernancePosition>,
+)> {
     let executor_is_read_only = !is_state_op
         && crate::group_store::is_read_only_for_context(&datastore, &context.id, &executor)
             .unwrap_or(false);
@@ -1299,7 +1318,7 @@ async fn internal_execute(
             error = ?outcome.returns,
             "WASM execution returned error"
         );
-        return Ok((outcome, None, None));
+        return Ok((outcome, None, None, None));
     }
 
     'fine: {
@@ -1327,6 +1346,17 @@ async fn internal_execute(
     // gossip broadcast. Stays `None` when no delta was produced (e.g.,
     // empty artifact) or signing wasn't applicable.
     let mut delta_signature_for_broadcast: Option<[u8; 64]> = None;
+    // Captured alongside the signature: the EXACT
+    // `governance_position` the signature was computed against. The
+    // outer broadcast site MUST reuse this value rather than
+    // recomputing from a fresh store snapshot — between the persist
+    // and broadcast points the local governance state can advance
+    // (a member is added/removed, a namespace op lands), and
+    // recomputing would produce a different position that no longer
+    // matches the signed payload, so receivers would reject the
+    // delta on signature mismatch. This single source of truth
+    // collapses that race window.
+    let mut governance_position_for_broadcast: Option<GovernancePosition> = None;
 
     if executor_is_read_only && outcome.root_hash.is_some() {
         info!(
@@ -1338,7 +1368,7 @@ async fn internal_execute(
         outcome.root_hash = None;
         outcome.artifact.clear();
         outcome.xcalls.clear();
-        return Ok((outcome, None, None));
+        return Ok((outcome, None, None, None));
     }
 
     if executor_not_authorized_for_state_op && outcome.root_hash.is_some() {
@@ -1351,7 +1381,7 @@ async fn internal_execute(
         outcome.root_hash = None;
         outcome.artifact.clear();
         outcome.xcalls.clear();
-        return Ok((outcome, None, None));
+        return Ok((outcome, None, None, None));
     }
 
     // Always update root_hash if present (even if storage is empty)
@@ -1553,6 +1583,11 @@ async fn internal_execute(
                 )?;
             let delta_signature = Some(identity_private_key.sign(&signature_payload)?.to_bytes());
             delta_signature_for_broadcast = delta_signature;
+            // Pin the exact position the signature was bound to so
+            // the broadcast site can advertise it verbatim instead of
+            // recomputing (see `governance_position_for_broadcast`'s
+            // declaration for why recomputation is unsafe).
+            governance_position_for_broadcast = governance_position.clone();
 
             handle.put(
                 &key::ContextDagDelta::new(context.id, delta.id),
@@ -1628,7 +1663,12 @@ async fn internal_execute(
         }))?;
     }
 
-    Ok((outcome, causal_delta, delta_signature_for_broadcast))
+    Ok((
+        outcome,
+        causal_delta,
+        delta_signature_for_broadcast,
+        governance_position_for_broadcast,
+    ))
 }
 
 pub async fn execute(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -496,7 +496,7 @@ impl Handler<ExecuteRequest> for ContextManager {
 
                 let start = Instant::now();
 
-                let (outcome, causal_delta) = internal_execute(
+                let (outcome, causal_delta, delta_signature) = internal_execute(
                     datastore,
                     &node_client,
                     &context_client,
@@ -562,13 +562,13 @@ impl Handler<ExecuteRequest> for ContextManager {
                     "Execution outcome details"
                 );
 
-                Ok((guard, context, outcome, causal_delta))
+                Ok((guard, context, outcome, causal_delta, delta_signature))
             }
             .into_actor(act)
         });
 
         let external_task =
-            execute_task.and_then(move |(guard, context, outcome, causal_delta), act, _ctx| {
+            execute_task.and_then(move |(guard, context, outcome, causal_delta, delta_signature), act, _ctx| {
                 if let Some(cached_context) = act.contexts.get_mut(&context_id) {
                     debug!(
                         %context_id,
@@ -761,6 +761,13 @@ impl Handler<ExecuteRequest> for ContextManager {
                                     events_data,
                                     governance_position,
                                     broadcast_key_id,
+                                    // Per-delta envelope signature computed
+                                    // inside `internal_execute` against the
+                                    // same `governance_position` used here
+                                    // (both helpers compute from the same
+                                    // store snapshot, see the persist site
+                                    // comment).
+                                    delta_signature,
                                 )
                                 .await?;
                         }
@@ -1214,7 +1221,7 @@ async fn internal_execute(
     input: Cow<'static, [u8]>,
     is_state_op: bool,
     identity_private_key: &PrivateKey,
-) -> eyre::Result<(Outcome, Option<CausalDelta>)> {
+) -> eyre::Result<(Outcome, Option<CausalDelta>, Option<[u8; 64]>)> {
     let executor_is_read_only = !is_state_op
         && crate::group_store::is_read_only_for_context(&datastore, &context.id, &executor)
             .unwrap_or(false);
@@ -1292,7 +1299,7 @@ async fn internal_execute(
             error = ?outcome.returns,
             "WASM execution returned error"
         );
-        return Ok((outcome, None));
+        return Ok((outcome, None, None));
     }
 
     'fine: {
@@ -1315,6 +1322,11 @@ async fn internal_execute(
     }
 
     let mut causal_delta = None;
+    // Populated when we sign the locally-produced delta envelope so the
+    // outer `execute` task can carry the same signature bytes into the
+    // gossip broadcast. Stays `None` when no delta was produced (e.g.,
+    // empty artifact) or signing wasn't applicable.
+    let mut delta_signature_for_broadcast: Option<[u8; 64]> = None;
 
     if executor_is_read_only && outcome.root_hash.is_some() {
         info!(
@@ -1326,7 +1338,7 @@ async fn internal_execute(
         outcome.root_hash = None;
         outcome.artifact.clear();
         outcome.xcalls.clear();
-        return Ok((outcome, None));
+        return Ok((outcome, None, None));
     }
 
     if executor_not_authorized_for_state_op && outcome.root_hash.is_some() {
@@ -1339,7 +1351,7 @@ async fn internal_execute(
         outcome.root_hash = None;
         outcome.artifact.clear();
         outcome.xcalls.clear();
-        return Ok((outcome, None));
+        return Ok((outcome, None, None));
     }
 
     // Always update root_hash if present (even if storage is empty)
@@ -1523,6 +1535,26 @@ async fn internal_execute(
                 .as_ref()
                 .and_then(|gp| borsh::to_vec(gp).ok());
 
+            // Sign the canonical envelope payload with the author's
+            // identity key. Signature binds `(context_id, delta_id,
+            // author_id, governance_position)` together so a current
+            // group-key holder can't relabel a foreign delta as their
+            // own (or vice versa) on the wire — receivers reject any
+            // mismatch via `verify_delta_signature`. The same signature
+            // is persisted on the row and passed back to the broadcast
+            // site so the gossip and DAG-catchup paths advertise the
+            // same bytes.
+            let signature_payload =
+                calimero_node_primitives::sync::delta_auth::delta_signature_payload(
+                    context.id,
+                    delta.id,
+                    executor,
+                    governance_position.as_ref(),
+                )?;
+            let delta_signature =
+                Some(identity_private_key.sign(&signature_payload)?.to_bytes());
+            delta_signature_for_broadcast = delta_signature;
+
             handle.put(
                 &key::ContextDagDelta::new(context.id, delta.id),
                 &types::ContextDagDelta {
@@ -1535,9 +1567,7 @@ async fn internal_execute(
                     events: None, // No events stored for locally created deltas
                     author_id: Some(executor),
                     governance_position_blob,
-                    // Per-delta envelope signature is scaffolded but not
-                    // yet populated end-to-end; tracked separately.
-                    delta_signature: None,
+                    delta_signature,
                 },
             )?;
 
@@ -1599,7 +1629,7 @@ async fn internal_execute(
         }))?;
     }
 
-    Ok((outcome, causal_delta))
+    Ok((outcome, causal_delta, delta_signature_for_broadcast))
 }
 
 pub async fn execute(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1512,6 +1512,18 @@ async fn internal_execute(
         if let Some(ref delta) = causal_delta {
             let serialized_actions = borsh::to_vec(&delta.actions)?;
 
+            // Compute the governance position for the cross-DAG check
+            // that DAG-catchup responders advertise on the wire. Mirrors
+            // the position computed for the broadcast envelope above so
+            // peers that pull this delta via `request_dag_heads_and_sync`
+            // can run the same `membership_status_at` check the gossip
+            // path runs.
+            let governance_position =
+                compute_governance_position_for_context(&store, &context.id);
+            let governance_position_blob = governance_position
+                .as_ref()
+                .and_then(|gp| borsh::to_vec(gp).ok());
+
             handle.put(
                 &key::ContextDagDelta::new(context.id, delta.id),
                 &types::ContextDagDelta {
@@ -1522,6 +1534,8 @@ async fn internal_execute(
                     applied: true,
                     expected_root_hash: delta.expected_root_hash,
                     events: None, // No events stored for locally created deltas
+                    author_id: Some(executor),
+                    governance_position_blob,
                 },
             )?;
 

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1535,6 +1535,9 @@ async fn internal_execute(
                     events: None, // No events stored for locally created deltas
                     author_id: Some(executor),
                     governance_position_blob,
+                    // Per-delta envelope signature is scaffolded but not
+                    // yet populated end-to-end; tracked separately.
+                    delta_signature: None,
                 },
             )?;
 

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -444,6 +444,7 @@ impl NodeClient {
         events: Option<Vec<u8>>,
         governance_position: Option<GovernancePosition>,
         key_id: [u8; 32],
+        delta_signature: Option<[u8; 64]>,
     ) -> eyre::Result<()> {
         info!(
             context_id=%context.id,
@@ -481,6 +482,7 @@ impl NodeClient {
             events: events.map(Cow::from),
             governance_position,
             key_id,
+            delta_signature,
         };
 
         let payload = borsh::to_vec(&payload)?;

--- a/crates/node/primitives/src/delta_buffer.rs
+++ b/crates/node/primitives/src/delta_buffer.rs
@@ -116,6 +116,13 @@ pub struct BufferedDelta {
     /// every delta that happened to arrive during a sync. `None` for
     /// legacy non-group contexts that have no governance DAG.
     pub governance_position: Option<GovernancePosition>,
+    /// Per-delta envelope signature carried alongside `author_id` /
+    /// `governance_position`, used by the receiver to verify the
+    /// envelope before applying. `None` for legacy deltas that
+    /// predate the signing wire-up. Must survive snapshot-sync
+    /// buffering so a replayed delta is verified against the same
+    /// payload the original sender signed.
+    pub delta_signature: Option<[u8; 64]>,
     /// Number of times the governance-pending drain has re-buffered this
     /// delta because its governance heads are still unknown locally.
     /// Bounded by `MAX_GOVERNANCE_DRAIN_ATTEMPTS` — after that, the drain
@@ -317,6 +324,7 @@ mod tests {
             source_peer: libp2p::PeerId::random(),
             key_id: [0; 32],
             governance_position: None,
+            delta_signature: None,
             governance_drain_attempts: 0,
         }
     }

--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -33,6 +33,7 @@
 
 pub mod bloom_filter;
 pub mod delta;
+pub mod delta_auth;
 pub mod handshake;
 pub mod hash_comparison;
 pub mod levelwise;

--- a/crates/node/primitives/src/sync/delta_auth.rs
+++ b/crates/node/primitives/src/sync/delta_auth.rs
@@ -115,9 +115,8 @@ pub fn verify_delta_signature(
     governance_position: Option<&GovernancePosition>,
     signature: &[u8; 64],
 ) -> eyre::Result<()> {
-    let payload =
-        delta_signature_payload(context_id, delta_id, author_id, governance_position)
-            .map_err(|err| eyre::eyre!("failed to serialize delta signature payload: {err}"))?;
+    let payload = delta_signature_payload(context_id, delta_id, author_id, governance_position)
+        .map_err(|err| eyre::eyre!("failed to serialize delta signature payload: {err}"))?;
     author_id
         .verify_raw_signature(&payload, signature)
         .map_err(|err| eyre::eyre!("delta envelope signature verification failed: {err}"))

--- a/crates/node/primitives/src/sync/delta_auth.rs
+++ b/crates/node/primitives/src/sync/delta_auth.rs
@@ -37,13 +37,33 @@ use calimero_context_config::types::GovernancePosition;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 
+/// Domain separator prefixed to every delta-envelope signature payload.
+///
+/// Without this, an ed25519 signature produced for a `DeltaSignaturePayload`
+/// could in principle be replayed as a signature for a different protocol
+/// message that happened to borsh-serialize to identical bytes (cross-
+/// protocol replay). The separator is included as a typed field on
+/// `DeltaSignaturePayload` so its borsh-serialization is part of the
+/// signed bytes; receivers reconstruct the payload with the same
+/// constant, so any signature produced for a different domain fails
+/// verification.
+///
+/// The literal string is part of the protocol — never change it without
+/// a wire-format version bump.
+pub const DOMAIN_SEPARATOR: &[u8; 16] = b"calimero/delta/1";
+
 /// Canonical payload for the delta-envelope signature. Borsh-serialized
 /// and signed by `author_id`'s ed25519 key. Only used for serialization —
 /// receivers re-construct it from their own data and compare signature
 /// bytes, so `BorshDeserialize` isn't needed (and wouldn't work with the
 /// `&GovernancePosition` borrow anyway).
+///
+/// The `domain` field is always [`DOMAIN_SEPARATOR`] — it's serialized
+/// into the signed bytes so signatures from other protocols using the
+/// same key can't be replayed here.
 #[derive(BorshSerialize)]
 pub struct DeltaSignaturePayload<'a> {
+    pub domain: [u8; 16],
     pub context_id: ContextId,
     pub delta_id: [u8; 32],
     pub author_id: PublicKey,
@@ -63,6 +83,7 @@ pub fn delta_signature_payload(
     governance_position: Option<&GovernancePosition>,
 ) -> Result<Vec<u8>, borsh::io::Error> {
     let payload = DeltaSignaturePayload {
+        domain: *DOMAIN_SEPARATOR,
         context_id,
         delta_id,
         author_id,

--- a/crates/node/primitives/src/sync/delta_auth.rs
+++ b/crates/node/primitives/src/sync/delta_auth.rs
@@ -70,3 +70,92 @@ pub fn delta_signature_payload(
     };
     borsh::to_vec(&payload)
 }
+
+/// Verify a per-delta envelope signature against the canonical payload.
+///
+/// Reconstructs the payload the author signed at send time
+/// (`delta_signature_payload`) and verifies the ed25519 signature with
+/// the claimed author's public key. Receivers call this on every apply
+/// path (gossip receive, DAG-catchup receive, snapshot-buffer replay)
+/// before the delta touches storage.
+///
+/// Returns `Ok(())` only on a valid signature. Any borsh-serialize
+/// failure on the payload, or signature mismatch, returns `Err`.
+///
+/// **Caller contract:** the `author_id` passed here MUST be the same
+/// author bound into the payload — verification doesn't check that
+/// invariant for you, it just verifies that `author_id`'s key signed
+/// THIS payload bytes. If you pass a different author for the
+/// verification key vs. the payload, you're checking the wrong thing.
+pub fn verify_delta_signature(
+    context_id: ContextId,
+    delta_id: [u8; 32],
+    author_id: PublicKey,
+    governance_position: Option<&GovernancePosition>,
+    signature: &[u8; 64],
+) -> eyre::Result<()> {
+    let payload =
+        delta_signature_payload(context_id, delta_id, author_id, governance_position)
+            .map_err(|err| eyre::eyre!("failed to serialize delta signature payload: {err}"))?;
+    author_id
+        .verify_raw_signature(&payload, signature)
+        .map_err(|err| eyre::eyre!("delta envelope signature verification failed: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use calimero_primitives::identity::PrivateKey;
+
+    fn fixture() -> (ContextId, [u8; 32], PrivateKey, PublicKey) {
+        let private_key = PrivateKey::from([3u8; 32]);
+        let author_id = private_key.public_key();
+        let context_id = ContextId::from([7u8; 32]);
+        let delta_id = [9u8; 32];
+        (context_id, delta_id, private_key, author_id)
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrip_no_position() {
+        let (context_id, delta_id, sk, pk) = fixture();
+        let payload = delta_signature_payload(context_id, delta_id, pk, None).unwrap();
+        let sig = sk.sign(&payload).unwrap().to_bytes();
+        assert!(verify_delta_signature(context_id, delta_id, pk, None, &sig).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_context_id() {
+        let (context_id, delta_id, sk, pk) = fixture();
+        let payload = delta_signature_payload(context_id, delta_id, pk, None).unwrap();
+        let sig = sk.sign(&payload).unwrap().to_bytes();
+        // Author signed for `context_id`; verifier reconstructs payload
+        // with a *different* context_id, so the bytes diverge and the
+        // signature should not verify. This is the anti-cross-context-
+        // replay property the payload buys us.
+        let other_context = ContextId::from([1u8; 32]);
+        assert!(verify_delta_signature(other_context, delta_id, pk, None, &sig).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_author() {
+        let (context_id, delta_id, sk, pk) = fixture();
+        let payload = delta_signature_payload(context_id, delta_id, pk, None).unwrap();
+        let sig = sk.sign(&payload).unwrap().to_bytes();
+        // Same signature bytes, but a *different* author is claimed on
+        // the wire. `verify_raw_signature` uses the claimed author's key,
+        // which never signed this payload — must fail. This is the
+        // anti-impersonation property that gossip's
+        // `membership_status_at` check alone doesn't catch.
+        let other_pk = PrivateKey::from([4u8; 32]).public_key();
+        assert!(verify_delta_signature(context_id, delta_id, other_pk, None, &sig).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_signature_bytes() {
+        let (context_id, delta_id, sk, pk) = fixture();
+        let payload = delta_signature_payload(context_id, delta_id, pk, None).unwrap();
+        let mut sig = sk.sign(&payload).unwrap().to_bytes();
+        sig[0] ^= 0xff;
+        assert!(verify_delta_signature(context_id, delta_id, pk, None, &sig).is_err());
+    }
+}

--- a/crates/node/primitives/src/sync/delta_auth.rs
+++ b/crates/node/primitives/src/sync/delta_auth.rs
@@ -1,0 +1,72 @@
+//! Delta-envelope signature primitive.
+//!
+//! Closes the anti-impersonation gap on the delta-envelope level: a
+//! current group-key holder can no longer write a delta claiming
+//! another member as `author_id`. The author signs a canonical
+//! payload that binds `(context_id, delta_id, author_id,
+//! governance_position)`; every receive path verifies before
+//! applying.
+//!
+//! The signature primitive is intentionally separate from per-action
+//! signatures (which live in `StorageType::{User, Shared}::signature_data`
+//! and verify in `Interface::apply_action`). Per-action signatures
+//! attribute INDIVIDUAL writes within a delta; the envelope
+//! signature binds the WHOLE delta to its author. Both are needed for
+//! full coverage — per-action sigs don't catch envelope forgery
+//! (a current member relabeling a foreign delta as their own), and
+//! the envelope signature doesn't catch per-action forgery within a
+//! Public-only delta.
+//!
+//! ## Payload shape
+//!
+//! ```ignore
+//! DeltaSignaturePayload {
+//!     context_id,        // pins to the context (cross-context replay)
+//!     delta_id,          // hash(parents || actions); commits to the content
+//!     author_id,         // claimed author
+//!     governance_position, // cited cut for the membership check
+//! }
+//! ```
+//!
+//! Borsh-serialized. Signed with the author's ed25519 identity key.
+//! `delta_id` is the existing content hash, so committing to it covers
+//! the action bytes via the hash chain.
+
+use borsh::BorshSerialize;
+use calimero_context_config::types::GovernancePosition;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+
+/// Canonical payload for the delta-envelope signature. Borsh-serialized
+/// and signed by `author_id`'s ed25519 key. Only used for serialization —
+/// receivers re-construct it from their own data and compare signature
+/// bytes, so `BorshDeserialize` isn't needed (and wouldn't work with the
+/// `&GovernancePosition` borrow anyway).
+#[derive(BorshSerialize)]
+pub struct DeltaSignaturePayload<'a> {
+    pub context_id: ContextId,
+    pub delta_id: [u8; 32],
+    pub author_id: PublicKey,
+    pub governance_position: Option<&'a GovernancePosition>,
+}
+
+/// Borsh-serialize the canonical payload. Used at sign time (execute
+/// path) and verify time (every delta receive path).
+///
+/// Returns `borsh::io::Error` only if the borsh writer fails on the
+/// in-memory buffer — practically infallible for these field types,
+/// but the result type matches `borsh::to_vec`'s shape.
+pub fn delta_signature_payload(
+    context_id: ContextId,
+    delta_id: [u8; 32],
+    author_id: PublicKey,
+    governance_position: Option<&GovernancePosition>,
+) -> Result<Vec<u8>, borsh::io::Error> {
+    let payload = DeltaSignaturePayload {
+        context_id,
+        delta_id,
+        author_id,
+        governance_position,
+    };
+    borsh::to_vec(&payload)
+}

--- a/crates/node/primitives/src/sync/delta_auth.rs
+++ b/crates/node/primitives/src/sync/delta_auth.rs
@@ -178,4 +178,41 @@ mod tests {
         sig[0] ^= 0xff;
         assert!(verify_delta_signature(context_id, delta_id, pk, None, &sig).is_err());
     }
+
+    #[test]
+    fn sign_then_verify_roundtrip_with_position() {
+        let (context_id, delta_id, sk, pk) = fixture();
+        let pos = calimero_context_config::types::GovernancePosition {
+            group_id: calimero_context_config::types::ContextGroupId::from([5u8; 32]),
+            governance_dag_heads: vec![[6u8; 32], [7u8; 32]],
+            group_state_hash: [8u8; 32],
+        };
+        let payload = delta_signature_payload(context_id, delta_id, pk, Some(&pos)).unwrap();
+        let sig = sk.sign(&payload).unwrap().to_bytes();
+        assert!(verify_delta_signature(context_id, delta_id, pk, Some(&pos), &sig).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_governance_position() {
+        let (context_id, delta_id, sk, pk) = fixture();
+        let pos_signed = calimero_context_config::types::GovernancePosition {
+            group_id: calimero_context_config::types::ContextGroupId::from([5u8; 32]),
+            governance_dag_heads: vec![[6u8; 32]],
+            group_state_hash: [8u8; 32],
+        };
+        let payload = delta_signature_payload(context_id, delta_id, pk, Some(&pos_signed)).unwrap();
+        let sig = sk.sign(&payload).unwrap().to_bytes();
+
+        // Verifier reconstructs payload with a different position
+        // (different `group_state_hash`); signature must not verify.
+        // This is the per-cut binding property — a signature for one
+        // governance cut can't be reused for a different cut even if
+        // every other field matches.
+        let pos_other = calimero_context_config::types::GovernancePosition {
+            group_id: pos_signed.group_id,
+            governance_dag_heads: pos_signed.governance_dag_heads.clone(),
+            group_state_hash: [99u8; 32],
+        };
+        assert!(verify_delta_signature(context_id, delta_id, pk, Some(&pos_other), &sig).is_err());
+    }
 }

--- a/crates/node/primitives/src/sync/snapshot.rs
+++ b/crates/node/primitives/src/sync/snapshot.rs
@@ -702,6 +702,20 @@ pub enum BroadcastMessage<'a> {
         /// delta. Receivers look up the corresponding key from their local
         /// `GroupKeyEntry` store to decrypt.
         key_id: [u8; 32],
+
+        /// Ed25519 signature by `author_id`'s identity key over the
+        /// canonical [`super::delta_auth::DeltaSignaturePayload`]
+        /// `(context_id, delta_id, author_id, governance_position)`.
+        /// Closes the anti-impersonation gap on the delta envelope: a
+        /// current group-key holder can no longer relabel a foreign
+        /// delta as their own (or vice versa) — `membership_status_at`
+        /// alone would accept both since both are members.
+        ///
+        /// `Option` for the wire-up transition. The schema is in place
+        /// and receivers verify when `Some`; signing at the `execute`
+        /// site is wired up in a follow-up, after which this tightens
+        /// to required and `None` becomes a hard reject.
+        delta_signature: Option<[u8; 64]>,
     },
 
     /// Hash heartbeat for divergence detection

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -286,6 +286,20 @@ pub enum MessagePayload<'a> {
         /// governance cut to cite — initiator skips the membership
         /// check in that case (there's nothing to check against).
         governance_position_blob: Option<Cow<'a, [u8]>>,
+        /// Ed25519 signature by `author_id`'s identity key over the
+        /// canonical [`super::delta_auth::DeltaSignaturePayload`].
+        /// Closes the anti-impersonation gap on the delta envelope:
+        /// without this, a current group-key holder could relabel a
+        /// foreign delta as their own (or vice versa) since
+        /// `membership_status_at` would pass for both members.
+        ///
+        /// `Option` for the transition: the storage schema and wire
+        /// carry the field, but signing isn't yet populated at the
+        /// `execute` site, so existing rows + freshly authored deltas
+        /// report `None` until that lands. Initiators that see `Some`
+        /// MUST verify; `None` is tolerated until the signing wire-up
+        /// is complete, then this tightens to required.
+        delta_signature: Option<[u8; 64]>,
     },
 
     /// Delta not found response.

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -271,19 +271,20 @@ pub enum MessagePayload<'a> {
     DeltaResponse {
         /// The serialized delta data.
         delta: Cow<'a, [u8]>,
-        /// Signing identity of the node that authored this delta, if
-        /// the responder has it on file. Present when the delta was
-        /// persisted with the post-2457 schema (`author_id` column);
-        /// `None` for legacy rows. Initiator runs the cross-DAG
-        /// membership check when `Some` and accepts on `None` (legacy
-        /// rows have no claim to verify; the gossip path's check
-        /// remains the primary author-authorization gate for those).
-        author_id: Option<calimero_primitives::identity::PublicKey>,
+        /// Signing identity of the node that authored this delta.
+        /// Required — the responder only serves deltas that have a
+        /// recorded author (rows missing the field return
+        /// `DeltaNotFound`, forcing the initiator to fall back to
+        /// snapshot sync where the per-entity signature path applies).
+        /// Initiator runs `membership_status_at` against this author
+        /// unconditionally; there is no legacy-accept escape hatch.
+        author_id: calimero_primitives::identity::PublicKey,
         /// Serialized `calimero_context_config::types::GovernancePosition`
         /// (borsh bytes) at the delta's sign time. Pairs with
         /// `author_id` for the apply-time `membership_status_at` check.
-        /// `None` when the responder has no governance position recorded
-        /// for the delta (legacy rows OR non-group context).
+        /// `None` only for non-group contexts where the author has no
+        /// governance cut to cite — initiator skips the membership
+        /// check in that case (there's nothing to check against).
         governance_position_blob: Option<Cow<'a, [u8]>>,
     },
 

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -293,12 +293,16 @@ pub enum MessagePayload<'a> {
         /// foreign delta as their own (or vice versa) since
         /// `membership_status_at` would pass for both members.
         ///
-        /// `Option` for the transition: the storage schema and wire
-        /// carry the field, but signing isn't yet populated at the
-        /// `execute` site, so existing rows + freshly authored deltas
-        /// report `None` until that lands. Initiators that see `Some`
-        /// MUST verify; `None` is tolerated until the signing wire-up
-        /// is complete, then this tightens to required.
+        /// `Option` because legacy rows (deltas authored before the
+        /// envelope-signature feature landed) have no signature on
+        /// file — the responder forwards `None` for those rather than
+        /// withholding the delta entirely. Freshly-authored deltas
+        /// always carry `Some(_)` (`internal_execute` signs against
+        /// the same `governance_position` it persists on the row).
+        /// Initiators MUST verify any present signature; `None` is
+        /// tolerated only for that legacy-row case and will tighten
+        /// to required once those rows have aged out of every peer's
+        /// storage.
         delta_signature: Option<[u8; 64]>,
     },
 

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -271,6 +271,20 @@ pub enum MessagePayload<'a> {
     DeltaResponse {
         /// The serialized delta data.
         delta: Cow<'a, [u8]>,
+        /// Signing identity of the node that authored this delta, if
+        /// the responder has it on file. Present when the delta was
+        /// persisted with the post-2457 schema (`author_id` column);
+        /// `None` for legacy rows. Initiator runs the cross-DAG
+        /// membership check when `Some` and accepts on `None` (legacy
+        /// rows have no claim to verify; the gossip path's check
+        /// remains the primary author-authorization gate for those).
+        author_id: Option<calimero_primitives::identity::PublicKey>,
+        /// Serialized `calimero_context_config::types::GovernancePosition`
+        /// (borsh bytes) at the delta's sign time. Pairs with
+        /// `author_id` for the apply-time `membership_status_at` check.
+        /// `None` when the responder has no governance position recorded
+        /// for the delta (legacy rows OR non-group context).
+        governance_position_blob: Option<Cow<'a, [u8]>>,
     },
 
     /// Delta not found response.

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1115,15 +1115,25 @@ impl DeltaStore {
         &self,
         delta: CausalDelta<Vec<Action>>,
         events: Option<Vec<u8>>,
+        author_id: Option<calimero_primitives::identity::PublicKey>,
+        governance_position_blob: Option<Vec<u8>>,
     ) -> Result<AddDeltaResult> {
-        self.add_delta_internal(delta, events).await
+        self.add_delta_internal(delta, events, author_id, governance_position_blob)
+            .await
     }
 
     /// Add a delta to the store (without event data)
     ///
     /// Returns Ok(true) if applied immediately, Ok(false) if pending
-    pub async fn add_delta(&self, delta: CausalDelta<Vec<Action>>) -> Result<bool> {
-        let result = self.add_delta_internal(delta, None).await?;
+    pub async fn add_delta(
+        &self,
+        delta: CausalDelta<Vec<Action>>,
+        author_id: Option<calimero_primitives::identity::PublicKey>,
+        governance_position_blob: Option<Vec<u8>>,
+    ) -> Result<bool> {
+        let result = self
+            .add_delta_internal(delta, None, author_id, governance_position_blob)
+            .await?;
         Ok(result.applied)
     }
 
@@ -1258,6 +1268,8 @@ impl DeltaStore {
         &self,
         delta: CausalDelta<Vec<Action>>,
         events: Option<Vec<u8>>,
+        author_id: Option<calimero_primitives::identity::PublicKey>,
+        governance_position_blob: Option<Vec<u8>>,
     ) -> Result<AddDeltaResult> {
         let delta_id = delta.id;
         let expected_root_hash = delta.expected_root_hash;
@@ -1289,17 +1301,8 @@ impl DeltaStore {
                         applied: false, // Not applied yet, will update if it applies
                         expected_root_hash,
                         events: events.clone(), // Store events for potential cascade
-                        // Receive-side persistence: author / governance
-                        // position aren't threaded through this path yet
-                        // (followup to surface them from the gossip
-                        // envelope into `add_delta_internal`). Setting
-                        // None keeps DAG-catchup serving these deltas
-                        // without an author claim — initiator-side
-                        // membership check treats None as legacy and
-                        // accepts. Anti-impersonation parity for the
-                        // receive→serve path is its own follow-up.
-                        author_id: None,
-                        governance_position_blob: None,
+                        author_id,
+                        governance_position_blob: governance_position_blob.clone(),
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to pre-persist delta with events: {}", e))?;
@@ -1375,8 +1378,8 @@ impl DeltaStore {
                         applied: true,
                         expected_root_hash,
                         events: events.clone(),
-                        author_id: None,
-                        governance_position_blob: None,
+                        author_id,
+                        governance_position_blob: governance_position_blob.clone(),
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to update applied delta: {}", e))?;
@@ -1403,8 +1406,8 @@ impl DeltaStore {
                         applied: true,
                         expected_root_hash,
                         events: None,
-                        author_id: None,
-                        governance_position_blob: None,
+                        author_id,
+                        governance_position_blob,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to persist applied delta: {}", e))?;

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1117,9 +1117,16 @@ impl DeltaStore {
         events: Option<Vec<u8>>,
         author_id: Option<calimero_primitives::identity::PublicKey>,
         governance_position_blob: Option<Vec<u8>>,
+        delta_signature: Option<[u8; 64]>,
     ) -> Result<AddDeltaResult> {
-        self.add_delta_internal(delta, events, author_id, governance_position_blob)
-            .await
+        self.add_delta_internal(
+            delta,
+            events,
+            author_id,
+            governance_position_blob,
+            delta_signature,
+        )
+        .await
     }
 
     /// Add a delta to the store (without event data)
@@ -1130,9 +1137,16 @@ impl DeltaStore {
         delta: CausalDelta<Vec<Action>>,
         author_id: Option<calimero_primitives::identity::PublicKey>,
         governance_position_blob: Option<Vec<u8>>,
+        delta_signature: Option<[u8; 64]>,
     ) -> Result<bool> {
         let result = self
-            .add_delta_internal(delta, None, author_id, governance_position_blob)
+            .add_delta_internal(
+                delta,
+                None,
+                author_id,
+                governance_position_blob,
+                delta_signature,
+            )
             .await?;
         Ok(result.applied)
     }
@@ -1270,6 +1284,7 @@ impl DeltaStore {
         events: Option<Vec<u8>>,
         author_id: Option<calimero_primitives::identity::PublicKey>,
         governance_position_blob: Option<Vec<u8>>,
+        delta_signature: Option<[u8; 64]>,
     ) -> Result<AddDeltaResult> {
         let delta_id = delta.id;
         let expected_root_hash = delta.expected_root_hash;
@@ -1303,6 +1318,7 @@ impl DeltaStore {
                         events: events.clone(), // Store events for potential cascade
                         author_id,
                         governance_position_blob: governance_position_blob.clone(),
+                        delta_signature,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to pre-persist delta with events: {}", e))?;
@@ -1380,6 +1396,7 @@ impl DeltaStore {
                         events: events.clone(),
                         author_id,
                         governance_position_blob: governance_position_blob.clone(),
+                        delta_signature,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to update applied delta: {}", e))?;
@@ -1408,6 +1425,7 @@ impl DeltaStore {
                         events: None,
                         author_id,
                         governance_position_blob,
+                        delta_signature,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to persist applied delta: {}", e))?;
@@ -1971,6 +1989,7 @@ impl DeltaStore {
                     events: stored_events.clone(),
                     author_id: None,
                     governance_position_blob: None,
+                    delta_signature: None,
                 };
                 if let Err(e) = handle.put(&db_key, &record) {
                     warn!(
@@ -2246,6 +2265,7 @@ impl DeltaStore {
                         // peer-authored deltas; no author claim to verify.
                         author_id: None,
                         governance_position_blob: None,
+                        delta_signature: None,
                     },
                 ) {
                     tracing::warn!(

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1289,6 +1289,17 @@ impl DeltaStore {
                         applied: false, // Not applied yet, will update if it applies
                         expected_root_hash,
                         events: events.clone(), // Store events for potential cascade
+                        // Receive-side persistence: author / governance
+                        // position aren't threaded through this path yet
+                        // (followup to surface them from the gossip
+                        // envelope into `add_delta_internal`). Setting
+                        // None keeps DAG-catchup serving these deltas
+                        // without an author claim — initiator-side
+                        // membership check treats None as legacy and
+                        // accepts. Anti-impersonation parity for the
+                        // receive→serve path is its own follow-up.
+                        author_id: None,
+                        governance_position_blob: None,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to pre-persist delta with events: {}", e))?;
@@ -1364,6 +1375,8 @@ impl DeltaStore {
                         applied: true,
                         expected_root_hash,
                         events: events.clone(),
+                        author_id: None,
+                        governance_position_blob: None,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to update applied delta: {}", e))?;
@@ -1390,6 +1403,8 @@ impl DeltaStore {
                         applied: true,
                         expected_root_hash,
                         events: None,
+                        author_id: None,
+                        governance_position_blob: None,
                     },
                 )
                 .map_err(|e| eyre::eyre!("Failed to persist applied delta: {}", e))?;
@@ -1951,6 +1966,8 @@ impl DeltaStore {
                     applied: true,
                     expected_root_hash: applied_delta.expected_root_hash,
                     events: stored_events.clone(),
+                    author_id: None,
+                    governance_position_blob: None,
                 };
                 if let Err(e) = handle.put(&db_key, &record) {
                     warn!(
@@ -2221,6 +2238,11 @@ impl DeltaStore {
                         applied: true, // Checkpoints are always "applied"
                         expected_root_hash: checkpoint.expected_root_hash,
                         events: None,
+                        // Snapshot checkpoints are receiver-side derived
+                        // (boundary heads from a snapshot transfer), not
+                        // peer-authored deltas; no author claim to verify.
+                        author_id: None,
+                        governance_position_blob: None,
                     },
                 ) {
                     tracing::warn!(

--- a/crates/node/src/handlers/network_event.rs
+++ b/crates/node/src/handlers/network_event.rs
@@ -70,6 +70,7 @@ impl Handler<NetworkEvent> for NodeManager {
                         events,
                         governance_position,
                         key_id,
+                        delta_signature,
                     } => {
                         info!(
                             %context_id,
@@ -104,6 +105,7 @@ impl Handler<NetworkEvent> for NodeManager {
                                 events: events.map(|e| e.into_owned()),
                                 governance_position,
                                 key_id,
+                                delta_signature,
                             },
                         };
 

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -825,8 +825,21 @@ pub(crate) async fn apply_authorized_state_delta(
     )
     .await?;
 
+    // Thread the envelope's author + governance position into the
+    // delta store so the persisted `ContextDagDelta` row carries the
+    // claim. Subsequent DAG-catchup serves from this node will then
+    // include the author info, letting the receiving initiator run
+    // the same `membership_status_at` check the gossip path ran here.
+    let governance_position_blob = governance_position
+        .as_ref()
+        .and_then(|gp| borsh::to_vec(gp).ok());
     let add_result = delta_store_ref
-        .add_delta_with_events(delta, events.clone())
+        .add_delta_with_events(
+            delta,
+            events.clone(),
+            Some(author_id),
+            governance_position_blob.clone(),
+        )
         .await?;
     let mut applied = add_result.applied;
     let mut handlers_already_executed = false;
@@ -2126,7 +2139,19 @@ async fn request_missing_deltas(
             // but `add_delta_internal`'s internal `apply_pending` can cascade
             // children that were pre-persisted with events, and those need
             // to reach `execute_cascaded_events` at the caller.
-            match delta_store.add_delta_with_events(dag_delta, None).await {
+            // Parent-fetch path: the wire's `DeltaResponse` carries
+            // `author_id` and `governance_position_blob`, but they
+            // aren't yet threaded into `fetched_deltas` (the loop
+            // builds the dag_delta from the wire content only). Persist
+            // with `None` for now — this means DAG-catchup serves from
+            // this node for the missing-parent delta would return
+            // `DeltaNotFound` until the next gossip / catch-up populates
+            // the author info. Follow-up: extend `fetched_deltas` to
+            // capture author + position from the response.
+            match delta_store
+                .add_delta_with_events(dag_delta, None, None, None)
+                .await
+            {
                 Ok(result) => {
                     if !result.cascaded_events.is_empty() {
                         info!(
@@ -2582,9 +2607,21 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
             cascaded_events: vec![],
         }
     } else {
-        // Normal case: add delta to DAG with events for handler execution
+        // Normal case: add delta to DAG with events for handler execution.
+        // The buffered envelope carries author + governance_position
+        // captured at the original gossip receive; persist them with the
+        // row so subsequent DAG-catchup serves include the claim.
+        let buffered_gov_blob = buffered
+            .governance_position
+            .as_ref()
+            .and_then(|gp| borsh::to_vec(gp).ok());
         delta_store
-            .add_delta_with_events(delta.clone(), buffered.events.clone())
+            .add_delta_with_events(
+                delta.clone(),
+                buffered.events.clone(),
+                Some(buffered.author_id),
+                buffered_gov_blob,
+            )
             .await?
     };
 

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -138,11 +138,16 @@ async fn lookup_group_key_with_wait(
 /// Each call site translates the outcome to its local error handling
 /// (warn-message wording, return-value shape, metric labels).
 ///
-/// Module-private: every consumer lives in this same file. Keeping the
-/// surface narrow means any future caller has to come through the same
-/// module that owns the TOCTOU and forward-only invariants; reducing
-/// the blast radius for accidental misuse.
-enum GroupIdCheck {
+/// `pub(crate)` because the DAG-catchup paths in `sync::manager` and
+/// `sync::delta_request` now share the same anti-bypass logic — a
+/// single source of truth for "does the claimed governance position's
+/// group match this context's owning group?". A copy-paste of the
+/// match table across modules drifted in review (the DAG-catchup
+/// head-pull was running `membership_status_at` without first checking
+/// the group_id, leaving the bypass gap open); centralising fixes that
+/// for good. New consumers must respect the TOCTOU and forward-only
+/// invariants documented on `verify_position_group_id_matches_context`.
+pub(crate) enum GroupIdCheck {
     /// Non-group context with no claimed group on the position. Legacy
     /// path: no enforcement applies. Fall through to apply.
     NonGroupOk,
@@ -214,7 +219,7 @@ impl std::fmt::Debug for GroupIdCheck {
 /// invariant that mitigates the TOCTOU window; if that ever changes,
 /// the check needs to be promoted to a snapshot read across both
 /// lookups.
-fn verify_position_group_id_matches_context(
+pub(crate) fn verify_position_group_id_matches_context(
     store: &calimero_store::Store,
     context_id: &ContextId,
     claimed_group_id: Option<calimero_context_config::types::ContextGroupId>,
@@ -870,13 +875,19 @@ pub(crate) async fn apply_authorized_state_delta(
     let governance_position_blob = governance_position
         .as_ref()
         .and_then(|gp| borsh::to_vec(gp).ok());
+    // Persist the wire-received `delta_signature` (verified above)
+    // so subsequent DAG-catchup serves from this node include the
+    // envelope signature. Without this, the anti-impersonation
+    // property the signature provides only holds for the originating
+    // node — every relay would drop the signature and downstream
+    // peers couldn't verify.
     let add_result = delta_store_ref
         .add_delta_with_events(
             delta,
             events.clone(),
             Some(author_id),
             governance_position_blob.clone(),
-            None,
+            delta_signature,
         )
         .await?;
     let mut applied = add_result.applied;
@@ -2829,7 +2840,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                 buffered.events.clone(),
                 Some(buffered.author_id),
                 buffered_gov_blob,
-                None,
+                buffered.delta_signature,
             )
             .await?
     };

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2151,6 +2151,38 @@ async fn request_missing_deltas(
                         "Received missing parent delta"
                     );
 
+                    // Genesis carve-out: the responder serves the
+                    // genesis delta with the all-zeros sentinel
+                    // `author_id` because the wire requires an author
+                    // but genesis predates any governance op. Skip
+                    // every author-keyed check, persist directly with
+                    // `None` author info so subsequent serves see it
+                    // as the genesis row and use the same sentinel
+                    // dispatch.
+                    if crate::sync::delta_request::is_genesis_author_sentinel(&response_author) {
+                        debug!(
+                            %context_id,
+                            delta_id = ?missing_id,
+                            "parent-fetch: accepting genesis delta via author sentinel"
+                        );
+                        let dag_delta = calimero_dag::CausalDelta {
+                            id: storage_delta.id,
+                            parents: storage_delta.parents.clone(),
+                            payload: storage_delta.actions,
+                            hlc: storage_delta.hlc,
+                            expected_root_hash: storage_delta.expected_root_hash,
+                            kind: calimero_dag::DeltaKind::Regular,
+                        };
+                        // Persist with `author_id: None` so when this
+                        // node later serves the genesis row, the
+                        // responder's existing genesis carve-out
+                        // (`stored_delta.author_id is None &&
+                        // parents == [[0;32]]`) fires and re-wraps
+                        // with the sentinel for the next hop.
+                        fetched_deltas.push((dag_delta, missing_id, response_author, None, None));
+                        continue;
+                    }
+
                     // Decode governance_position once for both the
                     // envelope-signature verification and the cross-
                     // DAG membership check below.

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2203,6 +2203,82 @@ async fn request_missing_deltas(
                         }
                     }
 
+                    // Sanity check: peer returned the delta we
+                    // requested. A malicious or buggy peer could send
+                    // a different delta's body in response to our
+                    // request; the envelope signature we verified
+                    // above bound `storage_delta.id`, not
+                    // `missing_id`, so a body-id mismatch would slip
+                    // an unrelated authorized delta into our DAG.
+                    if storage_delta.id != missing_id {
+                        warn!(
+                            %context_id,
+                            requested = ?missing_id,
+                            received = ?storage_delta.id,
+                            "parent-fetch: peer returned a different delta id than requested, dropping"
+                        );
+                        continue;
+                    }
+
+                    // Group-id parity check: same as the gossip apply
+                    // path. Without this, a delta whose author signed
+                    // a position citing a *different* group's
+                    // governance could pass the membership check
+                    // (`membership_status_at` walks the cited group's
+                    // DAG, not this context's owning group) and slip
+                    // through. Match the `GroupIdCheck` branches
+                    // `verify_position_group_id_matches_context`
+                    // returns to apply identical reject/skip rules.
+                    match verify_position_group_id_matches_context(
+                        &datastore,
+                        &context_id,
+                        governance_position.as_ref().map(|p| p.group_id),
+                    ) {
+                        GroupIdCheck::NonGroupOk | GroupIdCheck::Match => {
+                            // ok — fall through to membership check
+                        }
+                        GroupIdCheck::GroupContextNoPosition { owning } => {
+                            warn!(
+                                %context_id,
+                                delta_id = ?missing_id,
+                                author = %response_author,
+                                owning_group = ?owning,
+                                "parent-fetch: group context but no governance_position, dropping"
+                            );
+                            continue;
+                        }
+                        GroupIdCheck::NonGroupContextWithPosition { claimed } => {
+                            warn!(
+                                %context_id,
+                                delta_id = ?missing_id,
+                                author = %response_author,
+                                claimed_group = ?claimed,
+                                "parent-fetch: non-group context but position claims a group, dropping"
+                            );
+                            continue;
+                        }
+                        GroupIdCheck::Mismatch { owning, claimed } => {
+                            warn!(
+                                %context_id,
+                                delta_id = ?missing_id,
+                                author = %response_author,
+                                owning_group = ?owning,
+                                claimed_group = ?claimed,
+                                "parent-fetch: governance_position cites a different group than context owns, dropping"
+                            );
+                            continue;
+                        }
+                        GroupIdCheck::LookupError(err) => {
+                            warn!(
+                                %context_id,
+                                delta_id = ?missing_id,
+                                %err,
+                                "parent-fetch: get_group_for_context failed, dropping to avoid silent bypass"
+                            );
+                            continue;
+                        }
+                    }
+
                     // Cross-DAG membership check: same as the
                     // request_dag_heads_and_sync path. Reject deltas
                     // whose author was removed at the cited cut.

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2071,10 +2071,10 @@ async fn request_missing_deltas(
     let mut to_fetch = missing_ids;
     type ParentFetch = (
         calimero_dag::CausalDelta<Vec<Action>>,
-        [u8; 32],                // delta_id (redundant with .id but kept for log clarity)
-        PublicKey,               // author_id from wire
-        Option<Vec<u8>>,         // governance_position_blob from wire
-        Option<[u8; 64]>,        // delta_signature from wire
+        [u8; 32],         // delta_id (redundant with .id but kept for log clarity)
+        PublicKey,        // author_id from wire
+        Option<Vec<u8>>,  // governance_position_blob from wire
+        Option<[u8; 64]>, // delta_signature from wire
     );
     let mut fetched_deltas: Vec<ParentFetch> = Vec::new();
     let mut fetch_count = 0;
@@ -2147,7 +2147,9 @@ async fn request_missing_deltas(
                         calimero_context_config::types::GovernancePosition,
                     > = match governance_position_blob
                         .as_deref()
-                        .map(borsh::from_slice::<calimero_context_config::types::GovernancePosition>)
+                        .map(
+                            borsh::from_slice::<calimero_context_config::types::GovernancePosition>,
+                        )
                         .transpose()
                     {
                         Ok(pos) => pos,
@@ -2169,13 +2171,15 @@ async fn request_missing_deltas(
                     // `None` is tolerated for the wire-up transition;
                     // any present signature MUST verify.
                     if let Some(ref sig) = response_delta_signature {
-                        if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
-                            context_id,
-                            storage_delta.id,
-                            response_author,
-                            governance_position.as_ref(),
-                            sig,
-                        ) {
+                        if let Err(err) =
+                            calimero_node_primitives::sync::delta_auth::verify_delta_signature(
+                                context_id,
+                                storage_delta.id,
+                                response_author,
+                                governance_position.as_ref(),
+                                sig,
+                            )
+                        {
                             warn!(
                                 %context_id,
                                 delta_id = ?missing_id,
@@ -2269,7 +2273,9 @@ async fn request_missing_deltas(
                         // Skip if we already have it or are about to fetch it
                         if !delta_store.has_delta(parent_id).await
                             && !to_fetch.contains(parent_id)
-                            && !fetched_deltas.iter().any(|(d, _, _, _, _)| d.id == *parent_id)
+                            && !fetched_deltas
+                                .iter()
+                                .any(|(d, _, _, _, _)| d.id == *parent_id)
                         {
                             to_fetch.push(*parent_id);
                         }
@@ -2300,8 +2306,8 @@ async fn request_missing_deltas(
         // Reverse so oldest ancestors are added first
         fetched_deltas.reverse();
 
-        for (dag_delta, delta_id, author_id, governance_position_blob, delta_signature)
-            in fetched_deltas
+        for (dag_delta, delta_id, author_id, governance_position_blob, delta_signature) in
+            fetched_deltas
         {
             // Use the events-aware entry point so we can forward any events
             // attached to *cascaded children* to the caller. The peer-fetched

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -246,6 +246,7 @@ pub(crate) struct StateDeltaMessage {
     pub(crate) events: Option<Vec<u8>>,
     pub(crate) governance_position: Option<GovernancePosition>,
     pub(crate) key_id: [u8; 32],
+    pub(crate) delta_signature: Option<[u8; 64]>,
 }
 
 #[derive(Clone)]
@@ -542,6 +543,7 @@ fn state_delta_message_from_buffered(
         events: buffered.events,
         governance_position: buffered.governance_position,
         key_id: buffered.key_id,
+        delta_signature: buffered.delta_signature,
     }
 }
 
@@ -601,7 +603,40 @@ pub(crate) async fn apply_authorized_state_delta(
         events,
         governance_position,
         key_id,
+        delta_signature,
     } = message;
+
+    // Per-delta envelope signature verification. Closes the anti-
+    // impersonation gap on the delta envelope: even if the sender holds
+    // the current group key (so per-action signatures pass) and even if
+    // `membership_status_at(author, pos)` returns `Member`, they can't
+    // relabel a foreign delta as their own (or claim authorship of a
+    // delta someone else wrote) without holding `author_id`'s identity
+    // key. Sits BEFORE the cross-DAG check and ReadOnly check because
+    // those checks key off `author_id` — there's no point asking
+    // "is this author a member?" if we haven't yet established that
+    // the claim of authorship is genuine. `None` is currently tolerated
+    // because signing at the execute site is wired up in a follow-up
+    // (Wave 5 sub-commit B); once that lands, `None` becomes a hard
+    // reject and this branch tightens.
+    if let Some(ref sig) = delta_signature {
+        if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
+            context_id,
+            delta_id,
+            author_id,
+            governance_position.as_ref(),
+            sig,
+        ) {
+            warn!(
+                %context_id,
+                %author_id,
+                delta_id = ?delta_id,
+                %err,
+                "Rejecting state delta — envelope signature verification failed"
+            );
+            return Ok(());
+        }
+    }
 
     let Some(context) = node_clients.context.get_context(&context_id)? else {
         bail!("context '{}' not found", context_id);
@@ -657,6 +692,7 @@ pub(crate) async fn apply_authorized_state_delta(
             source_peer: source,
             key_id,
             governance_position: governance_position.clone(),
+            delta_signature,
             governance_drain_attempts: 0,
         };
 
@@ -692,6 +728,7 @@ pub(crate) async fn apply_authorized_state_delta(
                 source_peer: source,
                 key_id,
                 governance_position: governance_position.clone(),
+                delta_signature,
                 governance_drain_attempts: 0,
             };
 
@@ -1080,6 +1117,7 @@ pub async fn handle_state_delta(
         events,
         governance_position,
         key_id,
+        delta_signature,
     } = message;
 
     let Some(context) = node_clients.context.get_context(&context_id)? else {
@@ -1328,6 +1366,7 @@ pub async fn handle_state_delta(
                     source_peer: source,
                     key_id,
                     governance_position: governance_position.clone(),
+                    delta_signature,
                     governance_drain_attempts: 0,
                 };
                 node_state.buffer_governance_pending(context_id, buffered);
@@ -1371,6 +1410,7 @@ pub async fn handle_state_delta(
             events,
             governance_position,
             key_id,
+            delta_signature,
         },
     )
     .await

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2279,6 +2279,30 @@ async fn request_missing_deltas(
                         }
                     }
 
+                    // ReadOnly check — parity with the gossip apply
+                    // path in `apply_authorized_state_delta`.
+                    // `membership_status_at` treats ReadOnly as
+                    // `Member(ReadOnly)`, so without a separate
+                    // `is_read_only_for_context` gate a delta authored
+                    // by a ReadOnly / ReadOnlyTee identity passes the
+                    // membership check on the catchup path even
+                    // though gossip rejects the same envelope.
+                    if calimero_context::group_store::is_read_only_for_context(
+                        &datastore,
+                        &context_id,
+                        &response_author,
+                    )
+                    .unwrap_or(false)
+                    {
+                        warn!(
+                            %context_id,
+                            delta_id = ?missing_id,
+                            author = %response_author,
+                            "parent-fetch: rejecting delta from ReadOnly member"
+                        );
+                        continue;
+                    }
+
                     // Cross-DAG membership check: same as the
                     // request_dag_heads_and_sync path. Reject deltas
                     // whose author was removed at the cited cut.

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -839,6 +839,7 @@ pub(crate) async fn apply_authorized_state_delta(
             events.clone(),
             Some(author_id),
             governance_position_blob.clone(),
+            None,
         )
         .await?;
     let mut applied = add_result.applied;
@@ -2149,7 +2150,7 @@ async fn request_missing_deltas(
             // the author info. Follow-up: extend `fetched_deltas` to
             // capture author + position from the response.
             match delta_store
-                .add_delta_with_events(dag_delta, None, None, None)
+                .add_delta_with_events(dag_delta, None, None, None, None)
                 .await
             {
                 Ok(result) => {
@@ -2621,6 +2622,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                 buffered.events.clone(),
                 Some(buffered.author_id),
                 buffered_gov_blob,
+                None,
             )
             .await?
     };

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2051,7 +2051,7 @@ async fn request_missing_deltas(
             let timeout_budget = sync_timeout / 3;
             match crate::sync::stream::recv(&mut stream, None, timeout_budget).await? {
                 Some(StreamMessage::Message {
-                    payload: MessagePayload::DeltaResponse { delta },
+                    payload: MessagePayload::DeltaResponse { delta, .. },
                     ..
                 }) => {
                     // Deserialize storage delta

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -933,6 +933,7 @@ pub(crate) async fn apply_authorized_state_delta(
                 "Delta pending due to missing parents - requesting them from peer"
             );
 
+            let datastore_for_fetch = node_clients.context.datastore_handle().into_inner();
             match request_missing_deltas(
                 network_client,
                 sync_timeout,
@@ -941,6 +942,7 @@ pub(crate) async fn apply_authorized_state_delta(
                 source,
                 our_identity,
                 delta_store_ref.clone(),
+                datastore_for_fetch,
             )
             .await
             {
@@ -2049,6 +2051,7 @@ async fn request_missing_deltas(
     source: PeerId,
     our_identity: PublicKey,
     delta_store: DeltaStore,
+    datastore: calimero_store::Store,
 ) -> Result<Vec<([u8; 32], Vec<u8>)>> {
     use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
@@ -2060,9 +2063,20 @@ async fn request_missing_deltas(
     // Open stream to peer
     let mut stream = network_client.open_stream(source).await?;
 
-    // Fetch all missing ancestors, then add them in topological order (oldest first)
+    // Fetch all missing ancestors, then add them in topological order (oldest first).
+    // The tuple carries the wire-received author + governance position
+    // + envelope signature so the persist step writes them to the
+    // `ContextDagDelta` row (next DAG-catchup serves can pass them on)
+    // and the cross-DAG check + envelope verification fire before apply.
     let mut to_fetch = missing_ids;
-    let mut fetched_deltas: Vec<(calimero_dag::CausalDelta<Vec<Action>>, [u8; 32])> = Vec::new();
+    type ParentFetch = (
+        calimero_dag::CausalDelta<Vec<Action>>,
+        [u8; 32],                // delta_id (redundant with .id but kept for log clarity)
+        PublicKey,               // author_id from wire
+        Option<Vec<u8>>,         // governance_position_blob from wire
+        Option<[u8; 64]>,        // delta_signature from wire
+    );
+    let mut fetched_deltas: Vec<ParentFetch> = Vec::new();
     let mut fetch_count = 0;
     // Accumulated (delta_id, events_data) pairs from any cascades that
     // happen while adding peer-fetched parents below. Passed back to the
@@ -2105,7 +2119,13 @@ async fn request_missing_deltas(
             let timeout_budget = sync_timeout / 3;
             match crate::sync::stream::recv(&mut stream, None, timeout_budget).await? {
                 Some(StreamMessage::Message {
-                    payload: MessagePayload::DeltaResponse { delta, .. },
+                    payload:
+                        MessagePayload::DeltaResponse {
+                            delta,
+                            author_id: response_author,
+                            governance_position_blob,
+                            delta_signature: response_delta_signature,
+                        },
                     ..
                 }) => {
                     // Deserialize storage delta
@@ -2115,9 +2135,109 @@ async fn request_missing_deltas(
                     info!(
                         %context_id,
                         delta_id = ?missing_id,
+                        author = %response_author,
                         action_count = storage_delta.actions.len(),
                         "Received missing parent delta"
                     );
+
+                    // Decode governance_position once for both the
+                    // envelope-signature verification and the cross-
+                    // DAG membership check below.
+                    let governance_position: Option<
+                        calimero_context_config::types::GovernancePosition,
+                    > = match governance_position_blob
+                        .as_deref()
+                        .map(borsh::from_slice::<calimero_context_config::types::GovernancePosition>)
+                        .transpose()
+                    {
+                        Ok(pos) => pos,
+                        Err(err) => {
+                            warn!(
+                                %context_id,
+                                delta_id = ?missing_id,
+                                %err,
+                                "parent-fetch: failed to decode governance_position from \
+                                 peer; skipping this delta to avoid silent bypass"
+                            );
+                            continue;
+                        }
+                    };
+
+                    // Envelope-signature verification (parity with the
+                    // gossip + DAG-catchup paths in
+                    // `apply_authorized_state_delta` / `request_dag_heads_and_sync`).
+                    // `None` is tolerated for the wire-up transition;
+                    // any present signature MUST verify.
+                    if let Some(ref sig) = response_delta_signature {
+                        if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
+                            context_id,
+                            storage_delta.id,
+                            response_author,
+                            governance_position.as_ref(),
+                            sig,
+                        ) {
+                            warn!(
+                                %context_id,
+                                delta_id = ?missing_id,
+                                author = %response_author,
+                                %err,
+                                "parent-fetch: envelope signature verification failed, dropping"
+                            );
+                            continue;
+                        }
+                    }
+
+                    // Cross-DAG membership check: same as the
+                    // request_dag_heads_and_sync path. Reject deltas
+                    // whose author was removed at the cited cut.
+                    if let Some(ref pos) = governance_position {
+                        use calimero_context::group_store::{
+                            membership_status_at, MembershipStatus,
+                        };
+                        match membership_status_at(&datastore, &response_author, pos) {
+                            Ok(MembershipStatus::Member(_)) => {}
+                            Ok(MembershipStatus::Removed { last_role }) => {
+                                warn!(
+                                    %context_id,
+                                    delta_id = ?missing_id,
+                                    author = %response_author,
+                                    last_role = ?last_role,
+                                    "parent-fetch: author was removed at cited cut, dropping"
+                                );
+                                continue;
+                            }
+                            Ok(MembershipStatus::NeverMember) => {
+                                warn!(
+                                    %context_id,
+                                    delta_id = ?missing_id,
+                                    author = %response_author,
+                                    "parent-fetch: author never a member at cited cut, dropping"
+                                );
+                                continue;
+                            }
+                            Ok(MembershipStatus::Unknown { needed }) => {
+                                warn!(
+                                    %context_id,
+                                    delta_id = ?missing_id,
+                                    author = %response_author,
+                                    needed = ?needed,
+                                    "parent-fetch: governance cut not locally known, skipping"
+                                );
+                                continue;
+                            }
+                            Err(err) => {
+                                warn!(
+                                    %context_id,
+                                    delta_id = ?missing_id,
+                                    author = %response_author,
+                                    %err,
+                                    "parent-fetch: membership_status_at failed, dropping to \
+                                     avoid silent bypass"
+                                );
+                                continue;
+                            }
+                        }
+                    }
 
                     // Convert to DAG delta
                     let dag_delta = calimero_dag::CausalDelta {
@@ -2129,8 +2249,16 @@ async fn request_missing_deltas(
                         kind: calimero_dag::DeltaKind::Regular,
                     };
 
-                    // Store for later (don't add to DAG yet!)
-                    fetched_deltas.push((dag_delta, missing_id));
+                    // Store for later (don't add to DAG yet!) — carry
+                    // the verified wire fields so the persist step
+                    // can write them to the row.
+                    fetched_deltas.push((
+                        dag_delta,
+                        missing_id,
+                        response_author,
+                        governance_position_blob.as_ref().map(|c| c.to_vec()),
+                        response_delta_signature,
+                    ));
 
                     // Check what parents THIS delta needs
                     for parent_id in &storage_delta.parents {
@@ -2141,7 +2269,7 @@ async fn request_missing_deltas(
                         // Skip if we already have it or are about to fetch it
                         if !delta_store.has_delta(parent_id).await
                             && !to_fetch.contains(parent_id)
-                            && !fetched_deltas.iter().any(|(d, _)| d.id == *parent_id)
+                            && !fetched_deltas.iter().any(|(d, _, _, _, _)| d.id == *parent_id)
                         {
                             to_fetch.push(*parent_id);
                         }
@@ -2172,7 +2300,9 @@ async fn request_missing_deltas(
         // Reverse so oldest ancestors are added first
         fetched_deltas.reverse();
 
-        for (dag_delta, delta_id) in fetched_deltas {
+        for (dag_delta, delta_id, author_id, governance_position_blob, delta_signature)
+            in fetched_deltas
+        {
             // Use the events-aware entry point so we can forward any events
             // attached to *cascaded children* to the caller. The peer-fetched
             // parent itself has no events (the wire protocol doesn't carry
@@ -2180,17 +2310,20 @@ async fn request_missing_deltas(
             // but `add_delta_internal`'s internal `apply_pending` can cascade
             // children that were pre-persisted with events, and those need
             // to reach `execute_cascaded_events` at the caller.
-            // Parent-fetch path: the wire's `DeltaResponse` carries
-            // `author_id` and `governance_position_blob`, but they
-            // aren't yet threaded into `fetched_deltas` (the loop
-            // builds the dag_delta from the wire content only). Persist
-            // with `None` for now — this means DAG-catchup serves from
-            // this node for the missing-parent delta would return
-            // `DeltaNotFound` until the next gossip / catch-up populates
-            // the author info. Follow-up: extend `fetched_deltas` to
-            // capture author + position from the response.
+            //
+            // The wire-received author + governance position + envelope
+            // signature are persisted on the row so subsequent
+            // DAG-catchup serves from this node include the claim
+            // (responder filters out rows without an author claim, see
+            // `crates/node/src/sync/delta_request.rs`).
             match delta_store
-                .add_delta_with_events(dag_delta, None, None, None, None)
+                .add_delta_with_events(
+                    dag_delta,
+                    None,
+                    Some(author_id),
+                    governance_position_blob,
+                    delta_signature,
+                )
                 .await
             {
                 Ok(result) => {
@@ -2354,6 +2487,33 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
     let _context = context_client
         .get_context(&context_id)?
         .ok_or_else(|| eyre::eyre!("context not found after snapshot sync"))?;
+
+    // Per-delta envelope signature verification, parity with the
+    // gossip + DAG-catchup + parent-fetch paths. The `BufferedDelta`
+    // carries the signature through snapshot-sync buffering precisely
+    // so a replayed delta is re-verified against the same payload the
+    // original sender signed (Wave 5). Without this gate, snapshot-
+    // sync replay would silently accept envelope-forged buffered
+    // deltas — the very class of attack the envelope signature
+    // exists to prevent.
+    if let Some(ref sig) = buffered.delta_signature {
+        if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
+            context_id,
+            delta_id,
+            buffered.author_id,
+            buffered.governance_position.as_ref(),
+            sig,
+        ) {
+            warn!(
+                %context_id,
+                delta_id = ?delta_id,
+                author = %buffered.author_id,
+                %err,
+                "Rejecting buffered state delta — envelope signature verification failed"
+            );
+            return Ok(false);
+        }
+    }
 
     // ReadOnly check, parallel to `handle_state_delta` and
     // `apply_authorized_state_delta`. Snapshot-sync replay must enforce the

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -615,10 +615,10 @@ pub(crate) async fn apply_authorized_state_delta(
     // key. Sits BEFORE the cross-DAG check and ReadOnly check because
     // those checks key off `author_id` — there's no point asking
     // "is this author a member?" if we haven't yet established that
-    // the claim of authorship is genuine. `None` is currently tolerated
-    // because signing at the execute site is wired up in a follow-up
-    // (Wave 5 sub-commit B); once that lands, `None` becomes a hard
-    // reject and this branch tightens.
+    // the claim of authorship is genuine. `None` is tolerated only
+    // for legacy rows authored before envelope signing landed; all
+    // freshly-signed deltas (every output of `internal_execute`)
+    // carry `Some(_)` and MUST verify.
     if let Some(ref sig) = delta_signature {
         if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
             context_id,
@@ -2168,8 +2168,9 @@ async fn request_missing_deltas(
                     // Envelope-signature verification (parity with the
                     // gossip + DAG-catchup paths in
                     // `apply_authorized_state_delta` / `request_dag_heads_and_sync`).
-                    // `None` is tolerated for the wire-up transition;
-                    // any present signature MUST verify.
+                    // `None` is only tolerated for legacy rows
+                    // authored before envelope signing landed; any
+                    // present signature MUST verify.
                     if let Some(ref sig) = response_delta_signature {
                         if let Err(err) =
                             calimero_node_primitives::sync::delta_auth::verify_delta_signature(

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2082,8 +2082,12 @@ async fn request_missing_deltas(
     let mut to_fetch = missing_ids;
     type ParentFetch = (
         calimero_dag::CausalDelta<Vec<Action>>,
-        [u8; 32],         // delta_id (redundant with .id but kept for log clarity)
-        PublicKey,        // author_id from wire
+        [u8; 32], // delta_id (redundant with .id but kept for log clarity)
+        // `None` for genesis (matches what `create_context` persists
+        // — the row's existence + parents=[[0;32]] is what the
+        // responder's carve-out keys off, NOT the sentinel author id).
+        // `Some(author)` for every other delta.
+        Option<PublicKey>,
         Option<Vec<u8>>,  // governance_position_blob from wire
         Option<[u8; 64]>, // delta_signature from wire
     );
@@ -2178,8 +2182,9 @@ async fn request_missing_deltas(
                         // responder's existing genesis carve-out
                         // (`stored_delta.author_id is None &&
                         // parents == [[0;32]]`) fires and re-wraps
-                        // with the sentinel for the next hop.
-                        fetched_deltas.push((dag_delta, missing_id, response_author, None, None));
+                        // with the sentinel for the next hop. Matches
+                        // what `create_context` originally persists.
+                        fetched_deltas.push((dag_delta, missing_id, None, None, None));
                         continue;
                     }
 
@@ -2403,7 +2408,7 @@ async fn request_missing_deltas(
                     fetched_deltas.push((
                         dag_delta,
                         missing_id,
-                        response_author,
+                        Some(response_author),
                         governance_position_blob.as_ref().map(|c| c.to_vec()),
                         response_delta_signature,
                     ));
@@ -2470,7 +2475,7 @@ async fn request_missing_deltas(
                 .add_delta_with_events(
                     dag_delta,
                     None,
-                    Some(author_id),
+                    author_id,
                     governance_position_blob,
                     delta_signature,
                 )

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -60,6 +60,18 @@ pub(crate) struct GovernanceDrainLabels {
     pub(crate) outcome: String,
 }
 
+/// Outcome label for HC / LevelWise / EntityPush per-leaf drops in
+/// `sync::helpers::is_leaf_currently_authorized`. Separates "author is
+/// not currently a member" (an expected, common outcome under churn)
+/// from "the store lookup itself failed" (rare, indicates I/O trouble
+/// — should never approach the rate of the former).
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct LeafDropLabels {
+    /// One of: `unauthorized` (membership check returned `false`),
+    /// `lookup_error` (storage layer raised).
+    pub(crate) reason: String,
+}
+
 /// Snapshot of all node-level metric handles.
 ///
 /// Clone-friendly: the families and counters are wrapped in `Arc` by
@@ -90,6 +102,9 @@ pub(crate) struct NodeMetrics {
     pub(crate) delta_outcomes_total: Family<DeltaApplyLabels, Counter>,
     pub(crate) delta_cascade_size: Histogram,
     pub(crate) delta_missing_parents_total: Counter,
+
+    // HC / LevelWise / EntityPush per-leaf authorization drops.
+    pub(crate) hc_leaf_drops_total: Family<LeafDropLabels, Counter>,
 
     // Governance-pending drain outcomes (B2 buffer-on-unknown lifecycle).
     pub(crate) governance_drain_outcomes_total: Family<GovernanceDrainLabels, Counter>,
@@ -204,6 +219,14 @@ impl NodeMetrics {
             delta_missing_parents_total.clone(),
         );
 
+        let hc_leaf_drops_total: Family<LeafDropLabels, Counter> = Family::default();
+        registry.register(
+            "hc_leaf_drops_total",
+            "HC / LevelWise / EntityPush leaves dropped by the apply-time \
+             current-membership check, labelled by reason",
+            hc_leaf_drops_total.clone(),
+        );
+
         let governance_drain_outcomes_total: Family<GovernanceDrainLabels, Counter> =
             Family::default();
         registry.register(
@@ -252,6 +275,7 @@ impl NodeMetrics {
             delta_outcomes_total,
             delta_cascade_size,
             delta_missing_parents_total,
+            hc_leaf_drops_total,
             governance_drain_outcomes_total,
             process_resident_memory_bytes,
             process_virtual_memory_bytes,
@@ -509,6 +533,28 @@ pub(crate) fn record_governance_drain_outcome(outcome: &str) {
         m.governance_drain_outcomes_total
             .get_or_create(&GovernanceDrainLabels {
                 outcome: outcome.to_owned(),
+            })
+            .inc();
+    }
+}
+
+/// Bump the HC leaf-drop counter. `reason` is one of:
+///
+/// * `"unauthorized"` — the current-membership check returned `false`;
+///   author was either never a member or has been removed.
+/// * `"lookup_error"` — the underlying store lookup raised; receiver
+///   dropped the leaf defensively rather than risking a silent bypass.
+///
+/// Operators care about the *ratio* between these two: a steady stream
+/// of `unauthorized` under churn is normal (legitimate post-removal
+/// rejection); a non-trivial rate of `lookup_error` is an I/O signal
+/// that warrants investigation, since each one is a silently-dropped
+/// entity.
+pub(crate) fn record_hc_leaf_drop(reason: &str) {
+    if let Some(m) = global() {
+        m.hc_leaf_drops_total
+            .get_or_create(&LeafDropLabels {
+                reason: reason.to_owned(),
             })
             .inc();
     }

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -197,7 +197,7 @@ impl SyncManager {
 
         match super::stream::recv(stream, None, timeout_budget).await? {
             Some(StreamMessage::Message {
-                payload: MessagePayload::DeltaResponse { delta },
+                payload: MessagePayload::DeltaResponse { delta, .. },
                 ..
             }) => {
                 // Deserialize delta
@@ -280,11 +280,15 @@ impl SyncManager {
                 delta_id = ?delta_id,
                 size = serialized.len(),
                 source = "RocksDB",
+                author_present = stored_delta.author_id.is_some(),
+                governance_position_present = stored_delta.governance_position_blob.is_some(),
                 "Sending requested delta to peer"
             );
 
             MessagePayload::DeltaResponse {
                 delta: serialized.into(),
+                author_id: stored_delta.author_id,
+                governance_position_blob: stored_delta.governance_position_blob.map(Into::into),
             }
         } else if let Some(delta_store) = self.state_access.delta_store(&context_id) {
             // Not in RocksDB yet (race condition after broadcast), try DeltaStore
@@ -308,8 +312,16 @@ impl SyncManager {
                     "Sending requested delta to peer"
                 );
 
+                // In-memory DeltaStore doesn't carry author info (only
+                // RocksDB does, set at the post-apply persistence
+                // sites). Race-path serves without author claim; the
+                // initiator accepts it as legacy. Subsequent DAG-catchup
+                // calls for the same delta after the post-apply persist
+                // settles will carry the author info.
                 MessagePayload::DeltaResponse {
                     delta: serialized.into(),
+                    author_id: None,
+                    governance_position_blob: None,
                 }
             } else {
                 warn!(

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -261,68 +261,70 @@ impl SyncManager {
         let db_key = key::ContextDagDelta::new(context_id, delta_id);
 
         let response = if let Some(stored_delta) = handle.get(&db_key)? {
-            // Found in RocksDB - reconstruct CausalDelta with HLC
-            let actions: Vec<calimero_storage::interface::Action> =
-                borsh::from_slice(&stored_delta.actions)?;
+            // Found in RocksDB. If the stored row lacks an author
+            // claim (snapshot checkpoints, race-path persists that
+            // didn't carry author info), refuse to serve via this
+            // path — the initiator's check requires an author, and
+            // we won't bypass it. The initiator's fallback chain
+            // (DAG-catchup-None → snapshot) handles recovery.
+            match stored_delta.author_id {
+                None => {
+                    debug!(
+                        %context_id,
+                        delta_id = ?delta_id,
+                        "Delta found but stored without an author claim (likely a snapshot \
+                         checkpoint or pre-author-tracking row) — returning DeltaNotFound \
+                         so the initiator falls back to a verifiable path"
+                    );
+                    MessagePayload::DeltaNotFound
+                }
+                Some(author_id) => {
+                    let actions: Vec<calimero_storage::interface::Action> =
+                        borsh::from_slice(&stored_delta.actions)?;
 
-            let causal_delta = CausalDelta {
-                id: stored_delta.delta_id,
-                parents: stored_delta.parents,
-                actions,
-                hlc: stored_delta.hlc,
-                expected_root_hash: stored_delta.expected_root_hash,
-            };
+                    let causal_delta = CausalDelta {
+                        id: stored_delta.delta_id,
+                        parents: stored_delta.parents,
+                        actions,
+                        hlc: stored_delta.hlc,
+                        expected_root_hash: stored_delta.expected_root_hash,
+                    };
 
-            let serialized = borsh::to_vec(&causal_delta)?;
+                    let serialized = borsh::to_vec(&causal_delta)?;
 
-            debug!(
-                %context_id,
-                delta_id = ?delta_id,
-                size = serialized.len(),
-                source = "RocksDB",
-                author_present = stored_delta.author_id.is_some(),
-                governance_position_present = stored_delta.governance_position_blob.is_some(),
-                "Sending requested delta to peer"
-            );
+                    debug!(
+                        %context_id,
+                        delta_id = ?delta_id,
+                        size = serialized.len(),
+                        source = "RocksDB",
+                        governance_position_present =
+                            stored_delta.governance_position_blob.is_some(),
+                        "Sending requested delta to peer"
+                    );
 
-            MessagePayload::DeltaResponse {
-                delta: serialized.into(),
-                author_id: stored_delta.author_id,
-                governance_position_blob: stored_delta.governance_position_blob.map(Into::into),
+                    MessagePayload::DeltaResponse {
+                        delta: serialized.into(),
+                        author_id,
+                        governance_position_blob: stored_delta
+                            .governance_position_blob
+                            .map(Into::into),
+                    }
+                }
             }
         } else if let Some(delta_store) = self.state_access.delta_store(&context_id) {
-            // Not in RocksDB yet (race condition after broadcast), try DeltaStore
-            if let Some(dag_delta) = delta_store.get_delta(&delta_id).await {
-                // dag::CausalDelta now includes HLC, so we can directly convert
-                let causal_delta = CausalDelta {
-                    id: dag_delta.id,
-                    parents: dag_delta.parents,
-                    actions: dag_delta.payload,
-                    hlc: dag_delta.hlc,
-                    expected_root_hash: dag_delta.expected_root_hash,
-                };
-
-                let serialized = borsh::to_vec(&causal_delta)?;
-
+            // Not in RocksDB yet (race condition after broadcast). The
+            // in-memory `DeltaStore` doesn't carry author info, so we
+            // can't serve a verifiable response from there. Return
+            // DeltaNotFound and let the initiator re-fetch once the
+            // post-apply persist has settled (next sync tick).
+            if delta_store.get_delta(&delta_id).await.is_some() {
                 debug!(
                     %context_id,
                     delta_id = ?delta_id,
-                    size = serialized.len(),
-                    source = "DeltaStore",
-                    "Sending requested delta to peer"
+                    "Delta in in-memory DeltaStore but not yet persisted with author info — \
+                     returning DeltaNotFound; initiator will re-fetch after persist settles"
                 );
-
-                // In-memory DeltaStore doesn't carry author info (only
-                // RocksDB does, set at the post-apply persistence
-                // sites). Race-path serves without author claim; the
-                // initiator accepts it as legacy. Subsequent DAG-catchup
-                // calls for the same delta after the post-apply persist
-                // settles will carry the author info.
-                MessagePayload::DeltaResponse {
-                    delta: serialized.into(),
-                    author_id: None,
-                    governance_position_blob: None,
-                }
+                MessagePayload::DeltaNotFound
             } else {
                 warn!(
                     %context_id,

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -22,6 +22,34 @@ const MAX_DELTA_FETCH_LIMIT: usize = 3000;
 const DELTA_WARN_LIMIT: usize = 1000;
 const GENESIS_DELTA_ID: [u8; 32] = [0u8; 32];
 
+/// Sentinel `author_id` the DAG-catchup responder uses to serve the
+/// genesis delta on the wire. `create_context` persists the genesis
+/// row with `author_id: None` (genesis predates any governance op so
+/// there's no real author to verify), but the wire format requires
+/// `author_id: PublicKey`. The all-zeros pubkey is never a valid
+/// signing key, so it can't collide with a real author claim;
+/// receivers detect it via [`is_genesis_author_sentinel`] and skip
+/// every author-keyed check (signature verify, `is_read_only`,
+/// `membership_status_at`, `GroupIdCheck`) that doesn't apply to
+/// genesis. Without this carve-out late joiners stall on missing
+/// genesis ancestors.
+pub(crate) const GENESIS_AUTHOR_SENTINEL: [u8; 32] = [0u8; 32];
+
+/// Construct the genesis sentinel as a `PublicKey` for the responder.
+pub(crate) fn genesis_author_sentinel() -> PublicKey {
+    PublicKey::from(GENESIS_AUTHOR_SENTINEL)
+}
+
+/// Receivers use this to bail out of author-keyed checks before
+/// running them — a positive result means the delta on the wire is
+/// the genesis ancestor and the checks below either don't apply (no
+/// author to verify) or would always reject (sentinel isn't a real
+/// member of any group).
+pub(crate) fn is_genesis_author_sentinel(author: &PublicKey) -> bool {
+    let bytes: &[u8; 32] = author.as_ref();
+    bytes == &GENESIS_AUTHOR_SENTINEL
+}
+
 /// What `request_delta` returns when the peer had the delta: the
 /// payload plus the envelope metadata the caller needs to run the same
 /// anti-impersonation + cross-DAG membership check that the head-pull
@@ -68,6 +96,19 @@ fn verify_fetched_parent(
 ) -> VerifiedParent {
     use calimero_context::group_store::{membership_status_at, MembershipStatus};
     use calimero_context_config::types::GovernancePosition;
+
+    // Genesis carve-out: the responder serves the genesis delta with
+    // the all-zeros sentinel `author_id` because the wire requires an
+    // author but genesis predates any governance op. Skip every
+    // author-keyed check — none of them apply to genesis.
+    if is_genesis_author_sentinel(&fetched.author_id) {
+        debug!(
+            %context_id,
+            delta_id = ?delta_id,
+            "DAG-catchup parent-pull: accepting genesis delta via author sentinel"
+        );
+        return VerifiedParent::Apply { position: None };
+    }
 
     let pos = match fetched
         .governance_position_blob
@@ -542,7 +583,25 @@ impl SyncManager {
             // path — the initiator's check requires an author, and
             // we won't bypass it. The initiator's fallback chain
             // (DAG-catchup-None → snapshot) handles recovery.
-            match stored_delta.author_id {
+            // Genesis carve-out: `create_context` persists the
+            // genesis delta with `author_id: None` (it predates any
+            // governance op so there's no real author to verify). The
+            // wire requires an author, so we serve genesis with the
+            // sentinel `PublicKey::from([0; 32])` and the initiator
+            // recognizes the sentinel via `is_genesis_author_sentinel`
+            // and skips the membership / signature / ReadOnly checks
+            // that don't apply to genesis. Without this carve-out a
+            // late-joining peer that needed to backfill the genesis
+            // delta via DAG-catchup would get `DeltaNotFound` and
+            // stall — the same failure mode any other ancestor pull
+            // hits without an author.
+            let is_genesis_delta = stored_delta.parents == vec![[0u8; 32]];
+            let effective_author = match (stored_delta.author_id, is_genesis_delta) {
+                (Some(a), _) => Some(a),
+                (None, true) => Some(genesis_author_sentinel()),
+                (None, false) => None,
+            };
+            match effective_author {
                 None => {
                     debug!(
                         %context_id,

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -22,6 +22,211 @@ const MAX_DELTA_FETCH_LIMIT: usize = 3000;
 const DELTA_WARN_LIMIT: usize = 1000;
 const GENESIS_DELTA_ID: [u8; 32] = [0u8; 32];
 
+/// What `request_delta` returns when the peer had the delta: the
+/// payload plus the envelope metadata the caller needs to run the same
+/// anti-impersonation + cross-DAG membership check that the head-pull
+/// path in `request_dag_heads_and_sync` runs.
+///
+/// Fields mirror `MessagePayload::DeltaResponse` exactly; the only
+/// difference is `governance_position_blob` is owned (`Vec<u8>`)
+/// rather than `Cow<'_, [u8]>` so it can cross the await boundary
+/// without holding onto the stream's buffer.
+pub(crate) struct FetchedDelta {
+    pub delta: CausalDelta,
+    pub author_id: PublicKey,
+    pub governance_position_blob: Option<Vec<u8>>,
+    pub delta_signature: Option<[u8; 64]>,
+}
+
+/// Outcome of verifying a parent delta pulled in Phase 2 of DAG-catchup.
+///
+/// Mirrors the chain at `manager/mod.rs:1681` (head-pull) — decode the
+/// governance position, verify the envelope signature, check membership
+/// at the cited cut. Each per-delta rejection is a `Skip`, NOT a fatal
+/// error: one malformed or malicious response from a peer can't poison
+/// the rest of the catchup batch.
+enum VerifiedParent {
+    /// Verified. Persist the delta with the decoded position (when
+    /// present) and the wire-received author + signature.
+    Apply {
+        position: Option<calimero_context_config::types::GovernancePosition>,
+    },
+    /// Rejected — drop this delta and continue with the next one.
+    Skip,
+}
+
+/// Run the same chain as `request_dag_heads_and_sync`'s head-pull
+/// verify block: decode position → verify signature → check
+/// membership_status_at. Per-delta rejections are `Skip`; a stream-
+/// fatal error returns `Err` (none of the inner checks are
+/// stream-fatal, so this path only returns `Ok(...)` in practice).
+fn verify_fetched_parent(
+    context_id: &ContextId,
+    delta_id: [u8; 32],
+    fetched: &FetchedDelta,
+    datastore: &calimero_store::Store,
+) -> VerifiedParent {
+    use calimero_context::group_store::{membership_status_at, MembershipStatus};
+    use calimero_context_config::types::GovernancePosition;
+
+    let pos = match fetched
+        .governance_position_blob
+        .as_deref()
+        .map(borsh::from_slice::<GovernancePosition>)
+        .transpose()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                %context_id,
+                author = %fetched.author_id,
+                delta_id = ?delta_id,
+                %e,
+                "DAG-catchup parent-pull: failed to decode governance_position; \
+                 skipping this delta and continuing"
+            );
+            return VerifiedParent::Skip;
+        }
+    };
+
+    if let Some(ref sig) = fetched.delta_signature {
+        if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
+            *context_id,
+            delta_id,
+            fetched.author_id,
+            pos.as_ref(),
+            sig,
+        ) {
+            warn!(
+                %context_id,
+                author = %fetched.author_id,
+                delta_id = ?delta_id,
+                %err,
+                "DAG-catchup parent-pull: rejecting delta — envelope signature \
+                 verification failed"
+            );
+            return VerifiedParent::Skip;
+        }
+    }
+
+    // Anti-bypass parity (same as the head-pull path in
+    // `request_dag_heads_and_sync`): confirm the claimed position's
+    // group matches the context's owning group, or that no position is
+    // claimed for a non-group context. Catches the
+    // `GroupContextNoPosition`, `NonGroupContextWithPosition`, and
+    // `Mismatch` bypasses described on `GroupIdCheck`.
+    {
+        use crate::handlers::state_delta::{
+            verify_position_group_id_matches_context, GroupIdCheck,
+        };
+        match verify_position_group_id_matches_context(
+            datastore,
+            context_id,
+            pos.as_ref().map(|p| p.group_id),
+        ) {
+            GroupIdCheck::Match | GroupIdCheck::NonGroupOk => {}
+            GroupIdCheck::GroupContextNoPosition { owning } => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    owning_group = ?owning,
+                    "DAG-catchup parent-pull: rejecting delta — context is owned by a \
+                     group but delta carries no governance_position"
+                );
+                return VerifiedParent::Skip;
+            }
+            GroupIdCheck::NonGroupContextWithPosition { claimed } => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    claimed_group = ?claimed,
+                    "DAG-catchup parent-pull: rejecting delta — delta claims a \
+                     governance position but context is not in any group"
+                );
+                return VerifiedParent::Skip;
+            }
+            GroupIdCheck::Mismatch { owning, claimed } => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    owning_group = ?owning,
+                    claimed_group = ?claimed,
+                    "DAG-catchup parent-pull: rejecting delta — governance_position \
+                     references a different group than the context's owning group"
+                );
+                return VerifiedParent::Skip;
+            }
+            GroupIdCheck::LookupError(err) => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    %err,
+                    "DAG-catchup parent-pull: skipping delta — group lookup failed \
+                     during anti-bypass check"
+                );
+                return VerifiedParent::Skip;
+            }
+        }
+    }
+
+    if let Some(ref pos_ref) = pos {
+        match membership_status_at(datastore, &fetched.author_id, pos_ref) {
+            Ok(MembershipStatus::Member(_)) => {
+                // Authorized at the cited cut — proceed.
+            }
+            Ok(MembershipStatus::Removed { last_role }) => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    last_role = ?last_role,
+                    "DAG-catchup parent-pull: rejecting delta — author was removed \
+                     at the cited governance cut"
+                );
+                return VerifiedParent::Skip;
+            }
+            Ok(MembershipStatus::NeverMember) => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    "DAG-catchup parent-pull: rejecting delta — author was never \
+                     a member at the cited governance cut"
+                );
+                return VerifiedParent::Skip;
+            }
+            Ok(MembershipStatus::Unknown { needed }) => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    needed = ?needed,
+                    "DAG-catchup parent-pull: skipping delta — governance cut not \
+                     locally known; will re-attempt on next sync tick"
+                );
+                return VerifiedParent::Skip;
+            }
+            Err(e) => {
+                warn!(
+                    %context_id,
+                    author = %fetched.author_id,
+                    delta_id = ?delta_id,
+                    error = %e,
+                    "DAG-catchup parent-pull: skipping delta — membership_status_at \
+                     failed"
+                );
+                return VerifiedParent::Skip;
+            }
+        }
+    }
+
+    VerifiedParent::Apply { position: pos }
+}
+
 impl SyncManager {
     /// Request missing deltas from a peer and add them to the DAG
     ///
@@ -81,18 +286,35 @@ impl SyncManager {
                     .request_delta(&context_id, missing_id, &mut stream, our_identity)
                     .await
                 {
-                    Ok(Some(parent_delta)) => {
+                    Ok(Some(fetched)) => {
                         info!(
                             %context_id,
                             delta_id = ?missing_id,
-                            action_count = parent_delta.actions.len(),
+                            action_count = fetched.delta.actions.len(),
                             total_fetched = fetch_count,
                             "Received missing parent delta"
                         );
 
+                        // Anti-bypass parity with the head-pull path:
+                        // decode the governance position, verify the
+                        // envelope signature, and check membership at
+                        // the cited cut BEFORE persisting. Without this,
+                        // parent-pull was a back door for revoked-author
+                        // deltas to reach the DAG.
+                        let datastore = self.context_client.datastore_handle().into_inner();
+                        let position = match verify_fetched_parent(
+                            &context_id,
+                            missing_id,
+                            &fetched,
+                            &datastore,
+                        ) {
+                            VerifiedParent::Apply { position } => position,
+                            VerifiedParent::Skip => continue,
+                        };
+
                         // Check what parents THIS delta needs (identify grandparents).
                         // We also check local storage to avoid re-fetching known deltas.
-                        for parent_id in &parent_delta.parents {
+                        for parent_id in &fetched.delta.parents {
                             // Skip genesis
                             if *parent_id == GENESIS_DELTA_ID {
                                 continue;
@@ -112,30 +334,33 @@ impl SyncManager {
 
                         // Convert to DAG delta format
                         let dag_delta = calimero_dag::CausalDelta {
-                            id: parent_delta.id,
-                            parents: parent_delta.parents,
-                            payload: parent_delta.actions,
-                            hlc: parent_delta.hlc,
-                            expected_root_hash: parent_delta.expected_root_hash,
+                            id: fetched.delta.id,
+                            parents: fetched.delta.parents.clone(),
+                            payload: fetched.delta.actions.clone(),
+                            hlc: fetched.delta.hlc,
+                            expected_root_hash: fetched.delta.expected_root_hash,
                             kind: calimero_dag::DeltaKind::Regular,
                         };
 
-                        // Write deltas to DeltaStore. If parents are missing, DeltaStore marks it 'Pending'.
-                        // There's no need for topological order insert.
-                        // NOTE: currently delta store doesn't write the deltas on disk, that
-                        // should be optionally enabled in the future for robustness.
-                        // Author + governance position from the wire
-                        // are returned by `request_delta` alongside the
-                        // delta itself — see the destructuring there.
-                        // For now this call site doesn't have them in
-                        // scope (request_delta returns only the bare
-                        // CausalDelta); persisting with None means
-                        // DAG-catchup serves from this node for these
-                        // deltas would return DeltaNotFound until
-                        // gossip or another catch-up populates the
-                        // author. Follow-up: thread author through
-                        // request_delta's return.
-                        if let Err(e) = delta_store.add_delta(dag_delta, None, None, None).await {
+                        // Persist with the verified envelope so subsequent
+                        // DAG-catchup serves from this node carry the
+                        // same metadata downstream peers will check.
+                        // Re-serialise the position from the typed value
+                        // we just decoded — guarantees the stored blob
+                        // matches what `membership_status_at` was run
+                        // against (and what `verify_delta_signature`
+                        // verified against).
+                        let governance_position_blob =
+                            position.as_ref().and_then(|gp| borsh::to_vec(gp).ok());
+                        if let Err(e) = delta_store
+                            .add_delta(
+                                dag_delta,
+                                Some(fetched.author_id),
+                                governance_position_blob,
+                                fetched.delta_signature,
+                            )
+                            .await
+                        {
                             warn!(?e, %context_id, delta_id = ?missing_id, "Failed to persist fetched delta to DAG");
                             continue;
                         }
@@ -177,13 +402,20 @@ impl SyncManager {
     }
 
     /// Request a specific delta from a peer
+    ///
+    /// Returns the full envelope (delta + author + governance position +
+    /// envelope signature) so the caller can run the same membership /
+    /// signature checks the head-pull path in
+    /// `request_dag_heads_and_sync` runs. Without that, the parent-pull
+    /// path would bypass the anti-impersonation and revoked-author
+    /// gates the head-pull path enforces.
     pub(crate) async fn request_delta(
         &self,
         context_id: &ContextId,
         delta_id: [u8; 32],
         stream: &mut Stream,
         our_identity: PublicKey,
-    ) -> Result<Option<CausalDelta>> {
+    ) -> Result<Option<FetchedDelta>> {
         info!(
             %context_id,
             delta_id = ?delta_id,
@@ -208,7 +440,13 @@ impl SyncManager {
 
         match super::stream::recv(stream, None, timeout_budget).await? {
             Some(StreamMessage::Message {
-                payload: MessagePayload::DeltaResponse { delta, .. },
+                payload:
+                    MessagePayload::DeltaResponse {
+                        delta,
+                        author_id,
+                        governance_position_blob,
+                        delta_signature,
+                    },
                 ..
             }) => {
                 // Deserialize delta
@@ -230,7 +468,12 @@ impl SyncManager {
                     "Received requested delta"
                 );
 
-                Ok(Some(causal_delta))
+                Ok(Some(FetchedDelta {
+                    delta: causal_delta,
+                    author_id,
+                    governance_position_blob: governance_position_blob.map(|cow| cow.into_owned()),
+                    delta_signature,
+                }))
             }
             Some(StreamMessage::Message {
                 payload: MessagePayload::DeltaNotFound,

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -124,7 +124,18 @@ impl SyncManager {
                         // There's no need for topological order insert.
                         // NOTE: currently delta store doesn't write the deltas on disk, that
                         // should be optionally enabled in the future for robustness.
-                        if let Err(e) = delta_store.add_delta(dag_delta).await {
+                        // Author + governance position from the wire
+                        // are returned by `request_delta` alongside the
+                        // delta itself — see the destructuring there.
+                        // For now this call site doesn't have them in
+                        // scope (request_delta returns only the bare
+                        // CausalDelta); persisting with None means
+                        // DAG-catchup serves from this node for these
+                        // deltas would return DeltaNotFound until
+                        // gossip or another catch-up populates the
+                        // author. Follow-up: thread author through
+                        // request_delta's return.
+                        if let Err(e) = delta_store.add_delta(dag_delta, None, None).await {
                             warn!(?e, %context_id, delta_id = ?missing_id, "Failed to persist fetched delta to DAG");
                             continue;
                         }

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -135,7 +135,7 @@ impl SyncManager {
                         // gossip or another catch-up populates the
                         // author. Follow-up: thread author through
                         // request_delta's return.
-                        if let Err(e) = delta_store.add_delta(dag_delta, None, None).await {
+                        if let Err(e) = delta_store.add_delta(dag_delta, None, None, None).await {
                             warn!(?e, %context_id, delta_id = ?missing_id, "Failed to persist fetched delta to DAG");
                             continue;
                         }
@@ -319,6 +319,7 @@ impl SyncManager {
                         governance_position_blob: stored_delta
                             .governance_position_blob
                             .map(Into::into),
+                        delta_signature: stored_delta.delta_signature,
                     }
                 }
             }

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -173,6 +173,27 @@ fn verify_fetched_parent(
         }
     }
 
+    // ReadOnly check — parity with the gossip apply path.
+    // `membership_status_at` treats ReadOnly as `Member(ReadOnly)`,
+    // so a ReadOnly identity's delta would slip past the cross-DAG
+    // check on the catchup path even though gossip rejects it.
+    // Mirror the gate `apply_authorized_state_delta` uses.
+    if calimero_context::group_store::is_read_only_for_context(
+        datastore,
+        &context_id,
+        &fetched.author_id,
+    )
+    .unwrap_or(false)
+    {
+        warn!(
+            %context_id,
+            author = %fetched.author_id,
+            delta_id = ?delta_id,
+            "DAG-catchup parent-pull: rejecting delta from ReadOnly member"
+        );
+        return VerifiedParent::Skip;
+    }
+
     if let Some(ref pos_ref) = pos {
         match membership_status_at(datastore, &fetched.author_id, pos_ref) {
             Ok(MembershipStatus::Member(_)) => {

--- a/crates/node/src/sync/hash_comparison.rs
+++ b/crates/node/src/sync/hash_comparison.rs
@@ -180,7 +180,8 @@ impl SyncManager {
                     let entity_count = entities.len();
                     trace!(%context_id, entity_count, "Handling EntityPush from initiator");
 
-                    let applied = handle_entity_push(&runtime_env, context_id, &entities);
+                    let applied =
+                        handle_entity_push(&datastore, &runtime_env, context_id, &entities);
 
                     let msg = StreamMessage::Message {
                         sequence_id: sqx.next(),

--- a/crates/node/src/sync/hash_comparison.rs
+++ b/crates/node/src/sync/hash_comparison.rs
@@ -180,8 +180,26 @@ impl SyncManager {
                     let entity_count = entities.len();
                     trace!(%context_id, entity_count, "Handling EntityPush from initiator");
 
-                    let applied =
+                    let outcome =
                         handle_entity_push(&datastore, &runtime_env, context_id, &entities);
+                    let applied = outcome.applied;
+
+                    // Dispatch any deferred root-entity merges through
+                    // the WASM module before ACKing the push — keeps
+                    // the responder side symmetric with the initiator,
+                    // so a bidirectional push of root state still
+                    // converges. Identical helper to the one HC /
+                    // LevelWise initiators use.
+                    if !outcome.deferred_root_merges.is_empty() {
+                        super::protocol_selector::dispatch_deferred_root_merges(
+                            &self.context_client,
+                            &datastore,
+                            context_id,
+                            our_identity,
+                            &outcome.deferred_root_merges,
+                        )
+                        .await;
+                    }
 
                     let msg = StreamMessage::Message {
                         sequence_id: sqx.next(),
@@ -196,6 +214,7 @@ impl SyncManager {
                     info!(
                         %context_id,
                         applied,
+                        deferred_root_merges = outcome.deferred_root_merges.len(),
                         total = entity_count,
                         "Applied pushed entities via CRDT merge"
                     );

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -706,7 +706,27 @@ async fn run_responder_impl<T: SyncTransport>(
                 let entity_count = entities.len();
                 trace!(%context_id, entity_count, "Handling EntityPush from initiator");
 
-                let applied = handle_entity_push(store, &runtime_env, context_id, &entities);
+                let outcome = handle_entity_push(store, &runtime_env, context_id, &entities);
+                let applied = outcome.applied;
+
+                // This responder runs without a `ContextClient` in
+                // scope (trait signature limitation — see
+                // `SyncProtocolExecutor`), so it can't dispatch
+                // deferred root merges itself. The production
+                // responder in `hash_comparison.rs` does have
+                // `ContextClient` and dispatches. Surface the gap as
+                // a warn so persistent occurrences are visible; in
+                // practice the initiator's DFS catches the same root
+                // divergence and dispatches from there.
+                if !outcome.deferred_root_merges.is_empty() {
+                    warn!(
+                        %context_id,
+                        deferred = outcome.deferred_root_merges.len(),
+                        "EntityPush responder: dropped root-entity deferred merges \
+                         (protocol-trait responder lacks ContextClient — initiator-side \
+                         dispatch will pick up root divergence on next sync round)"
+                    );
+                }
 
                 let msg = StreamMessage::Message {
                     sequence_id,
@@ -723,6 +743,7 @@ async fn run_responder_impl<T: SyncTransport>(
                 info!(
                     %context_id,
                     applied,
+                    deferred_root_merges = outcome.deferred_root_merges.len(),
                     total = entity_count,
                     "Applied pushed entities via CRDT merge"
                 );

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -130,6 +130,17 @@ pub struct HashComparisonStats {
     /// merge did not converge the two peers — see #2407 for the
     /// failure mode this guards against.
     pub root_hash_verified: bool,
+    /// Root-state byte blobs the DFS encountered on remote leaves
+    /// that the host can't merge by itself (separate-address-space
+    /// merge registry — see [`crate::sync::helpers::apply_leaf_with_crdt_merge`]).
+    /// Each entry is `(entity_id_bytes, incoming_bytes)`. The caller
+    /// (`ProtocolSelector`) dispatches each one through
+    /// `ContextClient::merge_root_state` after the sync completes,
+    /// closing the loop on root-entity divergence that HC would
+    /// otherwise silently drop. Storing the entity id lets the caller
+    /// distinguish `ROOT_ID` from the `Root<T>` entry (both treated
+    /// as root by `is_app_root_entry`, both possible in HC leaves).
+    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>)>,
 }
 
 /// HashComparison sync protocol.
@@ -325,6 +336,24 @@ async fn run_initiator_impl<T: SyncTransport>(
                             key = %hex::encode(leaf_data.key),
                             "HC merge skipped: claimed author is not currently authorized for this context"
                         );
+                        continue;
+                    }
+
+                    // Root entity leaves can't be merged on the host
+                    // (the host's `merge_root_state` consults a registry
+                    // that's only populated inside WASM). Hand them off
+                    // to the caller, which dispatches each through
+                    // `ContextClient::merge_root_state` after the sync
+                    // session completes. `apply_leaf_with_crdt_merge`
+                    // also short-circuits root entities — we check here
+                    // too so we can record the incoming bytes (the helper
+                    // is sync and inside `with_runtime_env`, so it can't
+                    // call into the runtime to do the merge itself).
+                    let entity_id = calimero_storage::address::Id::new(leaf_data.key);
+                    if calimero_storage::collections::is_app_root_entry(entity_id) {
+                        stats
+                            .deferred_root_merges
+                            .push((leaf_data.key, leaf_data.value.clone()));
                         continue;
                     }
 

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -40,7 +40,7 @@
 
 use crate::sync::helpers::{
     apply_leaf_with_crdt_merge, generate_nonce, get_local_root_hash_for_context,
-    handle_entity_push, MAX_ENTITIES_PER_PUSH,
+    handle_entity_push, is_leaf_currently_authorized, MAX_ENTITIES_PER_PUSH,
 };
 use async_trait::async_trait;
 use calimero_node_primitives::sync::{
@@ -308,6 +308,25 @@ async fn run_initiator_impl<T: SyncTransport>(
                         key = %hex::encode(leaf_data.key),
                         "Merging leaf entity"
                     );
+
+                    // Authorization gate, parity with `handle_entity_push`.
+                    // Without this, the initiator's per-leaf merge in the
+                    // DFS would re-import entities whose claimed author has
+                    // been removed from the context's group — the same back
+                    // door batched EntityPush had before the helper-level
+                    // filter landed. Skipping silently here is fine because
+                    // the leaf will simply remain "missing locally," and
+                    // `root_hash_verified` will report `false` so the
+                    // session is treated as a partial merge rather than a
+                    // successful convergence.
+                    if !is_leaf_currently_authorized(store, &context_id, leaf_data) {
+                        warn!(
+                            %context_id,
+                            key = %hex::encode(leaf_data.key),
+                            "HC merge skipped: claimed author is not currently authorized for this context"
+                        );
+                        continue;
+                    }
 
                     with_runtime_env(runtime_env.clone(), || {
                         apply_leaf_with_crdt_merge(context_id, leaf_data)
@@ -658,7 +677,7 @@ async fn run_responder_impl<T: SyncTransport>(
                 let entity_count = entities.len();
                 trace!(%context_id, entity_count, "Handling EntityPush from initiator");
 
-                let applied = handle_entity_push(&runtime_env, context_id, &entities);
+                let applied = handle_entity_push(store, &runtime_env, context_id, &entities);
 
                 let msg = StreamMessage::Message {
                     sequence_id,

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -133,14 +133,17 @@ pub struct HashComparisonStats {
     /// Root-state byte blobs the DFS encountered on remote leaves
     /// that the host can't merge by itself (separate-address-space
     /// merge registry — see [`crate::sync::helpers::apply_leaf_with_crdt_merge`]).
-    /// Each entry is `(entity_id_bytes, incoming_bytes)`. The caller
-    /// (`ProtocolSelector`) dispatches each one through
+    /// Each entry is `(entity_id_bytes, incoming_bytes, incoming_hlc_ts)`.
+    /// The caller (`ProtocolSelector`) dispatches each one through
     /// `ContextClient::merge_root_state` after the sync completes,
     /// closing the loop on root-entity divergence that HC would
     /// otherwise silently drop. Storing the entity id lets the caller
     /// distinguish `ROOT_ID` from the `Root<T>` entry (both treated
-    /// as root by `is_app_root_entry`, both possible in HC leaves).
-    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>)>,
+    /// as root by `is_app_root_entry`, both possible in HC leaves);
+    /// the timestamp is the leaf's wire-carried `hlc_timestamp` so
+    /// the dispatch uses the actual remote write time instead of a
+    /// synthetic value.
+    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>, u64)>,
 }
 
 /// HashComparison sync protocol.
@@ -363,9 +366,11 @@ async fn run_initiator_impl<T: SyncTransport>(
                     if calimero_storage::collections::is_app_root_entry(entity_id)
                         && !is_opaque
                     {
-                        stats
-                            .deferred_root_merges
-                            .push((leaf_data.key, leaf_data.value.clone()));
+                        stats.deferred_root_merges.push((
+                            leaf_data.key,
+                            leaf_data.value.clone(),
+                            leaf_data.metadata.hlc_timestamp,
+                        ));
                         continue;
                     }
 

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -363,9 +363,7 @@ async fn run_initiator_impl<T: SyncTransport>(
                         calimero_primitives::crdt::CrdtType::LwwRegister { inner_type }
                             if inner_type == OPAQUE_LEAF_CRDT_TYPE_NAME
                     );
-                    if calimero_storage::collections::is_app_root_entry(entity_id)
-                        && !is_opaque
-                    {
+                    if calimero_storage::collections::is_app_root_entry(entity_id) && !is_opaque {
                         stats.deferred_root_merges.push((
                             leaf_data.key,
                             leaf_data.value.clone(),

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -74,7 +74,7 @@ const MAX_PENDING_NODES: usize = 10_000;
 /// emitting a leaf with this synthetic type is wire-format-stable and
 /// merge-equivalent to the `None` it stands in for. See
 /// `docs/superpowers/specs/2026-05-13-opaque-leaf-sync-design.md`.
-pub(super) const OPAQUE_LEAF_CRDT_TYPE_NAME: &str = "Opaque";
+pub(crate) const OPAQUE_LEAF_CRDT_TYPE_NAME: &str = "Opaque";
 
 /// Maximum depth allowed in TreeNodeRequest.
 pub const MAX_REQUEST_DEPTH: u8 = 16;
@@ -349,8 +349,20 @@ async fn run_initiator_impl<T: SyncTransport>(
                     // too so we can record the incoming bytes (the helper
                     // is sync and inside `with_runtime_env`, so it can't
                     // call into the runtime to do the merge itself).
+                    // Defer root entities with a real `crdt_type` for
+                    // WASM dispatch; opaque root entities (synthetic
+                    // `Opaque` LWW marker) fall through to
+                    // `apply_leaf_with_crdt_merge` which LWW-writes
+                    // them directly (no Mergeable to dispatch).
                     let entity_id = calimero_storage::address::Id::new(leaf_data.key);
-                    if calimero_storage::collections::is_app_root_entry(entity_id) {
+                    let is_opaque = matches!(
+                        &leaf_data.metadata.crdt_type,
+                        calimero_primitives::crdt::CrdtType::LwwRegister { inner_type }
+                            if inner_type == OPAQUE_LEAF_CRDT_TYPE_NAME
+                    );
+                    if calimero_storage::collections::is_app_root_entry(entity_id)
+                        && !is_opaque
+                    {
                         stats
                             .deferred_root_merges
                             .push((leaf_data.key, leaf_data.value.clone()));

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -394,7 +394,27 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
     // bytes come from a peer who already verified them. Empty ctx →
     // verifier falls back to v2 stored-writers, which is the safe
     // semantic for already-verified replicated state.
-    Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())?;
+    //
+    // Wrapped in `with_merge_mode` so the per-action nonce staleness
+    // check inside `save_internal` bypasses for this sync-apply path
+    // (`skip_nonce = nonce_check_disabled || in_merge_mode()`). HC's
+    // leaf apply re-runs actions a peer has already gossiped — the
+    // local node may already be at the same nonce, and the
+    // nonce-staleness skip would silently no-op the apply. That
+    // no-op was the smoking-gun "Shared upsert: stale-or-equal nonce"
+    // warning in the shared-storage + scaffolding-e2e failures on
+    // PR #2465: gossip + HC race meant HC re-applied gossip's
+    // entities at the same nonce, hit the skip, and the action's
+    // structural effects (children references, RGA characters) never
+    // landed — even though the underlying bytes were correct.
+    //
+    // Safety: signature verification still runs before the skip
+    // check, so forgeries are still rejected. Merge mode only stops
+    // the skip from misreading sync re-application as replay attacks
+    // of themselves.
+    calimero_storage::env::with_merge_mode(|| {
+        Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())
+    })?;
     Ok(())
 }
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -153,6 +153,20 @@ pub fn is_leaf_currently_authorized(
     }
 }
 
+/// Detect the synthetic "opaque" CRDT type sync senders attach to leaves
+/// whose stored metadata has no `crdt_type` (typically the `Root<T>`
+/// entry for apps that don't use `#[app::state]`, plus test fixtures).
+/// The sender wraps these in `CrdtType::LwwRegister { inner_type:
+/// OPAQUE_LEAF_CRDT_TYPE_NAME }` so the wire never carries an absent
+/// type; the receiver uses this helper to recognise them and route to a
+/// direct LWW write rather than expecting WASM-side merge dispatch
+/// (which doesn't exist for entities without a `Mergeable` impl).
+fn is_opaque_crdt_type(crdt_type: &calimero_primitives::crdt::CrdtType) -> bool {
+    use calimero_primitives::crdt::CrdtType;
+    matches!(crdt_type, CrdtType::LwwRegister { inner_type }
+        if inner_type == crate::sync::hash_comparison_protocol::OPAQUE_LEAF_CRDT_TYPE_NAME)
+}
+
 /// Apply leaf data using CRDT merge (Invariant I5: No Silent Data Loss).
 ///
 /// This function must be called within a `with_runtime_env` scope.
@@ -172,8 +186,6 @@ pub fn is_leaf_currently_authorized(
 /// * `context_id` - The context being synchronized
 /// * `leaf` - The leaf data containing entity key, value, and CRDT metadata
 ///
-/// Apply leaf data using CRDT merge (Invariant I5: No Silent Data Loss).
-///
 /// # Errors
 ///
 /// Returns error if storage operations fail.
@@ -181,32 +193,44 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
     let entity_id = Id::new(leaf.key);
     let root_id = Id::new(*context_id.as_ref());
 
-    // App root state — `ROOT_ID` or the `Root<T>` entry — needs CRDT
-    // merge against the app's typed `Mergeable` impl. That impl only
-    // exists inside the WASM module; the host's `merge_root_state` has
-    // never had a working dispatch table (the registry it consults is
-    // populated by the macro's `__calimero_register_merge` export,
-    // which writes to the WASM module's static memory, not the host's —
-    // separate address spaces, separate copies of `MERGE_REGISTRY`).
-    // Pre-pause the bootstrap fast-path masked it (`created == updated`
-    // accepts incoming unconditionally); post-pause divergence trips
-    // the post-bootstrap branch and the cascade in core#2469 fires.
+    // App root state — `ROOT_ID` or the `Root<T>` entry — needs the
+    // app's typed `Mergeable::merge`, which only exists inside the
+    // WASM module. The host's `merge_root_state` consults a
+    // `MERGE_REGISTRY` static that's never populated in production
+    // (the macro's `__calimero_register_merge` export writes the
+    // WASM module's copy, not the host's — separate address spaces).
+    // Two cases:
     //
-    // Until root-entity merges route through WASM via
-    // [`ContextClient::merge_root_state`] (the
-    // `__calimero_merge_root_state` export is in place; the dispatch
-    // plumbing through HC / snapshot / levelwise is a follow-up), skip
-    // them here. The root entity converges via the normal delta-sync
-    // path (`__calimero_sync_next`, which runs inside WASM where merge
-    // dispatch actually works). HC's `stats.root_hash_verified` reports
-    // `false` for this round; the sync manager handles that as a
-    // partial merge and the next tick retries via delta sync.
+    // * Root entity with `crdt_type: Some(_)` — real app state. Skip
+    //   here; the caller (HC initiator's DFS, `handle_entity_push`)
+    //   accumulates the bytes in `deferred_root_merges` and dispatches
+    //   via `ContextClient::merge_root_state` after the sync loop.
+    // * Root entity with `crdt_type: None` — opaque (no `Mergeable`
+    //   available). WASM dispatch can't help — there's no
+    //   `__calimero_merge_root_state` to invoke on a type with no
+    //   `Mergeable` impl. The only sensible behavior is direct LWW
+    //   write, which is what the old `AllFunctionsFailed` branch in
+    //   `merge_root_state` did. Fires in test fixtures and apps that
+    //   don't use `#[app::state]`; real apps always have a crdt_type
+    //   and take the deferred-dispatch path.
     if calimero_storage::collections::is_app_root_entry(entity_id) {
+        if is_opaque_crdt_type(&leaf.metadata.crdt_type) {
+            let mut md = Metadata::default();
+            md.created_at = leaf.metadata.created_at;
+            md.updated_at = leaf.metadata.hlc_timestamp.into();
+            calimero_storage::interface::Interface::<MainStorage>::write_pre_merged_root_state(
+                entity_id,
+                &leaf.value,
+                md,
+            )?;
+            return Ok(());
+        }
+        // Crdt-bearing root entity — caller defers.
         tracing::warn!(
             %context_id,
             entity_id = %entity_id,
             "HC apply: skipping root-entity merge on host (no host-side merge dispatch); \
-             root entity will converge via WASM-routed delta sync"
+             caller dispatches via ContextClient::merge_root_state"
         );
         return Ok(());
     }
@@ -441,8 +465,26 @@ pub fn handle_entity_push(
             // `dispatch_deferred_root_merges` in `protocol_selector`).
             // Defer to the caller, which has the `ContextClient` needed
             // to invoke `__calimero_merge_root_state` inside WASM.
+            //
+            // Exception: a root-entity leaf with `crdt_type: None`
+            // (no app-defined `Mergeable`) has nothing for WASM to
+            // dispatch to — `__calimero_merge_root_state` would error
+            // out, the deferred merge would be dropped, and the bytes
+            // would never land. For these opaque entities the only
+            // sensible behavior is LWW direct-write (matches the
+            // pre-rewrite `AllFunctionsFailed` fallback in
+            // `merge_root_state`). Fires in test fixtures + apps that
+            // don't use `#[app::state]`; real apps always have a
+            // `crdt_type` and go through the proper deferred dispatch.
+            // Root entities with a real `crdt_type` get deferred for
+            // WASM dispatch; opaque root entities (synthetic LWW marker
+            // tagged with `OPAQUE_LEAF_CRDT_TYPE_NAME`) are handled
+            // internally by `apply_leaf_with_crdt_merge` via direct LWW
+            // write — see the comment there.
             let entity_id = Id::new(leaf.key);
-            if calimero_storage::collections::is_app_root_entry(entity_id) {
+            if calimero_storage::collections::is_app_root_entry(entity_id)
+                && !is_opaque_crdt_type(&leaf.metadata.crdt_type)
+            {
                 deferred_root_merges.push((leaf.key, leaf.value.clone()));
                 continue;
             }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -399,7 +399,11 @@ pub const MAX_ENTITIES_PER_PUSH: usize = 500;
 #[derive(Debug, Default)]
 pub struct EntityPushOutcome {
     pub applied: u32,
-    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>)>,
+    /// `(entity_id_bytes, incoming_bytes, incoming_hlc_ts)` — same
+    /// shape as [`crate::sync::hash_comparison_protocol::HashComparisonStats::deferred_root_merges`].
+    /// Carrying the leaf's HLC timestamp lets the dispatcher use the
+    /// actual remote write time instead of a synthetic value.
+    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>, u64)>,
 }
 
 /// Handle an incoming `EntityPush` by applying CRDT merge for each entity.
@@ -440,7 +444,7 @@ pub fn handle_entity_push(
     calimero_storage::env::with_runtime_env(runtime_env.clone(), || {
         let mut applied = 0u32;
         let mut dropped_unauthorized = 0u32;
-        let mut deferred_root_merges: Vec<([u8; 32], Vec<u8>)> = Vec::new();
+        let mut deferred_root_merges: Vec<([u8; 32], Vec<u8>, u64)> = Vec::new();
         for leaf in entities {
             if !leaf.is_valid() {
                 tracing::warn!(
@@ -485,7 +489,11 @@ pub fn handle_entity_push(
             if calimero_storage::collections::is_app_root_entry(entity_id)
                 && !is_opaque_crdt_type(&leaf.metadata.crdt_type)
             {
-                deferred_root_merges.push((leaf.key, leaf.value.clone()));
+                deferred_root_merges.push((
+                    leaf.key,
+                    leaf.value.clone(),
+                    leaf.metadata.hlc_timestamp,
+                ));
                 continue;
             }
             match apply_leaf_with_crdt_merge(context_id, leaf) {

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -5,11 +5,13 @@
 use calimero_node_primitives::sync::TreeLeafData;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
 use calimero_storage::address::Id;
-use calimero_storage::entities::{ChildInfo, Metadata};
+use calimero_storage::entities::{ChildInfo, Metadata, StorageType};
 use calimero_storage::index::Index;
 use calimero_storage::interface::{Action, ApplyContext, Interface};
 use calimero_storage::store::MainStorage;
+use calimero_store::Store;
 use eyre::{bail, Result};
 use rand::Rng;
 
@@ -75,11 +77,78 @@ pub fn generate_nonce() -> calimero_crypto::Nonce {
 pub fn wire_authorization_for(
     metadata: &Metadata,
 ) -> Option<calimero_storage::entities::StorageType> {
-    use calimero_storage::entities::StorageType;
     match &metadata.storage_type {
         StorageType::Public | StorageType::Frozen => None,
         StorageType::Shared { .. } | StorageType::User { .. } => {
             Some(metadata.storage_type.clone())
+        }
+    }
+}
+
+/// Extract the claimed author of a sync'd leaf from its wire-carried
+/// authorization, when the storage type admits one.
+///
+/// * `User { owner, .. }` → `owner` is the author by definition.
+/// * `Shared { signature_data: Some(SignatureData { signer: Some(pk), .. }), .. }`
+///   → the per-action signature carries the explicit signer. When `signer`
+///   is `None` (older actions without the hint), returns `None` — the
+///   author can't be identified without scanning the writer set, and the
+///   caller treats this as "don't enforce membership here, defer to the
+///   per-action signature check inside `apply_action`."
+/// * `Public` / `Frozen` / authorization absent → `None`; no author to
+///   check (the per-action signature path verifies what's verifiable).
+fn extract_author_from_leaf_authorization(
+    authorization: Option<&StorageType>,
+) -> Option<PublicKey> {
+    match authorization? {
+        StorageType::User { owner, .. } => Some(*owner),
+        StorageType::Shared { signature_data, .. } => {
+            signature_data.as_ref().and_then(|sd| sd.signer)
+        }
+        StorageType::Public | StorageType::Frozen => None,
+    }
+}
+
+/// Authorization gate for sync apply paths that don't carry a per-leaf
+/// governance position on the wire (HashComparison EntityPush, snapshot
+/// apply). Mirrors `state_delta_bridge`'s cross-DAG `membership_status_at`
+/// check, coarsened to the receiver's *current* group state.
+///
+/// Returns `true` iff the entity should be applied:
+/// * No identifiable author → applied (Public / Frozen / Shared without
+///   `signer` hint; the per-action signature inside `apply_action`
+///   remains the verifier).
+/// * Author identified + currently a member of `context_id`'s owning
+///   group → applied.
+/// * Author identified + NOT currently a member (or lookup error) →
+///   dropped. Closes the HC back door where a now-removed author's
+///   entities entered storage without re-running the membership check
+///   that the gossip path runs unconditionally. The trade-off (over-
+///   rejection of legitimate pre-removal writes that propagate via HC)
+///   is documented on
+///   [`calimero_context::group_store::is_currently_authorized_for_context`].
+pub fn is_leaf_currently_authorized(
+    store: &Store,
+    context_id: &ContextId,
+    leaf: &TreeLeafData,
+) -> bool {
+    let Some(author) =
+        extract_author_from_leaf_authorization(leaf.metadata.authorization.as_ref())
+    else {
+        return true;
+    };
+    match calimero_context::group_store::is_currently_authorized_for_context(
+        store, context_id, &author,
+    ) {
+        Ok(authorized) => authorized,
+        Err(err) => {
+            tracing::warn!(
+                %context_id,
+                %author,
+                error = %err,
+                "is_leaf_currently_authorized: membership lookup failed; dropping entity to avoid silent bypass"
+            );
+            false
         }
     }
 }
@@ -271,8 +340,17 @@ pub const MAX_ENTITIES_PER_PUSH: usize = 500;
 /// Must be called within a `with_runtime_env` scope for each entity.
 /// Truncates to `MAX_ENTITIES_PER_PUSH` entities per message for DoS protection.
 ///
-/// Returns the number of entities successfully applied.
+/// Each leaf is first run through [`is_leaf_currently_authorized`] — entities
+/// whose claimed author is not currently an authorized member of the
+/// context's group are dropped before they touch storage. This closes the
+/// HC EntityPush authorization back door (gossip rejects a now-removed
+/// author's delta, but HC would re-import the same entity unverified).
+///
+/// Returns the number of entities successfully applied (excludes dropped
+/// entities, whether dropped for invalidity, unauthorized author, or apply
+/// failure).
 pub fn handle_entity_push(
+    store: &Store,
     runtime_env: &calimero_storage::env::RuntimeEnv,
     context_id: ContextId,
     entities: &[TreeLeafData],
@@ -291,6 +369,7 @@ pub fn handle_entity_push(
 
     calimero_storage::env::with_runtime_env(runtime_env.clone(), || {
         let mut applied = 0u32;
+        let mut dropped_unauthorized = 0u32;
         for leaf in entities {
             if !leaf.is_valid() {
                 tracing::warn!(
@@ -298,6 +377,15 @@ pub fn handle_entity_push(
                     key = %hex::encode(leaf.key),
                     len = leaf.value.len(),
                     "pushed entity failed TreeLeafData::is_valid(), skipping"
+                );
+                continue;
+            }
+            if !is_leaf_currently_authorized(store, &context_id, leaf) {
+                dropped_unauthorized += 1;
+                tracing::warn!(
+                    %context_id,
+                    key = %hex::encode(leaf.key),
+                    "pushed entity dropped: claimed author is not currently authorized for this context"
                 );
                 continue;
             }
@@ -312,6 +400,13 @@ pub fn handle_entity_push(
                     );
                 }
             }
+        }
+        if dropped_unauthorized > 0 {
+            tracing::info!(
+                %context_id,
+                dropped_unauthorized,
+                "EntityPush: dropped entities whose author is no longer authorized"
+            );
         }
         applied
     })
@@ -403,4 +498,73 @@ mod tests {
     // (via `with_runtime_env`). It is tested indirectly through the sync_sim
     // integration tests which set up `SimStorage` with proper storage backends.
     // See: crates/node/tests/sync_sim/
+
+    use calimero_storage::entities::{SignatureData, StorageType};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn extract_author_user_returns_owner() {
+        let owner = PublicKey::from([7u8; 32]);
+        let st = StorageType::User {
+            owner,
+            signature_data: None,
+        };
+        assert_eq!(
+            extract_author_from_leaf_authorization(Some(&st)),
+            Some(owner),
+        );
+    }
+
+    #[test]
+    fn extract_author_shared_with_signer_hint_returns_signer() {
+        let signer = PublicKey::from([9u8; 32]);
+        let st = StorageType::Shared {
+            writers: BTreeSet::from([signer]),
+            signature_data: Some(SignatureData {
+                signer: Some(signer),
+                signature: [0u8; 64],
+                nonce: 0,
+            }),
+        };
+        assert_eq!(
+            extract_author_from_leaf_authorization(Some(&st)),
+            Some(signer),
+        );
+    }
+
+    #[test]
+    fn extract_author_shared_without_signer_hint_returns_none() {
+        // Older actions can omit the signer hint — caller treats `None`
+        // as "defer to per-action signature verification inside apply_action."
+        let st = StorageType::Shared {
+            writers: BTreeSet::from([PublicKey::from([1u8; 32])]),
+            signature_data: Some(SignatureData {
+                signer: None,
+                signature: [0u8; 64],
+                nonce: 0,
+            }),
+        };
+        assert_eq!(extract_author_from_leaf_authorization(Some(&st)), None);
+    }
+
+    #[test]
+    fn extract_author_public_returns_none() {
+        assert_eq!(
+            extract_author_from_leaf_authorization(Some(&StorageType::Public)),
+            None,
+        );
+    }
+
+    #[test]
+    fn extract_author_frozen_returns_none() {
+        assert_eq!(
+            extract_author_from_leaf_authorization(Some(&StorageType::Frozen)),
+            None,
+        );
+    }
+
+    #[test]
+    fn extract_author_no_authorization_returns_none() {
+        assert_eq!(extract_author_from_leaf_authorization(None), None);
+    }
 }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -394,27 +394,7 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
     // bytes come from a peer who already verified them. Empty ctx →
     // verifier falls back to v2 stored-writers, which is the safe
     // semantic for already-verified replicated state.
-    //
-    // Wrapped in `with_merge_mode` so the per-action nonce staleness
-    // check inside `save_internal` bypasses for this sync-apply path
-    // (`skip_nonce = nonce_check_disabled || in_merge_mode()`). HC's
-    // leaf apply re-runs actions a peer has already gossiped — the
-    // local node may already be at the same nonce, and the
-    // nonce-staleness skip would silently no-op the apply. That
-    // no-op was the smoking-gun "Shared upsert: stale-or-equal nonce"
-    // warning in the shared-storage + scaffolding-e2e failures on
-    // PR #2465: gossip + HC race meant HC re-applied gossip's
-    // entities at the same nonce, hit the skip, and the action's
-    // structural effects (children references, RGA characters) never
-    // landed — even though the underlying bytes were correct.
-    //
-    // Safety: signature verification still runs before the skip
-    // check, so forgeries are still rejected. Merge mode only stops
-    // the skip from misreading sync re-application as replay attacks
-    // of themselves.
-    calimero_storage::env::with_merge_mode(|| {
-        Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())
-    })?;
+    Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())?;
     Ok(())
 }
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -139,14 +139,30 @@ pub fn is_leaf_currently_authorized(
     match calimero_context::group_store::is_currently_authorized_for_context(
         store, context_id, &author,
     ) {
-        Ok(authorized) => authorized,
+        Ok(true) => true,
+        Ok(false) => {
+            // Expected outcome under churn (post-removal authorship,
+            // ReadOnly role); track separately from lookup errors so
+            // operators can tell normal churn-driven drops from
+            // I/O-driven drops at a glance. See `record_hc_leaf_drop`
+            // for the ratio semantics.
+            crate::node_metrics::record_hc_leaf_drop("unauthorized");
+            false
+        }
         Err(err) => {
-            tracing::warn!(
+            // Storage layer raised — drop the leaf rather than risk a
+            // silent bypass, but escalate to ERROR (not WARN) so the
+            // signal isn't lost in routine sync chatter, and emit the
+            // counter so the operator dashboard reflects a non-trivial
+            // rate of I/O trouble even if individual log lines get
+            // dropped under load.
+            tracing::error!(
                 %context_id,
                 %author,
                 error = %err,
                 "is_leaf_currently_authorized: membership lookup failed; dropping entity to avoid silent bypass"
             );
+            crate::node_metrics::record_hc_leaf_drop("lookup_error");
             false
         }
     }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -179,6 +179,34 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
     let entity_id = Id::new(leaf.key);
     let root_id = Id::new(*context_id.as_ref());
 
+    // App root state — `ROOT_ID` or the `Root<T>` entry — needs CRDT
+    // merge against the app's typed `Mergeable` impl. That impl only
+    // exists inside the WASM module; the host's `merge_root_state` has
+    // never had a working dispatch table (the registry it consults is
+    // populated by the macro's `__calimero_register_merge` export,
+    // which writes to the WASM module's static memory, not the host's —
+    // separate address spaces, separate copies of `MERGE_REGISTRY`).
+    // Pre-pause the bootstrap fast-path masked it (`created == updated`
+    // accepts incoming unconditionally); post-pause divergence trips
+    // the post-bootstrap branch and the cascade in core#2469 fires.
+    //
+    // Until root-entity merges route through WASM via the new
+    // `__calimero_merge_root_state` export, skip them here. The root
+    // entity will converge via the normal delta-sync path
+    // (`__calimero_sync_next`, which runs inside WASM where merge
+    // dispatch actually works). HC's `stats.root_hash_verified` reports
+    // `false` for this round; the sync manager handles that as a
+    // partial merge and the next tick retries via delta sync.
+    if calimero_storage::collections::is_app_root_entry(entity_id) {
+        tracing::warn!(
+            %context_id,
+            entity_id = %entity_id,
+            "HC apply: skipping root-entity merge on host (no host-side merge dispatch); \
+             root entity will converge via WASM-routed delta sync"
+        );
+        return Ok(());
+    }
+
     // Check if entity already exists
     let existing_index = Index::<MainStorage>::get_index(entity_id).ok().flatten();
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -132,8 +132,7 @@ pub fn is_leaf_currently_authorized(
     context_id: &ContextId,
     leaf: &TreeLeafData,
 ) -> bool {
-    let Some(author) =
-        extract_author_from_leaf_authorization(leaf.metadata.authorization.as_ref())
+    let Some(author) = extract_author_from_leaf_authorization(leaf.metadata.authorization.as_ref())
     else {
         return true;
     };

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -364,6 +364,20 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
 /// The initiator batches at this limit; the responder truncates messages exceeding it.
 pub const MAX_ENTITIES_PER_PUSH: usize = 500;
 
+/// Outcome of an EntityPush batch.
+///
+/// `applied` is the count of leaves successfully written via the host
+/// CRDT apply path. `deferred_root_merges` collects root-entity leaves
+/// the host can't merge by itself (same rationale as
+/// [`HashComparisonStats::deferred_root_merges`](crate::sync::hash_comparison_protocol::HashComparisonStats::deferred_root_merges)) —
+/// the caller dispatches each through `ContextClient::merge_root_state`
+/// after the batch returns.
+#[derive(Debug, Default)]
+pub struct EntityPushOutcome {
+    pub applied: u32,
+    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>)>,
+}
+
 /// Handle an incoming `EntityPush` by applying CRDT merge for each entity.
 ///
 /// Shared between the production responder (`hash_comparison.rs`) and the
@@ -378,15 +392,15 @@ pub const MAX_ENTITIES_PER_PUSH: usize = 500;
 /// HC EntityPush authorization back door (gossip rejects a now-removed
 /// author's delta, but HC would re-import the same entity unverified).
 ///
-/// Returns the number of entities successfully applied (excludes dropped
-/// entities, whether dropped for invalidity, unauthorized author, or apply
-/// failure).
+/// Root-entity leaves are surfaced in `deferred_root_merges` for the
+/// caller to dispatch via `ContextClient::merge_root_state` — the host
+/// has no dispatch table for app-typed root state.
 pub fn handle_entity_push(
     store: &Store,
     runtime_env: &calimero_storage::env::RuntimeEnv,
     context_id: ContextId,
     entities: &[TreeLeafData],
-) -> u32 {
+) -> EntityPushOutcome {
     let entities = if entities.len() > MAX_ENTITIES_PER_PUSH {
         tracing::warn!(
             %context_id,
@@ -402,6 +416,7 @@ pub fn handle_entity_push(
     calimero_storage::env::with_runtime_env(runtime_env.clone(), || {
         let mut applied = 0u32;
         let mut dropped_unauthorized = 0u32;
+        let mut deferred_root_merges: Vec<([u8; 32], Vec<u8>)> = Vec::new();
         for leaf in entities {
             if !leaf.is_valid() {
                 tracing::warn!(
@@ -419,6 +434,16 @@ pub fn handle_entity_push(
                     key = %hex::encode(leaf.key),
                     "pushed entity dropped: claimed author is not currently authorized for this context"
                 );
+                continue;
+            }
+            // Root-entity leaves can't be merged on the host (same
+            // reason as the HC / LevelWise initiator paths — see
+            // `dispatch_deferred_root_merges` in `protocol_selector`).
+            // Defer to the caller, which has the `ContextClient` needed
+            // to invoke `__calimero_merge_root_state` inside WASM.
+            let entity_id = Id::new(leaf.key);
+            if calimero_storage::collections::is_app_root_entry(entity_id) {
+                deferred_root_merges.push((leaf.key, leaf.value.clone()));
                 continue;
             }
             match apply_leaf_with_crdt_merge(context_id, leaf) {
@@ -440,7 +465,10 @@ pub fn handle_entity_push(
                 "EntityPush: dropped entities whose author is no longer authorized"
             );
         }
-        applied
+        EntityPushOutcome {
+            applied,
+            deferred_root_merges,
+        }
     })
 }
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -172,6 +172,8 @@ pub fn is_leaf_currently_authorized(
 /// * `context_id` - The context being synchronized
 /// * `leaf` - The leaf data containing entity key, value, and CRDT metadata
 ///
+/// Apply leaf data using CRDT merge (Invariant I5: No Silent Data Loss).
+///
 /// # Errors
 ///
 /// Returns error if storage operations fail.
@@ -190,10 +192,12 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
     // accepts incoming unconditionally); post-pause divergence trips
     // the post-bootstrap branch and the cascade in core#2469 fires.
     //
-    // Until root-entity merges route through WASM via the new
-    // `__calimero_merge_root_state` export, skip them here. The root
-    // entity will converge via the normal delta-sync path
-    // (`__calimero_sync_next`, which runs inside WASM where merge
+    // Until root-entity merges route through WASM via
+    // [`ContextClient::merge_root_state`] (the
+    // `__calimero_merge_root_state` export is in place; the dispatch
+    // plumbing through HC / snapshot / levelwise is a follow-up), skip
+    // them here. The root entity converges via the normal delta-sync
+    // path (`__calimero_sync_next`, which runs inside WASM where merge
     // dispatch actually works). HC's `stats.root_hash_verified` reports
     // `false` for this round; the sync manager handles that as a
     // partial merge and the next tick retries via delta sync.

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -386,13 +386,20 @@ async fn run_initiator_impl<T: SyncTransport>(
                         continue;
                     }
 
-                    // Defer root-entity merges; same rationale as HC's
-                    // initiator (the host has no merge dispatch table
-                    // for app-typed root state). `ProtocolSelector`
-                    // dispatches these through `ContextClient::merge_root_state`
-                    // after the sync completes.
+                    // Defer root entities with a real `crdt_type` for
+                    // WASM dispatch; opaque root entities (synthetic
+                    // `Opaque` LWW marker) fall through to
+                    // `apply_leaf_with_crdt_merge` which LWW-writes
+                    // them directly (no Mergeable to dispatch).
                     let entity_id = calimero_storage::address::Id::new(leaf_data.key);
-                    if calimero_storage::collections::is_app_root_entry(entity_id) {
+                    let is_opaque = matches!(
+                        &leaf_data.metadata.crdt_type,
+                        calimero_primitives::crdt::CrdtType::LwwRegister { inner_type }
+                            if inner_type == crate::sync::hash_comparison_protocol::OPAQUE_LEAF_CRDT_TYPE_NAME
+                    );
+                    if calimero_storage::collections::is_app_root_entry(entity_id)
+                        && !is_opaque
+                    {
                         stats
                             .deferred_root_merges
                             .push((leaf_data.key, leaf_data.value.clone()));

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -398,9 +398,7 @@ async fn run_initiator_impl<T: SyncTransport>(
                         calimero_primitives::crdt::CrdtType::LwwRegister { inner_type }
                             if inner_type == crate::sync::hash_comparison_protocol::OPAQUE_LEAF_CRDT_TYPE_NAME
                     );
-                    if calimero_storage::collections::is_app_root_entry(entity_id)
-                        && !is_opaque
-                    {
+                    if calimero_storage::collections::is_app_root_entry(entity_id) && !is_opaque {
                         stats.deferred_root_merges.push((
                             leaf_data.key,
                             leaf_data.value.clone(),

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -136,6 +136,12 @@ pub struct LevelWiseStats {
     ///
     /// If true, the sync may be incomplete and a follow-up sync might be needed.
     pub truncation_occurred: bool,
+    /// Root-state byte blobs the level-by-level walk encountered on
+    /// remote leaves that the host can't merge itself. Same shape +
+    /// rationale as `HashComparisonStats::deferred_root_merges`; the
+    /// caller (`ProtocolSelector`) dispatches them through
+    /// `ContextClient::merge_root_state` after the sync completes.
+    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>)>,
 }
 
 // =============================================================================
@@ -377,6 +383,19 @@ async fn run_initiator_impl<T: SyncTransport>(
                             key = %hex::encode(leaf_data.key),
                             "LevelWise merge skipped: claimed author is not currently authorized for this context"
                         );
+                        continue;
+                    }
+
+                    // Defer root-entity merges; same rationale as HC's
+                    // initiator (the host has no merge dispatch table
+                    // for app-typed root state). `ProtocolSelector`
+                    // dispatches these through `ContextClient::merge_root_state`
+                    // after the sync completes.
+                    let entity_id = calimero_storage::address::Id::new(leaf_data.key);
+                    if calimero_storage::collections::is_app_root_entry(entity_id) {
+                        stats
+                            .deferred_root_merges
+                            .push((leaf_data.key, leaf_data.value.clone()));
                         continue;
                     }
 

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -76,6 +76,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::sync::helpers::{
     apply_leaf_with_crdt_merge, generate_nonce, get_local_root_hash_for_context,
+    is_leaf_currently_authorized,
 };
 
 // =============================================================================
@@ -362,6 +363,22 @@ async fn run_initiator_impl<T: SyncTransport>(
                         key = %hex::encode(leaf_data.key),
                         "Merging leaf entity"
                     );
+
+                    // Authorization gate, parity with HashComparison's
+                    // per-leaf check. LevelWise is a fallback the manager
+                    // selects when HC isn't a good fit (wide/shallow
+                    // trees), and it walks the same leaf-merge path —
+                    // without this check, a revoked author's writes that
+                    // gossip rejected could re-enter via LevelWise the
+                    // same way they did via HC.
+                    if !is_leaf_currently_authorized(store, &context_id, leaf_data) {
+                        warn!(
+                            %context_id,
+                            key = %hex::encode(leaf_data.key),
+                            "LevelWise merge skipped: claimed author is not currently authorized for this context"
+                        );
+                        continue;
+                    }
 
                     with_runtime_env(runtime_env.clone(), || {
                         apply_leaf_with_crdt_merge(context_id, leaf_data)

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -141,7 +141,8 @@ pub struct LevelWiseStats {
     /// rationale as `HashComparisonStats::deferred_root_merges`; the
     /// caller (`ProtocolSelector`) dispatches them through
     /// `ContextClient::merge_root_state` after the sync completes.
-    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>)>,
+    /// Each entry is `(entity_id_bytes, incoming_bytes, incoming_hlc_ts)`.
+    pub deferred_root_merges: Vec<([u8; 32], Vec<u8>, u64)>,
 }
 
 // =============================================================================
@@ -400,9 +401,11 @@ async fn run_initiator_impl<T: SyncTransport>(
                     if calimero_storage::collections::is_app_root_entry(entity_id)
                         && !is_opaque
                     {
-                        stats
-                            .deferred_root_merges
-                            .push((leaf_data.key, leaf_data.value.clone()));
+                        stats.deferred_root_merges.push((
+                            leaf_data.key,
+                            leaf_data.value.clone(),
+                            leaf_data.metadata.hlc_timestamp,
+                        ));
                         continue;
                     }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1693,6 +1693,36 @@ impl SyncManager {
                                          governance_position from peer: {e}"
                                     )
                                 })?;
+                            // Per-delta envelope signature verification —
+                            // parity with `apply_authorized_state_delta`'s
+                            // gossip-path check. Runs BEFORE the cross-DAG
+                            // membership check because that check keys off
+                            // `author`; we have to establish the authorship
+                            // claim is genuine before asking whether the
+                            // claimed author is authorized. `None` is
+                            // currently tolerated for the wire-up
+                            // transition (signing at execute lands in a
+                            // follow-up); once that lands, `None`
+                            // tightens to a hard reject.
+                            if let Some(ref sig) = response_delta_signature {
+                                if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
+                                    context_id,
+                                    storage_delta.id,
+                                    author,
+                                    pos.as_ref(),
+                                    sig,
+                                ) {
+                                    warn!(
+                                        %context_id,
+                                        %author,
+                                        head_id = ?head_id,
+                                        %err,
+                                        "DAG-catchup: rejecting delta — envelope signature \
+                                         verification failed"
+                                    );
+                                    continue;
+                                }
+                            }
                             if let Some(ref pos) = pos {
                                 let datastore = self.context_client.datastore_handle().into_inner();
                                 use calimero_context::group_store::{

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1648,12 +1648,114 @@ impl SyncManager {
 
                     match delta_response {
                         Some(StreamMessage::Message {
-                            payload: MessagePayload::DeltaResponse { delta },
+                            payload:
+                                MessagePayload::DeltaResponse {
+                                    delta,
+                                    author_id: response_author,
+                                    governance_position_blob,
+                                },
                             ..
                         }) => {
                             // Deserialize and add to DAG
                             let storage_delta: calimero_storage::delta::CausalDelta =
                                 borsh::from_slice(&delta)?;
+
+                            // Apply-time cross-DAG membership check —
+                            // parity with the gossip-path check in
+                            // `handle_state_delta`. The responder includes
+                            // its persisted `author_id` and serialized
+                            // `governance_position` so we can verify the
+                            // delta's author was a member at the cited
+                            // cut. Without this check, a revoked author's
+                            // post-revocation deltas would propagate via
+                            // DAG-catchup even though the gossip path
+                            // rejects them — exactly the gap that
+                            // `group-remove-from-root-revokes-inherited`
+                            // catches (the broken HC fallback was masking
+                            // it before this PR's fix).
+                            //
+                            // None on author_id (race-path serve from
+                            // in-memory DeltaStore, or pre-PR persisted
+                            // rows) falls through to legacy accept — the
+                            // post-apply persist will tighten it for
+                            // subsequent serves.
+                            if let Some(author) = response_author {
+                                let pos = governance_position_blob
+                                    .as_deref()
+                                    .map(borsh::from_slice::<
+                                        calimero_context_config::types::GovernancePosition,
+                                    >)
+                                    .transpose()
+                                    .map_err(|e| {
+                                        eyre::eyre!(
+                                            "DAG-catchup: failed to decode \
+                                             governance_position from peer: {e}"
+                                        )
+                                    })?;
+                                if let Some(ref pos) = pos {
+                                    let datastore =
+                                        self.context_client.datastore_handle().into_inner();
+                                    use calimero_context::group_store::{
+                                        membership_status_at, MembershipStatus,
+                                    };
+                                    match membership_status_at(&datastore, &author, pos) {
+                                        Ok(MembershipStatus::Member(_)) => {
+                                            // Authorized at the cited cut — proceed.
+                                        }
+                                        Ok(MembershipStatus::Removed { last_role }) => {
+                                            warn!(
+                                                %context_id,
+                                                %author,
+                                                head_id = ?head_id,
+                                                last_role = ?last_role,
+                                                "DAG-catchup: rejecting delta — author was \
+                                                 removed at the cited governance cut"
+                                            );
+                                            continue;
+                                        }
+                                        Ok(MembershipStatus::NeverMember) => {
+                                            warn!(
+                                                %context_id,
+                                                %author,
+                                                head_id = ?head_id,
+                                                "DAG-catchup: rejecting delta — author was \
+                                                 never a member at the cited governance cut"
+                                            );
+                                            continue;
+                                        }
+                                        Ok(MembershipStatus::Unknown { needed }) => {
+                                            // Buffering this delta the way the gossip path
+                                            // does would close the loop, but the DAG-catchup
+                                            // dispatch flow doesn't have the buffer plumbing
+                                            // wired yet. Skipping for now means the next sync
+                                            // tick will re-attempt once governance state has
+                                            // caught up via gossip; safer than admitting an
+                                            // unverified delta on the catch-up path.
+                                            warn!(
+                                                %context_id,
+                                                %author,
+                                                head_id = ?head_id,
+                                                needed = ?needed,
+                                                "DAG-catchup: skipping delta — governance \
+                                                 cut not locally known; will re-attempt on \
+                                                 next sync tick"
+                                            );
+                                            continue;
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                %context_id,
+                                                %author,
+                                                head_id = ?head_id,
+                                                error = %e,
+                                                "DAG-catchup: skipping delta — \
+                                                 membership_status_at failed"
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
 
                             let dag_delta = calimero_dag::CausalDelta {
                                 id: storage_delta.id,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1662,99 +1662,96 @@ impl SyncManager {
 
                             // Apply-time cross-DAG membership check —
                             // parity with the gossip-path check in
-                            // `handle_state_delta`. The responder includes
-                            // its persisted `author_id` and serialized
-                            // `governance_position` so we can verify the
-                            // delta's author was a member at the cited
-                            // cut. Without this check, a revoked author's
-                            // post-revocation deltas would propagate via
-                            // DAG-catchup even though the gossip path
-                            // rejects them — exactly the gap that
-                            // `group-remove-from-root-revokes-inherited`
-                            // catches (the broken HC fallback was masking
-                            // it before this PR's fix).
+                            // `handle_state_delta`. `response_author` is
+                            // required on the wire (the responder filters
+                            // out rows without an author claim, returning
+                            // `DeltaNotFound` so the initiator can fall
+                            // back to a verifiable path). No legacy-accept
+                            // escape hatch here.
                             //
-                            // None on author_id (race-path serve from
-                            // in-memory DeltaStore, or pre-PR persisted
-                            // rows) falls through to legacy accept — the
-                            // post-apply persist will tighten it for
-                            // subsequent serves.
-                            if let Some(author) = response_author {
-                                let pos = governance_position_blob
-                                    .as_deref()
-                                    .map(
-                                        borsh::from_slice::<
-                                            calimero_context_config::types::GovernancePosition,
-                                        >,
+                            // `governance_position` is `Option` because
+                            // non-group contexts legitimately have no
+                            // cut to cite. In that case the membership
+                            // check is skipped (nothing to verify against
+                            // — context isn't governed by a group
+                            // membership DAG), and the per-action
+                            // signatures inside `apply_action` remain
+                            // the auth primitive.
+                            let author = response_author;
+                            let pos = governance_position_blob
+                                .as_deref()
+                                .map(
+                                    borsh::from_slice::<
+                                        calimero_context_config::types::GovernancePosition,
+                                    >,
+                                )
+                                .transpose()
+                                .map_err(|e| {
+                                    eyre::eyre!(
+                                        "DAG-catchup: failed to decode \
+                                         governance_position from peer: {e}"
                                     )
-                                    .transpose()
-                                    .map_err(|e| {
-                                        eyre::eyre!(
-                                            "DAG-catchup: failed to decode \
-                                             governance_position from peer: {e}"
-                                        )
-                                    })?;
-                                if let Some(ref pos) = pos {
-                                    let datastore =
-                                        self.context_client.datastore_handle().into_inner();
-                                    use calimero_context::group_store::{
-                                        membership_status_at, MembershipStatus,
-                                    };
-                                    match membership_status_at(&datastore, &author, pos) {
-                                        Ok(MembershipStatus::Member(_)) => {
-                                            // Authorized at the cited cut — proceed.
-                                        }
-                                        Ok(MembershipStatus::Removed { last_role }) => {
-                                            warn!(
-                                                %context_id,
-                                                %author,
-                                                head_id = ?head_id,
-                                                last_role = ?last_role,
-                                                "DAG-catchup: rejecting delta — author was \
-                                                 removed at the cited governance cut"
-                                            );
-                                            continue;
-                                        }
-                                        Ok(MembershipStatus::NeverMember) => {
-                                            warn!(
-                                                %context_id,
-                                                %author,
-                                                head_id = ?head_id,
-                                                "DAG-catchup: rejecting delta — author was \
-                                                 never a member at the cited governance cut"
-                                            );
-                                            continue;
-                                        }
-                                        Ok(MembershipStatus::Unknown { needed }) => {
-                                            // Buffering this delta the way the gossip path
-                                            // does would close the loop, but the DAG-catchup
-                                            // dispatch flow doesn't have the buffer plumbing
-                                            // wired yet. Skipping for now means the next sync
-                                            // tick will re-attempt once governance state has
-                                            // caught up via gossip; safer than admitting an
-                                            // unverified delta on the catch-up path.
-                                            warn!(
-                                                %context_id,
-                                                %author,
-                                                head_id = ?head_id,
-                                                needed = ?needed,
-                                                "DAG-catchup: skipping delta — governance \
-                                                 cut not locally known; will re-attempt on \
-                                                 next sync tick"
-                                            );
-                                            continue;
-                                        }
-                                        Err(e) => {
-                                            warn!(
-                                                %context_id,
-                                                %author,
-                                                head_id = ?head_id,
-                                                error = %e,
-                                                "DAG-catchup: skipping delta — \
-                                                 membership_status_at failed"
-                                            );
-                                            continue;
-                                        }
+                                })?;
+                            if let Some(ref pos) = pos {
+                                let datastore =
+                                    self.context_client.datastore_handle().into_inner();
+                                use calimero_context::group_store::{
+                                    membership_status_at, MembershipStatus,
+                                };
+                                match membership_status_at(&datastore, &author, pos) {
+                                    Ok(MembershipStatus::Member(_)) => {
+                                        // Authorized at the cited cut — proceed.
+                                    }
+                                    Ok(MembershipStatus::Removed { last_role }) => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            last_role = ?last_role,
+                                            "DAG-catchup: rejecting delta — author was \
+                                             removed at the cited governance cut"
+                                        );
+                                        continue;
+                                    }
+                                    Ok(MembershipStatus::NeverMember) => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            "DAG-catchup: rejecting delta — author was \
+                                             never a member at the cited governance cut"
+                                        );
+                                        continue;
+                                    }
+                                    Ok(MembershipStatus::Unknown { needed }) => {
+                                        // Buffering this delta the way the gossip path
+                                        // does would close the loop, but the DAG-catchup
+                                        // dispatch flow doesn't have the buffer plumbing
+                                        // wired yet. Skipping for now means the next sync
+                                        // tick will re-attempt once governance state has
+                                        // caught up via gossip; safer than admitting an
+                                        // unverified delta on the catch-up path.
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            needed = ?needed,
+                                            "DAG-catchup: skipping delta — governance \
+                                             cut not locally known; will re-attempt on \
+                                             next sync tick"
+                                        );
+                                        continue;
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            error = %e,
+                                            "DAG-catchup: skipping delta — \
+                                             membership_status_at failed"
+                                        );
+                                        continue;
                                     }
                                 }
                             }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1729,6 +1729,52 @@ impl SyncManager {
                             // signatures inside `apply_action` remain
                             // the auth primitive.
                             let author = response_author;
+
+                            // Genesis carve-out: the responder serves
+                            // the genesis delta with the all-zeros
+                            // sentinel `author_id` because the wire
+                            // requires an author but genesis predates
+                            // any governance op. Skip every
+                            // author-keyed check — none of them apply
+                            // to genesis. Persist directly via the
+                            // same add_delta path; gossip never sees
+                            // genesis (it's installed at context
+                            // creation), so the only way late joiners
+                            // backfill it is via this catchup path.
+                            if crate::sync::delta_request::is_genesis_author_sentinel(&author) {
+                                debug!(
+                                    %context_id,
+                                    head_id = ?head_id,
+                                    "DAG head pull: accepting genesis delta via author sentinel"
+                                );
+                                let dag_delta = calimero_dag::CausalDelta {
+                                    id: storage_delta.id,
+                                    parents: storage_delta.parents.clone(),
+                                    payload: storage_delta.actions,
+                                    hlc: storage_delta.hlc,
+                                    expected_root_hash: storage_delta.expected_root_hash,
+                                    kind: calimero_dag::DeltaKind::Regular,
+                                };
+                                if let Err(e) =
+                                    delta_store_ref.add_delta(dag_delta, None, None, None).await
+                                {
+                                    warn!(
+                                        ?e,
+                                        %context_id,
+                                        head_id = ?head_id,
+                                        "Failed to add genesis DAG head delta"
+                                    );
+                                } else {
+                                    heads_admitted = heads_admitted.saturating_add(1);
+                                    info!(
+                                        %context_id,
+                                        head_id = ?head_id,
+                                        "Successfully added genesis DAG head delta"
+                                    );
+                                }
+                                continue;
+                            }
+
                             let pos = match governance_position_blob
                                 .as_deref()
                                 .map(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1622,6 +1622,21 @@ impl SyncManager {
                 }
 
                 // Phase 1: Request and add ALL DAG heads
+                //
+                // Count outcomes so we can detect the silent-no-op case:
+                // a peer advertised N heads, every one was rejected by
+                // the signature/membership/group-id checks, and we
+                // therefore added zero deltas. Without the
+                // counters below, `missing_ids` would be empty after
+                // the loop and the fast-return at 1979 would claim
+                // success despite no progress — the divergence would
+                // persist and the caller would back off as if it had
+                // already converged. `heads_attempted` excludes the
+                // DeltaNotFound case (peer doesn't have it, not a
+                // rejection); `heads_admitted` includes the
+                // successful `add_delta` path only.
+                let mut heads_attempted: u32 = 0;
+                let mut heads_admitted: u32 = 0;
                 for head_id in &dag_heads {
                     info!(
                         %context_id,
@@ -1653,10 +1668,17 @@ impl SyncManager {
                                     delta,
                                     author_id: response_author,
                                     governance_position_blob,
+                                    // Peer claimed to have the delta; count the
+                                    // attempt regardless of whether the verify
+                                    // chain ultimately accepts it. The
+                                    // DeltaNotFound arm below is *not* an
+                                    // attempt — the peer simply doesn't have
+                                    // it, so it can't be a "rejection".
                                     delta_signature: response_delta_signature,
                                 },
                             ..
                         }) => {
+                            heads_attempted = heads_attempted.saturating_add(1);
                             // Deserialize and add to DAG
                             let storage_delta: calimero_storage::delta::CausalDelta =
                                 borsh::from_slice(&delta)?;
@@ -1715,10 +1737,13 @@ impl SyncManager {
                             // `author`; we have to establish the authorship
                             // claim is genuine before asking whether the
                             // claimed author is authorized. `None` is
-                            // currently tolerated for the wire-up
-                            // transition (signing at execute lands in a
-                            // follow-up); once that lands, `None`
-                            // tightens to a hard reject.
+                            // tolerated only for legacy rows authored
+                            // before envelope signing landed and for
+                            // snapshot checkpoints / genesis rows that
+                            // have no author signature to record; every
+                            // freshly-authored delta (every output of
+                            // `internal_execute`) carries `Some(_)` and
+                            // MUST verify.
                             if let Some(ref sig) = response_delta_signature {
                                 if let Err(err) = calimero_node_primitives::sync::delta_auth::verify_delta_signature(
                                     context_id,
@@ -1738,6 +1763,91 @@ impl SyncManager {
                                     continue;
                                 }
                             }
+
+                            // Anti-bypass parity with the gossip path: before
+                            // running `membership_status_at`, confirm the
+                            // claimed governance position's `group_id`
+                            // actually matches the context's owning group
+                            // (or, for non-group contexts, that no position
+                            // is claimed). Without this:
+                            //   * `GroupContextNoPosition` — a group context
+                            //     would accept a delta with no position at
+                            //     all, silently skipping the membership check
+                            //     entirely (the `if let Some(pos)` branch
+                            //     below would just fall through).
+                            //   * `Mismatch` — an attacker could sign a
+                            //     position for a group they're a member of
+                            //     and attach it to a delta targeted at a
+                            //     different context owned by a different
+                            //     group, and `membership_status_at` would
+                            //     still pass against the spoofed group.
+                            //   * `NonGroupContextWithPosition` — symmetric.
+                            // The gossip path catches all three via
+                            // `verify_position_group_id_matches_context`; we
+                            // share the same helper so the match table
+                            // stays in lockstep across the two code paths.
+                            {
+                                use crate::handlers::state_delta::{
+                                    verify_position_group_id_matches_context, GroupIdCheck,
+                                };
+                                let datastore = self.context_client.datastore_handle().into_inner();
+                                match verify_position_group_id_matches_context(
+                                    &datastore,
+                                    &context_id,
+                                    pos.as_ref().map(|p| p.group_id),
+                                ) {
+                                    GroupIdCheck::Match | GroupIdCheck::NonGroupOk => {}
+                                    GroupIdCheck::GroupContextNoPosition { owning } => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            owning_group = ?owning,
+                                            "DAG-catchup: rejecting delta — context is owned \
+                                             by a group but delta carries no \
+                                             governance_position (parity gap with gossip path)"
+                                        );
+                                        continue;
+                                    }
+                                    GroupIdCheck::NonGroupContextWithPosition { claimed } => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            claimed_group = ?claimed,
+                                            "DAG-catchup: rejecting delta — delta claims a \
+                                             governance position but context is not in any \
+                                             group"
+                                        );
+                                        continue;
+                                    }
+                                    GroupIdCheck::Mismatch { owning, claimed } => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            owning_group = ?owning,
+                                            claimed_group = ?claimed,
+                                            "DAG-catchup: rejecting delta — governance_position \
+                                             references a different group than the context's \
+                                             owning group"
+                                        );
+                                        continue;
+                                    }
+                                    GroupIdCheck::LookupError(err) => {
+                                        warn!(
+                                            %context_id,
+                                            %author,
+                                            head_id = ?head_id,
+                                            %err,
+                                            "DAG-catchup: skipping delta — group lookup failed \
+                                             during anti-bypass check"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+
                             if let Some(ref pos) = pos {
                                 let datastore = self.context_client.datastore_handle().into_inner();
                                 use calimero_context::group_store::{
@@ -1832,6 +1942,7 @@ impl SyncManager {
                                     "Failed to add DAG head delta"
                                 );
                             } else {
+                                heads_admitted = heads_admitted.saturating_add(1);
                                 info!(
                                     %context_id,
                                     head_id = ?head_id,
@@ -1872,6 +1983,28 @@ impl SyncManager {
                             warn!(%context_id, head_id = ?head_id, "Unexpected response to delta request");
                         }
                     }
+                }
+
+                // Detect "all-rejected" silent no-op: the peer advertised
+                // heads, every single one was rejected by the verify chain
+                // (signature / group-id / membership), and so we admitted
+                // zero deltas. If we let the code fall through to the
+                // `missing_ids.is_empty()` fast-return below, catchup would
+                // claim `Ok(DeltaSync { missing_delta_ids: vec![] })` —
+                // i.e. "success" — even though the divergence remains.
+                // Bail loudly here so the caller knows to back off and
+                // either try another peer or escalate to snapshot sync,
+                // matching how the rest of `handle_dag_sync`'s error paths
+                // propagate.
+                if heads_attempted > 0 && heads_admitted == 0 {
+                    bail!(
+                        "DAG-catchup made no progress against peer {peer_id}: \
+                         all {heads_attempted} advertised head deltas were rejected \
+                         by the apply-time verify chain (signature / group-id / \
+                         membership). Reporting as failure rather than claiming \
+                         convergence — caller should back off and retry against \
+                         another peer or fall back to snapshot sync."
+                    );
                 }
 
                 // Phase 2: Now check for missing parents and fetch them recursively

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1691,6 +1691,26 @@ impl SyncManager {
                             let storage_delta: calimero_storage::delta::CausalDelta =
                                 borsh::from_slice(&delta)?;
 
+                            // Sanity check: peer returned the head we
+                            // requested. A buggy or malicious peer
+                            // could substitute a different authorized
+                            // delta in response. The envelope signature
+                            // binds `storage_delta.id`, not `head_id`,
+                            // so without this guard a peer could swap
+                            // a valid delta for another and slip it
+                            // into our DAG under the wrong slot —
+                            // parity with the parent-fetch path's
+                            // sanity check, same security rationale.
+                            if storage_delta.id != *head_id {
+                                warn!(
+                                    %context_id,
+                                    requested = ?head_id,
+                                    received = ?storage_delta.id,
+                                    "DAG head pull: peer returned a different delta id than requested, dropping"
+                                );
+                                continue;
+                            }
+
                             // Apply-time cross-DAG membership check —
                             // parity with the gossip-path check in
                             // `handle_state_delta`. `response_author` is

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1679,7 +1679,7 @@ impl SyncManager {
                             // signatures inside `apply_action` remain
                             // the auth primitive.
                             let author = response_author;
-                            let pos = governance_position_blob
+                            let pos = match governance_position_blob
                                 .as_deref()
                                 .map(
                                     borsh::from_slice::<
@@ -1687,12 +1687,27 @@ impl SyncManager {
                                     >,
                                 )
                                 .transpose()
-                                .map_err(|e| {
-                                    eyre::eyre!(
-                                        "DAG-catchup: failed to decode \
-                                         governance_position from peer: {e}"
-                                    )
-                                })?;
+                            {
+                                Ok(p) => p,
+                                Err(e) => {
+                                    // Malformed governance_position
+                                    // blob on a single delta shouldn't
+                                    // poison the whole DAG-catchup
+                                    // batch — skip this delta and
+                                    // continue. Other deltas may still
+                                    // converge; this one will retry on
+                                    // the next sync tick.
+                                    warn!(
+                                        %context_id,
+                                        %author,
+                                        head_id = ?head_id,
+                                        %e,
+                                        "DAG-catchup: failed to decode governance_position \
+                                         from peer; skipping this delta and continuing"
+                                    );
+                                    continue;
+                                }
+                            };
                             // Per-delta envelope signature verification —
                             // parity with `apply_authorized_state_delta`'s
                             // gossip-path check. Runs BEFORE the cross-DAG

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1693,8 +1693,7 @@ impl SyncManager {
                                     )
                                 })?;
                             if let Some(ref pos) = pos {
-                                let datastore =
-                                    self.context_client.datastore_handle().into_inner();
+                                let datastore = self.context_client.datastore_handle().into_inner();
                                 use calimero_context::group_store::{
                                     membership_status_at, MembershipStatus,
                                 };
@@ -1765,7 +1764,16 @@ impl SyncManager {
                                 kind: calimero_dag::DeltaKind::Regular,
                             };
 
-                            if let Err(e) = delta_store_ref.add_delta(dag_delta).await {
+                            // Persist with the wire-received author +
+                            // governance position so this node can in
+                            // turn serve verifiable DAG-catchup responses
+                            // to other peers that ask for the same delta.
+                            let persisted_gov_blob =
+                                governance_position_blob.as_ref().map(|c| c.to_vec());
+                            if let Err(e) = delta_store_ref
+                                .add_delta(dag_delta, Some(author), persisted_gov_blob)
+                                .await
+                            {
                                 warn!(
                                     ?e,
                                     %context_id,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1682,9 +1682,11 @@ impl SyncManager {
                             if let Some(author) = response_author {
                                 let pos = governance_position_blob
                                     .as_deref()
-                                    .map(borsh::from_slice::<
-                                        calimero_context_config::types::GovernancePosition,
-                                    >)
+                                    .map(
+                                        borsh::from_slice::<
+                                            calimero_context_config::types::GovernancePosition,
+                                        >,
+                                    )
                                     .transpose()
                                     .map_err(|e| {
                                         eyre::eyre!(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1653,6 +1653,7 @@ impl SyncManager {
                                     delta,
                                     author_id: response_author,
                                     governance_position_blob,
+                                    delta_signature: response_delta_signature,
                                 },
                             ..
                         }) => {
@@ -1771,7 +1772,12 @@ impl SyncManager {
                             let persisted_gov_blob =
                                 governance_position_blob.as_ref().map(|c| c.to_vec());
                             if let Err(e) = delta_store_ref
-                                .add_delta(dag_delta, Some(author), persisted_gov_blob)
+                                .add_delta(
+                                    dag_delta,
+                                    Some(author),
+                                    persisted_gov_blob,
+                                    response_delta_signature,
+                                )
                                 .await
                             {
                                 warn!(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1637,6 +1637,14 @@ impl SyncManager {
                 // successful `add_delta` path only.
                 let mut heads_attempted: u32 = 0;
                 let mut heads_admitted: u32 = 0;
+                // Hoist the datastore handle outside the loop —
+                // `datastore_handle().into_inner()` clones an `Arc`
+                // and can take a brief lock; per-iteration creation
+                // showed up in reviewer profiling as redundant since
+                // every head reuses the same handle. The handle is
+                // borrowed read-only by the membership check and the
+                // group-id parity check; both can share.
+                let datastore_for_heads = self.context_client.datastore_handle().into_inner();
                 for head_id in &dag_heads {
                     info!(
                         %context_id,
@@ -1790,9 +1798,8 @@ impl SyncManager {
                                 use crate::handlers::state_delta::{
                                     verify_position_group_id_matches_context, GroupIdCheck,
                                 };
-                                let datastore = self.context_client.datastore_handle().into_inner();
                                 match verify_position_group_id_matches_context(
-                                    &datastore,
+                                    &datastore_for_heads,
                                     &context_id,
                                     pos.as_ref().map(|p| p.group_id),
                                 ) {
@@ -1849,11 +1856,10 @@ impl SyncManager {
                             }
 
                             if let Some(ref pos) = pos {
-                                let datastore = self.context_client.datastore_handle().into_inner();
                                 use calimero_context::group_store::{
                                     membership_status_at, MembershipStatus,
                                 };
-                                match membership_status_at(&datastore, &author, pos) {
+                                match membership_status_at(&datastore_for_heads, &author, pos) {
                                     Ok(MembershipStatus::Member(_)) => {
                                         // Authorized at the cited cut — proceed.
                                     }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1875,6 +1875,29 @@ impl SyncManager {
                                 }
                             }
 
+                            // ReadOnly check — parity with the gossip
+                            // apply path. `membership_status_at` treats
+                            // ReadOnly as `Member(ReadOnly)`, so a
+                            // ReadOnly identity's delta would slip past
+                            // the cross-DAG check on the catchup path
+                            // even though gossip rejects it. Mirror the
+                            // gate `apply_authorized_state_delta` uses.
+                            if calimero_context::group_store::is_read_only_for_context(
+                                &datastore_for_heads,
+                                &context_id,
+                                &author,
+                            )
+                            .unwrap_or(false)
+                            {
+                                warn!(
+                                    %context_id,
+                                    %author,
+                                    head_id = ?head_id,
+                                    "DAG-catchup: rejecting delta from ReadOnly member"
+                                );
+                                continue;
+                            }
+
                             if let Some(ref pos) = pos {
                                 use calimero_context::group_store::{
                                     membership_status_at, MembershipStatus,

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -34,7 +34,7 @@
 
 mod blobs;
 mod config;
-mod delta_request;
+pub(crate) mod delta_request;
 pub(crate) mod driver;
 mod hash_comparison;
 pub mod hash_comparison_protocol;

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -372,8 +372,24 @@ impl ProtocolSelector {
                             nodes_compared = stats.nodes_compared,
                             entities_merged = stats.entities_merged,
                             nodes_skipped = stats.nodes_skipped,
+                            deferred_root_merges = stats.deferred_root_merges.len(),
                             "LevelWise sync completed successfully"
                         );
+
+                        // Same deferred-root-merge dispatch as HC; the
+                        // BFS encounters root-entity leaves it can't
+                        // merge on the host.
+                        if !stats.deferred_root_merges.is_empty() {
+                            dispatch_deferred_root_merges(
+                                &self.context_client,
+                                &store,
+                                context_id,
+                                our_identity,
+                                &stats.deferred_root_merges,
+                            )
+                            .await;
+                        }
+
                         Ok(Some(SyncProtocol::LevelWise { max_depth }))
                     }
                     Err(e) => {

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -462,7 +462,7 @@ pub(crate) async fn dispatch_deferred_root_merges(
     store: &calimero_store::Store,
     context_id: ContextId,
     our_identity: PublicKey,
-    deferred: &[([u8; 32], Vec<u8>)],
+    deferred: &[([u8; 32], Vec<u8>, u64)],
 ) {
     use calimero_storage::address::Id;
     use calimero_storage::entities::Metadata;
@@ -480,7 +480,7 @@ pub(crate) async fn dispatch_deferred_root_merges(
         our_identity,
     );
 
-    for (key, incoming) in deferred {
+    for (key, incoming, incoming_hlc_ts) in deferred {
         let entity_id = Id::new(*key);
 
         // Read existing bytes + metadata under the runtime env so
@@ -515,19 +515,14 @@ pub(crate) async fn dispatch_deferred_root_merges(
             }
         };
 
-        // Use the maximum of existing and incoming timestamps for the
-        // merged result's updated_at — convention matches LWW timestamp
-        // semantics and ensures the merged write strictly advances the
-        // local logical clock for this entity.
+        // `incoming_ts` is the wire-carried HLC timestamp the remote
+        // peer recorded when it wrote the entity. The post-merge
+        // result's `updated_at` advances to `max(existing, incoming)`
+        // so the merged write is strictly newer than either input
+        // — necessary for the next sync round's LWW comparisons to
+        // resolve consistently.
         let existing_ts: u64 = (*existing_metadata.updated_at).into();
-        let incoming_ts: u64 = existing_ts.max(
-            // HC leaves don't carry an HLC-keyed update timestamp for
-            // the root entity (the leaf carries its own metadata, but
-            // that's per-leaf, not per-root-merge). Use existing_ts + 1
-            // as a synthetic monotonic tick; the merge IS the write so
-            // the local clock must advance.
-            existing_ts.saturating_add(1),
-        );
+        let incoming_ts: u64 = *incoming_hlc_ts;
 
         let request = MergeRootStateRequest {
             existing,
@@ -553,10 +548,15 @@ pub(crate) async fn dispatch_deferred_root_merges(
             }
         };
 
-        // Write merged bytes back. Bump `updated_at` to incoming_ts so the
-        // post-merge state is timestamped consistently for the next sync.
+        // Write merged bytes back. `updated_at` advances to
+        // `max(existing_ts, incoming_ts)` — the merged state must be
+        // strictly newer than both inputs so the next LWW comparison
+        // resolves consistently. If `incoming_ts` was older than
+        // `existing_ts` (a stale push during concurrent updates), we
+        // still keep the merged bytes but timestamp them at
+        // `existing_ts` rather than going backwards.
         let mut new_metadata = existing_metadata.clone();
-        new_metadata.updated_at = incoming_ts.into();
+        new_metadata.updated_at = existing_ts.max(incoming_ts).into();
 
         let write_result = with_runtime_env(runtime_env.clone(), || {
             Interface::<MainStorage>::write_pre_merged_root_state(

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -230,8 +230,29 @@ impl ProtocolSelector {
                             nodes_compared = stats.nodes_compared,
                             entities_merged = stats.entities_merged,
                             nodes_skipped = stats.nodes_skipped,
+                            deferred_root_merges = stats.deferred_root_merges.len(),
                             "HashComparison sync completed successfully"
                         );
+
+                        // Dispatch any deferred root-entity merges through
+                        // the WASM module. HC's DFS can't merge root
+                        // entities on the host side (the merge registry
+                        // it would consult is populated inside WASM,
+                        // not here), so it accumulates them in
+                        // `stats.deferred_root_merges` and lets the
+                        // selector finish the job using
+                        // `ContextClient::merge_root_state`.
+                        if !stats.deferred_root_merges.is_empty() {
+                            dispatch_deferred_root_merges(
+                                &self.context_client,
+                                &store,
+                                context_id,
+                                our_identity,
+                                &stats.deferred_root_merges,
+                            )
+                            .await;
+                        }
+
                         Ok(Some(SyncProtocol::HashComparison {
                             root_hash,
                             divergent_subtrees: vec![],
@@ -400,6 +421,154 @@ impl ProtocolSelector {
                 }
             }
         }
+    }
+}
+
+/// Apply root-entity merges that HC's DFS deferred because the host can't
+/// dispatch the app's typed `Mergeable::merge` (the registry it would
+/// consult is populated inside WASM, separate address space). For each
+/// deferred `(entity_id, incoming_bytes)` pair:
+///
+/// 1. Read the locally-stored bytes + metadata for `entity_id`.
+/// 2. Build a [`MergeRootStateRequest`] from existing + incoming.
+/// 3. Invoke `ContextClient::merge_root_state` — calls into WASM via
+///    the macro-generated `__calimero_merge_root_state` export.
+/// 4. Write the merged bytes back via
+///    `Interface::write_pre_merged_root_state`, which updates the
+///    Merkle index + storage without re-running the merge step.
+///
+/// Errors per-entry are logged and the next entry is attempted —
+/// partial progress is preferable to dropping the whole batch on a
+/// single failure. The next sync tick will re-attempt anything that
+/// stays divergent.
+async fn dispatch_deferred_root_merges(
+    context_client: &ContextClient,
+    store: &calimero_store::Store,
+    context_id: ContextId,
+    our_identity: PublicKey,
+    deferred: &[([u8; 32], Vec<u8>)],
+) {
+    use calimero_storage::address::Id;
+    use calimero_storage::entities::Metadata;
+    use calimero_storage::env::with_runtime_env;
+    use calimero_storage::index::Index;
+    use calimero_storage::interface::Interface;
+    use calimero_storage::merge::MergeRootStateRequest;
+    use calimero_storage::store::{MainStorage, StorageAdaptor};
+
+    // Build a runtime env so storage callbacks resolve against the
+    // right context — mirrors what HC initiator does for its DFS.
+    let runtime_env = calimero_node_primitives::sync::create_runtime_env(
+        store,
+        context_id,
+        our_identity,
+    );
+
+    for (key, incoming) in deferred {
+        let entity_id = Id::new(*key);
+
+        // Read existing bytes + metadata under the runtime env so
+        // storage callbacks resolve. `get_metadata` returns `None` if
+        // the receiver has never seen the root entity — in that case
+        // existing is empty + timestamps are 0, and the WASM-side
+        // bootstrap fast-path (existing.created_at == existing.updated_at)
+        // accepts incoming unconditionally.
+        let read_result: eyre::Result<(Vec<u8>, Metadata)> =
+            with_runtime_env(runtime_env.clone(), || {
+                let meta = Index::<MainStorage>::get_index(entity_id)
+                    .map_err(|e| eyre::eyre!("get_index: {e}"))?
+                    .map(|idx| idx.metadata)
+                    .unwrap_or_default();
+                let existing = <MainStorage as StorageAdaptor>::storage_read(
+                    calimero_storage::store::Key::Entry(entity_id),
+                )
+                .unwrap_or_default();
+                Ok((existing, meta))
+            });
+
+        let (existing, existing_metadata) = match read_result {
+            Ok(pair) => pair,
+            Err(err) => {
+                warn!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    %err,
+                    "deferred root merge: failed to read existing root state, skipping"
+                );
+                continue;
+            }
+        };
+
+        // Use the maximum of existing and incoming timestamps for the
+        // merged result's updated_at — convention matches LWW timestamp
+        // semantics and ensures the merged write strictly advances the
+        // local logical clock for this entity.
+        let existing_ts: u64 = (*existing_metadata.updated_at).into();
+        let incoming_ts: u64 = existing_ts.max(
+            // HC leaves don't carry an HLC-keyed update timestamp for
+            // the root entity (the leaf carries its own metadata, but
+            // that's per-leaf, not per-root-merge). Use existing_ts + 1
+            // as a synthetic monotonic tick; the merge IS the write so
+            // the local clock must advance.
+            existing_ts.saturating_add(1),
+        );
+
+        let request = MergeRootStateRequest {
+            existing,
+            incoming: incoming.clone(),
+            existing_created_at: existing_metadata.created_at,
+            existing_ts,
+            incoming_ts,
+        };
+
+        let merged = match context_client
+            .merge_root_state(&context_id, &our_identity, request)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                warn!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    ?err,
+                    "deferred root merge: WASM dispatch failed, skipping"
+                );
+                continue;
+            }
+        };
+
+        // Write merged bytes back. Bump `updated_at` to incoming_ts so the
+        // post-merge state is timestamped consistently for the next sync.
+        let mut new_metadata = existing_metadata.clone();
+        new_metadata.updated_at = incoming_ts.into();
+
+        let write_result = with_runtime_env(runtime_env.clone(), || {
+            Interface::<MainStorage>::write_pre_merged_root_state(
+                entity_id,
+                &merged,
+                new_metadata,
+            )
+            .map_err(|e| eyre::eyre!("write_pre_merged_root_state: {e}"))
+        });
+
+        match write_result {
+            Ok(_full_hash) => {
+                info!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    "deferred root merge: applied"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    %err,
+                    "deferred root merge: failed to write merged bytes back"
+                );
+            }
+        }
+
     }
 }
 

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -457,7 +457,7 @@ impl ProtocolSelector {
 /// partial progress is preferable to dropping the whole batch on a
 /// single failure. The next sync tick will re-attempt anything that
 /// stays divergent.
-async fn dispatch_deferred_root_merges(
+pub(crate) async fn dispatch_deferred_root_merges(
     context_client: &ContextClient,
     store: &calimero_store::Store,
     context_id: ContextId,

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -474,11 +474,8 @@ pub(crate) async fn dispatch_deferred_root_merges(
 
     // Build a runtime env so storage callbacks resolve against the
     // right context — mirrors what HC initiator does for its DFS.
-    let runtime_env = calimero_node_primitives::sync::create_runtime_env(
-        store,
-        context_id,
-        our_identity,
-    );
+    let runtime_env =
+        calimero_node_primitives::sync::create_runtime_env(store, context_id, our_identity);
 
     for (key, incoming, incoming_hlc_ts) in deferred {
         let entity_id = Id::new(*key);
@@ -559,12 +556,8 @@ pub(crate) async fn dispatch_deferred_root_merges(
         new_metadata.updated_at = existing_ts.max(incoming_ts).into();
 
         let write_result = with_runtime_env(runtime_env.clone(), || {
-            Interface::<MainStorage>::write_pre_merged_root_state(
-                entity_id,
-                &merged,
-                new_metadata,
-            )
-            .map_err(|e| eyre::eyre!("write_pre_merged_root_state: {e}"))
+            Interface::<MainStorage>::write_pre_merged_root_state(entity_id, &merged, new_metadata)
+                .map_err(|e| eyre::eyre!("write_pre_merged_root_state: {e}"))
         });
 
         match write_result {
@@ -584,7 +577,6 @@ pub(crate) async fn dispatch_deferred_root_merges(
                 );
             }
         }
-
     }
 }
 

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -117,13 +117,16 @@ impl ProtocolSelector {
     /// - `DeltaSync`: passed straight to `request_dag_heads_and_sync`,
     ///   which may consume it; indeterminate on return.
     /// - `HashComparison`: passed to `StreamTransport`, consumed by
-    ///   `HashComparisonProtocol::run_initiator`; the responder's
-    ///   state is well-defined on success (idle) and indeterminate on
-    ///   failure (see the HashComparison-fallback note below).
+    ///   `HashComparisonProtocol::run_initiator`; the fallback path
+    ///   opens a fresh stream because the responder dispatch is
+    ///   one-shot per stream — once the HashComparison handler
+    ///   returns the stream is dropped and can't carry a follow-up
+    ///   request.
     /// - `LevelWise`: passed to `StreamTransport`, consumed by
     ///   `LevelWiseProtocol::run_initiator`; the fallback path opens
-    ///   a fresh stream because the responder may be in a
-    ///   LevelWise-specific state.
+    ///   a fresh stream for the same one-shot-dispatch reason
+    ///   (responder is also locked into LevelWise-specific message
+    ///   types until the handler returns).
     ///
     /// Bottom line: `stream` should be treated as consumed after this
     /// call returns regardless of variant — the caller's drop runs
@@ -240,13 +243,30 @@ impl ProtocolSelector {
                             error = %e,
                             "HashComparison sync failed, falling back to DAG catchup"
                         );
-                        // Fall back to DAG heads request
+                        // Fall back to DAG heads request — open a fresh
+                        // stream. The HashComparison responder loop
+                        // gracefully exits on any non-TreeNodeRequest /
+                        // non-EntityPush message, but the responder
+                        // dispatch in `internal_handle_opened_stream` is
+                        // one-shot per stream: when the HashComparison
+                        // handler returns, the stream is dropped. So
+                        // sending a `DagHeadsRequest` on the same
+                        // `stream` here would either hit a closed pipe
+                        // or write into a buffer the responder will
+                        // never read. A fresh stream re-enters the
+                        // responder dispatch and gets routed to
+                        // `handle_dag_heads_request`. Same shape as the
+                        // LevelWise fallback below.
+                        let mut fallback_stream = dispatch
+                            .open_stream(chosen_peer)
+                            .await
+                            .wrap_err("open stream for hash-comparison fallback")?;
                         let result = dispatch
                             .request_dag_heads_and_sync(
                                 context_id,
                                 chosen_peer,
                                 our_identity,
-                                stream,
+                                &mut fallback_stream,
                             )
                             .await
                             .wrap_err("hash comparison fallback")?;
@@ -257,6 +277,11 @@ impl ProtocolSelector {
                                 %context_id,
                                 "DAG catchup failed, falling back to snapshot sync"
                             );
+                            // Drop the consumed fallback_stream before
+                            // opening fresh streams in snapshot sync
+                            // (fallback_stream is in indeterminate
+                            // state after DAG sync exchanges).
+                            drop(fallback_stream);
                             let result = dispatch
                                 .fallback_to_snapshot_sync(context_id, our_identity, chosen_peer)
                                 .await

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -423,27 +423,75 @@ fn generate_mergeable_impl(
     }
 }
 
-/// Generate registration hook for automatic merge during sync
+/// Generate the WASM export the host calls for root-state CRDT merge.
 fn generate_registration_hook(ident: &Ident, ty_generics: &syn::TypeGenerics<'_>) -> TokenStream {
     quote! {
         // ============================================================================
-        // AUTO-GENERATED WASM Export for Merge Registration
+        // AUTO-GENERATED WASM Export for Root-State CRDT Merge
         // ============================================================================
         //
-        // This function is called ONCE when the WASM module is loaded by the node runtime.
-        // It registers the app's merge function so that sync can automatically call it.
+        // The host invokes this export whenever it needs to merge two root-state
+        // byte blobs (HC sync apply, snapshot apply, anywhere a sync path encounters
+        // root-entity divergence). The host can't deserialize the app's root type
+        // — only the WASM module can, since the type only exists here.
         //
-        // Lifecycle:
-        // 1. WASM loads → runtime calls __calimero_register_merge()
-        // 2. Registration → stores merge function in global registry
-        // 3. Sync → automatically uses registered merge
+        // Input: borsh-serialized `MergeRootStateRequest` via `env::input()`.
+        // Output: borsh-serialized `MergeRootStateResponse` via `env::value_return()`.
         //
-        // Developer impact: ZERO - this is completely automatic!
+        // This export replaces the deleted `__calimero_register_merge` /
+        // `register_crdt_merge` registry indirection. The registry was a vestige
+        // of an attempt to dispatch merge functions on the host where they can't
+        // possibly work (type erasure); the type-aware dispatch belongs here.
+        //
+        // Developer impact: ZERO — the macro hides the export entirely.
         //
         #[cfg(target_arch = "wasm32")]
         #[no_mangle]
-        pub extern "C" fn __calimero_register_merge() {
-            ::calimero_storage::register_crdt_merge::<#ident #ty_generics>();
+        pub extern "C" fn __calimero_merge_root_state() {
+            ::calimero_sdk::env::setup_panic_hook();
+
+            let Some(args) = ::calimero_sdk::env::input() else {
+                ::calimero_sdk::env::panic_str(
+                    "Expected MergeRootStateRequest payload for __calimero_merge_root_state",
+                )
+            };
+
+            let request: ::calimero_storage::merge::MergeRootStateRequest =
+                ::calimero_sdk::borsh::from_slice(&args).unwrap_or_else(|err| {
+                    ::calimero_sdk::env::panic_str(&::std::format!(
+                        "Failed to deserialize MergeRootStateRequest: {err}",
+                    ))
+                });
+
+            let response = match ::calimero_storage::merge::merge_root_state_typed::<
+                #ident #ty_generics,
+            >(&request.existing, &request.incoming)
+            {
+                ::core::result::Result::Ok(bytes) => {
+                    ::calimero_storage::merge::MergeRootStateResponse::Ok(bytes)
+                }
+                ::core::result::Result::Err(err) => {
+                    ::calimero_storage::merge::MergeRootStateResponse::Err(::std::format!(
+                        "{err:?}",
+                    ))
+                }
+            };
+
+            let serialized = ::calimero_sdk::borsh::to_vec(&response).unwrap_or_else(|err| {
+                ::calimero_sdk::env::panic_str(&::std::format!(
+                    "Failed to serialize MergeRootStateResponse: {err}",
+                ))
+            });
+
+            // `value_return` wraps the bytes in a `Result` discriminant
+            // on the wire — match the convention every other generated
+            // export uses (see migration.rs:96 / method.rs:149). The
+            // success / error semantics of the merge itself live inside
+            // the `MergeRootStateResponse` payload, not the wire wrapper.
+            ::calimero_sdk::env::value_return(&::core::result::Result::<
+                ::std::vec::Vec<u8>,
+                ::std::vec::Vec<u8>,
+            >::Ok(serialized));
         }
     }
 }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -494,8 +494,13 @@ fn generate_registration_hook(ident: &Ident, ty_generics: &syn::TypeGenerics<'_>
 
             let response = match ::calimero_storage::merge::merge_root_state_typed::<
                 #ident #ty_generics,
-            >(&request.existing, &request.incoming)
-            {
+            >(
+                &request.existing,
+                &request.incoming,
+                request.existing_created_at,
+                request.existing_ts,
+                request.incoming_ts,
+            ) {
                 ::core::result::Result::Ok(bytes) => {
                     ::calimero_storage::merge::MergeRootStateResponse::Ok(bytes)
                 }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -423,25 +423,54 @@ fn generate_mergeable_impl(
     }
 }
 
-/// Generate the WASM export the host calls for root-state CRDT merge.
+/// Generate the WASM exports the host + WASM runtime call for root-state CRDT merge.
+///
+/// Two exports are emitted:
+///
+/// 1. `__calimero_register_merge` — called by the WASM runtime at
+///    module-load time. Populates the WASM-side `MERGE_REGISTRY`
+///    static so that `Interface::save_internal` (running inside WASM
+///    during normal delta apply via `__calimero_sync_next`) can
+///    dispatch the typed merge. This is the WASM-internal dispatch
+///    path and is load-bearing — without it, every WASM-side root
+///    entity merge fails with `NoMergeFunctionRegistered`.
+///
+/// 2. `__calimero_merge_root_state` — called by the host (via
+///    `ContextClient::merge_root_state`) when HC / LevelWise sync
+///    needs to merge a root entity. The host can't dispatch the
+///    typed merge itself (separate address space), so it hands the
+///    bytes to this export, which deserializes as `T`, runs
+///    `Mergeable::merge`, returns serialized bytes.
 fn generate_registration_hook(ident: &Ident, ty_generics: &syn::TypeGenerics<'_>) -> TokenStream {
     quote! {
         // ============================================================================
-        // AUTO-GENERATED WASM Export for Root-State CRDT Merge
+        // AUTO-GENERATED WASM Export — WASM-Internal Registration Hook
+        // ============================================================================
+        //
+        // Called by the runtime at WASM module load. Populates the
+        // WASM-side `MERGE_REGISTRY` so the WASM `Interface::save_internal`
+        // can dispatch root-entity merges via the app's typed
+        // `Mergeable::merge`. Required for normal `__calimero_sync_next`
+        // delta apply when the delta touches the root entity.
+        //
+        #[cfg(target_arch = "wasm32")]
+        #[no_mangle]
+        pub extern "C" fn __calimero_register_merge() {
+            ::calimero_storage::register_crdt_merge::<#ident #ty_generics>();
+        }
+
+        // ============================================================================
+        // AUTO-GENERATED WASM Export — Host-Initiated Root-State Merge
         // ============================================================================
         //
         // The host invokes this export whenever it needs to merge two root-state
-        // byte blobs (HC sync apply, snapshot apply, anywhere a sync path encounters
-        // root-entity divergence). The host can't deserialize the app's root type
-        // — only the WASM module can, since the type only exists here.
+        // byte blobs (HC sync apply, LevelWise sync apply, anywhere a sync
+        // path on the host encounters root-entity divergence). The host
+        // can't deserialize the app's root type — only the WASM module
+        // can, since the type only exists here.
         //
         // Input: borsh-serialized `MergeRootStateRequest` via `env::input()`.
         // Output: borsh-serialized `MergeRootStateResponse` via `env::value_return()`.
-        //
-        // This export replaces the deleted `__calimero_register_merge` /
-        // `register_crdt_merge` registry indirection. The registry was a vestige
-        // of an attempt to dispatch merge functions on the host where they can't
-        // possibly work (type erasure); the type-aware dispatch belongs here.
         //
         // Developer impact: ZERO — the macro hides the export entirely.
         //

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -39,4 +39,21 @@ calimero-sdk.workspace = true
 
 [features]
 default = []
-testing = []  # Exposes test utilities for dependent crates
+# Exposes the WASM-side merge registry to host-build test code so
+# integration tests can exercise the dispatch shape without a real
+# WASM runtime. Required by the registry integration tests; dependent
+# crates that want to mock registered merge functions enable this too.
+testing = []
+
+# Registry tests live in `tests/` as separate integration binaries
+# rather than `src/tests/` unit modules so they exercise the production
+# `RwLock`-backed registry path instead of the `#[cfg(test)]`
+# thread-local one. They need the registry to be callable from outside
+# `cfg(test)`, which is what the `testing` feature unlocks.
+[[test]]
+name = "merge_registry_concurrent"
+required-features = ["testing"]
+
+[[test]]
+name = "merge_registry_integration"
+required-features = ["testing"]

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -180,7 +180,7 @@ pub(crate) const ROOT_ENTRY_ID: Id = Id::new([118; 32]);
 /// happens to carry a later HLC (which it usually does, since it was
 /// constructed after the remote's writes).
 #[inline]
-pub(crate) fn is_app_root_entry(id: Id) -> bool {
+pub fn is_app_root_entry(id: Id) -> bool {
     id.is_root() || id == ROOT_ENTRY_ID
 }
 

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2099,13 +2099,31 @@ impl<S: StorageAdaptor> Interface<S> {
         merged: &[u8],
         metadata: Metadata,
     ) -> Result<[u8; 32], StorageError> {
-        // Mirror the post-merge work in `save_internal` for `id.is_root()`:
-        // hash the merged bytes, update the Merkle index, write storage.
-        // `add_root` if no last_metadata exists yet — same as save_internal's
-        // "first time creating root entity" branch.
+        // Mirror the post-merge work in `save_internal` for the app
+        // root: hash the merged bytes, update the Merkle index, write
+        // storage. When this is the first time the receiver has seen
+        // the entity, the index doesn't exist yet — create it so
+        // `update_hash_for` doesn't fail with `IndexNotFound`.
+        //
+        // App root state covers TWO ids: `ROOT_ID` (the system root)
+        // and `ROOT_ENTRY_ID` (the `Root<T>` entry). Pre-fix only
+        // `id.is_root()` was checked, missing the latter — first-time
+        // merges for `Root<T>` entries would fail with `IndexNotFound`
+        // and the deferred WASM merge would be dropped, leaving the
+        // receiver's root entity permanently divergent.
         let last_metadata = <Index<S>>::get_metadata(id)?;
-        if last_metadata.is_none() && id.is_root() {
-            <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32], metadata.clone()))?;
+        if last_metadata.is_none() {
+            if id.is_root() {
+                <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32], metadata.clone()))?;
+            } else if crate::collections::is_app_root_entry(id) {
+                // `Root<T>` entry — attach as a child of the system
+                // root so the index hierarchy stays consistent with
+                // the layout `Root::new` produces locally.
+                <Index<S>>::add_child_to(
+                    Id::root(),
+                    ChildInfo::new(id, [0_u8; 32], metadata.clone()),
+                )?;
+            }
         }
 
         let own_hash: [u8; 32] = Sha256::digest(merged).into();

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2134,6 +2134,36 @@ impl<S: StorageAdaptor> Interface<S> {
         // and the deferred WASM merge would be dropped, leaving the
         // receiver's root entity permanently divergent.
         let last_metadata = <Index<S>>::get_metadata(id)?;
+
+        // LWW guard — same shape as `save_internal`'s LWW-by-HLC
+        // check. If the locally-stored state is already newer (e.g.
+        // gossip already applied the action and stored the entity
+        // with a newer `updated_at`), HC / LevelWise re-syncing the
+        // same root via this path would otherwise overwrite the
+        // metadata with the wire's older `updated_at` and regress
+        // the Merkle parent's full_hash. Root cause of the
+        // shared-storage e2e: gossip applied set_shared correctly,
+        // then HC re-pushed the root entity via this LWW path and
+        // the timestamp regression silently broke convergence.
+        //
+        // When the timestamps tie we still write — the bytes may
+        // differ (concurrent writes resolved differently). Strictly
+        // greater = newer here, equal = re-apply, older = no-op.
+        if let Some(ref existing) = last_metadata {
+            if existing.updated_at > metadata.updated_at {
+                let existing_full = <Index<S>>::get_hashes_for(id)?
+                    .map(|(full, _own)| full)
+                    .unwrap_or([0_u8; 32]);
+                tracing::debug!(
+                    %id,
+                    existing_ts = %*existing.updated_at,
+                    incoming_ts = %*metadata.updated_at,
+                    "write_pre_merged_root_state: local state is newer, skipping (LWW)"
+                );
+                return Ok(existing_full);
+            }
+        }
+
         if last_metadata.is_none() {
             if id.is_root() {
                 <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32], metadata.clone()))?;

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2076,6 +2076,44 @@ impl<S: StorageAdaptor> Interface<S> {
         Ok(Some((is_new, full_hash)))
     }
 
+    /// Write a root-state byte blob that has *already* been CRDT-merged
+    /// by an external dispatcher (e.g. the WASM module via
+    /// `ContextClient::merge_root_state`). Bypasses the host-side
+    /// merge step entirely — the caller has guaranteed the merge has
+    /// happened — and just does the post-merge work: hash, Merkle
+    /// index update, storage write.
+    ///
+    /// Necessary because host-side `merge_root_state` can't dispatch the
+    /// app's typed `Mergeable::merge` (the registry it consults is only
+    /// populated inside WASM). The sync paths that encounter root-entity
+    /// divergence delegate the merge itself to WASM, then call this to
+    /// commit the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError` if the index update fails or the storage
+    /// write fails. Does NOT enforce I5 — the caller IS the source of
+    /// the merged bytes and is responsible for I5 compliance.
+    pub fn write_pre_merged_root_state(
+        id: Id,
+        merged: &[u8],
+        metadata: Metadata,
+    ) -> Result<[u8; 32], StorageError> {
+        // Mirror the post-merge work in `save_internal` for `id.is_root()`:
+        // hash the merged bytes, update the Merkle index, write storage.
+        // `add_root` if no last_metadata exists yet — same as save_internal's
+        // "first time creating root entity" branch.
+        let last_metadata = <Index<S>>::get_metadata(id)?;
+        if last_metadata.is_none() && id.is_root() {
+            <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32], metadata.clone()))?;
+        }
+
+        let own_hash: [u8; 32] = Sha256::digest(merged).into();
+        let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
+        _ = S::storage_write(Key::Entry(id), merged);
+        Ok(full_hash)
+    }
+
     /// Attempt to merge two versions of data using CRDT semantics.
     ///
     /// Returns the merged data, or an error if merge fails.

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -686,7 +686,26 @@ impl<S: StorageAdaptor> Interface<S> {
                         let last_nonce = <Index<S>>::get_metadata(*id)?
                             .map(|m| *m.updated_at)
                             .unwrap_or(0);
-                        let skip_nonce = nonce_check_disabled_for_testing();
+                        // `nonce_check_disabled_for_testing` is the explicit
+                        // test escape hatch; `in_merge_mode` covers the
+                        // production case where this very action is being
+                        // re-evaluated as part of a CRDT merge (e.g. the
+                        // host-side deferred-root-merge dispatch hands the
+                        // root-state bytes back into the WASM Mergeable,
+                        // which re-runs each sub-action including the
+                        // upserts already-applied on the local side).
+                        // Without the merge-mode bypass, the second pass
+                        // hits `new_nonce == last_nonce`, skips the apply,
+                        // and the merged children references / RGA edits
+                        // never land — exactly the
+                        // shared-storage / scaffolding-e2e regression on
+                        // PR #2465. Skipping is safe in merge mode because:
+                        // (1) the signature still verifies (so the bytes
+                        // are authentic), and (2) merge is by definition
+                        // idempotent — re-applying the same action is the
+                        // expected, deterministic behaviour.
+                        let skip_nonce =
+                            nonce_check_disabled_for_testing() || crate::env::in_merge_mode();
 
                         // Verify signature FIRST, before deciding whether
                         // to skip. We need to know the action is
@@ -840,7 +859,10 @@ impl<S: StorageAdaptor> Interface<S> {
                         let new_nonce = sig_data.nonce;
                         let last_nonce =
                             stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);
-                        let skip_nonce = nonce_check_disabled_for_testing();
+                        // See the User arm for the merge-mode bypass
+                        // rationale — applies symmetrically here.
+                        let skip_nonce =
+                            nonce_check_disabled_for_testing() || crate::env::in_merge_mode();
 
                         // Verify signature first — see the User arm
                         // above for the full "verify-before-skip"

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -75,6 +75,10 @@ pub mod snapshot;
 pub mod store;
 
 // Re-export for convenience
+// `register_crdt_merge` is WASM/test-only — the registry it populates
+// no longer exists in host production builds. See `merge::registry`
+// module docs for the rationale (core#2469 architectural fix).
+#[cfg(any(target_arch = "wasm32", test))]
 pub use merge::register_crdt_merge;
 
 /// Re-exported types, mostly for use in macros (for convenience).

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -75,10 +75,11 @@ pub mod snapshot;
 pub mod store;
 
 // Re-export for convenience
-// `register_crdt_merge` is WASM/test-only — the registry it populates
-// no longer exists in host production builds. See `merge::registry`
-// module docs for the rationale (core#2469 architectural fix).
-#[cfg(any(target_arch = "wasm32", test))]
+// `register_crdt_merge` is WASM-only in production. Re-exposed under
+// `cfg(test)` for the storage crate's own unit tests and under the
+// `testing` feature flag for dependent crates' tests. See
+// `merge::registry` module docs for the rationale (core#2469).
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 pub use merge::register_crdt_merge;
 
 /// Re-exported types, mostly for use in macros (for convenience).

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -472,3 +472,96 @@ fn merge_unordered_set(_existing: &[u8], incoming: &[u8]) -> Result<Vec<u8>, Mer
 fn merge_vector(_existing: &[u8], incoming: &[u8]) -> Result<Vec<u8>, MergeError> {
     Ok(incoming.to_vec())
 }
+
+#[cfg(test)]
+mod typed_dispatch_tests {
+    use super::*;
+    use crate::collections::Counter;
+    use crate::env;
+    use serial_test::serial;
+
+    // Minimal Mergeable app type for the typed-dispatch test. Counter
+    // is the simplest Mergeable that produces an observably-different
+    // post-merge state from either input alone.
+    #[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Debug)]
+    struct DispatchTestApp {
+        counter: Counter,
+    }
+
+    impl Mergeable for DispatchTestApp {
+        fn merge(
+            &mut self,
+            other: &Self,
+        ) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counter.merge(&other.counter)
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn merge_root_state_typed_combines_disjoint_executor_counts() {
+        env::reset_for_testing();
+
+        // Executor A: counter incremented twice — value 2.
+        env::set_executor_id([1; 32]);
+        let mut state_a = DispatchTestApp {
+            counter: Counter::new(),
+        };
+        state_a.counter.increment().unwrap();
+        state_a.counter.increment().unwrap();
+        let bytes_a = borsh::to_vec(&state_a).unwrap();
+
+        // Executor B: counter incremented once — value 1.
+        env::set_executor_id([2; 32]);
+        let mut state_b = DispatchTestApp {
+            counter: Counter::new(),
+        };
+        state_b.counter.increment().unwrap();
+        let bytes_b = borsh::to_vec(&state_b).unwrap();
+
+        // Typed merge: A receives B's increments. G-Counter union per
+        // executor → 2 + 1 = 3.
+        let merged_bytes = merge_root_state_typed::<DispatchTestApp>(&bytes_a, &bytes_b)
+            .expect("typed merge should succeed");
+        let merged: DispatchTestApp = borsh::from_slice(&merged_bytes).unwrap();
+        assert_eq!(merged.counter.value().unwrap(), 3);
+    }
+
+    #[test]
+    #[serial]
+    fn merge_root_state_typed_rejects_malformed_existing() {
+        env::reset_for_testing();
+
+        let valid_bytes = borsh::to_vec(&DispatchTestApp {
+            counter: Counter::new(),
+        })
+        .unwrap();
+        let bad = vec![0xff, 0xff, 0xff, 0xff];
+
+        let result = merge_root_state_typed::<DispatchTestApp>(&bad, &valid_bytes);
+        assert!(
+            matches!(result, Err(MergeError::SerializationError(_))),
+            "expected SerializationError, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn merge_root_state_typed_rejects_malformed_incoming() {
+        env::reset_for_testing();
+
+        let valid_bytes = borsh::to_vec(&DispatchTestApp {
+            counter: Counter::new(),
+        })
+        .unwrap();
+        let bad = vec![0xff, 0xff, 0xff, 0xff];
+
+        let result = merge_root_state_typed::<DispatchTestApp>(&valid_bytes, &bad);
+        assert!(
+            matches!(result, Err(MergeError::SerializationError(_))),
+            "expected SerializationError, got {:?}",
+            result
+        );
+    }
+}

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -92,27 +92,43 @@ pub enum MergeRootStateResponse {
 /// Typed root-state merge for use inside the WASM module's
 /// macro-generated `__calimero_merge_root_state` export.
 ///
-/// Deserializes both sides as `T`, runs the app-provided
-/// `Mergeable::merge`, returns serialized merged bytes. Mirrors the
-/// closure built by `register_crdt_merge` but without the registry
-/// indirection — the macro knows `T` at compile time and calls this
-/// directly.
+/// Implements the same two-tier dispatch the pre-rewrite host-side
+/// `merge_root_state` provided:
 ///
-/// Wrapped in `with_merge_mode` to suppress timestamp generation during
-/// merge: every node must produce the same merged hash from the same
-/// inputs.
+/// 1. **Bootstrap fast-path** — when `existing_created_at == existing_ts`,
+///    the local entity was created but has never been explicitly
+///    updated since (the freshly-materialised default state on a
+///    joiner). In that case `incoming` carries the only real history
+///    and must be accepted unconditionally. Plain CRDT merge would
+///    treat the local defaults as a competing branch and produce a
+///    union-like result that drops parts of the remote's writes —
+///    exactly the regression `kv-store-with-shared-storage` exposes.
+///
+/// 2. **Typed merge** — deserialize both sides as `T`, run
+///    `Mergeable::merge` (wrapped in `with_merge_mode` so timestamp
+///    generation is suppressed and the merged hash is deterministic),
+///    return serialized bytes.
 ///
 /// # Errors
 ///
 /// Returns `MergeError::SerializationError` if either input bytes
 /// fail to deserialize as `T`, or if the merged state fails to
 /// re-serialize. Returns whatever error variant
-/// `<T as Mergeable>::merge` produces if the app's merge logic fails
-/// (typically a `MergeError`).
-pub fn merge_root_state_typed<T>(existing: &[u8], incoming: &[u8]) -> Result<Vec<u8>, MergeError>
+/// `<T as Mergeable>::merge` produces if the app's merge logic fails.
+pub fn merge_root_state_typed<T>(
+    existing: &[u8],
+    incoming: &[u8],
+    existing_created_at: u64,
+    existing_ts: u64,
+    _incoming_ts: u64,
+) -> Result<Vec<u8>, MergeError>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
 {
+    if existing_created_at == existing_ts {
+        return Ok(incoming.to_vec());
+    }
+
     let mut existing_state = borsh::from_slice::<T>(existing)
         .map_err(|e| MergeError::SerializationError(format!("existing: {e}")))?;
     let incoming_state = borsh::from_slice::<T>(incoming)
@@ -546,12 +562,40 @@ mod typed_dispatch_tests {
         state_b.counter.increment().unwrap();
         let bytes_b = borsh::to_vec(&state_b).unwrap();
 
-        // Typed merge: A receives B's increments. G-Counter union per
-        // executor → 2 + 1 = 3.
-        let merged_bytes = merge_root_state_typed::<DispatchTestApp>(&bytes_a, &bytes_b)
-            .expect("typed merge should succeed");
+        // Typed merge with non-bootstrap timestamps (existing was
+        // written, so we want the real CRDT merge, not the fast-path).
+        // A receives B's increments. G-Counter union per executor → 2 + 1 = 3.
+        let merged_bytes = merge_root_state_typed::<DispatchTestApp>(
+            &bytes_a, &bytes_b, /* created_at */ 50, /* existing_ts */ 100,
+            /* incoming_ts */ 200,
+        )
+        .expect("typed merge should succeed");
         let merged: DispatchTestApp = borsh::from_slice(&merged_bytes).unwrap();
         assert_eq!(merged.counter.value().unwrap(), 3);
+    }
+
+    #[test]
+    #[serial]
+    fn merge_root_state_typed_bootstrap_returns_incoming_verbatim() {
+        env::reset_for_testing();
+
+        // Bootstrap shape: existing was created but never written
+        // (`created_at == existing_ts`). The fast-path must accept
+        // incoming bytes verbatim, regardless of whether they'd
+        // deserialize as the typed `T` — this is the joiner-bootstrap
+        // case the kv-store-with-shared-storage regression exposed.
+        let some_bytes = vec![9, 9, 9, 9];
+        let incoming = vec![1, 2, 3, 4];
+
+        let out = merge_root_state_typed::<DispatchTestApp>(
+            &some_bytes,
+            &incoming,
+            /* created_at */ 100,
+            /* existing_ts */ 100,
+            /* incoming_ts */ 50,
+        )
+        .expect("bootstrap fast-path must succeed");
+        assert_eq!(out, incoming, "bootstrap must return incoming verbatim");
     }
 
     #[test]
@@ -565,7 +609,15 @@ mod typed_dispatch_tests {
         .unwrap();
         let bad = vec![0xff, 0xff, 0xff, 0xff];
 
-        let result = merge_root_state_typed::<DispatchTestApp>(&bad, &valid_bytes);
+        // Post-bootstrap timestamps to avoid the fast-path so the
+        // typed deserialize is reached.
+        let result = merge_root_state_typed::<DispatchTestApp>(
+            &bad,
+            &valid_bytes,
+            /* created_at */ 50,
+            /* existing_ts */ 100,
+            /* incoming_ts */ 200,
+        );
         assert!(
             matches!(result, Err(MergeError::SerializationError(_))),
             "expected SerializationError, got {:?}",
@@ -584,7 +636,13 @@ mod typed_dispatch_tests {
         .unwrap();
         let bad = vec![0xff, 0xff, 0xff, 0xff];
 
-        let result = merge_root_state_typed::<DispatchTestApp>(&valid_bytes, &bad);
+        let result = merge_root_state_typed::<DispatchTestApp>(
+            &valid_bytes,
+            &bad,
+            /* created_at */ 50,
+            /* existing_ts */ 100,
+            /* incoming_ts */ 200,
+        );
         assert!(
             matches!(result, Err(MergeError::SerializationError(_))),
             "expected SerializationError, got {:?}",

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -34,17 +34,22 @@
 
 pub mod registry;
 
-// The registry is WASM/test-only — host production binaries can no
-// longer call `register_crdt_merge` (it doesn't exist) or pattern-match
-// on `MergeRegistryResult` (also gone). Host root-state merges route
-// through `merge_root_state_typed` via the WASM
+// The registry is WASM-only in production. Host production binaries
+// can no longer call `register_crdt_merge` (it doesn't exist) or
+// pattern-match on `MergeRegistryResult` (also gone). Host root-state
+// merges route through `merge_root_state_typed` via the WASM
 // `__calimero_merge_root_state` export +
 // `ContextClient::merge_root_state` — see
 // [`crate::merge::registry`] module docs for the rationale (core#2469).
-#[cfg(any(target_arch = "wasm32", test))]
+//
+// The `testing` feature flag re-exposes the registry to dependent
+// crates' tests (calimero-storage integration tests, calimero-node
+// sim tests) so they can keep exercising the WASM-side dispatch
+// shape without spinning up a real WASM runtime.
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub use registry::clear_merge_registry;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -89,17 +94,22 @@ pub enum MergeRootStateResponse {
 ///
 /// Deserializes both sides as `T`, runs the app-provided
 /// `Mergeable::merge`, returns serialized merged bytes. Mirrors the
-/// closure built by `register_crdt_merge` (which is being deleted) but
-/// without the registry indirection — the macro knows `T` at compile
-/// time and calls this directly.
+/// closure built by `register_crdt_merge` but without the registry
+/// indirection — the macro knows `T` at compile time and calls this
+/// directly.
 ///
 /// Wrapped in `with_merge_mode` to suppress timestamp generation during
-/// merge, matching the contract of the deleted registry path: every
-/// node must produce the same merged hash from the same inputs.
-pub fn merge_root_state_typed<T>(
-    existing: &[u8],
-    incoming: &[u8],
-) -> Result<Vec<u8>, MergeError>
+/// merge: every node must produce the same merged hash from the same
+/// inputs.
+///
+/// # Errors
+///
+/// Returns `MergeError::SerializationError` if either input bytes
+/// fail to deserialize as `T`, or if the merged state fails to
+/// re-serialize. Returns whatever error variant
+/// `<T as Mergeable>::merge` produces if the app's merge logic fails
+/// (typically a `MergeError`).
+pub fn merge_root_state_typed<T>(existing: &[u8], incoming: &[u8]) -> Result<Vec<u8>, MergeError>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
 {
@@ -180,9 +190,9 @@ pub fn merge_root_state(
     // bootstrap fast-path / I5 error path stay reachable for the
     // (uncommon) host code paths that still call `merge_root_state`.
     // WASM and test builds still consult the real registry.
-    #[cfg(any(target_arch = "wasm32", test))]
+    #[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
     let dispatch_result = try_merge_registered(existing, incoming, existing_ts, incoming_ts);
-    #[cfg(not(any(target_arch = "wasm32", test)))]
+    #[cfg(not(any(target_arch = "wasm32", test, feature = "testing")))]
     let dispatch_result = registry::MergeRegistryResult::NoFunctionsRegistered;
     match dispatch_result {
         registry::MergeRegistryResult::Success(merged) => Ok(merged),
@@ -509,10 +519,7 @@ mod typed_dispatch_tests {
     }
 
     impl Mergeable for DispatchTestApp {
-        fn merge(
-            &mut self,
-            other: &Self,
-        ) -> Result<(), crate::collections::crdt_meta::MergeError> {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counter.merge(&other.counter)
         }
     }

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -33,6 +33,15 @@
 //!   entity metadata for correct dispatch.
 
 pub mod registry;
+
+// The registry is WASM/test-only — host production binaries can no
+// longer call `register_crdt_merge` (it doesn't exist) or pattern-match
+// on `MergeRegistryResult` (also gone). Host root-state merges route
+// through `merge_root_state_typed` via the WASM
+// `__calimero_merge_root_state` export +
+// `ContextClient::merge_root_state` — see
+// [`crate::merge::registry`] module docs for the rationale (core#2469).
+#[cfg(any(target_arch = "wasm32", test))]
 pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
 
 #[cfg(test)]
@@ -164,9 +173,20 @@ pub fn merge_root_state(
 ) -> Result<Vec<u8>, MergeError> {
     // Try registered CRDT merge functions first.
     // This enables automatic nested CRDT merging when apps use `#[app::state]`.
-    match try_merge_registered(existing, incoming, existing_ts, incoming_ts) {
-        MergeRegistryResult::Success(merged) => Ok(merged),
-        MergeRegistryResult::NoFunctionsRegistered => {
+    //
+    // On host production builds the registry doesn't exist (deleted in
+    // the WASM-owns-merges architectural fix for core#2469) — the local
+    // closure below produces `NoFunctionsRegistered` directly so the
+    // bootstrap fast-path / I5 error path stay reachable for the
+    // (uncommon) host code paths that still call `merge_root_state`.
+    // WASM and test builds still consult the real registry.
+    #[cfg(any(target_arch = "wasm32", test))]
+    let dispatch_result = try_merge_registered(existing, incoming, existing_ts, incoming_ts);
+    #[cfg(not(any(target_arch = "wasm32", test)))]
+    let dispatch_result = registry::MergeRegistryResult::NoFunctionsRegistered;
+    match dispatch_result {
+        registry::MergeRegistryResult::Success(merged) => Ok(merged),
+        registry::MergeRegistryResult::NoFunctionsRegistered => {
             // Bootstrap-aware default.
             //
             // `existing_created_at == existing_ts` means the local entity
@@ -196,7 +216,7 @@ pub fn merge_root_state(
             // error pointing the developer at `#[app::state]`.
             Err(MergeError::NoMergeFunctionRegistered)
         }
-        MergeRegistryResult::AllFunctionsFailed => {
+        registry::MergeRegistryResult::AllFunctionsFailed => {
             // Merge functions are registered but none could merge the data.
             // This typically happens when:
             // - The data type doesn't match any registered type (test contamination)

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -44,6 +44,66 @@ use crate::collections::crdt_meta::{CrdtType, MergeError, Mergeable};
 use crate::collections::{Counter, ReplicatedGrowableArray};
 use crate::store::MainStorage;
 
+/// Canonical wire format for a host→WASM root-state merge invocation.
+///
+/// The host can't deserialize an app's root-state type (it doesn't have
+/// the type at compile time), so when it needs to merge two root-state
+/// byte blobs it sends this payload into the WASM module, where the
+/// macro-generated `__calimero_merge_root_state` export knows the type
+/// and dispatches `Mergeable::merge`.
+///
+/// Borsh-serialized for symmetry with every other host↔WASM payload in
+/// the codebase.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub struct MergeRootStateRequest {
+    pub existing: Vec<u8>,
+    pub incoming: Vec<u8>,
+    pub existing_created_at: u64,
+    pub existing_ts: u64,
+    pub incoming_ts: u64,
+}
+
+/// Response from the WASM-side root-merge dispatcher.
+///
+/// `Ok(bytes)` carries the merged root-state bytes the host writes back
+/// into storage. `Err(message)` surfaces a merge failure (typically a
+/// deserialization or app-`Mergeable::merge` error) to the host without
+/// having to panic in WASM.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub enum MergeRootStateResponse {
+    Ok(Vec<u8>),
+    Err(String),
+}
+
+/// Typed root-state merge for use inside the WASM module's
+/// macro-generated `__calimero_merge_root_state` export.
+///
+/// Deserializes both sides as `T`, runs the app-provided
+/// `Mergeable::merge`, returns serialized merged bytes. Mirrors the
+/// closure built by `register_crdt_merge` (which is being deleted) but
+/// without the registry indirection — the macro knows `T` at compile
+/// time and calls this directly.
+///
+/// Wrapped in `with_merge_mode` to suppress timestamp generation during
+/// merge, matching the contract of the deleted registry path: every
+/// node must produce the same merged hash from the same inputs.
+pub fn merge_root_state_typed<T>(
+    existing: &[u8],
+    incoming: &[u8],
+) -> Result<Vec<u8>, MergeError>
+where
+    T: BorshSerialize + BorshDeserialize + Mergeable,
+{
+    let mut existing_state = borsh::from_slice::<T>(existing)
+        .map_err(|e| MergeError::SerializationError(format!("existing: {e}")))?;
+    let incoming_state = borsh::from_slice::<T>(incoming)
+        .map_err(|e| MergeError::SerializationError(format!("incoming: {e}")))?;
+
+    crate::env::with_merge_mode(|| existing_state.merge(&incoming_state))?;
+
+    borsh::to_vec(&existing_state).map_err(|e| MergeError::SerializationError(e.to_string()))
+}
+
 /// Attempts to merge two Borsh-serialized app state blobs using CRDT semantics.
 ///
 /// # When is This Called?

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -1,12 +1,12 @@
 //! Merge registry for automatic CRDT merging — WASM-side only.
 //!
-//! This module provides a type registry the macro-generated
-//! `__calimero_register_merge` export populates so the WASM-side
-//! `Interface::save_internal` can dispatch root-state CRDT merges via
-//! the app's typed `Mergeable::merge`. The macro emits `register_crdt_merge`
-//! calls inside the WASM module's static-init; the registry then lives
-//! in WASM's static memory and is consulted by WASM-side
-//! `merge_root_state` whenever a root-entity action is applied.
+//! The `#[app::state]` macro emits a `__calimero_register_merge` WASM
+//! export the runtime calls at module-load time; that export calls
+//! `register_crdt_merge::<AppState>()` inside the WASM module, which
+//! writes a merge closure into this registry. WASM-side
+//! `merge_root_state` (called from `Interface::save_internal` when a
+//! root-entity action applies inside WASM) then consults the registry
+//! to dispatch the typed merge.
 //!
 //! ## Scope
 //!

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -1,46 +1,76 @@
-//! Merge registry for automatic CRDT merging
+//! Merge registry for automatic CRDT merging — WASM-side only.
 //!
-//! This module provides a type registry that allows merge_root_state()
-//! to automatically call the correct merge logic for any app state type.
+//! This module provides a type registry the macro-generated
+//! `__calimero_register_merge` export populates so the WASM-side
+//! `Interface::save_internal` can dispatch root-state CRDT merges via
+//! the app's typed `Mergeable::merge`. The macro emits `register_crdt_merge`
+//! calls inside the WASM module's static-init; the registry then lives
+//! in WASM's static memory and is consulted by WASM-side
+//! `merge_root_state` whenever a root-entity action is applied.
 //!
-//! # Problem
+//! ## Scope
 //!
-//! The root state can be any type defined by the app. We can't know at compile
-//! time what type to deserialize to. We need runtime type dispatch.
+//! Compiled **only** when `cfg(target_arch = "wasm32")` or `cfg(test)`.
+//! The host binary doesn't link the registry at all:
 //!
-//! # Solution
+//! - Host code can't accidentally call `register_crdt_merge` — the
+//!   symbol doesn't exist. (Pre-cleanup it did, but nothing ever
+//!   populated it, and host-side `merge_root_state` consulting an
+//!   empty registry was the root cause of core#2469.)
+//! - Host root-state merges route through WASM via the macro-generated
+//!   `__calimero_merge_root_state` export +
+//!   [`crate::merge::merge_root_state_typed`] +
+//!   `ContextClient::merge_root_state`. The registry is no longer the
+//!   dispatch boundary.
 //!
-//! Apps register their state type with a merge function:
+//! Tests still build the registry so the existing
+//! `merge_registry_integration` / `merge_registry_concurrent` /
+//! `merge_integration` test suites keep exercising the dispatch shape
+//! the WASM side relies on.
 //!
-//! ```ignore
-//! // In app initialization:
-//! register_crdt_merge::<MyAppState>();
+//! ## Storage backend
 //!
-//! // Now sync automatically calls MyAppState::merge()
-//! ```
-//!
-//! # Storage
-//!
-//! Production uses a process-global `RwLock<HashMap<...>>`; apps register
-//! their state types once at startup and every async worker dispatches
-//! against the same table.
-//!
-//! Under `#[cfg(test)]` the backing store is a `thread_local!` so that
+//! Production WASM uses a process-global `RwLock<HashMap<...>>` — apps
+//! register their state types once at static-init and dispatch is
+//! against the same table thereafter. Tests use a `thread_local!` so
 //! parallel-running tests can't stomp on each other's registrations.
-//! See the comment on the `#[cfg(test)]` declaration below.
 
+#[cfg(any(target_arch = "wasm32", test))]
 use std::any::TypeId;
 #[cfg(test)]
 use std::cell::RefCell;
+#[cfg(any(target_arch = "wasm32", test))]
 use std::collections::HashMap;
-#[cfg(not(test))]
+#[cfg(all(not(test), target_arch = "wasm32"))]
 use std::sync::{LazyLock, RwLock};
 
 /// Function signature for merging serialized state
+#[cfg(any(target_arch = "wasm32", test))]
 pub type MergeFn = fn(&[u8], &[u8], u64, u64) -> Result<Vec<u8>, Box<dyn std::error::Error>>;
 
+/// Result of attempting to merge using registered merge functions.
+///
+/// Available on every target — `merge_root_state` pattern-matches on
+/// this enum to choose the bootstrap / I5-error / LWW-fallback path.
+/// On host production builds the registry doesn't exist so the
+/// `Success` and `AllFunctionsFailed` arms can't be produced from
+/// inside the storage crate, but the enum still has to be matchable
+/// (the host stub in `merge_root_state` constructs
+/// `NoFunctionsRegistered` and the match handles it identically to the
+/// WASM path).
+#[derive(Debug)]
+#[must_use]
+pub enum MergeRegistryResult {
+    /// A registered merge function succeeded
+    Success(Vec<u8>),
+    /// No merge functions are registered (I5 enforcement needed)
+    NoFunctionsRegistered,
+    /// Merge functions are registered but all failed (e.g., type mismatch)
+    AllFunctionsFailed,
+}
+
 /// Production registry — process-global, shared across async workers.
-#[cfg(not(test))]
+#[cfg(all(target_arch = "wasm32", not(test)))]
 static MERGE_REGISTRY: LazyLock<RwLock<HashMap<TypeId, MergeFn>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
@@ -94,7 +124,7 @@ thread_local! {
 /// if the lock is poisoned (a poisoned lock means a prior writer
 /// panicked, which we treat as unrecoverable for a process-global
 /// singleton).
-#[cfg(not(test))]
+#[cfg(all(target_arch = "wasm32", not(test)))]
 fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
     let mut registry = MERGE_REGISTRY.write().unwrap_or_else(|_| {
         tracing::error!(
@@ -127,7 +157,7 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R
 
 /// Runs `f` with read-only access to the registry. Aborts the process
 /// if the lock is poisoned (same reasoning as `with_registry_mut`).
-#[cfg(not(test))]
+#[cfg(all(target_arch = "wasm32", not(test)))]
 fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     let registry = MERGE_REGISTRY.read().unwrap_or_else(|_| {
         tracing::error!(
@@ -190,6 +220,7 @@ fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
 /// // Register at app startup
 /// register_crdt_merge::<MyState>();
 /// ```
+#[cfg(any(target_arch = "wasm32", test))]
 pub fn register_crdt_merge<T>()
 where
     T: borsh::BorshSerialize + borsh::BorshDeserialize + crate::collections::Mergeable + 'static,
@@ -229,24 +260,13 @@ pub fn clear_merge_registry() {
     with_registry_mut(|registry| registry.clear());
 }
 
-/// Result of attempting to merge using registered merge functions
-#[derive(Debug)]
-#[must_use]
-pub enum MergeRegistryResult {
-    /// A registered merge function succeeded
-    Success(Vec<u8>),
-    /// No merge functions are registered (I5 enforcement needed)
-    NoFunctionsRegistered,
-    /// Merge functions are registered but all failed (e.g., type mismatch)
-    AllFunctionsFailed,
-}
-
 /// Try to merge using registered merge function
 ///
 /// Returns:
 /// - `Success(merged)` if a merge function succeeded
 /// - `NoFunctionsRegistered` if no merge functions are registered (I5 violation)
 /// - `AllFunctionsFailed` if merge functions exist but none could merge the data
+#[cfg(any(target_arch = "wasm32", test))]
 pub fn try_merge_registered(
     existing: &[u8],
     incoming: &[u8],

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -35,17 +35,17 @@
 //! against the same table thereafter. Tests use a `thread_local!` so
 //! parallel-running tests can't stomp on each other's registrations.
 
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 use std::any::TypeId;
 #[cfg(test)]
 use std::cell::RefCell;
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 use std::collections::HashMap;
-#[cfg(all(not(test), target_arch = "wasm32"))]
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
 use std::sync::{LazyLock, RwLock};
 
 /// Function signature for merging serialized state
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 pub type MergeFn = fn(&[u8], &[u8], u64, u64) -> Result<Vec<u8>, Box<dyn std::error::Error>>;
 
 /// Result of attempting to merge using registered merge functions.
@@ -70,7 +70,7 @@ pub enum MergeRegistryResult {
 }
 
 /// Production registry — process-global, shared across async workers.
-#[cfg(all(target_arch = "wasm32", not(test)))]
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
 static MERGE_REGISTRY: LazyLock<RwLock<HashMap<TypeId, MergeFn>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
@@ -124,7 +124,7 @@ thread_local! {
 /// if the lock is poisoned (a poisoned lock means a prior writer
 /// panicked, which we treat as unrecoverable for a process-global
 /// singleton).
-#[cfg(all(target_arch = "wasm32", not(test)))]
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
 fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R {
     let mut registry = MERGE_REGISTRY.write().unwrap_or_else(|_| {
         tracing::error!(
@@ -157,7 +157,7 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<TypeId, MergeFn>) -> R) -> R
 
 /// Runs `f` with read-only access to the registry. Aborts the process
 /// if the lock is poisoned (same reasoning as `with_registry_mut`).
-#[cfg(all(target_arch = "wasm32", not(test)))]
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
 fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
     let registry = MERGE_REGISTRY.read().unwrap_or_else(|_| {
         tracing::error!(
@@ -220,7 +220,7 @@ fn with_registry<R>(f: impl FnOnce(&HashMap<TypeId, MergeFn>) -> R) -> R {
 /// // Register at app startup
 /// register_crdt_merge::<MyState>();
 /// ```
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 pub fn register_crdt_merge<T>()
 where
     T: borsh::BorshSerialize + borsh::BorshDeserialize + crate::collections::Mergeable + 'static,
@@ -255,7 +255,7 @@ where
 }
 
 /// Clear the merge registry (for testing only)
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub fn clear_merge_registry() {
     with_registry_mut(|registry| registry.clear());
 }
@@ -266,7 +266,7 @@ pub fn clear_merge_registry() {
 /// - `Success(merged)` if a merge function succeeded
 /// - `NoFunctionsRegistered` if no merge functions are registered (I5 violation)
 /// - `AllFunctionsFailed` if merge functions exist but none could merge the data
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 pub fn try_merge_registered(
     existing: &[u8],
     incoming: &[u8],

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -151,6 +151,21 @@ pub struct ContextDagDelta {
     pub applied: bool,
     pub expected_root_hash: [u8; 32],
     pub events: Option<Vec<u8>>,
+    /// Signing identity of the node that authored this delta. Populated
+    /// from the gossip envelope on receive; populated from the local
+    /// node identity on local apply. Used by the DAG-catchup responder
+    /// to advertise the author on the wire so initiator-side membership
+    /// checks can reject revoked-author deltas at apply time (parity
+    /// with the gossip-receive cross-DAG check).
+    pub author_id: Option<calimero_primitives::identity::PublicKey>,
+    /// Serialized `calimero_context_config::types::GovernancePosition`
+    /// (borsh bytes) at sign time. Stored as a blob to avoid pulling
+    /// `calimero-context-config` into `calimero-store` — matches the
+    /// existing pattern for `actions` / `events`. Initiator-side
+    /// DAG-catchup deserializes this and runs `membership_status_at`
+    /// against it. `None` for legacy deltas authored before this
+    /// field was added.
+    pub governance_position_blob: Option<Vec<u8>>,
 }
 
 impl ContextDagDelta {

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -166,6 +166,14 @@ pub struct ContextDagDelta {
     /// against it. `None` for legacy deltas authored before this
     /// field was added.
     pub governance_position_blob: Option<Vec<u8>>,
+    /// Ed25519 signature by `author_id`'s identity key over the
+    /// canonical `DeltaSignaturePayload`. Closes the anti-impersonation
+    /// gap on the delta envelope: a current group-key holder can't
+    /// relabel a foreign delta as their own (or vice versa). Served
+    /// alongside `author_id` on the wire; verified by every receive
+    /// path before applying. `None` for snapshot checkpoints / genesis
+    /// rows that have no author signature to record.
+    pub delta_signature: Option<[u8; 64]>,
 }
 
 impl ContextDagDelta {


### PR DESCRIPTION
Closes #2457. Addresses #2469. **Scope expanded significantly mid-review** — the original two-part fix unmasked progressively deeper architectural gaps; rather than ship a partial cure and queue follow-ups, the full WASM-owns-merges rewrite landed here together with the security audit findings the rewrite surfaced. 20 commits, ~3000 lines net.

## Original scope (the bug that started this)

- **HC fallback opens a fresh stream** — the prior fallback wrote into a stream the responder had already torn down (one-shot dispatch). Mirrors the LevelWise pattern.
- **DAG-catchup membership-check parity with gossip** — `ContextDagDelta` storage + `DeltaResponse` wire format gained `author_id` + `governance_position_blob` so the receiver can run the same `membership_status_at` check `handle_state_delta` runs.

## Wave 5: per-delta envelope signature, end-to-end

The author signs a canonical payload binding `(domain_separator, context_id, delta_id, author_id, governance_position)` with their ed25519 identity key at the execute site. Every receive path verifies before applying:

- gossip apply (`apply_authorized_state_delta`)
- DAG-catchup head-pull (`request_dag_heads_and_sync`)
- gossip parent-fetch (`request_missing_deltas`)
- snapshot-buffer replay (`replay_buffered_delta`)

Domain separator (`calimero/delta/1`) is borsh-serialized into the signed bytes so cross-protocol replay can't reuse a signature against this scheme. Per-cut binding: the governance position is part of the payload, so a signature for one cut can't be replayed against another. 6 unit tests pin the sign/verify roundtrip + tamper rejection across context_id / author / signature bytes / governance_position.

Signatures persist through every relay hop: gossip receive saves them on the row, DAG-catchup responder serves them, snapshot-buffer carries them through replay. So the anti-impersonation property holds end-to-end, not just at the originating node.

## HC/LevelWise authorization back door (the bug Wave 5 audit surfaced)

`state_delta_bridge` runs a cross-DAG membership check on gossip and rejects deltas authored by members the receiver has seen removed. HC's `EntityPush` apply path and inline DFS merge skipped this check entirely — any leaf went straight to `apply_leaf_with_crdt_merge`, so a now-removed author's writes that gossip correctly rejected re-entered storage via HC. Same gap in LevelWise.

Added `is_currently_authorized_for_context` in `calimero_context::group_store` and `is_leaf_currently_authorized` in `calimero_node::sync::helpers`. Wired into `handle_entity_push`, the HC initiator inline DFS merge, and the LevelWise per-leaf merge. Trade-off (documented in code): this checks the receiver's *current* group state since HC doesn't carry per-leaf governance position on the wire; strictly coarser than the gossip path's signed-position check, follow-up issue for per-leaf position on the wire.

## WASM-owns-merges architectural rewrite (core#2469 root cause)

The host's `MERGE_REGISTRY` static was never populated in production — the macro's `__calimero_register_merge` export wrote to the *WASM-side* copy, in the WASM module's static memory, separate address space from the host's process. Pre-pause the bootstrap fast-path masked this; post-pause divergence tripped the post-bootstrap branch and the cascade in #2469.

**Architecture**: host now has zero merge logic for app types. Root-state CRDT merges round-trip through WASM via a new macro-generated `__calimero_merge_root_state` export.

- Macro `#[app::state]` emits both the existing `__calimero_register_merge` (WASM-internal dispatch, load-bearing for normal `__calimero_sync_next` delta apply) AND the new `__calimero_merge_root_state` (host-callable).
- `merge_root_state_typed::<T>` primitive in `calimero-storage` — deserialize, run app's `Mergeable::merge`, re-serialize. Preserves the bootstrap fast-path (`existing_created_at == existing_ts` → accept incoming verbatim).
- `ContextClient::merge_root_state(context_id, executor, request)` — host wrapper invoking the WASM export via the existing actor-based `execute` path.
- `Interface::write_pre_merged_root_state` — write-back primitive that updates Merkle index + storage without re-running merge; correctly handles both `ROOT_ID` and `ROOT_ENTRY_ID` cases.
- HC initiator + responder, LevelWise initiator — accumulate root-entity leaves in `deferred_root_merges` (carrying `(key, value, hlc_ts)`); `ProtocolSelector::dispatch_deferred_root_merges` runs after the sync to dispatch each through WASM and write back.
- Opaque root entities (`crdt_type: None` apps, test fixtures) → direct LWW write via `write_pre_merged_root_state` since there's no `Mergeable` to dispatch to.
- Host-side `MERGE_REGISTRY` + `register_crdt_merge` cfg-gated to `cfg(any(target_arch = "wasm32", test, feature = "testing"))` — host production builds can no longer accidentally reach for the dead path.

## Storage layer fix: merge-mode bypasses per-action nonce check

The deferred-merge dispatch exposed a real interaction bug. WASM-side `Mergeable::merge` on collection types (`SharedStorage`, `AuthoredMap`, RGA) re-runs sub-action processing through `Interface::apply_action` / `save_internal`, which enforces a per-action nonce check on `Shared`/`User` `signature_data`. On the second pass (merge re-applying actions the local node already saw via gossip), `new_nonce == last_nonce` → silent skip → action's effects don't land → node-2 read empty.

Extended the existing `with_merge_mode` flag (already used to suppress timestamp generation during merge) to also bypass the nonce-staleness check:

```rust
let skip_nonce = nonce_check_disabled_for_testing() || crate::env::in_merge_mode();
```

Safe — the signature check still runs first and rejects forgeries. The bypass only stops merge-mode operations from being treated as replay-attacks-of-themselves. This was the root cause of the shared-storage + scaffolding-e2e regressions.

## Additional review-driven fixes

- Parent-fetch (`request_missing_deltas`): added envelope-verify, `GroupIdCheck` parity, `membership_status_at`, delta-id sanity check (peer can't substitute a different authorized delta in response).
- Head-pull (`request_dag_heads_and_sync`): same delta-id sanity check.
- Malformed `governance_position` in DAG-catchup: skip the delta, don't abort the whole sync batch.
- HC responder edge case: production responder (`hash_comparison.rs`) dispatches deferred root merges; trait-based responder logs warn (lacks `ContextClient` in scope).
- Authorization check refactor (`is_currently_authorized_for_context`): rejects ReadOnly/ReadOnlyTee up-front, parity with gossip path's filter.
- Position-parity at execute: `internal_execute` returns the `governance_position` the signature was bound to; broadcast site uses it verbatim instead of re-computing.
- Bootstrap fast-path preserved in `merge_root_state_typed` (was the shared-storage regression's root cause prior to the nonce-mode fix).
- Datastore handle hoisted out of `for head_id in dag_heads` tight loop.
- Documentation accuracy pass: `delta_auth` module doc, `wire.rs` field doc, `state_delta` inline comments updated to reflect signing IS wired (was originally written when signing was deferred).

## Schema / wire-format breaks

Pre-1.0, break-freely applies. Operators need fresh data dirs and all peers on the new wire.

- `ContextDagDelta`: `author_id`, `governance_position_blob`, `delta_signature` fields added.
- `MessagePayload::DeltaResponse`: `author_id` (required), `governance_position_blob` (optional), `delta_signature` (optional pending legacy-row aging).
- `BroadcastMessage::StateDelta`: `delta_signature` (optional pending legacy-row aging).
- `BufferedDelta`: `delta_signature` (optional).

## Test coverage

- 207 `calimero-node` lib tests pass.
- 308 `calimero-node` sync_sim integration tests pass.
- 463 `calimero-storage` lib tests pass (with and without `--features testing`).
- New unit tests:
  - 6 in `delta_auth::tests` (sign/verify roundtrip + tamper rejection, with and without governance_position)
  - 4 in `typed_dispatch_tests` (bootstrap fast-path, executor union, malformed input rejection)
  - 6 in `helpers::tests::extract_author_*` (StorageType variants for the authorization check)
- The 39 originally-failing e2e jobs (and the regressions this PR introduced) are addressed; CI confirms.

## Test plan

- [x] Workspace compile + clippy clean.
- [x] All lib + integration tests pass.
- [x] All e2e workflows (sync-resilience, shared-storage, scaffolding-e2e, member-removed paths) green on the most recent commit.
- [x] WASM build for `scaffolding-e2e` + `kv-store-with-shared-storage` clean.

## Known follow-ups (not blocking)

- Per-leaf governance position on HC wire (strict version of the authorization check — current implementation uses receiver's-current-state, documented trade-off).
- `delta_auth` module placement (sits in `node/primitives` but imports `calimero-context-config` — layering nitpick).
- `MergeRegistryResult` enum cfg surface tidy-up.
- Trait-based HC responder needs `ContextClient` plumbed if it ever sees production traffic carrying root-entity bidirectional pushes (rare; trait responder is sim/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes across authentication, sync apply paths, and wire/storage formats; incorrect verification or authorization could reject valid deltas or admit forged state, and operators need coordinated upgrades.
> 
> **Overview**
> This PR hardens **sync and delta authorization** and fixes **root-state merging** so HashComparison/LevelWise/DAG-catchup paths match gossip-level guarantees.
> 
> **Delta envelopes** are now signed at execute time over `(domain, context_id, delta_id, author_id, governance_position)` and verified on gossip apply, DAG head-pull, parent-fetch, and snapshot-buffer replay. Signatures and the **exact** governance position used at sign time are persisted and relayed so broadcast cannot drift from what receivers verify.
> 
> **DAG catchup** gains parity checks with gossip: group-id vs owning group, ReadOnly rejection, `membership_status_at`, genesis sentinel handling, and failure when every advertised head is rejected. **`DeltaResponse`** carries required author metadata; responders refuse rows without author claims (except genesis carve-out).
> 
> **HC / LevelWise / EntityPush** no longer apply leaves from authors who are not **currently** authorized writers (including ReadOnly), closing a path where removed members could re-import state. Metrics track unauthorized vs lookup-error drops.
> 
> **Root CRDT merges** move to WASM via `ContextClient::merge_root_state` and deferred post-sync dispatch; opaque root leaves still LWW on host. HashComparison fallback opens a **fresh stream** for DAG catchup instead of reusing a consumed responder stream.
> 
> Wire/storage adds `author_id`, `governance_position_blob`, and `delta_signature` on deltas and broadcasts — **breaking** for mixed-version peers without fresh data dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33513c60cd1e1148c62dd791a82cb3180cfd067e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->