### PR TITLE
ci(fuzzy): fail instead of testing a stale profiling binary

### DIFF
--- a/scripts/determine-image-tag.sh
+++ b/scripts/determine-image-tag.sh
@@ -209,7 +209,7 @@ elif [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then
             echo "Master push touches release.yml trigger paths - waiting for release.yml on ${HEAD_SHA} to republish :edge${TAG_SUFFIX}"
 
             if [ "$PROFILING_MODE" = "--profiling" ]; then
-                MAX_WAIT=1800  # 30 minutes - profiling container build takes longer
+                MAX_WAIT=3600  # 60 minutes - profiling builds observed ~44min; 30min raced them
             else
                 MAX_WAIT=1200  # 20 minutes - same budget as the PR-branch path
             fi
@@ -234,8 +234,8 @@ elif [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then
                     if [ "$CONCLUSION" = "success" ]; then
                         echo "release.yml completed successfully after ${ELAPSED}s - :edge${TAG_SUFFIX} now resolves to ${HEAD_SHA}"
                     else
-                        echo "release.yml completed with conclusion: ${CONCLUSION}"
-                        echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
+                        echo "::error::release.yml for ${HEAD_SHA} concluded ${CONCLUSION} - refusing to test against a stale :edge${TAG_SUFFIX} (the previous commit's binary). Fix the release build, then re-run."
+                        exit 1
                     fi
                     break
                 fi
@@ -253,16 +253,15 @@ elif [ "$EVENT_NAME" = "push" ] && [ "$HEAD_BRANCH" = "master" ]; then
             done
 
             if [ $ELAPSED -ge $MAX_WAIT ]; then
-                echo "Timeout waiting for release.yml after ${MAX_WAIT}s"
-                echo "Falling back to :edge${TAG_SUFFIX} as-is (may be the previous commit's binary)"
+                echo "::error::Timed out after ${MAX_WAIT}s waiting for release.yml to republish :edge${TAG_SUFFIX} for ${HEAD_SHA}."
+                echo "::error::Refusing to test against the previous commit's binary - that source/binary mismatch masqueraded as a fuzzy bug in run 26679287804. Re-run once release.yml has published the matching image."
+                exit 1
             fi
 
-            # Same final tag in all three exit paths (success, failure,
-            # timeout). Only the timing and the log message differ — the
-            # caller's `docker pull ghcr.io/.../merod:edge${TAG_SUFFIX}`
-            # works either way because :edge${TAG_SUFFIX} always exists
-            # (it points at the previous master commit's binary if the
-            # current one's release.yml hasn't repointed it yet).
+            # Only the success path reaches here: release.yml has repointed
+            # :edge${TAG_SUFFIX} at ${HEAD_SHA}, so the moving tag matches the
+            # checked-out source. The failure and timeout paths above exit
+            # non-zero rather than silently test the previous commit's binary.
             TAG="edge${TAG_SUFFIX}"
         fi
     fi


### PR DESCRIPTION
## Problem

On a master push, the profiling fuzzy jobs (`scripts/determine-image-tag.sh`, profiling path) wait for `release.yml` to republish `:edge-profiling` for the just-merged commit so the `merod` binary matches the checked-out source/harness. On a **failed or slow** release build the script logged `Falling back to :edge-profiling as-is (may be the previous commit's binary)` and tested it anyway.

## Why it matters

This produced a misleading `scaffolding-e2e` failure in run [26679287804](https://github.com/calimero-network/core/actions/runs/26679287804): the job checked out **#2514**'s source/workflow but ran the **#2517** `merod` binary (release.yml for #2514 finished at 09:14Z, after the test started at 09:07Z and timed out waiting). A real-but-already-known sync divergence on the #2517 binary therefore looked like a fresh "#2514 fuzzy bug." Silently testing a mismatched binary can equally **mask** genuine regressions.

## Fix

In the master-push profiling path:
- on a **non-success** release conclusion → `::error::` + `exit 1` (no fallback to the stale tag);
- on **timeout** → same;
- only the **success** path resolves `TAG=edge-profiling`;
- bump the profiling wait **1800s → 3600s** (observed `release.yml` builds take ~44 min; the 30-min window raced them, causing false timeouts).

Net: a profiling fuzzy job either runs the *matching* binary or fails loudly with an actionable message — it never silently tests the previous commit's binary. The non-profiling and `pull_request` paths are unchanged; the one remaining "Falling back" line is the legitimate local-invocation (no `GITHUB_SHA`) path.

## Verification

`bash -n` clean; post-edit checks: exactly 1 `Falling back` remains (local-invocation), 2 `exit 1`, `MAX_WAIT=3600` present, 3 `::error::` markers. (The CI path itself can't be exercised locally.)

## Follow-up (separate PR)

The underlying sync split-brain this run *surfaced* (a residual empty-ancestors fallback in the #2508 tree-position fix, `apply_leaf_with_crdt_merge`) is real and tracked separately — this PR only stops CI from testing the wrong binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to image-tag resolution for master profiling fuzzy runs; no runtime product code paths affected.
> 
> **Overview**
> On **master** pushes that trigger `release.yml`, the profiling path in `determine-image-tag.sh` no longer falls back to `:edge-profiling` when the release workflow **fails** or **times out**—those cases now emit GitHub **`::error::`** annotations and **`exit 1`**, so fuzzy jobs only run when `release.yml` has successfully repointed the tag to the merge commit’s image.
> 
> The profiling wait budget is increased from **30 to 60 minutes** so long `release.yml` builds (~44 min observed) are less likely to hit a false timeout. Comments are updated to state that only the success path sets `TAG=edge-profiling`; **pull_request** and non-profiling master behavior are unchanged, and local runs without `GITHUB_SHA` still use the existing fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983db4c0e4fc1cd7d3dd4fd2164761449c0e8c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->