### PR TITLE
fix(node/sync): heal frozen-storage HashComparison split-brain

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -140,6 +140,9 @@ jobs:
           - workflow: scaffolding-e2e
             file: workflows/e2e.yml
             app: scaffolding-e2e
+          - workflow: frozen-rga-convergence
+            file: workflows/frozen-rga-convergence.yml
+            app: scaffolding-e2e
           - workflow: groups
             file: workflows/groups.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
@@ -1,0 +1,223 @@
+name: Frozen + RGA convergence repro
+description: >
+  Focused repro for the frozen-storage sync divergence (#scaffolding-e2e
+  "Frozen data cannot be updated" split-brain). A frozen entry added early
+  syncs cleanly, but a later multi-collection op sequence (RGA document
+  edits + a title change) makes one node's view of that earlier frozen
+  entry diverge: `compare_trees` emits an `Action::Update` for the frozen
+  element, which the storage layer categorically rejects, and the node can
+  never reconcile. This workflow isolates that sequence with explicit
+  cross-node convergence checks so the failure surfaces directly at the
+  final `wait_for_sync` instead of being buried in the full e2e suite.
+
+force_pull_image: false
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  # --- Setup: 3-node mesh ---
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create mesh with node-2
+    type: create_mesh
+    context_node: e2e-node-1
+    application_id: "{{app_id}}"
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - e2e-node-2
+    capability: member
+    outputs:
+      context_id: contextId
+      node1_key: memberPublicKey
+      group_id: groupId
+
+  - name: Create namespace invitation for node-3
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: "{{group_id}}"
+    outputs:
+      open_invitation_3: invitation
+
+  - name: Join namespace - node-3
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: "{{group_id}}"
+    invitation: "{{open_invitation_3}}"
+    outputs:
+      node3_key: memberIdentity
+
+  - name: Wait for sync after node-3 joins
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  # --- Frozen entry added early (this part syncs cleanly) ---
+  - name: Add frozen value on node-1
+    type: call
+    node: e2e-node-1
+    context_id: "{{context_id}}"
+    method: add_frozen
+    args:
+      value: "Immutable data"
+    outputs:
+      frozen_hash: result.output
+
+  - name: Wait for sync after frozen add
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  - name: Get frozen value on node-3 (sanity - synced cleanly)
+    type: call
+    node: e2e-node-3
+    context_id: "{{context_id}}"
+    method: get_frozen
+    args:
+      hash_hex: "{{frozen_hash}}"
+    outputs:
+      frozen_value_node3: result
+
+  - name: Assert frozen value present on node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{frozen_value_node3}}, {"output": "Immutable data"})'
+
+  # --- Multi-collection churn: RGA document edits from several nodes ---
+  - name: RGA insert text on node-1
+    type: call
+    node: e2e-node-1
+    context_id: "{{context_id}}"
+    method: rga_insert_text
+    args:
+      position: 0
+      text: "Hello"
+
+  - name: Wait for sync after node-1 insert
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  - name: RGA append text on node-2
+    type: call
+    node: e2e-node-2
+    context_id: "{{context_id}}"
+    method: rga_append_text
+    args:
+      text: " brave new World"
+
+  - name: RGA append text on node-3
+    type: call
+    node: e2e-node-3
+    context_id: "{{context_id}}"
+    method: rga_append_text
+    args:
+      text: " of frozen bugs"
+
+  - name: Wait for sync after concurrent appends
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  - name: RGA delete text on node-1
+    type: call
+    node: e2e-node-1
+    context_id: "{{context_id}}"
+    method: rga_delete_text
+    args:
+      start: 0
+      end: 5
+
+  - name: Wait for sync after delete
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 60
+    trigger_sync: true
+
+  # --- The trigger: a title change (LWW) driving a whole-tree sync ---
+  - name: Set document title on node-1
+    type: call
+    node: e2e-node-1
+    context_id: "{{context_id}}"
+    method: rga_set_title
+    args:
+      new_title: "E2E Test Document"
+
+  # This is the convergence check that fails in the full e2e suite: after
+  # the title change the whole-tree sync walks the frozen entry and (on the
+  # divergent node) tries to Update it, which is rejected — so the nodes
+  # never converge and this step times out.
+  - name: Wait for sync after title change (CONVERGENCE CHECK)
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    trigger_sync: true
+
+  # --- Post-convergence assertions: the frozen entry is still consistent ---
+  - name: Get frozen value on node-2 after title change
+    type: call
+    node: e2e-node-2
+    context_id: "{{context_id}}"
+    method: get_frozen
+    args:
+      hash_hex: "{{frozen_hash}}"
+    outputs:
+      frozen_after_node2: result
+
+  - name: Assert frozen value still present on node-2
+    type: json_assert
+    statements:
+      - 'json_equal({{frozen_after_node2}}, {"output": "Immutable data"})'
+
+  - name: Get frozen value on node-3 after title change
+    type: call
+    node: e2e-node-3
+    context_id: "{{context_id}}"
+    method: get_frozen
+    args:
+      hash_hex: "{{frozen_hash}}"
+    outputs:
+      frozen_after_node3: result
+
+  - name: Assert frozen value still present on node-3
+    type: json_assert
+    statements:
+      - 'json_equal({{frozen_after_node3}}, {"output": "Immutable data"})'
+
+stop_all_nodes: true

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -1222,4 +1222,111 @@ mod tests {
             assert_eq!(leaf_data.value, b"app-root-state");
         });
     }
+
+    /// Regression guard for the frozen-storage HashComparison split-brain.
+    ///
+    /// `apply_leaf_with_crdt_merge` previously emitted `Action::Update` for
+    /// ANY entity that already existed locally — including `Frozen` ones.
+    /// The storage layer categorically rejects `Update` for `Frozen`
+    /// ("Frozen data cannot be updated"), so re-applying an already-present
+    /// frozen leaf (which a bulk leaf push does while repairing a divergent
+    /// sibling) aborted the ENTIRE repair and left the context permanently
+    /// split-brained. Frozen entries are content-addressed + immutable, so
+    /// an already-present one must be skipped, not updated. This test pins
+    /// that: re-applying an existing frozen leaf is a no-op success.
+    #[test]
+    fn apply_leaf_skips_existing_frozen_entry() {
+        use std::sync::Arc;
+
+        use calimero_node_primitives::sync::hash_comparison::{LeafMetadata, TreeLeafData};
+        use calimero_primitives::crdt::CrdtType;
+        use calimero_storage::action::Action;
+        use calimero_storage::entities::{ChildInfo, Metadata, StorageType};
+        use calimero_storage::interface::ApplyContext;
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::Store;
+        use sha2::{Digest, Sha256};
+
+        use crate::sync::helpers::apply_leaf_with_crdt_merge;
+
+        let context_id = ContextId::from([0xCA; 32]);
+        let identity = PublicKey::from([0u8; 32]);
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let runtime_env = create_runtime_env(&store, context_id, identity);
+
+        let root_id = Id::new(*context_id.as_ref());
+        let frozen_id = Id::new([0x42u8; 32]);
+
+        // Frozen content-addressed blob: [key_hash(32)][value][element_id(32)].
+        let value = b"immutable-frozen-payload".to_vec();
+        let key_hash: [u8; 32] = Sha256::digest(&value).into();
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&key_hash);
+        blob.extend_from_slice(&value);
+        blob.extend_from_slice(frozen_id.as_bytes());
+
+        with_runtime_env(runtime_env.clone(), || {
+            // Create the context root.
+            Interface::<MainStorage>::apply_action(
+                Action::Update {
+                    id: root_id,
+                    data: vec![],
+                    ancestors: vec![],
+                    metadata: Metadata::default(),
+                },
+                &ApplyContext::empty(),
+            )
+            .expect("create root");
+
+            // Seed a Frozen entry as a child of root.
+            let root_hash = Index::<MainStorage>::get_hashes_for(root_id)
+                .ok()
+                .flatten()
+                .map(|(full, _)| full)
+                .unwrap_or([0; 32]);
+            let root_meta = Index::<MainStorage>::get_index(root_id)
+                .ok()
+                .flatten()
+                .map(|idx| idx.metadata.clone())
+                .unwrap_or_default();
+
+            let mut frozen_meta = Metadata::new(100, 100);
+            frozen_meta.storage_type = StorageType::Frozen;
+            frozen_meta.crdt_type = Some(CrdtType::FrozenStorage);
+
+            Interface::<MainStorage>::apply_action(
+                Action::Add {
+                    id: frozen_id,
+                    data: blob.clone(),
+                    ancestors: vec![ChildInfo::new(root_id, root_hash, root_meta)],
+                    metadata: frozen_meta,
+                },
+                &ApplyContext::empty(),
+            )
+            .expect("seed frozen entry");
+
+            // A peer re-pushes the SAME frozen leaf (as happens during a
+            // bulk leaf push while repairing a sibling). Frozen leaves carry
+            // no wire authorization, so apply_leaf resolves storage_type from
+            // the existing (Frozen) entry and would otherwise emit Update.
+            let leaf = TreeLeafData::new(
+                *frozen_id.as_bytes(),
+                blob.clone(),
+                LeafMetadata::new(CrdtType::FrozenStorage, 100, *root_id.as_bytes()),
+            );
+
+            // Before the fix this returned Err("Frozen data cannot be
+            // updated"); after the fix it is a no-op success.
+            apply_leaf_with_crdt_merge(context_id, &leaf)
+                .expect("re-applying an existing frozen leaf must be a no-op, not a fatal Update");
+
+            // The frozen entry is still present and unchanged.
+            assert!(
+                Index::<MainStorage>::get_index(frozen_id)
+                    .unwrap()
+                    .is_some(),
+                "frozen entry must remain present after the skipped re-apply"
+            );
+        });
+    }
 }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -298,6 +298,22 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
     }
 
     let action = if existing_index.is_some() {
+        // Frozen entities are content-addressed and immutable: an entry
+        // that already exists locally is by definition the correct
+        // content (its id is derived from its content hash), so there is
+        // nothing to update. Critically, the storage layer categorically
+        // REJECTS `Action::Update` for `Frozen` ("Frozen data cannot be
+        // updated"). Emitting one here — e.g. when a bulk leaf push
+        // re-sends an already-present frozen leaf while repairing a
+        // divergence in a *sibling* entity — fails and aborts the ENTIRE
+        // HashComparison repair, leaving the actually-divergent entity
+        // unreconciled. That is the intermittent scaffolding-e2e "Frozen
+        // data cannot be updated" split-brain: a frozen leaf is the
+        // victim that blocks recovery, not the source of divergence.
+        // Skip it; the immutable entry is already present and correct.
+        if matches!(metadata.storage_type, StorageType::Frozen) {
+            return Ok(());
+        }
         // Update existing entity - storage layer handles CRDT merge
         Action::Update {
             id: entity_id,

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1812,3 +1812,190 @@ fn test_e2e_counter_sync_with_isolated_storage() {
 
     println!("\n✅ Counter sync test PASSED!");
 }
+
+// ---------------------------------------------------------------------------
+// Frozen-storage sync robustness suite.
+//
+// Investigation of the intermittent scaffolding-e2e "Frozen data cannot be
+// updated" split-brain established that the straightforward frozen paths
+// converge deterministically (own_hash is content-only; merkle children are
+// id-sorted). These tests lock that in as regression guards so a future
+// change that makes frozen sync order- or path-dependent fails fast here
+// rather than as a rare e2e flake.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod frozen_sync_robustness {
+    use super::*;
+    use crate::address::Id;
+    use crate::collections::{FrozenStorage, Root};
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    type NodeStorage = MainStorage;
+
+    fn root_full_hash() -> [u8; 32] {
+        Index::<NodeStorage>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(f, _)| f)
+            .unwrap_or([0; 32])
+    }
+
+    fn init_frozen(executor: [u8; 32]) {
+        reset_delta_context();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(executor);
+        let mut r = Root::<FrozenStorage<String>, NodeStorage>::new_internal(FrozenStorage::new);
+        r.reassign_deterministic_id("frozen_items");
+        r.commit();
+    }
+
+    /// Two nodes independently inserting the SAME frozen value converge.
+    #[test]
+    #[serial]
+    fn independent_same_value_converges() {
+        env::reset_for_testing();
+        clear_merge_registry();
+        register_crdt_merge::<FrozenStorage<String>>();
+
+        init_frozen([1; 32]);
+        let mut n1 = Root::<FrozenStorage<String>, NodeStorage>::fetch().unwrap();
+        n1.insert("payload".to_string()).unwrap();
+        let d1 = borsh::to_vec(&*n1).unwrap();
+        Interface::<NodeStorage>::save_raw(Id::root(), d1, Metadata::default()).unwrap();
+        let h1 = root_full_hash();
+        drop(n1);
+
+        env::reset_for_testing();
+        init_frozen([2; 32]);
+        let mut n2 = Root::<FrozenStorage<String>, NodeStorage>::fetch().unwrap();
+        n2.insert("payload".to_string()).unwrap();
+        let d2 = borsh::to_vec(&*n2).unwrap();
+        Interface::<NodeStorage>::save_raw(Id::root(), d2, Metadata::default()).unwrap();
+        let h2 = root_full_hash();
+
+        assert_eq!(h1, h2, "same frozen value on two nodes must converge");
+    }
+
+    /// Re-inserting the same value is idempotent (content-addressed).
+    #[test]
+    #[serial]
+    fn reinsert_same_value_is_idempotent() {
+        env::reset_for_testing();
+        clear_merge_registry();
+        register_crdt_merge::<FrozenStorage<String>>();
+        init_frozen([1; 32]);
+
+        let mut n1 = Root::<FrozenStorage<String>, NodeStorage>::fetch().unwrap();
+        let k1 = n1.insert("dup".to_string()).unwrap();
+        let d1 = borsh::to_vec(&*n1).unwrap();
+        Interface::<NodeStorage>::save_raw(Id::root(), d1, Metadata::default()).unwrap();
+        let after_first = root_full_hash();
+
+        let k2 = n1.insert("dup".to_string()).unwrap();
+        let d2 = borsh::to_vec(&*n1).unwrap();
+        Interface::<NodeStorage>::save_raw(Id::root(), d2, Metadata::default()).unwrap();
+        let after_second = root_full_hash();
+
+        assert_eq!(k1, k2, "same content must produce the same key");
+        assert_eq!(
+            after_first, after_second,
+            "re-inserting identical frozen content must be a no-op"
+        );
+    }
+
+    /// Creator → applier (via delta sync) converge for a single frozen entry.
+    #[test]
+    #[serial]
+    fn create_then_apply_converges() {
+        env::reset_for_testing();
+        clear_merge_registry();
+        register_crdt_merge::<FrozenStorage<String>>();
+
+        // Node-1 creates + captures delta.
+        init_frozen([1; 32]);
+        let init = root_full_hash();
+        reset_delta_context();
+        set_current_heads(vec![init]);
+        env::set_executor_id([1; 32]);
+        let mut n1 = Root::<FrozenStorage<String>, NodeStorage>::fetch().unwrap();
+        n1.insert("synced".to_string()).unwrap();
+        let d1 = borsh::to_vec(&*n1).unwrap();
+        Interface::<NodeStorage>::save_raw(Id::root(), d1, Metadata::default()).unwrap();
+        let h1 = root_full_hash();
+        let delta = commit_causal_delta(&h1).unwrap();
+        drop(n1);
+
+        // Node-2 fresh init + applies the delta.
+        env::reset_for_testing();
+        init_frozen([2; 32]);
+        let init2 = root_full_hash();
+        assert_eq!(init, init2, "init must match");
+        reset_delta_context();
+        set_current_heads(vec![init2]);
+        env::set_executor_id([2; 32]);
+        if let Some(delta) = delta {
+            let payload = borsh::to_vec(&StorageDelta::Actions(delta.actions)).unwrap();
+            Root::<FrozenStorage<String>, NodeStorage>::sync(&payload, &ApplyContext::empty())
+                .expect("applying a frozen Add delta must not error");
+        }
+        assert_eq!(h1, root_full_hash(), "creator and applier must converge");
+    }
+
+    /// Applying two frozen Adds in either order yields the same state
+    /// (delta-application-order independence — the property whose
+    /// violation would manifest as the intermittent e2e divergence).
+    #[test]
+    #[serial]
+    fn delta_apply_order_independent() {
+        fn apply_in_order(values: &[&str]) -> [u8; 32] {
+            env::reset_for_testing();
+            clear_merge_registry();
+            register_crdt_merge::<FrozenStorage<String>>();
+
+            // Build one delta per value on a "producer" node.
+            let mut deltas = Vec::new();
+            init_frozen([1; 32]);
+            let mut head = root_full_hash();
+            for v in values {
+                reset_delta_context();
+                set_current_heads(vec![head]);
+                env::set_executor_id([1; 32]);
+                let mut n = Root::<FrozenStorage<String>, NodeStorage>::fetch().unwrap();
+                n.insert((*v).to_string()).unwrap();
+                let d = borsh::to_vec(&*n).unwrap();
+                Interface::<NodeStorage>::save_raw(Id::root(), d, Metadata::default()).unwrap();
+                head = root_full_hash();
+                let delta = commit_causal_delta(&head).unwrap();
+                drop(n);
+                if let Some(delta) = delta {
+                    deltas.push(delta.actions);
+                }
+            }
+
+            // Apply those deltas to a fresh consumer node in the given order.
+            env::reset_for_testing();
+            init_frozen([2; 32]);
+            let base = root_full_hash();
+            for actions in &deltas {
+                reset_delta_context();
+                set_current_heads(vec![base]);
+                env::set_executor_id([2; 32]);
+                let payload = borsh::to_vec(&StorageDelta::Actions(actions.clone())).unwrap();
+                Root::<FrozenStorage<String>, NodeStorage>::sync(&payload, &ApplyContext::empty())
+                    .expect("frozen delta apply must not error");
+            }
+            root_full_hash()
+        }
+
+        let forward = apply_in_order(&["alpha", "beta", "gamma"]);
+        let reverse = apply_in_order(&["gamma", "beta", "alpha"]);
+        assert_eq!(
+            forward, reverse,
+            "frozen entries must converge regardless of delta application order"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent `scaffolding-e2e` **"Frozen data cannot be updated"** split-brain (a context permanently fails to converge after a sync).

## Root cause (deterministic)

`crates/node/src/sync/helpers.rs::apply_leaf_with_crdt_merge` chose the apply action by existence alone:

```rust
let action = if existing_index.is_some() {
    Action::Update { ... }   // ← no StorageType check
} else {
    Action::Add { ... }
};
```

The storage layer **categorically rejects `Action::Update` for `Frozen`** entities (they're content-addressed + immutable). So when a HashComparison repair re-pushes an **already-present frozen leaf** — which happens while reconciling a divergent *sibling* entity — the frozen `Update` fails and **aborts the entire repair**, leaving the actually-divergent entity unreconciled. The frozen leaf is the *victim that blocks recovery*, not the source of divergence — which is why it's intermittent and why the node never heals (119 failed HashComparison rounds in the captured run).

## Fix

A frozen entity already present locally is by definition correct (its id is derived from its content hash) and immutable, so **skip it** instead of emitting the fatal `Update`:

```rust
if matches!(metadata.storage_type, StorageType::Frozen) {
    return Ok(());
}
```

Convergent-safe: for content-addressed storage, "exists locally" ⇒ "has the correct content". This unblocks the repair so the real divergence heals.

## Tests

- **Deterministic regression test** (`apply_leaf_skips_existing_frozen_entry`, node crate): seeds a frozen entry, re-applies the same leaf via `apply_leaf_with_crdt_merge`. **Fails with the exact production error** (`Frozen data cannot be updated`) *without* the fix; no-op success *with* it. Verified both directions.
- **Storage robustness suite** (4 tests): proves the storage merge layer is content-deterministic and order-independent for frozen entries (independent-creation convergence, idempotent re-insert, create-then-apply, delta-apply-order independence) — establishing that this sync-repair path, not the merge, is the defect.
- **e2e coverage** (`frozen-rga-convergence` workflow): a focused 3-node frozen + RGA + title-change convergence check, wired into the e2e-rust-apps matrix.

All node sync tests (143) and storage tests (469) green; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HashComparison leaf-apply behavior on the sync convergence path; scope is narrow (early return for Frozen) but incorrect logic would still allow stuck multi-node divergence.
> 
> **Overview**
> Fixes an intermittent **3-node split-brain** where HashComparison repair re-applies an already-present **frozen** leaf as `Action::Update`, storage rejects it (`Frozen data cannot be updated`), and the whole repair aborts before the real divergence heals.
> 
> **`apply_leaf_with_crdt_merge`** now **no-ops** when a frozen entity already exists locally (content-addressed + immutable), instead of emitting a fatal update during bulk leaf push.
> 
> Adds a **node unit test** (`apply_leaf_skips_existing_frozen_entry`), a **storage frozen-sync robustness** suite (convergence, idempotent re-insert, delta apply), a **`frozen-rga-convergence`** merobox workflow (frozen + RGA churn + title `wait_for_sync`), and wires that workflow into the **e2e-rust-apps** matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb68da6a98022d2f31f383a6f70f6284be99d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->