### PR TITLE
fix(storage): write Entry before updating Merkle index (close read-after-publish race)

### DIFF
--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -462,6 +462,11 @@ pub fn storage_remove(key: &[u8]) -> bool {
 /// which propagates as a runtime error, not as `false`. Callers that
 /// don't care whether the key existed before can safely discard the bool.
 ///
+/// **Note:** [`private_storage_write`] uses a different return-value
+/// convention (true = succeeded, false = private storage unavailable)
+/// because that backend can be absent at runtime, unlike main storage
+/// which is always available.
+///
 /// # Example
 ///
 /// ```rust,no_run
@@ -562,8 +567,20 @@ pub fn private_storage_remove(key: &[u8]) -> bool {
 ///
 /// # Returns
 ///
-/// * `true` - If the write operation succeeded
-/// * `false` - If the write operation failed or private storage is not available
+/// * `true` - The write succeeded (a new entry was inserted, or an
+///   existing entry was overwritten).
+/// * `false` - Private storage is not available on this node (the
+///   backend is optional and may be absent at runtime; the write
+///   was a no-op).
+///
+/// Other failure modes (`KeyLengthOverflow`, `ValueLengthOverflow`,
+/// `InvalidMemoryAccess`) trap the WASM module via `HostError` rather
+/// than returning `false`.
+///
+/// **Note:** [`storage_write`] uses a different return-value
+/// convention (true = previous value evicted, false = new key
+/// inserted) because main storage is always available, so a
+/// success/failure bool would be tautological.
 ///
 /// # Example
 ///
@@ -572,6 +589,8 @@ pub fn private_storage_remove(key: &[u8]) -> bool {
 ///
 /// if env::private_storage_write(b"my_secret", b"secret_value") {
 ///     println!("Private value stored successfully");
+/// } else {
+///     println!("Private storage is not available on this node");
 /// }
 /// ```
 #[inline]

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -453,8 +453,14 @@ pub fn storage_remove(key: &[u8]) -> bool {
 ///
 /// # Returns
 ///
-/// * `true` - If the write operation succeeded
-/// * `false` - If the write operation failed
+/// * `true` - A previous value existed under `key` and was evicted.
+/// * `false` - No previous value; a new entry was inserted.
+///
+/// The return value is **not** a success/failure indicator. The write
+/// itself either succeeds or traps the WASM module with a `HostError`
+/// (`KeyLengthOverflow`, `ValueLengthOverflow`, `InvalidMemoryAccess`),
+/// which propagates as a runtime error, not as `false`. Callers that
+/// don't care whether the key existed before can safely discard the bool.
 ///
 /// # Example
 ///
@@ -462,7 +468,9 @@ pub fn storage_remove(key: &[u8]) -> bool {
 /// use calimero_sdk::env;
 ///
 /// if env::storage_write(b"my_key", b"my_value") {
-///     println!("Value stored successfully");
+///     println!("Overwrote an existing value");
+/// } else {
+///     println!("Inserted a new entry");
 /// }
 /// ```
 #[inline]

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2097,8 +2097,9 @@ impl<S: StorageAdaptor> Interface<S> {
         // success/failure. Actual write failures surface as `HostError`
         // traps from the runtime (`KeyLengthOverflow`,
         // `ValueLengthOverflow`, `InvalidMemoryAccess`), not as
-        // `Ok(false)`. Discard the bool.
-        _ = S::storage_write(Key::Entry(id), &final_data);
+        // `Ok(false)`. Discard the bool — `let _ignored = ...` matches
+        // the style used at the `storage_remove` site (line 1448).
+        let _ignored = S::storage_write(Key::Entry(id), &final_data);
 
         // If `update_hash_for` errors below after the entry write above
         // succeeded, the entry bytes remain in storage with no index
@@ -2251,7 +2252,7 @@ impl<S: StorageAdaptor> Interface<S> {
         // concurrent writer for the same id, and the storage layer
         // doesn't serialize concurrent writes anyway — re-checking
         // would just narrow the race window without closing it.
-        _ = S::storage_write(Key::Entry(id), merged);
+        let _ignored = S::storage_write(Key::Entry(id), merged);
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
         Ok(full_hash)
     }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2100,6 +2100,22 @@ impl<S: StorageAdaptor> Interface<S> {
         // `Ok(false)`. Discard the bool.
         _ = S::storage_write(Key::Entry(id), &final_data);
 
+        // If `update_hash_for` errors below after the entry write above
+        // succeeded, the entry bytes remain in storage with no index
+        // entry pointing at them — an "orphan." This is unavoidable
+        // without a transactional storage layer, and it's the lesser
+        // evil compared to the inverse (index advertising bytes that
+        // aren't there) because:
+        //   * The orphan is unreachable via the normal read path:
+        //     `find_by_id` consults the index first (line 1689,
+        //     1702) and bails when the index entry is missing or
+        //     deleted.
+        //   * The next successful `apply_action` for the same id
+        //     overwrites the orphan bytes, so the storage cost is
+        //     transient.
+        // The pre-fix ordering (index-then-entry) had the symmetric
+        // problem with much worse user-visible behavior — the rga
+        // "Hello Wor" flake described above.
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
 
         if id.is_root() {
@@ -2206,6 +2222,17 @@ impl<S: StorageAdaptor> Interface<S> {
         // `storage_write` is the eviction signal ("did a previous value
         // exist under this key"), not a success/failure flag — write
         // failures trap from the runtime as `HostError`, not `Ok(false)`.
+        //
+        // Same orphan trade-off as `save_internal`: if `update_hash_for`
+        // errors below, the merged bytes are persisted but the index
+        // isn't updated. The orphan is unreachable via the normal read
+        // path (`find_by_id` bails on missing index) and will be
+        // overwritten by the next successful merge for this id. We
+        // don't re-check the LWW guard after the entry write because
+        // the only thing that could invalidate it is a concurrent
+        // writer for the same id, and the storage layer doesn't
+        // serialize concurrent writes anyway — re-checking would just
+        // narrow the race window without closing it.
         _ = S::storage_write(Key::Entry(id), merged);
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
         Ok(full_hash)

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2079,6 +2079,20 @@ impl<S: StorageAdaptor> Interface<S> {
 
         let own_hash: [u8; 32] = Sha256::digest(&final_data).into();
 
+        // Write the entry bytes BEFORE updating the Merkle index. The
+        // index update propagates the new own_hash up the parent chain,
+        // making the new state observable via the root-hash poll path
+        // (`compute_root_hash`). Readers that iterate a collection's
+        // children silently drop entries whose `Key::Entry` lookup
+        // returns `None` (`UnorderedMap::entries` → `flatten().fuse()`
+        // swallows the `NotFound` Err), so an admin-server reader hit
+        // mid-write would otherwise see a converged root hash with
+        // missing children — the "Hello Wor" vs "Hello World" rga
+        // flake reproduced post-#2465. Writing the entry first means
+        // readers see either (old hash + old entries) or
+        // (new hash + new entries), never the inconsistent middle.
+        _ = S::storage_write(Key::Entry(id), &final_data);
+
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
 
         if id.is_root() {
@@ -2090,8 +2104,6 @@ impl<S: StorageAdaptor> Interface<S> {
                 "ROOT MERGE: Final hashes after Merkle tree update"
             );
         }
-
-        _ = S::storage_write(Key::Entry(id), &final_data);
 
         let is_new = metadata.created_at == *metadata.updated_at;
 
@@ -2179,8 +2191,13 @@ impl<S: StorageAdaptor> Interface<S> {
         }
 
         let own_hash: [u8; 32] = Sha256::digest(merged).into();
-        let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
+        // Entry-before-index ordering — same rationale as `save_internal`:
+        // updating the Merkle index first makes the new root hash
+        // observable before the entry bytes are stored, so a concurrent
+        // reader can see a converged root hash with missing children
+        // (the "Hello Wor" rga flake).
         _ = S::storage_write(Key::Entry(id), merged);
+        let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
         Ok(full_hash)
     }
 

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2091,6 +2091,13 @@ impl<S: StorageAdaptor> Interface<S> {
         // flake reproduced post-#2465. Writing the entry first means
         // readers see either (old hash + old entries) or
         // (new hash + new entries), never the inconsistent middle.
+        //
+        // `storage_write` returns `bool` meaning "evicted a previous
+        // value" (true) vs "inserted a new key" (false) — not
+        // success/failure. Actual write failures surface as `HostError`
+        // traps from the runtime (`KeyLengthOverflow`,
+        // `ValueLengthOverflow`, `InvalidMemoryAccess`), not as
+        // `Ok(false)`. Discard the bool.
         _ = S::storage_write(Key::Entry(id), &final_data);
 
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
@@ -2195,7 +2202,10 @@ impl<S: StorageAdaptor> Interface<S> {
         // updating the Merkle index first makes the new root hash
         // observable before the entry bytes are stored, so a concurrent
         // reader can see a converged root hash with missing children
-        // (the "Hello Wor" rga flake).
+        // (the "Hello Wor" rga flake). The discarded `bool` from
+        // `storage_write` is the eviction signal ("did a previous value
+        // exist under this key"), not a success/failure flag — write
+        // failures trap from the runtime as `HostError`, not `Ok(false)`.
         _ = S::storage_write(Key::Entry(id), merged);
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
         Ok(full_hash)

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2106,16 +2106,30 @@ impl<S: StorageAdaptor> Interface<S> {
         // without a transactional storage layer, and it's the lesser
         // evil compared to the inverse (index advertising bytes that
         // aren't there) because:
-        //   * The orphan is unreachable via the normal read path:
-        //     `find_by_id` consults the index first (line 1689,
-        //     1702) and bails when the index entry is missing or
-        //     deleted.
+        //   * `find_by_id` consults the index first (line 1689, 1702)
+        //     and bails when the index entry is missing or deleted —
+        //     so the read path used by collections (`Collection::get`,
+        //     `Collection::entries`) silently skips the orphan.
+        //   * `find_by_id_raw` does NOT consult the index — it returns
+        //     raw bytes whenever `Key::Entry(id)` is present. In
+        //     principle this exposes the orphan, but every production
+        //     caller (`compare_trees` and its sync-layer cousins in
+        //     `hash_comparison{,_protocol}.rs`, `level_sync.rs`)
+        //     reaches `find_by_id_raw` only after iterating a parent's
+        //     index-derived child list — and the orphan's id is, by
+        //     definition, not in any parent's index. `compare_trees`
+        //     called directly with the orphan's id also bails: line
+        //     1525 returns `IndexNotFound` from the `local_metadata`
+        //     check before the orphan bytes can become an `Action`.
         //   * The next successful `apply_action` for the same id
         //     overwrites the orphan bytes, so the storage cost is
         //     transient.
         // The pre-fix ordering (index-then-entry) had the symmetric
         // problem with much worse user-visible behavior — the rga
-        // "Hello Wor" flake described above.
+        // "Hello Wor" flake described above — because the read path
+        // *does* propagate index-advertised entries through every
+        // production caller, so a "hash exists, bytes don't"
+        // inconsistency surfaces immediately as a wrong-content read.
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
 
         if id.is_root() {
@@ -2223,16 +2237,20 @@ impl<S: StorageAdaptor> Interface<S> {
         // exist under this key"), not a success/failure flag — write
         // failures trap from the runtime as `HostError`, not `Ok(false)`.
         //
-        // Same orphan trade-off as `save_internal`: if `update_hash_for`
-        // errors below, the merged bytes are persisted but the index
-        // isn't updated. The orphan is unreachable via the normal read
-        // path (`find_by_id` bails on missing index) and will be
-        // overwritten by the next successful merge for this id. We
-        // don't re-check the LWW guard after the entry write because
-        // the only thing that could invalidate it is a concurrent
-        // writer for the same id, and the storage layer doesn't
-        // serialize concurrent writes anyway — re-checking would just
-        // narrow the race window without closing it.
+        // Same orphan trade-off as `save_internal` (see the longer
+        // comment there): if `update_hash_for` errors below, the
+        // merged bytes are persisted but the index isn't updated.
+        // `find_by_id` bails on the missing index; `find_by_id_raw`
+        // would expose the orphan in principle, but every production
+        // caller reaches it only via an index-derived child list that
+        // the orphan isn't in. The next successful merge for this id
+        // overwrites the orphan bytes.
+        //
+        // We don't re-check the LWW guard after the entry write
+        // because the only thing that could invalidate it is a
+        // concurrent writer for the same id, and the storage layer
+        // doesn't serialize concurrent writes anyway — re-checking
+        // would just narrow the race window without closing it.
         _ = S::storage_write(Key::Entry(id), merged);
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
         Ok(full_hash)


### PR DESCRIPTION
## Summary

- `Interface::save_internal` and `Interface::write_pre_merged_root_state` updated the Merkle index (`Index::update_hash_for`) **before** writing the actual entry bytes (`storage_write(Key::Entry(id), ...)`).
- Between the index update and the entry write, a concurrent reader sees a converged root hash that promises content that isn't yet readable.
- `UnorderedMap::entries` does `.flatten().fuse()` on the inner iterator of `Result`s, silently dropping any `NotFound` Err from a missing `Key::Entry` lookup — so the partial child set surfaces with no error.

## Reproduction

`apps/scaffolding-e2e/workflows/e2e.yml` rga section, post-#2465 master run (`ca8f7dea54`):

1. Node-1 inserts "Hello" + appends " World" (11 chars).
2. `wait_for_sync` polls all 3 nodes' root hashes → converges on `G75KgR9...` within ~0.5s.
3. ~15ms later, `rga_get_text` on node-3 returns `"Hello Wor"` (9 chars) while node-2 returns `"Hello World"`.

Node-3 had indexed all 11 char entries (Merkle root matched peers), but 2 char `Key::Entry` writes were still in flight when the read came in. `UnorderedMap::entries` swallowed both as `NotFound` and yielded 9 of 11 chars.

The bug existed since the Merkle index was introduced; PR #2465 widened the race window (extra apply paths via `write_pre_merged_root_state`, slightly longer apply duration from the LWW guard) and surfaced it on the post-merge e2e run.

## Fix

Swap the order in both sites: `storage_write(Key::Entry(id), ...)` first, then `Index::update_hash_for(id, ...)`. `update_hash_for` only reads/writes index entries (verified at `index.rs:726-768`); it never touches `Key::Entry`, so the swap is safe.

Readers now observe either:
- Old hash + old entries (apply hasn't started or entry-write hasn't landed), or
- New hash + new entries (both writes settled),

never the inconsistent middle.

The deletion path (`save_internal` line 1448) already does entry-first; leaving that alone since the brief \"child in index, entry gone\" window iterates to the same eventually-consistent result.

## Test plan

- [x] 463 calimero-storage lib tests pass
- [x] 207 calimero-node lib tests pass
- [x] 308 sync_sim integration tests pass
- [ ] CI scaffolding-e2e green (the rga \"Hello World\" assertion that failed on `ca8f7dea54`)
- [ ] CI shared-storage / kv-store / mesh-soak green (no regression from the order swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence ordering on every entity save and pre-merged root commit; wrong ordering would regress the RGA e2e flake, though the change aligns read paths with hash visibility and is covered by existing lib tests.
> 
> **Overview**
> Fixes a **read-after-publish race** where `save_internal` and `write_pre_merged_root_state` updated the Merkle index before persisting `Key::Entry` bytes. After sync, a reader could see a **matching root hash** while collection iteration still dropped children whose entry blobs were not written yet (`UnorderedMap::entries` uses `flatten().fuse()`, hiding missing entries)—the scaffolding RGA flake (`"Hello Wor"` vs `"Hello World"`).
> 
> **Behavior change:** both paths now **`storage_write(Key::Entry, …)` first**, then `Index::update_hash_for`. Observers see either old hash + old entries or new hash + new entries, not index-ahead-of-bytes. Comments document the accepted **orphan** case if index update fails after entry write, and that `storage_write`’s `bool` means eviction vs insert, not success (real failures trap as `HostError`).
> 
> **SDK docs:** `env::storage_write` vs `private_storage_write` return-value semantics are clarified and cross-linked so callers do not treat the bool as a failure flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 272c5368c64f3791502bf45c15c088b6d2c5979d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->