### PR TITLE
test(app-migration): e2e for get_cascade_status + assert_cascade_complete

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -139,6 +139,7 @@ jobs:
           - 11-scenario-field-split
           - 12-scenario-field-remove-archive
           - 13-scenario-invariant-reshuffle
+          - 14-cascade-status-rpc
     env:
       WORKFLOW: ${{ matrix.workflow }}
     steps:

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -219,16 +219,21 @@ steps:
 
   - name: Assert cascade-status roll-up on BOTH nodes
     type: json_assert
+    # The status counts export as integers; merobox substitutes a `"{{var}}"`
+    # holding a non-string as the BARE value (the wrapping quotes are
+    # stripped), so `"{{status_total_node1}}"` becomes `2`, not `"2"`. Compare
+    # against bare integer literals — `equal(2, "2")` fails (int != string),
+    # `equal(2, 2)` passes.
     statements:
       # nothing left pending on either node
-      - 'equal("{{status_pending_node1}}", "0")'
-      - 'equal("{{status_pending_node2}}", "0")'
+      - 'equal("{{status_pending_node1}}", 0)'
+      - 'equal("{{status_pending_node2}}", 0)'
       # every reported group completed (completed == total)
       - 'equal("{{status_completed_node1}}", "{{status_total_node1}}")'
       - 'equal("{{status_completed_node2}}", "{{status_total_node2}}")'
       # the subtree is namespace root + 1 descendant subgroup = 2 groups
-      - 'equal("{{status_total_node1}}", "2")'
-      - 'equal("{{status_total_node2}}", "2")'
+      - 'equal("{{status_total_node1}}", 2)'
+      - 'equal("{{status_total_node2}}", 2)'
 
   # Phase 7: Teardown (node 1 holds admin authority).
   - name: Delete context

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -31,10 +31,10 @@ nodes:
   count: 2
   image: merod:local
   prefix: app-migration-status
-  # Continues the per-scenario base-port sequence (13 = 9350/9450) so this
-  # scenario's host ports don't collide with any sibling's.
-  base_port: 9360
-  base_rpc_port: 9460
+  # Above every sibling's range (00-13 occupy 9220-9351 P2P / 9320-9451 RPC)
+  # so this scenario's host ports can't collide with any of them.
+  base_port: 9460
+  base_rpc_port: 9560
 
 steps:
   # Phase 1: Install v1 + v2 binaries on the ADMIN node only (node 2

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -221,12 +221,6 @@ steps:
 
   - name: Assert cascade-status roll-up on BOTH nodes
     type: json_assert
-    # json_assert runs json.loads on each arg. Quoting the placeholder
-    # (`"{{x}}"`) makes the resolved value the JSON string "2", which never
-    # equals the integer count. Leave the placeholder UNQUOTED so the resolved
-    # value parses as the JSON integer 2 — matching the bare integer literals
-    # below (and robust to whether substitution is string-replace or
-    # type-aware).
     statements:
       # nothing left pending on either node
       - "equal({{status_pending_node1}}, 0)"

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -1,0 +1,262 @@
+name: 14 — Cascade status RPC (get_cascade_status + assert_cascade_complete, 2-node)
+description: >
+  E2E coverage for the get_cascade_status RPC and the cascade-completion
+  assertion shipped in #2524 / merobox#255. Reuses 01's proven 2-node
+  namespace-cascade setup (namespace + one Open descendant subgroup +
+  one context, node 2 joins via inheritance), runs ONE
+  upgrade_group(cascade=true), then drives the new merobox steps:
+
+    - assert_cascade_complete polls get_cascade_status on EACH node until
+      every group in the namespace subtree reports `completed`.
+    - get_cascade_status returns one entry per group (namespace root +
+      descendant subgroup); this asserts the roll-up on both the emitter
+      (node 1) and the receiver (node 2): pending == 0 and
+      completed == total, proving the atomic CascadeUpgrade op wrote a
+      Completed upgrade record on every matched descendant on BOTH peers.
+
+  Whereas 01 verifies the state-migration side of the cascade, this
+  scenario is the dedicated regression guard for the get_cascade_status
+  RPC surface (actor → ContextMessage → context client → admin HTTP
+  GET /groups/:namespace_id/cascade-status) and the cascade_hlc the atomic
+  op stamps per descendant.
+
+  Requires merobox >= 0.6.32 (get_cascade_status / assert_cascade_complete
+  steps; calimero-network/merobox#272).
+
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 2
+  image: merod:local
+  prefix: app-migration-status
+  base_port: 9250
+  base_rpc_port: 9350
+
+steps:
+  # Phase 1: Install v1 + v2 binaries on the ADMIN node only (node 2
+  # obtains v1 on context join and v2 during lazy migration — same
+  # content-addressed distribution as 01).
+  - name: Install migration-suite-v1 on node 1
+    type: install_application
+    node: app-migration-status-1
+    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    dev: true
+    outputs:
+      app_v1: applicationId
+
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-status-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  # Phase 2: Node 1 builds namespace + Open subgroup + context.
+  - name: Create namespace on node 1 (anchors app_v1)
+    type: create_namespace
+    node: app-migration-status-1
+    application_id: "{{app_v1}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Capture admin key (for teardown)
+    type: get_namespace_identity
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      admin_key: publicKey
+
+  - name: Create descendant Open subgroup on node 1
+    type: create_group_in_namespace
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    group_name: "cascade-status-subgroup"
+    outputs:
+      group_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: app-migration-status-1
+    group_id: "{{group_id}}"
+    visibility: open
+
+  - name: Create context in subgroup on node 1 (v1)
+    type: create_context
+    node: app-migration-status-1
+    application_id: "{{app_v1}}"
+    group_id: "{{group_id}}"
+    outputs:
+      ctx_id: contextId
+
+  # Phase 3: Invite node 2, materialise inherited membership, join context.
+  - name: Create namespace invitation for node 2
+    type: create_namespace_invitation
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Wait for subgroup visibility + context-registered ops to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node 2 joins namespace
+    type: join_namespace
+    node: app-migration-status-2
+    namespace_id: "{{namespace_id}}"
+    invitation: "{{namespace_invitation}}"
+
+  - name: Node 2 materialises subgroup membership via inheritance
+    type: join_subgroup_inheritance
+    node: app-migration-status-2
+    group_id: "{{group_id}}"
+
+  - name: Node 2 joins the context
+    type: join_context
+    node: app-migration-status-2
+    context_id: "{{ctx_id}}"
+
+  # Phase 4: Write v1 state on node 1, wait for node 2 to catch up.
+  - name: Node 1 writes v1 state (description)
+    type: call
+    node: app-migration-status-1
+    context_id: "{{ctx_id}}"
+    method: set_description
+    args:
+      description: "set-before-cascade"
+
+  - name: Wait for v1 state to sync to node 2
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - app-migration-status-1
+      - app-migration-status-2
+    timeout: 90
+    trigger_sync: true
+
+  # Phase 5: lazy-on-access upgrade policy, then ONE cascade.
+  - name: Set upgrade policy to lazy-on-access on node 1
+    type: update_group_settings
+    node: app-migration-status-1
+    group_id: "{{namespace_id}}"
+    upgrade_policy: lazy_on_access
+
+  - name: Cascade namespace v1 → v2 (initiated by node 1)
+    type: upgrade_group
+    node: app-migration-status-1
+    group_id: "{{namespace_id}}"
+    target_application_id: "{{app_v2}}"
+    migrate_method: migrate_v1_to_v2
+    cascade: true
+
+  - name: Wait for cascade op to gossip + apply on both nodes
+    type: wait
+    seconds: 15
+
+  # Phase 6a: the cascade actually landed (sanity — makes the status
+  # assertions meaningful). Atomic CascadeUpgrade applies on the emitter
+  # AND every receiver subscribed to the namespace.
+  - name: Assert cascade apply log on node 1 (emitter)
+    type: assert_log_present
+    nodes:
+      - app-migration-status-1
+    patterns:
+      - "CascadeUpgrade: applied"
+    min_matches: 2
+
+  - name: Assert cascade apply log on node 2 (receiver)
+    type: assert_log_present
+    nodes:
+      - app-migration-status-2
+    patterns:
+      - "CascadeUpgrade: applied"
+    min_matches: 2
+
+  # Phase 6b: NEW — assert_cascade_complete polls get_cascade_status until
+  # every group in the subtree is `completed`, on EACH node independently.
+  # The atomic CascadeUpgrade op writes a Completed upgrade record per
+  # matched descendant on every peer that applies it, so both nodes
+  # converge to all_completed. Per-node assertions catch the asymmetric
+  # regression where the emitter completes but a receiver's records never
+  # populate.
+  - name: Assert cascade complete on node 1 (emitter)
+    type: assert_cascade_complete
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 60
+    poll_interval: 2
+
+  - name: Assert cascade complete on node 2 (receiver)
+    type: assert_cascade_complete
+    node: app-migration-status-2
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 2
+
+  # Phase 6c: NEW — read get_cascade_status directly and assert the
+  # roll-up on both nodes. total = namespace root + 1 descendant subgroup
+  # = 2 groups, all completed, none pending.
+  - name: Read cascade status on node 1
+    type: get_cascade_status
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      status_total_node1: total
+      status_completed_node1: completed
+      status_pending_node1: pending
+
+  - name: Read cascade status on node 2
+    type: get_cascade_status
+    node: app-migration-status-2
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      status_total_node2: total
+      status_completed_node2: completed
+      status_pending_node2: pending
+
+  - name: Assert cascade-status roll-up on BOTH nodes
+    type: json_assert
+    statements:
+      # nothing left pending on either node
+      - 'equal("{{status_pending_node1}}", "0")'
+      - 'equal("{{status_pending_node2}}", "0")'
+      # every reported group completed (completed == total)
+      - 'equal("{{status_completed_node1}}", "{{status_total_node1}}")'
+      - 'equal("{{status_completed_node2}}", "{{status_total_node2}}")'
+      # the subtree is namespace root + 1 descendant subgroup = 2 groups
+      - 'equal("{{status_total_node1}}", "2")'
+      - 'equal("{{status_total_node2}}", "2")'
+
+  # Phase 7: Teardown (node 1 holds admin authority).
+  - name: Delete context
+    type: delete_context
+    node: app-migration-status-1
+    context_id: "{{ctx_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete subgroup
+    type: delete_group
+    node: app-migration-status-1
+    group_id: "{{group_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete namespace
+    type: delete_namespace
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Uninstall v1 on node 1
+    type: uninstall_application
+    node: app-migration-status-1
+    application_id: "{{app_v1}}"
+
+  - name: Uninstall v2 on node 1
+    type: uninstall_application
+    node: app-migration-status-1
+    application_id: "{{app_v2}}"
+
+stop_all_nodes: false

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -221,21 +221,22 @@ steps:
 
   - name: Assert cascade-status roll-up on BOTH nodes
     type: json_assert
-    # The status counts export as integers; merobox substitutes a `"{{var}}"`
-    # holding a non-string as the BARE value (the wrapping quotes are
-    # stripped), so `"{{status_total_node1}}"` becomes `2`, not `"2"`. Compare
-    # against bare integer literals — `equal(2, "2")` fails (int != string),
-    # `equal(2, 2)` passes.
+    # json_assert runs json.loads on each arg. Quoting the placeholder
+    # (`"{{x}}"`) makes the resolved value the JSON string "2", which never
+    # equals the integer count. Leave the placeholder UNQUOTED so the resolved
+    # value parses as the JSON integer 2 — matching the bare integer literals
+    # below (and robust to whether substitution is string-replace or
+    # type-aware).
     statements:
       # nothing left pending on either node
-      - 'equal("{{status_pending_node1}}", 0)'
-      - 'equal("{{status_pending_node2}}", 0)'
+      - "equal({{status_pending_node1}}, 0)"
+      - "equal({{status_pending_node2}}, 0)"
       # every reported group completed (completed == total)
-      - 'equal("{{status_completed_node1}}", "{{status_total_node1}}")'
-      - 'equal("{{status_completed_node2}}", "{{status_total_node2}}")'
+      - "equal({{status_completed_node1}}, {{status_total_node1}})"
+      - "equal({{status_completed_node2}}, {{status_total_node2}})"
       # the subtree is namespace root + 1 descendant subgroup = 2 groups
-      - 'equal("{{status_total_node1}}", 2)'
-      - 'equal("{{status_total_node2}}", 2)'
+      - "equal({{status_total_node1}}, 2)"
+      - "equal({{status_total_node2}}, 2)"
 
   # Phase 7: Teardown (node 1 holds admin authority).
   - name: Delete context

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -1,7 +1,7 @@
 name: 14 — Cascade status RPC (get_cascade_status + assert_cascade_complete, 2-node)
 description: >
   E2E coverage for the get_cascade_status RPC and the cascade-completion
-  assertion shipped in #2524 / merobox#255. Reuses 01's proven 2-node
+  assertion shipped in #2524 / merobox#272 (issue merobox#255). Reuses 01's proven 2-node
   namespace-cascade setup (namespace + one Open descendant subgroup +
   one context, node 2 joins via inheritance), runs ONE
   upgrade_group(cascade=true), then drives the new merobox steps:
@@ -31,8 +31,10 @@ nodes:
   count: 2
   image: merod:local
   prefix: app-migration-status
-  base_port: 9250
-  base_rpc_port: 9350
+  # Continues the per-scenario base-port sequence (13 = 9350/9450) so this
+  # scenario's host ports don't collide with any sibling's.
+  base_port: 9360
+  base_rpc_port: 9460
 
 steps:
   # Phase 1: Install v1 + v2 binaries on the ADMIN node only (node 2


### PR DESCRIPTION
## Summary

Closes the e2e coverage gap for the cascade-status surface from #2524, now that the merobox step types shipped (calimero-network/merobox#272, merobox 0.6.32).

### What's added — workflow `14-cascade-status-rpc`
The first e2e consumer of the `get_cascade_status` RPC and `assert_cascade_complete`. Reuses `01`'s proven 2-node namespace-cascade setup (namespace + one Open descendant subgroup + one context, node 2 joins via inheritance), runs one `upgrade_group(cascade=true)`, then:

- **`assert_cascade_complete`** polls `get_cascade_status` on **each node** until every group in the subtree reports `completed`;
- **`get_cascade_status`** roll-up asserted on **both emitter and receiver**: `pending == 0`, `completed == total`, `total == 2` (namespace root + descendant subgroup) — proving the atomic `CascadeUpgrade` op wrote a `Completed` upgrade record on every matched descendant on both peers.

Added to the `app-migration-e2e` matrix.

**Before this:** `get_cascade_status` had only unit/integration coverage (`crates/context/tests/cascade_status_rpc.rs`). Now it's exercised end-to-end through the full stack (actor → ContextMessage → context client → admin HTTP `GET /groups/:namespace_id/cascade-status`).

## On the HLC fence (`06-fence-rejects-straggler`) — not added, and why

Triggering the fence end-to-end requires a node to **produce a stale-schema state delta** — i.e. write under the *old* `app_key`, with an HLC *after* the cascade boundary — **while not having seen the cascade**. That means a node that is simultaneously:
- **partitioned** from the cascade gossip (so it stays on v1), and
- **RPC-reachable** (so a `call` can write the stale delta).

merobox's `disconnect_node` severs the container's docker network, which takes the host-mapped admin RPC down with it — a `call` on a disconnected node fails (confirmed by merobox's own `fault-injection-convergence-example`, whose comment notes a partitioned-node call is expected to fail). `pause`/`stop` freeze the process, so they can't write either. No current merobox primitive provides *partition-with-RPC-alive* (or a stale-delta injector), so the straggler scenario can't be driven deterministically from a workflow yet.

**The fence is already validated** at the unit + integration level:
- `crates/context/src/hlc_fence.rs` + `crates/context/tests/hlc_fence.rs` — `should_fence` / `delta_is_fenced` boundary logic (strict `>`, key-mismatch, None-never-fences);
- `crates/node/src/handlers/state_delta/mod.rs` `fence_drop_tests` — the drop+warn+metric path in both `apply_authorized_state_delta` and `replay_buffered_delta`;
- `crates/context/tests/cascade_atomic_apply.rs` — cross-replica deterministic `cascade_hlc`.

So the fix is covered; only the workflow-layer reproduction is blocked on a missing merobox fault primitive (tracked for a follow-up).

## Dependency
Requires **merobox >= 0.6.32** (the `get_cascade_status` / `assert_cascade_complete` steps), installed via `setup-merobox` from the APT repo. 0.6.32 publishes from merobox#272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only workflow and CI matrix change; no production or runtime code paths modified.
> 
> **Overview**
> Adds end-to-end coverage for **cascade status** after a namespace cascade upgrade: a new merobox workflow `14-cascade-status-rpc` and inclusion in the **app-migration-e2e** CI matrix.
> 
> The scenario mirrors the existing 2-node namespace + open subgroup + cascade setup, runs one `upgrade_group(cascade=true)`, then exercises **merobox ≥ 0.6.32** steps `assert_cascade_complete` (poll until every subtree group is completed on **both** emitter and receiver) and `get_cascade_status` with **json_assert** roll-ups (`pending == 0`, `completed == total`, `total == 2`). Log checks for `CascadeUpgrade: applied` remain as a sanity gate before the new RPC assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714be7acadb3689f0f65bff7bc40c1f5bbc64c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->