### PR TITLE
feat(sdk): first-class BlobId / ContextId newtypes (consolidate base58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,6 @@ dependencies = [
 name = "blobs"
 version = "0.0.0"
 dependencies = [
- "bs58 0.5.1",
  "calimero-sdk",
  "calimero-storage",
  "calimero-wasm-abi",
@@ -12371,7 +12370,6 @@ dependencies = [
 name = "xcall-example"
 version = "0.0.0"
 dependencies = [
- "bs58 0.5.1",
  "calimero-sdk",
  "calimero-storage",
  "calimero-wasm-abi",

--- a/apps/blobs/Cargo.toml
+++ b/apps/blobs/Cargo.toml
@@ -16,7 +16,6 @@ calimero-sdk.workspace = true
 calimero-storage.workspace = true
 sha2 = "0.10"
 hex = "0.4"
-bs58 = "0.5"
 
 [build-dependencies]
 calimero-wasm-abi.workspace = true

--- a/apps/blobs/README.md
+++ b/apps/blobs/README.md
@@ -15,10 +15,11 @@ This application demonstrates how to use the Calimero blob storage API to build 
 
 ### Blob IDs
 
-Blobs are identified by 32-byte IDs. For safe transmission and storage:
+Blobs are identified by 32-byte IDs, modelled by the SDK's `BlobId` newtype
+(`calimero_sdk::BlobId`):
 
-- **Internal**: `[u8; 32]` - Raw bytes for storage and network operations
-- **External**: `String` - Base58-encoded for JSON serialization and API responses
+- **In Rust**: `BlobId` - a 32-byte ID with `Display`/`FromStr` and serde/borsh impls
+- **Over the wire**: a Base58 string - `BlobId` (de)serializes to/from base58 in JSON
 
 ### Blob Announcement
 
@@ -44,7 +45,7 @@ Stores metadata about each uploaded file:
 pub struct FileRecord {
     pub id: String,              // Unique file ID (e.g., "file_0")
     pub name: String,            // Human-readable name
-    pub blob_id: [u8; 32],       // Binary blob ID
+    pub blob_id: BlobId,         // Blob ID (base58 string in JSON via the SDK newtype)
     pub size: u64,               // File size in bytes
     pub mime_type: String,       // Content type
     pub uploaded_by: String,     // Uploader's ID
@@ -71,7 +72,7 @@ pub struct FileShareState {
 ```rust
 upload_file(
     name: String,
-    blob_id_str: String,  // Base58-encoded blob ID
+    blob_id: BlobId,  // Blob ID (base58 string over the wire)
     size: u64,
     mime_type: String
 ) -> Result<String, String>
@@ -79,11 +80,10 @@ upload_file(
 
 **Process:**
 
-1. Parse blob ID from base58
-2. Generate unique file ID
-3. **Announce blob to network** (key blob API usage)
-4. Store file metadata
-5. Emit event
+1. Generate unique file ID
+2. **Announce blob to network** (key blob API usage)
+3. Store file metadata
+4. Emit event
 
 **Example:**
 
@@ -123,7 +123,7 @@ Retrieves a single file's metadata by ID.
 ### Get Blob ID
 
 ```rust
-get_blob_id_b58(file_id: String) -> Result<String, String>
+get_blob_id_b58(file_id: String) -> Result<BlobId, String>
 ```
 
 Returns the base58-encoded blob ID for a file (useful for downloading).
@@ -171,12 +171,11 @@ These events can be subscribed to by clients for real-time updates.
 The key blob API integration happens in `upload_file`:
 
 ```rust
-// 1. Parse the blob ID from client-provided base58 string
-let blob_id = parse_blob_id_base58(&blob_id_str)?;
+// 1. `blob_id: BlobId` is already parsed from its base58 string by the SDK.
 
 // 2. Announce to network - THIS IS THE CORE BLOB API USAGE
 let current_context = env::context_id();
-if env::blob_announce_to_context(&blob_id, &current_context) {
+if env::blob_announce_to_context(blob_id.as_ref(), &current_context) {
     app::log!("✓ Successfully announced blob to network");
 } else {
     app::log!("⚠ Warning: Failed to announce blob");
@@ -185,24 +184,28 @@ if env::blob_announce_to_context(&blob_id, &current_context) {
 
 // 3. Store metadata for later retrieval
 let file_record = FileRecord {
-    blob_id,  // Store raw bytes
+    blob_id,  // Store the BlobId
     // ... other fields
 };
 ```
 
-## Helper Functions
+## Blob ID Encoding
 
-### Base58 Encoding/Decoding
+Base58 ↔ bytes conversion is owned by the SDK's `BlobId` newtype
+(`calimero_sdk::BlobId`), so this app no longer hand-rolls encode/decode
+helpers:
 
 ```rust
-// Encode blob ID to string
-fn encode_blob_id_base58(blob_id_bytes: &[u8; 32]) -> String
+use calimero_sdk::BlobId;
 
-// Decode string to blob ID
-fn parse_blob_id_base58(blob_id_str: &str) -> Result<[u8; 32], String>
+// Base58 string -> BlobId (FromStr)
+let blob_id: BlobId = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty".parse()?;
 
-// Custom serializer for JSON
-fn serialize_blob_id_bytes<S>(blob_id_bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+// BlobId -> base58 string (Display)
+let encoded = blob_id.to_string();
+
+// BlobId -> &[u8; 32] (for env/blob host functions)
+let bytes: &[u8; 32] = blob_id.as_ref();
 ```
 
 ## Complete End-to-End Workflow

--- a/apps/blobs/src/lib.rs
+++ b/apps/blobs/src/lib.rs
@@ -8,63 +8,16 @@
 
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_sdk::{app, env};
+use calimero_sdk::{app, env, BlobId, PublicKey};
 use calimero_storage::collections::{Counter, LwwRegister, UnorderedMap};
 
 // === CONSTANTS ===
-
-/// Size of blob ID in bytes (32 bytes = 256 bits)
-const BLOB_ID_SIZE: usize = 32;
-
-/// Maximum size of base58-encoded blob ID string
-/// Base58 encoding of 32 bytes requires max 44 characters
-const BASE58_ENCODED_MAX_SIZE: usize = 44;
 
 /// Bytes per kilobyte
 const BYTES_PER_KB: f64 = 1024.0;
 
 /// Bytes per megabyte
 const BYTES_PER_MB: f64 = BYTES_PER_KB * 1024.0;
-
-// === BLOB ID ENCODING HELPERS ===
-
-/// Convert blob ID bytes to base58 string
-fn encode_blob_id_base58(blob_id_bytes: &[u8; BLOB_ID_SIZE]) -> String {
-    let mut buf = [0u8; BASE58_ENCODED_MAX_SIZE];
-    let len = bs58::encode(blob_id_bytes).onto(&mut buf[..]).unwrap();
-    std::str::from_utf8(&buf[..len]).unwrap().to_owned()
-}
-
-/// Parse base58 string to blob ID bytes
-fn parse_blob_id_base58(blob_id_str: &str) -> Result<[u8; BLOB_ID_SIZE], String> {
-    match bs58::decode(blob_id_str).into_vec() {
-        Ok(bytes) => {
-            if bytes.len() != BLOB_ID_SIZE {
-                return Err(format!(
-                    "Invalid blob ID length: expected {} bytes, got {}",
-                    BLOB_ID_SIZE,
-                    bytes.len()
-                ));
-            }
-            let mut blob_id = [0u8; BLOB_ID_SIZE];
-            blob_id.copy_from_slice(&bytes);
-            Ok(blob_id)
-        }
-        Err(e) => Err(format!("Failed to decode blob ID '{blob_id_str}': {e}")),
-    }
-}
-
-/// Serialize blob ID as base58 string for JSON responses
-fn serialize_blob_id_bytes<S>(
-    blob_id_bytes: &[u8; BLOB_ID_SIZE],
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: calimero_sdk::serde::Serializer,
-{
-    let safe_string = encode_blob_id_base58(blob_id_bytes);
-    serializer.serialize_str(&safe_string)
-}
 
 // === DATA STRUCTURES ===
 
@@ -79,11 +32,10 @@ pub struct FileRecord {
     /// Human-readable file name (e.g., "document.pdf", "image.png")
     pub name: String,
 
-    /// Blob ID as 32-byte array
-    /// Serialized as base58 string in JSON (e.g., "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
-    /// Note: Must use literal `32` instead of `BLOB_ID_SIZE` const for ABI generator compatibility
-    #[serde(serialize_with = "serialize_blob_id_bytes")]
-    pub blob_id: [u8; 32],
+    /// Blob ID. Serializes to/from a base58 string in JSON (e.g.
+    /// "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty") via the SDK's
+    /// `BlobId` newtype, so no per-app encoding helper is needed.
+    pub blob_id: BlobId,
 
     /// File size in bytes
     pub size: u64,
@@ -170,8 +122,9 @@ impl FileShareState {
     /// Initialize a new file sharing context
     #[app::init]
     pub fn init() -> FileShareState {
-        let owner_id = env::executor_id();
-        let owner = encode_blob_id_base58(&owner_id);
+        // `executor_id()` is the caller's public key, so render it with the
+        // SDK's `PublicKey` newtype rather than the (now-removed) blob helper.
+        let owner = PublicKey::from(env::executor_id()).to_string();
 
         app::log!("Initializing file sharing app for owner: {}", owner);
 
@@ -190,22 +143,20 @@ impl FileShareState {
     ///
     /// # Arguments
     /// * `name` - Human-readable file name
-    /// * `blob_id_str` - Base58-encoded blob ID (obtained from blob client)
+    /// * `blob_id` - Blob ID (base58 string over the wire; obtained from the blob client)
     /// * `size` - File size in bytes
     /// * `mime_type` - MIME type (e.g., "application/pdf", "image/png")
     ///
     /// # Returns
     /// * `Ok(String)` - The generated file ID (e.g., "file_0", "file_1")
-    /// * `Err(String)` - Error message if blob ID is invalid or storage operation fails
+    /// * `Err(String)` - Error message if storage operation fails
     pub fn upload_file(
         &mut self,
         name: String,
-        blob_id_str: String,
+        blob_id: BlobId,
         size: u64,
         mime_type: String,
     ) -> Result<String, String> {
-        let blob_id = parse_blob_id_base58(&blob_id_str)?;
-
         // Counter is a monotonic CRDT — it converges across replicas (taking
         // the per-source max on merge). Using its current value as the file ID
         // means concurrent uploads on different nodes can still pick the same
@@ -219,17 +170,16 @@ impl FileShareState {
             .increment()
             .map_err(|e| format!("Failed to increment file counter: {e:?}"))?;
 
-        let uploader_id = env::executor_id();
-        let uploader = encode_blob_id_base58(&uploader_id);
+        let uploader = PublicKey::from(env::executor_id()).to_string();
         let timestamp = env::time_now();
 
         // BLOB API: Announce blob to network for peer discovery
         // This makes the blob discoverable by other nodes in this context
         let current_context = env::context_id();
-        if env::blob_announce_to_context(&blob_id, &current_context) {
-            app::log!("Announced blob {} to network", blob_id_str);
+        if env::blob_announce_to_context(blob_id.as_ref(), &current_context) {
+            app::log!("Announced blob {} to network", blob_id);
         } else {
-            app::log!("Warning: Failed to announce blob {}", blob_id_str);
+            app::log!("Warning: Failed to announce blob {}", blob_id);
         }
 
         // Create the file record
@@ -344,11 +294,12 @@ impl FileShareState {
     /// * `file_id` - The ID of the file (e.g., "file_0")
     ///
     /// # Returns
-    /// * `Ok(String)` - Base58-encoded blob ID (e.g., "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+    /// * `Ok(BlobId)` - The blob ID (base58 string over the wire, e.g.
+    ///   "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
     /// * `Err(String)` - Error message if file not found
-    pub fn get_blob_id_b58(&self, file_id: String) -> Result<String, String> {
+    pub fn get_blob_id_b58(&self, file_id: String) -> Result<BlobId, String> {
         let file_record = self.get_file(file_id)?;
-        Ok(encode_blob_id_base58(&file_record.blob_id))
+        Ok(file_record.blob_id)
     }
 
     /// Search files by name (case-insensitive substring match)

--- a/apps/blobs/workflows/blobs-example.yml
+++ b/apps/blobs/workflows/blobs-example.yml
@@ -60,7 +60,7 @@ steps:
     method: upload_file
     args:
       name: screenshot.png
-      blob_id_str: "{{png_blob_id}}"
+      blob_id: "{{png_blob_id}}"
       size: "{{png_blob_size}}"
       mime_type: image/png
     outputs:
@@ -91,7 +91,7 @@ steps:
     method: upload_file
     args:
       name: readme.txt
-      blob_id_str: "{{txt_blob_id}}"
+      blob_id: "{{txt_blob_id}}"
       size: "{{txt_blob_size}}"
       mime_type: text/plain
     outputs:

--- a/apps/blobs/workflows/blobs.yml
+++ b/apps/blobs/workflows/blobs.yml
@@ -46,7 +46,7 @@ steps:
     method: upload_file
     args:
       name: screenshot.png
-      blob_id_str: "{{png_blob_id}}"
+      blob_id: "{{png_blob_id}}"
       size: "{{png_blob_size}}"
       mime_type: image/png
     outputs:
@@ -73,7 +73,7 @@ steps:
     method: upload_file
     args:
       name: readme.txt
-      blob_id_str: "{{txt_blob_id}}"
+      blob_id: "{{txt_blob_id}}"
       size: "{{txt_blob_size}}"
       mime_type: text/plain
     outputs:

--- a/apps/xcall-example/Cargo.toml
+++ b/apps/xcall-example/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-bs58 = { version = "0.5", default-features = false, features = ["alloc"] }
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
 thiserror.workspace = true

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::len_without_is_empty)]
 
-use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::{app, ContextId};
 use calimero_storage::collections::Counter;
 
 #[app::state(emits = Event)]
@@ -15,10 +15,10 @@ pub struct XCallExample {
 #[app::event]
 pub enum Event {
     PingSent {
-        to_context: [u8; 32],
+        to_context: ContextId,
     },
     PongReceived {
-        from_context: [u8; 32],
+        from_context: ContextId,
         counter: u64,
     },
 }
@@ -43,20 +43,13 @@ impl XCallExample {
     ///   "target_context": "AmxF5dVaqTTAWNbv4uDJhxdoQTEY1wfv6Ld8Gjbu6Zdk"
     /// }
     /// ```
-    pub fn ping(&mut self, target_context: String) -> app::Result<()> {
-        // Decode the base58 context ID to bytes
-        let target_context_bytes: [u8; 32] = bs58::decode(&target_context)
-            .into_vec()
-            .map_err(|e| {
-                calimero_sdk::types::Error::msg(format!("Failed to decode context ID: {e}"))
-            })?
-            .try_into()
-            .map_err(|_| calimero_sdk::types::Error::msg("Context ID must be exactly 32 bytes"))?;
-
-        let current_context = calimero_sdk::env::context_id();
+    pub fn ping(&mut self, target_context: ContextId) -> app::Result<()> {
+        // `target_context` arrives as a base58 string and is parsed into a
+        // `ContextId` by the SDK — no hand-rolled bs58 decoding needed.
+        let current_context = ContextId::from(calimero_sdk::env::context_id());
 
         app::log!(
-            "Sending ping from context {:?} to context {}",
+            "Sending ping from context {} to context {}",
             current_context,
             target_context
         );
@@ -65,7 +58,7 @@ impl XCallExample {
         #[derive(calimero_sdk::serde::Serialize)]
         #[serde(crate = "calimero_sdk::serde")]
         struct PongParams {
-            from_context: [u8; 32],
+            from_context: ContextId,
         }
 
         let params = calimero_sdk::serde_json::to_vec(&PongParams {
@@ -73,11 +66,11 @@ impl XCallExample {
         })?;
 
         // Make the cross-context call to the pong method
-        calimero_sdk::env::xcall(&target_context_bytes, "pong", &params);
+        calimero_sdk::env::xcall(target_context.as_ref(), "pong", &params);
 
         // Emit an event to notify that a ping was sent
         app::emit!(Event::PingSent {
-            to_context: target_context_bytes,
+            to_context: target_context,
         });
 
         app::log!("Ping sent successfully");
@@ -91,12 +84,12 @@ impl XCallExample {
     /// It increments the counter when a pong is received.
     ///
     /// # Arguments
-    /// * `from_context` - The 32-byte ID of the context sending the pong
-    pub fn pong(&mut self, from_context: [u8; 32]) -> app::Result<()> {
-        let current_context = calimero_sdk::env::context_id();
+    /// * `from_context` - The ID of the context sending the pong (base58 string over the wire)
+    pub fn pong(&mut self, from_context: ContextId) -> app::Result<()> {
+        let current_context = ContextId::from(calimero_sdk::env::context_id());
 
         app::log!(
-            "Context {:?} received pong from {:?}",
+            "Context {} received pong from {}",
             current_context,
             from_context
         );

--- a/crates/primitives/src/blobs.rs
+++ b/crates/primitives/src/blobs.rs
@@ -89,3 +89,44 @@ pub struct BlobMetadata {
     pub hash: [u8; 32],
     pub mime_type: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blob_id_roundtrip() {
+        let blob_id = BlobId::from([1; DIGEST_SIZE]);
+        let encoded = blob_id.to_string();
+        // Same base58 vector as the other 32-byte Hash newtypes for `[1; 32]`.
+        let expected = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi";
+        assert_eq!(encoded, expected);
+        assert_eq!(BlobId::from_str(&encoded).unwrap(), blob_id);
+    }
+
+    #[test]
+    fn test_blob_id_digest_matches_source_bytes() {
+        let bytes = [7; DIGEST_SIZE];
+        let blob_id = BlobId::from(bytes);
+        assert_eq!(blob_id.digest(), &bytes);
+        assert_eq!(blob_id.as_ref(), &bytes);
+    }
+
+    #[test]
+    fn test_blob_id_invalid_base58() {
+        let result = BlobId::from_str("Invalid!");
+        assert!(matches!(
+            result,
+            Err(InvalidBlobId(HashError::DecodeError(_)))
+        ));
+    }
+
+    #[test]
+    fn test_blob_id_json_is_base58_string() {
+        let blob_id = BlobId::from([1; DIGEST_SIZE]);
+        let json = serde_json::to_string(&blob_id).unwrap();
+        assert_eq!(json, "\"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi\"");
+        let parsed: BlobId = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, blob_id);
+    }
+}

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
 calimero-prelude.workspace = true
-calimero-primitives.workspace = true
+calimero-primitives = { workspace = true, features = ["borsh"] }
 calimero-sdk-macros.workspace = true
 calimero-sys.workspace = true
 calimero-wasm-abi.workspace = true

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -23,6 +23,8 @@ pub mod private_storage;
 mod returns;
 pub mod state;
 pub mod types;
+pub use calimero_primitives::blobs::BlobId;
+pub use calimero_primitives::context::ContextId;
 pub use calimero_primitives::identity::PublicKey;
 pub use state::read_raw;
 

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -506,6 +506,12 @@ fn normalize_scalar_type(
             // PublicKey is [u8; 32], so it's bytes with a fixed size
             Ok(TypeRef::bytes_with_size(32, None))
         }
+        // SDK identity newtypes (`calimero_primitives`). Each wraps a 32-byte
+        // Hash and is exposed to apps via `calimero_sdk::{BlobId, ContextId,
+        // ApplicationId}`. They live outside the app's own source, so the
+        // `resolve_local` fallback below can't see them — describe them here
+        // with the same fixed-size-bytes shape as `PublicKey`.
+        "BlobId" | "ContextId" | "ApplicationId" => Ok(TypeRef::bytes_with_size(32, None)),
         // Storage CRDT wrappers – treat as opaque blobs until ABI definitions exist.
         "Counter" => Ok(TypeRef::Collection {
             collection: CollectionType::Record {

--- a/crates/wasm-abi/tests/normalize.rs
+++ b/crates/wasm-abi/tests/normalize.rs
@@ -469,3 +469,42 @@ fn test_authored_collections_preserve_crdt_type() {
         other => panic!("expected Collection variant, got {other:?}"),
     }
 }
+
+#[test]
+fn test_sdk_identity_newtypes_normalize_to_fixed_bytes() {
+    // `BlobId` / `ContextId` / `ApplicationId` are SDK identity newtypes from
+    // `calimero_primitives`, exposed to apps via `calimero_sdk`. They are
+    // defined outside the app's own source, so `MockResolver` (which knows no
+    // local types) returns `None` for them — they only normalize because
+    // `normalize_scalar_type` has an explicit arm. This locks in that they
+    // render as a fixed 32-byte value, matching the long-standing `PublicKey`
+    // behaviour, so apps can take them directly as method params/returns.
+    let resolver = MockResolver::new();
+    let expected = TypeRef::bytes_with_size(32, None);
+
+    assert_eq!(
+        normalize_type(&parse_type("PublicKey"), true, &resolver).unwrap(),
+        expected
+    );
+    assert_eq!(
+        normalize_type(&parse_type("BlobId"), true, &resolver).unwrap(),
+        expected
+    );
+    assert_eq!(
+        normalize_type(&parse_type("ContextId"), true, &resolver).unwrap(),
+        expected
+    );
+    assert_eq!(
+        normalize_type(&parse_type("ApplicationId"), true, &resolver).unwrap(),
+        expected
+    );
+}
+
+#[test]
+fn test_unregistered_external_type_still_errors() {
+    // Guards against the identity arm being widened into a catch-all: a
+    // genuinely unknown, unregistered type must still fail to normalize.
+    let resolver = MockResolver::new();
+    let result = normalize_type(&parse_type("TotallyUnknownExternalType"), true, &resolver);
+    assert!(matches!(result, Err(NormalizeError::TypePathError(_))));
+}


### PR DESCRIPTION
## Summary

Implements #2554. Exposes the existing `calimero_primitives` `BlobId` / `ContextId` newtypes through `calimero_sdk` and uses them in the example apps, deleting the per-app base58 ↔ `[u8;32]` conversion that was reimplemented in each.

These newtypes already existed in `crates/primitives` (wrapping `Hash`, with `Display`/`FromStr`/serde/borsh, serializing as base58). This PR is the **consolidation/wiring** the issue asked for — not new types.

## Changes

- **sdk**: re-export `BlobId` / `ContextId`; enable the `calimero-primitives/borsh` feature (`FileRecord` is Borsh and now holds a `BlobId`).
- **apps/blobs**: drop `encode_blob_id_base58` / `parse_blob_id_base58` / `serialize_blob_id_bytes` and the `bs58` dep; `FileRecord.blob_id` and method signatures use `BlobId`. `executor_id()` is a public key, so it now uses `PublicKey` instead of the (removed) blob helper.
- **apps/xcall-example**: drop the inline `bs58::decode().try_into()` and the `bs58` dep; ping/pong/events use `ContextId`.
- **wasm-abi**: teach `normalize_scalar_type` about `BlobId` / `ContextId` / `ApplicationId` (same fixed 32-byte shape as `PublicKey`). The ABI normalizer is syntactic and app-source-scoped, so these external SDK types would otherwise fail with `unknown type`.
- **tests**: `BlobId` unit tests in primitives; normalize tests for the SDK identity newtypes (and that unknown types still error).
- **docs/workflows**: refresh `apps/blobs/README.md`; rename the `blob_id_str` → `blob_id` arg key in the blobs workflows.

## Compatibility

- **ABI is byte-identical** to before — the newtypes normalize to `bytes size 32`, exactly what `[u8;32]` / `String`+custom-serializer produced. Wire format stays base58 strings over JSON-RPC. The only ABI delta is method **param names**.
- ⚠️ The `upload_file` param rename `blob_id_str` → `blob_id` is breaking for any external caller outside this repo. In-repo workflows and README are updated; downstream clients would need the same rename.

## Verification

`cargo fmt --check` · `clippy` · primitives blob tests (4) · wasm-abi normalize tests (9 pass, 11 pre-existing `#[ignore]`) · `blobs` + `xcall-example` wasm32 builds · `scripts/verify-abi.sh` (abi_conformance golden unchanged) — all green.

Closes #2554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Published SDK surface and a breaking RPC param name for upload_file; ABI/wire encoding is intended to stay compatible, but downstream clients must adopt blob_id and the new types.
> 
> **Overview**
> Exposes **`BlobId`** and **`ContextId`** from `calimero_sdk` (re-exporting `calimero_primitives`) and wires example apps to use them instead of per-app base58 ↔ `[u8; 32]` helpers. The SDK enables **`calimero-primitives/borsh`** so state types like `FileRecord` can store `BlobId` directly.
> 
> **`apps/blobs`** drops `bs58` and local encode/decode/serde helpers; `FileRecord` and `upload_file` / `get_blob_id_b58` use **`BlobId`**, and owner/uploader IDs use **`PublicKey`** instead of misusing blob encoding. **`apps/xcall-example`** uses **`ContextId`** for ping/pong/events and removes inline `bs58` decoding before **`env::xcall`**.
> 
> **`wasm-abi`** treats **`BlobId`**, **`ContextId`**, and **`ApplicationId`** like **`PublicKey`** (fixed 32-byte bytes in the ABI). **Primitives** and **normalize** tests lock in base58 round-trip and that unknown types still error.
> 
> **Breaking for callers:** `upload_file` JSON arg **`blob_id_str` → `blob_id`** (in-repo workflows/README updated). On-wire JSON remains base58 strings; ABI byte shape is unchanged vs prior `[u8; 32]` / custom serializer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3fb879ab84c8189db153a0bf092186deb4fceb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->