### PR TITLE
feat(meroctl): network status admin command + endpoint (#2488)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "calimero-server-primitives",
  "calimero-store",
  "calimero-tee-attestation",
+ "chrono",
  "color-eyre",
  "eyre",
  "futures-util",

--- a/crates/client/src/client/system.rs
+++ b/crates/client/src/client/system.rs
@@ -2,7 +2,7 @@
 
 use calimero_server_primitives::admin::{
     FleetJoinRequest, FleetJoinResponse, GenerateContextIdentityResponse, GetPeersCountResponse,
-    InviteSpecializedNodeRequest, InviteSpecializedNodeResponse,
+    InviteSpecializedNodeRequest, InviteSpecializedNodeResponse, NetworkStatusResponse,
 };
 use eyre::Result;
 
@@ -24,6 +24,14 @@ where
 
     pub async fn get_peers_count(&self) -> Result<GetPeersCountResponse> {
         let response = self.connection.get("admin-api/peers").await?;
+        Ok(response)
+    }
+
+    /// Snapshot the local node's libp2p connectivity state — relays,
+    /// rendezvous registrations, DCUtR upgrade outcomes per peer, and
+    /// AutoNAT v2 reachability. Backs `meroctl network status`.
+    pub async fn network_status(&self) -> Result<NetworkStatusResponse> {
+        let response = self.connection.get("admin-api/network/status").await?;
         Ok(response)
     }
 

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -24,6 +24,7 @@ mod context;
 mod dev;
 mod group;
 mod namespace;
+mod network;
 mod node;
 mod peers;
 mod tee;
@@ -37,6 +38,7 @@ use context::ContextCommand;
 use dev::DevCommand;
 use group::GroupCommand;
 use namespace::NamespaceCommand;
+use network::NetworkCommand;
 use node::NodeCommand;
 use peers::PeersCommand;
 use tee::TeeCommand;
@@ -94,6 +96,7 @@ pub enum SubCommands {
     #[command(alias = "ns")]
     Namespace(NamespaceCommand),
     Call(CallCommand),
+    Network(NetworkCommand),
     Peers(PeersCommand),
     Tee(TeeCommand),
     #[command(subcommand)]
@@ -169,6 +172,7 @@ impl RootCommand {
             SubCommands::Group(group) => group.run(&mut environment).await,
             SubCommands::Namespace(ns) => ns.run(&mut environment).await,
             SubCommands::Call(call) => call.run(&mut environment).await,
+            SubCommands::Network(network) => network.run(&mut environment).await,
             SubCommands::Peers(peers) => peers.run(&mut environment).await,
             SubCommands::Tee(tee) => tee.run(&mut environment).await,
             SubCommands::Node(node) => {

--- a/crates/meroctl/src/cli/network.rs
+++ b/crates/meroctl/src/cli/network.rs
@@ -1,0 +1,40 @@
+use clap::{Parser, Subcommand};
+use const_format::concatcp;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+pub mod status;
+
+pub const EXAMPLES: &str = r"
+  # Dump this node's swarm connectivity state — listen/external addresses,
+  # relay reservations, rendezvous registrations, DCUtR upgrades, AutoNAT.
+  $ meroctl --node node1 network status
+
+  # Same, as JSON (use the root --output-format flag).
+  $ meroctl --output-format json --node node1 network status
+";
+
+#[derive(Debug, Parser)]
+#[command(about = "Inspect libp2p networking state")]
+#[command(after_help = concatcp!(
+    "Examples:",
+    EXAMPLES
+))]
+pub struct NetworkCommand {
+    #[command(subcommand)]
+    pub subcommand: NetworkSubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum NetworkSubCommands {
+    Status(status::StatusCommand),
+}
+
+impl NetworkCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        match self.subcommand {
+            NetworkSubCommands::Status(cmd) => cmd.run(environment).await,
+        }
+    }
+}

--- a/crates/meroctl/src/cli/network/status.rs
+++ b/crates/meroctl/src/cli/network/status.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use eyre::Result;
+
+use crate::cli::Environment;
+
+#[derive(Copy, Clone, Debug, Parser)]
+#[command(about = "Snapshot libp2p connectivity: relays, rendezvous, DCUtR, AutoNAT")]
+pub struct StatusCommand;
+
+impl StatusCommand {
+    pub async fn run(&self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?;
+        let response = client.network_status().await?;
+        environment.output.write(&response);
+        Ok(())
+    }
+}

--- a/crates/meroctl/src/output.rs
+++ b/crates/meroctl/src/output.rs
@@ -5,6 +5,7 @@ pub mod blobs;
 pub mod common;
 pub mod contexts;
 pub mod groups;
+pub mod network;
 pub mod tee;
 
 // Re-export common types

--- a/crates/meroctl/src/output/network.rs
+++ b/crates/meroctl/src/output/network.rs
@@ -1,0 +1,118 @@
+use calimero_server_primitives::admin::NetworkStatusResponse;
+use comfy_table::{Cell, Color, Table};
+
+use super::Report;
+
+impl Report for NetworkStatusResponse {
+    fn report(&self) {
+        // Identity table — peer id + every address the swarm currently knows about.
+        let mut identity = Table::new();
+        let _ = identity.set_header(vec![
+            Cell::new("Identity").fg(Color::Green),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = identity.add_row(vec!["Local peer ID", &self.local_peer_id]);
+        for (idx, addr) in self.listen_addrs.iter().enumerate() {
+            let _ = identity.add_row(vec![&format!("Listen [{idx}]"), addr]);
+        }
+        if self.listen_addrs.is_empty() {
+            let _ = identity.add_row(vec!["Listen", "(none)"]);
+        }
+        for (idx, addr) in self.external_addrs.iter().enumerate() {
+            let _ = identity.add_row(vec![&format!("External [{idx}]"), addr]);
+        }
+        if self.external_addrs.is_empty() {
+            let _ = identity.add_row(vec!["External", "(none)"]);
+        }
+        println!("{identity}");
+
+        // AutoNAT — reachability + last probe.
+        let mut autonat = Table::new();
+        let _ = autonat.set_header(vec![
+            Cell::new("AutoNAT").fg(Color::Green),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = autonat.add_row(vec!["Reachability", &self.autonat.reachability]);
+        let _ = autonat.add_row(vec![
+            "Last test addr",
+            self.autonat.last_test_addr.as_deref().unwrap_or("(none)"),
+        ]);
+        let _ = autonat.add_row(vec![
+            "Last test result",
+            self.autonat.last_test_result.as_deref().unwrap_or("(none)"),
+        ]);
+        if let Some(ref observed) = self.autonat.last_test_observed_addr {
+            let _ = autonat.add_row(vec!["Observed addr", observed]);
+        }
+        if let Some(ref reason) = self.autonat.last_test_reason {
+            let _ = autonat.add_row(vec!["Failure reason", reason]);
+        }
+        let _ = autonat.add_row(vec![
+            "Last test at",
+            self.autonat.last_test_at.as_deref().unwrap_or("(none)"),
+        ]);
+        println!("{autonat}");
+
+        // Relays.
+        let mut relays = Table::new();
+        let _ = relays.set_header(vec![
+            Cell::new("Relay peer").fg(Color::Blue),
+            Cell::new("Reservation").fg(Color::Blue),
+            Cell::new("Last state change").fg(Color::Blue),
+        ]);
+        if self.relays.is_empty() {
+            let _ = relays.add_row(vec!["(no known relays)", "", ""]);
+        } else {
+            for r in &self.relays {
+                let _ = relays.add_row(vec![
+                    &r.peer_id,
+                    &r.reservation_status,
+                    &r.last_state_change,
+                ]);
+            }
+        }
+        println!("{relays}");
+
+        // Rendezvous.
+        let mut rdv = Table::new();
+        let _ = rdv.set_header(vec![
+            Cell::new("Rendezvous peer").fg(Color::Blue),
+            Cell::new("Registration").fg(Color::Blue),
+            Cell::new("Last state change").fg(Color::Blue),
+        ]);
+        if self.rendezvous.is_empty() {
+            let _ = rdv.add_row(vec!["(no known rendezvous)", "", ""]);
+        } else {
+            for r in &self.rendezvous {
+                let _ = rdv.add_row(vec![
+                    &r.peer_id,
+                    &r.registration_status,
+                    &r.last_state_change,
+                ]);
+            }
+        }
+        println!("{rdv}");
+
+        // Direct upgrades (DCUtR).
+        let mut dc = Table::new();
+        let _ = dc.set_header(vec![
+            Cell::new("DCUtR peer").fg(Color::Blue),
+            Cell::new("Status").fg(Color::Blue),
+            Cell::new("Detail").fg(Color::Blue),
+            Cell::new("Last attempt").fg(Color::Blue),
+        ]);
+        if self.direct_upgrades.is_empty() {
+            let _ = dc.add_row(vec!["(no upgrade attempts observed)", "", "", ""]);
+        } else {
+            for d in &self.direct_upgrades {
+                let detail = d
+                    .reason
+                    .as_deref()
+                    .or(d.connection_id.as_deref())
+                    .unwrap_or("-");
+                let _ = dc.add_row(vec![&d.peer_id, &d.status, detail, &d.last_attempt]);
+            }
+        }
+        println!("{dc}");
+    }
+}

--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -35,9 +35,11 @@ pub fn is_no_peers_subscribed_error(err: &eyre::Report) -> bool {
 use crate::blob_types::BlobAuth;
 use crate::messages::{
     AnnounceBlob, Bootstrap, Dial, ListenOn, MeshPeerCount, MeshPeers, MeshStats, NetworkMessage,
-    OpenStream, PeerCount, Publish, QueryBlob, RequestBlob, SendSpecializedNodeInvitationResponse,
-    SendSpecializedNodeVerificationRequest, Subscribe, Unsubscribe,
+    NetworkStatus, OpenStream, PeerCount, Publish, QueryBlob, RequestBlob,
+    SendSpecializedNodeInvitationResponse, SendSpecializedNodeVerificationRequest, Subscribe,
+    Unsubscribe,
 };
+use crate::network_status::NetworkStatusSnapshot;
 use crate::specialized_node_invite::{SpecializedNodeInvitationResponse, VerificationRequest};
 use crate::stream::Stream;
 
@@ -200,6 +202,23 @@ impl NetworkClient {
         self.network_manager
             .send(NetworkMessage::MeshStats {
                 request: MeshStats,
+                outcome: tx,
+            })
+            .await
+            .expect("Mailbox not to be dropped");
+
+        rx.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Snapshot of the local node's libp2p connectivity state. Feeds
+    /// `GET /admin-api/network/status` and the corresponding
+    /// `meroctl network status` CLI.
+    pub async fn network_status(&self) -> NetworkStatusSnapshot {
+        let (tx, rx) = oneshot::channel();
+
+        self.network_manager
+            .send(NetworkMessage::NetworkStatus {
+                request: NetworkStatus,
                 outcome: tx,
             })
             .await

--- a/crates/network/primitives/src/lib.rs
+++ b/crates/network/primitives/src/lib.rs
@@ -3,5 +3,6 @@ pub mod blob_types;
 pub mod client;
 pub mod config;
 pub mod messages;
+pub mod network_status;
 pub mod specialized_node_invite;
 pub mod stream;

--- a/crates/network/primitives/src/messages.rs
+++ b/crates/network/primitives/src/messages.rs
@@ -54,6 +54,7 @@ use libp2p::{Multiaddr, StreamProtocol};
 use tokio::sync::oneshot;
 
 use crate::blob_types::BlobAuth;
+use crate::network_status::NetworkStatusSnapshot;
 use crate::specialized_node_invite::{SpecializedNodeInvitationResponse, VerificationRequest};
 use crate::stream::Stream;
 
@@ -132,6 +133,11 @@ pub enum NetworkMessage {
     MeshStats {
         request: MeshStats,
         outcome: oneshot::Sender<<MeshStats as actix::Message>::Result>,
+    },
+    /// Snapshot the swarm connectivity state for `GET /admin-api/network/status`.
+    NetworkStatus {
+        request: NetworkStatus,
+        outcome: oneshot::Sender<<NetworkStatus as actix::Message>::Result>,
     },
     /// Announce blob availability to the DHT.
     AnnounceBlob {
@@ -237,6 +243,19 @@ pub struct MeshStats;
 
 impl actix::Message for MeshStats {
     type Result = Vec<(TopicHash, usize)>;
+}
+
+/// Request a snapshot of the local node's libp2p connectivity state —
+/// listen addresses, external addresses, relay reservations,
+/// rendezvous registrations, DCUtR upgrade outcomes per peer, and the
+/// most recent AutoNAT v2 probe result. Used by
+/// `GET /admin-api/network/status` and by integration tests that want
+/// typed assertions instead of grepping logs.
+#[derive(Clone, Copy, Debug)]
+pub struct NetworkStatus;
+
+impl actix::Message for NetworkStatus {
+    type Result = NetworkStatusSnapshot;
 }
 
 /// Request to open a direct stream to a peer.

--- a/crates/network/primitives/src/network_status.rs
+++ b/crates/network/primitives/src/network_status.rs
@@ -1,0 +1,104 @@
+//! Snapshot types for the `NetworkStatus` actor query — the data the
+//! `NetworkManager` returns when asked "what does your swarm look like
+//! right now?". Consumed by `GET /admin-api/network/status` (which
+//! converts to a wire-friendly all-strings shape) and by anything else
+//! that wants a typed connectivity view without subscribing to events.
+//!
+//! Timestamps are `SystemTime` rather than `Instant` because the
+//! consumer is an HTTP endpoint that ultimately wants a wall-clock
+//! string. We do the `Instant → SystemTime` conversion inside the
+//! handler so callers don't have to carry an `Instant` reference clock.
+
+use std::time::SystemTime;
+
+use libp2p::swarm::ConnectionId;
+use libp2p::{Multiaddr, PeerId};
+
+/// Snapshot of the local node's libp2p connectivity state.
+///
+/// Returned in-process by `NetworkMessage::NetworkStatus`. The
+/// admin-api handler renders this into JSON for operators; tests can
+/// consume it directly without touching HTTP.
+#[derive(Clone, Debug)]
+pub struct NetworkStatusSnapshot {
+    pub local_peer_id: PeerId,
+    pub listen_addrs: Vec<Multiaddr>,
+    pub external_addrs: Vec<Multiaddr>,
+    pub relays: Vec<RelayEntry>,
+    pub rendezvous: Vec<RendezvousEntry>,
+    pub direct_upgrades: Vec<DirectUpgradeEntry>,
+    pub autonat: AutonatEntry,
+}
+
+#[derive(Clone, Debug)]
+pub struct RelayEntry {
+    pub peer_id: PeerId,
+    pub reservation_status: RelayReservationKind,
+    pub last_state_change: SystemTime,
+}
+
+/// Mirrors `calimero_network::discovery::state::RelayReservationStatus`
+/// but lives in primitives so the wire crate can name it without
+/// pulling in the network behaviour crate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RelayReservationKind {
+    Discovered,
+    Requested,
+    Accepted,
+    Expired,
+}
+
+#[derive(Clone, Debug)]
+pub struct RendezvousEntry {
+    pub peer_id: PeerId,
+    pub registration_status: RendezvousRegistrationKind,
+    pub last_state_change: SystemTime,
+}
+
+/// Mirrors `calimero_network::discovery::state::RendezvousRegistrationStatus`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RendezvousRegistrationKind {
+    Discovered,
+    Requested,
+    Registered,
+    Expired,
+}
+
+#[derive(Clone, Debug)]
+pub struct DirectUpgradeEntry {
+    pub peer_id: PeerId,
+    pub outcome: DirectUpgradeOutcome,
+    pub last_attempt: SystemTime,
+}
+
+#[derive(Clone, Debug)]
+pub enum DirectUpgradeOutcome {
+    Succeeded { connection_id: ConnectionId },
+    Failed { reason: String },
+}
+
+#[derive(Clone, Debug)]
+pub struct AutonatEntry {
+    pub reachability: ReachabilityKind,
+    pub last_test: Option<AutonatTestEntry>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReachabilityKind {
+    Unknown,
+    Public,
+    Private,
+}
+
+#[derive(Clone, Debug)]
+pub struct AutonatTestEntry {
+    pub tested_addr: Multiaddr,
+    pub result: AutonatTestKind,
+    pub at: SystemTime,
+}
+
+#[derive(Clone, Debug)]
+pub enum AutonatTestKind {
+    Reachable { addr: Multiaddr },
+    Failed { reason: String },
+}

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 use libp2p::core::transport::ListenerId;
 use libp2p::relay::HOP_PROTOCOL_NAME;
 use libp2p::rendezvous::Cookie;
+use libp2p::swarm::ConnectionId;
 use libp2p::{Multiaddr, PeerId, StreamProtocol};
 use multiaddr::Protocol;
 use tracing::info;
@@ -44,10 +45,31 @@ pub struct DiscoveryState {
     /// allocation).
     relay_listeners: HashMap<ListenerId, PeerId>,
     reachability_state: ReachabilityState,
+    /// Most recent AutoNAT v2 client probe outcome. Overwritten on every
+    /// probe; `None` until the first probe lands. Surfaced via
+    /// `meroctl network status` so operators can answer "is this node
+    /// behind NAT?" without trawling `RUST_LOG=debug`.
+    last_autonat_test: Option<AutonatTest>,
+}
+
+/// Latest AutoNAT client test outcome retained for introspection.
+/// One slot only — we don't keep history; the value is the freshest
+/// observation. The address tested and the result are both reported.
+#[derive(Clone, Debug)]
+pub struct AutonatTest {
+    pub tested_addr: Multiaddr,
+    pub result: AutonatTestResult,
+    pub at: Instant,
+}
+
+#[derive(Clone, Debug)]
+pub enum AutonatTestResult {
+    Reachable { addr: Multiaddr },
+    Failed { reason: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReachabilityState {
+pub enum ReachabilityState {
     Unknown,
     Reachable,
     Unreachable,
@@ -63,6 +85,7 @@ impl Default for DiscoveryState {
             confirmed_external_addresses: HashSet::new(),
             relay_listeners: HashMap::new(),
             reachability_state: ReachabilityState::Unknown,
+            last_autonat_test: None,
         }
     }
 }
@@ -256,6 +279,7 @@ impl DiscoveryState {
                     discoveries,
                     relay: None,
                     rendezvous: None,
+                    dcutr: None,
                 });
             }
         }
@@ -404,6 +428,44 @@ impl DiscoveryState {
         _ = self.peers.entry(*peer_id).or_default();
     }
 
+    /// Record the outcome of a DCUtR hole-punch attempt with `peer_id`.
+    /// Ensures the peer exists in the registry first — a dcutr event can
+    /// fire for a peer we don't otherwise track (no identify yet, no
+    /// rendezvous discovery), and we still want to surface the result.
+    pub(crate) fn record_dcutr_outcome(&mut self, peer_id: PeerId, status: DcutrUpgradeStatus) {
+        self.peers.entry(peer_id).or_default().update_dcutr(status);
+    }
+
+    /// Record the outcome of the most recent AutoNAT client probe.
+    /// Overwrites any prior observation — callers wanting history should
+    /// read `last_autonat_test` between calls.
+    pub(crate) fn record_autonat_test(
+        &mut self,
+        tested_addr: Multiaddr,
+        result: AutonatTestResult,
+    ) {
+        self.last_autonat_test = Some(AutonatTest {
+            tested_addr,
+            result,
+            at: Instant::now(),
+        });
+    }
+
+    pub(crate) fn last_autonat_test(&self) -> Option<&AutonatTest> {
+        self.last_autonat_test.as_ref()
+    }
+
+    pub(crate) const fn reachability_state(&self) -> ReachabilityState {
+        self.reachability_state
+    }
+
+    /// Iterate over `(peer_id, info)` pairs for every peer we track.
+    /// Used by the network-status snapshot builder to enumerate relay,
+    /// rendezvous and dcutr state in one pass.
+    pub(crate) fn iter_peers(&self) -> impl Iterator<Item = (&PeerId, &PeerInfo)> {
+        self.peers.iter()
+    }
+
     #[expect(
         clippy::arithmetic_side_effects,
         reason = "Cannot use saturating_add() due to non-specific integer type"
@@ -464,6 +526,11 @@ pub struct PeerInfo {
     discoveries: HashSet<PeerDiscoveryMechanism>,
     relay: Option<PeerRelayInfo>,
     rendezvous: Option<PeerRendezvousInfo>,
+    /// Latest DCUtR hole-punch outcome observed for this peer. `None`
+    /// means we've never seen a dcutr event (either the peer isn't
+    /// reachable over a relay we attempted to upgrade, or the upgrade
+    /// hasn't happened yet). Populated by the dcutr swarm-event handler.
+    dcutr: Option<PeerDcutrInfo>,
 }
 
 impl PeerInfo {
@@ -499,6 +566,10 @@ impl PeerInfo {
         self.relay.as_ref()
     }
 
+    pub(crate) const fn dcutr(&self) -> Option<&PeerDcutrInfo> {
+        self.dcutr.as_ref()
+    }
+
     fn add_discovery_mechanism(&mut self, mechanism: PeerDiscoveryMechanism) {
         let _ = self.discoveries.insert(mechanism);
     }
@@ -509,19 +580,20 @@ impl PeerInfo {
         }
     }
 
-    const fn update_relay_reservation_status(&mut self, status: RelayReservationStatus) {
+    fn update_relay_reservation_status(&mut self, status: RelayReservationStatus) {
         if let Some(ref mut info) = self.relay {
             info.update_reservation_status(status);
         }
     }
 
-    const fn update_rendezvous_registartion_status(
-        &mut self,
-        status: RendezvousRegistrationStatus,
-    ) {
+    fn update_rendezvous_registartion_status(&mut self, status: RendezvousRegistrationStatus) {
         if let Some(ref mut info) = self.rendezvous {
             info.update_registration_status(status);
         }
+    }
+
+    fn update_dcutr(&mut self, status: DcutrUpgradeStatus) {
+        self.dcutr = Some(PeerDcutrInfo::new(status));
     }
 }
 
@@ -531,9 +603,23 @@ pub enum PeerDiscoveryMechanism {
     Rendezvous,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PeerRelayInfo {
     reservation_status: RelayReservationStatus,
+    /// Wall-clock instant of the most recent reservation status mutation,
+    /// or of struct creation if no mutation has occurred. Surfaced as
+    /// `last_state_change` in the network-status snapshot so operators
+    /// can tell a fresh transition from a stale one.
+    last_state_change: Instant,
+}
+
+impl Default for PeerRelayInfo {
+    fn default() -> Self {
+        Self {
+            reservation_status: RelayReservationStatus::default(),
+            last_state_change: Instant::now(),
+        }
+    }
 }
 
 impl PeerRelayInfo {
@@ -541,8 +627,13 @@ impl PeerRelayInfo {
         self.reservation_status
     }
 
-    const fn update_reservation_status(&mut self, status: RelayReservationStatus) {
+    pub(crate) const fn last_state_change(&self) -> Instant {
+        self.last_state_change
+    }
+
+    fn update_reservation_status(&mut self, status: RelayReservationStatus) {
         self.reservation_status = status;
+        self.last_state_change = Instant::now();
     }
 }
 
@@ -555,11 +646,28 @@ pub enum RelayReservationStatus {
     Expired,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PeerRendezvousInfo {
     cookie: Option<Cookie>,
     last_discovery_at: Option<Instant>,
     registration_status: RendezvousRegistrationStatus,
+    /// Wall-clock instant of the most recent registration status
+    /// mutation. Surfaced as `last_registered_at` in the network-status
+    /// snapshot (the name follows the issue spec — it reads as "last
+    /// time registration status changed", which is what an operator
+    /// debugging rendezvous churn cares about).
+    last_state_change: Instant,
+}
+
+impl Default for PeerRendezvousInfo {
+    fn default() -> Self {
+        Self {
+            cookie: None,
+            last_discovery_at: None,
+            registration_status: RendezvousRegistrationStatus::default(),
+            last_state_change: Instant::now(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -589,7 +697,45 @@ impl PeerRendezvousInfo {
         self.registration_status
     }
 
-    const fn update_registration_status(&mut self, status: RendezvousRegistrationStatus) {
-        self.registration_status = status;
+    pub(crate) const fn last_state_change(&self) -> Instant {
+        self.last_state_change
     }
+
+    fn update_registration_status(&mut self, status: RendezvousRegistrationStatus) {
+        self.registration_status = status;
+        self.last_state_change = Instant::now();
+    }
+}
+
+/// DCUtR (Direct Connection Upgrade through Relay) hole-punch outcome
+/// retained per peer. We keep only the latest observation — a failed
+/// upgrade followed by a successful retry should leave the peer in the
+/// `Succeeded` state. Populated by the dcutr swarm-event handler.
+#[derive(Clone, Debug)]
+pub struct PeerDcutrInfo {
+    status: DcutrUpgradeStatus,
+    at: Instant,
+}
+
+impl PeerDcutrInfo {
+    pub(crate) fn new(status: DcutrUpgradeStatus) -> Self {
+        Self {
+            status,
+            at: Instant::now(),
+        }
+    }
+
+    pub(crate) fn status(&self) -> &DcutrUpgradeStatus {
+        &self.status
+    }
+
+    pub(crate) const fn at(&self) -> Instant {
+        self.at
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum DcutrUpgradeStatus {
+    Succeeded { connection_id: ConnectionId },
+    Failed { reason: String },
 }

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -604,6 +604,21 @@ fn test_multiple_listeners_map_to_distinct_relays() {
     assert_eq!(state.take_relay_listener(&listener_b), Some(relay_b));
 }
 
+/// Spin until the monotonic clock has strictly advanced past `prior`,
+/// bounded by a generous 100ms ceiling. Replaces `thread::sleep(2ms)`,
+/// which was flaky on slow CI where the kernel scheduler doesn't wake
+/// within the requested window and on Windows where `Instant`
+/// resolution is coarser than 1ms.
+fn wait_past(prior: std::time::Instant) {
+    let deadline = prior + std::time::Duration::from_millis(100);
+    while std::time::Instant::now() <= prior {
+        if std::time::Instant::now() > deadline {
+            panic!("clock failed to advance within 100ms — broken Instant");
+        }
+        std::hint::spin_loop();
+    }
+}
+
 #[test]
 fn record_dcutr_outcome_replaces_prior_observation() {
     let mut state = DiscoveryState::default();
@@ -623,7 +638,7 @@ fn record_dcutr_outcome_replaces_prior_observation() {
     assert!(matches!(first.status(), DcutrUpgradeStatus::Failed { .. }));
 
     // A subsequent success must overwrite the failure and bump the timestamp.
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    wait_past(first_at);
     state.record_dcutr_outcome(
         peer,
         DcutrUpgradeStatus::Succeeded {
@@ -658,7 +673,7 @@ fn record_autonat_test_keeps_only_the_freshest_probe() {
     );
     let first_at = state.last_autonat_test().expect("recorded").at;
 
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    wait_past(first_at);
     state.record_autonat_test(
         addr_two.clone(),
         AutonatTestResult::Reachable {
@@ -684,7 +699,7 @@ fn relay_reservation_status_change_bumps_last_state_change() {
         .map(|r| r.last_state_change())
         .expect("relay info initialized");
 
-    std::thread::sleep(std::time::Duration::from_millis(2));
+    wait_past(baseline);
     state.update_relay_reservation_status(&relay, RelayReservationStatus::Accepted);
 
     let after = state

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -603,3 +603,97 @@ fn test_multiple_listeners_map_to_distinct_relays() {
     assert_eq!(state.take_relay_listener(&listener_a), None);
     assert_eq!(state.take_relay_listener(&listener_b), Some(relay_b));
 }
+
+#[test]
+fn record_dcutr_outcome_replaces_prior_observation() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+
+    // First observation: a failure. ensure_peer side-effect should create
+    // a PeerInfo entry even though we never identified the peer.
+    state.record_dcutr_outcome(
+        peer,
+        DcutrUpgradeStatus::Failed {
+            reason: "timeout".to_owned(),
+        },
+    );
+    let info = state.get_peer_info(&peer).expect("peer created");
+    let first = info.dcutr().expect("dcutr observation recorded");
+    let first_at = first.at();
+    assert!(matches!(first.status(), DcutrUpgradeStatus::Failed { .. }));
+
+    // A subsequent success must overwrite the failure and bump the timestamp.
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    state.record_dcutr_outcome(
+        peer,
+        DcutrUpgradeStatus::Succeeded {
+            connection_id: libp2p::swarm::ConnectionId::new_unchecked(7),
+        },
+    );
+    let second = state
+        .get_peer_info(&peer)
+        .and_then(|i| i.dcutr())
+        .expect("still recorded");
+    assert!(matches!(
+        second.status(),
+        DcutrUpgradeStatus::Succeeded { .. }
+    ));
+    assert!(
+        second.at() > first_at,
+        "second observation must postdate the first",
+    );
+}
+
+#[test]
+fn record_autonat_test_keeps_only_the_freshest_probe() {
+    let mut state = DiscoveryState::default();
+    let addr_one: Multiaddr = "/ip4/1.2.3.4/tcp/1234".parse().unwrap();
+    let addr_two: Multiaddr = "/ip4/5.6.7.8/tcp/5678".parse().unwrap();
+
+    state.record_autonat_test(
+        addr_one.clone(),
+        AutonatTestResult::Failed {
+            reason: "no servers".to_owned(),
+        },
+    );
+    let first_at = state.last_autonat_test().expect("recorded").at;
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    state.record_autonat_test(
+        addr_two.clone(),
+        AutonatTestResult::Reachable {
+            addr: addr_two.clone(),
+        },
+    );
+
+    let probe = state.last_autonat_test().expect("still recorded");
+    assert_eq!(probe.tested_addr, addr_two);
+    assert!(matches!(probe.result, AutonatTestResult::Reachable { .. }));
+    assert!(probe.at > first_at, "second probe must postdate first");
+}
+
+#[test]
+fn relay_reservation_status_change_bumps_last_state_change() {
+    let mut state = DiscoveryState::default();
+    let relay = PeerId::random();
+    state.update_peer_protocols(&relay, &[HOP_PROTOCOL_NAME]);
+
+    let baseline = state
+        .get_peer_info(&relay)
+        .and_then(|i| i.relay())
+        .map(|r| r.last_state_change())
+        .expect("relay info initialized");
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    state.update_relay_reservation_status(&relay, RelayReservationStatus::Accepted);
+
+    let after = state
+        .get_peer_info(&relay)
+        .and_then(|i| i.relay())
+        .map(|r| r.last_state_change())
+        .expect("still tracked");
+    assert!(
+        after > baseline,
+        "last_state_change must advance on status update",
+    );
+}

--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -11,6 +11,7 @@ mod listen;
 mod mesh_peer_count;
 mod mesh_peers;
 mod mesh_stats;
+mod network_status;
 mod open_stream;
 mod peer_count;
 mod publish;
@@ -57,6 +58,9 @@ impl Handler<NetworkMessage> for NetworkManager {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::MeshStats { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::NetworkStatus { request, outcome } => {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::AnnounceBlob { request, outcome } => {

--- a/crates/network/src/handlers/commands/network_status.rs
+++ b/crates/network/src/handlers/commands/network_status.rs
@@ -1,0 +1,147 @@
+//! Handler for `NetworkMessage::NetworkStatus` — snapshots the swarm's
+//! current connectivity state for the admin-api consumer.
+//!
+//! Read-only: walks `self.swarm` and `self.discovery.state` once, copies
+//! the live data into owned `NetworkStatusSnapshot` types, and returns.
+//! The admin-api wire format (all strings, RFC3339 timestamps) is built
+//! one layer up in `crates/server/src/admin/handlers/network/status.rs`.
+
+use std::time::{Instant, SystemTime};
+
+use actix::{Context, Handler, MessageResult};
+use calimero_network_primitives::messages::NetworkStatus;
+use calimero_network_primitives::network_status::{
+    AutonatEntry, AutonatTestEntry, AutonatTestKind, DirectUpgradeEntry, DirectUpgradeOutcome,
+    NetworkStatusSnapshot, ReachabilityKind, RelayEntry, RelayReservationKind, RendezvousEntry,
+    RendezvousRegistrationKind,
+};
+
+use crate::discovery::state::{
+    AutonatTestResult, DcutrUpgradeStatus, ReachabilityState, RelayReservationStatus,
+    RendezvousRegistrationStatus,
+};
+use crate::NetworkManager;
+
+impl Handler<NetworkStatus> for NetworkManager {
+    // actix's `MessageResponse` is not implemented for arbitrary owned
+    // types — only for primitives, wrappers, and `MessageResult<M>`. We
+    // wrap our snapshot in `MessageResult` so the response plumbing
+    // accepts it; the caller's `oneshot::Receiver` resolves to the
+    // unwrapped `NetworkStatusSnapshot`.
+    type Result = MessageResult<NetworkStatus>;
+
+    fn handle(&mut self, _msg: NetworkStatus, _ctx: &mut Context<Self>) -> Self::Result {
+        // Capture a single (Instant, SystemTime) pair as the conversion
+        // anchor. Doing it once means every retained `Instant` is
+        // converted against the same wall clock — small consistency win
+        // worth the one extra binding.
+        let now_instant = Instant::now();
+        let now_system = SystemTime::now();
+        let to_system = |instant: Instant| -> SystemTime {
+            // `Instant` is monotonic and may be slightly in the future
+            // relative to `now_instant` if a concurrent recorder bumped
+            // it between our two reads. Saturate to `now_system` in
+            // that case rather than panicking on subtraction.
+            now_instant
+                .checked_duration_since(instant)
+                .map_or(now_system, |elapsed| now_system - elapsed)
+        };
+
+        let local_peer_id = *self.swarm.local_peer_id();
+        let listen_addrs = self.swarm.listeners().cloned().collect();
+        let external_addrs = self.swarm.external_addresses().cloned().collect();
+
+        let state = &self.discovery.state;
+
+        let mut relays = Vec::new();
+        let mut rendezvous = Vec::new();
+        let mut direct_upgrades = Vec::new();
+
+        for (peer_id, info) in state.iter_peers() {
+            if let Some(relay_info) = info.relay() {
+                relays.push(RelayEntry {
+                    peer_id: *peer_id,
+                    reservation_status: map_relay_status(relay_info.reservation_status()),
+                    last_state_change: to_system(relay_info.last_state_change()),
+                });
+            }
+            if let Some(rdv_info) = info.rendezvous() {
+                rendezvous.push(RendezvousEntry {
+                    peer_id: *peer_id,
+                    registration_status: map_rendezvous_status(rdv_info.registration_status()),
+                    last_state_change: to_system(rdv_info.last_state_change()),
+                });
+            }
+            if let Some(dcutr_info) = info.dcutr() {
+                direct_upgrades.push(DirectUpgradeEntry {
+                    peer_id: *peer_id,
+                    outcome: map_dcutr_status(dcutr_info.status()),
+                    last_attempt: to_system(dcutr_info.at()),
+                });
+            }
+        }
+
+        let autonat = AutonatEntry {
+            reachability: map_reachability(state.reachability_state()),
+            last_test: state.last_autonat_test().map(|test| AutonatTestEntry {
+                tested_addr: test.tested_addr.clone(),
+                result: match &test.result {
+                    AutonatTestResult::Reachable { addr } => {
+                        AutonatTestKind::Reachable { addr: addr.clone() }
+                    }
+                    AutonatTestResult::Failed { reason } => AutonatTestKind::Failed {
+                        reason: reason.clone(),
+                    },
+                },
+                at: to_system(test.at),
+            }),
+        };
+
+        MessageResult(NetworkStatusSnapshot {
+            local_peer_id,
+            listen_addrs,
+            external_addrs,
+            relays,
+            rendezvous,
+            direct_upgrades,
+            autonat,
+        })
+    }
+}
+
+fn map_relay_status(status: RelayReservationStatus) -> RelayReservationKind {
+    match status {
+        RelayReservationStatus::Discovered => RelayReservationKind::Discovered,
+        RelayReservationStatus::Requested => RelayReservationKind::Requested,
+        RelayReservationStatus::Accepted => RelayReservationKind::Accepted,
+        RelayReservationStatus::Expired => RelayReservationKind::Expired,
+    }
+}
+
+fn map_rendezvous_status(status: RendezvousRegistrationStatus) -> RendezvousRegistrationKind {
+    match status {
+        RendezvousRegistrationStatus::Discovered => RendezvousRegistrationKind::Discovered,
+        RendezvousRegistrationStatus::Requested => RendezvousRegistrationKind::Requested,
+        RendezvousRegistrationStatus::Registered => RendezvousRegistrationKind::Registered,
+        RendezvousRegistrationStatus::Expired => RendezvousRegistrationKind::Expired,
+    }
+}
+
+fn map_dcutr_status(status: &DcutrUpgradeStatus) -> DirectUpgradeOutcome {
+    match status {
+        DcutrUpgradeStatus::Succeeded { connection_id } => DirectUpgradeOutcome::Succeeded {
+            connection_id: *connection_id,
+        },
+        DcutrUpgradeStatus::Failed { reason } => DirectUpgradeOutcome::Failed {
+            reason: reason.clone(),
+        },
+    }
+}
+
+fn map_reachability(state: ReachabilityState) -> ReachabilityKind {
+    match state {
+        ReachabilityState::Unknown => ReachabilityKind::Unknown,
+        ReachabilityState::Reachable => ReachabilityKind::Public,
+        ReachabilityState::Unreachable => ReachabilityKind::Private,
+    }
+}

--- a/crates/network/src/handlers/stream/swarm/autonat.rs
+++ b/crates/network/src/handlers/stream/swarm/autonat.rs
@@ -1,5 +1,6 @@
 use super::EventHandler;
 use crate::autonat::{Event, TestResult};
+use crate::discovery::state::AutonatTestResult;
 use crate::NetworkManager;
 use owo_colors::OwoColorize;
 use tracing::{debug, info, warn};
@@ -13,6 +14,23 @@ impl EventHandler<Event> for NetworkManager {
                 result,
                 ..
             } => {
+                // Record the freshest probe outcome on the discovery state
+                // so the admin-api network-status snapshot can answer
+                // "is this node behind NAT?" without log scraping. We
+                // intentionally keep history depth = 1 here; ops cares
+                // about the current state, not a probe log.
+                let snapshot_result = match &result {
+                    TestResult::Reachable { addr } => {
+                        AutonatTestResult::Reachable { addr: addr.clone() }
+                    }
+                    TestResult::Failed { error } => AutonatTestResult::Failed {
+                        reason: error.to_string(),
+                    },
+                };
+                self.discovery
+                    .state
+                    .record_autonat_test(tested_addr.clone(), snapshot_result);
+
                 match result {
                     TestResult::Reachable { addr } => {
                         info!(

--- a/crates/network/src/handlers/stream/swarm/dcutr.rs
+++ b/crates/network/src/handlers/stream/swarm/dcutr.rs
@@ -4,6 +4,7 @@ use owo_colors::OwoColorize;
 use tracing::{debug, info, warn};
 
 use super::{EventHandler, NetworkManager};
+use crate::discovery::state::DcutrUpgradeStatus;
 
 impl EventHandler<Event> for NetworkManager {
     fn handle(&mut self, event: Event) {
@@ -24,7 +25,12 @@ impl EventHandler<Event> for NetworkManager {
         //   * Failed → warn (peer is staying on the relay path —
         //     either symmetric-NAT'd or the predicted hole didn't
         //     open in time; ops needs to see this without --debug)
-        match &event.result {
+        //
+        // In addition to the log lines we record the outcome on the
+        // peer's DiscoveryState entry so `GET /admin-api/network/status`
+        // can surface it as typed data instead of asking operators to
+        // grep logs.
+        let status = match &event.result {
             Ok(connection_id) => {
                 info!(
                     "{}: direct-connection upgrade succeeded with peer {} (connection {:?})",
@@ -32,6 +38,9 @@ impl EventHandler<Event> for NetworkManager {
                     event.remote_peer_id,
                     connection_id
                 );
+                DcutrUpgradeStatus::Succeeded {
+                    connection_id: *connection_id,
+                }
             }
             Err(err) => {
                 warn!(
@@ -40,8 +49,14 @@ impl EventHandler<Event> for NetworkManager {
                     event.remote_peer_id,
                     err
                 );
+                DcutrUpgradeStatus::Failed {
+                    reason: err.to_string(),
+                }
             }
-        }
+        };
+        self.discovery
+            .state
+            .record_dcutr_outcome(event.remote_peer_id, status);
         debug!("{}: {:?}", "dcutr".yellow(), event);
     }
 }

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -479,6 +479,15 @@ impl NodeClient {
         self.network_client.mesh_peer_count(topic).await
     }
 
+    /// Snapshot of the local node's libp2p connectivity state — relays,
+    /// rendezvous registrations, DCUtR upgrade outcomes, AutoNAT v2
+    /// reachability. Backs `GET /admin-api/network/status`.
+    pub async fn network_status(
+        &self,
+    ) -> calimero_network_primitives::network_status::NetworkStatusSnapshot {
+        self.network_client.network_status().await
+    }
+
     pub async fn broadcast(
         &self,
         context: &Context,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -11,6 +11,7 @@ publish = true
 [dependencies]
 axum = { workspace = true, features = ["multipart", "ws", "tokio"] }
 base64.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 eyre.workspace = true
 futures-util.workspace = true
 hex.workspace = true

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1206,6 +1206,70 @@ pub struct UsageResponse {
     pub namespaces: Vec<NamespaceUsage>,
 }
 
+/// Response for `GET /admin-api/network/status`. Wire-format snapshot of
+/// the local node's libp2p connectivity state — what relays we hold
+/// reservations with, which rendezvous registrations are live, the
+/// outcome of the latest DCUtR hole-punch per peer, and the most recent
+/// AutoNAT v2 probe. Surfaced verbatim by `meroctl network status`.
+///
+/// All multiaddrs / peer ids are stringified, all timestamps are RFC3339
+/// UTC, all status fields are flat strings (lowercase enum names). This
+/// keeps the wire shape stable across libp2p upgrades and friendly to
+/// consumers in any language.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkStatusResponse {
+    pub local_peer_id: String,
+    pub listen_addrs: Vec<String>,
+    pub external_addrs: Vec<String>,
+    pub relays: Vec<RelayStatusEntry>,
+    pub rendezvous: Vec<RendezvousStatusEntry>,
+    pub direct_upgrades: Vec<DirectUpgradeStatusEntry>,
+    pub autonat: AutonatStatusEntry,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayStatusEntry {
+    pub peer_id: String,
+    /// One of: `discovered`, `requested`, `accepted`, `expired`.
+    pub reservation_status: String,
+    pub last_state_change: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RendezvousStatusEntry {
+    pub peer_id: String,
+    /// One of: `discovered`, `requested`, `registered`, `expired`.
+    pub registration_status: String,
+    pub last_state_change: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DirectUpgradeStatusEntry {
+    pub peer_id: String,
+    /// `succeeded` or `failed`. When `failed`, `reason` is populated.
+    pub status: String,
+    pub reason: Option<String>,
+    pub connection_id: Option<String>,
+    pub last_attempt: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutonatStatusEntry {
+    /// One of: `unknown`, `public`, `private`.
+    pub reachability: String,
+    pub last_test_addr: Option<String>,
+    /// `reachable`, `failed`, or `null` if no probe has landed.
+    pub last_test_result: Option<String>,
+    pub last_test_reason: Option<String>,
+    pub last_test_observed_addr: Option<String>,
+    pub last_test_at: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeeInfoResponseData {

--- a/crates/server/src/admin/handlers.rs
+++ b/crates/server/src/admin/handlers.rs
@@ -8,6 +8,7 @@ pub mod identity;
 pub mod list_packages;
 pub mod list_versions;
 pub mod namespaces;
+pub mod network;
 pub mod packages;
 pub mod peers;
 pub mod tee;

--- a/crates/server/src/admin/handlers/network/mod.rs
+++ b/crates/server/src/admin/handlers/network/mod.rs
@@ -1,0 +1,1 @@
+pub mod status;

--- a/crates/server/src/admin/handlers/network/status.rs
+++ b/crates/server/src/admin/handlers/network/status.rs
@@ -70,10 +70,14 @@ pub fn render(snapshot: NetworkStatusSnapshot) -> NetworkStatusResponse {
             .into_iter()
             .map(|d| {
                 let (status, reason, connection_id) = match d.outcome {
+                    // `Display` on libp2p's `ConnectionId` writes the bare
+                    // integer; `Debug` would write `ConnectionId(N)` and
+                    // could change shape across libp2p versions. Keep the
+                    // wire stable.
                     DirectUpgradeOutcome::Succeeded { connection_id } => (
                         "succeeded".to_owned(),
                         None,
-                        Some(format!("{connection_id:?}")),
+                        Some(connection_id.to_string()),
                     ),
                     DirectUpgradeOutcome::Failed { reason } => {
                         ("failed".to_owned(), Some(reason), None)
@@ -155,5 +159,173 @@ const fn reachability_str(kind: ReachabilityKind) -> &'static str {
         ReachabilityKind::Unknown => "unknown",
         ReachabilityKind::Public => "public",
         ReachabilityKind::Private => "private",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use calimero_network_primitives::network_status::{
+        AutonatEntry, AutonatTestEntry, AutonatTestKind, DirectUpgradeEntry, DirectUpgradeOutcome,
+        NetworkStatusSnapshot, ReachabilityKind, RelayEntry, RelayReservationKind, RendezvousEntry,
+        RendezvousRegistrationKind,
+    };
+    use libp2p::swarm::ConnectionId;
+    use libp2p::{Multiaddr, PeerId};
+
+    use super::*;
+
+    fn fixed_ts(secs: u64) -> std::time::SystemTime {
+        UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().unwrap()
+    }
+
+    fn empty_snapshot() -> NetworkStatusSnapshot {
+        NetworkStatusSnapshot {
+            local_peer_id: PeerId::random(),
+            listen_addrs: vec![],
+            external_addrs: vec![],
+            relays: vec![],
+            rendezvous: vec![],
+            direct_upgrades: vec![],
+            autonat: AutonatEntry {
+                reachability: ReachabilityKind::Unknown,
+                last_test: None,
+            },
+        }
+    }
+
+    #[test]
+    fn render_empty_snapshot_has_empty_collections_and_unknown_autonat() {
+        let resp = render(empty_snapshot());
+        assert!(resp.listen_addrs.is_empty());
+        assert!(resp.external_addrs.is_empty());
+        assert!(resp.relays.is_empty());
+        assert!(resp.rendezvous.is_empty());
+        assert!(resp.direct_upgrades.is_empty());
+        assert_eq!(resp.autonat.reachability, "unknown");
+        assert_eq!(resp.autonat.last_test_addr, None);
+        assert_eq!(resp.autonat.last_test_result, None);
+        assert_eq!(resp.autonat.last_test_reason, None);
+        assert_eq!(resp.autonat.last_test_observed_addr, None);
+        assert_eq!(resp.autonat.last_test_at, None);
+    }
+
+    #[test]
+    fn render_reachable_autonat_populates_observed_addr_and_clears_reason() {
+        let mut snap = empty_snapshot();
+        snap.autonat = AutonatEntry {
+            reachability: ReachabilityKind::Public,
+            last_test: Some(AutonatTestEntry {
+                tested_addr: addr("/ip4/1.2.3.4/tcp/4001"),
+                result: AutonatTestKind::Reachable {
+                    addr: addr("/ip4/5.6.7.8/tcp/4001"),
+                },
+                at: fixed_ts(1_700_000_000),
+            }),
+        };
+        let resp = render(snap);
+        assert_eq!(resp.autonat.reachability, "public");
+        assert_eq!(resp.autonat.last_test_result.as_deref(), Some("reachable"));
+        assert_eq!(
+            resp.autonat.last_test_addr.as_deref(),
+            Some("/ip4/1.2.3.4/tcp/4001"),
+        );
+        assert_eq!(
+            resp.autonat.last_test_observed_addr.as_deref(),
+            Some("/ip4/5.6.7.8/tcp/4001"),
+        );
+        assert_eq!(resp.autonat.last_test_reason, None);
+        assert_eq!(
+            resp.autonat.last_test_at.as_deref(),
+            Some("2023-11-14T22:13:20Z"),
+        );
+    }
+
+    #[test]
+    fn render_failed_autonat_populates_reason_and_clears_observed_addr() {
+        let mut snap = empty_snapshot();
+        snap.autonat = AutonatEntry {
+            reachability: ReachabilityKind::Private,
+            last_test: Some(AutonatTestEntry {
+                tested_addr: addr("/ip4/1.2.3.4/tcp/4001"),
+                result: AutonatTestKind::Failed {
+                    reason: "dial back rejected".to_owned(),
+                },
+                at: fixed_ts(1_700_000_000),
+            }),
+        };
+        let resp = render(snap);
+        assert_eq!(resp.autonat.reachability, "private");
+        assert_eq!(resp.autonat.last_test_result.as_deref(), Some("failed"));
+        assert_eq!(
+            resp.autonat.last_test_reason.as_deref(),
+            Some("dial back rejected"),
+        );
+        assert_eq!(resp.autonat.last_test_observed_addr, None);
+    }
+
+    #[test]
+    fn render_direct_upgrade_succeeded_uses_display_for_connection_id() {
+        let peer = PeerId::random();
+        let mut snap = empty_snapshot();
+        snap.direct_upgrades = vec![DirectUpgradeEntry {
+            peer_id: peer,
+            outcome: DirectUpgradeOutcome::Succeeded {
+                connection_id: ConnectionId::new_unchecked(42),
+            },
+            last_attempt: fixed_ts(1_700_000_000),
+        }];
+        let resp = render(snap);
+        assert_eq!(resp.direct_upgrades.len(), 1);
+        let entry = &resp.direct_upgrades[0];
+        assert_eq!(entry.status, "succeeded");
+        assert_eq!(entry.reason, None);
+        // Display on ConnectionId writes the bare integer; Debug would write
+        // `ConnectionId(42)`. This test pins the choice.
+        assert_eq!(entry.connection_id.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn render_direct_upgrade_failed_carries_reason_no_connection_id() {
+        let peer = PeerId::random();
+        let mut snap = empty_snapshot();
+        snap.direct_upgrades = vec![DirectUpgradeEntry {
+            peer_id: peer,
+            outcome: DirectUpgradeOutcome::Failed {
+                reason: "hole-punch timeout".to_owned(),
+            },
+            last_attempt: fixed_ts(1_700_000_000),
+        }];
+        let resp = render(snap);
+        let entry = &resp.direct_upgrades[0];
+        assert_eq!(entry.status, "failed");
+        assert_eq!(entry.reason.as_deref(), Some("hole-punch timeout"));
+        assert_eq!(entry.connection_id, None);
+    }
+
+    #[test]
+    fn render_relay_and_rendezvous_status_strings_match_kind() {
+        let peer = PeerId::random();
+        let mut snap = empty_snapshot();
+        snap.listen_addrs = vec![addr("/ip4/127.0.0.1/tcp/2428")];
+        snap.relays = vec![RelayEntry {
+            peer_id: peer,
+            reservation_status: RelayReservationKind::Accepted,
+            last_state_change: fixed_ts(1_700_000_000),
+        }];
+        snap.rendezvous = vec![RendezvousEntry {
+            peer_id: peer,
+            registration_status: RendezvousRegistrationKind::Registered,
+            last_state_change: fixed_ts(1_700_000_000),
+        }];
+        let resp = render(snap);
+        assert_eq!(resp.listen_addrs, vec!["/ip4/127.0.0.1/tcp/2428"]);
+        assert_eq!(resp.relays[0].reservation_status, "accepted");
+        assert_eq!(resp.rendezvous[0].registration_status, "registered");
     }
 }

--- a/crates/server/src/admin/handlers/network/status.rs
+++ b/crates/server/src/admin/handlers/network/status.rs
@@ -1,0 +1,159 @@
+//! `GET /admin-api/network/status` — snapshot of libp2p connectivity.
+//!
+//! Asks the network actor for a `NetworkStatusSnapshot` and renders it
+//! into the wire-stable `NetworkStatusResponse` (all strings, RFC3339
+//! UTC timestamps). The rich types stay on the actor side; this layer
+//! exists to keep the HTTP contract from drifting whenever libp2p
+//! changes the shape of a `PeerId`, `Multiaddr`, or `ConnectionId`.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_network_primitives::network_status::{
+    AutonatTestKind, DirectUpgradeOutcome, NetworkStatusSnapshot, ReachabilityKind,
+    RelayReservationKind, RendezvousRegistrationKind,
+};
+use calimero_server_primitives::admin::{
+    AutonatStatusEntry, DirectUpgradeStatusEntry, NetworkStatusResponse, RelayStatusEntry,
+    RendezvousStatusEntry,
+};
+use chrono::{DateTime, SecondsFormat, Utc};
+
+use crate::admin::service::ApiResponse;
+use crate::AdminState;
+
+pub async fn handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {
+    let snapshot = state.node_client.network_status().await;
+    ApiResponse {
+        payload: render(snapshot),
+    }
+    .into_response()
+}
+
+/// Pure conversion: snapshot → wire response. Extracted so tests can
+/// drive it without spinning up a network actor.
+pub fn render(snapshot: NetworkStatusSnapshot) -> NetworkStatusResponse {
+    NetworkStatusResponse {
+        local_peer_id: snapshot.local_peer_id.to_string(),
+        listen_addrs: snapshot
+            .listen_addrs
+            .into_iter()
+            .map(|a| a.to_string())
+            .collect(),
+        external_addrs: snapshot
+            .external_addrs
+            .into_iter()
+            .map(|a| a.to_string())
+            .collect(),
+        relays: snapshot
+            .relays
+            .into_iter()
+            .map(|r| RelayStatusEntry {
+                peer_id: r.peer_id.to_string(),
+                reservation_status: relay_status_str(r.reservation_status).to_owned(),
+                last_state_change: rfc3339(r.last_state_change),
+            })
+            .collect(),
+        rendezvous: snapshot
+            .rendezvous
+            .into_iter()
+            .map(|r| RendezvousStatusEntry {
+                peer_id: r.peer_id.to_string(),
+                registration_status: rendezvous_status_str(r.registration_status).to_owned(),
+                last_state_change: rfc3339(r.last_state_change),
+            })
+            .collect(),
+        direct_upgrades: snapshot
+            .direct_upgrades
+            .into_iter()
+            .map(|d| {
+                let (status, reason, connection_id) = match d.outcome {
+                    DirectUpgradeOutcome::Succeeded { connection_id } => (
+                        "succeeded".to_owned(),
+                        None,
+                        Some(format!("{connection_id:?}")),
+                    ),
+                    DirectUpgradeOutcome::Failed { reason } => {
+                        ("failed".to_owned(), Some(reason), None)
+                    }
+                };
+                DirectUpgradeStatusEntry {
+                    peer_id: d.peer_id.to_string(),
+                    status,
+                    reason,
+                    connection_id,
+                    last_attempt: rfc3339(d.last_attempt),
+                }
+            })
+            .collect(),
+        autonat: {
+            let reachability = reachability_str(snapshot.autonat.reachability).to_owned();
+            let (
+                last_test_addr,
+                last_test_result,
+                last_test_reason,
+                last_test_observed_addr,
+                last_test_at,
+            ) = match snapshot.autonat.last_test {
+                None => (None, None, None, None, None),
+                Some(test) => {
+                    let (result, reason, observed) = match test.result {
+                        AutonatTestKind::Reachable { addr } => {
+                            ("reachable".to_owned(), None, Some(addr.to_string()))
+                        }
+                        AutonatTestKind::Failed { reason } => {
+                            ("failed".to_owned(), Some(reason), None)
+                        }
+                    };
+                    (
+                        Some(test.tested_addr.to_string()),
+                        Some(result),
+                        reason,
+                        observed,
+                        Some(rfc3339(test.at)),
+                    )
+                }
+            };
+            AutonatStatusEntry {
+                reachability,
+                last_test_addr,
+                last_test_result,
+                last_test_reason,
+                last_test_observed_addr,
+                last_test_at,
+            }
+        },
+    }
+}
+
+fn rfc3339(ts: SystemTime) -> String {
+    DateTime::<Utc>::from(ts).to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+const fn relay_status_str(kind: RelayReservationKind) -> &'static str {
+    match kind {
+        RelayReservationKind::Discovered => "discovered",
+        RelayReservationKind::Requested => "requested",
+        RelayReservationKind::Accepted => "accepted",
+        RelayReservationKind::Expired => "expired",
+    }
+}
+
+const fn rendezvous_status_str(kind: RendezvousRegistrationKind) -> &'static str {
+    match kind {
+        RendezvousRegistrationKind::Discovered => "discovered",
+        RendezvousRegistrationKind::Requested => "requested",
+        RendezvousRegistrationKind::Registered => "registered",
+        RendezvousRegistrationKind::Expired => "expired",
+    }
+}
+
+const fn reachability_str(kind: ReachabilityKind) -> &'static str {
+    match kind {
+        ReachabilityKind::Unknown => "unknown",
+        ReachabilityKind::Public => "public",
+        ReachabilityKind::Private => "private",
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -29,6 +29,7 @@ use crate::admin::handlers::context::{
     leave_context, sync, update_context_application,
 };
 use crate::admin::handlers::identity::generate_context_identity;
+use crate::admin::handlers::network;
 use crate::admin::handlers::packages::{get_latest_version, list_packages, list_versions};
 use crate::admin::handlers::peers::get_peers_count_handler;
 use crate::admin::handlers::usage;
@@ -153,6 +154,8 @@ pub(crate) fn setup(
         )
         // Per-namespace usage (counts + on-disk bytes)
         .route("/usage", get(usage::handler))
+        // libp2p connectivity snapshot (relays, rendezvous, DCUtR, AutoNAT)
+        .route("/network/status", get(network::status::handler))
         // Network info
         .route("/peers", get(get_peers_count_handler))
         // Blob management


### PR DESCRIPTION
## Summary

- New `GET /admin-api/network/status` endpoint snapshots the swarm's libp2p connectivity state — local peer id, listen/external addresses, relay reservations, rendezvous registrations, DCUtR hole-punch outcomes per peer, and AutoNAT v2 reachability + last probe result.
- New `meroctl network status` subcommand renders the snapshot as comfy-table sections (or JSON via the existing root `--output-format json` flag).
- New per-peer state: optional `DcutrUpgradeStatus` (populated from the dcutr swarm-event handler) and single-slot `AutonatTest` on `DiscoveryState` (populated from the autonat client event). `PeerRelayInfo` / `PeerRendezvousInfo` gain a `last_state_change: Instant` bumped in their status setters.

Closes #2488.

## Why this matters

Until this PR, ops needed `RUST_LOG=debug` and `grep ReservationReqAccepted` to know whether a node's libp2p subsystem was healthy. That's fine for the developer who built the subsystem; bad for operators debugging "why is my home node not reaching the fleet?" and a blocker for merobox#254, which currently scrapes container logs to assert NAT-topology behaviour. With this endpoint, both flows get a typed API.

## Design notes

Two response shapes:
- **Internal** (`calimero_network_primitives::network_status::NetworkStatusSnapshot`) — typed `PeerId` / `Multiaddr` / `SystemTime`. This is the actor reply, what in-process tests will assert against.
- **Wire** (`calimero_server_primitives::admin::NetworkStatusResponse`) — all-strings + RFC3339 UTC timestamps. Stable across libp2p upgrades.

The admin handler does the conversion in a pure `render()` function, extracted so it can be unit-tested without spinning up an actor.

The DCUtR / AutoNAT log lines stay — this PR only adds typed state retention alongside them.

## Out of scope (potential follow-ups)

- No Prometheus metric for these fields.
- No `meroctl network watch` / streaming — single snapshot per call.
- No history beyond "last" for AutoNAT / DCUtR — bounded memory.
- merobox#254 swap from log-grep → typed assertion is the natural follow-up.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo build --workspace --all-targets` succeeds
- [x] `cargo test -p calimero-network --lib discovery::state` — 24/24 pass, including 3 new tests for `record_dcutr_outcome`, `record_autonat_test`, and `last_state_change` advancement
- [x] `cargo clippy` clean on touched packages (pre-existing warnings in `calimero-wasm-abi`, `calimero-sdk-macros`, `calimero-context-config`, `crates/server/build.rs`, and `crates/network/src/discovery.rs:350` are unrelated to this PR)
- [x] `meroctl network --help` and `meroctl network status --help` render correctly
- [ ] End-to-end via merobox: boot a 2-node cluster, `meroctl --node node1 network status` shows expected relay/rendezvous state; AutoNAT transitions visible after connect
- [ ] `meroctl --output-format json --node node1 network status | jq` validates the wire keys match the issue sketch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only introspection and additive admin/CLI surface; discovery state extensions only record latest probe/upgrade outcomes without changing connection logic.
> 
> **Overview**
> Adds **operator-facing libp2p connectivity introspection** end-to-end: a read-only snapshot from the network actor through admin HTTP to the CLI.
> 
> **`GET /admin-api/network/status`** returns a stable JSON shape (string peer IDs, multiaddrs, lowercase status strings, RFC3339 timestamps) covering local identity, listen/external addresses, per-relay reservation state, per-rendezvous registration, per-peer **DCUtR** upgrade outcomes, and **AutoNAT v2** reachability plus the latest probe.
> 
> The stack introduces typed **`NetworkStatusSnapshot`** in network primitives, a **`NetworkMessage::NetworkStatus`** handler that walks the swarm and discovery state, and a pure **`render()`** conversion in the server. **`DiscoveryState`** now retains the latest AutoNAT probe, per-peer DCUtR results, and **`last_state_change`** on relay/rendezvous info (fed from autonat/dcutr swarm handlers). **`meroctl network status`** calls the new client API and prints table sections or JSON via existing output formatting.
> 
> Unit tests cover discovery state updates and wire rendering; **`chrono`** is added for timestamp formatting on the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc0fb58f214bf5ca0f70590ae8bdc16a809969b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->