### PR TITLE
fix(storage): converge concurrent first-touch nested CRDTs (value + root hash)

### DIFF
--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -28,6 +28,7 @@ pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageStrategy
 pub mod composite_key;
 mod crdt_impls;
 mod decompose_impls;
+pub(crate) mod rekey;
 pub use composite_key::CompositeKey;
 pub mod nested;
 pub use nested::{get_nested, insert_nested, insert_nested_decomposable, NestedConfig};
@@ -269,7 +270,27 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         field_name: &str,
         crdt_type: CrdtType,
     ) {
-        let new_id = compute_collection_id(None, field_name);
+        self.reassign_deterministic_id_under(None, field_name, crdt_type);
+    }
+
+    /// Like [`reassign_deterministic_id_with_crdt_type`], but derives the new
+    /// id relative to `parent_id` via `compute_collection_id(Some(parent), ..)`.
+    ///
+    /// Used when a collection is nested inside another entity (e.g. a `Counter`
+    /// stored as a map value): the nested collection's id must be a function of
+    /// the *parent entity's deterministic id* so every node mints the same id
+    /// and the children converge. With `parent_id == None` this is exactly the
+    /// top-level (ROOT-relative) reassignment.
+    ///
+    /// [`reassign_deterministic_id_with_crdt_type`]: Self::reassign_deterministic_id_with_crdt_type
+    #[expect(clippy::expect_used, reason = "fatal error if cleanup fails")]
+    pub(crate) fn reassign_deterministic_id_under(
+        &mut self,
+        parent_id: Option<Id>,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) {
+        let new_id = compute_collection_id(parent_id, field_name);
         let old_id = self.storage.id();
 
         // If already has the correct ID, nothing to do
@@ -318,6 +339,22 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         field_name: &str,
         crdt_type: CrdtType,
     ) {
+        self.reassign_deterministic_id_with_indexed_children_under(None, field_name, crdt_type);
+    }
+
+    /// Parent-relative variant of
+    /// [`reassign_deterministic_id_with_indexed_children`] for a vector nested
+    /// inside another entity (re-keys the collection id and its index-derived
+    /// children relative to `parent_id`).
+    ///
+    /// [`reassign_deterministic_id_with_indexed_children`]: Self::reassign_deterministic_id_with_indexed_children
+    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
+    pub(crate) fn reassign_deterministic_id_with_indexed_children_under(
+        &mut self,
+        parent_id: Option<Id>,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) {
         // Snapshot (value, storage_type) for every child in append order
         // before mutating anything. `storage_type` carries the
         // `AuthoredVector` per-entry owner stamp, which must survive the
@@ -345,7 +382,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         // didn't snapshot, and an empty vector stays empty. The clear path
         // only runs when we hold a non-empty snapshot to restore from.
         if snapshot.is_empty() {
-            self.reassign_deterministic_id_with_crdt_type(field_name, crdt_type);
+            self.reassign_deterministic_id_under(parent_id, field_name, crdt_type);
             return;
         }
 
@@ -353,7 +390,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         // deterministic id, then re-insert each child under
         // `compute_id(parent, index)`.
         self.clear().expect("clear for reindex");
-        self.reassign_deterministic_id_with_crdt_type(field_name, crdt_type);
+        self.reassign_deterministic_id_under(parent_id, field_name, crdt_type);
 
         let parent = self.id();
         for (index, (item, storage_type)) in snapshot.into_iter().enumerate() {

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -298,12 +298,31 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
             return;
         }
 
+        let old_metadata = self.storage.metadata.clone();
+
         // Clean up old storage entry and index
         let _ignored = S::storage_remove(Key::Entry(old_id));
         let _ignored = S::storage_remove(Key::Index(old_id));
 
         // Remove old child reference from ROOT (without creating tombstone)
         let _ = <Index<S>>::remove_child_reference_only(*ROOT_ID, old_id);
+
+        // Broadcast a tombstone for the old id when re-keying a NESTED collection
+        // (`parent_id.is_some()`). Such a collection was created on-demand with a
+        // random id (`Collection::new(None)`) and its `Add` was already pushed to
+        // the delta; without a matching `DeleteRef` a receiver applies that `Add`
+        // but never the local `storage_remove` above, so it keeps the old-id
+        // entity as an orphan and its parent's `full_hash` diverges from the
+        // writer's (the scaffolding-e2e PN-counter "Wait for sync" timeout).
+        // Top-level init re-keys (`parent_id == None`) run before the state is
+        // broadcast, so the old id was never shipped — no tombstone needed there.
+        if parent_id.is_some() && S::participates_in_sync() {
+            crate::delta::push_action(crate::action::Action::DeleteRef {
+                id: old_id,
+                deleted_at: crate::env::time_now(),
+                metadata: old_metadata,
+            });
+        }
 
         // Update in-memory ID, field name, and CRDT type
         self.storage.reassign_id_and_field_name(new_id, field_name);

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -576,6 +576,13 @@ where
     T: BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
+    /// The storage id of this entry. Used by the map's occupied-entry replace
+    /// path to re-key nested collections in a replacement value relative to the
+    /// (stable) entry id.
+    fn id(&self) -> Id {
+        self.entry.id()
+    }
+
     fn remove(mut self) -> StoreResult<T> {
         let old = self
             .collection

--- a/crates/storage/src/collections/authored_map.rs
+++ b/crates/storage/src/collections/authored_map.rs
@@ -80,7 +80,8 @@ where
     /// have stable IDs across nodes.
     pub fn reassign_deterministic_id(&mut self, field_name: &str)
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
         use super::compute_collection_id;
         let new_id = compute_collection_id(None, field_name);
@@ -115,7 +116,11 @@ where
     /// # Errors
     /// Returns `ActionNotAllowed` if `k` already exists, or any underlying
     /// storage error.
-    pub fn insert(&mut self, k: K, v: V) -> Result<(), StoreError> {
+    pub fn insert(&mut self, k: K, v: V) -> Result<(), StoreError>
+    where
+        K: 'static,
+        V: 'static,
+    {
         if self.inner.contains(&k)? {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "AuthoredMap::insert: key already exists".to_owned(),

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -124,7 +124,10 @@ where
     /// Returns `InvalidData` if `index` is out of bounds, `ActionNotAllowed`
     /// if the current executor is not the stored owner, `NotFound` if the
     /// underlying entry disappears mid-call, or any underlying storage error.
-    pub fn update(&mut self, index: usize, value: V) -> Result<(), StoreError> {
+    pub fn update(&mut self, index: usize, value: V) -> Result<(), StoreError>
+    where
+        V: 'static,
+    {
         let (entry_id, stored_owner) = self.require_owner(index)?;
 
         if !super::authored_common::executor_matches_owner(&stored_owner) {
@@ -149,7 +152,7 @@ where
     /// Same as [`update`](Self::update).
     pub fn tombstone(&mut self, index: usize) -> Result<(), StoreError>
     where
-        V: Default,
+        V: Default + 'static,
     {
         self.update(index, V::default())
     }

--- a/crates/storage/src/collections/counter.rs
+++ b/crates/storage/src/collections/counter.rs
@@ -224,19 +224,31 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> super::rekey::RekeyTarget
     for Counter<ALLOW_DECREMENT, S>
 {
     fn rekey_relative_to(&mut self, parent_id: crate::address::Id) {
-        let crdt_type = if ALLOW_DECREMENT {
-            CrdtType::PnCounter
-        } else {
-            CrdtType::GCounter
-        };
-        self.positive
-            .reassign_deterministic_id_under(parent_id, "__counter_positive", crdt_type);
+        // The internal slot maps are plain `UnorderedMap`s of executor-id ->
+        // count, and MUST be tagged as such — not with the counter's own
+        // `GCounter`/`PnCounter` type. Each per-executor slot has a single
+        // writer (its executor), so the slots converge by ordinary structural
+        // sync. Tagging a slot map itself as a counter routes it through
+        // `merge_by_crdt_type` -> `merge_pn_counter`, which deserializes the
+        // single-map blob as a whole `Counter`, trips the missing-negative-map
+        // upgrade fallback, and mints a stray random ROOT child on every merge
+        // — leaving the receiver with orphan entities the writer never had and
+        // diverging the root hash.
+        let map_crdt_type = CrdtType::unordered_map(
+            std::any::type_name::<String>(),
+            std::any::type_name::<u64>(),
+        );
+        self.positive.reassign_deterministic_id_under(
+            parent_id,
+            "__counter_positive",
+            map_crdt_type.clone(),
+        );
         // GCounter's negative map is detached and never persisted — skip it.
         if ALLOW_DECREMENT {
             self.negative.reassign_deterministic_id_under(
                 parent_id,
                 "__counter_negative",
-                CrdtType::PnCounter,
+                map_crdt_type,
             );
         }
     }
@@ -271,18 +283,14 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Counter<ALLOW_DECREMENT, S>
         // that a Counter with field name "X" won't collide with a user-created collection
         // named "X_positive" or "X_negative".
         //
-        // The positive map gets the appropriate CrdtType for this counter.
-        // The negative map is internal and doesn't need special CRDT type.
-        let crdt_type = if ALLOW_DECREMENT {
-            CrdtType::PnCounter
-        } else {
-            CrdtType::GCounter
-        };
+        // Both internal maps are tagged as plain `UnorderedMap`s (the default in
+        // `new_with_field_name_internal`), NOT with the counter's own
+        // GCounter/PnCounter type — see `rekey_relative_to` for why tagging a slot
+        // map as a counter mints orphan ROOT children during merge.
         Self {
-            positive: UnorderedMap::new_with_field_name_and_crdt_type(
+            positive: UnorderedMap::new_with_field_name_internal(
                 parent_id,
                 &format!("__counter_internal_{field_name}_positive"),
-                crdt_type,
             ),
             // GCounter: negative map is never used, so use detached
             // PNCounter: negative map is used, so register it properly
@@ -309,16 +317,12 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Counter<ALLOW_DECREMENT, S>
     /// # Arguments
     /// * `field_name` - The name of the struct field containing this counter
     pub fn reassign_deterministic_id(&mut self, field_name: &str) {
-        // Positive map: always needs deterministic ID and entry migration
+        // Positive map: always needs deterministic ID and entry migration.
+        // `reassign_deterministic_id` tags it with the natural `UnorderedMap`
+        // CRDT type, which is what we want — the slot map must NOT carry the
+        // counter's own GCounter/PnCounter type (see `rekey_relative_to`).
         self.positive
             .reassign_deterministic_id(&format!("__counter_internal_{field_name}_positive"));
-        // Update CRDT type after reassignment
-        let crdt_type = if ALLOW_DECREMENT {
-            CrdtType::PnCounter
-        } else {
-            CrdtType::GCounter
-        };
-        self.positive.set_collection_crdt_type(crdt_type);
 
         // Negative map: only for PNCounter (ALLOW_DECREMENT = true)
         // GCounter's negative map is detached and never used, so skip it

--- a/crates/storage/src/collections/counter.rs
+++ b/crates/storage/src/collections/counter.rs
@@ -216,9 +216,36 @@ impl<const ALLOW_DECREMENT: bool> Counter<ALLOW_DECREMENT, MainStorage> {
     }
 }
 
+/// Re-key the counter's internal map(s) relative to its storage parent so two
+/// nodes that independently first-create the same nested counter derive the
+/// same internal-map id and their per-executor slots converge. See
+/// [`super::rekey`].
+impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> super::rekey::RekeyTarget
+    for Counter<ALLOW_DECREMENT, S>
+{
+    fn rekey_relative_to(&mut self, parent_id: crate::address::Id) {
+        let crdt_type = if ALLOW_DECREMENT {
+            CrdtType::PnCounter
+        } else {
+            CrdtType::GCounter
+        };
+        self.positive
+            .reassign_deterministic_id_under(parent_id, "__counter_positive", crdt_type);
+        // GCounter's negative map is detached and never persisted — skip it.
+        if ALLOW_DECREMENT {
+            self.negative.reassign_deterministic_id_under(
+                parent_id,
+                "__counter_negative",
+                CrdtType::PnCounter,
+            );
+        }
+    }
+}
+
 impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Counter<ALLOW_DECREMENT, S> {
     /// Creates a new counter (internal) - must use same visibility as UnorderedMap
     pub(super) fn new_internal() -> Self {
+        super::rekey::register_rekey::<Self>();
         Self {
             positive: UnorderedMap::new_internal(),
             // GCounter (ALLOW_DECREMENT = false): negative map is never used,

--- a/crates/storage/src/collections/counter.rs
+++ b/crates/storage/src/collections/counter.rs
@@ -277,6 +277,11 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Counter<ALLOW_DECREMENT, S>
         parent_id: Option<crate::address::Id>,
         field_name: &str,
     ) -> Self {
+        // Register the re-key thunk here too (not only in `new_internal`), so a
+        // counter first constructed via the deterministic-id path still teaches
+        // the registry about its type — keeps registration independent of which
+        // constructor an app happens to hit first.
+        super::rekey::register_rekey::<Self>();
         // For Counter, we need to create deterministic IDs for both positive and negative maps
         // Use a reserved internal prefix to prevent collisions with user-created collections.
         // The prefix "__counter_internal_" is reserved for Counter's internal maps and ensures

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -245,8 +245,8 @@ where
 
 impl<K, V, S> Mergeable for UnorderedMap<K, V, S>
 where
-    K: borsh::BorshSerialize + borsh::BorshDeserialize + AsRef<[u8]> + Clone + PartialEq,
-    V: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable,
+    K: borsh::BorshSerialize + borsh::BorshDeserialize + AsRef<[u8]> + Clone + PartialEq + 'static,
+    V: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable + 'static,
     S: StorageAdaptor,
 {
     /// Merge two maps entry-by-entry
@@ -309,7 +309,7 @@ where
 
 impl<T, S> Mergeable for UnorderedSet<T, S>
 where
-    T: borsh::BorshSerialize + borsh::BorshDeserialize + AsRef<[u8]> + Clone + PartialEq,
+    T: borsh::BorshSerialize + borsh::BorshDeserialize + AsRef<[u8]> + Clone + PartialEq + 'static,
     S: StorageAdaptor,
 {
     /// Merge two sets using union (add-wins) semantics
@@ -370,7 +370,7 @@ where
 
 impl<T, S> Mergeable for Vector<T, S>
 where
-    T: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable,
+    T: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable + 'static,
     S: StorageAdaptor,
 {
     /// Merge two vectors using element-wise strategy

--- a/crates/storage/src/collections/decompose_impls.rs
+++ b/crates/storage/src/collections/decompose_impls.rs
@@ -14,8 +14,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 impl<K, V, S> Decomposable for UnorderedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq,
-    V: BorshSerialize + BorshDeserialize + Clone,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + Clone + 'static,
     S: StorageAdaptor,
 {
     type Key = CompositeKey;
@@ -75,7 +75,7 @@ where
 
 impl<T, S> Decomposable for Vector<T, S>
 where
-    T: BorshSerialize + BorshDeserialize + Clone,
+    T: BorshSerialize + BorshDeserialize + Clone + 'static,
     S: StorageAdaptor,
 {
     type Key = CompositeKey;

--- a/crates/storage/src/collections/frozen.rs
+++ b/crates/storage/src/collections/frozen.rs
@@ -83,7 +83,10 @@ where
     ///
     /// # Arguments
     /// * `field_name` - The name of the struct field containing this FrozenStorage
-    pub fn reassign_deterministic_id(&mut self, field_name: &str) {
+    pub fn reassign_deterministic_id(&mut self, field_name: &str)
+    where
+        T: 'static,
+    {
         use super::compute_collection_id;
         let new_id = compute_collection_id(None, field_name);
         self.storage.reassign_id_and_field_name(new_id, field_name);
@@ -116,7 +119,10 @@ where
     ///
     /// # Errors
     /// Returns a `StoreError` if serialization or storage fails.
-    pub fn insert(&mut self, value: T) -> Result<Hash, StoreError> {
+    pub fn insert(&mut self, value: T) -> Result<Hash, StoreError>
+    where
+        T: 'static,
+    {
         // Serialize the value to get its content-addressable key
         let data_bytes = borsh::to_vec(&value)
             .map_err(|e| StoreError::StorageError(StorageError::SerializationError(e)))?;
@@ -196,7 +202,7 @@ where
 // Implement Mergeable so it correctly merges in #[app::state]
 impl<T, S> Mergeable for FrozenStorage<T, S>
 where
-    T: BorshSerialize + BorshDeserialize + Clone,
+    T: BorshSerialize + BorshDeserialize + Clone + 'static,
     S: StorageAdaptor,
 {
     fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {

--- a/crates/storage/src/collections/nested.rs
+++ b/crates/storage/src/collections/nested.rs
@@ -72,8 +72,8 @@ pub fn insert_nested<K, V, S>(
     value: V,
 ) -> Result<bool, StoreError>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {
     // For Phase 2.1, we use standard insert for all types
@@ -94,8 +94,13 @@ pub fn insert_nested_decomposable<K, V, S>(
     value: V,
 ) -> Result<bool, StoreError>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq,
-    V: BorshSerialize + BorshDeserialize + Clone + CrdtMeta + Decomposable<Key = CompositeKey>,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq + 'static,
+    V: BorshSerialize
+        + BorshDeserialize
+        + Clone
+        + CrdtMeta
+        + Decomposable<Key = CompositeKey>
+        + 'static,
     S: StorageAdaptor,
 {
     // Check if V can contain CRDTs
@@ -169,7 +174,7 @@ where
 /// Returns error if storage operations fail or reconstruction fails.
 pub fn get_nested<K, V, S>(map: &UnorderedMap<K, V, S>, key: &K) -> Result<Option<V>, StoreError>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Clone + PartialEq + 'static,
     V: BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {

--- a/crates/storage/src/collections/nested_map.rs
+++ b/crates/storage/src/collections/nested_map.rs
@@ -44,7 +44,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 /// Provides methods to modify nested maps without the get-modify-put pattern.
 pub trait NestedMapOps<K1, K2, V, S>
 where
-    K1: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone,
+    K1: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone + 'static,
     K2: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone,
     V: BorshSerialize + BorshDeserialize + Clone,
     S: StorageAdaptor,
@@ -89,9 +89,9 @@ where
 /// Implementation for Map<K1, Map<K2, V>>
 impl<K1, K2, V, S> NestedMapOps<K1, K2, V, S> for UnorderedMap<K1, UnorderedMap<K2, V, S>, S>
 where
-    K1: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone,
-    K2: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone,
-    V: BorshSerialize + BorshDeserialize + Clone,
+    K1: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone + 'static,
+    K2: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + Clone + 'static,
+    V: BorshSerialize + BorshDeserialize + Clone + 'static,
     S: StorageAdaptor,
 {
     fn insert_nested(

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -86,6 +86,12 @@ pub(crate) fn register_rekey<T: RekeyTarget + 'static>() {
 /// to `parent_id`. No-op for value types that never registered (leaves, plain
 /// data structs). Idempotent.
 pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
+    // Copy the fn pointer out and DROP the read guard before invoking the thunk.
+    // This is load-bearing, not incidental: a thunk re-enters the registry — a
+    // map/set/vector re-key re-inserts its entries, and `insert` calls
+    // `register_rekey`, which takes the WRITE lock. Holding the read guard across
+    // the call would deadlock the std `RwLock` on that same-thread upgrade. The
+    // statement ends at the `;`, so `thunk` is owned and lock-free below.
     let thunk = REGISTRY
         .read()
         .unwrap_or_else(|e| e.into_inner())

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -61,16 +61,19 @@ static REGISTRY: LazyLock<RwLock<HashMap<TypeId, RekeyThunk>>> =
 /// cheap (a read-lock hit on the common already-registered path).
 pub(crate) fn register_rekey<T: RekeyTarget + 'static>() {
     let tid = TypeId::of::<T>();
+    // Recover from a poisoned lock rather than propagating the panic: the
+    // registry is an append-only map of independent fn pointers, so a thread
+    // that panicked mid-access left it in a usable state.
     if REGISTRY
         .read()
-        .expect("rekey registry poisoned")
+        .unwrap_or_else(|e| e.into_inner())
         .contains_key(&tid)
     {
         return;
     }
     REGISTRY
         .write()
-        .expect("rekey registry poisoned")
+        .unwrap_or_else(|e| e.into_inner())
         .entry(tid)
         .or_insert(|any: &mut dyn Any, parent: Id| {
             if let Some(t) = any.downcast_mut::<T>() {
@@ -85,7 +88,7 @@ pub(crate) fn register_rekey<T: RekeyTarget + 'static>() {
 pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
     let thunk = REGISTRY
         .read()
-        .expect("rekey registry poisoned")
+        .unwrap_or_else(|e| e.into_inner())
         .get(&TypeId::of::<V>())
         .copied();
     if let Some(thunk) = thunk {

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -1,0 +1,94 @@
+//! Deterministic re-keying of nested collection ids on insert.
+//!
+//! # The problem this solves
+//!
+//! Collections created on-demand at runtime — e.g. `Counter::new()` stored as
+//! an `UnorderedMap` value on first touch — get a RANDOM internal collection id
+//! (`Collection::new(None)` → `Id::random()`). The storage sync model converges
+//! collections by matching entity ids (container merge is add-wins; children
+//! sync as separate entities and merge by id). So two nodes that independently
+//! first-create the same logical nested CRDT mint DIFFERENT random internal ids,
+//! their children land under different parents, and they NEVER merge — a
+//! permanent divergence (e.g. a `GCounter` reads 1 instead of 2).
+//!
+//! `__assign_deterministic_ids` (the `#[app::state]` macro) fixes only
+//! TOP-LEVEL state fields. This module extends that to nested values: when a
+//! value is inserted into a map/set/vector under a deterministic entity id, its
+//! nested collection ids are re-keyed deterministically relative to that id, so
+//! every node derives the same ids and the children converge.
+//!
+//! # Why a TypeId registry instead of a trait bound or `Any`-enumeration
+//!
+//! A `RekeyNested` trait bound on the insert APIs would be the obvious design,
+//! but on stable Rust (no `specialization`) there is no blanket no-op impl, so
+//! every value type — including every app-defined one — would have to implement
+//! it, breaking existing apps. Enumerating concrete collection types via `Any`
+//! downcasts avoids that but is fragile: a new `UnorderedSet<NewType>` value
+//! would silently not re-key.
+//!
+//! Instead, each collection type registers a type-erased re-key thunk keyed by
+//! its `TypeId` in its constructor (the only place that mints the random id we
+//! need to fix). `rekey_nested_value` looks `V`'s `TypeId` up and invokes the
+//! thunk if present. This is:
+//! - **source-compatible** — no trait bound on insert (only `V: 'static`),
+//!   leaf/app value types simply have no registration and are left untouched;
+//! - **not fragile** — any collection instantiation that is ever constructed
+//!   registers itself, so coverage is automatic for all `V`;
+//! - **sufficient** — re-keying only matters at *first creation* (where the id
+//!   would otherwise be random), which always flows through a constructor;
+//!   updates of an already-deterministic entity need no re-key.
+
+use core::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
+
+use crate::address::Id;
+
+/// Implemented by collection types that carry nested collection ids needing
+/// deterministic re-keying relative to their storage parent.
+pub(crate) trait RekeyTarget: Any {
+    /// Re-key this value's nested collection ids relative to `parent_id` (the
+    /// deterministic entity id under which this value is stored). Idempotent.
+    fn rekey_relative_to(&mut self, parent_id: Id);
+}
+
+type RekeyThunk = fn(&mut dyn Any, Id);
+
+static REGISTRY: LazyLock<RwLock<HashMap<TypeId, RekeyThunk>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Register `T`'s re-key thunk. Called from `T`'s constructor; idempotent and
+/// cheap (a read-lock hit on the common already-registered path).
+pub(crate) fn register_rekey<T: RekeyTarget + 'static>() {
+    let tid = TypeId::of::<T>();
+    if REGISTRY
+        .read()
+        .expect("rekey registry poisoned")
+        .contains_key(&tid)
+    {
+        return;
+    }
+    REGISTRY
+        .write()
+        .expect("rekey registry poisoned")
+        .entry(tid)
+        .or_insert(|any: &mut dyn Any, parent: Id| {
+            if let Some(t) = any.downcast_mut::<T>() {
+                t.rekey_relative_to(parent);
+            }
+        });
+}
+
+/// Re-key any nested collections carried by `value` deterministically relative
+/// to `parent_id`. No-op for value types that never registered (leaves, plain
+/// data structs). Idempotent.
+pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
+    let thunk = REGISTRY
+        .read()
+        .expect("rekey registry poisoned")
+        .get(&TypeId::of::<V>())
+        .copied();
+    if let Some(thunk) = thunk {
+        thunk(value, parent_id);
+    }
+}

--- a/crates/storage/src/collections/rga.rs
+++ b/crates/storage/src/collections/rga.rs
@@ -140,6 +140,16 @@ pub struct ReplicatedGrowableArray<S: StorageAdaptor = MainStorage> {
     pub(crate) chars: UnorderedMap<CharKey, RgaChar, S>,
 }
 
+/// Re-key the RGA's char map relative to its storage parent so an RGA stored as
+/// a collection value converges across nodes. See [`super::rekey`].
+impl<S: StorageAdaptor> super::rekey::RekeyTarget for ReplicatedGrowableArray<S> {
+    fn rekey_relative_to(&mut self, parent_id: crate::address::Id) {
+        self.chars
+            .reassign_deterministic_id_under(parent_id, "__rga_chars", CrdtType::Rga);
+        self.chars.set_collection_crdt_type(CrdtType::Rga);
+    }
+}
+
 impl ReplicatedGrowableArray<MainStorage> {
     /// Create a new empty RGA with a random ID.
     ///
@@ -217,6 +227,9 @@ impl<S: StorageAdaptor> ReplicatedGrowableArray<S> {
     ///
     /// Returns error if position is out of bounds or storage operation fails
     pub fn insert(&mut self, pos: usize, content: char) -> Result<(), StoreError> {
+        // Register this RGA type's nested-id re-key thunk so an RGA stored as a
+        // collection value is re-keyed when the outer collection is stored.
+        super::rekey::register_rekey::<Self>();
         let timestamp = env::hlc_timestamp();
 
         // Find the left neighbor at the visible position

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -609,14 +609,20 @@ where
 impl<K, V, S> Extend<(K, V)> for UnorderedMap<K, V, S>
 where
     K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
-    V: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         let parent = self.inner.id();
 
-        let iter = iter.into_iter().map(|(k, v)| {
+        let iter = iter.into_iter().map(|(k, mut v)| {
             let id = compute_id(parent, k.as_ref());
+
+            // Re-key nested collections in the value relative to its entry id,
+            // matching `insert`/`VacantEntry::insert`. Without this, a nested CRDT
+            // bulk-inserted via `extend`/`collect` keeps a random internal id and
+            // two nodes that independently build the same entry never converge.
+            super::rekey::rekey_nested_value(&mut v, id);
 
             (Some(id), (k, v))
         });
@@ -628,7 +634,7 @@ where
 impl<K, V, S> FromIterator<(K, V)> for UnorderedMap<K, V, S>
 where
     K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
-    V: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
@@ -788,7 +794,16 @@ where
     }
 
     /// Replaces the value in the entry and returns the old value.
-    pub fn insert(&mut self, value: V) -> V {
+    pub fn insert(&mut self, mut value: V) -> V
+    where
+        V: 'static,
+    {
+        // Re-key nested collections in the replacement value relative to this
+        // entry's (stable, deterministic) id — same reason as `VacantEntry::insert`.
+        // Replacing an occupied entry with a freshly-built nested CRDT would
+        // otherwise leave it carrying a random internal id that diverges across
+        // nodes.
+        super::rekey::rekey_nested_value(&mut value, self.entry_mut.id());
         mem::replace(&mut self.entry_mut.1, value)
     }
 

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -24,6 +24,25 @@ pub struct UnorderedMap<K, V, S: StorageAdaptor = MainStorage> {
     inner: Collection<(K, V), S>,
 }
 
+/// Re-key a nested map (a map stored as another collection's value) relative to
+/// its storage parent. `reassign_deterministic_id_under` re-inserts entries,
+/// which recurses the re-key into each entry's own nested collections. See
+/// [`super::rekey`].
+impl<K, V, S> super::rekey::RekeyTarget for UnorderedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
+    S: StorageAdaptor,
+{
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        self.reassign_deterministic_id_under(
+            parent_id,
+            "__nested_map",
+            CrdtType::unordered_map(std::any::type_name::<K>(), std::any::type_name::<V>()),
+        );
+    }
+}
+
 impl<K, V, S> UnorderedMap<K, V, S>
 where
     K: BorshSerialize + BorshDeserialize,
@@ -132,7 +151,8 @@ where
         field_name: &str,
         crdt_type: CrdtType,
     ) where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
         let new_id = super::compute_collection_id(None, field_name);
         let old_id = self.inner.id();
@@ -163,6 +183,41 @@ where
         }
     }
 
+    /// Like [`reassign_deterministic_id_with_crdt_type`], but keys the new id
+    /// relative to `parent_id` (for a map nested inside another entity). Entries
+    /// are re-inserted under the new parent id, so they (and their own nested
+    /// values, via `insert`'s re-key) stay reachable and deterministic.
+    ///
+    /// [`reassign_deterministic_id_with_crdt_type`]: Self::reassign_deterministic_id_with_crdt_type
+    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
+    pub(crate) fn reassign_deterministic_id_under(
+        &mut self,
+        parent_id: Id,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) where
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
+    {
+        let new_id = super::compute_collection_id(Some(parent_id), field_name);
+        let old_id = self.inner.id();
+        if old_id == new_id {
+            self.set_collection_crdt_type(crdt_type);
+            return;
+        }
+        let entries: Vec<(K, V)> = self
+            .entries()
+            .expect("failed to read entries for re-key")
+            .collect();
+        self.inner.clear().expect("failed to clear for re-key");
+        self.inner
+            .reassign_deterministic_id_under(Some(parent_id), field_name, crdt_type);
+        for (key, value) in entries {
+            self.insert(key, value)
+                .expect("failed to re-insert entry during re-key");
+        }
+    }
+
     /// Reassigns the map's ID to a deterministic ID based on field name.
     ///
     /// This is called by the `#[app::state]` macro after `init()` returns to ensure
@@ -177,7 +232,8 @@ where
     #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
     pub fn reassign_deterministic_id(&mut self, field_name: &str)
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
         self.reassign_deterministic_id_with_crdt_type(
             field_name,
@@ -195,7 +251,8 @@ where
     ///
     pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreError>
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
         // By default, add as the Public storage.
         self.insert_with_storage_type(key, value, StorageType::Public, None)
@@ -213,14 +270,25 @@ where
     pub(crate) fn insert_with_storage_type(
         &mut self,
         key: K,
-        value: V,
+        mut value: V,
         storage_type: StorageType,
         custom_id: Option<Id>,
     ) -> Result<Option<V>, StoreError>
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
+        // Register this map type's nested-id re-key thunk, so a map stored as
+        // another collection's value (map-of-map) is re-keyed when that outer
+        // collection is itself stored (see `super::rekey`).
+        super::rekey::register_rekey::<Self>();
+
         let id = custom_id.unwrap_or_else(|| compute_id(self.inner.id(), key.as_ref()));
+
+        // Re-key any nested collections in `value` deterministically relative to
+        // this entry's (deterministic) id, so independently-created nested CRDTs
+        // converge across nodes instead of carrying per-node random ids.
+        super::rekey::rekey_nested_value(&mut value, id);
 
         if let Some(mut entry) = self.inner.get_mut(id)? {
             let (_, v) = &mut *entry;

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -611,11 +611,16 @@ where
 
 impl<K, V, S> Extend<(K, V)> for UnorderedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
     V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        // Register this map type's own re-key thunk, exactly as the other store
+        // paths do, so a map populated only via `extend`/`collect` is still
+        // re-keyed when it is itself nested as a value (map-of-map).
+        super::rekey::register_rekey::<Self>();
+
         let parent = self.inner.id();
 
         let iter = iter.into_iter().map(|(k, mut v)| {
@@ -636,7 +641,7 @@ where
 
 impl<K, V, S> FromIterator<(K, V)> for UnorderedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
     V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -141,20 +141,24 @@ where
         self.inner.element_mut().metadata.crdt_type = Some(crdt_type);
     }
 
-    /// Reassigns the map's ID and collection CRDT type to deterministic values.
+    /// Reassign the map's id + collection CRDT type to a deterministic value
+    /// keyed under `parent_id` (`None` = top-level / ROOT-relative). Shared
+    /// implementation behind the two `reassign_deterministic_id_*` entry points.
     ///
-    /// This is used by wrappers like RGA that store map entries but expose a
-    /// custom collection-level CRDT type.
+    /// Migration is: snapshot entries → clear (drops old-id entries) → reassign
+    /// the collection id → re-insert (each entry, and its own nested values via
+    /// `insert`'s re-key, gets a new deterministic id under the new parent).
     #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
-    pub(crate) fn reassign_deterministic_id_with_crdt_type(
+    fn reassign_deterministic_id_keyed(
         &mut self,
+        parent_id: Option<Id>,
         field_name: &str,
         crdt_type: CrdtType,
     ) where
         K: AsRef<[u8]> + PartialEq + 'static,
         V: 'static,
     {
-        let new_id = super::compute_collection_id(None, field_name);
+        let new_id = super::compute_collection_id(parent_id, field_name);
         let old_id = self.inner.id();
 
         // If already has the correct ID, only ensure CRDT type is correct.
@@ -163,24 +167,40 @@ where
             return;
         }
 
-        // Collect all entries before migration (must do this before clearing).
+        // Snapshot all entries before migration (must do this before clearing).
         let entries: Vec<(K, V)> = self
             .entries()
-            .expect("failed to read entries for migration")
+            .expect("failed to read entries for re-key")
             .collect();
 
         // Clear the collection (removes old entries with old IDs).
-        self.inner.clear().expect("failed to clear for migration");
+        self.inner.clear().expect("failed to clear for re-key");
 
-        // Now reassign the collection's ID with the requested CRDT type.
+        // Reassign the collection's ID (Collection's `_with_crdt_type` is itself
+        // just `_under(None, ..)`, so this single call covers both variants).
         self.inner
-            .reassign_deterministic_id_with_crdt_type(field_name, crdt_type);
+            .reassign_deterministic_id_under(parent_id, field_name, crdt_type);
 
         // Re-insert all entries (they will get new IDs based on new parent ID).
         for (key, value) in entries {
             self.insert(key, value)
-                .expect("failed to re-insert entry during migration");
+                .expect("failed to re-insert entry during re-key");
         }
+    }
+
+    /// Reassigns the map's ID and collection CRDT type to deterministic values.
+    ///
+    /// This is used by wrappers like RGA that store map entries but expose a
+    /// custom collection-level CRDT type.
+    pub(crate) fn reassign_deterministic_id_with_crdt_type(
+        &mut self,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) where
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
+    {
+        self.reassign_deterministic_id_keyed(None, field_name, crdt_type);
     }
 
     /// Like [`reassign_deterministic_id_with_crdt_type`], but keys the new id
@@ -189,7 +209,6 @@ where
     /// values, via `insert`'s re-key) stay reachable and deterministic.
     ///
     /// [`reassign_deterministic_id_with_crdt_type`]: Self::reassign_deterministic_id_with_crdt_type
-    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
     pub(crate) fn reassign_deterministic_id_under(
         &mut self,
         parent_id: Id,
@@ -199,23 +218,7 @@ where
         K: AsRef<[u8]> + PartialEq + 'static,
         V: 'static,
     {
-        let new_id = super::compute_collection_id(Some(parent_id), field_name);
-        let old_id = self.inner.id();
-        if old_id == new_id {
-            self.set_collection_crdt_type(crdt_type);
-            return;
-        }
-        let entries: Vec<(K, V)> = self
-            .entries()
-            .expect("failed to read entries for re-key")
-            .collect();
-        self.inner.clear().expect("failed to clear for re-key");
-        self.inner
-            .reassign_deterministic_id_under(Some(parent_id), field_name, crdt_type);
-        for (key, value) in entries {
-            self.insert(key, value)
-                .expect("failed to re-insert entry during re-key");
-        }
+        self.reassign_deterministic_id_keyed(Some(parent_id), field_name, crdt_type);
     }
 
     /// Reassigns the map's ID to a deterministic ID based on field name.

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -735,7 +735,10 @@ where
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn or_insert(self, default: V) -> Result<ValueMut<'a, K, V, S>, StoreError> {
+    pub fn or_insert(self, default: V) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        V: 'static,
+    {
         match self {
             Entry::Occupied(entry) => Ok(ValueMut {
                 entry_mut: entry.entry_mut,
@@ -754,6 +757,7 @@ where
     pub fn or_insert_with<F>(self, f: F) -> Result<ValueMut<'a, K, V, S>, StoreError>
     where
         F: FnOnce() -> V,
+        V: 'static,
     {
         match self {
             Entry::Occupied(entry) => Ok(ValueMut {
@@ -812,8 +816,19 @@ where
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn insert(self, value: V) -> Result<ValueMut<'a, K, V, S>, StoreError> {
+    pub fn insert(self, mut value: V) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        V: 'static,
+    {
         let id = compute_id(self.map.inner.id(), self.key.as_ref());
+
+        // Re-key any nested collections in `value` deterministically relative to
+        // this entry's (deterministic) id — exactly as `insert_with_storage_type`
+        // does. Without this, a nested CRDT stored via the Entry API
+        // (`entry(k).or_insert(Counter::new())`) keeps the random internal id it
+        // was minted with, so two nodes that independently first-create it never
+        // converge. See `super::rekey`.
+        super::rekey::rekey_nested_value(&mut value, id);
 
         // Insert the new (key, value) pair
         drop(self.map.inner.insert(Some(id), (self.key, value))?);

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -19,6 +19,32 @@ pub struct UnorderedSet<V, S: StorageAdaptor = MainStorage> {
     inner: Collection<V, S>,
 }
 
+/// Re-key the set's inner collection (and its content-addressed members)
+/// relative to its storage parent, so independently-created sets converge.
+/// See [`super::rekey`].
+impl<V, S> super::rekey::RekeyTarget for UnorderedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    S: StorageAdaptor,
+{
+    fn rekey_relative_to(&mut self, parent_id: crate::address::Id) {
+        let new_id = super::compute_collection_id(Some(parent_id), "__set");
+        if self.inner.id() == new_id {
+            return; // already deterministic — idempotent
+        }
+        let elements: Vec<V> = self.iter().expect("read set elements for re-key").collect();
+        self.inner.clear().expect("clear set for re-key");
+        self.inner.reassign_deterministic_id_under(
+            Some(parent_id),
+            "__set",
+            CrdtType::unordered_set(std::any::type_name::<V>()),
+        );
+        for v in elements {
+            let _ = self.insert(v).expect("re-insert set element during re-key");
+        }
+    }
+}
+
 impl<V, S> UnorderedSet<V, S>
 where
     V: BorshSerialize + BorshDeserialize,
@@ -96,7 +122,7 @@ where
     #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
     pub fn reassign_deterministic_id(&mut self, field_name: &str)
     where
-        V: AsRef<[u8]> + PartialEq,
+        V: AsRef<[u8]> + PartialEq + 'static,
     {
         use super::compute_collection_id;
 
@@ -140,8 +166,12 @@ where
     ///
     pub fn insert(&mut self, value: V) -> Result<bool, StoreError>
     where
-        V: AsRef<[u8]> + PartialEq,
+        V: AsRef<[u8]> + PartialEq + 'static,
     {
+        // Register this set type's nested-id re-key thunk so that when the set
+        // is itself stored as a map/set/vector value, `insert`'s re-key path
+        // can find it (see `super::rekey`).
+        super::rekey::register_rekey::<Self>();
         let id = compute_id(self.inner.id(), value.as_ref());
 
         if self.inner.get_mut(id)?.is_some() {

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -27,6 +27,7 @@ where
     V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
     S: StorageAdaptor,
 {
+    #[expect(clippy::expect_used, reason = "fatal error if re-key migration fails")]
     fn rekey_relative_to(&mut self, parent_id: crate::address::Id) {
         let new_id = super::compute_collection_id(Some(parent_id), "__set");
         if self.inner.id() == new_id {

--- a/crates/storage/src/collections/user.rs
+++ b/crates/storage/src/collections/user.rs
@@ -71,7 +71,10 @@ where
     ///
     /// # Arguments
     /// * `field_name` - The name of the struct field containing this UserStorage
-    pub fn reassign_deterministic_id(&mut self, field_name: &str) {
+    pub fn reassign_deterministic_id(&mut self, field_name: &str)
+    where
+        T: 'static,
+    {
         use super::compute_collection_id;
         let new_id = compute_collection_id(None, field_name);
         self.storage.reassign_id_and_field_name(new_id, field_name);
@@ -102,7 +105,10 @@ where
     ///
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
-    pub fn insert(&mut self, value: T) -> Result<Option<T>, StoreError> {
+    pub fn insert(&mut self, value: T) -> Result<Option<T>, StoreError>
+    where
+        T: 'static,
+    {
         let executor_public_key: PublicKey = env::executor_id().into();
 
         // Construct the StorageType. It will be signed later, on the upper levels by
@@ -205,7 +211,7 @@ where
 // Implement Mergeable so it correctly merges in #[app::state]
 impl<T, S> Mergeable for UserStorage<T, S>
 where
-    T: BorshSerialize + BorshDeserialize + Mergeable,
+    T: BorshSerialize + BorshDeserialize + Mergeable + 'static,
     S: StorageAdaptor,
 {
     fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -236,12 +236,24 @@ where
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned. Returns an error if the index would cause arithmetic overflow.
     ///
-    pub fn update(&mut self, index: usize, value: V) -> Result<Option<V>, StoreError> {
+    pub fn update(&mut self, index: usize, mut value: V) -> Result<Option<V>, StoreError>
+    where
+        V: 'static,
+    {
         validate_index_bounds(index)?;
 
         let Some(id) = self.inner.nth(index)? else {
             return Ok(None);
         };
+
+        // Re-key nested collections in the replacement value relative to the
+        // existing element id (which is shared across nodes). Two nodes that
+        // concurrently `update` the same positional element with a freshly-built
+        // nested CRDT would otherwise mint divergent random internal ids. `push`
+        // needs no such re-key: it mints a fresh RANDOM element id that rides
+        // along in the sync delta (single-writer append, never independently
+        // re-created), so the value's nested ids are shipped, not re-derived.
+        super::rekey::rekey_nested_value(&mut value, id);
 
         let Some(mut entry) = self.inner.get_mut(id)? else {
             return Ok(None);

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -39,6 +39,24 @@ pub struct Vector<V, S: StorageAdaptor = MainStorage> {
     inner: Collection<V, S>,
 }
 
+/// Re-key the vector's inner collection (and its index-keyed children) relative
+/// to its storage parent so a vector stored as a collection value converges.
+/// See [`super::rekey`].
+impl<V, S> super::rekey::RekeyTarget for Vector<V, S>
+where
+    V: BorshSerialize + BorshDeserialize + 'static,
+    S: StorageAdaptor,
+{
+    fn rekey_relative_to(&mut self, parent_id: crate::address::Id) {
+        self.inner
+            .reassign_deterministic_id_with_indexed_children_under(
+                Some(parent_id),
+                "__vector",
+                CrdtType::vector(std::any::type_name::<V>()),
+            );
+    }
+}
+
 impl<V, S> Vector<V, S>
 where
     V: BorshSerialize + BorshDeserialize,
@@ -132,7 +150,13 @@ where
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned.
     ///
-    pub fn push(&mut self, value: V) -> Result<(), StoreError> {
+    pub fn push(&mut self, value: V) -> Result<(), StoreError>
+    where
+        V: 'static,
+    {
+        // Register this vector type's nested-id re-key thunk so a vector stored
+        // as a collection value is re-keyed when the outer collection is stored.
+        super::rekey::register_rekey::<Self>();
         let _ignored = self.inner.insert(None, value)?;
 
         Ok(())

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -352,6 +352,20 @@ impl<S: StorageAdaptor> Index<S> {
         // here on the merge hot path.
         let children_vec = parent_index.children.get_or_insert_with(Vec::new);
         let new_entry = ChildInfo::new(child.id(), child_index.full_hash, child.metadata);
+        // Dedup by ID, not by `ChildInfo`'s `(created_at, id)` Ord. A child can
+        // be re-added with a CHANGED `created_at` (e.g. CRDT merge re-materialises
+        // an entity that two nodes first-created at different HLC times). The
+        // `(created_at, id)`-ordered `binary_search` below would then miss the
+        // existing same-id entry and `insert` a SECOND ChildInfo for the same id.
+        // `calculate_full_hash_for_children` hashes every child's `merkle_hash`
+        // (sorted by id), so a duplicate entry hashes that child twice → the
+        // parent's `full_hash` (and the root) diverges depending on the order the
+        // creating deltas were applied — the "same DAG, different root hash"
+        // family. Removing any existing same-id entry first guarantees at most
+        // one ChildInfo per id. For a healthy single-entry list this is identical
+        // to the old replace (so the hash is unchanged for converged data); it
+        // only eliminates the duplicate.
+        children_vec.retain(|c| c.id() != new_entry.id());
         match children_vec.binary_search(&new_entry) {
             Ok(pos) => children_vec[pos] = new_entry,
             Err(pos) => children_vec.insert(pos, new_entry),

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -355,20 +355,34 @@ impl<S: StorageAdaptor> Index<S> {
         // Dedup by ID, not by `ChildInfo`'s `(created_at, id)` Ord. A child can
         // be re-added with a CHANGED `created_at` (e.g. CRDT merge re-materialises
         // an entity that two nodes first-created at different HLC times). The
-        // `(created_at, id)`-ordered `binary_search` below would then miss the
-        // existing same-id entry and `insert` a SECOND ChildInfo for the same id.
+        // `(created_at, id)`-ordered `binary_search` would then miss the existing
+        // same-id entry and `insert` a SECOND ChildInfo for the same id.
         // `calculate_full_hash_for_children` hashes every child's `merkle_hash`
         // (sorted by id), so a duplicate entry hashes that child twice → the
         // parent's `full_hash` (and the root) diverges depending on the order the
         // creating deltas were applied — the "same DAG, different root hash"
-        // family. Removing any existing same-id entry first guarantees at most
-        // one ChildInfo per id. For a healthy single-entry list this is identical
-        // to the old replace (so the hash is unchanged for converged data); it
-        // only eliminates the duplicate.
-        children_vec.retain(|c| c.id() != new_entry.id());
+        // family. We must keep at most one ChildInfo per id.
+        //
+        // The common case — re-adding an unchanged child — hits the `Ok` branch
+        // and replaces in place in O(log K) with no scan, preserving the
+        // invariant inductively (there is never a pre-existing same-id
+        // duplicate). Only the rare `created_at`-changed miss pays an O(K) scan to
+        // evict the stale same-id entry before inserting. (The `insert`/`remove`
+        // shifts are already O(K), so this adds no asymptotic cost over the
+        // pre-dedup code.)
         match children_vec.binary_search(&new_entry) {
             Ok(pos) => children_vec[pos] = new_entry,
-            Err(pos) => children_vec.insert(pos, new_entry),
+            Err(pos) => {
+                if let Some(stale) = children_vec.iter().position(|c| c.id() == new_entry.id()) {
+                    let _ = children_vec.remove(stale);
+                    match children_vec.binary_search(&new_entry) {
+                        Ok(p) => children_vec[p] = new_entry,
+                        Err(p) => children_vec.insert(p, new_entry),
+                    }
+                } else {
+                    children_vec.insert(pos, new_entry);
+                }
+            }
         }
 
         parent_index.full_hash =

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -2522,3 +2522,136 @@ fn test_nested_set_first_touch_concurrent_converges() {
         hex::encode(b_root),
     );
 }
+
+/// OPEN REGRESSION (currently failing — hence `#[ignore]`). Reproduces the
+/// scaffolding-e2e "Wait for sync after node-1 PN-Counter operations" timeout.
+///
+/// A PN-counter (`Counter<true>`, with a negative map G-counter lacks) nested in
+/// a map; single-writer (node-1 increments thrice + decrements once); a receiver
+/// then applies node-1's delta. The VALUE converges (2) but the writer and
+/// receiver root hashes DIVERGE: the receiver ends with extra orphan entities.
+///
+/// ROOT CAUSE: the nested-id re-key (`reassign_deterministic_id_under`) removes
+/// the old random-id collection/slot entities from the WRITER's storage via raw
+/// `storage_remove`, but the broadcast delta still carries their `Add` actions
+/// (recorded when they were first created) WITHOUT a matching `DeleteRef`. A
+/// receiver applies the orphan `Add`s but never removes them, so it keeps
+/// entities the writer dropped → divergent `full_hash`. This asymmetric
+/// (native-create → broadcast) path is what real nodes use; the symmetric
+/// first-touch tests (every node imports the same deltas) don't expose it.
+///
+/// FIX DIRECTION: the re-key must emit `DeleteRef`s for every churned old-id
+/// entity (so receivers drop them), or assign deterministic ids at creation so
+/// no random-id entity is ever persisted/broadcast. Remove `#[ignore]` once the
+/// re-key is delta-consistent.
+#[ignore = "OPEN: re-key ships orphan Add actions without DeleteRef -> writer/receiver root divergence"]
+#[test]
+#[serial]
+fn test_nested_pncounter_single_writer_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct PnDoc {
+        counters: UnorderedMap<String, Counter<true>>,
+    }
+    impl Mergeable for PnDoc {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<PnDoc, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<PnDoc>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+
+    // Genesis: empty map base.
+    fresh([9; 32]);
+    let g = Root::<PnDoc, S>::new(|| PnDoc {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    // node-1 (writer): create "bal" PN-counter, increment x3, decrement x1.
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let mut doc = Root::<PnDoc, S>::fetch().unwrap();
+    let mut ctr = doc
+        .counters
+        .get(&"bal".to_string())
+        .unwrap()
+        .unwrap_or_else(Counter::<true>::new);
+    ctr.increment().unwrap();
+    ctr.increment().unwrap();
+    ctr.increment().unwrap();
+    ctr.decrement().unwrap();
+    doc.counters.insert("bal".to_string(), ctr).unwrap();
+    let n1_data = borsh::to_vec(&*doc).unwrap();
+    drop(doc);
+    let delta = capture(n1_data);
+    let n1_root = root_hash();
+    let n1_val = Root::<PnDoc, S>::fetch()
+        .unwrap()
+        .counters
+        .get(&"bal".to_string())
+        .unwrap()
+        .map(|c| c.value().unwrap())
+        .unwrap_or(0);
+
+    // node-2 (receiver): import base, apply node-1's delta.
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    import(delta);
+    let n2_root = root_hash();
+    let n2_val = Root::<PnDoc, S>::fetch()
+        .unwrap()
+        .counters
+        .get(&"bal".to_string())
+        .unwrap()
+        .map(|c| c.value().unwrap())
+        .unwrap_or(0);
+
+    assert_eq!(n1_val, 2, "writer PN value should be 3-1=2 (got {n1_val})");
+    assert_eq!(n2_val, 2, "receiver PN value should be 2 (got {n2_val})");
+    assert_eq!(
+        n1_root,
+        n2_root,
+        "PN-counter single-writer root must converge (writer vs receiver): n1={} n2={}",
+        hex::encode(n1_root),
+        hex::encode(n2_root),
+    );
+}

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -2391,6 +2391,138 @@ fn test_nested_counter_first_touch_concurrent_converges() {
     );
 }
 
+/// Same first-touch nested-counter convergence, but the value is introduced via
+/// the **Entry API** (`map.entry(k).or_insert_with(Counter::new)`) instead of
+/// `get(...).unwrap_or_else(..)` + `insert`. `VacantEntry::insert` is a distinct
+/// store path that previously bypassed `rekey_nested_value`, so a nested CRDT
+/// added this way kept its random internal id and never converged. Guards that
+/// the Entry path now re-keys identically to `insert`.
+#[test]
+#[serial]
+fn test_nested_counter_first_touch_via_entry_api_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct NestedCounters {
+        counters: UnorderedMap<String, Counter>,
+    }
+    impl Mergeable for NestedCounters {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<NestedCounters, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<NestedCounters>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let incr_create_via_entry = || {
+        let mut doc = Root::<NestedCounters, S>::fetch().unwrap();
+        // First touch through the Entry API: vacant -> create a fresh Counter.
+        {
+            let mut guard = doc
+                .counters
+                .entry("k".to_string())
+                .unwrap()
+                .or_insert_with(Counter::new)
+                .unwrap();
+            guard.increment().unwrap();
+        }
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: EMPTY map (no "k"); only the map container is shared.
+    fresh([9; 32]);
+    let g = Root::<NestedCounters, S>::new(|| NestedCounters {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = incr_create_via_entry();
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = incr_create_via_entry();
+
+    let value_of = || -> u64 {
+        Root::<NestedCounters, S>::fetch()
+            .unwrap()
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|c| c.value().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, 2,
+        "node A: Entry-API-created 'k' counters must merge to 2 (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: Entry-API-created 'k' counters must merge to 2 (got {b_val})"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "Entry-API first-touch nested-counter root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
 /// Same first-touch scenario for an `UnorderedMap<String, UnorderedSet<String>>`
 /// (the scaffolding `crdt_tags`/`add_tag` shape): two nodes independently
 /// first-create the set under key "k", each adding a DIFFERENT tag, then

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -2523,6 +2523,131 @@ fn test_nested_counter_first_touch_via_entry_api_converges() {
     );
 }
 
+/// Same first-touch nested-counter convergence, but the value is bulk-inserted
+/// via `Extend` (`map.extend([(k, counter)])`) — the path `collect()` /
+/// `FromIterator` also funnels through. `Extend::extend` was a third store path
+/// (besides `insert` and the Entry API) that previously bypassed
+/// `rekey_nested_value`. Guards that bulk insertion re-keys identically.
+#[test]
+#[serial]
+fn test_nested_counter_first_touch_via_extend_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct NestedCounters {
+        counters: UnorderedMap<String, Counter>,
+    }
+    impl Mergeable for NestedCounters {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<NestedCounters, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<NestedCounters>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let incr_create_via_extend = || {
+        let mut doc = Root::<NestedCounters, S>::fetch().unwrap();
+        // First touch through Extend: build a fresh Counter, bulk-insert it.
+        let mut ctr = Counter::new();
+        ctr.increment().unwrap();
+        doc.counters.extend([("k".to_string(), ctr)]);
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: EMPTY map (no "k"); only the map container is shared.
+    fresh([9; 32]);
+    let g = Root::<NestedCounters, S>::new(|| NestedCounters {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = incr_create_via_extend();
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = incr_create_via_extend();
+
+    let value_of = || -> u64 {
+        Root::<NestedCounters, S>::fetch()
+            .unwrap()
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|c| c.value().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, 2,
+        "node A: extend-created 'k' counters must merge to 2 (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: extend-created 'k' counters must merge to 2 (got {b_val})"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "extend first-touch nested-counter root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
 /// Same first-touch scenario for an `UnorderedMap<String, UnorderedSet<String>>`
 /// (the scaffolding `crdt_tags`/`add_tag` shape): two nodes independently
 /// first-create the set under key "k", each adding a DIFFERENT tag, then

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1999,3 +1999,526 @@ mod frozen_sync_robustness {
         );
     }
 }
+
+/// Deterministic reproduction target for the Bug-B class: TWO nodes each
+/// increment the SAME `GCounter` (different executors) against a shared base,
+/// then exchange deltas. A correct CRDT must converge — same value AND same
+/// Merkle root — regardless of the order each node applies the two deltas.
+///
+/// This drives the real merge path the node's `apply_action` uses
+/// (`try_merge_non_root` -> `merge_by_crdt_type` -> `merge_g_counter`), via the
+/// capture-delta -> reset -> `Root::sync` flow. The base counter is created
+/// ONCE (genesis executor) and replayed into each node so they share identical
+/// collection ids — concurrent increments then add distinct per-executor slots.
+#[test]
+#[serial]
+fn test_gcounter_concurrent_increments_converge_via_delta_sync() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<Counter, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<Counter>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+
+    // Genesis: empty counter base shared by every node (carries collection ids).
+    fresh([9; 32]);
+    let g = Root::<Counter, S>::new(Counter::new);
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    // Capture node-A's increment (executor 1) against the shared base.
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let mut a = Root::<Counter, S>::fetch().unwrap();
+    a.increment().unwrap();
+    let a_data = borsh::to_vec(&*a).unwrap();
+    drop(a);
+    let delta_a = capture(a_data);
+
+    // Capture node-B's increment (executor 2) against the same shared base.
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let mut b = Root::<Counter, S>::fetch().unwrap();
+    b.increment().unwrap();
+    let b_data = borsh::to_vec(&*b).unwrap();
+    drop(b);
+    let delta_b = capture(b_data);
+
+    // node-A applies its own then B's delta (order A, B).
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        let val = Root::<Counter, S>::fetch().unwrap().value().unwrap();
+        (val, root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(a_val, 2, "node A must see both increments (GCounter sum)");
+    assert_eq!(b_val, 2, "node B must see both increments (GCounter sum)");
+    assert_eq!(
+        a_root,
+        b_root,
+        "GCounter root must converge regardless of delta apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
+/// Bug-B hypothesis probe: a CRDT NESTED inside an `UnorderedMap`
+/// (`UnorderedMap<String, Counter>` — the shape scaffolding-e2e's
+/// `increment_counter`/`increment_g_counter`/`add_tag` use). Two nodes
+/// concurrently increment the counter under the SAME key against a shared
+/// base, then exchange deltas. If the map merges its values via recursive CRDT
+/// merge, both nodes converge to value 2 with one root hash. If it LWW-replaces
+/// the value instead, they clobber (value 1) and/or diverge — which is the
+/// suspected `frozen-rga`/conformance failure mode for map-nested CRDTs.
+#[test]
+#[serial]
+fn test_nested_counter_in_map_concurrent_increments_converge() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct NestedCounters {
+        counters: UnorderedMap<String, Counter>,
+    }
+    impl Mergeable for NestedCounters {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<NestedCounters, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<NestedCounters>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let incr = || {
+        let mut doc = Root::<NestedCounters, S>::fetch().unwrap();
+        let mut ctr = doc
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .unwrap_or_else(Counter::new);
+        ctr.increment().unwrap();
+        doc.counters.insert("k".to_string(), ctr).unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: base with the "k" counter created once (shared ids), value 0.
+    fresh([9; 32]);
+    let mut g = Root::<NestedCounters, S>::new(|| NestedCounters {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    g.counters.insert("k".to_string(), Counter::new()).unwrap();
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    // node-A increment under "k" (executor 1).
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = incr();
+
+    // node-B increment under "k" (executor 2).
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = incr();
+
+    let value_of = || -> u64 {
+        Root::<NestedCounters, S>::fetch()
+            .unwrap()
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|c| c.value().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, 2,
+        "node A: nested counter under 'k' must sum both increments (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: nested counter under 'k' must sum both increments (got {b_val})"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "nested-counter root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
+/// Regression test for the nested-id re-key fix.
+///
+/// The key "k" is NOT pre-created in the shared base — each node creates it
+/// INDEPENDENTLY (via `get(...).unwrap_or_else(Counter::new)` + `insert`),
+/// exactly what scaffolding-e2e's `increment_g_counter`/`increment_counter`/
+/// `add_tag` do on first touch.
+///
+/// Before the fix the two nodes' counters never merged (value clobbered to 1):
+/// `Counter::new()` builds its internal `positive` map via
+/// `Collection::new(None)` → `Id::random()`, so each node's counter had a
+/// DIFFERENT random internal-map id and the per-executor count slots lived
+/// under different parents. `insert` now re-keys nested collections
+/// deterministically relative to the value's entity id
+/// (`rekey::rekey_nested_value`), so both nodes' slots share an id and the
+/// COUNTS converge to 2. This test asserts that value convergence.
+///
+/// NOTE: full ROOT-HASH convergence is a separate, still-open problem — see
+/// `test_nested_counter_first_touch_root_hash_converges`.
+#[test]
+#[serial]
+fn test_nested_counter_first_touch_concurrent_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct NestedCounters {
+        counters: UnorderedMap<String, Counter>,
+    }
+    impl Mergeable for NestedCounters {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<NestedCounters, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<NestedCounters>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let incr_create = || {
+        let mut doc = Root::<NestedCounters, S>::fetch().unwrap();
+        // First touch: key absent -> create a fresh Counter (the scaffolding path).
+        let mut ctr = doc
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .unwrap_or_else(Counter::new);
+        ctr.increment().unwrap();
+        doc.counters.insert("k".to_string(), ctr).unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: EMPTY map (no "k"); only the map container is shared.
+    fresh([9; 32]);
+    let g = Root::<NestedCounters, S>::new(|| NestedCounters {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = incr_create();
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = incr_create();
+
+    let value_of = || -> u64 {
+        Root::<NestedCounters, S>::fetch()
+            .unwrap()
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|c| c.value().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    // node A applies [its own, then B]; node B applies [its own, then A] —
+    // opposite orders, the cross-node sync pattern.
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    // (1) Nested-id re-key: both nodes sum the two independently-created
+    // executor slots to 2 (previously one clobbered the other → 1).
+    assert_eq!(
+        a_val, 2,
+        "node A: independently-created 'k' counters must merge to 2 (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: independently-created 'k' counters must merge to 2 (got {b_val})"
+    );
+
+    // (2) Merkle child-dedup: the root HASH converges regardless of apply order.
+    // Before the `add_child_to` dedup fix the diverging parents had identical
+    // `own_hash` but different `full_hash` because a child re-added with a
+    // changed `created_at` was appended as a DUPLICATE `ChildInfo`, hashing that
+    // child twice in one order only.
+    assert_eq!(
+        a_root,
+        b_root,
+        "first-touch nested-counter root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
+/// Same first-touch scenario for an `UnorderedMap<String, UnorderedSet<String>>`
+/// (the scaffolding `crdt_tags`/`add_tag` shape): two nodes independently
+/// first-create the set under key "k", each adding a DIFFERENT tag, then
+/// exchange deltas. The nested-id re-key (`UnorderedSet: RekeyTarget`) makes
+/// both nodes' sets share an internal id, so the set UNION converges (both tags
+/// present) instead of one node's tag clobbering the other's. (Root-hash
+/// convergence is the same separate open issue as the counter case.)
+#[test]
+#[serial]
+fn test_nested_set_first_touch_concurrent_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct Tags {
+        tags: UnorderedMap<String, UnorderedSet<String>>,
+    }
+    impl Mergeable for Tags {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.tags.merge(&other.tags)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<Tags, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<Tags>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let add_tag = |tag: &str| -> Vec<Action> {
+        let mut doc = Root::<Tags, S>::fetch().unwrap();
+        let mut set = doc
+            .tags
+            .get(&"k".to_string())
+            .unwrap()
+            .unwrap_or_else(UnorderedSet::new);
+        let _ = set.insert(tag.to_string()).unwrap();
+        doc.tags.insert("k".to_string(), set).unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: empty tags map (no "k").
+    fresh([9; 32]);
+    let g = Root::<Tags, S>::new(|| Tags {
+        tags: UnorderedMap::new_with_field_name("tags"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = add_tag("rust");
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = add_tag("crdt");
+
+    let tag_count = || -> usize {
+        Root::<Tags, S>::fetch()
+            .unwrap()
+            .tags
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|s| s.len().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (usize, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (tag_count(), root_hash())
+    };
+
+    let (a_count, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_count, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    // Set union converges (nested-id re-key) ...
+    assert_eq!(
+        a_count, 2,
+        "node A: independently-created 'k' sets must union to 2 tags (got {a_count})"
+    );
+    assert_eq!(
+        b_count, 2,
+        "node B: independently-created 'k' sets must union to 2 tags (got {b_count})"
+    );
+    // ... and the root hash converges regardless of apply order (child-dedup).
+    assert_eq!(
+        a_root,
+        b_root,
+        "first-touch nested-set root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -2523,28 +2523,25 @@ fn test_nested_set_first_touch_concurrent_converges() {
     );
 }
 
-/// OPEN REGRESSION (currently failing — hence `#[ignore]`). Reproduces the
-/// scaffolding-e2e "Wait for sync after node-1 PN-Counter operations" timeout.
+/// Regression for the scaffolding-e2e "Wait for sync after node-1 PN-Counter
+/// operations" timeout.
 ///
 /// A PN-counter (`Counter<true>`, with a negative map G-counter lacks) nested in
 /// a map; single-writer (node-1 increments thrice + decrements once); a receiver
-/// then applies node-1's delta. The VALUE converges (2) but the writer and
-/// receiver root hashes DIVERGE: the receiver ends with extra orphan entities.
+/// then applies node-1's delta. Both the VALUE (2) and the root hash must
+/// converge between writer and receiver.
 ///
-/// ROOT CAUSE: the nested-id re-key (`reassign_deterministic_id_under`) removes
-/// the old random-id collection/slot entities from the WRITER's storage via raw
-/// `storage_remove`, but the broadcast delta still carries their `Add` actions
-/// (recorded when they were first created) WITHOUT a matching `DeleteRef`. A
-/// receiver applies the orphan `Add`s but never removes them, so it keeps
-/// entities the writer dropped → divergent `full_hash`. This asymmetric
-/// (native-create → broadcast) path is what real nodes use; the symmetric
-/// first-touch tests (every node imports the same deltas) don't expose it.
-///
-/// FIX DIRECTION: the re-key must emit `DeleteRef`s for every churned old-id
-/// entity (so receivers drop them), or assign deterministic ids at creation so
-/// no random-id entity is ever persisted/broadcast. Remove `#[ignore]` once the
-/// re-key is delta-consistent.
-#[ignore = "OPEN: re-key ships orphan Add actions without DeleteRef -> writer/receiver root divergence"]
+/// ROOT CAUSE (fixed): the counter's internal positive/negative slot maps were
+/// tagged with the counter's own `PnCounter` CRDT type. On the receiver, applying
+/// a slot-map entity routed it through `merge_by_crdt_type` -> `merge_pn_counter`,
+/// which deserialized the single ~32-byte map blob as a whole `Counter<true>`,
+/// hit the missing-negative-map upgrade fallback (`UnorderedMap::new_internal`),
+/// and minted a stray random ROOT child on every merge. The receiver thus ended
+/// with orphan entities the writer never had → divergent root hash. (G-counter
+/// dodged this only because its deserialize fallback uses `new_detached`, which
+/// doesn't persist a ROOT child.) The fix tags the slot maps as plain
+/// `UnorderedMap`s — they converge by ordinary structural sync since each
+/// per-executor slot has a single writer.
 #[test]
 #[serial]
 fn test_nested_pncounter_single_writer_converges() {
@@ -2653,5 +2650,156 @@ fn test_nested_pncounter_single_writer_converges() {
         "PN-counter single-writer root must converge (writer vs receiver): n1={} n2={}",
         hex::encode(n1_root),
         hex::encode(n2_root),
+    );
+}
+
+/// Two writers concurrently mutate the same nested PN-counter (node-A: +2 -1,
+/// node-B: +1), then each applies the other's delta. Both the signed VALUE (=2)
+/// and the root hash must converge regardless of apply order.
+///
+/// This is the concurrent companion to
+/// [`test_nested_pncounter_single_writer_converges`]: it guards the same
+/// slot-map-tagging fix under genuine multi-writer interleaving, where each node
+/// owns a distinct executor slot in both the positive and negative maps. Before
+/// the fix the receiver minted orphan ROOT children when merging the
+/// `PnCounter`-tagged slot maps, diverging the root hash.
+#[test]
+#[serial]
+fn test_nested_pncounter_concurrent_writers_converge() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct PnDoc {
+        counters: UnorderedMap<String, Counter<true>>,
+    }
+    impl Mergeable for PnDoc {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<PnDoc, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<PnDoc>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+
+    // Genesis: base with the "bal" PN-counter created once (shared ids), value 0.
+    fresh([9; 32]);
+    let mut g = Root::<PnDoc, S>::new(|| PnDoc {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    g.counters
+        .insert("bal".to_string(), Counter::<true>::new())
+        .unwrap();
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    // node-A: +2 then -1 under "bal" (executor 1) -> contributes +1.
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = {
+        let mut doc = Root::<PnDoc, S>::fetch().unwrap();
+        let mut ctr = doc
+            .counters
+            .get(&"bal".to_string())
+            .unwrap()
+            .unwrap_or_else(Counter::<true>::new);
+        ctr.increment().unwrap();
+        ctr.increment().unwrap();
+        ctr.decrement().unwrap();
+        doc.counters.insert("bal".to_string(), ctr).unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // node-B: +1 under "bal" (executor 2) -> contributes +1.
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = {
+        let mut doc = Root::<PnDoc, S>::fetch().unwrap();
+        let mut ctr = doc
+            .counters
+            .get(&"bal".to_string())
+            .unwrap()
+            .unwrap_or_else(Counter::<true>::new);
+        ctr.increment().unwrap();
+        doc.counters.insert("bal".to_string(), ctr).unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    let value_of = || -> i64 {
+        Root::<PnDoc, S>::fetch()
+            .unwrap()
+            .counters
+            .get(&"bal".to_string())
+            .unwrap()
+            .map(|c| c.value().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (i64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, 2,
+        "node A: PN-counter must be (2-1)+1=2 across both writers (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: PN-counter must be (2-1)+1=2 across both writers (got {b_val})"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "concurrent PN-counter root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
     );
 }


### PR DESCRIPTION
## Problem

Two independent nodes that **first-create the same nested CRDT** (e.g. a `Counter` or `UnorderedSet` stored as a map value, on first touch — the shape of scaffolding-e2e's `increment_g_counter` / `add_tag` / `increment_counter`) diverged **permanently**:

- the **value** clobbered (a `GCounter` read `1` instead of `2`), and
- the **Merkle root hashes** differed depending on the order deltas were applied — the "same DAG, different root hash" / writer-outlier family that surfaces as intermittent `wait_for_sync` failures.

This fixes **both** halves. Both are **source-compatible** (no app changes; the whole workspace builds untouched).

## 1. Deterministic nested-collection ids (value convergence)

Collections created on-demand (`Counter::new()` as a map value) got a **random** internal-collection id (`Collection::new(None)` → `Id::random()`). Sync converges collections by matching entity ids, so two nodes minted different ids and their children (per-executor counter slots, set members) never merged.

New `TypeId` registry (`collections/rekey.rs`): each collection registers a re-key thunk in its constructor/mutator; `UnorderedMap`/`Set`/`Vector` insert looks up the value's `TypeId` and re-keys its nested collections deterministically relative to the (deterministic) entry id. Implemented for **`Counter`, `UnorderedSet`, `UnorderedMap` (map-of-map, recurses), `RGA`, `Vector`**.

Chosen over a trait bound because stable Rust (no `specialization`) can't provide a blanket no-op impl — a bound would force every app value type to implement it. The registry only adds a `'static` bound, kept inside the storage crate's generic code; leaf/app value types just don't register and are left untouched.

## 2. Merkle child-dedup (root-hash convergence)

`Index::add_child_to` dedup'd a parent's children list by `ChildInfo`'s `(created_at, id)` ordering via `binary_search`. A child re-added with a **changed `created_at`** (CRDT merge re-materialises an entity two nodes first-created at different HLC times) was **missed** by the search and **appended as a duplicate** `ChildInfo` for the same id. `calculate_full_hash_for_children` hashes every child's `merkle_hash` (sorted by id, not deduped), so the duplicate hashed that child twice → the parent's `full_hash` (and the root) diverged by apply order.

**Fix:** `retain`-by-id before the insert, so there is at most one `ChildInfo` per id. **Wire-safe:** for a healthy single-entry list it is identical to the old replace (hash unchanged for already-converged data); it only removes the buggy duplicate. This is a general determinism fix and likely also resolves the broader scaffolding "same DAG, different root hash" flakes.

## Tests

New regression tests in `crates/storage/src/tests/merge_integration.rs` (additive — no existing tests removed): concurrent first-touch of a map-nested `Counter` and a map-nested `UnorderedSet`, applied in **opposite orders** on two simulated nodes, now assert **both** value convergence (sum/union = 2) **and** root-hash convergence.

## Test plan

- `cargo test -p calimero-storage --lib` → **480 passed, 0 failed**
- `cargo test -p calimero-node --lib sync::` → **161 passed, 0 failed**
- `cargo build --workspace` → clean; `cargo fmt --check` → clean

## Related

Test infra that reproduces these bugs through the real compiled app (the runtime CRDT-conformance suite) is in #2535; once both land, its 4 `#[ignore]`d concurrent-same-entity cases can be un-ignored to prove the fix end-to-end through WASM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core storage sync, entity re-keying, delta tombstones, counter merge metadata, and Merkle index hashing—any bug affects multi-node state convergence.
> 
> **Overview**
> Fixes **permanent divergence** when two nodes independently **first-touch** the same nested CRDT (e.g. `Counter` or `UnorderedSet` in a map) and when Merkle roots disagree for the same delta order.
> 
> **Nested value convergence:** Adds a `TypeId` registry (`collections/rekey.rs`) so collection types register re-key thunks at construction; on `insert` / `extend` / map `Entry` / vector `update`, nested collections are re-keyed with `compute_collection_id` relative to the stable entry id. Parent-scoped `reassign_deterministic_id_under` (and vector indexed-child variants) migrate storage; nested re-keys also emit **`DeleteRef`** for the old random id so peers do not keep orphan entities. **`Counter`** internal slot maps are tagged as plain **`UnorderedMap`**, not `GCounter`/`PnCounter`, so merge does not mint stray ROOT children (PN-counter sync timeout).
> 
> **Root-hash convergence:** **`Index::add_child_to`** deduplicates children by **id** when the same child is re-added with a new `created_at`, instead of appending a second `ChildInfo` that double-counts in `full_hash`.
> 
> Broad **`'static`** bounds on affected map/set APIs; large new **`merge_integration`** regressions (first-touch counter/set, entry/extend paths, nested PN-counter).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7482d82dcddff66bc7f57c85bb8bf23a5e2bee2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->