### PR TITLE
chore: bump node version to 0.10.1-rc.45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.44"
+version = "0.10.1-rc.45"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
Cuts a new rc with the network-side fix from #2483 included.

Notable in this rc:
- #2483 — `fix(network): always try relay reservation on Identify, not only when advertise=None` (closes #2475)

Once this lands and the Release pipeline publishes a fresh `merod:edge`, [merobox#254](https://github.com/calimero-network/merobox/pull/254) can be undrafted — its NAT-topology smoke test was deliberately blocked on the upstream fix and should go green with the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line workspace version bump with no code changes in the PR itself.
> 
> **Overview**
> Bumps the shared workspace release version in `Cargo.toml` from **`0.10.1-rc.44`** to **`0.10.1-rc.45`**, cutting a new release candidate so published artifacts (e.g. `merod:edge`) pick up code already merged on the branch—notably the network change that **always attempts relay reservation on Identify** for relay peers, instead of only when advertise is unset.
> 
> No application logic changes in this diff; it is a version/metadata release step per `docs/RELEASE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c871825b4cfd35d40bcc88c715145fafa1eb2fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->