### PR TITLE
fix(network): surface rendezvous NoExternalAddresses as Pending state

### DIFF
--- a/crates/network/primitives/src/network_status.rs
+++ b/crates/network/primitives/src/network_status.rs
@@ -59,6 +59,7 @@ pub struct RendezvousEntry {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RendezvousRegistrationKind {
     Discovered,
+    Pending,
     Requested,
     Registered,
     Expired,

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -14,7 +14,7 @@ use libp2p::rendezvous::Namespace;
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use libp2p::PeerId;
 use multiaddr::{Multiaddr, Protocol};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use super::NetworkManager;
 use crate::discovery::peer_cache::{PeerAddrCache, PersistedPeer};
@@ -437,8 +437,10 @@ impl NetworkManager {
     // co-members find us under the exact namespace/group/context key, so
     // steady-state discovery is relevant rather than network-wide.
     //
-    // If there are no external addresses for the node, registration is
-    // considered successful. Expects the rendezvous peer to be connected.
+    // If there are no external addresses for the node yet, the rendezvous
+    // peer is marked `Pending` (queued, not registered) and the call returns
+    // Ok; the next `ExternalAddrConfirmed` re-attempts. Expects the rendezvous
+    // peer to be connected.
     pub(crate) fn rendezvous_register(&mut self, rendezvous_peer: &PeerId) -> EyreResult<()> {
         // `registrations_limit` gates how many rendezvous *peers* we
         // register with (infra fan-out), independent of how many keys we
@@ -469,9 +471,16 @@ impl NetworkManager {
                 }
                 Err(RegisterError::NoExternalAddresses) => {
                     // No external addresses yet — nothing to register
-                    // anywhere this round; stop early, the next
-                    // reachability/identify event retries.
-                    debug!("No external addresses to register at rendezvous");
+                    // anywhere this round; stop early. Mark the peer Pending
+                    // so the discovery state reflects "tried, waiting on an
+                    // external address" rather than the misleading Requested.
+                    // The next ExternalAddrConfirmed fires
+                    // broadcast_rendezvous_registrations, which re-attempts.
+                    trace!(%rendezvous_peer, "No external addresses to register at rendezvous; marking Pending");
+                    self.discovery.state.update_rendezvous_registration_status(
+                        rendezvous_peer,
+                        RendezvousRegistrationStatus::Pending,
+                    );
                     return Ok(());
                 }
                 Err(err @ RegisterError::FailedToMakeRecord(_)) => bail!(err),
@@ -533,8 +542,10 @@ impl NetworkManager {
                     RendezvousRegistrationStatus::Expired,
                 );
             }
-            RendezvousRegistrationStatus::Discovered | RendezvousRegistrationStatus::Expired => {
-                // Nothing to unregister
+            RendezvousRegistrationStatus::Discovered
+            | RendezvousRegistrationStatus::Pending
+            | RendezvousRegistrationStatus::Expired => {
+                // Nothing to unregister (Pending never actually sent a record)
             }
         }
 
@@ -558,7 +569,8 @@ impl NetworkManager {
                         RendezvousRegistrationStatus::Expired if candidate.is_none() => {
                             candidate = Some(peer_id);
                         }
-                        RendezvousRegistrationStatus::Requested
+                        RendezvousRegistrationStatus::Pending
+                        | RendezvousRegistrationStatus::Requested
                         | RendezvousRegistrationStatus::Registered
                         | RendezvousRegistrationStatus::Expired => {}
                     }

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -470,12 +470,27 @@ impl NetworkManager {
                     );
                 }
                 Err(RegisterError::NoExternalAddresses) => {
-                    // No external addresses yet — nothing to register
-                    // anywhere this round; stop early. Mark the peer Pending
-                    // so the discovery state reflects "tried, waiting on an
-                    // external address" rather than the misleading Requested.
-                    // The next ExternalAddrConfirmed fires
-                    // broadcast_rendezvous_registrations, which re-attempts.
+                    // `NoExternalAddresses` is a swarm-level condition: the
+                    // swarm has no confirmed external address to advertise,
+                    // which is independent of the rendezvous namespace. So
+                    // every remaining key in this loop would fail
+                    // identically — breaking early is safe, and it
+                    // necessarily fires on the *first* key, so
+                    // `registered_any` is always false here (no key went out
+                    // this round). Marking the peer Pending reflects "tried,
+                    // waiting on an external address" rather than the
+                    // misleading Requested; the next ExternalAddrConfirmed
+                    // fires broadcast_rendezvous_registrations, which
+                    // re-attempts.
+                    //
+                    // This may transition a previously Registered/Requested
+                    // peer to Pending (e.g. its external address expired and
+                    // a re-attempt now finds none). That is correct, not a
+                    // regression: with no external address there is nothing
+                    // backing any registration, and because the condition is
+                    // swarm-wide no other peer can hold a slot either, so the
+                    // freed slot cannot cause over-fan-out — all re-attempts
+                    // are Pending until an address returns.
                     trace!(%rendezvous_peer, "No external addresses to register at rendezvous; marking Pending");
                     self.discovery.state.update_rendezvous_registration_status(
                         rendezvous_peer,

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -477,25 +477,29 @@ impl NetworkManager {
                     // identically — breaking early is safe, and it
                     // necessarily fires on the *first* key, so
                     // `registered_any` is always false here (no key went out
-                    // this round). Marking the peer Pending reflects "tried,
-                    // waiting on an external address" rather than the
-                    // misleading Requested; the next ExternalAddrConfirmed
-                    // fires broadcast_rendezvous_registrations, which
-                    // re-attempts.
+                    // this round).
                     //
-                    // This may transition a previously Registered/Requested
-                    // peer to Pending (e.g. its external address expired and
-                    // a re-attempt now finds none). That is correct, not a
-                    // regression: with no external address there is nothing
-                    // backing any registration, and because the condition is
-                    // swarm-wide no other peer can hold a slot either, so the
-                    // freed slot cannot cause over-fan-out — all re-attempts
-                    // are Pending until an address returns.
-                    trace!(%rendezvous_peer, "No external addresses to register at rendezvous; marking Pending");
-                    self.discovery.state.update_rendezvous_registration_status(
-                        rendezvous_peer,
-                        RendezvousRegistrationStatus::Pending,
-                    );
+                    // Mark the peer Pending ("tried, waiting on an external
+                    // address") rather than the misleading Requested; the
+                    // next ExternalAddrConfirmed fires
+                    // broadcast_rendezvous_registrations, which re-attempts.
+                    // But only if the peer is idle: `mark_..._if_idle` leaves
+                    // an already Requested/Registered peer untouched. A
+                    // re-broadcast can land here while a register is in
+                    // flight (status Requested); clobbering it to Pending
+                    // would make the Registered handler drop the incoming
+                    // confirmation (it requires status == Requested) and
+                    // would free a live slot, risking over-fan-out. Such
+                    // peers transition out via their own Expired event.
+                    if self
+                        .discovery
+                        .state
+                        .mark_rendezvous_pending_if_idle(rendezvous_peer)
+                    {
+                        trace!(%rendezvous_peer, "No external addresses to register at rendezvous; marked Pending");
+                    } else {
+                        trace!(%rendezvous_peer, "No external addresses to register at rendezvous; keeping in-flight registration status");
+                    }
                     return Ok(());
                 }
                 Err(err @ RegisterError::FailedToMakeRecord(_)) => bail!(err),

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -552,35 +552,6 @@ impl NetworkManager {
         Ok(())
     }
 
-    // Finds a new rendezvous peer for registration.
-    // Prioritizes Discovered peers, falls back to dialing Expired peers if necessary.
-    // Returns Some(PeerId) if a suitable peer is found, None otherwise.
-    pub(crate) fn find_new_rendezvous_peer(&self) -> Option<PeerId> {
-        let mut candidate = None;
-
-        for peer_id in self.discovery.state.get_rendezvous_peer_ids() {
-            if let Some(peer_info) = self.discovery.state.get_peer_info(&peer_id) {
-                if let Some(rendezvous_info) = peer_info.rendezvous() {
-                    match rendezvous_info.registration_status() {
-                        RendezvousRegistrationStatus::Discovered => {
-                            // If we find a Discovered peer, return it right away
-                            return Some(peer_id);
-                        }
-                        RendezvousRegistrationStatus::Expired if candidate.is_none() => {
-                            candidate = Some(peer_id);
-                        }
-                        RendezvousRegistrationStatus::Pending
-                        | RendezvousRegistrationStatus::Requested
-                        | RendezvousRegistrationStatus::Registered
-                        | RendezvousRegistrationStatus::Expired => {}
-                    }
-                }
-            }
-        }
-
-        candidate
-    }
-
     // Requests relay reservation on relay peer if one is required.
     // This function expectes that the relay peer is already connected.
     pub(crate) fn create_relay_reservation(&mut self, relay_peer: &PeerId) -> EyreResult<()> {

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -529,7 +529,7 @@ impl DiscoveryState {
         let _ = self
             .peers
             .entry(*rendezvous_peer)
-            .and_modify(|info| info.update_rendezvous_registartion_status(status));
+            .and_modify(|info| info.update_rendezvous_registration_status(status));
     }
 
     pub(crate) fn get_peer_info(&self, peer_id: &PeerId) -> Option<&PeerInfo> {
@@ -808,7 +808,7 @@ impl PeerInfo {
         }
     }
 
-    fn update_rendezvous_registartion_status(&mut self, status: RendezvousRegistrationStatus) {
+    fn update_rendezvous_registration_status(&mut self, status: RendezvousRegistrationStatus) {
         if let Some(ref mut info) = self.rendezvous {
             info.update_registration_status(status);
         }

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -644,7 +644,11 @@ impl DiscoveryState {
                     match rendezvous_info.registration_status() {
                         RendezvousRegistrationStatus::Requested
                         | RendezvousRegistrationStatus::Registered => acc + 1,
+                        // `Pending` is not a real registration — it doesn't
+                        // occupy a slot, so the fan-out gate keeps re-attempting
+                        // until the registration actually lands.
                         RendezvousRegistrationStatus::Discovered
+                        | RendezvousRegistrationStatus::Pending
                         | RendezvousRegistrationStatus::Expired => acc,
                     }
                 })
@@ -839,6 +843,12 @@ impl Default for PeerRendezvousInfo {
 pub enum RendezvousRegistrationStatus {
     #[default]
     Discovered,
+    /// We attempted to register but the swarm had no external address to
+    /// advertise yet, so nothing was actually sent. The registration is
+    /// queued and re-attempted on the next `ExternalAddrConfirmed`. Distinct
+    /// from `Discovered` (never tried) so observability reflects the truth:
+    /// engaged, waiting on an external address.
+    Pending,
     Requested,
     Registered,
     Expired,

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -532,6 +532,41 @@ impl DiscoveryState {
             .and_modify(|info| info.update_rendezvous_registration_status(status));
     }
 
+    /// Mark a rendezvous peer `Pending` (tried, blocked on a missing
+    /// external address) — but only when it isn't currently holding or
+    /// awaiting a registration. Returns `true` if the status changed.
+    ///
+    /// A `Requested` peer has an in-flight register whose `Registered`
+    /// confirmation is dropped if the status is no longer `Requested` when
+    /// it lands, so clobbering it to `Pending` would strand the
+    /// registration. A `Registered` peer still has a live server-side
+    /// record; flipping it to `Pending` would also free its fan-out slot
+    /// (`Pending` doesn't count), letting the node over-register. Both keep
+    /// their slot-holding status and transition out via their own
+    /// `Expired` event instead. Only idle peers (`Discovered`, `Expired`,
+    /// or already `Pending`) are moved to `Pending`.
+    pub(crate) fn mark_rendezvous_pending_if_idle(&mut self, rendezvous_peer: &PeerId) -> bool {
+        let current = self
+            .get_peer_info(rendezvous_peer)
+            .and_then(|info| info.rendezvous())
+            .map(|info| info.registration_status());
+
+        if matches!(
+            current,
+            Some(
+                RendezvousRegistrationStatus::Requested | RendezvousRegistrationStatus::Registered
+            )
+        ) {
+            return false;
+        }
+
+        self.update_rendezvous_registration_status(
+            rendezvous_peer,
+            RendezvousRegistrationStatus::Pending,
+        );
+        true
+    }
+
     pub(crate) fn get_peer_info(&self, peer_id: &PeerId) -> Option<&PeerInfo> {
         self.peers.get(peer_id)
     }

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -656,6 +656,48 @@ impl DiscoveryState {
         sum < max
     }
 
+    /// Nominate a rendezvous peer to (re)register with.
+    ///
+    /// Prioritizes peers that want to register but hold no fan-out slot:
+    /// `Discovered` (never tried) and `Pending` (tried, waiting on an
+    /// external address) are returned eagerly, with an `Expired` peer as
+    /// the fallback. Returns `None` when every known rendezvous peer is
+    /// already `Requested`/`Registered`.
+    ///
+    /// `Pending` must be nominated here, not skipped: when a slot frees
+    /// (e.g. another peer's registration `Expired`), this is the path that
+    /// re-drives a peer blocked on a missing external address. Skipping it
+    /// would strand that peer until the next `ExternalAddrConfirmed` —
+    /// which is exactly the slot it occupied as `Discovered` before the
+    /// `Pending` state existed.
+    pub(crate) fn find_new_rendezvous_peer(&self) -> Option<PeerId> {
+        let mut candidate = None;
+
+        for peer_id in self.get_rendezvous_peer_ids() {
+            let Some(peer_info) = self.get_peer_info(&peer_id) else {
+                continue;
+            };
+            let Some(rendezvous_info) = peer_info.rendezvous() else {
+                continue;
+            };
+            match rendezvous_info.registration_status() {
+                RendezvousRegistrationStatus::Discovered
+                | RendezvousRegistrationStatus::Pending => {
+                    // Registerable target holding no slot — take it now.
+                    return Some(peer_id);
+                }
+                RendezvousRegistrationStatus::Expired if candidate.is_none() => {
+                    candidate = Some(peer_id);
+                }
+                RendezvousRegistrationStatus::Requested
+                | RendezvousRegistrationStatus::Registered
+                | RendezvousRegistrationStatus::Expired => {}
+            }
+        }
+
+        candidate
+    }
+
     #[expect(
         clippy::arithmetic_side_effects,
         reason = "Cannot use saturating_add() due to non-specific integer type"

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -658,18 +658,29 @@ impl DiscoveryState {
 
     /// Nominate a rendezvous peer to (re)register with.
     ///
-    /// Prioritizes peers that want to register but hold no fan-out slot:
-    /// `Discovered` (never tried) and `Pending` (tried, waiting on an
-    /// external address) are returned eagerly, with an `Expired` peer as
-    /// the fallback. Returns `None` when every known rendezvous peer is
-    /// already `Requested`/`Registered`.
+    /// Two priority tiers:
+    /// - **Eager (first match wins, returned immediately):** `Discovered`
+    ///   (never tried) and `Pending` (tried, waiting on an external
+    ///   address). These are *equal* priority — whichever the (PeerId-
+    ///   sorted) iteration reaches first is taken. There is deliberately
+    ///   no preference between them: `Pending` is not a failed peer, just
+    ///   one blocked on a transient missing-external-address condition, so
+    ///   there's no reason to deprioritize re-attempting it over a fresh
+    ///   `Discovered` peer.
+    /// - **Fallback:** an `Expired` peer, used only if no eager peer
+    ///   exists.
+    ///
+    /// Returns `None` when every known rendezvous peer is already
+    /// `Requested`/`Registered`.
     ///
     /// `Pending` must be nominated here, not skipped: when a slot frees
     /// (e.g. another peer's registration `Expired`), this is the path that
     /// re-drives a peer blocked on a missing external address. Skipping it
     /// would strand that peer until the next `ExternalAddrConfirmed` —
     /// which is exactly the slot it occupied as `Discovered` before the
-    /// `Pending` state existed.
+    /// `Pending` state existed. An eager peer wins over an already-found
+    /// `Expired` candidate via early return, independent of iteration
+    /// order.
     pub(crate) fn find_new_rendezvous_peer(&self) -> Option<PeerId> {
         let mut candidate = None;
 

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -206,6 +206,41 @@ fn test_discovery_state_rendezvous_registration_required() {
 }
 
 #[test]
+fn test_pending_rendezvous_registration_does_not_occupy_slot() {
+    let mut state = DiscoveryState::default();
+
+    let peer1 = PeerId::random();
+    let peer2 = PeerId::random();
+
+    state.update_peer_protocols(&peer1, &[RENDEZVOUS_PROTOCOL_NAME]);
+    state.update_peer_protocols(&peer2, &[RENDEZVOUS_PROTOCOL_NAME]);
+
+    // A peer that tried to register but had no external address yet is marked
+    // Pending. Like Discovered/Expired, Pending is NOT a real registration, so
+    // it must not satisfy the fan-out gate — otherwise the node would believe
+    // it is registered and never re-attempt once an external address arrives.
+    state.update_rendezvous_registration_status(&peer1, RendezvousRegistrationStatus::Pending);
+    assert!(
+        state.is_rendezvous_registration_required(1),
+        "Pending must not occupy a registration slot (registration still required)"
+    );
+
+    // Once the registration actually goes out (Requested), the slot is taken.
+    state.update_rendezvous_registration_status(&peer1, RendezvousRegistrationStatus::Requested);
+    assert!(
+        !state.is_rendezvous_registration_required(1),
+        "Requested occupies the slot (no further registration required at limit 1)"
+    );
+
+    // Sanity: a second Pending peer still doesn't count toward the limit.
+    state.update_rendezvous_registration_status(&peer2, RendezvousRegistrationStatus::Pending);
+    assert!(
+        !state.is_rendezvous_registration_required(1),
+        "Pending peer2 adds no slot; the single Requested peer already meets limit 1"
+    );
+}
+
+#[test]
 fn test_state_mutations() {
     let mut state = DiscoveryState::default();
     let peer_id = PeerId::random();

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -265,6 +265,55 @@ fn test_pending_to_expired_transition_keeps_slot_free() {
     );
 }
 
+fn rendezvous_status(state: &DiscoveryState, peer: &PeerId) -> RendezvousRegistrationStatus {
+    state.peers[peer]
+        .rendezvous
+        .as_ref()
+        .unwrap()
+        .registration_status()
+}
+
+#[test]
+fn test_mark_rendezvous_pending_if_idle_guards_slot_holders() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    state.update_peer_protocols(&peer, &[RENDEZVOUS_PROTOCOL_NAME]);
+
+    // Idle statuses (Discovered / Expired / already Pending) move to Pending.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Discovered);
+    assert!(state.mark_rendezvous_pending_if_idle(&peer));
+    assert_eq!(
+        rendezvous_status(&state, &peer),
+        RendezvousRegistrationStatus::Pending
+    );
+
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Expired);
+    assert!(state.mark_rendezvous_pending_if_idle(&peer));
+    assert_eq!(
+        rendezvous_status(&state, &peer),
+        RendezvousRegistrationStatus::Pending
+    );
+
+    // Requested must NOT be clobbered: a register is in flight, and the
+    // Registered event handler drops the confirmation unless status is
+    // still Requested. The call is a no-op and reports no change.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Requested);
+    assert!(!state.mark_rendezvous_pending_if_idle(&peer));
+    assert_eq!(
+        rendezvous_status(&state, &peer),
+        RendezvousRegistrationStatus::Requested
+    );
+
+    // Registered must NOT be clobbered: it holds a live server record and a
+    // fan-out slot that must keep counting.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Registered);
+    assert!(!state.mark_rendezvous_pending_if_idle(&peer));
+    assert_eq!(
+        rendezvous_status(&state, &peer),
+        RendezvousRegistrationStatus::Registered
+    );
+}
+
 #[test]
 fn test_find_new_rendezvous_peer_nominates_pending() {
     let mut state = DiscoveryState::default();
@@ -309,6 +358,14 @@ fn test_find_new_rendezvous_peer_prefers_pending_over_expired() {
     ids.sort();
     let expired_peer = ids[0];
     let pending_peer = ids[1];
+    // Pin the ordering assumption loudly: if get_rendezvous_peer_ids ever
+    // stops iterating in ascending PeerId order, this fails here rather
+    // than silently no longer exercising the early-return-over-candidate
+    // path.
+    assert!(
+        expired_peer < pending_peer,
+        "expired_peer must sort before pending_peer for this test to mean anything"
+    );
     state.update_peer_protocols(&expired_peer, &[RENDEZVOUS_PROTOCOL_NAME]);
     state.update_peer_protocols(&pending_peer, &[RENDEZVOUS_PROTOCOL_NAME]);
 

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -274,14 +274,21 @@ fn test_find_new_rendezvous_peer_nominates_pending() {
 fn test_find_new_rendezvous_peer_prefers_pending_over_expired() {
     let mut state = DiscoveryState::default();
 
-    let expired_peer = PeerId::random();
-    let pending_peer = PeerId::random();
+    // `get_rendezvous_peer_ids` iterates the BTreeSet in PeerId order, so
+    // assign roles deterministically: the Expired peer sorts *first* and
+    // is therefore encountered (and recorded as the fallback candidate)
+    // before the Pending peer. This proves the eager Pending peer wins via
+    // early return even when an Expired candidate was already found — the
+    // preference is not an artifact of iteration order.
+    let mut ids = [PeerId::random(), PeerId::random()];
+    ids.sort();
+    let expired_peer = ids[0];
+    let pending_peer = ids[1];
     state.update_peer_protocols(&expired_peer, &[RENDEZVOUS_PROTOCOL_NAME]);
     state.update_peer_protocols(&pending_peer, &[RENDEZVOUS_PROTOCOL_NAME]);
 
     // Expired = was registered, lapsed (fallback). Pending = registerable
-    // target holding no slot (eager). The eager target wins regardless of
-    // iteration order.
+    // target holding no slot (eager).
     state.update_rendezvous_registration_status(
         &expired_peer,
         RendezvousRegistrationStatus::Expired,
@@ -293,7 +300,7 @@ fn test_find_new_rendezvous_peer_prefers_pending_over_expired() {
     assert_eq!(
         state.find_new_rendezvous_peer(),
         Some(pending_peer),
-        "Pending (eager) is preferred over Expired (fallback)"
+        "Pending (eager) wins over an already-found Expired (fallback) candidate"
     );
 
     // With only an Expired peer left, it is the fallback nomination.

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -241,6 +241,74 @@ fn test_pending_rendezvous_registration_does_not_occupy_slot() {
 }
 
 #[test]
+fn test_find_new_rendezvous_peer_nominates_pending() {
+    let mut state = DiscoveryState::default();
+
+    let peer = PeerId::random();
+    state.update_peer_protocols(&peer, &[RENDEZVOUS_PROTOCOL_NAME]);
+
+    // A lone Pending peer (tried, blocked on a missing external address)
+    // must still be nominatable. The Expired-event handler relies on this
+    // to re-drive registration once a slot frees; skipping Pending would
+    // strand the peer until the next ExternalAddrConfirmed.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Pending);
+    assert_eq!(
+        state.find_new_rendezvous_peer(),
+        Some(peer),
+        "a Pending peer must be nominated, like Discovered"
+    );
+
+    // Once registration is in flight (Requested) or live (Registered) the
+    // peer occupies a slot and is no longer a nomination target.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Requested);
+    assert_eq!(
+        state.find_new_rendezvous_peer(),
+        None,
+        "a Requested peer is not a nomination target"
+    );
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Registered);
+    assert_eq!(state.find_new_rendezvous_peer(), None);
+}
+
+#[test]
+fn test_find_new_rendezvous_peer_prefers_pending_over_expired() {
+    let mut state = DiscoveryState::default();
+
+    let expired_peer = PeerId::random();
+    let pending_peer = PeerId::random();
+    state.update_peer_protocols(&expired_peer, &[RENDEZVOUS_PROTOCOL_NAME]);
+    state.update_peer_protocols(&pending_peer, &[RENDEZVOUS_PROTOCOL_NAME]);
+
+    // Expired = was registered, lapsed (fallback). Pending = registerable
+    // target holding no slot (eager). The eager target wins regardless of
+    // iteration order.
+    state.update_rendezvous_registration_status(
+        &expired_peer,
+        RendezvousRegistrationStatus::Expired,
+    );
+    state.update_rendezvous_registration_status(
+        &pending_peer,
+        RendezvousRegistrationStatus::Pending,
+    );
+    assert_eq!(
+        state.find_new_rendezvous_peer(),
+        Some(pending_peer),
+        "Pending (eager) is preferred over Expired (fallback)"
+    );
+
+    // With only an Expired peer left, it is the fallback nomination.
+    state.update_rendezvous_registration_status(
+        &pending_peer,
+        RendezvousRegistrationStatus::Registered,
+    );
+    assert_eq!(
+        state.find_new_rendezvous_peer(),
+        Some(expired_peer),
+        "Expired peer is nominated when no eager target exists"
+    );
+}
+
+#[test]
 fn test_state_mutations() {
     let mut state = DiscoveryState::default();
     let peer_id = PeerId::random();

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -241,6 +241,31 @@ fn test_pending_rendezvous_registration_does_not_occupy_slot() {
 }
 
 #[test]
+fn test_pending_to_expired_transition_keeps_slot_free() {
+    let mut state = DiscoveryState::default();
+
+    let peer = PeerId::random();
+    state.update_peer_protocols(&peer, &[RENDEZVOUS_PROTOCOL_NAME]);
+
+    // Pending holds no slot, so registration is still required.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Pending);
+    assert!(
+        state.is_rendezvous_registration_required(1),
+        "Pending occupies no slot"
+    );
+
+    // Transitioning Pending -> Expired (e.g. an unregister/expiry path
+    // touching a never-registered peer) must not invent a slot: neither
+    // status counts, so registration stays required and the count is
+    // unchanged.
+    state.update_rendezvous_registration_status(&peer, RendezvousRegistrationStatus::Expired);
+    assert!(
+        state.is_rendezvous_registration_required(1),
+        "Expired (like Pending) occupies no slot"
+    );
+}
+
+#[test]
 fn test_find_new_rendezvous_peer_nominates_pending() {
     let mut state = DiscoveryState::default();
 

--- a/crates/network/src/handlers/commands/network_status.rs
+++ b/crates/network/src/handlers/commands/network_status.rs
@@ -121,6 +121,7 @@ fn map_relay_status(status: RelayReservationStatus) -> RelayReservationKind {
 fn map_rendezvous_status(status: RendezvousRegistrationStatus) -> RendezvousRegistrationKind {
     match status {
         RendezvousRegistrationStatus::Discovered => RendezvousRegistrationKind::Discovered,
+        RendezvousRegistrationStatus::Pending => RendezvousRegistrationKind::Pending,
         RendezvousRegistrationStatus::Requested => RendezvousRegistrationKind::Requested,
         RendezvousRegistrationStatus::Registered => RendezvousRegistrationKind::Registered,
         RendezvousRegistrationStatus::Expired => RendezvousRegistrationKind::Expired,

--- a/crates/network/src/handlers/stream/swarm/rendezvous.rs
+++ b/crates/network/src/handlers/stream/swarm/rendezvous.rs
@@ -137,7 +137,7 @@ impl EventHandler<Event> for NetworkManager {
                     RendezvousRegistrationStatus::Expired,
                 );
 
-                if let Some(nominated_peer) = self.find_new_rendezvous_peer() {
+                if let Some(nominated_peer) = self.discovery.state.find_new_rendezvous_peer() {
                     if self.swarm.is_connected(&nominated_peer) {
                         if let Err(err) = self.rendezvous_register(&nominated_peer) {
                             error!(%err, "Failed to register with nominated rendezvous peer");

--- a/crates/server/src/admin/handlers/network/status.rs
+++ b/crates/server/src/admin/handlers/network/status.rs
@@ -148,6 +148,7 @@ const fn relay_status_str(kind: RelayReservationKind) -> &'static str {
 const fn rendezvous_status_str(kind: RendezvousRegistrationKind) -> &'static str {
     match kind {
         RendezvousRegistrationKind::Discovered => "discovered",
+        RendezvousRegistrationKind::Pending => "pending",
         RendezvousRegistrationKind::Requested => "requested",
         RendezvousRegistrationKind::Registered => "registered",
         RendezvousRegistrationKind::Expired => "expired",


### PR DESCRIPTION
Closes #2490.

## Problem

`rendezvous_register` swallowed `RegisterError::NoExternalAddresses` as a successful no-op: it logged at `debug`, left the rendezvous peer at `Discovered`, and returned `Ok`. The discovery state machine then reported "untried" when the node had actually attempted to register and was blocked waiting on an external address (e.g. a `/p2p-circuit/` relay address that hasn't landed yet). With `meroctl network status` (#2488) now surfacing this state to operators, that's a persistent lie — indistinguishable from "never got around to it".

## Fix

Introduce a `RendezvousRegistrationStatus::Pending` variant — *"tried, no external address yet, will retry on the next `ExternalAddrConfirmed`"*:

- `rendezvous_register` now marks the peer `Pending` (instead of silently leaving it `Discovered`) and demotes the log to `trace`.
- `Pending` does **not** occupy a registration slot in `is_rendezvous_registration_required`, so the fan-out gate keeps re-attempting until a real registration lands. The existing `ExternalAddrConfirmed`/`ExternalAddrExpired` → `broadcast_rendezvous_registrations` path handles the retry — no new wiring.
- `Pending` is a no-op in `rendezvous_unregister` (nothing was ever sent) and `find_new_rendezvous_peer` (already engaged with this peer).
- The response handler's `!= Requested` guard already correctly ignores any stray response for a `Pending` peer — no change needed there.
- Threaded `Pending` through the network-status command, `network-primitives`, and the admin handler (renders as `"pending"`).

## Behavior

End-to-end behavior is unchanged — the retry path was already correct. This only fixes what the state machine *reports*, so observability tells the truth instead of showing a misleading `discovered`. As the issue notes, this is hygiene best done alongside #2488, which has since landed.

## Tests

- New `test_pending_rendezvous_registration_does_not_occupy_slot` pins that `Pending` keeps the gate open while `Requested` closes it.
- `cargo test -p calimero-network --lib` → 63 passed.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and state-machine accuracy around rendezvous registration; retry behavior stays on existing `ExternalAddrConfirmed` paths, with targeted unit tests.
> 
> **Overview**
> Adds **`Pending`** rendezvous registration status for peers where register was attempted but the swarm had **no external address** yet (`NoExternalAddresses`), instead of leaving them at **`discovered`** (misleading for operators and `meroctl network status`).
> 
> On that error, **`rendezvous_register`** calls **`mark_rendezvous_pending_if_idle`** so in-flight **`requested`** / live **`registered`** peers are not overwritten (avoids dropped confirmations and slot over-counting). **`Pending`** does not consume a fan-out slot; **`find_new_rendezvous_peer`** treats **`Pending`** like **`discovered`** for re-nomination when slots free. **`rendezvous_unregister`** treats **`Pending`** as a no-op. Status is exposed end-to-end as **`pending`** (primitives, network-status snapshot, admin API). Fixes the **`update_rendezvous_registration_status`** typo and moves peer nomination logic into **`DiscoveryState`**, with new unit tests for slot counting and nomination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f14a4d8d70d9375eb3c92f6b1c9b108734d177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->