### PR TITLE
feat(node/metrics): expose dag_heads_count histogram (#2356 item 2 instrumentation)

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1358,6 +1358,12 @@ impl DeltaStore {
         // Update context's dag_heads after the DAG has been updated
         let heads = dag.get_heads();
 
+        // Observe DAG head fan-out for #2356 item 2. The histogram drives
+        // the cap-mechanism decision (checkpoint vs periodic consolidation
+        // vs no cap) — currently we have no production data for what
+        // heads_count actually looks like post-#2238 / #2465.
+        crate::node_metrics::observe_dag_heads_count(heads.len());
+
         // Get list of deltas that were pending but are now applied (cascade effect)
         let cascaded_deltas: Vec<[u8; 32]> = if !pending_before.is_empty() {
             let pending_after: HashSet<[u8; 32]> =

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -102,6 +102,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) delta_outcomes_total: Family<DeltaApplyLabels, Counter>,
     pub(crate) delta_cascade_size: Histogram,
     pub(crate) delta_missing_parents_total: Counter,
+    pub(crate) dag_heads_count: Histogram,
 
     // HC / LevelWise / EntityPush per-leaf authorization drops.
     pub(crate) hc_leaf_drops_total: Family<LeafDropLabels, Counter>,
@@ -219,6 +220,22 @@ impl NodeMetrics {
             delta_missing_parents_total.clone(),
         );
 
+        // DAG heads observed after every delta apply. Per-context labels are
+        // intentionally omitted (see "Cardinality discipline" above); the
+        // sum-across-contexts distribution is enough to chart fan-out
+        // growth. Buckets stop at 256 because anything past that is a
+        // pathology that should page someone — operators will see the
+        // overflow bucket fill rather than the histogram lose resolution.
+        // The instrumentation step for #2356 item 2: data the cap-mechanism
+        // discussion currently lacks.
+        let dag_heads_count = Histogram::new([1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]);
+        registry.register(
+            "dag_heads_count",
+            "Number of concurrent DAG heads observed at the end of each delta apply, \
+             across all contexts on this node",
+            dag_heads_count.clone(),
+        );
+
         let hc_leaf_drops_total: Family<LeafDropLabels, Counter> = Family::default();
         registry.register(
             "hc_leaf_drops_total",
@@ -275,6 +292,7 @@ impl NodeMetrics {
             delta_outcomes_total,
             delta_cascade_size,
             delta_missing_parents_total,
+            dag_heads_count,
             hc_leaf_drops_total,
             governance_drain_outcomes_total,
             process_resident_memory_bytes,
@@ -516,6 +534,18 @@ pub(crate) fn record_delta_outcome(outcome: &str) {
 pub(crate) fn observe_delta_cascade(size: usize) {
     if let Some(m) = global() {
         m.delta_cascade_size.observe(size as f64);
+    }
+}
+
+/// Observe the number of concurrent DAG heads after a delta apply.
+/// Called from `DeltaStore::add_delta_internal` right after the DAG
+/// reports its post-apply heads. Drives the #2356 item 2 head-fan-out
+/// decision: the cap mechanism + threshold should be picked from this
+/// histogram's p99 over a representative production window, not from
+/// #2293's stale 9.6 s anecdote.
+pub(crate) fn observe_dag_heads_count(heads: usize) {
+    if let Some(m) = global() {
+        m.dag_heads_count.observe(heads as f64);
     }
 }
 


### PR DESCRIPTION
Addresses item 2 of #2356 — \"Cap `__calimero_sync_next` head fan-out\" — as the **instrumentation step before the actual fix**.

## Why instrument first

The fix #2293 / item 2 proposed was \"maximum-heads checkpoint or periodic head consolidation,\" both of which need a threshold. The threshold should come from data, not from #2293's 9.6 s sync-session anecdote — that anecdote predates #2238 / #2240 / #2241 / #2465, which substantially cut the per-merge cost. We currently have no production data on what `heads_count` actually looks like on master, so any cap value picked today is a guess.

## What this adds

A single Prometheus histogram, `dag_heads_count`, observed at `DeltaStore::add_delta_internal` right after `dag.get_heads()`:

- Buckets: `[1, 2, 4, 8, 16, 32, 64, 128, 256]`
- Per-context labels intentionally omitted (cardinality discipline, see the module docstring in `node_metrics.rs`)
- Sum-across-contexts is enough to chart fan-out growth + spot pathological tails

That's it — no new logs, no behavior change, no new dependencies. Once this lands and bakes for a week or two against the fuzzy / e2e workflows + any production deploys, the cap-mechanism decision (checkpoint vs periodic consolidation vs no-cap-needed) can be calibrated rather than guessed.

## What this does NOT do

- No actual cap. Item 2's cap mechanism stays open until we have the histogram data.
- No per-context labels. If a particular context shows pathological fan-out, debug logs at `delta_store.rs:1446` (`heads_count = heads.len()`, existing) still cover drilldown.
- No warn log on threshold. The histogram is the signal; logs would either spam (always-on at threshold) or miss (rate-limited and stateful).

## Test plan

- [x] `cargo fmt --check -p calimero-node`
- [x] `cargo test -p calimero-node --lib` — 216 passed, 0 failed
- [ ] After merge: confirm `dag_heads_count_bucket{le=\"...\"}` / `_sum` / `_count` series appear in `/metrics`
- [ ] After ~2 weeks of baking: revisit item 2 with the observed p99 + tail distribution

## Stacks on / relates to

- #2496 (item 1) and #2497 (item 3) are independent.
- Item 4 was closed-as-verified via [issue comment](https://github.com/calimero-network/core/issues/2356#issuecomment-4552615542).
- After this lands, #2356 has no open scope: items 1/3 captured by PRs, item 4 verified, item 2's cap deferred pending the data this histogram provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change on the delta-apply path; no auth, persistence semantics, or cap logic altered.
> 
> **Overview**
> Adds **Prometheus instrumentation** for concurrent DAG head fan-out so issue **#2356** item 2 (capping `__calimero_sync_next` head fan-out) can pick a threshold from production data instead of older anecdotes.
> 
> After each delta apply in `DeltaStore::add_delta_internal`, the node records `dag.get_heads().len()` into a new histogram **`dag_heads_count`** (buckets 1 through 256, no per-context labels). A small `observe_dag_heads_count` helper in `node_metrics` wires the series into the existing global metrics registry.
> 
> **No sync or DAG behavior changes** — only metrics for a later cap/checkpoint vs consolidation decision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0711cd42752c1549617d317a480039b7fd4c8501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->