### PR TITLE
fix(tee): bootstrap an admitted ReadOnlyTee replica so it self-confirms and replicates

### DIFF
--- a/crates/context/src/group_store/local_state.rs
+++ b/crates/context/src/group_store/local_state.rs
@@ -109,6 +109,40 @@ pub(crate) fn append_op_log_entry(
     Ok(())
 }
 
+/// Append an op to the group op-log and advance the op head, WITHOUT
+/// touching the per-signer nonce.
+///
+/// Used by the namespace-governance apply path
+/// (`namespace_governance::apply_group_op_inner`), which manages the nonce
+/// itself via `set_local_gov_nonce`. The authoring path uses
+/// [`persist_group_governance_progress`] instead, which also writes the
+/// nonce in the same batch. Keeping these separate avoids the
+/// namespace-governance path double-writing the nonce.
+pub(crate) fn persist_group_op_log_entry(
+    store: &Store,
+    group_id: &ContextGroupId,
+    sequence: u64,
+    dag_heads: Vec<[u8; 32]>,
+    op_bytes: &[u8],
+) -> EyreResult<()> {
+    let gid = group_id.to_bytes();
+    let mut handle = store.handle();
+
+    let op_log_key = GroupOpLog::new(gid, sequence);
+    handle.put(&op_log_key, &op_bytes.to_vec())?;
+
+    let head_key = GroupOpHead::new(gid);
+    handle.put(
+        &head_key,
+        &GroupOpHeadValue {
+            sequence,
+            dag_heads,
+        },
+    )?;
+
+    Ok(())
+}
+
 pub(crate) fn persist_group_governance_progress(
     store: &Store,
     group_id: &ContextGroupId,

--- a/crates/context/src/group_store/local_state.rs
+++ b/crates/context/src/group_store/local_state.rs
@@ -1,3 +1,4 @@
+use calimero_context_client::local_governance::SignedGroupOp;
 use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
@@ -118,6 +119,32 @@ pub(crate) fn append_op_log_entry(
 /// [`persist_group_governance_progress`] instead, which also writes the
 /// nonce in the same batch. Keeping these separate avoids the
 /// namespace-governance path double-writing the nonce.
+///
+/// CRASH-SAFETY INVARIANT (no atomic multi-key write available):
+/// `calimero-store` has no transactional batch — `StoreBatch` commits each
+/// `put` immediately (see `crates/store/src/batch.rs`) and `Store::handle()`
+/// writes straight through to the backend. So the two `put`s below are NOT
+/// atomic; a crash can land between them. The write ORDER is therefore
+/// chosen to be crash-safe: the op-log ENTRY is written first, the
+/// `GroupOpHead` second.
+///
+/// - Crash after entry, before head: an ORPHAN log entry exists at
+///   `sequence` while the head still points at `sequence - 1`. This is
+///   benign — every reader scans the log directly (`read_op_log_after`,
+///   `read_tee_admission_policy`, `is_quote_hash_used`), so the entry is
+///   already visible; the next apply re-derives `next_seq` from the stale
+///   head and overwrites the orphan at the same `(group_id, sequence)` key.
+/// - The reverse order (head first) would be UNSAFE: a crash would leave a
+///   head whose `sequence` references a log entry that was never written,
+///   so `read_op_log_after` would silently skip the gap and the op-head's
+///   `dag_heads` would advertise a frontier op nobody can read back.
+///
+/// This mirrors the entry-then-head ordering the authoring side uses
+/// (`persist_group_governance_progress` below) and the head-advance /
+/// store-operation ordering note in
+/// `namespace_governance::apply_signed_op`. Replacing this with a real
+/// single-batch atomic write is deferred to the codebase-wide store-batch
+/// work tracked alongside the cascade-delete atomicity discussion.
 pub(crate) fn persist_group_op_log_entry(
     store: &Store,
     group_id: &ContextGroupId,
@@ -128,6 +155,8 @@ pub(crate) fn persist_group_op_log_entry(
     let gid = group_id.to_bytes();
     let mut handle = store.handle();
 
+    // Entry first (see CRASH-SAFETY INVARIANT above): an orphan entry is
+    // benign; a head referencing a missing entry is not.
     let op_log_key = GroupOpLog::new(gid, sequence);
     handle.put(&op_log_key, &op_bytes.to_vec())?;
 
@@ -143,6 +172,17 @@ pub(crate) fn persist_group_op_log_entry(
     Ok(())
 }
 
+/// Authoring-side variant of [`persist_group_op_log_entry`] that ALSO advances
+/// the per-(group, signer) nonce in the same call.
+///
+/// The two paths share the op-log entry + head write (delegated to
+/// [`persist_group_op_log_entry`]) but differ in nonce handling: the authoring
+/// path owns the nonce here, whereas the namespace-governance apply path
+/// manages it separately via `set_local_gov_nonce` (it advances the nonce only
+/// AFTER the full op apply succeeds — see the invariant comment in
+/// `apply_group_op_inner`). The nonce `put` runs LAST so the same crash-safety
+/// ordering holds: entry → head → nonce. An un-advanced nonce after a crash
+/// just replays the (idempotent) op; it never skips one.
 pub(crate) fn persist_group_governance_progress(
     store: &Store,
     group_id: &ContextGroupId,
@@ -152,22 +192,10 @@ pub(crate) fn persist_group_governance_progress(
     dag_heads: Vec<[u8; 32]>,
     op_bytes: &[u8],
 ) -> EyreResult<()> {
-    let gid = group_id.to_bytes();
+    persist_group_op_log_entry(store, group_id, sequence, dag_heads, op_bytes)?;
+
     let mut handle = store.handle();
-
-    let op_log_key = GroupOpLog::new(gid, sequence);
-    handle.put(&op_log_key, &op_bytes.to_vec())?;
-
-    let head_key = GroupOpHead::new(gid);
-    handle.put(
-        &head_key,
-        &GroupOpHeadValue {
-            sequence,
-            dag_heads,
-        },
-    )?;
-
-    let nonce_key = GroupLocalGovNonce::new(gid, *signer);
+    let nonce_key = GroupLocalGovNonce::new(group_id.to_bytes(), *signer);
     handle.put(&nonce_key, &nonce)?;
 
     Ok(())
@@ -198,6 +226,46 @@ pub fn read_op_log_after(
     }
 
     Ok(results)
+}
+
+/// Whether the group op-log already holds an entry whose op has the given
+/// `content_hash`.
+///
+/// This is the durable dedup signal for the replica apply path
+/// (`namespace_governance::apply_group_op_inner`). It scans the persisted
+/// op-log — the same column the readers (`read_tee_admission_policy`,
+/// `is_quote_hash_used`, `is_tee_admitted_identity`) scan — rather than
+/// consulting the op-head's `dag_heads`. `dag_heads` only tracks the CURRENT
+/// frontier: once a later op supersedes an earlier one, the earlier op's
+/// content hash is pruned from the head set, so a head-based check would
+/// wrongly report a superseded-then-re-received op as "not yet logged" and
+/// append a second copy — skewing every log scan. Keying the check on the
+/// persisted log makes it monotonic: an op that was ever logged stays logged.
+///
+/// Cost is an O(n) scan over the group's governance op-log (governance ops
+/// only — not state-DAG traffic), matching what the readers already pay; the
+/// per-(group, signer) nonce guard in `apply_group_op_inner` short-circuits
+/// the common re-receive before this is reached, so this is the backstop for
+/// the retry/backfill path that re-applies without having advanced the nonce.
+pub(crate) fn op_log_contains_content_hash(
+    store: &Store,
+    group_id: &ContextGroupId,
+    content_hash: &[u8; 32],
+) -> EyreResult<bool> {
+    let entries = read_op_log_after(store, group_id, 0, usize::MAX)?;
+    for (_seq, bytes) in &entries {
+        let Ok(op) = borsh::from_slice::<SignedGroupOp>(bytes) else {
+            continue;
+        };
+        if op
+            .content_hash()
+            .map(|h| h == *content_hash)
+            .unwrap_or(false)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn delete_op_log_and_head(store: &Store, group_id: &ContextGroupId) -> EyreResult<()> {

--- a/crates/context/src/group_store/local_state.rs
+++ b/crates/context/src/group_store/local_state.rs
@@ -132,8 +132,13 @@ pub(crate) fn append_op_log_entry(
 ///   `sequence` while the head still points at `sequence - 1`. This is
 ///   benign — every reader scans the log directly (`read_op_log_after`,
 ///   `read_tee_admission_policy`, `is_quote_hash_used`), so the entry is
-///   already visible; the next apply re-derives `next_seq` from the stale
-///   head and overwrites the orphan at the same `(group_id, sequence)` key.
+///   already visible; and the replica apply path derives `next_seq` from
+///   [`max_op_log_sequence`] (the actual max persisted sequence), NOT from
+///   this possibly-stale head, so the next op lands strictly above the orphan
+///   and never overwrites it. (The authoring side still derives `next_seq`
+///   from the head, but a crash there leaves an entry this node authored with
+///   its nonce un-advanced, so the next authored op re-derives the identical
+///   op and an overwrite is an idempotent self-replay.)
 /// - The reverse order (head first) would be UNSAFE: a crash would leave a
 ///   head whose `sequence` references a log entry that was never written,
 ///   so `read_op_log_after` would silently skip the gap and the op-head's
@@ -226,6 +231,32 @@ pub fn read_op_log_after(
     }
 
     Ok(results)
+}
+
+/// The highest sequence number present in the group's op-log, or `None` if the
+/// log is empty.
+///
+/// Derived by scanning the persisted op-log rather than reading
+/// `GroupOpHeadValue.sequence`, so it is correct even when the head is stale
+/// relative to the log — e.g. after a crash that landed between the entry `put`
+/// and the head `put` in [`persist_group_op_log_entry`] (see the CRASH-SAFETY
+/// INVARIANT there). The replica apply path uses this to derive `next_seq` so a
+/// new op never reuses a sequence already occupied by an orphan entry, which
+/// would silently overwrite it.
+///
+/// Keys are big-endian on the sequence component, so the op-log iterates in
+/// ascending order and the last entry carries the max; cost is the same O(n)
+/// governance-only scan the other log readers already pay.
+pub(crate) fn max_op_log_sequence(
+    store: &Store,
+    group_id: &ContextGroupId,
+) -> EyreResult<Option<u64>> {
+    let gid = group_id.to_bytes();
+    let keys =
+        collect_keys_with_prefix(store, GroupOpLog::new(gid, 1), GROUP_OP_LOG_PREFIX, |k| {
+            k.group_id() == gid
+        })?;
+    Ok(keys.last().map(GroupOpLog::sequence))
 }
 
 /// Whether the group op-log already holds an entry whose op has the given

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -858,7 +858,10 @@ impl<'a> NamespaceGovernance<'a> {
     /// governance DAG genesis and drops the `KeyDelivery`-signer TOFU entirely.
     /// That touches the `RootOp` borsh discriminant set and must be coordinated
     /// as a versioned schema change.
-    fn seed_bootstrap_admin_if_absent(
+    // `pub(crate)` (not private) so the repair/idempotency invariant below is
+    // directly exercisable from `group_store::tests` without driving a full
+    // `KeyDelivery` apply; it is not part of any published surface.
+    pub(crate) fn seed_bootstrap_admin_if_absent(
         &self,
         group_id: [u8; 32],
         founder: &PublicKey,
@@ -867,31 +870,54 @@ impl<'a> NamespaceGovernance<'a> {
             return Ok(());
         }
         let gid = ContextGroupId::from(group_id);
-        if load_group_meta(self.store, &gid)?.is_some() {
-            return Ok(());
+
+        // Repairable / idempotent seed. The seed writes two independent rows —
+        // group meta and the admin member row — and `calimero-store` has no
+        // atomic multi-key write (see the CRASH-SAFETY INVARIANT in
+        // `local_state::persist_group_op_log_entry`), so a crash (or a transient
+        // error) between the two `put`s can leave meta present but the admin
+        // member row missing. Gating the WHOLE seed on `load_group_meta(..)
+        // .is_some()` would then return early forever, never adding the member
+        // row, and encrypted replay would keep failing the verifier-membership
+        // check with no way to self-repair.
+        //
+        // Instead, gate each row on its OWN presence: only write meta if absent,
+        // and ALWAYS ensure the admin member row exists. A later `KeyDelivery`
+        // re-enters here and repairs whichever half a previous partial seed left
+        // behind. Both writes are individually idempotent, so re-running is safe.
+        let meta_existed = load_group_meta(self.store, &gid)?.is_some();
+        if !meta_existed {
+            let meta = calimero_store::key::GroupMetaValue {
+                app_key: [0u8; 32],
+                target_application_id: calimero_primitives::application::ApplicationId::from(
+                    [0u8; 32],
+                ),
+                upgrade_policy: calimero_primitives::context::UpgradePolicy::default(),
+                created_at: 0,
+                admin_identity: (*founder).into(),
+                owner_identity: (*founder).into(),
+                migration: None,
+                auto_join: true,
+            };
+            save_group_meta(self.store, &gid, &meta)?;
         }
 
-        let meta = calimero_store::key::GroupMetaValue {
-            app_key: [0u8; 32],
-            target_application_id: calimero_primitives::application::ApplicationId::from([0u8; 32]),
-            upgrade_policy: calimero_primitives::context::UpgradePolicy::default(),
-            created_at: 0,
-            admin_identity: (*founder).into(),
-            owner_identity: (*founder).into(),
-            migration: None,
-            auto_join: true,
-        };
-        save_group_meta(self.store, &gid, &meta)?;
-
-        if super::get_group_member_role(self.store, &gid, founder)?.is_none() {
+        let member_existed = super::get_group_member_role(self.store, &gid, founder)?.is_some();
+        if !member_existed {
             add_group_member(self.store, &gid, founder, GroupMemberRole::Admin)?;
         }
 
-        tracing::info!(
-            namespace_id = %hex::encode(group_id),
-            %founder,
-            "seeded founding namespace admin from KeyDelivery signer (TEE bootstrap)"
-        );
+        // Nothing to do (and nothing to log) if both halves were already
+        // present — the common steady-state re-entry.
+        if !meta_existed || !member_existed {
+            tracing::info!(
+                namespace_id = %hex::encode(group_id),
+                %founder,
+                meta_seeded = !meta_existed,
+                member_seeded = !member_existed,
+                "seeded/repaired founding namespace admin from KeyDelivery signer (TEE bootstrap)"
+            );
+        }
         Ok(())
     }
 
@@ -1080,7 +1106,18 @@ impl<'a> NamespaceGovernance<'a> {
             let content_hash = signed_group_op
                 .content_hash()
                 .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
-            let head = super::get_op_head(self.store, group_id)?;
+            // CONCURRENCY ASSUMPTION (single-threaded per-group apply): the
+            // read-then-write of the op-log below (max-sequence scan + persist)
+            // is NOT individually atomic, so it is only correct if applies for a
+            // given group never interleave. They don't: every receive-path apply
+            // runs inside `ContextManager`'s actix actor, which processes its
+            // mailbox sequentially, so all `apply_signed_op` →
+            // `apply_group_op_inner` calls for one namespace/group are
+            // serialized. The authoring path (`apply_local_signed_group_op`)
+            // documents the same "callers must serialize per `group_id`"
+            // contract. Concurrent applies for the SAME group would be unsafe
+            // (duplicate/overwritten sequences); cross-group concurrency is fine.
+            //
             // Idempotency: a re-received op (gossip duplicate, backfill
             // replay) must not append a second log entry — that would
             // duplicate policy/quote rows and skew the node-local sequence.
@@ -1090,32 +1127,44 @@ impl<'a> NamespaceGovernance<'a> {
             // the nonce guard's `set_local_gov_nonce` on first apply).
             //
             // Dedup against the PERSISTED op-log, not the op-head's
-            // `dag_heads`. `dag_heads` is only the current DAG frontier:
-            // when a later op supersedes this one, this op's `content_hash`
-            // is pruned out of the head set (`filter(!parent_set.contains)`
-            // below), so a `dag_heads.contains` check would miss a
-            // superseded-then-replayed op and append a duplicate — skewing
+            // `dag_heads`: scanning the log is monotonic, so an op that was
+            // ever logged stays deduped, whereas a head-based check would miss
+            // a superseded-then-replayed op and append a duplicate — skewing
             // the very log scans (`is_quote_hash_used`, policy replay,
-            // `read_tee_admission_policy`) this entry feeds. Scanning the log
-            // is monotonic: an op that was ever logged stays deduped.
+            // `read_tee_admission_policy`) this entry feeds.
             let already_logged = super::local_state::op_log_contains_content_hash(
                 self.store,
                 group_id,
                 &content_hash,
             )?;
             if !already_logged {
-                let next_seq = head.as_ref().map_or(1, |h| h.sequence.saturating_add(1));
+                // Derive `next_seq` from the ACTUAL max op-log sequence, not
+                // from `GroupOpHeadValue.sequence`. The head can lag the log
+                // after a crash that landed between the entry `put` and the
+                // head `put` in `persist_group_op_log_entry`: a stale head
+                // would make a different op reuse the orphan's sequence and
+                // silently overwrite it (e.g. losing a `TeeAdmissionPolicySet`
+                // that a later membership op depends on). Scanning the log is
+                // self-healing — the next op always lands strictly above every
+                // persisted entry. This also removes any reliance on a possibly
+                // stale `get_op_head` snapshot for sequencing.
+                let next_seq = super::local_state::max_op_log_sequence(self.store, group_id)?
+                    .map_or(1, |max| max.saturating_add(1));
                 let op_bytes =
                     borsh::to_vec(signed_group_op).map_err(|e| eyre::eyre!("borsh: {e}"))?;
-                let parent_set: std::collections::HashSet<[u8; 32]> =
-                    signed_group_op.parent_op_hashes.iter().copied().collect();
-                let mut new_heads: Vec<[u8; 32]> = head
-                    .map(|h| h.dag_heads)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|h| !parent_set.contains(h))
-                    .collect();
-                new_heads.push(content_hash);
+                // The group op-log is a node-local LINEAR append-only sequence;
+                // its op-head's `dag_heads` is a purely-local frontier that
+                // never escapes the node (all wire/heartbeat/readiness positions
+                // read `NamespaceGovHead.dag_heads`, a different key). Set the
+                // head to exactly the just-logged op's hash. The previous
+                // append-then-prune used `signed_group_op.parent_op_hashes`,
+                // which on this replica path are the reconstructed NAMESPACE op's
+                // DAG parents (see `decrypt_and_apply_group_op`), NOT group-op
+                // hashes — so the prune `filter` never matched and `dag_heads`
+                // grew without bound. A linear single-element head is correct for
+                // the only remaining group-op-head reader (the authoring path's
+                // `parent_op_hashes`, also node-local) and bounded by design.
+                let new_heads = vec![content_hash];
                 super::local_state::persist_group_op_log_entry(
                     self.store, group_id, next_seq, new_heads, &op_bytes,
                 )?;

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -820,6 +820,44 @@ impl<'a> NamespaceGovernance<'a> {
     ///   authoritative copy and this is a no-op;
     /// - `target_application_id` is left zero and self-heals on the first
     ///   `ContextRegistered` apply (same contract as `join_group`).
+    ///
+    /// THREAT MODEL — trust-on-first-use limitation (PR #2473 finding 3):
+    /// `KeyDelivery` carries no signer-authority check on apply
+    /// (`apply_root_op` returns `Ok(())` for it; the side-effect only checks
+    /// `envelope.recipient == our namespace identity`). To mint a `KeyDelivery`
+    /// the signer must merely HOLD the group key — i.e. be ANY current member
+    /// of this namespace, not necessarily the owner/admin. So if a non-owner
+    /// member races the owner and their `KeyDelivery` lands first, this seeds
+    /// the WRONG `admin_identity`/`owner_identity` locally.
+    ///
+    /// Blast radius is bounded and local-only:
+    /// - NOT a cross-node privilege escalation — the seeded meta is node-local
+    ///   state, never gossiped; no peer trusts it.
+    /// - Effect is a LOCAL DoS on this one bootstrapping replica: subsequent
+    ///   authority-checked ops from the true owner (`require_namespace_admin`)
+    ///   are rejected. It does NOT self-heal: the meta-exists guard above turns
+    ///   a later correct `KeyDelivery` into a no-op, and there is no root-admin
+    ///   `AdminChanged` to overwrite it — recovery requires a namespace teardown
+    ///   + re-sync.
+    ///
+    /// Why this is not tightened to "seed only from a DAG-shown admin": the
+    /// namespace ROOT's founding admin/owner is never recorded as a replayable
+    /// governance op (`execute_group_created` rejects a self-parent and notes
+    /// "namespace roots are created via a different path … no GroupCreated op";
+    /// `RootOp` has no namespace-genesis variant). At bootstrap the replica has
+    /// applied NO authority-bearing root op yet — every owner-authored op is
+    /// itself buffered behind this seed (chicken-and-egg). So there is no local,
+    /// DAG-derived admin signal to validate the `KeyDelivery` signer against,
+    /// which is exactly why TOFU is used at all.
+    ///
+    /// RECOMMENDED FOLLOW-UP (correct root-of-trust, deferred — it is a
+    /// wire-protocol change, not a contained fix): add a replayable
+    /// `RootOp::NamespaceCreated { founder }` (or equivalent genesis op) emitted
+    /// by `handlers/create_group.rs` at namespace creation, so a bootstrapping
+    /// replica derives the founding admin/owner authoritatively from the synced
+    /// governance DAG genesis and drops the `KeyDelivery`-signer TOFU entirely.
+    /// That touches the `RootOp` borsh discriminant set and must be coordinated
+    /// as a versioned schema change.
     fn seed_bootstrap_admin_if_absent(
         &self,
         group_id: [u8; 32],
@@ -1050,9 +1088,21 @@ impl<'a> NamespaceGovernance<'a> {
             // re-receive; this content-hash check covers the retry path,
             // which re-applies via `decrypt_and_apply_group_op` (bypassing
             // the nonce guard's `set_local_gov_nonce` on first apply).
-            let already_logged = head
-                .as_ref()
-                .is_some_and(|h| h.dag_heads.contains(&content_hash));
+            //
+            // Dedup against the PERSISTED op-log, not the op-head's
+            // `dag_heads`. `dag_heads` is only the current DAG frontier:
+            // when a later op supersedes this one, this op's `content_hash`
+            // is pruned out of the head set (`filter(!parent_set.contains)`
+            // below), so a `dag_heads.contains` check would miss a
+            // superseded-then-replayed op and append a duplicate — skewing
+            // the very log scans (`is_quote_hash_used`, policy replay,
+            // `read_tee_admission_policy`) this entry feeds. Scanning the log
+            // is monotonic: an op that was ever logged stays deduped.
+            let already_logged = super::local_state::op_log_contains_content_hash(
+                self.store,
+                group_id,
+                &content_hash,
+            )?;
             if !already_logged {
                 let next_seq = head.as_ref().map_or(1, |h| h.sequence.saturating_add(1));
                 let op_bytes =

--- a/crates/context/src/group_store/namespace_governance.rs
+++ b/crates/context/src/group_store/namespace_governance.rs
@@ -233,6 +233,44 @@ impl<'a> NamespaceGovernance<'a> {
                                                 group_id: *group_id,
                                                 recipient: recipient_sk.public_key(),
                                             });
+                                            // Bootstrap the founding admin/owner
+                                            // for a node that joined WITHOUT an
+                                            // invitation (the TEE fleet-join
+                                            // path). The invited-join flow seeds
+                                            // this from the invitation's inviter
+                                            // identity (`handlers/join_group.rs`),
+                                            // but a TEE node has no invitation —
+                                            // so it would replay A's encrypted
+                                            // governance ops and reject every one
+                                            // ("verifier must be a group member",
+                                            // "only admin can register a
+                                            // context") because it never recorded
+                                            // who the namespace admin is. The
+                                            // KeyDelivery signer is precisely that
+                                            // trust anchor: only an existing
+                                            // key-holding member of THIS namespace
+                                            // can mint a KeyDelivery for us, and
+                                            // for the bootstrap case that member
+                                            // is the namespace owner that just
+                                            // admitted us. Seed only when (a) the
+                                            // delivery is for the namespace root
+                                            // group and (b) we have no group meta
+                                            // yet — so the invited-join path
+                                            // (which already wrote meta) is never
+                                            // touched, and a node already holding
+                                            // meta keeps its authoritative copy.
+                                            // The retry below then applies A's
+                                            // membership/context ops cleanly.
+                                            if let Err(e) = self.seed_bootstrap_admin_if_absent(
+                                                *group_id, &op.signer,
+                                            ) {
+                                                tracing::warn!(
+                                                    group_id = %hex::encode(group_id),
+                                                    error = %format!("{e:#}"),
+                                                    "failed to seed bootstrap admin from KeyDelivery \
+                                                     signer; encrypted-op retry may reject"
+                                                );
+                                            }
                                             let retry_divergence = self
                                                 .retry_encrypted_ops_for_group(*group_id)
                                                 .map_err(|e| {
@@ -761,6 +799,64 @@ impl<'a> NamespaceGovernance<'a> {
         Ok(report)
     }
 
+    /// Seed the founding admin/owner of the namespace root group from the
+    /// trust anchor that bootstrapped us (the KeyDelivery signer), when no
+    /// group meta exists locally.
+    ///
+    /// This closes the no-invitation bootstrap gap for TEE fleet-join: the
+    /// founding owner/admin row is written purely locally at namespace
+    /// creation (`handlers/create_group.rs`) and is NOT a replayable
+    /// governance op, so a node that replays the namespace DAG never learns
+    /// who the admin is and rejects every authority-checked op. The invited
+    /// path recovers this from the invitation; the TEE path has none, so we
+    /// take the KeyDelivery signer — which can only be an existing member of
+    /// this namespace (they hold the group key), and for the bootstrap case
+    /// is the owner that admitted us.
+    ///
+    /// Strictly gated and idempotent:
+    /// - only acts when `group_id` is the namespace root (`== namespace_id`);
+    /// - only acts when no `GroupMetaValue` is stored yet, so an established
+    ///   node (invited joiner, or a node that already synced meta) keeps its
+    ///   authoritative copy and this is a no-op;
+    /// - `target_application_id` is left zero and self-heals on the first
+    ///   `ContextRegistered` apply (same contract as `join_group`).
+    fn seed_bootstrap_admin_if_absent(
+        &self,
+        group_id: [u8; 32],
+        founder: &PublicKey,
+    ) -> EyreResult<()> {
+        if group_id != self.namespace_id {
+            return Ok(());
+        }
+        let gid = ContextGroupId::from(group_id);
+        if load_group_meta(self.store, &gid)?.is_some() {
+            return Ok(());
+        }
+
+        let meta = calimero_store::key::GroupMetaValue {
+            app_key: [0u8; 32],
+            target_application_id: calimero_primitives::application::ApplicationId::from([0u8; 32]),
+            upgrade_policy: calimero_primitives::context::UpgradePolicy::default(),
+            created_at: 0,
+            admin_identity: (*founder).into(),
+            owner_identity: (*founder).into(),
+            migration: None,
+            auto_join: true,
+        };
+        save_group_meta(self.store, &gid, &meta)?;
+
+        if super::get_group_member_role(self.store, &gid, founder)?.is_none() {
+            add_group_member(self.store, &gid, founder, GroupMemberRole::Admin)?;
+        }
+
+        tracing::info!(
+            namespace_id = %hex::encode(group_id),
+            %founder,
+            "seeded founding namespace admin from KeyDelivery signer (TEE bootstrap)"
+        );
+        Ok(())
+    }
+
     fn retry_encrypted_ops_for_group(
         &self,
         group_id: [u8; 32],
@@ -817,7 +913,7 @@ impl<'a> NamespaceGovernance<'a> {
                     record_namespace_retry_event("failed");
                     tracing::warn!(
                         group_id = %hex::encode(group_id),
-                        ?e,
+                        error = %format!("{e:#}"),
                         "failed to retry encrypted op after KeyDelivery"
                     );
                 }
@@ -851,16 +947,17 @@ impl<'a> NamespaceGovernance<'a> {
             signature: ns_op.signature,
         };
 
-        self.apply_group_op_inner(group_id, &ns_op.signer, ns_op.nonce, &signed_group_op.op)
+        self.apply_group_op_inner(group_id, &signed_group_op)
     }
 
     fn apply_group_op_inner(
         &self,
         group_id: &ContextGroupId,
-        signer: &PublicKey,
-        nonce: u64,
-        op: &GroupOp,
+        signed_group_op: &SignedGroupOp,
     ) -> EyreResult<Option<super::DivergenceReport>> {
+        let signer = &signed_group_op.signer;
+        let nonce = signed_group_op.nonce;
+        let op = &signed_group_op.op;
         let last = get_local_gov_nonce(self.store, group_id, signer)?.unwrap_or(0);
         if nonce <= last {
             tracing::debug!(
@@ -923,6 +1020,80 @@ impl<'a> NamespaceGovernance<'a> {
             );
         }
 
+        // Append the decrypted op to the local group op-log, mirroring the
+        // authoring node's `apply_local_signed_group_op`. Several readers
+        // reconstruct namespace-scoped state from this log rather than from
+        // dedicated tables — notably `read_tee_admission_policy`,
+        // `is_quote_hash_used`, and `is_tee_admitted_identity`
+        // (`group_store/tee.rs`). Before this, the op-log was only ever
+        // written on the node that *authored* an op, so a replica that
+        // received the same op via the namespace governance DAG could apply
+        // its state mutation but could NOT later read it back through these
+        // log-scanning helpers. That left a freshly-admitted TEE replica
+        // unable to validate (and therefore apply) its own
+        // `MemberJoinedViaTeeAttestation` op — the policy that admission
+        // requires is read from this very log. Persisting here makes the
+        // replica's op-log symmetric with the author's, so policy / quote /
+        // admitted-identity lookups resolve on every member. The op-log
+        // sequence is node-local (not part of consensus), so a divergent
+        // sequence between nodes is fine. Only persist a *handled* op — an
+        // unhandled variant is intentionally skeleton-only.
+        if handled {
+            let content_hash = signed_group_op
+                .content_hash()
+                .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
+            let head = super::get_op_head(self.store, group_id)?;
+            // Idempotency: a re-received op (gossip duplicate, backfill
+            // replay) must not append a second log entry — that would
+            // duplicate policy/quote rows and skew the node-local sequence.
+            // The nonce guard above already short-circuits the common
+            // re-receive; this content-hash check covers the retry path,
+            // which re-applies via `decrypt_and_apply_group_op` (bypassing
+            // the nonce guard's `set_local_gov_nonce` on first apply).
+            let already_logged = head
+                .as_ref()
+                .is_some_and(|h| h.dag_heads.contains(&content_hash));
+            if !already_logged {
+                let next_seq = head.as_ref().map_or(1, |h| h.sequence.saturating_add(1));
+                let op_bytes =
+                    borsh::to_vec(signed_group_op).map_err(|e| eyre::eyre!("borsh: {e}"))?;
+                let parent_set: std::collections::HashSet<[u8; 32]> =
+                    signed_group_op.parent_op_hashes.iter().copied().collect();
+                let mut new_heads: Vec<[u8; 32]> = head
+                    .map(|h| h.dag_heads)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|h| !parent_set.contains(h))
+                    .collect();
+                new_heads.push(content_hash);
+                super::local_state::persist_group_op_log_entry(
+                    self.store, group_id, next_seq, new_heads, &op_bytes,
+                )?;
+            }
+        }
+
+        // INVARIANT: the per-(group, signer) nonce only advances AFTER the op
+        // has been fully applied above — i.e. `apply_group_op_mutations`
+        // returned `Ok` and (for handled ops) the op-log entry is durably
+        // written. Any precondition failure inside `apply_group_op_mutations`
+        // (e.g. `MemberJoinedViaTeeAttestation` reading a not-yet-visible
+        // `TeeAdmissionPolicySet`, or a verifier-membership check that depends
+        // on an earlier op) returns `Err` via the `?` above and short-circuits
+        // BEFORE this line, so the nonce is left unadvanced and the op is
+        // re-attempted on the next sync/retry pass once its predecessor op is
+        // durable. This is what lets a freshly-admitted TEE replica recover:
+        // within a single retry batch the policy op (nonce N) commits its
+        // op-log entry (the store is unbuffered, so the write is immediately
+        // readable), and the membership op (nonce N+1) — applied next because
+        // candidates are sorted by (signer, nonce) — sees it. Were the policy
+        // ever not-yet-visible, the membership op would `Err` here and NOT burn
+        // its nonce, so a later round retries it rather than skipping it
+        // forever as "already-processed". Conversely a genuinely-applied op
+        // (or an unhandled skeleton variant) reaches this line and advances the
+        // nonce so it is not replayed. We deliberately do NOT advance the nonce
+        // for a deferrable precondition failure, and we deliberately DO advance
+        // it for a successful apply — the security check against the policy is
+        // never skipped, only made visible in time.
         set_local_gov_nonce(self.store, group_id, signer, nonce)?;
         Ok(divergence)
     }

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3821,6 +3821,171 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
     );
 }
 
+/// Replica op-log dedup must survive head pruning (PR #2473, finding 4).
+///
+/// The replica apply path (`apply_group_op_inner`) appends every handled op to
+/// the group op-log and guards against a re-received duplicate. The guard used
+/// to consult the op-head's `dag_heads` — but `dag_heads` is only the CURRENT
+/// DAG frontier: once a later op supersedes an earlier one, the earlier op's
+/// content hash is pruned out of the head set. A `dag_heads`-based check would
+/// then miss a superseded-then-replayed op (gossip dup / backfill replay during
+/// a retry that never advanced the per-signer nonce) and append a SECOND log
+/// entry, double-counting it in every log scan (`read_tee_admission_policy`,
+/// `is_quote_hash_used`, `is_tee_admitted_identity`).
+///
+/// The fix dedups against the PERSISTED op-log
+/// (`local_state::op_log_contains_content_hash`), which is monotonic. This test:
+///   1. applies op A (policy set, nonce 1) and op B (policy set, nonce 2, with A
+///      as its parent) via the real `NamespaceGovernance::apply_signed_op` path,
+///   2. asserts A's content hash is PRUNED from the op-head's `dag_heads` (the
+///      condition that broke the old check) yet `op_log_contains_content_hash`
+///      still reports A as logged,
+///   3. re-drives op A through the full apply path under the exact retry/backfill
+///      condition the guard exists for (its per-signer nonce reset to 0, and its
+///      namespace op-log entry removed so the namespace-level dedup does not
+///      short-circuit first), and asserts the GROUP op-log still holds exactly
+///      two entries — no duplicate.
+///
+/// With the old `dag_heads.contains` check step 3 appends a third entry and the
+/// final assertion fails.
+#[test]
+fn replica_op_log_dedup_survives_head_pruning() {
+    use calimero_context_client::local_governance::{
+        NamespaceOp, SignedGroupOp, SignedNamespaceOp, SIGNED_GROUP_OP_SCHEMA_VERSION,
+    };
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+
+    let signer_sk = PrivateKey::random(&mut rng);
+    let signer_pk = signer_sk.public_key();
+
+    let namespace_id = [0xC4u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+
+    // Replica bootstrap state: namespace meta with the signer as admin + the
+    // group key so the encrypted ops decrypt.
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(signer_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &signer_pk, GroupMemberRole::Admin).unwrap();
+    let group_key = [0x5Au8; 32];
+    let key_id = store_group_key(&store, &ns_gid, &group_key).unwrap();
+
+    let gov = NamespaceGovernance::new(&store, namespace_id);
+
+    // Helper: build the SignedGroupOp exactly as `decrypt_and_apply_group_op`
+    // reconstructs it from a namespace op, so we can compute its content hash.
+    let group_op_content_hash = |ns_op: &SignedNamespaceOp, inner: &GroupOp| -> [u8; 32] {
+        SignedGroupOp {
+            version: SIGNED_GROUP_OP_SCHEMA_VERSION,
+            group_id: namespace_id,
+            parent_op_hashes: ns_op.parent_op_hashes.clone(),
+            state_hash: ns_op.state_hash,
+            signer: ns_op.signer,
+            nonce: ns_op.nonce,
+            op: inner.clone(),
+            signature: ns_op.signature,
+        }
+        .content_hash()
+        .unwrap()
+    };
+
+    let make_policy_op = |mrtd: &str| GroupOp::TeeAdmissionPolicySet {
+        allowed_mrtd: vec![mrtd.to_owned()],
+        allowed_rtmr0: vec![],
+        allowed_rtmr1: vec![],
+        allowed_rtmr2: vec![],
+        allowed_rtmr3: vec![],
+        allowed_tcb_statuses: vec!["ok".to_owned()],
+        accept_mock: true,
+    };
+
+    // ---- Op A (nonce 1). ----
+    let inner_a = make_policy_op("mA");
+    let op_a = SignedNamespaceOp::sign(
+        &signer_sk,
+        namespace_id,
+        vec![],
+        [0u8; 32],
+        1,
+        NamespaceOp::Group {
+            group_id: namespace_id,
+            key_id,
+            encrypted: encrypt_group_op(&group_key, &inner_a).unwrap(),
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    let hash_a = group_op_content_hash(&op_a, &inner_a);
+    gov.apply_signed_op(&op_a).expect("apply op A");
+
+    // After A: log has one entry, head frontier is [hash_a].
+    assert_eq!(read_op_log_after(&store, &ns_gid, 0, 10).unwrap().len(), 1);
+    assert!(get_op_head(&store, &ns_gid)
+        .unwrap()
+        .unwrap()
+        .dag_heads
+        .contains(&hash_a));
+
+    // ---- Op B (nonce 2) supersedes A by listing A's group-op hash as parent.
+    // This prunes hash_a out of the op-head's dag_heads. ----
+    let inner_b = make_policy_op("mB");
+    let op_b = SignedNamespaceOp::sign(
+        &signer_sk,
+        namespace_id,
+        vec![hash_a],
+        [0u8; 32],
+        2,
+        NamespaceOp::Group {
+            group_id: namespace_id,
+            key_id,
+            encrypted: encrypt_group_op(&group_key, &inner_b).unwrap(),
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    gov.apply_signed_op(&op_b).expect("apply op B");
+
+    // After B: log has two entries; hash_a is PRUNED from dag_heads (the old
+    // `dag_heads.contains` check would now report A as not-logged) but the
+    // persisted-log check still sees A.
+    assert_eq!(read_op_log_after(&store, &ns_gid, 0, 10).unwrap().len(), 2);
+    assert!(
+        !get_op_head(&store, &ns_gid)
+            .unwrap()
+            .unwrap()
+            .dag_heads
+            .contains(&hash_a),
+        "op A's hash must be pruned from dag_heads once B supersedes it"
+    );
+    assert!(
+        super::local_state::op_log_contains_content_hash(&store, &ns_gid, &hash_a).unwrap(),
+        "the persisted-log dedup must still see superseded op A"
+    );
+
+    // ---- Re-drive op A through the FULL apply path under the retry/backfill
+    // condition the dedup exists for: nonce un-advanced + namespace-level dedup
+    // not short-circuiting. ----
+    set_local_gov_nonce(&store, &ns_gid, &signer_pk, 0).unwrap();
+    {
+        let mut handle = store.handle();
+        let key =
+            calimero_store::key::NamespaceGovOp::new(namespace_id, op_a.content_hash().unwrap());
+        handle.delete(&key).unwrap();
+    }
+    gov.apply_signed_op(&op_a).expect("re-apply op A");
+
+    // The decisive assertion: NO duplicate log entry was appended.
+    assert_eq!(
+        read_op_log_after(&store, &ns_gid, 0, 10).unwrap().len(),
+        2,
+        "re-applying superseded op A must NOT append a duplicate op-log entry"
+    );
+}
+
 fn append_tee_policy_op(store: &Store, group: &ContextGroupId, seq: u64, mrtd: &str) {
     use calimero_primitives::identity::PrivateKey;
     use rand::rngs::OsRng;

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3643,6 +3643,184 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
     assert!(!is_quote_hash_used(&store, &gid, &quote_b).unwrap());
 }
 
+/// Replica-side TEE bootstrap regression guard (PR #2473, finding B).
+///
+/// This is the REPLICA counterpart to the owner-side coverage in
+/// `crates/node/src/local_governance_node_e2e.rs::
+/// ns_announce_admits_announcer_as_read_only_tee_member`. It exercises the
+/// exact apply path a freshly-admitted ReadOnlyTee fleet node (B) takes when
+/// its post-KeyDelivery retry batch replays the namespace's governance ops
+/// that it did NOT author: a `TeeAdmissionPolicySet` (nonce 1) followed by a
+/// `MemberJoinedViaTeeAttestation` (nonce 2), both arriving as encrypted
+/// `NamespaceOp::Group` ops through `NamespaceGovernance::apply_signed_op`.
+///
+/// The membership op's apply reads the admission policy via
+/// `read_required_tee_admission_policy`, which reconstructs the policy purely
+/// by scanning the local group op-log (`group_store/tee.rs`). Before the fix,
+/// a replica applied an op's state mutation but never wrote its op-log entry —
+/// only the authoring node did — so the just-applied policy op was invisible
+/// to the membership op and the apply was rejected with
+/// "no TeeAdmissionPolicySet exists for group". The node then never recorded
+/// its own membership.
+///
+/// The fix (`apply_group_op_inner` in `namespace_governance.rs`) persists each
+/// handled op to the replica's op-log, so within the single retry batch the
+/// policy op (nonce 1) commits its log entry before the membership op (nonce 2)
+/// reads it back. This test FAILS (membership apply errors with
+/// "no TeeAdmissionPolicySet exists") if that op-log persistence is removed.
+#[test]
+fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
+    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+
+    // The verifier (owner/admin of the namespace) AUTHORS both ops. On the
+    // replica this is a remote signer — the node under test is NOT the author.
+    let verifier_sk = PrivateKey::random(&mut rng);
+    let verifier_pk = verifier_sk.public_key();
+
+    // The TEE node being admitted as a ReadOnlyTee member.
+    let tee_member = PublicKey::from([0xD3; 32]);
+    let quote_hash = [0xE1; 32];
+
+    // Namespace root group (policy ops are namespace-scoped: must be the root).
+    let namespace_id = [0xA7u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+
+    // Replica bootstrap state: namespace meta + the verifier recorded as an
+    // admin member (so `require_tee_attestation_verifier_membership` passes —
+    // in the real fleet-join flow this row is seeded from the KeyDelivery
+    // signer by `seed_bootstrap_admin_if_absent`), plus the group key the
+    // replica received via KeyDelivery so it can decrypt the group ops.
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(verifier_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &verifier_pk, GroupMemberRole::Admin).unwrap();
+    let group_key = [0x97u8; 32];
+    let key_id = store_group_key(&store, &ns_gid, &group_key).unwrap();
+
+    let gov = NamespaceGovernance::new(&store, namespace_id);
+
+    // Sanity: before any op is applied the replica has no policy and the TEE
+    // node is not yet a member.
+    assert!(
+        read_tee_admission_policy(&store, &ns_gid)
+            .unwrap()
+            .is_none(),
+        "no policy should exist before any op is applied on the replica"
+    );
+
+    // ---- Op 1 (nonce 1): TeeAdmissionPolicySet, authored by the verifier. ----
+    // `accept_mock` with allowlists that match the join op's mock measurements
+    // (empty RTMR lists allow all; mrtd/tcb_status are matched explicitly).
+    let policy_op = encrypt_group_op(
+        &group_key,
+        &GroupOp::TeeAdmissionPolicySet {
+            allowed_mrtd: vec!["m1".to_owned()],
+            allowed_rtmr0: vec![],
+            allowed_rtmr1: vec![],
+            allowed_rtmr2: vec![],
+            allowed_rtmr3: vec![],
+            allowed_tcb_statuses: vec!["ok".to_owned()],
+            accept_mock: true,
+        },
+    )
+    .unwrap();
+    let policy_ns_op = SignedNamespaceOp::sign(
+        &verifier_sk,
+        namespace_id,
+        vec![],
+        [0u8; 32],
+        1,
+        NamespaceOp::Group {
+            group_id: namespace_id,
+            key_id,
+            encrypted: policy_op,
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    gov.apply_signed_op(&policy_ns_op)
+        .expect("replica must apply TeeAdmissionPolicySet");
+
+    // After the policy op, a log-scanning reader on the REPLICA must see it —
+    // this is the read the membership op depends on. Without the op-log
+    // persistence fix the policy op leaves no log entry here.
+    let policy = read_tee_admission_policy(&store, &ns_gid)
+        .unwrap()
+        .expect("policy must be visible on the replica after applying it");
+    assert_eq!(policy.allowed_mrtd, vec!["m1".to_owned()]);
+    assert!(policy.accept_mock);
+
+    // ---- Op 2 (nonce 2): MemberJoinedViaTeeAttestation, authored by the
+    // verifier — applied next, exactly as in the retry batch. Its apply reads
+    // the policy from the op-log; with the fix that read succeeds. ----
+    let join_op = encrypt_group_op(
+        &group_key,
+        &GroupOp::MemberJoinedViaTeeAttestation {
+            member: tee_member,
+            quote_hash,
+            mrtd: "m1".to_owned(),
+            rtmr0: "r0".to_owned(),
+            rtmr1: "r1".to_owned(),
+            rtmr2: "r2".to_owned(),
+            rtmr3: "r3".to_owned(),
+            tcb_status: "ok".to_owned(),
+            role: GroupMemberRole::ReadOnlyTee,
+        },
+    )
+    .unwrap();
+    let join_ns_op = SignedNamespaceOp::sign(
+        &verifier_sk,
+        namespace_id,
+        vec![],
+        [0u8; 32],
+        2,
+        NamespaceOp::Group {
+            group_id: namespace_id,
+            key_id,
+            encrypted: join_op,
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    gov.apply_signed_op(&join_ns_op).expect(
+        "replica must apply MemberJoinedViaTeeAttestation — the just-applied \
+         TeeAdmissionPolicySet must be visible in its op-log (PR #2473 fix)",
+    );
+
+    // (a) policy still resolves; (b) the ReadOnlyTee member row exists and the
+    // op-log records the admission; (c) the member count reflects it (verifier
+    // admin + the newly admitted TEE node).
+    assert!(
+        read_tee_admission_policy(&store, &ns_gid)
+            .unwrap()
+            .is_some(),
+        "policy must remain readable after the membership op applies"
+    );
+    assert_eq!(
+        get_group_member_role(&store, &ns_gid, &tee_member).unwrap(),
+        Some(GroupMemberRole::ReadOnlyTee),
+        "the TEE node must be recorded as a ReadOnlyTee member on the replica"
+    );
+    assert!(
+        is_tee_admitted_identity(&store, &ns_gid, &tee_member).unwrap(),
+        "the admission op must be visible in the replica's op-log"
+    );
+    assert!(
+        is_quote_hash_used(&store, &ns_gid, &quote_hash).unwrap(),
+        "the admission quote hash must be recorded in the replica's op-log"
+    );
+    assert_eq!(
+        count_group_members(&store, &ns_gid).unwrap(),
+        2,
+        "verifier admin + newly admitted ReadOnlyTee member"
+    );
+}
+
 fn append_tee_policy_op(store: &Store, group: &ContextGroupId, seq: u64, mrtd: &str) {
     use calimero_primitives::identity::PrivateKey;
     use rand::rngs::OsRng;

--- a/crates/context/src/group_store/tests.rs
+++ b/crates/context/src/group_store/tests.rs
@@ -3986,6 +3986,198 @@ fn replica_op_log_dedup_survives_head_pruning() {
     );
 }
 
+/// A stale op-head (crash between the entry `put` and the head `put`) must not
+/// let a later op overwrite the orphan entry (PR #2473, finding B1).
+///
+/// `persist_group_op_log_entry` writes the op-log entry first, then the head
+/// (non-atomic — `calimero-store` has no batch). A crash in between leaves an
+/// ORPHAN entry at sequence N while the head still points at N-1. Deriving the
+/// next op's sequence from `GroupOpHeadValue.sequence` would then reuse N and
+/// silently overwrite the orphan (e.g. clobbering a `TeeAdmissionPolicySet`
+/// that a later membership op depends on). The fix derives `next_seq` from the
+/// ACTUAL max op-log sequence, so the next op always lands strictly above every
+/// persisted entry.
+///
+/// This test:
+///   1. applies op A (nonce 1) via the real apply path — entry + head at seq 1,
+///   2. simulates the crash by rewinding the head to seq 0 (the entry stays),
+///   3. applies a DIFFERENT op B (nonce 2) and asserts the op-log now holds
+///      TWO entries (A preserved at seq 1, B appended at seq 2) — i.e. B did
+///      not overwrite the orphan.
+#[test]
+fn replica_stale_head_does_not_overwrite_orphan_entry() {
+    use calimero_context_client::local_governance::{
+        NamespaceOp, SignedGroupOp, SignedNamespaceOp, SIGNED_GROUP_OP_SCHEMA_VERSION,
+    };
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+
+    let signer_sk = PrivateKey::random(&mut rng);
+    let signer_pk = signer_sk.public_key();
+
+    let namespace_id = [0xC5u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+
+    save_group_meta(&store, &ns_gid, &sample_meta_with_admin(signer_pk)).unwrap();
+    add_group_member(&store, &ns_gid, &signer_pk, GroupMemberRole::Admin).unwrap();
+    let group_key = [0x5Bu8; 32];
+    let key_id = store_group_key(&store, &ns_gid, &group_key).unwrap();
+
+    let gov = NamespaceGovernance::new(&store, namespace_id);
+
+    let group_op_content_hash = |ns_op: &SignedNamespaceOp, inner: &GroupOp| -> [u8; 32] {
+        SignedGroupOp {
+            version: SIGNED_GROUP_OP_SCHEMA_VERSION,
+            group_id: namespace_id,
+            parent_op_hashes: ns_op.parent_op_hashes.clone(),
+            state_hash: ns_op.state_hash,
+            signer: ns_op.signer,
+            nonce: ns_op.nonce,
+            op: inner.clone(),
+            signature: ns_op.signature,
+        }
+        .content_hash()
+        .unwrap()
+    };
+
+    let make_policy_op = |mrtd: &str| GroupOp::TeeAdmissionPolicySet {
+        allowed_mrtd: vec![mrtd.to_owned()],
+        allowed_rtmr0: vec![],
+        allowed_rtmr1: vec![],
+        allowed_rtmr2: vec![],
+        allowed_rtmr3: vec![],
+        allowed_tcb_statuses: vec!["ok".to_owned()],
+        accept_mock: true,
+    };
+
+    // ---- Op A (nonce 1): entry + head land at seq 1. ----
+    let inner_a = make_policy_op("mA");
+    let op_a = SignedNamespaceOp::sign(
+        &signer_sk,
+        namespace_id,
+        vec![],
+        [0u8; 32],
+        1,
+        NamespaceOp::Group {
+            group_id: namespace_id,
+            key_id,
+            encrypted: encrypt_group_op(&group_key, &inner_a).unwrap(),
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    let hash_a = group_op_content_hash(&op_a, &inner_a);
+    gov.apply_signed_op(&op_a).expect("apply op A");
+    assert_eq!(read_op_log_after(&store, &ns_gid, 0, 10).unwrap().len(), 1);
+    assert_eq!(get_op_head(&store, &ns_gid).unwrap().unwrap().sequence, 1);
+
+    // ---- Crash simulation: the orphan condition. Entry at seq 1 survives,
+    // but the head is rewound to seq 0 as if the head `put` never committed. ----
+    set_op_head(&store, &ns_gid, 0, vec![]).unwrap();
+
+    // ---- Op B (nonce 2), different content. With a stale-head-derived
+    // sequence it would reuse seq 1 and clobber A. ----
+    let inner_b = make_policy_op("mB");
+    let op_b = SignedNamespaceOp::sign(
+        &signer_sk,
+        namespace_id,
+        vec![],
+        [0u8; 32],
+        2,
+        NamespaceOp::Group {
+            group_id: namespace_id,
+            key_id,
+            encrypted: encrypt_group_op(&group_key, &inner_b).unwrap(),
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    let hash_b = group_op_content_hash(&op_b, &inner_b);
+    gov.apply_signed_op(&op_b).expect("apply op B");
+
+    // The decisive assertions: A's orphan entry is preserved (still at seq 1),
+    // B appended at seq 2, and both content hashes are present.
+    let entries = read_op_log_after(&store, &ns_gid, 0, 10).unwrap();
+    assert_eq!(
+        entries.len(),
+        2,
+        "op B must NOT overwrite the orphan entry left by the simulated crash"
+    );
+    assert_eq!(entries[0].0, 1, "op A stays at seq 1");
+    assert_eq!(entries[1].0, 2, "op B appended at seq 2, above the orphan");
+    assert!(
+        super::local_state::op_log_contains_content_hash(&store, &ns_gid, &hash_a).unwrap(),
+        "op A's content must survive"
+    );
+    assert!(
+        super::local_state::op_log_contains_content_hash(&store, &ns_gid, &hash_b).unwrap(),
+        "op B's content must be logged"
+    );
+}
+
+/// A partial bootstrap seed (meta written, admin member row missing) must be
+/// repaired by a later seed call, not skipped forever (PR #2473, finding C).
+///
+/// `seed_bootstrap_admin_if_absent` writes two non-atomic rows: group meta and
+/// the admin member row. A crash between them leaves meta present but the member
+/// row missing. Gating the whole seed on `load_group_meta(..).is_some()` would
+/// return early forever and never add the member row, so encrypted replay keeps
+/// failing the verifier-membership check with no way to self-repair. The fix
+/// gates each row on its own presence and always ensures the member row exists,
+/// so a later `KeyDelivery` re-entry repairs the partial seed.
+#[test]
+fn seed_bootstrap_admin_repairs_missing_member_row() {
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::namespace_governance::NamespaceGovernance;
+
+    let store = test_store();
+    let mut rng = OsRng;
+
+    let founder_sk = PrivateKey::random(&mut rng);
+    let founder = founder_sk.public_key();
+
+    let namespace_id = [0xC6u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+
+    let gov = NamespaceGovernance::new(&store, namespace_id);
+
+    // ---- First seed: both meta and the admin member row are written. ----
+    gov.seed_bootstrap_admin_if_absent(namespace_id, &founder)
+        .expect("initial seed");
+    assert!(load_group_meta(&store, &ns_gid).unwrap().is_some());
+    assert_eq!(
+        get_group_member_role(&store, &ns_gid, &founder).unwrap(),
+        Some(GroupMemberRole::Admin),
+        "first seed must add the admin member row"
+    );
+
+    // ---- Simulate the partial-seed crash: meta survives, member row lost. ----
+    remove_group_member(&store, &ns_gid, &founder).unwrap();
+    assert!(load_group_meta(&store, &ns_gid).unwrap().is_some());
+    assert_eq!(
+        get_group_member_role(&store, &ns_gid, &founder).unwrap(),
+        None,
+        "member row is gone, only meta remains (partial seed)"
+    );
+
+    // ---- Re-seed (later KeyDelivery re-entry): the OLD code returned early on
+    // the meta gate and never repaired the member row. ----
+    gov.seed_bootstrap_admin_if_absent(namespace_id, &founder)
+        .expect("repair seed");
+    assert_eq!(
+        get_group_member_role(&store, &ns_gid, &founder).unwrap(),
+        Some(GroupMemberRole::Admin),
+        "re-seed must repair the missing admin member row"
+    );
+}
+
 fn append_tee_policy_op(store: &Store, group: &ContextGroupId, seq: u64, mrtd: &str) {
     use calimero_primitives::identity::PrivateKey;
     use rand::rngs::OsRng;

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -2,14 +2,77 @@ use std::sync::Arc;
 
 use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::AdmitTeeNodeRequest;
-use calimero_context_client::local_governance::GroupOp;
+use calimero_context_client::local_governance::{AckRouter, GroupOp, NamespaceOp, RootOp};
+use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::GroupMemberRole;
-use calimero_primitives::identity::PrivateKey;
-use tracing::info;
+use calimero_primitives::identity::{PrivateKey, PublicKey};
+use calimero_store::Store;
+use tracing::{info, warn};
 
 use crate::governance_broadcast::ObserveDelivery;
 use crate::group_store;
 use crate::ContextManager;
+
+/// Publish a `RootOp::KeyDelivery` wrapping the namespace group key for
+/// `member`, signed with the verifier's namespace identity (`signer_sk`).
+///
+/// Mirrors `key_delivery::maybe_publish_key_delivery` (node crate), which is
+/// the receiver-side reaction for `MemberJoined` / `MemberJoinedOpen`. The
+/// TEE-attestation join op is an encrypted `NamespaceOp::Group` that only the
+/// verifier can apply, so that reaction never fires for it and the delivery
+/// must be issued directly here. Idempotent on the recipient side: a duplicate
+/// `KeyDelivery` for a key the node already holds is a no-op (`store_group_key`
+/// keys by content).
+async fn deliver_group_key_to_member(
+    store: &Store,
+    node_client: &calimero_node_primitives::client::NodeClient,
+    ack_router: &AckRouter,
+    group_id: &ContextGroupId,
+    signer_sk: &PrivateKey,
+    member: &PublicKey,
+) -> eyre::Result<()> {
+    let namespace_id = group_store::resolve_namespace(store, group_id)?;
+
+    let Some((_key_id, group_key)) = group_store::load_current_group_key(store, group_id)? else {
+        // The verifier admitted the node against this namespace's policy but
+        // holds no group key for it — there is nothing to deliver. This should
+        // not happen for a namespace owner/admin, but bail loudly rather than
+        // silently leave the admitted node un-bootstrappable.
+        eyre::bail!("verifier has no group key for namespace; cannot deliver to admitted TEE node");
+    };
+
+    let envelope = group_store::wrap_group_key_for_member(signer_sk, member, &group_key)?;
+
+    let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
+        group_id: group_id.to_bytes(),
+        envelope,
+    });
+
+    // Target only the admitted member's ack for delivery confirmation, matching
+    // `maybe_publish_key_delivery`. Best-effort: an unformed mesh downgrades
+    // readiness rather than failing, and the announcer re-announces (re-admit)
+    // to retry.
+    let report = group_store::sign_and_publish_namespace_op(
+        store,
+        node_client,
+        ack_router,
+        namespace_id.to_bytes(),
+        signer_sk,
+        delivery_op,
+        Some(vec![*member]),
+    )
+    .await?;
+
+    info!(
+        group_id = %hex::encode(group_id.to_bytes()),
+        %member,
+        acked = report.acked_by.len(),
+        elapsed_ms = report.elapsed_ms,
+        "published KeyDelivery for admitted TEE node"
+    );
+
+    Ok(())
+}
 
 impl Handler<AdmitTeeNodeRequest> for ContextManager {
     type Result = ActorResponse<Self, <AdmitTeeNodeRequest as Message>::Result>;
@@ -150,6 +213,47 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
                 report.observe("admit_tee_node", "MemberJoinedViaTeeAttestation");
 
                 info!(%member, ?group_id, "TEE node admitted via attestation");
+
+                // Deliver the namespace group key to the freshly-admitted TEE
+                // node. Unlike the invited-member path (`RootOp::MemberJoined`)
+                // and the Open-subgroup self-join path
+                // (`RootOp::MemberJoinedOpen`) — both of which trigger
+                // `key_delivery::maybe_publish_key_delivery` on every peer that
+                // applies the join op — a `MemberJoinedViaTeeAttestation` op is
+                // an encrypted `NamespaceOp::Group`. No other peer can decrypt
+                // (and therefore apply) it, so the receiver-side key-delivery
+                // reaction never fires and the admitted node would never receive
+                // the group key. Without the key it can never decrypt its own
+                // membership op, never see itself as a member, and never learn
+                // about the namespace's contexts — HA admission would be inert.
+                //
+                // The verifier (this node) holds the group key and signs with
+                // its namespace identity (`sk`), so it is the right party to
+                // publish the `KeyDelivery`. The envelope is ECDH-wrapped for
+                // `member` only; the bare-announcer node picks it up when it
+                // pulls the namespace governance DAG (it subscribed to the
+                // `ns/` topic at fleet-join time and the self-confirm loop in
+                // `fleet_join.rs` actively triggers `sync_namespace`).
+                if let Err(err) = deliver_group_key_to_member(
+                    &datastore,
+                    &node_client,
+                    &ack_router,
+                    &group_id,
+                    &sk,
+                    &member,
+                )
+                .await
+                {
+                    warn!(
+                        %member,
+                        ?group_id,
+                        ?err,
+                        "TEE admission succeeded but KeyDelivery to the admitted node \
+                         failed — it will not bootstrap until the key is delivered. \
+                         Re-admission (the announcer re-announces) retries this."
+                    );
+                }
+
                 // Auto-follow flags for the admitted TEE member are
                 // published by the member itself in `fleet_join.rs` after
                 // it observes admission — signed with its own namespace

--- a/crates/server/src/admin/handlers/tee/fleet_join.rs
+++ b/crates/server/src/admin/handlers/tee/fleet_join.rs
@@ -323,6 +323,34 @@ pub async fn handler(
                             "re-announce publish failed; will retry next cycle"
                         ),
                     }
+
+                    // Bootstrap pull: a bare announcer holds NO namespace
+                    // governance state (it only `subscribe_namespace`'d to send
+                    // the announce). Once the verifier admits it, the verifier
+                    // publishes the membership op (encrypted with the namespace
+                    // group key) plus a `KeyDelivery` wrapping that key for this
+                    // node — but both ride the namespace governance DAG, which
+                    // this node has not pulled yet. The beacon-driven anti-entropy
+                    // path deliberately skips a node with no local DAG head (it
+                    // would race the bootstrap and pull undecryptable skeletons),
+                    // so nothing pulls the DAG for us automatically. Trigger the
+                    // pull ourselves each cycle: it fetches the full namespace
+                    // governance DAG from a mesh peer, applies the `KeyDelivery`
+                    // (decryptable with our namespace identity SK alone), then
+                    // retries the previously-undecryptable membership op now that
+                    // the group key is present. After that the `list_group_contexts`
+                    // self-confirm above resolves and we join + replicate contexts.
+                    // Best-effort: a missing mesh peer is logged inside
+                    // `sync_namespace` and retried next cycle. Guarded by the same
+                    // `now < deadline` check as the re-announce because it is a
+                    // network op that should not run past the deadline.
+                    if let Err(sync_err) = state.node_client.sync_namespace(group_id_bytes).await {
+                        tracing::debug!(
+                            group_id = %req.group_id,
+                            error = ?sync_err,
+                            "namespace governance bootstrap pull failed; will retry next cycle"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Third and final piece of the HA fleet-join fix, after #2441 (owner routes the `ns/` announce → admits) and #2460 (announcer re-announces until admitted). With those two an admitted `ReadOnlyTee` node showed up in the owner's member list — but it never **became a usable replica**: its own fleet-join reported `admitted:false`, its admin-api reported the namespace "not found for itself", and it never joined/replicated the contexts.

## Root cause
When the admitted node replays its own (now-decrypted) `MemberJoinedViaTeeAttestation` op, the apply path re-runs the TEE admission policy check (`group_store/mod.rs` → `read_required_tee_admission_policy`, `membership_policy.rs`), which reads the `TeeAdmissionPolicySet` by **scanning the group op-log**. On the committed HEAD the op-log was only ever written by the **authoring** node — a replica applied state mutations but never persisted op-log entries. So the policy op the replica had "just applied" was invisible to its membership op (a read-your-own-writes gap), the membership apply was rejected with `no TeeAdmissionPolicySet exists for group`, and the node never recorded its own membership. The nonce then advanced past the failed op, locking out retries.

## Fix
- **`namespace_governance.rs` / `local_state.rs`** — a replica now persists each *handled* governance op to its node-local op-log on apply (idempotent: `content_hash` ∈ `dag_heads`), mirroring the authoring node. The retry batch applies candidates in `(signer, nonce)` order, so the policy op (lower nonce) commits its log entry before the membership op reads it. `set_local_gov_nonce` advances **only after a successful apply**, so a deferrable precondition failure (policy not yet visible) retries on the next sync round instead of burning the nonce. The policy check is **preserved** — it's made visible in time, not skipped.
- **`admit_tee_node.rs`** — the verifier delivers the namespace group key to the freshly-admitted node (`RootOp::KeyDelivery`, ECDH-wrapped for the member) and seeds the founding admin on the replica, so the bare announcer can decrypt its own membership op.
- **`fleet_join.rs`** — the self-confirm loop actively pulls the namespace governance DAG each cycle (`sync_namespace`) to fetch the `KeyDelivery` + membership op, then `list_group_contexts` resolves and the node joins + replicates.

## ⚠️ Review note (consensus-adjacent)
The load-bearing change is that **every member now persists each handled governance op to its node-local op-log on apply**, where before only the authoring node did. The op-log sequence is **node-local — not part of consensus and not on the wire** — and the write is gated `if handled` + idempotent on content hash, so divergent local sequences are fine. No storage-schema or wire-format break; no mero-tee rev bump. Please give the op-log idempotency check (`content_hash` ∈ `dag_heads` in `apply_group_op_inner`) a careful read — it's the one piece that now runs on every member for every governance op.

## Verification
Proven end-to-end with a local two-node setup: owner admits the announcer (member_count 1→2), the announcer reports `admitted:true`, joins the context, and **serves a value the owner wrote** (real replication, not just membership). `cargo test -p calimero-context` (311+23) and `-p calimero-node --lib local_governance_node_e2e` (4, incl. the owner-side admission regression) pass; fmt + clippy clean.

Follow-up worth filing: a dedicated **replica-bootstrap** integration test in CI (the owner-side admission is already covered by `local_governance_node_e2e`; the replica self-confirm/replicate path is currently proven by the local two-node demo).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every member records node-local governance op-logs and introduces KeyDelivery-signer TOFU for founding admin on TEE bootstrap; sequences/nonces are not consensus but affect admission, policy replay, and encrypted-op retry correctness on replicas.
> 
> **Overview**
> Fixes **ReadOnlyTee fleet-join** so an admitted announcer can self-confirm, decrypt governance ops, and replicate—not only appear on the owner’s member list.
> 
> **Replica op-log symmetry** — On namespace governance apply (`apply_group_op_inner`), each *handled* decrypted group op is appended to the node-local group op-log (like the authoring path). TEE policy and membership checks (`read_tee_admission_policy`, quote/admission scans) read that log; without persistence, replicas applied mutations but could not see their own `TeeAdmissionPolicySet` when applying `MemberJoinedViaTeeAttestation`. **Nonce advances only after a successful apply** so a failed membership op retries instead of being skipped. Dedup uses **persisted log content-hash** (not `dag_heads`); **next sequence** comes from **`max_op_log_sequence`** so a stale op-head after a non-atomic crash cannot overwrite orphan entries. `persist_group_op_log_entry` splits entry/head writes from nonce handling for the replica path.
> 
> **TEE bootstrap without invitation** — After admission, the verifier publishes **`RootOp::KeyDelivery`** (`admit_tee_node.rs`). On apply, **`seed_bootstrap_admin_if_absent`** seeds/repairs namespace root meta and admin member from the delivery signer when meta was missing (invited join unchanged). Documented **local TOFU** risk if a non-owner member’s delivery wins the race.
> 
> **Fleet-join pull** — While waiting for admission, the announcer calls **`sync_namespace`** each cycle so `KeyDelivery` and encrypted ops are pulled (beacon anti-entropy skips nodes with no DAG head).
> 
> New **`calimero-context`** tests cover replica policy→membership apply, op-log dedup after head prune, stale-head orphan safety, and partial admin seed repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69292c221c79f3267ad8bb7ac4bcf3cf90d70ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->