### PR TITLE
perf(node/delta): observe dag_heads_count outside the DAG write lock

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1357,12 +1357,7 @@ impl DeltaStore {
 
         // Update context's dag_heads after the DAG has been updated
         let heads = dag.get_heads();
-
-        // Observe DAG head fan-out for #2356 item 2. The histogram drives
-        // the cap-mechanism decision (checkpoint vs periodic consolidation
-        // vs no cap) — currently we have no production data for what
-        // heads_count actually looks like post-#2238 / #2465.
-        crate::node_metrics::observe_dag_heads_count(heads.len());
+        let heads_count = heads.len();
 
         // Get list of deltas that were pending but are now applied (cascade effect)
         let cascaded_deltas: Vec<[u8; 32]> = if !pending_before.is_empty() {
@@ -1376,6 +1371,16 @@ impl DeltaStore {
         let hold = lock_start.elapsed();
         drop(dag); // Release lock before calling context_client
         self.record_dag_write_lock_hold("add_delta_internal", hold, None, cascaded_deltas.len());
+
+        // Observe DAG head fan-out for #2356 item 2. The histogram drives
+        // the cap-mechanism decision (checkpoint vs periodic consolidation
+        // vs no cap) — currently we have no production data for what
+        // heads_count actually looks like post-#2238 / #2465.
+        //
+        // Recorded after `drop(dag)` so the (sub-microsecond) atomic
+        // observe doesn't extend the write-lock critical section every
+        // caller waits on.
+        crate::node_metrics::observe_dag_heads_count(heads_count);
 
         // Update persistence if delta applied. Preserve events until
         // the caller confirms handler execution via


### PR DESCRIPTION
Post-merge review feedback on #2499 — MeroReviewer flagged that `observe_dag_heads_count(heads.len())` lands inside the `add_delta_internal` write-lock critical section.

## What changed

Capture `heads.len()` before `drop(dag)`; move the observe call to just after the lock release, next to `record_dag_write_lock_hold`. That recorder is already deliberately outside the lock (same atomic-counter shape), so this brings the histogram observe in line.

```rust
let heads = dag.get_heads();
let heads_count = heads.len();

// ... cascaded_deltas computation under the lock ...

let hold = lock_start.elapsed();
drop(dag);
self.record_dag_write_lock_hold("add_delta_internal", hold, None, cascaded_deltas.len());

// observe AFTER drop, sub-microsecond but no reason to extend the critical section
crate::node_metrics::observe_dag_heads_count(heads_count);
```

## Why

The observe is a single atomic histogram increment — sub-microsecond. The cost isn't the observe itself, it's that the write-lock critical section is on the apply hot path; every concurrent caller waiting on the lock pays whatever's inside it. No reason to keep it there when capturing the `usize` first costs nothing.

## Test plan

- [x] `cargo fmt --check -p calimero-node`
- [x] `cargo test -p calimero-node --lib` — 216 passed, 0 failed
- [x] No behavior change: histogram still observes one sample per `add_delta_internal` call, with the same `heads.len()` value as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lock-scope-only refactor on metrics; no change to delta apply, persistence, or histogram values.
> 
> **Overview**
> In `add_delta_internal`, the DAG head-count histogram for #2356 is recorded **after** the DAG write lock is released instead of while the lock is held.
> 
> `heads.len()` is captured as `heads_count` before `drop(dag)`; `observe_dag_heads_count` runs next to `record_dag_write_lock_hold`, so the atomic histogram increment no longer extends the apply hot-path critical section. **Metric semantics are unchanged** — one sample per call with the same head count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee68ba472ceb9617864ed4d231fd59171e551736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->