### PR TITLE
fix(storage): emit Action::Compare on stale-by-HLC apply (#2356 item 1)

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1294,7 +1294,20 @@ impl<S: StorageAdaptor> Interface<S> {
                         %id,
                         "Remote action produced no storage change (save_internal returned None)"
                     );
-                    // we didn't save anything, so we skip updating the ancestors
+                    // save_internal short-circuited because stored.updated_at >
+                    // incoming.updated_at: nothing changed locally, but the
+                    // apply still "happened" from the network's perspective —
+                    // we received and acknowledged this delta. Push
+                    // Action::Compare so this node's current Merkle state for
+                    // `id` ships in the next outbound delta and peers can
+                    // reconcile via state-based sync. Without this, two nodes
+                    // that concurrently merge the same entity (each holding
+                    // the locally-newer side) keep emitting deltas the other
+                    // drops, and the Merkle root divergence stalls until an
+                    // unrelated trigger forces a hash-comparison sweep.
+                    if S::participates_in_sync() {
+                        crate::delta::push_action(Action::Compare { id });
+                    }
                     return Ok(());
                 };
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -308,6 +308,54 @@ mod interface__apply_actions {
         assert!(retrieved_page.is_some());
         assert_eq!(retrieved_page.unwrap().title, "Test Page");
     }
+
+    // Regression for #2356 item 1: a stale-by-HLC apply (incoming.updated_at <
+    // stored.updated_at) hits the `save_internal -> None` short-circuit. The
+    // apply must still enqueue Action::Compare so the receiver's current
+    // Merkle state for this entity propagates to peers — otherwise two nodes
+    // that each hold the locally-newer side of a concurrent CRDT merge keep
+    // dropping each other's deltas, and root-hash convergence stalls until an
+    // unrelated trigger forces a hash-comparison sweep.
+    #[test]
+    fn apply_action__stale_update_still_emits_compare() {
+        use crate::delta::{commit_causal_delta, reset_delta_context};
+
+        crate::tests::common::register_test_merge_functions();
+        reset_delta_context();
+
+        // Seed an entity locally at time T2.
+        let mut page = Page::new_from_element("Test Page", Element::root());
+        let id = page.id();
+        assert!(MainInterface::save(&mut page).unwrap());
+        let stored_updated_at = *page.element().metadata.updated_at;
+        // Discard actions emitted by the local save — the assertion below is
+        // only about what the stale apply contributes.
+        reset_delta_context();
+
+        // Build a remote-style Update with metadata at T1 < T2.
+        let mut stale_metadata = page.element().metadata.clone();
+        stale_metadata.set_updated_at(stored_updated_at.saturating_sub(1_000_000));
+        let stale_action = Action::Update {
+            id,
+            data: to_vec(&page).unwrap(),
+            ancestors: vec![],
+            metadata: stale_metadata,
+        };
+
+        assert!(MainInterface::apply_action(stale_action, &ApplyContext::empty()).is_ok());
+
+        let delta = commit_causal_delta(&[0; 32])
+            .unwrap()
+            .expect("stale apply must still emit a delta (Action::Compare)");
+        assert!(
+            delta
+                .actions
+                .iter()
+                .any(|a| matches!(a, Action::Compare { id: cid } if *cid == id)),
+            "expected Action::Compare for id={id} after stale apply, got: {:?}",
+            delta.actions
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Addresses item 1 of #2356 — "Merkle root not recomputed after concurrent CRDT merge."

## The bug

`Interface::apply_action`'s Add/Update arm calls `save_internal`, which short-circuits and returns `None` whenever `stored.updated_at > incoming.updated_at`. The old code then early-returned without pushing `Action::Compare`, so the receiver's current Merkle state for the entity never rode the next outbound delta.

Two nodes that each held the locally-newer side of a concurrent CRDT merge would keep dropping each other's deltas, and root-hash convergence stalled until an unrelated trigger forced a hash-comparison sweep — the ~30 s Round-2 stall observed in `Sync regression (smoke)` on PR #2344 head `81710d5`, still reproducible after #2344, #2352, #2470, and #2472 because the `save_internal -> None -> skip Compare` path is independent of all four.

## The fix

In the `save_internal -> None` branch, still push `Action::Compare { id }` (gated on `participates_in_sync` so `PrivateStorage` stays node-local). The apply did "happen" from the network's perspective — the receiver acknowledged the delta — so the receiver's state for `id` propagates to peers via state-based sync.

This is candidate fix (a) from the issue body. (b) "WASM merge handlers set `updated_at = max(local, incoming)`" would touch every merge handler; (c) a dedicated "acknowledge-merge" path is more invasive. (a) is the smallest-blast-radius option that closes the symptom.

## Test

`apply_action__stale_update_still_emits_compare` in `crates/storage/src/tests/interface.rs`:

1. Seed an entity locally at HLC T2.
2. Reset the delta context to discard the local-save actions.
3. Apply a remote-style `Action::Update` for the same id at HLC T1 < T2 — this hits the `save_internal -> None` path.
4. Assert the resulting `CausalDelta` contains `Action::Compare` for that id.

Verified to **fail on master** and **pass with the fix**.

Full storage suite: 464 passed, 0 failed. Node suite: 216 passed, 0 failed.

## Out of scope

Items 2, 3, 4 of #2356 — they will land as separate PRs, per the issue body's own guidance that each item warrants its own PR + sim test.

## Test plan

- [x] `cargo fmt --check -p calimero-storage`
- [x] `cargo test -p calimero-storage --lib`
- [x] `cargo test -p calimero-node --lib`
- [ ] Sync regression (smoke) workflow on this branch: Round-2 sync should now complete in seconds, not ~30 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the distributed sync apply path for a common concurrent-merge case; scope is one branch plus a regression test, with behavior aligned to the existing post-save Compare push.
> 
> **Overview**
> Fixes **#2356 (item 1)**: when a remote Add/Update is applied but **`save_internal` short-circuits** because local `updated_at` is newer than the incoming metadata, the handler used to return without queuing sync actions. Peers then never learned this node’s current Merkle hash for that entity, so concurrent CRDT merges could leave Merkle roots diverged until an unrelated hash-comparison sweep.
> 
> **`Interface::apply_action`** now still pushes **`Action::Compare { id }`** on that no-op path (same as after a successful save), gated on **`participates_in_sync()`** so private storage stays local.
> 
> Adds regression test **`apply_action__stale_update_still_emits_compare`**: stale remote update → committed causal delta must include `Compare` for the entity id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12799d049750911cb6bcf49f07cc186646dd7a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->