### PR TITLE
perf(node/blob): exponential backoff for blob discovery retries

### DIFF
--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -149,11 +149,16 @@ impl NodeClient {
                 core::time::Duration::from_millis(100);
             const MAX_RETRY_DELAY: core::time::Duration = core::time::Duration::from_secs(2);
 
-            for attempt in 1..=MAX_RETRIES {
-                let retry_delay = INITIAL_RETRY_DELAY
-                    .saturating_mul(1_u32.checked_shl((attempt - 1) as u32).unwrap_or(u32::MAX))
-                    .min(MAX_RETRY_DELAY);
+            // 100ms, doubling per attempt, capped at MAX_RETRY_DELAY. The
+            // `.min(31)` bounds the shift so it stays well-defined if
+            // MAX_RETRIES is ever raised past 32.
+            let backoff = |attempt: usize| {
+                INITIAL_RETRY_DELAY
+                    .saturating_mul(1_u32 << (attempt as u32 - 1).min(31))
+                    .min(MAX_RETRY_DELAY)
+            };
 
+            for attempt in 1..=MAX_RETRIES {
                 tracing::debug!(
                     blob_id = %blob_id,
                     context_id = %context_id,
@@ -177,7 +182,7 @@ impl NodeClient {
                             "Failed to query DHT for blob"
                         );
                         if attempt < MAX_RETRIES {
-                            tokio::time::sleep(retry_delay).await;
+                            tokio::time::sleep(backoff(attempt)).await;
                             continue;
                         }
                         return Err(e);
@@ -192,7 +197,7 @@ impl NodeClient {
                         "No peers found with blob"
                     );
                     if attempt < MAX_RETRIES {
-                        tokio::time::sleep(retry_delay).await;
+                        tokio::time::sleep(backoff(attempt)).await;
                         continue;
                     }
                     return Ok(None);
@@ -275,10 +280,10 @@ impl NodeClient {
                         blob_id = %blob_id,
                         context_id = %context_id,
                         attempt,
-                        retry_delay_ms = retry_delay.as_millis(),
+                        retry_delay_ms = backoff(attempt).as_millis(),
                         "All peers failed, retrying after backoff"
                     );
-                    tokio::time::sleep(retry_delay).await;
+                    tokio::time::sleep(backoff(attempt)).await;
                 }
             }
 

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -276,14 +276,15 @@ impl NodeClient {
 
                 // If we reach here, all peers failed for this attempt
                 if attempt < MAX_RETRIES {
+                    let retry_delay = backoff(attempt);
                     tracing::info!(
                         blob_id = %blob_id,
                         context_id = %context_id,
                         attempt,
-                        retry_delay_ms = backoff(attempt).as_millis(),
+                        retry_delay_ms = retry_delay.as_millis(),
                         "All peers failed, retrying after backoff"
                     );
-                    tokio::time::sleep(backoff(attempt)).await;
+                    tokio::time::sleep(retry_delay).await;
                 }
             }
 

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -140,10 +140,20 @@ impl NodeClient {
                 "Blob not found locally, attempting network discovery"
             );
 
-            const MAX_RETRIES: usize = 3;
-            const RETRY_DELAY: core::time::Duration = core::time::Duration::from_secs(2);
+            // Poll the DHT quickly at first and widen the gap only if the record
+            // stays missing. The blob record is usually available within a few
+            // hundred ms on a warm cluster; a flat multi-second wait otherwise
+            // dominates time-to-first-byte even when both peers are local.
+            const MAX_RETRIES: usize = 6;
+            const INITIAL_RETRY_DELAY: core::time::Duration =
+                core::time::Duration::from_millis(100);
+            const MAX_RETRY_DELAY: core::time::Duration = core::time::Duration::from_secs(2);
 
             for attempt in 1..=MAX_RETRIES {
+                let retry_delay = INITIAL_RETRY_DELAY
+                    .saturating_mul(1_u32.checked_shl((attempt - 1) as u32).unwrap_or(u32::MAX))
+                    .min(MAX_RETRY_DELAY);
+
                 tracing::debug!(
                     blob_id = %blob_id,
                     context_id = %context_id,
@@ -167,7 +177,7 @@ impl NodeClient {
                             "Failed to query DHT for blob"
                         );
                         if attempt < MAX_RETRIES {
-                            tokio::time::sleep(RETRY_DELAY).await;
+                            tokio::time::sleep(retry_delay).await;
                             continue;
                         }
                         return Err(e);
@@ -182,7 +192,7 @@ impl NodeClient {
                         "No peers found with blob"
                     );
                     if attempt < MAX_RETRIES {
-                        tokio::time::sleep(RETRY_DELAY).await;
+                        tokio::time::sleep(retry_delay).await;
                         continue;
                     }
                     return Ok(None);
@@ -265,10 +275,10 @@ impl NodeClient {
                         blob_id = %blob_id,
                         context_id = %context_id,
                         attempt,
-                        "All peers failed, retrying in {} seconds",
-                        RETRY_DELAY.as_secs()
+                        retry_delay_ms = retry_delay.as_millis(),
+                        "All peers failed, retrying after backoff"
                     );
-                    tokio::time::sleep(RETRY_DELAY).await;
+                    tokio::time::sleep(retry_delay).await;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Cross-peer blob reads fall back to DHT discovery (`query_blob` → kad `get_record`) when the blob isn't found locally. The retry loop in `NodeClient::get_blob` slept a **flat 2s** between attempts (`MAX_RETRIES = 3`).
- When the first lookup comes back empty — common right after a write, before the DHT record has propagated — this cost **2–4s before a single byte moved**, even when both peers are on the same host. This dominates the felt "blob sharing is slow" latency far more than the byte transfer itself.
- Replaced the flat wait with **exponential backoff**: 100ms initial, doubling per attempt, capped at 2s, over 6 attempts (100ms → 200ms → 400ms → 800ms → 1.6s).

## Behavior
- **Common case** (record available within a few hundred ms): returns in **~100ms instead of 2s**.
- **Worst case**: ~3.1s cumulative sleeping over 6 attempts — slightly *under* the previous 4s budget, so slow-propagation cases still get comparable time to converge.
- Backoff shift is overflow-guarded (`checked_shl(...).unwrap_or(u32::MAX)`); `attempt` starts at 1 so `attempt - 1` can't underflow.

## Notes / follow-up
This shortens the discovery-loop stall but doesn't remove the underlying gate — the loop still depends on the DHT record having propagated. The complementary fix (announce blobs eagerly + ask known context peers directly, skipping the DHT round) would eliminate the empty-result retries in the first place; left for a follow-up.

## Test plan
- [x] `cargo check -p calimero-node-primitives`
- [x] `cargo fmt -p calimero-node-primitives -- --check`
- [ ] Manual: write a blob on node A, read from node B in the same context; confirm time-to-first-byte drops and no regression in discovery success rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized timing and retry policy in blob fetch; no auth, API, or persistence changes.
> 
> **Overview**
> When a blob is missing locally, **`NodeClient::get_blob`** still discovers it via DHT (`query_blob`) and peer download, but the retry loop no longer waits a **fixed 2 seconds** between tries.
> 
> The change raises **`MAX_RETRIES` from 3 to 6** and uses **exponential backoff** starting at **100ms**, doubling each attempt up to a **2s cap**, on DHT errors, empty peer lists, and failed peer downloads. Logging now reports backoff in milliseconds instead of a fixed “N seconds” message.
> 
> **Typical case:** faster time-to-first-byte when the record appears quickly (~100ms vs ~2s). **Slow DHT:** total sleep is still bounded (roughly comparable to the old ~4s budget over fewer, longer waits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ece156383f86b98044dc64b030fe976656bbedd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->