### PR TITLE
perf(node/blob): drop artificial 10ms flow-control sleep on blob send

### DIFF
--- a/crates/node/src/handlers/blob_protocol.rs
+++ b/crates/node/src/handlers/blob_protocol.rs
@@ -13,13 +13,12 @@ use calimero_network_primitives::{
 use calimero_node_primitives::client::NodeClient;
 use futures_util::{SinkExt, StreamExt};
 use libp2p::PeerId;
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
-// Timeout and flow control settings for blob serving
+// Timeout settings for blob serving
 const BLOB_SERVE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes total
 const CHUNK_SEND_TIMEOUT: Duration = Duration::from_secs(30); // 30 seconds per chunk
-const FLOW_CONTROL_DELAY: Duration = Duration::from_millis(10); // Small delay between chunks
 
 // Replay protection window (30 seconds past, 10 seconds future)
 const MAX_REQUEST_AGE_SECS: u64 = 30;
@@ -82,7 +81,6 @@ pub async fn handle_blob_protocol_stream(
 /// 3. Send empty chunk to signal end
 ///
 /// Features:
-/// - Flow control (delay every 10 chunks)
 /// - Timeouts (5 min total, 30 sec per chunk)
 /// - Binary chunk encoding for efficiency
 async fn handle_blob_request_stream(
@@ -185,12 +183,6 @@ async fn handle_blob_request_stream(
                         .await
                         .map_err(|_| eyre::eyre!("Timeout sending chunk {}", chunk_count))?
                         .map_err(|e| eyre::eyre!("Failed to send blob chunk: {}", e))?;
-
-                        // Add small delay for flow control to prevent overwhelming receiver
-                        if chunk_count % 10 == 0 {
-                            // Every 10 chunks (~10MB), add a small pause
-                            sleep(FLOW_CONTROL_DELAY).await;
-                        }
                     }
                     Err(e) => {
                         warn!(%peer_id, error = %e, "Failed to read blob chunk");


### PR DESCRIPTION
## Summary
- The blob-serving loop in `handle_blob_request_stream` slept **10ms after every 10 chunks** (`FLOW_CONTROL_DELAY`) to "prevent overwhelming the receiver".
- This isn't real flow control — the transport already provides backpressure: `stream.send().await` won't complete until the framed sink and the underlying yamux/QUIC window have room, so a genuinely slow receiver naturally stalls the sender.
- The sleep just throttled healthy transfers (~1s of pure sleeping per GB at 1 MiB chunks) without adding any safety.

## Change
- Removed the `FLOW_CONTROL_DELAY` constant, the `sleep` import, the sleep block, and the stale doc-comment/feature line. No other behavior changes.

## Context
Part of the blob-sharing performance work (companion to #2510, which shortens the discovery-retry stall). This one targets the request-response *transfer* path.

## Test plan
- [x] `cargo check -p calimero-node`
- [x] `cargo fmt -p calimero-node -- --check`
- [ ] Manual: transfer a multi-MiB blob between two peers; confirm no regression and that throughput is unchanged-or-better

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path performance tweak with no auth, data-model, or protocol-format changes; remaining send timeouts and chunk protocol are unchanged.
> 
> **Overview**
> Removes **artificial throttling** on the P2P blob **serve** path in `handle_blob_request_stream`: the **10ms sleep every 10 chunks** and the `FLOW_CONTROL_DELAY` constant are gone, along with the unused `sleep` import.
> 
> Chunk streaming still uses the same **timeouts** and **`stream.send().await`** per chunk; the intent is to rely on **transport backpressure** instead of pausing healthy transfers (the PR notes ~**1s/GiB** of idle sleep at 1 MiB chunks).
> 
> Docs/comments in that handler are updated to drop the “flow control delay” feature line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8adc7991261c36e94e6eb9acc7a0005717b38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->