### PR TITLE
fix(node): drop application-level zero-peers gate in broadcast (#2356 item 3)

### DIFF
--- a/crates/context/src/governance_broadcast.rs
+++ b/crates/context/src/governance_broadcast.rs
@@ -17,10 +17,11 @@ use calimero_context_client::local_governance::{
     hash_scoped_namespace, AckRouter, GovernanceError, NamespaceOp, NamespaceTopicMsg, RootOp,
     SignedAck, SignedNamespaceOp, SignedReadinessBeacon,
 };
+use calimero_network_primitives::client::is_no_peers_subscribed_error;
 use calimero_node_primitives::sync::{BroadcastMessage, MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::Store;
-use libp2p::gossipsub::{PublishError, TopicHash};
+use libp2p::gossipsub::TopicHash;
 use thiserror::Error;
 use tokio::sync::broadcast;
 use tokio::time::timeout;
@@ -40,13 +41,7 @@ pub enum BroadcastPublishError {
 }
 
 pub(crate) fn classify_network_publish_error(e: eyre::Report) -> BroadcastPublishError {
-    let no_peers = e.chain().any(|cause| {
-        matches!(
-            cause.downcast_ref::<PublishError>(),
-            Some(PublishError::NoPeersSubscribedToTopic)
-        )
-    });
-    if no_peers {
+    if is_no_peers_subscribed_error(&e) {
         BroadcastPublishError::NoPeersSubscribed
     } else {
         BroadcastPublishError::Other(e.to_string())

--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -1,9 +1,36 @@
 use calimero_primitives::{blobs::BlobId, context::ContextId};
 use calimero_utils_actix::LazyRecipient;
-use libp2p::gossipsub::{IdentTopic, MessageId, TopicHash};
+use libp2p::gossipsub::{IdentTopic, MessageId, PublishError, TopicHash};
 use libp2p::request_response::{OutboundRequestId, ResponseChannel};
 use libp2p::Multiaddr;
 use tokio::sync::oneshot;
+
+/// Returns true when `err`'s `eyre::Report` chain contains
+/// `gossipsub::PublishError::NoPeersSubscribedToTopic`.
+///
+/// Single source of truth for classifying the one gossipsub publish error
+/// callers handle differently from the rest: it's a normal cold-start
+/// outcome (the topic has no subscribed peers yet), not a transport
+/// failure. Callers that broadcast state deltas (`broadcast`,
+/// `broadcast_heartbeat`) silence this variant and surface every other
+/// error; callers that publish governance ops surface it explicitly via
+/// `BroadcastPublishError::NoPeersSubscribed` so the higher-level
+/// publish-with-acks flow can decide whether to wait for mesh formation.
+///
+/// Only walks `eyre::Report::chain()`. A `PublishError` wrapped in a
+/// non-eyre `Box<dyn std::error::Error>` would not be detected here, but
+/// every current caller goes through `NetworkClient::publish`, whose
+/// return type is `eyre::Result<_>`, so the eyre chain is the only
+/// shape that reaches this helper in practice.
+#[must_use]
+pub fn is_no_peers_subscribed_error(err: &eyre::Report) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<PublishError>(),
+            Some(PublishError::NoPeersSubscribedToTopic)
+        )
+    })
+}
 
 use crate::blob_types::BlobAuth;
 use crate::messages::{
@@ -293,5 +320,37 @@ impl NetworkClient {
             .expect("Mailbox not to be dropped");
 
         rx.await.expect("Mailbox not to be dropped")
+    }
+}
+
+#[cfg(test)]
+mod is_no_peers_subscribed_error_tests {
+    use libp2p::gossipsub::PublishError;
+
+    use super::is_no_peers_subscribed_error;
+
+    #[test]
+    fn classifies_no_peers_subscribed_at_root() {
+        let err: eyre::Report = PublishError::NoPeersSubscribedToTopic.into();
+        assert!(is_no_peers_subscribed_error(&err));
+    }
+
+    #[test]
+    fn classifies_no_peers_subscribed_when_wrapped() {
+        let err = eyre::Report::from(PublishError::NoPeersSubscribedToTopic)
+            .wrap_err("failed to publish state delta");
+        assert!(is_no_peers_subscribed_error(&err));
+    }
+
+    #[test]
+    fn does_not_classify_other_publish_errors() {
+        let err: eyre::Report = PublishError::MessageTooLarge.into();
+        assert!(!is_no_peers_subscribed_error(&err));
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_errors() {
+        let err: eyre::Report = eyre::eyre!("some other failure");
+        assert!(!is_no_peers_subscribed_error(&err));
     }
 }

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -17,7 +17,7 @@ use calimero_utils_actix::LazyRecipient;
 use dashmap::DashMap;
 use eyre::{OptionExt, WrapErr};
 use futures_util::Stream;
-use libp2p::gossipsub::{IdentTopic, TopicHash};
+use libp2p::gossipsub::{IdentTopic, PublishError, TopicHash};
 use libp2p::PeerId;
 use rand::Rng;
 use tokio::sync::{broadcast, mpsc};
@@ -194,6 +194,26 @@ pub struct LocalAppliedDelta {
 /// publishes on an unhealthy mesh (gate too low).
 fn gossipsub_mesh_n_low_default() -> usize {
     GOSSIPSUB_MESH_N_LOW
+}
+
+/// Returns true when `err`'s chain contains `PublishError::NoPeersSubscribedToTopic`.
+///
+/// Used by `broadcast` and `broadcast_heartbeat` to silence the one
+/// publish-error variant that's a normal cold-start outcome rather than a
+/// transport failure. We do not queue or retry the payload — see #2356
+/// item 3 and the post-mortem on the closed PR #2369: queuing state
+/// deltas at the network layer races the receiver's DAG sync and
+/// replays stale snapshots. State deltas have a sync-pull recovery
+/// path (HashComparison via heartbeats); heartbeats are idempotent at
+/// their own cadence; either way, dropping one publish on a topic
+/// with zero subscribers is the safe behavior.
+fn is_no_peers_subscribed_error(err: &eyre::Report) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<PublishError>(),
+            Some(PublishError::NoPeersSubscribedToTopic)
+        )
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -486,10 +506,6 @@ impl NodeClient {
             "Sending state delta"
         );
 
-        if self.get_peers_count(Some(&context.id)).await == 0 {
-            return Ok(());
-        }
-
         let shared_key = SharedKey::from_sk(sender_key);
         let nonce = rand::thread_rng().gen();
 
@@ -516,9 +532,28 @@ impl NodeClient {
 
         let topic = TopicHash::from_raw(context.id);
 
-        let _ignored = self.network_client.publish(topic, payload).await?;
-
-        Ok(())
+        // Previously this returned early when `mesh_peer_count == 0`,
+        // which silently dropped state deltas during the cold-start
+        // window where peers are subscribed-but-not-yet-mesh. With
+        // `flood_publish(true)` (#2352), gossipsub itself decides
+        // reachability, so the application-level gate was both wrong
+        // (missed flood-eligible peers) and silent (no logs). Attempt
+        // the publish unconditionally and let gossipsub report the
+        // actual outcome; convert the one cold-start error variant
+        // to a debug log because the receiver's sync-pull path
+        // (HashComparison via heartbeats) recovers any drop.
+        match self.network_client.publish(topic, payload).await {
+            Ok(_) => Ok(()),
+            Err(err) if is_no_peers_subscribed_error(&err) => {
+                debug!(
+                    context_id = %context.id,
+                    delta_id = ?delta_id,
+                    "no peers subscribed to context topic, state delta dropped (sync-pull will recover)"
+                );
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn broadcast_heartbeat(
@@ -527,10 +562,6 @@ impl NodeClient {
         root_hash: calimero_primitives::hash::Hash,
         dag_heads: Vec<[u8; 32]>,
     ) -> eyre::Result<()> {
-        if self.get_peers_count(Some(context_id)).await == 0 {
-            return Ok(());
-        }
-
         let payload = BroadcastMessage::HashHeartbeat {
             context_id: *context_id,
             root_hash,
@@ -540,9 +571,21 @@ impl NodeClient {
         let payload = borsh::to_vec(&payload)?;
         let topic = TopicHash::from_raw(*context_id);
 
-        let _ignored = self.network_client.publish(topic, payload).await?;
-
-        Ok(())
+        // See `broadcast`: drop the application-level zero-peers gate so
+        // gossipsub's `flood_publish` decides reachability, and silence
+        // the cold-start `NoPeersSubscribed` variant — the next
+        // heartbeat tick (~5 s) carries fresh state regardless.
+        match self.network_client.publish(topic, payload).await {
+            Ok(_) => Ok(()),
+            Err(err) if is_no_peers_subscribed_error(&err) => {
+                debug!(
+                    %context_id,
+                    "no peers subscribed to context topic, heartbeat dropped (next tick will retry)"
+                );
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Mesh peer count for the namespace topic `ns/<hex>` — used by callers
@@ -970,5 +1013,37 @@ mod publish_on_namespace_now_tests {
             1 + ADMIT_AFTER_CYCLES,
             "must stop announcing the instant admission is observed"
         );
+    }
+}
+
+#[cfg(test)]
+mod is_no_peers_subscribed_error_tests {
+    use libp2p::gossipsub::PublishError;
+
+    use super::is_no_peers_subscribed_error;
+
+    #[test]
+    fn classifies_no_peers_subscribed_at_root() {
+        let err: eyre::Report = PublishError::NoPeersSubscribedToTopic.into();
+        assert!(is_no_peers_subscribed_error(&err));
+    }
+
+    #[test]
+    fn classifies_no_peers_subscribed_when_wrapped() {
+        let err = eyre::Report::from(PublishError::NoPeersSubscribedToTopic)
+            .wrap_err("failed to publish state delta");
+        assert!(is_no_peers_subscribed_error(&err));
+    }
+
+    #[test]
+    fn does_not_classify_other_publish_errors() {
+        let err: eyre::Report = PublishError::MessageTooLarge.into();
+        assert!(!is_no_peers_subscribed_error(&err));
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_errors() {
+        let err: eyre::Report = eyre::eyre!("some other failure");
+        assert!(!is_no_peers_subscribed_error(&err));
     }
 }

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_stream::stream;
 use calimero_context_config::types::GovernancePosition;
 use calimero_crypto::SharedKey;
-use calimero_network_primitives::client::NetworkClient;
+use calimero_network_primitives::client::{is_no_peers_subscribed_error, NetworkClient};
 use calimero_network_primitives::config::GOSSIPSUB_MESH_N_LOW;
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::NodeEvent;
@@ -17,7 +17,7 @@ use calimero_utils_actix::LazyRecipient;
 use dashmap::DashMap;
 use eyre::{OptionExt, WrapErr};
 use futures_util::Stream;
-use libp2p::gossipsub::{IdentTopic, PublishError, TopicHash};
+use libp2p::gossipsub::{IdentTopic, TopicHash};
 use libp2p::PeerId;
 use rand::Rng;
 use tokio::sync::{broadcast, mpsc};
@@ -194,26 +194,6 @@ pub struct LocalAppliedDelta {
 /// publishes on an unhealthy mesh (gate too low).
 fn gossipsub_mesh_n_low_default() -> usize {
     GOSSIPSUB_MESH_N_LOW
-}
-
-/// Returns true when `err`'s chain contains `PublishError::NoPeersSubscribedToTopic`.
-///
-/// Used by `broadcast` and `broadcast_heartbeat` to silence the one
-/// publish-error variant that's a normal cold-start outcome rather than a
-/// transport failure. We do not queue or retry the payload — see #2356
-/// item 3 and the post-mortem on the closed PR #2369: queuing state
-/// deltas at the network layer races the receiver's DAG sync and
-/// replays stale snapshots. State deltas have a sync-pull recovery
-/// path (HashComparison via heartbeats); heartbeats are idempotent at
-/// their own cadence; either way, dropping one publish on a topic
-/// with zero subscribers is the safe behavior.
-fn is_no_peers_subscribed_error(err: &eyre::Report) -> bool {
-    err.chain().any(|cause| {
-        matches!(
-            cause.downcast_ref::<PublishError>(),
-            Some(PublishError::NoPeersSubscribedToTopic)
-        )
-    })
 }
 
 #[derive(Clone, Debug)]
@@ -411,6 +391,19 @@ impl NodeClient {
     }
 
     /// Publish raw payload on the namespace topic `ns/<hex(namespace_id)>`.
+    ///
+    /// # Why this path keeps the mesh-peer wait (unlike `broadcast`)
+    ///
+    /// `broadcast` / `broadcast_heartbeat` dropped their `mesh_peer_count == 0`
+    /// gate and silence `PublishError::NoPeersSubscribedToTopic` because state
+    /// deltas have a sync-pull recovery path (HashComparison via heartbeats):
+    /// a drop into an empty topic is recoverable by the next pull. Governance
+    /// ops carry no such recovery — a `ContextRegistered` lost on cold start
+    /// cannot be re-derived by the receiver, only re-published. So the
+    /// publisher-side wait stays: we poll for at least one mesh peer up to
+    /// `MAX_WAIT` before publishing, log when we give up, and propagate any
+    /// publish error (including `NoPeersSubscribedToTopic`) so the caller can
+    /// decide whether to retry/re-announce.
     pub async fn publish_on_namespace(
         &self,
         namespace_id: [u8; 32],
@@ -456,6 +449,13 @@ impl NodeClient {
     /// Kept separate from [`publish_on_namespace`](Self::publish_on_namespace)
     /// so the up-front wait-then-publish semantics other callers rely on are
     /// untouched; this is the opt-in, per-cycle building block.
+    ///
+    /// Like [`publish_on_namespace`](Self::publish_on_namespace), this method
+    /// propagates `PublishError::NoPeersSubscribedToTopic` to the caller
+    /// rather than silencing it — that's the exact "publish into an empty
+    /// mesh" signal the re-announce loop needs to know it must keep trying.
+    /// State-delta paths (`broadcast` / `broadcast_heartbeat`) silence the
+    /// same error because they have sync-pull recovery; governance does not.
     pub async fn publish_on_namespace_now(
         &self,
         namespace_id: [u8; 32],
@@ -580,7 +580,7 @@ impl NodeClient {
             Err(err) if is_no_peers_subscribed_error(&err) => {
                 debug!(
                     %context_id,
-                    "no peers subscribed to context topic, heartbeat dropped (next tick will retry)"
+                    "no peers subscribed to context topic, heartbeat dropped (next tick will carry fresh state)"
                 );
                 Ok(())
             }
@@ -1013,37 +1013,5 @@ mod publish_on_namespace_now_tests {
             1 + ADMIT_AFTER_CYCLES,
             "must stop announcing the instant admission is observed"
         );
-    }
-}
-
-#[cfg(test)]
-mod is_no_peers_subscribed_error_tests {
-    use libp2p::gossipsub::PublishError;
-
-    use super::is_no_peers_subscribed_error;
-
-    #[test]
-    fn classifies_no_peers_subscribed_at_root() {
-        let err: eyre::Report = PublishError::NoPeersSubscribedToTopic.into();
-        assert!(is_no_peers_subscribed_error(&err));
-    }
-
-    #[test]
-    fn classifies_no_peers_subscribed_when_wrapped() {
-        let err = eyre::Report::from(PublishError::NoPeersSubscribedToTopic)
-            .wrap_err("failed to publish state delta");
-        assert!(is_no_peers_subscribed_error(&err));
-    }
-
-    #[test]
-    fn does_not_classify_other_publish_errors() {
-        let err: eyre::Report = PublishError::MessageTooLarge.into();
-        assert!(!is_no_peers_subscribed_error(&err));
-    }
-
-    #[test]
-    fn does_not_classify_unrelated_errors() {
-        let err: eyre::Report = eyre::eyre!("some other failure");
-        assert!(!is_no_peers_subscribed_error(&err));
     }
 }


### PR DESCRIPTION
Addresses item 3 of #2356 — the `broadcast()` short-circuit on zero mesh peers.

## The bug

`NodeClient::broadcast` and `NodeClient::broadcast_heartbeat` early-return when `get_peers_count(context) == 0`. That function calls `mesh_peer_count(topic)`, which after #2352's `flood_publish(true)` is a strict subset of \"reachable subscribers\" — peers that are subscribed but not yet in the mesh during cold-start were silently dropped even though flood_publish would have delivered to them. No log, no metric, no way to tell the difference between \"delivered\" and \"silently dropped.\"

## The fix

Remove both early-returns and attempt the publish unconditionally — gossipsub decides reachability. The one cold-start error variant `PublishError::NoPeersSubscribedToTopic` (truly no subscribers on the topic) is classified by a new `is_no_peers_subscribed_error` helper and downgraded to a `debug!` log so the public `Ok(())` contract is preserved. Other publish errors continue to propagate.

## Deliberately not queueing or retrying

Per the post-mortem on the closed PR #2369: a network-layer outbox was tried in four iterations and each one surfaced a distinct failure mode, the deepest being that re-publishing state deltas after a delay races the receiver's DAG sync and pushes it onto a snapshot path that skips apply-time side-effects.

State deltas have a sync-pull recovery path (HashComparison via heartbeats). Heartbeats are idempotent at their ~5 s cadence. Dropping one publish into a topic with zero subscribers is the safe outcome; queueing it is not.

This is candidate fix #3 from the issue body — \"remove the short-circuit and let `flood_publish` handle the 'no subscribed peers' case naturally.\"

## Test

`is_no_peers_subscribed_error_tests`, four cases:
- `PublishError::NoPeersSubscribedToTopic` at the root of an `eyre::Report` → true.
- Same, wrapped via `.wrap_err()` → true.
- `PublishError::MessageTooLarge` → false (other PublishError variants must not match).
- Unrelated `eyre::eyre!(...)` → false.

`calimero-node-primitives`: 327 passed, 0 failed. Downstream `calimero-node`: 216 passed, 0 failed.

## Stacks on #2496

This PR is independent of #2496 (item 1 fix); they touch different files and can land in either order.

## Out of scope

Items 2 (head fan-out cap) and 4 (JOIN-time mesh population verification) of #2356 — each will get its own PR per the issue's guidance.

## Test plan

- [x] `cargo fmt --check -p calimero-node-primitives`
- [x] `cargo test -p calimero-node-primitives --lib`
- [x] `cargo test -p calimero-node --lib`
- [ ] Sync regression (smoke) workflow on this branch: cold-start cases should now log `no peers subscribed to context topic, state delta dropped` instead of silently returning Ok; flood_publish-eligible peers should now receive deltas they were previously missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path gossip publish behavior for all context state deltas and heartbeats; misclassification of publish errors could hide real failures, though governance paths remain strict and tests cover the helper.
> 
> **Overview**
> Removes the **`mesh_peer_count == 0`** early return from **`NodeClient::broadcast`** and **`broadcast_heartbeat`**, so state deltas and heartbeats are always handed to gossipsub (aligned with **`flood_publish`** after #2352). Subscribed-but-not-yet-mesh peers are no longer skipped with a silent **`Ok(())`**.
> 
> Adds shared **`is_no_peers_subscribed_error`** in **`calimero-network-primitives`** to detect **`PublishError::NoPeersSubscribedToTopic`** in an **`eyre::Report`** chain; state-delta paths log at **debug** and still return **`Ok(())`** because sync-pull / the next heartbeat can recover. **Governance** paths (**`publish_on_namespace`**, **`publish_on_namespace_now`**, **`governance_broadcast::classify_network_publish_error`**) keep surfacing that case so callers can retry or wait for mesh.
> 
> Includes unit tests for the classifier and doc comments contrasting recoverable state broadcast vs non-recoverable governance publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ba2e08cd229670fa54bd3eab39429f2bd70735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->