### PR TITLE
refactor(sync): remove unused divergent_subtrees field from HashComparison

### DIFF
--- a/crates/node/primitives/src/sync/handshake.rs
+++ b/crates/node/primitives/src/sync/handshake.rs
@@ -191,10 +191,7 @@ mod tests {
     #[test]
     fn test_sync_handshake_response_roundtrip() {
         let response = SyncHandshakeResponse::with_protocol(
-            SyncProtocol::HashComparison {
-                root_hash: [7; 32],
-                divergent_subtrees: vec![],
-            },
+            SyncProtocol::HashComparison { root_hash: [7; 32] },
             [8; 32],
             500,
         );

--- a/crates/node/primitives/src/sync/protocol.rs
+++ b/crates/node/primitives/src/sync/protocol.rs
@@ -67,8 +67,6 @@ pub enum SyncProtocol {
     HashComparison {
         /// Root hash to compare against.
         root_hash: [u8; 32],
-        /// Subtree roots that differ (if known).
-        divergent_subtrees: Vec<[u8; 32]>,
     },
 
     /// Full state snapshot transfer.
@@ -205,7 +203,6 @@ pub fn select_protocol(local: &SyncHandshake, remote: &SyncHandshake) -> Protoco
         return ProtocolSelection {
             protocol: SyncProtocol::HashComparison {
                 root_hash: remote.root_hash,
-                divergent_subtrees: vec![],
             },
             reason: "version mismatch, using safe fallback",
         };
@@ -241,7 +238,6 @@ pub fn select_protocol(local: &SyncHandshake, remote: &SyncHandshake) -> Protoco
         return ProtocolSelection {
             protocol: SyncProtocol::HashComparison {
                 root_hash: remote.root_hash,
-                divergent_subtrees: vec![],
             },
             reason: "high divergence (>50%), using hash comparison with CRDT merge",
         };
@@ -290,7 +286,6 @@ pub fn select_protocol(local: &SyncHandshake, remote: &SyncHandshake) -> Protoco
     ProtocolSelection {
         protocol: SyncProtocol::HashComparison {
             root_hash: remote.root_hash,
-            divergent_subtrees: vec![],
         },
         reason: "default: using hash comparison",
     }
@@ -323,7 +318,6 @@ pub fn select_protocol_with_fallback(
     if local.has_state {
         let fallback = SyncProtocol::HashComparison {
             root_hash: remote.root_hash,
-            divergent_subtrees: vec![],
         };
         if is_protocol_supported(&fallback, remote_capabilities) {
             return ProtocolSelection {
@@ -356,10 +350,7 @@ mod tests {
             SyncProtocol::DeltaSync {
                 missing_delta_ids: vec![[1; 32], [2; 32]],
             },
-            SyncProtocol::HashComparison {
-                root_hash: [3; 32],
-                divergent_subtrees: vec![[4; 32]],
-            },
+            SyncProtocol::HashComparison { root_hash: [3; 32] },
             SyncProtocol::Snapshot {
                 compressed: true,
                 verified: false,
@@ -412,11 +403,7 @@ mod tests {
             SyncProtocolKind::DeltaSync
         );
         assert_eq!(
-            SyncProtocol::HashComparison {
-                root_hash: [2; 32],
-                divergent_subtrees: vec![]
-            }
-            .kind(),
+            SyncProtocol::HashComparison { root_hash: [2; 32] }.kind(),
             SyncProtocolKind::HashComparison
         );
         assert_eq!(
@@ -448,10 +435,7 @@ mod tests {
         );
 
         // Test From trait directly
-        let protocol = SyncProtocol::HashComparison {
-            root_hash: [3; 32],
-            divergent_subtrees: vec![],
-        };
+        let protocol = SyncProtocol::HashComparison { root_hash: [3; 32] };
         let kind: SyncProtocolKind = (&protocol).into();
         assert_eq!(kind, SyncProtocolKind::HashComparison);
     }
@@ -648,10 +632,7 @@ mod tests {
         // Supported (in default list)
         assert!(is_protocol_supported(&SyncProtocol::None, &caps));
         assert!(is_protocol_supported(
-            &SyncProtocol::HashComparison {
-                root_hash: [0; 32],
-                divergent_subtrees: vec![]
-            },
+            &SyncProtocol::HashComparison { root_hash: [0; 32] },
             &caps
         ));
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -894,7 +894,7 @@ impl SyncManager {
         // so it matches the fixed `KNOWN_PROTOCOLS` set in
         // `PrometheusSyncMetrics::sanitize_protocol`. Formatting the
         // data-carrying `SyncProtocol` with `{:?}` would yield strings
-        // like `HashComparison { root_hash: [...], divergent_subtrees: [...] }`
+        // like `HashComparison { root_hash: [...] }`
         // which never match the sanitiser and would label every sync
         // `protocol="unknown"`, breaking the per-protocol slicing on
         // `sync_successes_total` and `sync_duration_seconds`.

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -253,10 +253,7 @@ impl ProtocolSelector {
                             .await;
                         }
 
-                        Ok(Some(SyncProtocol::HashComparison {
-                            root_hash,
-                            divergent_subtrees: vec![],
-                        }))
+                        Ok(Some(SyncProtocol::HashComparison { root_hash }))
                     }
                     Err(e) => {
                         warn!(

--- a/crates/node/src/sync/tracking.rs
+++ b/crates/node/src/sync/tracking.rs
@@ -216,10 +216,7 @@ mod tests {
     /// Test that HashComparison maps to SnapshotSync (fallback category)
     #[test]
     fn test_from_primitives_hash_comparison() {
-        let primitive = PrimitivesSyncProtocol::HashComparison {
-            root_hash: [3; 32],
-            divergent_subtrees: vec![],
-        };
+        let primitive = PrimitivesSyncProtocol::HashComparison { root_hash: [3; 32] };
         let tracking: SyncProtocol = (&primitive).into();
         assert!(matches!(tracking, SyncProtocol::SnapshotSync));
     }
@@ -263,10 +260,7 @@ mod tests {
             PrimitivesSyncProtocol::DeltaSync {
                 missing_delta_ids: vec![],
             },
-            PrimitivesSyncProtocol::HashComparison {
-                root_hash: [0; 32],
-                divergent_subtrees: vec![],
-            },
+            PrimitivesSyncProtocol::HashComparison { root_hash: [0; 32] },
             PrimitivesSyncProtocol::Snapshot {
                 compressed: false,
                 verified: false,


### PR DESCRIPTION
## What

Removes the `divergent_subtrees: Vec<[u8; 32]>` field from `SyncProtocol::HashComparison`.

Per #2055, this field was **dead**:
- **Never written** — every `select_protocol()` / post-sync path passed `vec![]`.
- **Never read** — the HashComparison initiator (`HashComparisonProtocol::run_initiator`) discovers divergent subtrees *during* DFS traversal via `compare_tree_nodes`; it never consulted this hint.
- It only carried weight in the borsh wire format and added construction/test noise.

The issue proposed either removing the field or implementing it (populate from a prior comparison or a bloom-filter pre-pass). Implementing it is a speculative optimization that needs protocol design; removing it is the clearly-correct simplification, so this PR takes the removal path.

## Changes

- Drop the field from the `HashComparison` variant definition.
- Update all construction sites (`protocol.rs` selection rules, `protocol_selector.rs` post-sync result) and tests across `protocol.rs`, `handshake.rs`, `tracking.rs`.
- Fix a stale doc comment in `manager/mod.rs`.

## Wire compatibility

This changes the borsh layout of the `HashComparison` variant (drops the trailing empty-`Vec` length prefix). `SYNC_PROTOCOL_VERSION` is intentionally **left at 1** — backward compatibility is not a concern at this stage.

## Testing

- `cargo build -p calimero-node-primitives -p calimero-node` — clean
- `cargo test -p calimero-node-primitives --lib sync::` — 265 passed
- `cargo test -p calimero-node --lib sync::tracking` — 8 passed
- `cargo fmt --check` — clean

Closes #2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wire-format change for `HashComparison` can break mixed-version peers until all nodes upgrade; runtime behavior is unchanged because the field was never read.
> 
> **Overview**
> Removes the unused **`divergent_subtrees`** field from **`SyncProtocol::HashComparison`**, leaving only **`root_hash`**. Every construction site (protocol selection, fallbacks, post-sync in **`protocol_selector`**) and related tests were updated accordingly.
> 
> This **changes the borsh wire layout** for that variant (no trailing empty `Vec`); **`SYNC_PROTOCOL_VERSION` stays at 1** per the PR. A stale metrics comment in **`manager/mod.rs`** was updated to match the slimmer **`Debug`** shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b81394053a7e02406cbd941dbeb1072e476422d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->