### PR TITLE
fix(e2e): add group_id to wait_for_sync in group-governance-peer-down

### DIFF
--- a/apps/scaffolding-e2e/workflows/group-governance-peer-down.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-peer-down.yml
@@ -113,8 +113,17 @@ steps:
     wait_timeout: 60
 
   - name: Wait for node-2 to catch up
+    # `context_id` polls WASM-root convergence; `group_id` polls
+    # `groupStateHash` convergence. The next step reads
+    # `get_member_capabilities` — a governance-store lookup that
+    # depends on the namespace governance DAG, NOT the WASM root.
+    # Without the `group_id` poll, this step trivially passes because
+    # the WASM root never changed (governance ops don't touch it), and
+    # the assertion fires before node-2 has applied the missed
+    # governance ops. See the post-#2470 flake on this same job.
     type: wait_for_sync
     context_id: '{{ctx_id}}'
+    group_id: '{{namespace_id}}'
     nodes:
       - e2e-node-1
       - e2e-node-2


### PR DESCRIPTION
## Summary

- `Test (group-governance-peer-down)` flaked intermittently after PR #2470 merged. Investigation showed the root cause is workflow-side: `wait_for_sync` was missing a `group_id` (governance-state) poll.
- The step polled only `context_id` → WASM-root convergence. The ops that happened while node-2 was down (`set_default_capabilities`, `join_namespace`) are governance-only and don't touch the WASM root. After node-2 restart the poll trivially saw "converged in 0.00s (1 attempts)" because all 3 nodes shared the same unchanged WASM root, and the assertion (`get_member_capabilities`) followed within 15 ms — before node-2's beacon-driven namespace governance sync (median ~5s) ran.
- Adds `group_id: '{{namespace_id}}'` to the same `wait_for_sync` step so merobox also polls `groupStateHash` convergence (the namespace governance DAG head digest exposed by `groups/get_group_info`). This pattern is already used in 10+ other workflows under `apps/scaffolding-e2e/`.

## Why this works

In Calimero, namespaces are groups: `namespace_id` doubles as `group_id` for membership / capabilities queries — exactly what `get_member_capabilities` accepts via `group_id: '{{namespace_id}}'`. So `groupStateHash` for the namespace_id IS the convergence signal we need.

## Test plan

- [ ] CI green on `Test (group-governance-peer-down)` across multiple runs (the failure was intermittent: 1/3 chance pre-fix, expected 0/N post-fix)
- [ ] Other workflows that mix WASM-root + governance assertions remain green (the fix touches only one workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only workflow YAML change; no production runtime or auth paths touched.
> 
> **Overview**
> Fixes an intermittent flake in **`group-governance-peer-down`** by tightening when the workflow considers nodes “caught up” after node-2 restarts.
> 
> The **“Wait for node-2 to catch up”** step still uses `context_id` for WASM-root sync, and now also passes **`group_id: '{{namespace_id}}'`** so merobox waits on **`groupStateHash`** (namespace governance DAG), not only an unchanged WASM root. That matches how other e2e workflows gate governance-sensitive checks before **`get_member_capabilities`**.
> 
> Inline comments document why **`context_id` alone** was a false positive (governance ops while node-2 was down do not move the WASM root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091481cd7521f3aea25c55b318cf255793d93706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->