### PR TITLE
chore: bump version to 0.10.1-rc.47

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.46"
+version = "0.10.1-rc.47"
 exclude = [
     "./apps/abi_conformance",
     "./apps/blobs",


### PR DESCRIPTION
## Summary
- Bump `[workspace.metadata.workspaces].version` in `Cargo.toml` from `0.10.1-rc.46` to `0.10.1-rc.47`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no runtime or security impact.
> 
> **Overview**
> Bumps the shared **cargo-workspaces** release version in root `Cargo.toml` from `0.10.1-rc.46` to **`0.10.1-rc.47`**, updating `[workspace.metadata.workspaces].version` only. No crate source or dependency changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce087340a50266b2367f6ad12abb3baa79a4f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->