### PR TITLE
fix(#2319): refresh stale root-hash cache + entry-before-parent ordering, with divergence-dump diagnostic

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -6,11 +6,21 @@ runs:
   steps:
     - name: Install merobox (apt)
       shell: bash
+      # Each network step gets its own bounded timeout. Without these, a
+      # stalled curl / apt-get on a slow Azure runner can wedge the job
+      # for the runner-wide 6h limit — one such hang on PR #2472 ran 90
+      # min in this step alone. Use `timeout` for the GNU-coreutils
+      # bound + `--connect-timeout` / `apt -o` so each tool's own
+      # network retries are also bounded.
       run: |
-        curl -fsSL https://calimero-network.github.io/merobox/gpg.key \
+        set -euo pipefail
+        timeout 60 curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 \
+          https://calimero-network.github.io/merobox/gpg.key \
           | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
           | sudo tee /etc/apt/sources.list.d/merobox.list
-        sudo apt-get update
-        sudo apt-get install -y merobox
+        timeout 120 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
+          -o Acquire::https::Timeout=20 update
+        timeout 180 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
+          -o Acquire::https::Timeout=20 install -y merobox
         merobox --version

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -67,12 +67,16 @@ pub struct ContextRegistry {
     datastore: Store,
 }
 
-/// One row of [`ContextRegistry::dump_root_children`] — a child entry in
-/// the context root's Merkle index. Exported for the divergence
-/// diagnostic in `handle_hash_heartbeat` (#2319): a flake of "same DAG
-/// heads, different root hash" can be triaged by diffing the two peers'
-/// dumps to find the divergent child. Field names are stable for
-/// `tracing` consumption (json output keys).
+/// One row of [`ContextRegistry::dump_root`] — a child entry in the
+/// context root's Merkle index. Diagnostic-only: a #2319 flake ("same
+/// DAG heads, different root hash") is triaged by diffing the two
+/// peers' dumps. Field names are stable for `tracing` consumption
+/// (json output keys).
+///
+/// Not stable API — pulled in by `calimero-node`'s heartbeat handler
+/// across crate boundaries, which is why it's `pub` rather than
+/// `pub(crate)`.
+#[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct RootChildDump {
     pub id: [u8; 32],
@@ -87,6 +91,7 @@ pub struct RootChildDump {
 /// + Key::Entry(ROOT) bytes hash. Lets a #2319 diff distinguish
 /// "children diverge" from "ROOT.own_hash diverges with identical
 /// children" (the latter pattern surfaced on PR #2472 attempt 1).
+#[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct RootSelfDump {
     pub own_hash: [u8; 32],
@@ -95,6 +100,77 @@ pub struct RootSelfDump {
     pub entry_bytes_hash: Option<[u8; 32]>,
     pub entry_bytes_len: usize,
     pub children_count: usize,
+}
+
+/// Borsh layout-faithful mirrors of `calimero_storage::index::EntityIndex`
+/// and the embedded `entities::ChildInfo`/`Metadata`/`StorageType`/
+/// `SignatureData` types. Used by [`ContextRegistry::compute_root_hash`]
+/// and [`ContextRegistry::dump_root`] to decode the index without pulling
+/// in the full `calimero-storage` types (which would force a dep cycle).
+///
+/// **SYNC NOTE**: When `calimero_storage::index::EntityIndex` or its
+/// transitively-borshed children change, update these mirrors *and*
+/// `calimero-storage/src/tests/index.rs::minimal_struct_layout_compat`.
+/// A missed update produces silent misdeserialization on a diagnostic
+/// path that fires only during rare divergence events — exactly when
+/// correct output matters most.
+mod borsh_layout {
+    use borsh::BorshDeserialize;
+    use calimero_primitives::crdt::CrdtType;
+
+    /// Captures every field [`super::ContextRegistry::dump_root`] needs in
+    /// a single pass: children (with metadata), full_hash, own_hash.
+    /// `compute_root_hash_via_borsh` reads only `full_hash`.
+    #[derive(BorshDeserialize)]
+    #[allow(dead_code, reason = "fields required for borsh layout fidelity")]
+    pub(super) struct EntityIndex {
+        pub(super) id: [u8; 32],
+        pub(super) parent_id: Option<[u8; 32]>,
+        pub(super) children: Option<Vec<ChildInfo>>,
+        pub(super) full_hash: [u8; 32],
+        pub(super) own_hash: [u8; 32],
+    }
+
+    #[derive(BorshDeserialize)]
+    #[allow(dead_code, reason = "fields required for borsh layout fidelity")]
+    pub(super) struct ChildInfo {
+        pub(super) id: [u8; 32],
+        pub(super) merkle_hash: [u8; 32],
+        pub(super) metadata: Metadata,
+    }
+
+    #[derive(BorshDeserialize)]
+    #[allow(dead_code, reason = "fields required for borsh layout fidelity")]
+    pub(super) struct Metadata {
+        pub(super) created_at: u64,
+        pub(super) updated_at: u64,
+        pub(super) storage_type: StorageType,
+        pub(super) crdt_type: Option<CrdtType>,
+        pub(super) field_name: Option<String>,
+    }
+
+    #[derive(BorshDeserialize)]
+    #[allow(dead_code, reason = "borsh layout-faithful enum mirror")]
+    pub(super) enum StorageType {
+        Public,
+        User {
+            owner: [u8; 32],
+            signature_data: Option<SignatureData>,
+        },
+        Frozen,
+        Shared {
+            writers: std::collections::BTreeSet<[u8; 32]>,
+            signature_data: Option<SignatureData>,
+        },
+    }
+
+    #[derive(BorshDeserialize)]
+    #[allow(dead_code, reason = "fields required for borsh layout fidelity")]
+    pub(super) struct SignatureData {
+        pub(super) signature: [u8; 64],
+        pub(super) nonce: u64,
+        pub(super) signer: Option<[u8; 32]>,
+    }
 }
 
 impl ContextRegistry {
@@ -256,16 +332,26 @@ impl ContextRegistry {
     /// # Returns
     ///
     /// The computed root hash, or `[0; 32]` if no root index exists (empty state).
-    pub fn compute_root_hash(&self, context_id: &ContextId) -> eyre::Result<[u8; 32]> {
-        // Compute the state_key for Key::Index(Id::root())
-        // Id::root() = Id::new(context_id) in WASM context
-        // Key::Index(id).to_bytes() = SHA256([0] || id.as_bytes())
-        let root_id: [u8; 32] = **context_id;
+    /// State-key bytes for `Key::Index(Id::root())` of a context.
+    /// `Key::Index(id).to_bytes() = SHA256([0] || id.as_bytes())`.
+    fn index_state_key(context_id: &ContextId) -> [u8; 32] {
         let mut key_bytes = [0u8; 33];
         key_bytes[0] = 0; // Index discriminant
-        key_bytes[1..33].copy_from_slice(&root_id);
-        let state_key: [u8; 32] = Sha256::digest(key_bytes).into();
+        key_bytes[1..33].copy_from_slice(&**context_id);
+        Sha256::digest(key_bytes).into()
+    }
 
+    /// State-key bytes for `Key::Entry(Id::root())` of a context.
+    /// `Key::Entry(id).to_bytes() = SHA256([1] || id.as_bytes())`.
+    fn entry_state_key(context_id: &ContextId) -> [u8; 32] {
+        let mut key_bytes = [0u8; 33];
+        key_bytes[0] = 1; // Entry discriminant
+        key_bytes[1..33].copy_from_slice(&**context_id);
+        Sha256::digest(key_bytes).into()
+    }
+
+    pub fn compute_root_hash(&self, context_id: &ContextId) -> eyre::Result<[u8; 32]> {
+        let state_key = Self::index_state_key(context_id);
         let handle = self.datastore.handle();
         let db_key = key::ContextState::new(*context_id, state_key);
 
@@ -356,81 +442,17 @@ impl ContextRegistry {
 
     /// Helper to compute root hash using full borsh deserialization.
     ///
-    /// The minimal structs below MUST match the borsh layout of the real types in
-    /// `calimero-storage/src/entities.rs` and `calimero-storage/src/index.rs`.
-    /// We use `deserialize_reader` (not `try_from_slice`) so that trailing fields
-    /// after `full_hash` (own_hash, metadata, deleted_at) don't cause
-    /// "Not all bytes read" errors.
-    ///
-    /// **SYNC NOTE**: An identical copy of these minimal structs lives in
-    /// `calimero-storage/src/tests/index.rs` (`minimal_struct_layout_compat`).
-    /// When modifying the structs here, update the test copy too (and vice-versa).
+    /// Used when `parse_entity_index_root_hash`'s fast-path can't skip past
+    /// the `children` field (i.e. children present). Reuses the shared
+    /// [`borsh_layout::EntityIndex`] mirror so that any layout change
+    /// touches exactly one definition.
     fn compute_root_hash_via_borsh(
         &self,
         context_id: &ContextId,
         bytes: &[u8],
     ) -> eyre::Result<[u8; 32]> {
-        use calimero_primitives::crdt::CrdtType;
-
-        // EntityIndex: we only need fields through full_hash.
-        // Remaining fields (own_hash, metadata, deleted_at) are skipped by
-        // using deserialize_reader which doesn't require all bytes consumed.
-        #[derive(BorshDeserialize)]
-        struct EntityIndexMinimal {
-            _id: [u8; 32],
-            _parent_id: Option<[u8; 32]>,
-            _children: Option<Vec<ChildInfoMinimal>>,
-            full_hash: [u8; 32],
-        }
-
-        // Must match ChildInfo in calimero-storage/src/entities.rs
-        #[derive(BorshDeserialize)]
-        struct ChildInfoMinimal {
-            _id: [u8; 32],
-            _merkle_hash: [u8; 32],
-            _metadata: MetadataMinimal,
-        }
-
-        // Must match Metadata in calimero-storage/src/entities.rs
-        // Fields: created_at, updated_at, storage_type, crdt_type, field_name
-        #[derive(BorshDeserialize)]
-        struct MetadataMinimal {
-            _created_at: u64,
-            _updated_at: u64, // UpdatedAt is a newtype over u64
-            _storage_type: StorageTypeMinimal,
-            _crdt_type: Option<CrdtType>,
-            _field_name: Option<String>,
-        }
-
-        // Must match StorageType enum in calimero-storage/src/entities.rs
-        #[derive(BorshDeserialize)]
-        #[allow(
-            dead_code,
-            reason = "fields required for correct borsh layout deserialization"
-        )]
-        enum StorageTypeMinimal {
-            Public,
-            User {
-                owner: [u8; 32], // PublicKey = Hash = 32 bytes in borsh
-                signature_data: Option<SignatureDataMinimal>,
-            },
-            Frozen,
-            Shared {
-                writers: std::collections::BTreeSet<[u8; 32]>, // BTreeSet<PublicKey>
-                signature_data: Option<SignatureDataMinimal>,
-            },
-        }
-
-        // Must match SignatureData in calimero-storage/src/entities.rs
-        #[derive(BorshDeserialize)]
-        struct SignatureDataMinimal {
-            _signature: [u8; 64],
-            _nonce: u64,
-            _signer: Option<[u8; 32]>, // Option<PublicKey>
-        }
-
         let mut reader: &[u8] = bytes;
-        let index = EntityIndexMinimal::deserialize_reader(&mut reader)
+        let index = borsh_layout::EntityIndex::deserialize_reader(&mut reader)
             .map_err(|e| eyre::eyre!("Failed to deserialize EntityIndex: {}", e))?;
 
         let trailing = reader.len();
@@ -527,85 +549,40 @@ impl ContextRegistry {
         Ok(())
     }
 
-    /// Returns ROOT's children list for a context — diagnostic dump.
+    /// Reads ROOT's index entry + `Key::Entry(ROOT)` bytes in a single
+    /// pass and returns both the self-dump (own_hash/full_hash/entry
+    /// summary) and the children list — diagnostic for #2319.
     ///
-    /// Reads the EntityIndex for `Id::root()` from RocksDB and decodes
-    /// just the `children` slice (id + merkle_hash + key metadata
-    /// fields). Used by the hash-heartbeat handler when it detects
-    /// "Same DAG heads but different root hash" (#2319): logging this
-    /// dump from both peers lets us diff the child sets and pinpoint
-    /// the divergent subtree without re-running the failure.
+    /// Used by the hash-heartbeat handler when it observes "Same DAG
+    /// heads but different root hash". Logging this dump from both
+    /// peers lets a flake be triaged by diff: matching children +
+    /// mismatched `own_hash` → ROOT-entity write-path divergence;
+    /// mismatched children → subtree divergence at the listed entity.
     ///
-    /// Returns an empty Vec if ROOT has no index entry (empty state).
-    pub fn dump_root_children(&self, context_id: &ContextId) -> eyre::Result<Vec<RootChildDump>> {
-        use calimero_primitives::crdt::CrdtType;
-
-        let root_id: [u8; 32] = **context_id;
-        let mut key_bytes = [0u8; 33];
-        key_bytes[0] = 0;
-        key_bytes[1..33].copy_from_slice(&root_id);
-        let state_key: [u8; 32] = Sha256::digest(key_bytes).into();
-
+    /// One RocksDB read per key (Index + Entry), one borsh
+    /// deserialize. Returns `Ok(None)` if ROOT has no index entry
+    /// (empty state); `entry_bytes_hash` is `None` if the Index entry
+    /// exists but Key::Entry(ROOT) is absent.
+    pub fn dump_root(
+        &self,
+        context_id: &ContextId,
+    ) -> eyre::Result<Option<(RootSelfDump, Vec<RootChildDump>)>> {
+        let idx_state_key = Self::index_state_key(context_id);
         let handle = self.datastore.handle();
-        let db_key = key::ContextState::new(*context_id, state_key);
-        let Some(data) = handle.get(&db_key)? else {
-            return Ok(Vec::new());
+        let idx_db_key = key::ContextState::new(*context_id, idx_state_key);
+        let Some(idx_data) = handle.get(&idx_db_key)? else {
+            return Ok(None);
         };
-        let bytes: Vec<u8> = data.as_ref().to_vec();
-        drop(data);
+        let idx_bytes: Vec<u8> = idx_data.as_ref().to_vec();
+        drop(idx_data);
 
-        // Minimal-layout structs mirroring `calimero_storage::index::EntityIndex`
-        // + `entities::ChildInfo`/`Metadata`/`StorageType`/`SignatureData`. Same
-        // layout-compat caveat as `compute_root_hash_via_borsh` above —
-        // touched when those structs change.
-        #[derive(BorshDeserialize)]
-        struct EntityIndexDump {
-            _id: [u8; 32],
-            _parent_id: Option<[u8; 32]>,
-            children: Option<Vec<ChildInfoDump>>,
-        }
-        #[derive(BorshDeserialize)]
-        struct ChildInfoDump {
-            id: [u8; 32],
-            merkle_hash: [u8; 32],
-            metadata: MetadataDump,
-        }
-        #[derive(BorshDeserialize)]
-        struct MetadataDump {
-            created_at: u64,
-            updated_at: u64,
-            _storage_type: StorageTypeDump,
-            crdt_type: Option<CrdtType>,
-            field_name: Option<String>,
-        }
-        #[derive(BorshDeserialize)]
-        #[allow(dead_code, reason = "borsh layout-faithful")]
-        enum StorageTypeDump {
-            Public,
-            User {
-                owner: [u8; 32],
-                signature_data: Option<SignatureDataDump>,
-            },
-            Frozen,
-            Shared {
-                writers: std::collections::BTreeSet<[u8; 32]>,
-                signature_data: Option<SignatureDataDump>,
-            },
-        }
-        #[derive(BorshDeserialize)]
-        struct SignatureDataDump {
-            _signature: [u8; 64],
-            _nonce: u64,
-            _signer: Option<[u8; 32]>,
-        }
+        let mut reader: &[u8] = &idx_bytes;
+        let index = borsh_layout::EntityIndex::deserialize_reader(&mut reader)
+            .map_err(|e| eyre::eyre!("dump_root: EntityIndex deserialize failed: {e}"))?;
 
-        let mut reader: &[u8] = &bytes;
-        let index = EntityIndexDump::deserialize_reader(&mut reader).map_err(|e| {
-            eyre::eyre!("dump_root_children: failed to deserialize EntityIndex: {e}")
-        })?;
-
-        let children = index.children.unwrap_or_default();
-        Ok(children
+        let children: Vec<RootChildDump> = index
+            .children
+            .unwrap_or_default()
             .into_iter()
             .map(|c| RootChildDump {
                 id: c.id,
@@ -615,111 +592,29 @@ impl ContextRegistry {
                 crdt_type: c.metadata.crdt_type,
                 field_name: c.metadata.field_name,
             })
-            .collect())
-    }
+            .collect();
 
-    /// Diagnostic — read ROOT's own index entry + `Key::Entry(ROOT)` bytes.
-    /// Used alongside [`Self::dump_root_children`] when the heartbeat
-    /// detects #2319 divergence: identical children + different
-    /// `full_hash` implies `own_hash` divergence, and same `own_hash`
-    /// implies a `children`-vec ordering or count drift the row-by-row
-    /// dump didn't catch (e.g. extra/missing child collapsed under the
-    /// same id by a borsh-deserialization quirk).
-    pub fn dump_root_self(&self, context_id: &ContextId) -> eyre::Result<Option<RootSelfDump>> {
-        let root_id: [u8; 32] = **context_id;
-        let mut idx_key_bytes = [0u8; 33];
-        idx_key_bytes[0] = 0; // Index discriminant
-        idx_key_bytes[1..33].copy_from_slice(&root_id);
-        let idx_state_key: [u8; 32] = Sha256::digest(idx_key_bytes).into();
-
-        let handle = self.datastore.handle();
-        let idx_db_key = key::ContextState::new(*context_id, idx_state_key);
-        let Some(idx_bytes_owned) = handle.get(&idx_db_key)? else {
-            return Ok(None);
-        };
-        let idx_bytes: Vec<u8> = idx_bytes_owned.as_ref().to_vec();
-        drop(idx_bytes_owned);
-
-        // Minimal-layout struct: id + parent_id + children + full_hash +
-        // own_hash. Mirrors the existing minimal-layout structs above
-        // (`compute_root_hash_via_borsh`, `dump_root_children`). Same
-        // layout-compat contract — touched together with EntityIndex.
-        #[derive(BorshDeserialize)]
-        struct EntityIndexSelf {
-            _id: [u8; 32],
-            _parent_id: Option<[u8; 32]>,
-            children: Option<Vec<ChildInfoMin>>,
-            full_hash: [u8; 32],
-            own_hash: [u8; 32],
-        }
-        #[derive(BorshDeserialize)]
-        struct ChildInfoMin {
-            _id: [u8; 32],
-            _merkle_hash: [u8; 32],
-            // We only need `children.len()` here, not the metadata.
-            // Read just enough bytes via #[borsh(skip)] equivalence:
-            // borsh has no `skip` on deserialize so we must mirror the
-            // full layout. Reuse the same minimal types as `dump_root_children`
-            // by inlining tiny copies — keeps the change self-contained.
-            _metadata: MetadataMin,
-        }
-        #[derive(BorshDeserialize)]
-        struct MetadataMin {
-            _created_at: u64,
-            _updated_at: u64,
-            _storage_type: StorageTypeMin,
-            _crdt_type: Option<calimero_primitives::crdt::CrdtType>,
-            _field_name: Option<String>,
-        }
-        #[derive(BorshDeserialize)]
-        #[allow(dead_code, reason = "borsh layout-faithful")]
-        enum StorageTypeMin {
-            Public,
-            User {
-                owner: [u8; 32],
-                signature_data: Option<SigMin>,
-            },
-            Frozen,
-            Shared {
-                writers: std::collections::BTreeSet<[u8; 32]>,
-                signature_data: Option<SigMin>,
-            },
-        }
-        #[derive(BorshDeserialize)]
-        struct SigMin {
-            _signature: [u8; 64],
-            _nonce: u64,
-            _signer: Option<[u8; 32]>,
-        }
-
-        let mut reader: &[u8] = &idx_bytes;
-        let index = EntityIndexSelf::deserialize_reader(&mut reader)
-            .map_err(|e| eyre::eyre!("dump_root_self: index deserialize failed: {e}"))?;
-        let children_count = index.children.as_ref().map_or(0, Vec::len);
-
-        // Now read `Key::Entry(ROOT)` if it exists.
-        let mut entry_key_bytes = [0u8; 33];
-        entry_key_bytes[0] = 1; // Entry discriminant
-        entry_key_bytes[1..33].copy_from_slice(&root_id);
-        let entry_state_key: [u8; 32] = Sha256::digest(entry_key_bytes).into();
+        let entry_state_key = Self::entry_state_key(context_id);
         let entry_db_key = key::ContextState::new(*context_id, entry_state_key);
         let (entry_bytes_hash, entry_bytes_len) = match handle.get(&entry_db_key)? {
-            Some(entry_owned) => {
-                let entry_bytes: Vec<u8> = entry_owned.as_ref().to_vec();
-                drop(entry_owned);
+            Some(entry_data) => {
+                let entry_bytes: Vec<u8> = entry_data.as_ref().to_vec();
+                drop(entry_data);
                 let h: [u8; 32] = Sha256::digest(&entry_bytes).into();
                 (Some(h), entry_bytes.len())
             }
             None => (None, 0),
         };
 
-        Ok(Some(RootSelfDump {
+        let self_dump = RootSelfDump {
             own_hash: index.own_hash,
             full_hash: index.full_hash,
             entry_bytes_hash,
             entry_bytes_len,
-            children_count,
-        }))
+            children_count: children.len(),
+        };
+
+        Ok(Some((self_dump, children)))
     }
 
     /// Returns a stream of all context IDs stored locally.
@@ -1145,16 +1040,13 @@ impl ContextClient {
         self.registry.verify_root_hash(context_id, claimed_hash)
     }
 
-    /// Diagnostic — dump ROOT's children list for a context. See
-    /// [`ContextRegistry::dump_root_children`] for the rationale.
-    pub fn dump_root_children(&self, context_id: &ContextId) -> eyre::Result<Vec<RootChildDump>> {
-        self.registry.dump_root_children(context_id)
-    }
-
-    /// Diagnostic — dump ROOT's own_hash + full_hash + Key::Entry hash.
-    /// See [`ContextRegistry::dump_root_self`].
-    pub fn dump_root_self(&self, context_id: &ContextId) -> eyre::Result<Option<RootSelfDump>> {
-        self.registry.dump_root_self(context_id)
+    /// Diagnostic — dump ROOT's self summary + children list in one read.
+    /// See [`ContextRegistry::dump_root`].
+    pub fn dump_root(
+        &self,
+        context_id: &ContextId,
+    ) -> eyre::Result<Option<(RootSelfDump, Vec<RootChildDump>)>> {
+        self.registry.dump_root(context_id)
     }
 
     /// Returns a stream of all context IDs stored locally.

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -67,6 +67,22 @@ pub struct ContextRegistry {
     datastore: Store,
 }
 
+/// One row of [`ContextRegistry::dump_root_children`] — a child entry in
+/// the context root's Merkle index. Exported for the divergence
+/// diagnostic in `handle_hash_heartbeat` (#2319): a flake of "same DAG
+/// heads, different root hash" can be triaged by diffing the two peers'
+/// dumps to find the divergent child. Field names are stable for
+/// `tracing` consumption (json output keys).
+#[derive(Debug, Clone)]
+pub struct RootChildDump {
+    pub id: [u8; 32],
+    pub merkle_hash: [u8; 32],
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub crdt_type: Option<calimero_primitives::crdt::CrdtType>,
+    pub field_name: Option<String>,
+}
+
 impl ContextRegistry {
     #[must_use]
     pub const fn new(datastore: Store) -> Self {
@@ -497,6 +513,99 @@ impl ContextRegistry {
         Ok(())
     }
 
+    /// Returns ROOT's children list for a context — diagnostic dump.
+    ///
+    /// Reads the EntityIndex for `Id::root()` from RocksDB and decodes
+    /// just the `children` slice (id + merkle_hash + key metadata
+    /// fields). Used by the hash-heartbeat handler when it detects
+    /// "Same DAG heads but different root hash" (#2319): logging this
+    /// dump from both peers lets us diff the child sets and pinpoint
+    /// the divergent subtree without re-running the failure.
+    ///
+    /// Returns an empty Vec if ROOT has no index entry (empty state).
+    pub fn dump_root_children(
+        &self,
+        context_id: &ContextId,
+    ) -> eyre::Result<Vec<RootChildDump>> {
+        use calimero_primitives::crdt::CrdtType;
+
+        let root_id: [u8; 32] = **context_id;
+        let mut key_bytes = [0u8; 33];
+        key_bytes[0] = 0;
+        key_bytes[1..33].copy_from_slice(&root_id);
+        let state_key: [u8; 32] = Sha256::digest(key_bytes).into();
+
+        let handle = self.datastore.handle();
+        let db_key = key::ContextState::new(*context_id, state_key);
+        let Some(data) = handle.get(&db_key)? else {
+            return Ok(Vec::new());
+        };
+        let bytes: Vec<u8> = data.as_ref().to_vec();
+        drop(data);
+
+        // Minimal-layout structs mirroring `calimero_storage::index::EntityIndex`
+        // + `entities::ChildInfo`/`Metadata`/`StorageType`/`SignatureData`. Same
+        // layout-compat caveat as `compute_root_hash_via_borsh` above —
+        // touched when those structs change.
+        #[derive(BorshDeserialize)]
+        struct EntityIndexDump {
+            _id: [u8; 32],
+            _parent_id: Option<[u8; 32]>,
+            children: Option<Vec<ChildInfoDump>>,
+        }
+        #[derive(BorshDeserialize)]
+        struct ChildInfoDump {
+            id: [u8; 32],
+            merkle_hash: [u8; 32],
+            metadata: MetadataDump,
+        }
+        #[derive(BorshDeserialize)]
+        struct MetadataDump {
+            created_at: u64,
+            updated_at: u64,
+            _storage_type: StorageTypeDump,
+            crdt_type: Option<CrdtType>,
+            field_name: Option<String>,
+        }
+        #[derive(BorshDeserialize)]
+        #[allow(dead_code, reason = "borsh layout-faithful")]
+        enum StorageTypeDump {
+            Public,
+            User {
+                owner: [u8; 32],
+                signature_data: Option<SignatureDataDump>,
+            },
+            Frozen,
+            Shared {
+                writers: std::collections::BTreeSet<[u8; 32]>,
+                signature_data: Option<SignatureDataDump>,
+            },
+        }
+        #[derive(BorshDeserialize)]
+        struct SignatureDataDump {
+            _signature: [u8; 64],
+            _nonce: u64,
+            _signer: Option<[u8; 32]>,
+        }
+
+        let mut reader: &[u8] = &bytes;
+        let index = EntityIndexDump::deserialize_reader(&mut reader)
+            .map_err(|e| eyre::eyre!("dump_root_children: failed to deserialize EntityIndex: {e}"))?;
+
+        let children = index.children.unwrap_or_default();
+        Ok(children
+            .into_iter()
+            .map(|c| RootChildDump {
+                id: c.id,
+                merkle_hash: c.merkle_hash,
+                created_at: c.metadata.created_at,
+                updated_at: c.metadata.updated_at,
+                crdt_type: c.metadata.crdt_type,
+                field_name: c.metadata.field_name,
+            })
+            .collect())
+    }
+
     /// Returns a stream of all context IDs stored locally.
     ///
     /// # Arguments
@@ -918,6 +1027,15 @@ impl ContextClient {
         claimed_hash: [u8; 32],
     ) -> eyre::Result<()> {
         self.registry.verify_root_hash(context_id, claimed_hash)
+    }
+
+    /// Diagnostic — dump ROOT's children list for a context. See
+    /// [`ContextRegistry::dump_root_children`] for the rationale.
+    pub fn dump_root_children(
+        &self,
+        context_id: &ContextId,
+    ) -> eyre::Result<Vec<RootChildDump>> {
+        self.registry.dump_root_children(context_id)
     }
 
     /// Returns a stream of all context IDs stored locally.

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -523,10 +523,7 @@ impl ContextRegistry {
     /// the divergent subtree without re-running the failure.
     ///
     /// Returns an empty Vec if ROOT has no index entry (empty state).
-    pub fn dump_root_children(
-        &self,
-        context_id: &ContextId,
-    ) -> eyre::Result<Vec<RootChildDump>> {
+    pub fn dump_root_children(&self, context_id: &ContextId) -> eyre::Result<Vec<RootChildDump>> {
         use calimero_primitives::crdt::CrdtType;
 
         let root_id: [u8; 32] = **context_id;
@@ -589,8 +586,9 @@ impl ContextRegistry {
         }
 
         let mut reader: &[u8] = &bytes;
-        let index = EntityIndexDump::deserialize_reader(&mut reader)
-            .map_err(|e| eyre::eyre!("dump_root_children: failed to deserialize EntityIndex: {e}"))?;
+        let index = EntityIndexDump::deserialize_reader(&mut reader).map_err(|e| {
+            eyre::eyre!("dump_root_children: failed to deserialize EntityIndex: {e}")
+        })?;
 
         let children = index.children.unwrap_or_default();
         Ok(children
@@ -1031,10 +1029,7 @@ impl ContextClient {
 
     /// Diagnostic — dump ROOT's children list for a context. See
     /// [`ContextRegistry::dump_root_children`] for the rationale.
-    pub fn dump_root_children(
-        &self,
-        context_id: &ContextId,
-    ) -> eyre::Result<Vec<RootChildDump>> {
+    pub fn dump_root_children(&self, context_id: &ContextId) -> eyre::Result<Vec<RootChildDump>> {
         self.registry.dump_root_children(context_id)
     }
 

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -83,6 +83,20 @@ pub struct RootChildDump {
     pub field_name: Option<String>,
 }
 
+/// Companion to [`RootChildDump`] — captures ROOT's own_hash + full_hash
+/// + Key::Entry(ROOT) bytes hash. Lets a #2319 diff distinguish
+/// "children diverge" from "ROOT.own_hash diverges with identical
+/// children" (the latter pattern surfaced on PR #2472 attempt 1).
+#[derive(Debug, Clone)]
+pub struct RootSelfDump {
+    pub own_hash: [u8; 32],
+    pub full_hash: [u8; 32],
+    /// Sha256 of `Key::Entry(ROOT)` if it exists. `None` if no entry.
+    pub entry_bytes_hash: Option<[u8; 32]>,
+    pub entry_bytes_len: usize,
+    pub children_count: usize,
+}
+
 impl ContextRegistry {
     #[must_use]
     pub const fn new(datastore: Store) -> Self {
@@ -604,6 +618,110 @@ impl ContextRegistry {
             .collect())
     }
 
+    /// Diagnostic — read ROOT's own index entry + `Key::Entry(ROOT)` bytes.
+    /// Used alongside [`Self::dump_root_children`] when the heartbeat
+    /// detects #2319 divergence: identical children + different
+    /// `full_hash` implies `own_hash` divergence, and same `own_hash`
+    /// implies a `children`-vec ordering or count drift the row-by-row
+    /// dump didn't catch (e.g. extra/missing child collapsed under the
+    /// same id by a borsh-deserialization quirk).
+    pub fn dump_root_self(&self, context_id: &ContextId) -> eyre::Result<Option<RootSelfDump>> {
+        let root_id: [u8; 32] = **context_id;
+        let mut idx_key_bytes = [0u8; 33];
+        idx_key_bytes[0] = 0; // Index discriminant
+        idx_key_bytes[1..33].copy_from_slice(&root_id);
+        let idx_state_key: [u8; 32] = Sha256::digest(idx_key_bytes).into();
+
+        let handle = self.datastore.handle();
+        let idx_db_key = key::ContextState::new(*context_id, idx_state_key);
+        let Some(idx_bytes_owned) = handle.get(&idx_db_key)? else {
+            return Ok(None);
+        };
+        let idx_bytes: Vec<u8> = idx_bytes_owned.as_ref().to_vec();
+        drop(idx_bytes_owned);
+
+        // Minimal-layout struct: id + parent_id + children + full_hash +
+        // own_hash. Mirrors the existing minimal-layout structs above
+        // (`compute_root_hash_via_borsh`, `dump_root_children`). Same
+        // layout-compat contract — touched together with EntityIndex.
+        #[derive(BorshDeserialize)]
+        struct EntityIndexSelf {
+            _id: [u8; 32],
+            _parent_id: Option<[u8; 32]>,
+            children: Option<Vec<ChildInfoMin>>,
+            full_hash: [u8; 32],
+            own_hash: [u8; 32],
+        }
+        #[derive(BorshDeserialize)]
+        struct ChildInfoMin {
+            _id: [u8; 32],
+            _merkle_hash: [u8; 32],
+            // We only need `children.len()` here, not the metadata.
+            // Read just enough bytes via #[borsh(skip)] equivalence:
+            // borsh has no `skip` on deserialize so we must mirror the
+            // full layout. Reuse the same minimal types as `dump_root_children`
+            // by inlining tiny copies — keeps the change self-contained.
+            _metadata: MetadataMin,
+        }
+        #[derive(BorshDeserialize)]
+        struct MetadataMin {
+            _created_at: u64,
+            _updated_at: u64,
+            _storage_type: StorageTypeMin,
+            _crdt_type: Option<calimero_primitives::crdt::CrdtType>,
+            _field_name: Option<String>,
+        }
+        #[derive(BorshDeserialize)]
+        #[allow(dead_code, reason = "borsh layout-faithful")]
+        enum StorageTypeMin {
+            Public,
+            User {
+                owner: [u8; 32],
+                signature_data: Option<SigMin>,
+            },
+            Frozen,
+            Shared {
+                writers: std::collections::BTreeSet<[u8; 32]>,
+                signature_data: Option<SigMin>,
+            },
+        }
+        #[derive(BorshDeserialize)]
+        struct SigMin {
+            _signature: [u8; 64],
+            _nonce: u64,
+            _signer: Option<[u8; 32]>,
+        }
+
+        let mut reader: &[u8] = &idx_bytes;
+        let index = EntityIndexSelf::deserialize_reader(&mut reader)
+            .map_err(|e| eyre::eyre!("dump_root_self: index deserialize failed: {e}"))?;
+        let children_count = index.children.as_ref().map_or(0, Vec::len);
+
+        // Now read `Key::Entry(ROOT)` if it exists.
+        let mut entry_key_bytes = [0u8; 33];
+        entry_key_bytes[0] = 1; // Entry discriminant
+        entry_key_bytes[1..33].copy_from_slice(&root_id);
+        let entry_state_key: [u8; 32] = Sha256::digest(entry_key_bytes).into();
+        let entry_db_key = key::ContextState::new(*context_id, entry_state_key);
+        let (entry_bytes_hash, entry_bytes_len) = match handle.get(&entry_db_key)? {
+            Some(entry_owned) => {
+                let entry_bytes: Vec<u8> = entry_owned.as_ref().to_vec();
+                drop(entry_owned);
+                let h: [u8; 32] = Sha256::digest(&entry_bytes).into();
+                (Some(h), entry_bytes.len())
+            }
+            None => (None, 0),
+        };
+
+        Ok(Some(RootSelfDump {
+            own_hash: index.own_hash,
+            full_hash: index.full_hash,
+            entry_bytes_hash,
+            entry_bytes_len,
+            children_count,
+        }))
+    }
+
     /// Returns a stream of all context IDs stored locally.
     ///
     /// # Arguments
@@ -1031,6 +1149,12 @@ impl ContextClient {
     /// [`ContextRegistry::dump_root_children`] for the rationale.
     pub fn dump_root_children(&self, context_id: &ContextId) -> eyre::Result<Vec<RootChildDump>> {
         self.registry.dump_root_children(context_id)
+    }
+
+    /// Diagnostic — dump ROOT's own_hash + full_hash + Key::Entry hash.
+    /// See [`ContextRegistry::dump_root_self`].
+    pub fn dump_root_self(&self, context_id: &ContextId) -> eyre::Result<Option<RootSelfDump>> {
+        self.registry.dump_root_self(context_id)
     }
 
     /// Returns a stream of all context IDs stored locally.

--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -6,6 +6,13 @@ use tracing::{debug, error, info, warn};
 
 use crate::NodeManager;
 
+/// Cap on per-child `warn!` events emitted from the divergence dump.
+/// A wide context (e.g. UnorderedMap with hundreds of entries) could
+/// otherwise produce a log burst that overwhelms aggregation
+/// pipelines on every divergence tick. The summary row below the
+/// loop reports the full count regardless.
+const MAX_DUMP_CHILDREN: usize = 64;
+
 pub(super) fn handle_hash_heartbeat(
     manager: &mut NodeManager,
     ctx: &mut actix::Context<NodeManager>,
@@ -37,7 +44,7 @@ pub(super) fn handle_hash_heartbeat(
             // either the peer's hash or our prior cache, refresh the
             // cache and skip the false-positive divergence event; only
             // a *post-refresh* hash mismatch is a real divergence.
-            match context_client.compute_root_hash(&context_id) {
+            let our_hash = match context_client.compute_root_hash(&context_id) {
                 Ok(live) => {
                     let live_hash = calimero_primitives::hash::Hash::from(live);
                     if live_hash != our_context.root_hash {
@@ -48,12 +55,23 @@ pub(super) fn handle_hash_heartbeat(
                             live_hash = ?live_hash,
                             "Heartbeat divergence: cache stale vs live index, refreshing"
                         );
-                        let _ignored = context_client.force_root_hash(&context_id, live_hash);
+                        if let Err(err) = context_client.force_root_hash(&context_id, live_hash) {
+                            debug!(
+                                %context_id,
+                                ?source,
+                                %err,
+                                "Heartbeat divergence: failed to refresh cached root hash"
+                            );
+                        }
                         if live_hash == their_root_hash {
                             return;
                         }
-                        // Continue with live hash as the comparison value.
                     }
+                    // Use live_hash as the authoritative "our hash" — the
+                    // cached value may be stale (and the refresh above
+                    // may itself have failed); the live index is the
+                    // truth we want in the divergence log for triage.
+                    live_hash
                 }
                 Err(err) => {
                     debug!(
@@ -62,8 +80,9 @@ pub(super) fn handle_hash_heartbeat(
                         %err,
                         "Heartbeat divergence: failed to read live root hash; using cache"
                     );
+                    our_context.root_hash
                 }
-            }
+            };
 
             // #2319: surface divergence as a metric (`sync_root_hash_divergence_detected_total`)
             // so vmagent can alert on the rate without grepping logs —
@@ -72,26 +91,26 @@ pub(super) fn handle_hash_heartbeat(
             error!(
                 %context_id,
                 ?source,
-                our_hash = ?our_context.root_hash,
+                our_hash = ?our_hash,
                 their_hash = ?their_root_hash,
                 dag_heads = ?their_dag_heads,
                 "DIVERGENCE DETECTED: Same DAG heads but different root hash!"
             );
-            // #2319 triage aid — dump ROOT's children list so a future
-            // flake can be triaged by diffing the two peers' dumps to
-            // pinpoint the divergent subtree. Without this, the only
-            // observable signal is the two opaque root hashes and the
-            // remaining investigation requires re-running with more
-            // logging. Keep the dump rate-bounded by the heartbeat
-            // cadence (one DIVERGENCE event per peer per heartbeat).
+            // #2319 triage aid — dump ROOT's self summary + children
+            // list so a future flake can be triaged by diffing the two
+            // peers' dumps. Without this, the only observable signal
+            // is the two opaque root hashes and the remaining
+            // investigation requires re-running with more logging.
+            // Bounded by the heartbeat cadence (one DIVERGENCE event
+            // per peer per heartbeat) and by MAX_DUMP_CHILDREN.
             //
-            // Dump ROOT's own_hash/full_hash first so the diff order
-            // matches the analysis flow: identical children + different
-            // own_hash points at ROOT-entity write-path divergence
-            // (the pattern we saw on PR #2472 attempt 1, all 20
-            // children matched).
-            match context_client.dump_root_self(&context_id) {
-                Ok(Some(self_dump)) => {
+            // Self summary is logged before children so the diff order
+            // matches the analysis flow: identical children +
+            // different own_hash points at ROOT-entity write-path
+            // divergence (the pattern we saw on PR #2472 attempt 1,
+            // all 20 children matched).
+            match context_client.dump_root(&context_id) {
+                Ok(Some((self_dump, children))) => {
                     warn!(
                         target: "sync::divergence_dump",
                         %context_id,
@@ -103,32 +122,12 @@ pub(super) fn handle_hash_heartbeat(
                         children_count = self_dump.children_count,
                         "DIVERGENCE DUMP: ROOT self"
                     );
-                }
-                Ok(None) => {
-                    warn!(
-                        target: "sync::divergence_dump",
-                        %context_id,
-                        ?source,
-                        "DIVERGENCE DUMP: ROOT self — no index entry"
-                    );
-                }
-                Err(e) => {
-                    warn!(
-                        target: "sync::divergence_dump",
-                        %context_id,
-                        ?source,
-                        error = %e,
-                        "DIVERGENCE DUMP: failed to read ROOT self"
-                    );
-                }
-            }
-            match context_client.dump_root_children(&context_id) {
-                Ok(children) => {
+                    let child_count = children.len();
                     // Emit one event per child so log search/filter
-                    // tools can group by `entity_id`. The whole list
-                    // could also be emitted as `?children` but
-                    // structured single-row events grep + diff better.
-                    for c in &children {
+                    // tools can group by `entity_id`. Cap the per-child
+                    // emission at MAX_DUMP_CHILDREN — the summary row
+                    // below reports the full count regardless.
+                    for c in children.iter().take(MAX_DUMP_CHILDREN) {
                         warn!(
                             target: "sync::divergence_dump",
                             %context_id,
@@ -142,12 +141,30 @@ pub(super) fn handle_hash_heartbeat(
                             "DIVERGENCE DUMP: ROOT child entry"
                         );
                     }
+                    if child_count > MAX_DUMP_CHILDREN {
+                        warn!(
+                            target: "sync::divergence_dump",
+                            %context_id,
+                            ?source,
+                            emitted = MAX_DUMP_CHILDREN,
+                            total = child_count,
+                            "DIVERGENCE DUMP: ROOT children truncated"
+                        );
+                    }
                     warn!(
                         target: "sync::divergence_dump",
                         %context_id,
                         ?source,
-                        child_count = children.len(),
+                        child_count,
                         "DIVERGENCE DUMP: ROOT children list emitted"
+                    );
+                }
+                Ok(None) => {
+                    warn!(
+                        target: "sync::divergence_dump",
+                        %context_id,
+                        ?source,
+                        "DIVERGENCE DUMP: ROOT — no index entry"
                     );
                 }
                 Err(e) => {
@@ -156,7 +173,7 @@ pub(super) fn handle_hash_heartbeat(
                         %context_id,
                         ?source,
                         error = %e,
-                        "DIVERGENCE DUMP: failed to read ROOT children list"
+                        "DIVERGENCE DUMP: failed to read ROOT"
                     );
                 }
             }

--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -40,6 +40,44 @@ pub(super) fn handle_hash_heartbeat(
             // remaining investigation requires re-running with more
             // logging. Keep the dump rate-bounded by the heartbeat
             // cadence (one DIVERGENCE event per peer per heartbeat).
+            //
+            // Dump ROOT's own_hash/full_hash first so the diff order
+            // matches the analysis flow: identical children + different
+            // own_hash points at ROOT-entity write-path divergence
+            // (the pattern we saw on PR #2472 attempt 1, all 20
+            // children matched).
+            match context_client.dump_root_self(&context_id) {
+                Ok(Some(self_dump)) => {
+                    warn!(
+                        target: "sync::divergence_dump",
+                        %context_id,
+                        ?source,
+                        root_own_hash = %hex::encode(self_dump.own_hash),
+                        root_full_hash = %hex::encode(self_dump.full_hash),
+                        root_entry_bytes_hash = ?self_dump.entry_bytes_hash.map(hex::encode),
+                        root_entry_bytes_len = self_dump.entry_bytes_len,
+                        children_count = self_dump.children_count,
+                        "DIVERGENCE DUMP: ROOT self"
+                    );
+                }
+                Ok(None) => {
+                    warn!(
+                        target: "sync::divergence_dump",
+                        %context_id,
+                        ?source,
+                        "DIVERGENCE DUMP: ROOT self — no index entry"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        target: "sync::divergence_dump",
+                        %context_id,
+                        ?source,
+                        error = %e,
+                        "DIVERGENCE DUMP: failed to read ROOT self"
+                    );
+                }
+            }
             match context_client.dump_root_children(&context_id) {
                 Ok(children) => {
                     // Emit one event per child so log search/filter

--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -33,6 +33,51 @@ pub(super) fn handle_hash_heartbeat(
                 dag_heads = ?their_dag_heads,
                 "DIVERGENCE DETECTED: Same DAG heads but different root hash!"
             );
+            // #2319 triage aid — dump ROOT's children list so a future
+            // flake can be triaged by diffing the two peers' dumps to
+            // pinpoint the divergent subtree. Without this, the only
+            // observable signal is the two opaque root hashes and the
+            // remaining investigation requires re-running with more
+            // logging. Keep the dump rate-bounded by the heartbeat
+            // cadence (one DIVERGENCE event per peer per heartbeat).
+            match context_client.dump_root_children(&context_id) {
+                Ok(children) => {
+                    // Emit one event per child so log search/filter
+                    // tools can group by `entity_id`. The whole list
+                    // could also be emitted as `?children` but
+                    // structured single-row events grep + diff better.
+                    for c in &children {
+                        warn!(
+                            target: "sync::divergence_dump",
+                            %context_id,
+                            ?source,
+                            entity_id = %hex::encode(c.id),
+                            merkle_hash = %hex::encode(c.merkle_hash),
+                            created_at = c.created_at,
+                            updated_at = c.updated_at,
+                            crdt_type = ?c.crdt_type,
+                            field_name = ?c.field_name,
+                            "DIVERGENCE DUMP: ROOT child entry"
+                        );
+                    }
+                    warn!(
+                        target: "sync::divergence_dump",
+                        %context_id,
+                        ?source,
+                        child_count = children.len(),
+                        "DIVERGENCE DUMP: ROOT children list emitted"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        target: "sync::divergence_dump",
+                        %context_id,
+                        ?source,
+                        error = %e,
+                        "DIVERGENCE DUMP: failed to read ROOT children list"
+                    );
+                }
+            }
             warn!(
                 %context_id,
                 ?source,

--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -21,6 +21,50 @@ pub(super) fn handle_hash_heartbeat(
         let their_heads_set: HashSet<_> = their_dag_heads.iter().collect();
 
         if our_heads_set == their_heads_set && our_context.root_hash != their_root_hash {
+            // #2319 — before reporting a real divergence, reconcile the
+            // cached `ContextMeta.root_hash` with the live index. The
+            // cache is populated from the WASM-returned root_hash at the
+            // end of each method execution; a concurrent sync apply
+            // (HashComparison `EntityPush`, level-sync leaf push, etc.)
+            // can advance the actual index right after WASM returns but
+            // before the cache is written, leaving the cache pointing
+            // at a pre-recalc full_hash while the index has already
+            // moved on. The two nodes still converge in storage, but
+            // the heartbeat sees the stale caches and fires
+            // DIVERGENCE.
+            //
+            // Re-read the live full_hash from the index. If it matches
+            // either the peer's hash or our prior cache, refresh the
+            // cache and skip the false-positive divergence event; only
+            // a *post-refresh* hash mismatch is a real divergence.
+            match context_client.compute_root_hash(&context_id) {
+                Ok(live) => {
+                    let live_hash = calimero_primitives::hash::Hash::from(live);
+                    if live_hash != our_context.root_hash {
+                        debug!(
+                            %context_id,
+                            ?source,
+                            cached_hash = ?our_context.root_hash,
+                            live_hash = ?live_hash,
+                            "Heartbeat divergence: cache stale vs live index, refreshing"
+                        );
+                        let _ignored = context_client.force_root_hash(&context_id, live_hash);
+                        if live_hash == their_root_hash {
+                            return;
+                        }
+                        // Continue with live hash as the comparison value.
+                    }
+                }
+                Err(err) => {
+                    debug!(
+                        %context_id,
+                        ?source,
+                        %err,
+                        "Heartbeat divergence: failed to read live root hash; using cache"
+                    );
+                }
+            }
+
             // #2319: surface divergence as a metric (`sync_root_hash_divergence_detected_total`)
             // so vmagent can alert on the rate without grepping logs —
             // with the determinism fixes this should stay near zero.

--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -44,6 +44,16 @@ pub(super) fn handle_hash_heartbeat(
             // either the peer's hash or our prior cache, refresh the
             // cache and skip the false-positive divergence event; only
             // a *post-refresh* hash mismatch is a real divergence.
+            //
+            // Residual TOCTOU: a concurrent apply landing between
+            // `compute_root_hash` and `force_root_hash` can leave the
+            // cache transiently stale again. This doesn't eliminate
+            // the false-positive class — it narrows the window from
+            // "until the next WASM execution" to "until the next
+            // heartbeat tick" (also when the next ContextMeta write
+            // happens). The next heartbeat self-heals via this same
+            // branch, so we accept the residual window rather than
+            // double-reading.
             let our_hash = match context_client.compute_root_hash(&context_id) {
                 Ok(live) => {
                     let live_hash = calimero_primitives::hash::Hash::from(live);

--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -56,7 +56,14 @@ pub(super) fn handle_hash_heartbeat(
                             "Heartbeat divergence: cache stale vs live index, refreshing"
                         );
                         if let Err(err) = context_client.force_root_hash(&context_id, live_hash) {
-                            debug!(
+                            // `warn`, not `debug`: a single failure here
+                            // is usually a benign concurrent context
+                            // delete, but a *persistent* failure leaves
+                            // the cache stale and produces a stream of
+                            // false-positive DIVERGENCE events on every
+                            // heartbeat. Surface it where ops can see it
+                            // without log filtering.
+                            warn!(
                                 %context_id,
                                 ?source,
                                 %err,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1235,12 +1235,43 @@ impl<S: StorageAdaptor> Interface<S> {
                     <Index<S>>::add_child_to(parent.id(), this.clone())?;
                 }
 
-                // For new entities, create a minimal index entry first to avoid orphan errors
+                // For new entities, create a minimal index entry first to avoid orphan errors.
+                //
+                // ENTRY-BEFORE-PARENT ordering (#2319 root cause): the
+                // `add_child_to` call below inserts `id` into the
+                // parent's `children` list. A reader that iterates the
+                // parent's children (`UnorderedMap::entries()` etc.)
+                // would then see `id` and try `find_by_id(id)` →
+                // `storage_read(Key::Entry(id))` → `None` (entry not
+                // yet written by `save_internal` below). The collection
+                // iterator's `.flatten().fuse()` silently drops the
+                // `NotFound` Err, producing a partial child list — the
+                // "Hello Wor" rga flake. PR #2470 swapped the order
+                // inside `save_internal` (entry-then-index) but missed
+                // this `apply_action` pre-creation path, which
+                // advertises the child in the parent BEFORE
+                // `save_internal` is reached at all.
+                //
+                // Fix: write `Key::Entry(id)` here, before the
+                // placeholder `add_child_to`, so by the time the
+                // parent advertises this child, the entry already
+                // exists. `save_internal` below will go through the
+                // "concurrent update" path (`last_metadata.updated_at
+                // == metadata.updated_at` since the placeholder we
+                // create carries the same metadata) and produce the
+                // same final bytes for non-root non-merging cases — a
+                // redundant overwrite that's the price of closing the
+                // window.
                 if !<Index<S>>::has_index(id) {
                     if id.is_root() {
                         debug!(%id, "Creating root index entry for entity");
                         <Index<S>>::add_root(ChildInfo::new(id, [0; 32], metadata.clone()))?;
                     } else if let Some(parent) = parent {
+                        // Pre-write the entry bytes so the parent's
+                        // children list never advertises an id without
+                        // a backing `Key::Entry`. See the
+                        // ENTRY-BEFORE-PARENT comment above.
+                        let _ignored = S::storage_write(Key::Entry(id), &data);
                         // Create minimal index entry with placeholder hash
                         let placeholder_hash = Sha256::digest(&data).into();
                         debug!(

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -997,15 +997,19 @@ mod hashing {
 }
 
 /// Guard against borsh layout drift between the real `EntityIndex` (and its
-/// nested types) and the "Minimal" mirror structs used in
-/// `calimero-context-primitives/src/client.rs::compute_root_hash_via_borsh`.
+/// nested types) and the mirror structs used in
+/// `calimero-context-client/src/client/mod.rs::borsh_layout`.
 ///
-/// If any field is added/removed/reordered in the real types, this test will
-/// fail and remind the developer to update the minimal structs too.
+/// Validates that every field the mirror actually consumes round-trips
+/// correctly: `full_hash`, `own_hash`, and the children list including
+/// each child's `id`, `merkle_hash`, and metadata sub-fields
+/// (`created_at`, `updated_at`, `crdt_type`, `field_name`). If any
+/// field is added/removed/reordered in the real types, this test fails
+/// and reminds the developer to update the mirror too.
 ///
-/// **SYNC NOTE**: The minimal structs below are an identical copy of those in
-/// `calimero-context-primitives/src/client.rs::compute_root_hash_via_borsh`.
-/// When modifying either copy, update the other to keep them in sync.
+/// **SYNC NOTE**: The mirror structs below MUST match those in
+/// `calimero-context-client/src/client/mod.rs::borsh_layout`. When
+/// modifying either copy, update the other to keep them in sync.
 mod minimal_struct_layout_compat {
     use borsh::BorshDeserialize;
     use calimero_primitives::crdt::CrdtType;
@@ -1015,30 +1019,31 @@ mod minimal_struct_layout_compat {
     use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
     use crate::index::EntityIndex;
 
-    // ---- Minimal mirror structs (must match client.rs) ----
+    // ---- Mirror structs (must match borsh_layout in client/mod.rs) ----
 
     #[derive(BorshDeserialize)]
     struct EntityIndexMinimal {
         _id: [u8; 32],
         _parent_id: Option<[u8; 32]>,
-        _children: Option<Vec<ChildInfoMinimal>>,
+        children: Option<Vec<ChildInfoMinimal>>,
         full_hash: [u8; 32],
+        own_hash: [u8; 32],
     }
 
     #[derive(BorshDeserialize)]
     struct ChildInfoMinimal {
-        _id: [u8; 32],
-        _merkle_hash: [u8; 32],
-        _metadata: MetadataMinimal,
+        id: [u8; 32],
+        merkle_hash: [u8; 32],
+        metadata: MetadataMinimal,
     }
 
     #[derive(BorshDeserialize)]
     struct MetadataMinimal {
-        _created_at: u64,
-        _updated_at: u64,
+        created_at: u64,
+        updated_at: u64,
         _storage_type: StorageTypeMinimal,
-        _crdt_type: Option<CrdtType>,
-        _field_name: Option<String>,
+        crdt_type: Option<CrdtType>,
+        field_name: Option<String>,
     }
 
     #[derive(BorshDeserialize)]
@@ -1091,11 +1096,51 @@ mod minimal_struct_layout_compat {
         let mut reader: &[u8] = &bytes;
         let minimal = EntityIndexMinimal::deserialize_reader(&mut reader)
             .expect("deserialize with minimal structs — layout may have drifted");
+
         assert_eq!(
             minimal.full_hash,
             index.full_hash(),
             "full_hash mismatch after round-trip"
         );
+        assert_eq!(
+            minimal.own_hash, index.own_hash,
+            "own_hash mismatch after round-trip — layout may have drifted"
+        );
+
+        // Validate children round-trip if present: id, merkle_hash, and
+        // the metadata sub-fields the mirror in `borsh_layout` actually
+        // reads (created_at, updated_at, crdt_type, field_name).
+        match (&minimal.children, &index.children) {
+            (Some(decoded), Some(real)) => {
+                assert_eq!(
+                    decoded.len(),
+                    real.len(),
+                    "children count mismatch after round-trip"
+                );
+                for (d, r) in decoded.iter().zip(real.iter()) {
+                    assert_eq!(&d.id, r.id().as_bytes(), "child id mismatch");
+                    assert_eq!(d.merkle_hash, r.merkle_hash(), "child merkle_hash mismatch");
+                    assert_eq!(
+                        d.metadata.created_at, r.metadata.created_at,
+                        "child metadata.created_at mismatch"
+                    );
+                    assert_eq!(
+                        d.metadata.updated_at, *r.metadata.updated_at,
+                        "child metadata.updated_at mismatch"
+                    );
+                    assert_eq!(
+                        d.metadata.crdt_type, r.metadata.crdt_type,
+                        "child metadata.crdt_type mismatch"
+                    );
+                    assert_eq!(
+                        d.metadata.field_name, r.metadata.field_name,
+                        "child metadata.field_name mismatch"
+                    );
+                }
+            }
+            (None, None) => {}
+            _ => panic!("children Option discriminant mismatch after round-trip"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two distinct #2319 failure modes uncovered while building a diagnostic for "Same DAG heads but different root hash" flakes — plus the diagnostic itself and CI hardening.

### 1. Cache-refresh in heartbeat — false-positive divergence (`4dfa2ddd`)

`ContextMeta.root_hash` is populated from the WASM-returned hash at the end of method execution (`execute/mod.rs:1399`). A concurrent host-side `apply_action` from a sync task (`HashComparison EntityPush`, level-sync leaf push, etc.) can advance the live index immediately after WASM returns but before the cache write, leaving the cache pointing at a pre-recalc `full_hash` while storage has moved on. Both peers converge in storage, but the heartbeat reads the stale cache via `get_context()` and fires DIVERGENCE — wedging `wait_for_sync` in tests and spamming the metric in prod.

`handle_hash_heartbeat` now re-reads the live `full_hash` via `compute_root_hash` before reporting; if the live hash matches the peer it refreshes the cache via `force_root_hash` and returns early. Only a post-refresh mismatch is a real divergence.

Captured directly from PR #2472 attempt 1 (handler-test run 26390942018): node-1 cache `da62bb5e…` vs node-2 cache `adc54731…`, but both indexes agreed on `adc54731…` and on all 20 children's `merkle_hash`.

### 2. Entry-before-parent ordering in `apply_action` (`3207bdaf`)

PR #2470 fixed the entry-vs-index ordering inside `save_internal` to close the "Hello Wor" rga read race. A scaffolding-e2e flake on this PR (run 26398620824) reproduced the same symptom — because `apply_action` pre-creates the parent→child edge via `add_child_to(parent, placeholder)` **before** `save_internal` runs at all, exposing `id` in the parent's `children` list while `Key::Entry(id)` is still empty. A concurrent reader iterating the collection silently drops the child (`Collection::entries`' `.flatten().fuse()` swallows the `NotFound`).

`apply_action`'s Add/Update branch now writes `Key::Entry(id)` for brand-new children **before** the placeholder `add_child_to`. By the time the parent advertises the child, the entry bytes are in storage. `save_internal` later overwrites with identical bytes for the new-entry case.

### 3. Divergence-dump diagnostic (`921f5310` + `e66e8669`)

When the post-refresh hash still disagrees, both sides dump:
- `dump_root_self` → ROOT's `own_hash`, `full_hash`, optional `Key::Entry(ROOT)` bytes hash + length, children_count.
- `dump_root_children` → one `warn!` per ROOT child with `id`, `merkle_hash`, timestamps, CRDT metadata.

Emitted on the `sync::divergence_dump` tracing target. Diffing the two peers' dumps points directly at the divergent subtree (or, if children match on `merkle_hash`, at `ROOT.own_hash` itself — the pattern that drove fix #1).

### 4. CI: `setup-merobox` timeouts (`31205c64`)

One scaffolding-e2e job (run 26399604829) stalled on `curl`/`apt-get` for 90+ min on an Azure runner. Adds `timeout 60` wrappers, `curl --connect-timeout`/`--max-time`/`--retry`, `apt -o Acquire::http::Timeout`, and `set -euo pipefail` so a stalled network call fails the step in ~60–180s instead of running to the 6h runner cap.

## Cost & safety

- Diagnostic dump is read-only and gated on the existing DIVERGENCE-detected branch (already ~0/hour in convergent operation).
- Cache-refresh only fires when cached hash disagrees with live index — itself the diagnostic signal.
- Storage ordering change adds one redundant `storage_write` for the brand-new-child case (byte-identical to `save_internal`'s subsequent write) — the price of closing the read window.

## Test plan

- [x] 463 calimero-storage lib tests pass
- [x] 213 calimero-node lib tests pass
- [x] 33 calimero-context-client lib tests pass
- [ ] scaffolding-e2e `metric_push` + `hashcomparison-*` jobs green
- [ ] No new DIVERGENCE events on the metric `sync_root_hash_divergence_detected_total` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and heartbeat divergence logic on sync-critical paths; fixes are narrow but incorrect ordering or cache refresh could still affect convergence signals and e2e sync waits.
> 
> **Overview**
> Addresses **#2319** (“same DAG heads, different root hash”) with three coordinated changes plus CI hardening.
> 
> **Heartbeat false positives:** When DAG heads match but cached `ContextMeta.root_hash` disagrees with a peer, the handler now reads the live index via `compute_root_hash`, refreshes the cache with `force_root_hash` when stale, and only treats a **post-refresh** mismatch as real divergence—reducing spurious `DIVERGENCE` / metric noise when storage already converged but the WASM-written cache lagged a concurrent sync apply.
> 
> **Storage ordering:** In `apply_action`, new children get `Key::Entry` written **before** the placeholder `add_child_to`, closing a race where the parent’s children list advertised an id before entry bytes existed (partial collection reads / “Hello Wor” style flakes) that PR #2470’s `save_internal` fix did not cover.
> 
> **Diagnostics:** `ContextRegistry::dump_root` (borsh layout mirrors consolidated) logs ROOT self + per-child Merkle metadata on the `sync::divergence_dump` target when divergence still fires, capped at 64 children per peer per heartbeat.
> 
> **CI:** `setup-merobox` wraps `curl`/`apt-get` with bounded timeouts and `set -euo pipefail` so stalled network steps fail in minutes instead of wedging the job for hours.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e75c26fd67a11bdad242715bc7cf0256854eaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->