### PR TITLE
fix(context): capture pre-apply state_hash before local apply (#2500 follow-up)

### DIFF
--- a/crates/context/src/group_store/group_governance_publisher.rs
+++ b/crates/context/src/group_store/group_governance_publisher.rs
@@ -104,6 +104,24 @@ impl<'a> GroupGovernancePublisher<'a> {
             .await;
         let known = self.node_client.known_subscribers(&topic);
 
+        // Capture the pre-apply state hash BEFORE the local mutation
+        // runs. The receiver's staleness check in
+        // `apply_group_op_inner` recomputes the subgroup's state hash
+        // against its own pre-apply view; if we sampled here AFTER the
+        // local apply, the value we sign would reflect the post-apply
+        // view and every member-mutating op would fail the receiver's
+        // check (#2134 high-severity finding). Mirrors the sign-side
+        // bypass on `state_hash_for_op`: a not-yet-bootstrapped group
+        // has no meta row, so the zero value is the documented signal.
+        let pre_apply_state_hash = {
+            let repo = MetaRepository::new(self.store);
+            if repo.load(&self.group_id)?.is_none() {
+                [0u8; 32]
+            } else {
+                repo.compute_state_hash(&self.group_id)?
+            }
+        };
+
         let _output =
             sign_apply_local_group_op_borsh(self.store, &self.group_id, signer_sk, op.clone())?;
 
@@ -275,6 +293,7 @@ impl<'a> GroupGovernancePublisher<'a> {
                 ack_router,
                 &namespace_sk,
                 namespace_op,
+                pre_apply_state_hash,
                 mesh,
                 known,
                 true,

--- a/crates/context/src/group_store/namespace/governance.rs
+++ b/crates/context/src/group_store/namespace/governance.rs
@@ -167,6 +167,31 @@ impl<'a> NamespaceGovernance<'a> {
     /// semantics as the existing v1/v2 deployment. The bypass closes once
     /// every signer has rolled forward and stopped emitting zero hashes;
     /// no schema bump needed.
+    ///
+    /// **Known limitation:** there is no runtime enforcement that a
+    /// signer post-upgrade cannot emit `[0u8; 32]` to skip the check.
+    /// Defending against that case is not the purpose of this guard —
+    /// signature verification and the per-op authorization checks
+    /// (`require_namespace_admin`, capability checks, membership
+    /// recompute on the receiver) remain in force regardless of the
+    /// hash value. The staleness guard is a convergence aid for
+    /// concurrent-signer races between *honest* signers, not a
+    /// defence against adversarial signers — those are caught at the
+    /// authorization layer.
+    ///
+    /// # TOCTOU window between sign and apply
+    ///
+    /// Callers compute this hash, then sign, then apply locally and
+    /// publish. Between the compute call and the local apply, another
+    /// op could land — but every governance signer in the codebase
+    /// runs through the same actor mailbox (the `NodeManager` actor for
+    /// node-issued ops, or a single per-namespace driver for receiver
+    /// paths), which serializes applies for a given namespace.
+    /// `read_head_record` + this hash compute + local apply therefore
+    /// run atomically with respect to other governance applies on the
+    /// same node. The window only matters for divergence *across* nodes,
+    /// which is exactly what the staleness check on the receive side is
+    /// for.
     fn state_hash_for_op(&self, op: &NamespaceOp) -> EyreResult<[u8; 32]> {
         let target_gid = match op {
             NamespaceOp::Group { group_id, .. } => ContextGroupId::from(*group_id),
@@ -676,6 +701,14 @@ impl<'a> NamespaceGovernance<'a> {
         assert_transport_ready(mesh, known, node_client.gossipsub_mesh_n_low())
             .map_err(|e| eyre::eyre!(e))?;
 
+        // No-local-apply path: nothing has mutated state on this node yet,
+        // so the current `state_hash_for_op` value IS the pre-apply view
+        // every receiver will compare against. Capture it here (rather
+        // than inside `publish_post_gate`) so the call shape stays uniform
+        // with the apply-first path below, which must capture before its
+        // local mutation runs.
+        let state_hash = self.state_hash_for_op(&op)?;
+
         // Quorum / no-local-apply path: a publish that never reaches a
         // quorum is a genuine failure — nothing was applied locally to
         // fall back on. `best_effort = false` keeps the hard error.
@@ -684,6 +717,7 @@ impl<'a> NamespaceGovernance<'a> {
             ack_router,
             signer_sk,
             op,
+            state_hash,
             topic,
             mesh,
             known,
@@ -701,12 +735,21 @@ impl<'a> NamespaceGovernance<'a> {
     /// passes `best_effort = true`: it has no gate of its own (the local
     /// apply is unconditional), so a publish failure here is non-fatal and
     /// the op propagates via sync rather than diverging on a retry.
+    ///
+    /// `state_hash` MUST be the receiver-equivalent pre-apply hash —
+    /// i.e. computed BEFORE the caller ran
+    /// `sign_apply_local_group_op_borsh`. The apply-first path computes
+    /// the hash inside its own scope (where the pre-apply state is still
+    /// visible) and passes it in here. Recomputing inside this function
+    /// would shift the hash forward and every member-mutating op would
+    /// permanently bail on the receiver's staleness check.
     pub(crate) async fn sign_and_publish_post_gate(
         &self,
         node_client: &calimero_node_primitives::client::NodeClient,
         ack_router: &AckRouter,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
+        state_hash: [u8; 32],
         mesh: usize,
         known: usize,
         best_effort: bool,
@@ -717,6 +760,7 @@ impl<'a> NamespaceGovernance<'a> {
             ack_router,
             signer_sk,
             op,
+            state_hash,
             topic,
             mesh,
             known,
@@ -731,6 +775,10 @@ impl<'a> NamespaceGovernance<'a> {
     /// to feed the metric; the subscriber count is re-sampled at publish
     /// time (see below) so transient peer departures don't skew `min_acks`.
     ///
+    /// `state_hash` must be the pre-apply hash captured by the caller
+    /// before any local mutation. See `sign_and_publish_post_gate`'s doc
+    /// for the constraint and why we no longer recompute here.
+    ///
     /// `best_effort` selects the failure mode of the publish:
     /// * `false` (quorum / no-local-apply path) — a publish that gathers
     ///   no acks is a genuine `Err`; nothing was applied locally.
@@ -743,6 +791,7 @@ impl<'a> NamespaceGovernance<'a> {
         ack_router: &AckRouter,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
+        state_hash: [u8; 32],
         topic: TopicHash,
         mesh: usize,
         known_at_gate: usize,
@@ -753,7 +802,6 @@ impl<'a> NamespaceGovernance<'a> {
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
         let op_kind = op.op_kind_label();
         let op_timeout = timeout_for_namespace_op(&op);
-        let state_hash = self.state_hash_for_op(&op)?;
         let signed = SignedNamespaceOp::sign(
             signer_sk,
             self.namespace_id,
@@ -1363,17 +1411,30 @@ impl<'a> NamespaceGovernance<'a> {
         // capability checks in the executor arms below).
         if root_op_commits_to_namespace_state(root) && op.state_hash != [0u8; 32] {
             let ns_gid = ContextGroupId::from(self.namespace_id);
-            let current = MetaRepository::new(self.store).compute_state_hash(&ns_gid)?;
-            if op.state_hash != current {
-                tracing::warn!(
-                    namespace_id = %hex::encode(self.namespace_id),
-                    expected = %hex::encode(op.state_hash),
-                    actual = %hex::encode(current),
-                    nonce = op.nonce,
-                    signer = %op.signer,
-                    "namespace root op state_hash mismatch (signed against stale state; \
-                     applying anyway — see PR #2500 caveat)"
-                );
+            let repo = MetaRepository::new(self.store);
+            // Mirror the sign-side bypass: if the namespace meta row
+            // hasn't been seeded yet (cold-start, bootstrap, joiner
+            // catching up via backfill), there is no state to hash. The
+            // sign side falls through to `[0u8; 32]` for the same case,
+            // but a non-zero claim can still reach a node whose meta is
+            // not yet present (e.g. a peer that signed after their
+            // bootstrap finished but the joiner receives the op before
+            // applying the namespace genesis ops). Treat as a bypass —
+            // there is no honest claim we can refute. Authorization
+            // and signature verification remain in force.
+            if let Some(_meta) = repo.load(&ns_gid)? {
+                let current = repo.compute_state_hash(&ns_gid)?;
+                if op.state_hash != current {
+                    tracing::warn!(
+                        namespace_id = %hex::encode(self.namespace_id),
+                        expected = %hex::encode(op.state_hash),
+                        actual = %hex::encode(current),
+                        nonce = op.nonce,
+                        signer = %op.signer,
+                        "namespace root op state_hash mismatch (signed against stale state; \
+                         applying anyway — see PR #2500 caveat)"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to #2500 addressing the post-rebase bot review findings.

## Critical: pre-apply hash capture (Cursor Bugbot — High)

`publish_post_gate` computed `state_hash_for_op(&op)` AFTER the caller had already mutated the local group store via `sign_apply_local_group_op_borsh`. The sender signed a post-apply hash while the receiver compared against its pre-apply state. Every member-mutating op (`MemberAdded` / `MemberRemoved` / capability flips) therefore tripped the staleness mismatch on every receiver.

Master at #2500's merge degraded the receiver-side mismatch from `bail!` to `warn!`+apply-anyway, so apps still function — but every member-mutating op logs a spurious warning, and the staleness signal is meaningless until the hash is computed correctly.

**Fix:**

- `sign_and_publish_post_gate` and `publish_post_gate` now take an explicit `state_hash: [u8; 32]` parameter instead of recomputing it.
- `GroupGovernancePublisher::sign_apply_and_publish_inner` captures `MetaRepository::compute_state_hash(&self.group_id)?` **before** `sign_apply_local_group_op_borsh` runs, with the same meta-existence bypass `state_hash_for_op` uses on the sign side.
- `sign_and_publish_without_apply` captures inline at the same point as before (it has no local apply between read and publish, so the value is naturally pre-apply).

## Bootstrap bypass on root verify (MeroReviewer — Warning)

`apply_root_op` recomputed the namespace state hash without first checking whether the namespace meta row exists. A node receiving a gated root op before its namespace meta has been seeded (cold-start, backfill) would either error or compare against an empty hash. Mirrors the sign-side bypass: when `MetaRepository::load(&ns_gid)?.is_none()`, skip the staleness check entirely. The merged `warn!` + apply-anyway pattern is preserved when meta is present.

## Doc clarifications (no behavior change)

- TOCTOU window between `read_head_record` and the local apply is safe because every governance signer runs through a serializing actor mailbox; documented on `state_hash_for_op`.
- Zero-hash bypass relies on signature + authorization checks for defense against adversarial signers; the staleness guard is a convergence aid for honest concurrent signers, not a security mechanism. Limitation noted on `state_hash_for_op`.

## Test plan

- [x] `cargo fmt --check -p calimero-context`
- [x] `cargo test -p calimero-context --lib` — 379 passed, 0 failed
- [ ] e2e auto-follow / group-* tests should no longer log "state_hash mismatch (signed against stale state)" warnings for honest concurrent signers (only for genuine cross-node divergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes governance op signing and root staleness verification in the context store; incorrect hashing would break convergence signals but auth/signature checks are unchanged.
> 
> **Overview**
> Follow-up to **#2500** fixes how **`state_hash`** is chosen when namespace-wrapped group governance ops are published after a **local apply-first** path.
> 
> **Signing / publish:** `publish_post_gate` no longer calls `state_hash_for_op` at sign time (which ran **after** `sign_apply_local_group_op_borsh` and embedded a **post-apply** hash). Callers now pass an explicit pre-apply hash: `GroupGovernancePublisher` samples `MetaRepository::compute_state_hash` (or `[0u8; 32]` when meta is missing) **before** local apply; the no-local-apply path still captures via `state_hash_for_op` upstream.
> 
> **Receive:** `apply_root_op` only compares namespace root staleness when meta exists, matching the sign-side bootstrap bypass for cold-start / backfill.
> 
> Docs on `state_hash_for_op` clarify mailbox serialization (TOCTOU on-node) and that zero-hash / staleness are convergence aids for honest concurrent signers, not adversarial protection.
> 
> **Risk:** Medium — correctness fix in governance DAG signing/verification; behavior change is aligning hashes with receiver pre-apply semantics, not new auth rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d41a780b8fcca3e4cef8118207bf34477e4a7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->