### PR TITLE
test(node/sync): success-path unit test for namespace-join discovery loop (#2519)

### DIFF
--- a/crates/network/primitives/Cargo.toml
+++ b/crates/network/primitives/Cargo.toml
@@ -21,12 +21,21 @@ multiaddr.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["io-util"] }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing.workspace = true
 
 calimero-primitives = { workspace = true, features = ["borsh"] }
 calimero-utils-actix.workspace = true
+
+[features]
+# Exposes `Stream::test_pair()` — an in-memory duplex-backed `Stream`
+# so downstream crates (e.g. node's sync mocks) can synthesize a real
+# `Ok(Stream)` in tests without a libp2p swarm. Off by default; enable
+# via a dev-dependency edge so production builds never carry it.
+# (`tokio/io-util` is enabled unconditionally on the dependency above —
+# `duplex` is what backs the in-memory pipe.)
+test-utils = []
 
 [dev-dependencies]
 libp2p = { workspace = true, features = ["autonat", "identify", "macros", "tcp", "tokio", "noise", "yamux"] }

--- a/crates/network/primitives/src/stream.rs
+++ b/crates/network/primitives/src/stream.rs
@@ -4,6 +4,8 @@ use core::task::{Context, Poll};
 use futures_util::{Sink as FuturesSink, SinkExt, Stream as FuturesStream, StreamExt};
 use libp2p::{Stream as P2pStream, StreamProtocol};
 use tokio::io::BufStream;
+#[cfg(feature = "test-utils")]
+use tokio::io::{duplex, DuplexStream};
 use tokio_util::codec::Framed;
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt};
 
@@ -17,9 +19,29 @@ pub const MAX_MESSAGE_SIZE: usize = 8 * 1_024 * 1_024;
 pub const CALIMERO_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/calimero/stream/0.0.2");
 pub const CALIMERO_BLOB_PROTOCOL: StreamProtocol = StreamProtocol::new("/calimero/blob/0.0.2");
 
+type Libp2pFramed = Framed<BufStream<Compat<P2pStream>>, MessageCodec>;
+
+#[cfg(feature = "test-utils")]
+type MemoryFramed = Framed<BufStream<DuplexStream>, MessageCodec>;
+
 #[derive(Debug)]
 pub struct Stream {
-    inner: Framed<BufStream<Compat<P2pStream>>, MessageCodec>,
+    inner: StreamInner,
+}
+
+/// Backing transport for a [`Stream`].
+///
+/// Production always uses [`StreamInner::Libp2p`]; the in-memory
+/// variant exists only so the sync mocks can hand back a genuine
+/// `Ok(Stream)` (not just `Err`) without standing up a libp2p swarm.
+/// It is compiled away entirely unless the `test-utils` feature is on,
+/// so the `match` in the poll impls collapses to a single arm in
+/// production builds.
+#[derive(Debug)]
+enum StreamInner {
+    Libp2p(Libp2pFramed),
+    #[cfg(feature = "test-utils")]
+    Memory(MemoryFramed),
 }
 
 impl Stream {
@@ -27,7 +49,33 @@ impl Stream {
     pub fn new(stream: P2pStream) -> Self {
         let stream = BufStream::new(stream.compat());
         let stream = Framed::new(stream, MessageCodec::new(MAX_MESSAGE_SIZE));
-        Self { inner: stream }
+        Self {
+            inner: StreamInner::Libp2p(stream),
+        }
+    }
+
+    /// Construct a connected in-memory `Stream` pair for tests.
+    ///
+    /// The two ends are wired by a `tokio::io::duplex` pipe and carry
+    /// the same [`MessageCodec`] framing as a real libp2p stream, so
+    /// code under test can both observe a successful open (`Ok(Stream)`)
+    /// and exchange messages end-to-end without a libp2p swarm. Gated
+    /// behind the `test-utils` feature so production binaries never
+    /// compile the in-memory transport.
+    #[cfg(feature = "test-utils")]
+    #[must_use]
+    pub fn test_pair() -> (Self, Self) {
+        let (a, b) = duplex(MAX_MESSAGE_SIZE);
+        (Self::from_duplex(a), Self::from_duplex(b))
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn from_duplex(half: DuplexStream) -> Self {
+        let stream = BufStream::new(half);
+        let stream = Framed::new(stream, MessageCodec::new(MAX_MESSAGE_SIZE));
+        Self {
+            inner: StreamInner::Memory(stream),
+        }
     }
 }
 
@@ -35,7 +83,11 @@ impl FuturesStream for Stream {
     type Item = Result<Message<'static>, CodecError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.inner.poll_next_unpin(cx)
+        match &mut self.inner {
+            StreamInner::Libp2p(inner) => inner.poll_next_unpin(cx),
+            #[cfg(feature = "test-utils")]
+            StreamInner::Memory(inner) => inner.poll_next_unpin(cx),
+        }
     }
 }
 
@@ -43,18 +95,34 @@ impl<'a> FuturesSink<Message<'a>> for Stream {
     type Error = CodecError;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready_unpin(cx)
+        match &mut self.inner {
+            StreamInner::Libp2p(inner) => inner.poll_ready_unpin(cx),
+            #[cfg(feature = "test-utils")]
+            StreamInner::Memory(inner) => inner.poll_ready_unpin(cx),
+        }
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Message<'a>) -> Result<(), Self::Error> {
-        self.inner.start_send_unpin(item)
+        match &mut self.inner {
+            StreamInner::Libp2p(inner) => inner.start_send_unpin(item),
+            #[cfg(feature = "test-utils")]
+            StreamInner::Memory(inner) => inner.start_send_unpin(item),
+        }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_flush_unpin(cx)
+        match &mut self.inner {
+            StreamInner::Libp2p(inner) => inner.poll_flush_unpin(cx),
+            #[cfg(feature = "test-utils")]
+            StreamInner::Memory(inner) => inner.poll_flush_unpin(cx),
+        }
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_close_unpin(cx)
+        match &mut self.inner {
+            StreamInner::Libp2p(inner) => inner.poll_close_unpin(cx),
+            #[cfg(feature = "test-utils")]
+            StreamInner::Memory(inner) => inner.poll_close_unpin(cx),
+        }
     }
 }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -54,6 +54,11 @@ calimero-utils-actix.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 calimero-dag = { workspace = true, features = ["testing"] }
+# `test-utils` pulls in `Stream::test_pair()` so the sync mocks can
+# script a successful `open_stream` (`Ok(Stream)`). Dev-only edge:
+# production builds of the node take the plain `[dependencies]` entry
+# without the feature, so the in-memory transport is never compiled in.
+calimero-network-primitives = { workspace = true, features = ["test-utils"] }
 calimero-storage = { workspace = true, features = ["testing"] }
 ed25519-dalek.workspace = true
 parking_lot.workspace = true

--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -485,4 +485,42 @@ mod tests {
         );
         mock.assert_all_consumed();
     }
+
+    /// The recovery path: earlier peers fail, then a later peer's
+    /// `open_stream` succeeds → the loop returns `Ok`. This is the one
+    /// outcome the mock previously couldn't script (it had no synthetic
+    /// `Ok(Stream)`), so the discovery loop's "fallback actually works"
+    /// behaviour went unverified. Backed now by an in-memory
+    /// `Stream::test_pair()` end.
+    #[tokio::test(start_paused = true)]
+    async fn peer_succeeds_after_earlier_failures_returns_ok() {
+        let mock = MockSyncNetwork::default();
+        // Three candidates in the (sticky) mesh; all are tried in
+        // round 1 since 3 < DEADLINE_MAX_PEERS_PER_ROUND.
+        mock.push_mesh_peers(vec![PeerId::random(), PeerId::random(), PeerId::random()]);
+        // The mock ignores peer identity and pops responses in order:
+        // the first two opens fail, the third succeeds.
+        mock.push_open_stream_err("peer down")
+            .push_open_stream_err("peer rejected")
+            .push_open_stream_ok();
+
+        let (open_timeout, retries, retry_delay) = defaults();
+        let result = open_namespace_join_stream(
+            &mock,
+            NAMESPACE_ID,
+            open_timeout,
+            retries,
+            retry_delay,
+            &no_excluded(),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "discovery loop should recover once a later peer's open succeeds"
+        );
+        // Exactly the three scripted opens were consumed — the loop
+        // stopped at the first success: no extra round, no leftovers.
+        mock.assert_all_consumed();
+    }
 }

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -1,10 +1,10 @@
 //! Scriptable mock for [`super::SyncNetwork`].
 //!
-//! Scope is "failure-path tests" — `mesh_peers` returns recorded
-//! peer lists; `open_stream` returns recorded errors (or a queued
-//! callback returning `eyre::Error`). Success-path tests that
-//! actually exchange messages need a real `Stream`, which is
-//! tracked as a separate follow-up (see `super` module doc).
+//! `mesh_peers` returns recorded peer lists; `open_stream` returns
+//! recorded errors, hangs, or — via `Stream::test_pair()` behind the
+//! `test-utils` feature — a real `Ok(Stream)`. The success arm lets
+//! tests cover the discovery loop's recovery path (a peer succeeds
+//! after earlier ones fail), not just its give-up paths.
 //!
 //! ## Exhaustion semantics
 //!
@@ -32,6 +32,7 @@ use std::collections::VecDeque;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use calimero_network_primitives::stream::Stream;
 use libp2p::gossipsub::TopicHash;
 use libp2p::PeerId;
 use parking_lot::Mutex;
@@ -41,6 +42,10 @@ use super::SyncNetwork;
 
 /// Per-call directive for a mocked `open_stream` response.
 pub(crate) enum OpenStreamResponse {
+    /// Hand back a successfully-opened stream — an in-memory
+    /// `Stream::test_pair()` end. Lets tests exercise the
+    /// "peer succeeds after earlier failures" recovery path.
+    Ok(Stream),
     /// Synthesise an error string.
     Err(String),
     /// Sleep for `Duration` then return `Err` — useful for
@@ -74,6 +79,23 @@ impl MockSyncNetwork {
     /// Queue a response for the next `mesh_peers` call.
     pub(crate) fn push_mesh_peers(&self, peers: Vec<PeerId>) -> &Self {
         self.mesh_peers_responses.lock().push_back(peers);
+        self
+    }
+
+    /// Queue a successful `open_stream` response.
+    ///
+    /// The returned `Stream` is one end of an in-memory
+    /// `Stream::test_pair()`; the other end is dropped immediately.
+    /// That's sufficient for the discovery loop, which only needs the
+    /// open to *succeed* (it doesn't exchange messages here — the
+    /// post-open protocol runs in the caller). Available because the
+    /// node enables `calimero-network-primitives/test-utils` on its
+    /// dev-dependency edge.
+    pub(crate) fn push_open_stream_ok(&self) -> &Self {
+        let (stream, _peer_end) = Stream::test_pair();
+        self.open_stream_responses
+            .lock()
+            .push_back(OpenStreamResponse::Ok(stream));
         self
     }
 
@@ -201,15 +223,13 @@ impl SyncNetwork for MockSyncNetwork {
         }
     }
 
-    async fn open_stream(
-        &self,
-        _peer_id: PeerId,
-    ) -> eyre::Result<calimero_network_primitives::stream::Stream> {
+    async fn open_stream(&self, _peer_id: PeerId) -> eyre::Result<Stream> {
         let response = self.open_stream_responses.lock().pop_front();
         match response {
             None => Err(eyre::eyre!(
                 "MockSyncNetwork: open_stream called with no queued response"
             )),
+            Some(OpenStreamResponse::Ok(stream)) => Ok(stream),
             Some(OpenStreamResponse::Err(msg)) => Err(eyre::eyre!(msg)),
             Some(OpenStreamResponse::SleepThenErr(sleep_for, msg)) => {
                 time::sleep(sleep_for).await;

--- a/crates/node/src/sync/network/mod.rs
+++ b/crates/node/src/sync/network/mod.rs
@@ -12,13 +12,13 @@
 //! `manager/mod.rs` + `manager/tests.rs` precedent for the same
 //! mod-dir layout.
 //!
-//! **`open_stream` mockability**: `Stream` is a concrete type wrapping
-//! a real `libp2p::Stream` and currently has no synthetic constructor.
-//! Mocks can return `Err(_)` from `open_stream` (sufficient for
-//! testing retry/timeout/error paths in the namespace-join discovery
-//! loop, the snapshot/delta-request open paths, etc.) but cannot
-//! return a synthetic `Ok(Stream)` until a `Stream::test_pair()`
-//! constructor lands — tracked as a follow-up.
+//! **`open_stream` mockability**: `Stream` wraps a real `libp2p::Stream`
+//! in production, but `Stream::test_pair()` (behind the network-primitives
+//! `test-utils` feature, which the node enables on its dev-dependency
+//! edge) backs it with an in-memory duplex pipe. Mocks can therefore
+//! script `Err(_)`/hang *and* a synthetic `Ok(Stream)`, covering both
+//! the retry/timeout/error paths and the success/recovery paths of the
+//! namespace-join discovery loop, snapshot/delta-request opens, etc.
 //!
 //! See #2406 + #2302 (sync extraction epic).
 //!
@@ -56,7 +56,8 @@ pub trait SyncNetwork: Send + Sync + 'static {
     /// Open a new substream to `peer_id` over the calimero protocol.
     ///
     /// Used by every sync initiator path. Mock impls can return
-    /// `Err(_)` to exercise the retry/timeout/error branches.
+    /// `Err(_)` to exercise the retry/timeout/error branches, or a
+    /// `Stream::test_pair()` end to exercise the success branch.
     async fn open_stream(&self, peer_id: PeerId) -> eyre::Result<Stream>;
 }
 


### PR DESCRIPTION
## Summary

Closes #2519.

The namespace-join discovery loop (`open_namespace_join_stream`) had unit tests for every *failure* outcome but none for the success/recovery path ("a peer succeeds after earlier peers fail"). The blocker was that `SyncNetwork::open_stream` returns a concrete `Stream` with no test constructor, so `MockSyncNetwork` could only script `Err`/hang — never `Ok`.

This PR makes a synthetic `Ok(Stream)` possible and adds the missing test.

## Changes

- **`crates/network/primitives/src/stream.rs`** — `Stream` now wraps a `StreamInner` enum: the production `Libp2p` variant plus a `test-utils`-gated `Memory` variant backed by a `tokio::io::duplex` pipe carrying the same `MessageCodec` framing. Added `Stream::test_pair() -> (Stream, Stream)`. Poll/sink impls match on the variant; the in-memory arm is `#[cfg]`'d out in production, so the match collapses to a single arm with no runtime cost.
- **`crates/network/primitives/Cargo.toml`** — new `test-utils` feature; `tokio`'s `io-util` enabled directly on the dependency.
- **`crates/node/Cargo.toml`** — enables `calimero-network-primitives/test-utils` on the **dev-dependency** edge only, so production node builds never compile the in-memory transport (resolver v2).
- **`crates/node/src/sync/network/mock.rs`** — added `OpenStreamResponse::Ok(Stream)` + `push_open_stream_ok()`; updated the module doc.
- **`crates/node/src/sync/network/mod.rs`** — refreshed the stale doc note that said `Ok(Stream)` was unmockable.
- **`crates/node/src/sync/manager/namespace_join.rs`** — added `peer_succeeds_after_earlier_failures_returns_ok`: two peers fail, the third's open succeeds → loop returns `Ok`, with `assert_all_consumed()` confirming it stopped at the first success.

## Verification

- `cargo test -p calimero-node --lib namespace_join` → **8 passed, 0 failed** (new test included)
- `cargo fmt --check` → clean
- `cargo build -p calimero-network-primitives` and `-p calimero-node` (no `test-utils`) → **0 errors** — confirms the in-memory transport is compiled out of production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only surface behind `test-utils` on dev dependencies; production `Stream` path unchanged aside from enum dispatch that collapses to libp2p-only without the feature.
> 
> **Overview**
> Adds a **`test-utils`** feature on `calimero-network-primitives` so tests can obtain a real **`Ok(Stream)`** without libp2p: **`Stream`** now backs onto a **`StreamInner`** enum (production libp2p vs optional in-memory **`tokio::io::duplex`** with the same **`MessageCodec`**), exposing **`Stream::test_pair()`** when the feature is enabled. The node crate enables that feature only on its **dev-dependency** edge.
> 
> **`MockSyncNetwork`** gains **`push_open_stream_ok()`** / **`OpenStreamResponse::Ok`**, and a new namespace-join unit test **`peer_succeeds_after_earlier_failures_returns_ok`** asserts the discovery loop returns **`Ok`** after two failed opens and one success, with **`assert_all_consumed()`** guarding no extra attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab966922ee0b9bfac4320baa4ee7794376604f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->