### PR TITLE
chore: bump node version to 0.10.1-rc.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.43"
+version = "0.10.1-rc.44"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
Bump workspace release version `0.10.1-rc.43` → `0.10.1-rc.44`.

Cuts the next pre-release so the **HA fleet-join fix lands in a published `merod` binary** for fleet nodes. `rc.43` was cut before these merged, so it lacks the full fix:

- #2441 — owner routes the `ns/` `TeeAttestationAnnounce` into admission (was dropped)
- #2460 — fleet node re-announces until admitted (one-shot publish was lost on an empty mesh)
- #2473 — admitted `ReadOnlyTee` replica self-confirms, bootstraps the namespace, and replicates contexts

Verified end-to-end on merged `master` (two-node demo: owner admits the announcer → `member_count` 1→2 → the announcer serves a value the owner wrote).

Once published, `mdma`'s `merod_version` is pointed at `rc.44` so provisioned fleet nodes download it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version bump in workspace metadata with no runtime code changes in this PR.
> 
> **Overview**
> Bumps the shared workspace release version in `Cargo.toml` from **`0.10.1-rc.43`** to **`0.10.1-rc.44`** so the next published **`merod`** build carries recent HA fleet-join fixes that were not in `rc.43`.
> 
> This is a **release-metadata-only** change (no application code in the diff). Downstream provisioning (e.g. `mdma`'s `merod_version`) can target `rc.44` once artifacts are published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485a4d8417ba548465f155ce08e40ecfd7e6f817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->