### PR TITLE
feat(storage): SortedMap + SortedSet collections with on-disk ordered index (#2559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`SortedMap<K, V>` collection** — a key-ordered map for range queries, prefix scans, and pagination ([#2559])
+  - `range(a..b)`, `prefix("user:")`, `page(offset, limit)`, ascending `entries`/`keys`/`values`, and `first`/`last`
+  - Backed by a node-local, non-synced ordered secondary index (RocksDB `SortedIndex` column): `range`/`prefix` are `O(log n + k)` seeks and `page` is `O(limit)`. Adaptors without an ordered keyspace (e.g. `PrivateStorage`) transparently fall back to an in-memory sort
+  - Same add-wins CRDT merge as `UnorderedMap` — the index is a derived view of the synced entry set, not synced itself, so it adds no merge path and self-heals after a sync via a `full_hash` validity marker
+  - New `apps/sorted-kv-store` example; `SortedMap` ABI marker added to the conformance apps
+
 ## [0.10.1-rc.10] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Backed by a node-local, non-synced ordered secondary index (RocksDB `SortedIndex` column): `range`/`prefix` are `O(log n + k)` seeks and `page` is `O(limit)`. Adaptors without an ordered keyspace (e.g. `PrivateStorage`) transparently fall back to an in-memory sort
   - Same add-wins CRDT merge as `UnorderedMap` — the index is a derived view of the synced entry set, not synced itself, so it adds no merge path and self-heals after a sync via a `full_hash` validity marker
   - New `apps/sorted-kv-store` example; `SortedMap` ABI marker added to the conformance apps
+- **`SortedSet<T>` collection** — the `BTreeSet` to `UnorderedSet`'s `HashSet`: an ordered set with `range`/`prefix`/`page`/`first`/`last`, same add-wins union merge and the same on-disk ordered index as `SortedMap` ([#2559])
 
 ## [0.10.1-rc.10] - 2026-03-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9769,6 +9769,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-kv-store"
+version = "0.0.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+ "calimero-wasm-abi",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
     "./apps/blobs",
     "./apps/collaborative-editor",
     "./apps/kv-store",
+    "./apps/sorted-kv-store",
     "./apps/kv-store-init",
     "./apps/kv-store-with-handlers",
 	"./apps/kv-store-with-user-and-frozen-storage",
@@ -106,6 +107,7 @@ members = [
 
     "./apps/scaffolding-e2e",
     "./apps/kv-store",
+    "./apps/sorted-kv-store",
     "./apps/kv-store-init",
     "./apps/kv-store-with-handlers",
 	"./apps/kv-store-with-user-and-frozen-storage",

--- a/apps/abi_conformance/abi.expected.json
+++ b/apps/abi_conformance/abi.expected.json
@@ -23,6 +23,24 @@
           }
         },
         {
+          "name": "sorted_counters",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "string"
+            },
+            "value": {
+              "kind": "record",
+              "fields": [],
+              "crdt_type": "lww_register",
+              "inner_type": {
+                "kind": "u32"
+              }
+            },
+            "crdt_type": "sorted_map"
+          }
+        },
+        {
           "name": "users",
           "type": {
             "kind": "list",

--- a/apps/abi_conformance/src/lib.rs
+++ b/apps/abi_conformance/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::{Deserialize, Serialize};
-use calimero_storage::collections::{LwwRegister, UnorderedMap, Vector};
+use calimero_storage::collections::{LwwRegister, SortedMap, UnorderedMap, Vector};
 use thiserror::Error;
 
 // Test multi-file ABI generation

--- a/apps/abi_conformance/src/lib.rs
+++ b/apps/abi_conformance/src/lib.rs
@@ -118,6 +118,8 @@ pub enum Event {
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct AbiState {
     counters: UnorderedMap<String, LwwRegister<u32>>,
+    // Key-ordered map — locks the `SortedMap` ABI collection marker.
+    sorted_counters: SortedMap<String, LwwRegister<u32>>,
     users: Vector<LwwRegister<UserId32>>,
 }
 
@@ -129,6 +131,7 @@ impl AbiState {
     pub fn init() -> Self {
         Self {
             counters: UnorderedMap::new_with_field_name("counters"),
+            sorted_counters: SortedMap::new_with_field_name("sorted_counters"),
             users: Vector::new_with_field_name("users"),
         }
     }

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -14,7 +14,9 @@
 
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use calimero_storage::collections::{Counter, LwwRegister, UnorderedMap, UnorderedSet, Vector};
+use calimero_storage::collections::{
+    Counter, LwwRegister, SortedMap, UnorderedMap, UnorderedSet, Vector,
+};
 
 #[app::state(emits = TestEvent)]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -34,6 +36,11 @@ pub struct NestedCrdtTest {
 
     /// Map of sets - union merge
     pub tags: UnorderedMap<String, UnorderedSet<String>>,
+
+    /// Sorted map of registers - same add-wins/LWW merge as `registers`, but
+    /// iterated in ascending key order (exercises SortedMap range queries and
+    /// a CRDT value nested inside a SortedMap).
+    pub sorted_scores: SortedMap<String, LwwRegister<u64>>,
 }
 
 #[app::event]
@@ -60,6 +67,10 @@ pub enum TestEvent {
         key: String,
         tag: String,
     },
+    SortedScoreSet {
+        key: String,
+        value: u64,
+    },
 }
 
 #[app::logic]
@@ -73,6 +84,7 @@ impl NestedCrdtTest {
             metadata: UnorderedMap::new_with_field_name("metadata"),
             metrics: Vector::new_with_field_name("metrics"),
             tags: UnorderedMap::new_with_field_name("tags"),
+            sorted_scores: SortedMap::new_with_field_name("sorted_scores"),
         }
     }
 
@@ -117,6 +129,49 @@ impl NestedCrdtTest {
             .get(&key)?
             .map(|r| r.get().clone())
             .ok_or_else(|| app::err!("Register not found"))
+    }
+
+    // ===== SortedMap Operations =====
+
+    pub fn set_sorted_score(&mut self, key: String, value: u64) -> Result<(), String> {
+        drop(
+            self.sorted_scores
+                .insert(key.clone(), LwwRegister::new(value))
+                .map_err(|e| format!("Insert failed: {:?}", e))?,
+        );
+
+        app::emit!(TestEvent::SortedScoreSet { key, value });
+
+        Ok(())
+    }
+
+    pub fn get_sorted_score(&self, key: String) -> Result<u64, String> {
+        self.sorted_scores
+            .get(&key)
+            .map_err(|e| format!("Get failed: {:?}", e))?
+            .map(|r| *r.get())
+            .ok_or_else(|| "Score not found".to_owned())
+    }
+
+    /// Keys in ascending order — the property that distinguishes SortedMap from
+    /// the unordered `registers` field.
+    pub fn sorted_score_keys(&self) -> Result<Vec<String>, String> {
+        self.sorted_scores
+            .keys()
+            .map(|it| it.collect())
+            .map_err(|e| format!("Keys failed: {:?}", e))
+    }
+
+    /// Scores whose keys fall within `[start, end)`, in ascending order.
+    pub fn sorted_scores_range(
+        &self,
+        start: String,
+        end: String,
+    ) -> Result<Vec<(String, u64)>, String> {
+        self.sorted_scores
+            .range(start..end)
+            .map(|it| it.map(|(k, v)| (k, *v.get())).collect())
+            .map_err(|e| format!("Range failed: {:?}", e))
     }
 
     // ===== Nested Map Operations =====

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -133,11 +133,10 @@ impl NestedCrdtTest {
 
     // ===== SortedMap Operations =====
 
-    pub fn set_sorted_score(&mut self, key: String, value: u64) -> Result<(), String> {
+    pub fn set_sorted_score(&mut self, key: String, value: u64) -> app::Result<()> {
         drop(
             self.sorted_scores
-                .insert(key.clone(), LwwRegister::new(value))
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
+                .insert(key.clone(), LwwRegister::new(value))?,
         );
 
         app::emit!(TestEvent::SortedScoreSet { key, value });
@@ -145,21 +144,18 @@ impl NestedCrdtTest {
         Ok(())
     }
 
-    pub fn get_sorted_score(&self, key: String) -> Result<u64, String> {
-        self.sorted_scores
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .map(|r| *r.get())
-            .ok_or_else(|| "Score not found".to_owned())
+    pub fn get_sorted_score(&self, key: String) -> app::Result<u64> {
+        let Some(register) = self.sorted_scores.get(&key)? else {
+            app::bail!("Score not found");
+        };
+
+        Ok(*register.get())
     }
 
     /// Keys in ascending order — the property that distinguishes SortedMap from
     /// the unordered `registers` field.
-    pub fn sorted_score_keys(&self) -> Result<Vec<String>, String> {
-        self.sorted_scores
-            .keys()
-            .map(|it| it.collect())
-            .map_err(|e| format!("Keys failed: {:?}", e))
+    pub fn sorted_score_keys(&self) -> app::Result<Vec<String>> {
+        Ok(self.sorted_scores.keys()?.collect())
     }
 
     /// Scores whose keys fall within `[start, end)`, in ascending order.
@@ -167,11 +163,12 @@ impl NestedCrdtTest {
         &self,
         start: String,
         end: String,
-    ) -> Result<Vec<(String, u64)>, String> {
-        self.sorted_scores
-            .range(start..end)
-            .map(|it| it.map(|(k, v)| (k, *v.get())).collect())
-            .map_err(|e| format!("Range failed: {:?}", e))
+    ) -> app::Result<Vec<(String, u64)>> {
+        Ok(self
+            .sorted_scores
+            .range(start..end)?
+            .map(|(k, v)| (k, *v.get()))
+            .collect())
     }
 
     // ===== Nested Map Operations =====

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -528,6 +528,11 @@ impl E2eKvStore {
             .collect())
     }
 
+    /// The largest key (reverse-seek `last`, index-backed).
+    pub fn sorted_last_key(&self) -> app::Result<Option<String>> {
+        Ok(self.sorted_items.last()?.map(|(k, _)| k))
+    }
+
     pub fn len(&self) -> app::Result<usize> {
         app::log!("Getting the number of entries");
         Ok(self.kv_items.len()?)

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -26,8 +26,8 @@ use calimero_sdk::serde::Serialize;
 use calimero_sdk::{app, env, PublicKey};
 use calimero_storage::collections::{
     AuthoredMap, AuthoredVector, Counter, FrozenStorage, GCounter, LwwRegister, Mergeable,
-    PNCounter, ReplicatedGrowableArray, SharedStorage, UnorderedMap, UnorderedSet, UserStorage,
-    Vector,
+    PNCounter, ReplicatedGrowableArray, SharedStorage, SortedMap, UnorderedMap, UnorderedSet,
+    UserStorage, Vector,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -150,6 +150,10 @@ pub struct E2eKvStore {
     crdt_metrics: Vector<Counter>,
     /// Map of sets (union merge)
     crdt_tags: UnorderedMap<String, UnorderedSet<String>>,
+
+    // --- Sorted Map (key-ordered; range/prefix/pagination) ---
+    /// Key-ordered map exercised end-to-end through the WASM host index path.
+    sorted_items: SortedMap<String, LwwRegister<String>>,
 
     // --- RGA Document ---
     /// Collaborative text document
@@ -408,6 +412,7 @@ impl E2eKvStore {
             crdt_metadata: UnorderedMap::new(),
             crdt_metrics: Vector::new(),
             crdt_tags: UnorderedMap::new(),
+            sorted_items: SortedMap::new(),
             // RGA
             rga_document: ReplicatedGrowableArray::new(),
             rga_edit_count: GCounter::new(),
@@ -490,6 +495,35 @@ impl E2eKvStore {
         Ok(self
             .kv_items
             .entries()?
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
+    }
+
+    // --- SortedMap (key-ordered) operations ---
+    //
+    // These drive the WASM host ordered-index path end to end: `sorted_set`
+    // maintains the index via `storage_index_set`; `sorted_keys`/`sorted_range`
+    // read it back via `storage_index_scan`.
+
+    pub fn sorted_set(&mut self, key: String, value: String) -> app::Result<()> {
+        self.sorted_items.insert(key, value.into())?;
+        Ok(())
+    }
+
+    /// All keys in ascending order (index-backed).
+    pub fn sorted_keys(&self) -> app::Result<Vec<String>> {
+        Ok(self.sorted_items.keys()?.collect())
+    }
+
+    /// Entries whose keys fall within `[start, end)`, ascending (a range seek).
+    pub fn sorted_range(
+        &self,
+        start: String,
+        end: String,
+    ) -> app::Result<BTreeMap<String, String>> {
+        Ok(self
+            .sorted_items
+            .range(start..end)?
             .map(|(k, v)| (k, v.get().clone()))
             .collect())
     }

--- a/apps/sorted-kv-store/Cargo.toml
+++ b/apps/sorted-kv-store/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sorted-kv-store"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+thiserror.workspace = true
+calimero-sdk.workspace = true
+calimero-storage.workspace = true
+
+[build-dependencies]
+calimero-wasm-abi.workspace = true
+serde_json.workspace = true
+
+[package.metadata.workspaces]
+independent = true

--- a/apps/sorted-kv-store/build.rs
+++ b/apps/sorted-kv-store/build.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::Path;
+
+use calimero_wasm_abi::emitter::emit_manifest;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/lib.rs");
+
+    // Parse the source code
+    let src_path = Path::new("src/lib.rs");
+    let src_content = fs::read_to_string(src_path).expect("Failed to read src/lib.rs");
+
+    // Generate ABI manifest using the emitter
+    let manifest = emit_manifest(&src_content).expect("Failed to emit ABI manifest");
+
+    // Serialize the manifest to JSON
+    let json = serde_json::to_string_pretty(&manifest).expect("Failed to serialize manifest");
+
+    // Write the ABI JSON to the res directory
+    let res_dir = Path::new("res");
+    if !res_dir.exists() {
+        fs::create_dir_all(res_dir).expect("Failed to create res directory");
+    }
+
+    let abi_path = res_dir.join("abi.json");
+    fs::write(&abi_path, json).expect("Failed to write ABI JSON");
+
+    // Extract and write the state schema
+    if let Ok(mut state_schema) = manifest.extract_state_schema() {
+        state_schema.schema_version = "wasm-abi/1".to_owned();
+
+        let state_schema_json =
+            serde_json::to_string_pretty(&state_schema).expect("Failed to serialize state schema");
+        let state_schema_path = res_dir.join("state-schema.json");
+        fs::write(&state_schema_path, state_schema_json)
+            .expect("Failed to write state schema JSON");
+    }
+}

--- a/apps/sorted-kv-store/src/lib.rs
+++ b/apps/sorted-kv-store/src/lib.rs
@@ -1,0 +1,179 @@
+//! Canonical example for [`SortedMap`] — a key-ordered collection that supports
+//! range queries, prefix scans, and pagination (core#2559).
+//!
+//! Mirrors `kv-store` (the `UnorderedMap` example) so the two can be compared
+//! side by side: the storage/CRDT behaviour is identical; the difference is that
+//! every iteration here comes back in ascending key order, and the extra
+//! `range` / `prefix` / `page` / `first` / `last` methods let you read a slice
+//! of the keyspace without loading the whole map.
+
+#![allow(clippy::len_without_is_empty)]
+
+use std::collections::BTreeMap;
+
+use calimero_sdk::app;
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::serde::Serialize;
+use calimero_storage::collections::{LwwRegister, SortedMap};
+use thiserror::Error;
+
+#[app::state(emits = for<'a> Event<'a>)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
+pub struct SortedKvStore {
+    items: SortedMap<String, LwwRegister<String>>,
+}
+
+#[app::event]
+pub enum Event<'a> {
+    Inserted { key: &'a str, value: &'a str },
+    Updated { key: &'a str, value: &'a str },
+    Removed { key: &'a str },
+    Cleared,
+}
+
+#[derive(Debug, Error, Serialize)]
+#[serde(crate = "calimero_sdk::serde")]
+#[serde(tag = "kind", content = "data")]
+pub enum Error<'a> {
+    #[error("key not found: {0}")]
+    NotFound(&'a str),
+}
+
+/// A single key/value pair, returned by `first`/`last`. (A record rather than a
+/// tuple because the ABI represents named-field records, not tuples.)
+#[derive(Debug, Serialize)]
+#[serde(crate = "calimero_sdk::serde")]
+pub struct Entry {
+    pub key: String,
+    pub value: String,
+}
+
+#[app::logic]
+impl SortedKvStore {
+    #[app::init]
+    pub fn init() -> SortedKvStore {
+        SortedKvStore {
+            items: SortedMap::new_with_field_name("items"),
+        }
+    }
+
+    pub fn set(&mut self, key: String, value: String) -> app::Result<()> {
+        app::log!("Setting key: {:?} to value: {:?}", key, value);
+
+        if self.items.contains(&key)? {
+            app::emit!(Event::Updated {
+                key: &key,
+                value: &value,
+            });
+        } else {
+            app::emit!(Event::Inserted {
+                key: &key,
+                value: &value,
+            });
+        }
+
+        self.items.insert(key, value.into())?;
+
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> app::Result<Option<String>> {
+        app::log!("Getting key: {:?}", key);
+
+        Ok(self.items.get(key)?.map(|v| v.get().clone()))
+    }
+
+    pub fn get_result(&self, key: &str) -> app::Result<String> {
+        let Some(value) = self.get(key)? else {
+            app::bail!(Error::NotFound(key));
+        };
+
+        Ok(value)
+    }
+
+    pub fn remove(&mut self, key: &str) -> app::Result<Option<String>> {
+        app::log!("Removing key: {:?}", key);
+
+        app::emit!(Event::Removed { key });
+
+        Ok(self.items.remove(key)?.map(|v| v.get().clone()))
+    }
+
+    pub fn clear(&mut self) -> app::Result<()> {
+        app::log!("Clearing all entries");
+
+        app::emit!(Event::Cleared);
+
+        self.items.clear().map_err(Into::into)
+    }
+
+    pub fn len(&self) -> app::Result<usize> {
+        Ok(self.items.len()?)
+    }
+
+    /// All entries, **in ascending key order** (the headline difference from
+    /// `kv-store`'s `UnorderedMap`).
+    pub fn entries(&self) -> app::Result<BTreeMap<String, String>> {
+        app::log!("Getting all entries (sorted)");
+
+        Ok(self
+            .items
+            .entries()?
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
+    }
+
+    /// Entries whose keys fall within `[start, end)`, ascending — a range query
+    /// backed by the ordered index (no full scan). Returned as a key-ordered
+    /// map.
+    pub fn range(&self, start: String, end: String) -> app::Result<BTreeMap<String, String>> {
+        app::log!("Range query: [{:?}, {:?})", start, end);
+
+        Ok(self
+            .items
+            .range(start..end)?
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
+    }
+
+    /// Entries whose keys start with `prefix`, ascending — e.g. `prefix("user:")`.
+    pub fn prefix(&self, prefix: String) -> app::Result<BTreeMap<String, String>> {
+        app::log!("Prefix scan: {:?}", prefix);
+
+        Ok(self
+            .items
+            .prefix(prefix.as_bytes())?
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
+    }
+
+    /// A page of `limit` entries starting at `offset`, ascending — paginate
+    /// without materialising the whole map.
+    pub fn page(&self, offset: usize, limit: usize) -> app::Result<BTreeMap<String, String>> {
+        app::log!("Page: offset={offset} limit={limit}");
+
+        Ok(self
+            .items
+            .page(offset, limit)?
+            .into_iter()
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect())
+    }
+
+    /// The entry with the smallest key.
+    pub fn first(&self) -> app::Result<Option<Entry>> {
+        Ok(self.items.first()?.map(|(key, v)| Entry {
+            key,
+            value: v.get().clone(),
+        }))
+    }
+
+    /// The entry with the largest key.
+    pub fn last(&self) -> app::Result<Option<Entry>> {
+        Ok(self.items.last()?.map(|(key, v)| Entry {
+            key,
+            value: v.get().clone(),
+        }))
+    }
+}

--- a/apps/state-schema-conformance/src/lib.rs
+++ b/apps/state-schema-conformance/src/lib.rs
@@ -3,7 +3,9 @@
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::{Deserialize, Serialize};
-use calimero_storage::collections::{Counter, LwwRegister, UnorderedMap, UnorderedSet, Vector};
+use calimero_storage::collections::{
+    Counter, LwwRegister, SortedMap, UnorderedMap, UnorderedSet, Vector,
+};
 
 // Test types for state schema conformance
 
@@ -74,6 +76,12 @@ pub struct StateSchemaConformance {
     record_map: UnorderedMap<String, LwwRegister<Person>>, // map<string, Person>
     nested_map: UnorderedMap<String, UnorderedMap<String, LwwRegister<u32>>>, // map<string, map<string, u32>> (direct nesting)
 
+    // Sorted maps (key-ordered): same shapes as the maps above but iterated in
+    // ascending key order. Exercises the SortedMap ABI marker and nesting.
+    sorted_string_map: SortedMap<String, LwwRegister<String>>, // sorted map<string, string>
+    sorted_counter_map: SortedMap<String, Counter>,            // sorted map<string, Counter>
+    map_of_sorted_maps: UnorderedMap<String, SortedMap<String, LwwRegister<u32>>>, // map<string, sorted map<string, u32>>
+
     // Lists using Vector (Calimero collection) - Vector items must be CRDTs
     counter_list: Vector<Counter>,              // list<Counter>
     register_list: Vector<LwwRegister<String>>, // list<LwwRegister<String>>
@@ -115,6 +123,9 @@ impl StateSchemaConformance {
             int_map: UnorderedMap::new_with_field_name("int_map"),
             record_map: UnorderedMap::new_with_field_name("record_map"),
             nested_map: UnorderedMap::new_with_field_name("nested_map"),
+            sorted_string_map: SortedMap::new_with_field_name("sorted_string_map"),
+            sorted_counter_map: SortedMap::new_with_field_name("sorted_counter_map"),
+            map_of_sorted_maps: UnorderedMap::new_with_field_name("map_of_sorted_maps"),
             counter_list: Vector::new_with_field_name("counter_list"),
             register_list: Vector::new_with_field_name("register_list"),
             record_list: Vector::new_with_field_name("record_list"),

--- a/apps/state-schema-conformance/src/lib.rs
+++ b/apps/state-schema-conformance/src/lib.rs
@@ -4,7 +4,7 @@ use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::{Deserialize, Serialize};
 use calimero_storage::collections::{
-    Counter, LwwRegister, SortedMap, UnorderedMap, UnorderedSet, Vector,
+    Counter, LwwRegister, SortedMap, SortedSet, UnorderedMap, UnorderedSet, Vector,
 };
 
 // Test types for state schema conformance
@@ -94,7 +94,8 @@ pub struct StateSchemaConformance {
     list_of_maps: Vector<UnorderedMap<String, LwwRegister<u32>>>, // list<map<string, u32>>
 
     // Sets
-    string_set: UnorderedSet<String>, // set<string>
+    string_set: UnorderedSet<String>,     // set<string>
+    sorted_string_set: SortedSet<String>, // sorted set<string> (range/prefix)
 
     // Counters
     visit_counter: Counter, // counter
@@ -134,6 +135,7 @@ impl StateSchemaConformance {
             map_of_lists: UnorderedMap::new_with_field_name("map_of_lists"),
             list_of_maps: Vector::new_with_field_name("list_of_maps"),
             string_set: UnorderedSet::new_with_field_name("string_set"),
+            sorted_string_set: SortedSet::new_with_field_name("sorted_string_set"),
             visit_counter: Counter::new_with_field_name("visit_counter"),
             profile_map: UnorderedMap::new_with_field_name("profile_map"),
             status: LwwRegister::new(Status::Inactive),

--- a/apps/state-schema-conformance/state-schema.expected.json
+++ b/apps/state-schema-conformance/state-schema.expected.json
@@ -131,6 +131,64 @@
           }
         },
         {
+          "name": "sorted_string_map",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "string"
+            },
+            "value": {
+              "kind": "record",
+              "fields": [],
+              "crdt_type": "lww_register",
+              "inner_type": {
+                "kind": "string"
+              }
+            },
+            "crdt_type": "sorted_map"
+          }
+        },
+        {
+          "name": "sorted_counter_map",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "string"
+            },
+            "value": {
+              "kind": "record",
+              "fields": [],
+              "crdt_type": "counter"
+            },
+            "crdt_type": "sorted_map"
+          }
+        },
+        {
+          "name": "map_of_sorted_maps",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "string"
+            },
+            "value": {
+              "kind": "map",
+              "key": {
+                "kind": "string"
+              },
+              "value": {
+                "kind": "record",
+                "fields": [],
+                "crdt_type": "lww_register",
+                "inner_type": {
+                  "kind": "u32"
+                }
+              },
+              "crdt_type": "sorted_map"
+            },
+            "crdt_type": "unordered_map"
+          }
+        },
+        {
           "name": "counter_list",
           "type": {
             "kind": "list",
@@ -252,6 +310,16 @@
               "kind": "string"
             },
             "crdt_type": "unordered_set"
+          }
+        },
+        {
+          "name": "sorted_string_set",
+          "type": {
+            "kind": "list",
+            "items": {
+              "kind": "string"
+            },
+            "crdt_type": "sorted_set"
           }
         },
         {

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -200,7 +200,8 @@ impl Storage for ContextStorage {
         let lo = self.index_key(prefix);
         let hi = prefix_upper_bound(&lo);
         let store = self.borrow_index_store();
-        if let Ok(pairs) = store.raw_scan(Column::SortedIndex, &lo, &hi) {
+        // Unbounded: we need every key under the prefix to delete it.
+        if let Ok(pairs) = store.raw_scan(Column::SortedIndex, &lo, &hi, None) {
             for (k, _) in pairs {
                 let _ = store.raw_delete(Column::SortedIndex, &k);
             }
@@ -216,9 +217,12 @@ impl Storage for ContextStorage {
     ) -> Vec<(Vec<u8>, Vec<u8>)> {
         let full_lo = self.index_key(lo);
         let full_hi = self.index_key(hi);
+        // Stop the seek after `offset + limit` items so a bounded read walks
+        // O(offset + limit), not the whole range.
+        let max = limit.map(|n| offset.saturating_add(n));
         let pairs = self
             .borrow_index_store()
-            .raw_scan(Column::SortedIndex, &full_lo, &full_hi)
+            .raw_scan(Column::SortedIndex, &full_lo, &full_hi, max)
             .unwrap_or_default();
         // Strip the 32-byte context prefix to hand back the adaptor-level key.
         let stripped = pairs

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use calimero_primitives::context::ContextId;
 use calimero_runtime::store::{Key, Storage, Value};
+use calimero_store::db::Column;
 use calimero_store::layer::temporal::Temporal;
 use calimero_store::layer::{ReadLayer, WriteLayer};
 use calimero_store::{key, Store};
@@ -15,12 +16,34 @@ use ouroboros::self_referencing;
 pub struct ContextStorage {
     context_id: ContextId,
     store: Store,
+    /// Second handle to the same DB (cheap — the backend is `Arc`-shared) for
+    /// the node-local ordered secondary index (`SortedMap`, core#2559). The
+    /// synced `store` above is borrowed by `inner` (the temporal transaction),
+    /// so the index — which lives in a *separate*, non-synced column and is
+    /// written immediately rather than through the transaction — needs its own
+    /// handle.
+    index_store: Store,
 
     #[covariant]
     #[borrows(mut store)]
     inner: Temporal<'this, 'static, Store>,
     // todo! unideal, will revisit the shape of WriteLayer to own keys (since they are now fixed-sized)
     keys: RefCell<Vec<Arc<key::ContextState>>>,
+}
+
+/// The exclusive upper bound for a byte prefix (smallest key not starting with
+/// `prefix`) — used to scan/clear "all keys under this prefix".
+fn prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
+    let mut end = prefix.to_vec();
+    while let Some(&last) = end.last() {
+        if last == 0xFF {
+            let _ = end.pop();
+        } else {
+            *end.last_mut().expect("non-empty") += 1;
+            return end;
+        }
+    }
+    vec![0xFF; prefix.len() + 1]
 }
 
 /// Node-local private storage that is NOT synchronized across nodes.
@@ -49,13 +72,26 @@ unsafe impl Send for ContextStorage {}
 
 impl ContextStorage {
     pub fn from(store: Store, context_id: ContextId) -> Self {
+        let index_store = store.clone();
         ContextStorageBuilder {
             context_id,
+            index_store,
             store,
             inner_builder: |store| Temporal::new(store),
             keys: RefCell::default(),
         }
         .build()
+    }
+
+    /// Scope an ordered-index key to this context: `context_id ‖ key`. The
+    /// `key` is the adaptor's `collection ‖ order_key`; prefixing the context
+    /// keeps different contexts' indexes disjoint in the shared column.
+    fn index_key(&self, key: &[u8]) -> Vec<u8> {
+        let context = self.borrow_context_id();
+        let mut out = Vec::with_capacity(32 + key.len());
+        out.extend_from_slice(context.as_ref());
+        out.extend_from_slice(key);
+        out
     }
 
     fn state_key(&self, key: &[u8]) -> Option<&'static key::ContextState> {
@@ -139,6 +175,60 @@ impl Storage for ContextStorage {
         };
 
         self.borrow_inner().has(key).unwrap_or_default()
+    }
+
+    // Ordered secondary index (SortedMap, core#2559) — node-local, written
+    // straight to the non-synced `Column::SortedIndex` via the second store
+    // handle (not the temporal transaction). Keys are `context_id ‖ collection
+    // ‖ order_key` (all unhashed), so RocksDB's byte order is the key order.
+
+    fn index_set(&mut self, key: &[u8], value: &[u8]) {
+        let full = self.index_key(key);
+        let _ = self
+            .borrow_index_store()
+            .raw_put(Column::SortedIndex, &full, value);
+    }
+
+    fn index_del(&mut self, key: &[u8]) {
+        let full = self.index_key(key);
+        let _ = self
+            .borrow_index_store()
+            .raw_delete(Column::SortedIndex, &full);
+    }
+
+    fn index_del_prefix(&mut self, prefix: &[u8]) {
+        let lo = self.index_key(prefix);
+        let hi = prefix_upper_bound(&lo);
+        let store = self.borrow_index_store();
+        if let Ok(pairs) = store.raw_scan(Column::SortedIndex, &lo, &hi) {
+            for (k, _) in pairs {
+                let _ = store.raw_delete(Column::SortedIndex, &k);
+            }
+        }
+    }
+
+    fn index_scan(
+        &self,
+        lo: &[u8],
+        hi: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let full_lo = self.index_key(lo);
+        let full_hi = self.index_key(hi);
+        let pairs = self
+            .borrow_index_store()
+            .raw_scan(Column::SortedIndex, &full_lo, &full_hi)
+            .unwrap_or_default();
+        // Strip the 32-byte context prefix to hand back the adaptor-level key.
+        let stripped = pairs
+            .into_iter()
+            .filter_map(|(k, v)| k.get(32..).map(|key| (key.to_vec(), v)))
+            .skip(offset);
+        match limit {
+            Some(n) => stripped.take(n).collect(),
+            None => stripped.collect(),
+        }
     }
 }
 

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -234,6 +234,17 @@ impl Storage for ContextStorage {
             None => stripped.collect(),
         }
     }
+
+    fn index_last(&self, lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        let full_lo = self.index_key(lo);
+        let full_hi = self.index_key(hi);
+        let (k, v) = self
+            .borrow_index_store()
+            .raw_last(Column::SortedIndex, &full_lo, &full_hi)
+            .ok()??;
+        // Strip the 32-byte context prefix.
+        Some((k.get(32..)?.to_vec(), v))
+    }
 }
 
 // Same safety reasoning as ContextStorage

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -226,10 +226,27 @@ impl Storage for ContextStorage {
         // Stop the seek after `offset + limit` items so a bounded read walks
         // O(offset + limit), not the whole range.
         let max = limit.map(|n| offset.saturating_add(n));
-        let pairs = self
-            .borrow_index_store()
-            .raw_scan(Column::SortedIndex, &full_lo, &full_hi, max)
-            .unwrap_or_default();
+        // A scan error must not masquerade as "no entries": log it loudly so a
+        // backend fault is visible rather than silently dropping rows. The
+        // authoritative entity set is untouched, and the next ordered read
+        // rebuilds the index via the validity marker, so an empty page here is a
+        // recoverable degradation, not data loss.
+        let pairs = match self.borrow_index_store().raw_scan(
+            Column::SortedIndex,
+            &full_lo,
+            &full_hi,
+            max,
+        ) {
+            Ok(pairs) => pairs,
+            Err(error) => {
+                tracing::error!(
+                    target: "calimero_context::sorted_index",
+                    %error,
+                    "ordered-index scan failed; returning an empty page (entities intact, index self-heals on next read)"
+                );
+                Vec::new()
+            }
+        };
         // Strip the context-id prefix to hand back the adaptor-level key.
         let plen = self.index_prefix_len();
         let stripped = pairs

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -83,13 +83,21 @@ impl ContextStorage {
         .build()
     }
 
+    /// Byte length of the context-id prefix stamped onto every index key.
+    /// Derived from the live id (not hardcoded) so the strip on readback stays
+    /// in lockstep with [`Self::index_key`].
+    fn index_prefix_len(&self) -> usize {
+        self.borrow_context_id().as_ref().len()
+    }
+
     /// Scope an ordered-index key to this context: `context_id ‖ key`. The
     /// `key` is the adaptor's `collection ‖ order_key`; prefixing the context
     /// keeps different contexts' indexes disjoint in the shared column.
     fn index_key(&self, key: &[u8]) -> Vec<u8> {
         let context = self.borrow_context_id();
-        let mut out = Vec::with_capacity(32 + key.len());
-        out.extend_from_slice(context.as_ref());
+        let context = context.as_ref();
+        let mut out = Vec::with_capacity(context.len() + key.len());
+        out.extend_from_slice(context);
         out.extend_from_slice(key);
         out
     }
@@ -182,30 +190,28 @@ impl Storage for ContextStorage {
     // handle (not the temporal transaction). Keys are `context_id ‖ collection
     // ‖ order_key` (all unhashed), so RocksDB's byte order is the key order.
 
-    fn index_set(&mut self, key: &[u8], value: &[u8]) {
+    fn index_set(&mut self, key: &[u8], value: &[u8]) -> bool {
         let full = self.index_key(key);
-        let _ = self
-            .borrow_index_store()
-            .raw_put(Column::SortedIndex, &full, value);
+        self.borrow_index_store()
+            .raw_put(Column::SortedIndex, &full, value)
+            .is_ok()
     }
 
-    fn index_del(&mut self, key: &[u8]) {
+    fn index_del(&mut self, key: &[u8]) -> bool {
         let full = self.index_key(key);
-        let _ = self
-            .borrow_index_store()
-            .raw_delete(Column::SortedIndex, &full);
+        self.borrow_index_store()
+            .raw_delete(Column::SortedIndex, &full)
+            .is_ok()
     }
 
-    fn index_del_prefix(&mut self, prefix: &[u8]) {
+    fn index_del_prefix(&mut self, prefix: &[u8]) -> bool {
         let lo = self.index_key(prefix);
         let hi = prefix_upper_bound(&lo);
-        let store = self.borrow_index_store();
-        // Unbounded: we need every key under the prefix to delete it.
-        if let Ok(pairs) = store.raw_scan(Column::SortedIndex, &lo, &hi, None) {
-            for (k, _) in pairs {
-                let _ = store.raw_delete(Column::SortedIndex, &k);
-            }
-        }
+        // One range tombstone over the prefix slice — no scan, no per-key
+        // delete, no unbounded buffer of the collection's keys.
+        self.borrow_index_store()
+            .raw_delete_range(Column::SortedIndex, &lo, &hi)
+            .is_ok()
     }
 
     fn index_scan(
@@ -224,10 +230,11 @@ impl Storage for ContextStorage {
             .borrow_index_store()
             .raw_scan(Column::SortedIndex, &full_lo, &full_hi, max)
             .unwrap_or_default();
-        // Strip the 32-byte context prefix to hand back the adaptor-level key.
+        // Strip the context-id prefix to hand back the adaptor-level key.
+        let plen = self.index_prefix_len();
         let stripped = pairs
             .into_iter()
-            .filter_map(|(k, v)| k.get(32..).map(|key| (key.to_vec(), v)))
+            .filter_map(|(k, v)| k.get(plen..).map(|key| (key.to_vec(), v)))
             .skip(offset);
         match limit {
             Some(n) => stripped.take(n).collect(),
@@ -242,8 +249,8 @@ impl Storage for ContextStorage {
             .borrow_index_store()
             .raw_last(Column::SortedIndex, &full_lo, &full_hi)
             .ok()??;
-        // Strip the 32-byte context prefix.
-        Some((k.get(32..)?.to_vec(), v))
+        // Strip the context-id prefix.
+        Some((k.get(self.index_prefix_len()..)?.to_vec(), v))
     }
 }
 

--- a/crates/primitives/src/crdt.rs
+++ b/crates/primitives/src/crdt.rs
@@ -102,6 +102,17 @@ pub enum CrdtType {
         element_type: String,
     },
 
+    /// Sorted Set.
+    ///
+    /// Same add-wins union merge as [`UnorderedSet`](Self::UnorderedSet), but
+    /// iterated in ascending element order to support range and prefix queries.
+    /// Ordering is derived from `T: Ord` — no extra state is synced.
+    /// Merge: Union of all elements from both sets.
+    SortedSet {
+        /// Element type name
+        element_type: String,
+    },
+
     /// Vector (ordered collection).
     ///
     /// Ordered list with append operations.
@@ -187,6 +198,14 @@ impl CrdtType {
         }
     }
 
+    /// Create a SortedSet with a known element type.
+    #[must_use]
+    pub fn sorted_set(element_type: impl Into<String>) -> Self {
+        Self::SortedSet {
+            element_type: element_type.into(),
+        }
+    }
+
     /// Create a Vector with a known element type.
     #[must_use]
     pub fn vector(element_type: impl Into<String>) -> Self {
@@ -204,7 +223,7 @@ impl CrdtType {
     /// Returns `true` if this is a set type.
     #[must_use]
     pub const fn is_set(&self) -> bool {
-        matches!(self, Self::UnorderedSet { .. })
+        matches!(self, Self::UnorderedSet { .. } | Self::SortedSet { .. })
     }
 
     /// Returns `true` if this is a collection type (map, set, vector, or array).
@@ -215,6 +234,7 @@ impl CrdtType {
             Self::UnorderedMap { .. }
                 | Self::SortedMap { .. }
                 | Self::UnorderedSet { .. }
+                | Self::SortedSet { .. }
                 | Self::Vector { .. }
                 | Self::Rga
         )
@@ -267,6 +287,7 @@ mod tests {
     #[test]
     fn test_is_set() {
         assert!(CrdtType::unordered_set("String").is_set());
+        assert!(CrdtType::sorted_set("String").is_set());
         assert!(!CrdtType::unordered_map("String", "u64").is_set());
         assert!(!CrdtType::sorted_map("String", "u64").is_set());
         assert!(!CrdtType::vector("u64").is_set());
@@ -277,6 +298,7 @@ mod tests {
         assert!(CrdtType::unordered_map("String", "u64").is_collection());
         assert!(CrdtType::sorted_map("String", "u64").is_collection());
         assert!(CrdtType::unordered_set("String").is_collection());
+        assert!(CrdtType::sorted_set("String").is_collection());
         assert!(CrdtType::vector("u64").is_collection());
         assert!(CrdtType::Rga.is_collection());
         assert!(!CrdtType::lww_register("u64").is_collection());
@@ -326,6 +348,7 @@ mod tests {
             CrdtType::unordered_map("String", "u64"),
             CrdtType::sorted_map("String", "u64"),
             CrdtType::unordered_set("String"),
+            CrdtType::sorted_set("String"),
             CrdtType::vector("u64"),
             CrdtType::UserStorage,
             CrdtType::FrozenStorage,
@@ -352,6 +375,7 @@ mod tests {
             CrdtType::unordered_map("String", "u64"),
             CrdtType::sorted_map("String", "u64"),
             CrdtType::unordered_set("String"),
+            CrdtType::sorted_set("String"),
             CrdtType::vector("u64"),
             CrdtType::UserStorage,
             CrdtType::FrozenStorage,

--- a/crates/primitives/src/crdt.rs
+++ b/crates/primitives/src/crdt.rs
@@ -77,6 +77,21 @@ pub enum CrdtType {
         value_type: String,
     },
 
+    /// Sorted Map.
+    ///
+    /// Key-value store with the same add-wins merge semantics as
+    /// [`UnorderedMap`](Self::UnorderedMap), but iterated in ascending key
+    /// order to support range and prefix queries. The ordering is derived from
+    /// `K: Ord` and is therefore a pure function of the key set — no extra
+    /// state is synced and merge is byte-identical to `UnorderedMap`.
+    /// Merge: Union of keys, recursive merge of values.
+    SortedMap {
+        /// Key type name
+        key_type: String,
+        /// Value type name (may be a nested CRDT)
+        value_type: String,
+    },
+
     /// Unordered Set.
     ///
     /// Collection of unique values with add-wins semantics.
@@ -155,6 +170,15 @@ impl CrdtType {
         }
     }
 
+    /// Create a SortedMap with known key and value types.
+    #[must_use]
+    pub fn sorted_map(key_type: impl Into<String>, value_type: impl Into<String>) -> Self {
+        Self::SortedMap {
+            key_type: key_type.into(),
+            value_type: value_type.into(),
+        }
+    }
+
     /// Create an UnorderedSet with a known element type.
     #[must_use]
     pub fn unordered_set(element_type: impl Into<String>) -> Self {
@@ -188,7 +212,11 @@ impl CrdtType {
     pub const fn is_collection(&self) -> bool {
         matches!(
             self,
-            Self::UnorderedMap { .. } | Self::UnorderedSet { .. } | Self::Vector { .. } | Self::Rga
+            Self::UnorderedMap { .. }
+                | Self::SortedMap { .. }
+                | Self::UnorderedSet { .. }
+                | Self::Vector { .. }
+                | Self::Rga
         )
     }
 
@@ -240,18 +268,36 @@ mod tests {
     fn test_is_set() {
         assert!(CrdtType::unordered_set("String").is_set());
         assert!(!CrdtType::unordered_map("String", "u64").is_set());
+        assert!(!CrdtType::sorted_map("String", "u64").is_set());
         assert!(!CrdtType::vector("u64").is_set());
     }
 
     #[test]
     fn test_is_collection() {
         assert!(CrdtType::unordered_map("String", "u64").is_collection());
+        assert!(CrdtType::sorted_map("String", "u64").is_collection());
         assert!(CrdtType::unordered_set("String").is_collection());
         assert!(CrdtType::vector("u64").is_collection());
         assert!(CrdtType::Rga.is_collection());
         assert!(!CrdtType::lww_register("u64").is_collection());
         assert!(!CrdtType::GCounter.is_collection());
         assert!(!CrdtType::PnCounter.is_collection());
+    }
+
+    #[test]
+    fn test_sorted_map_constructor() {
+        assert_eq!(
+            CrdtType::sorted_map("String", "u64"),
+            CrdtType::SortedMap {
+                key_type: "String".to_string(),
+                value_type: "u64".to_string(),
+            }
+        );
+        // SortedMap is distinct from UnorderedMap.
+        assert_ne!(
+            CrdtType::sorted_map("String", "u64"),
+            CrdtType::unordered_map("String", "u64")
+        );
     }
 
     #[test]
@@ -278,6 +324,7 @@ mod tests {
             CrdtType::PnCounter,
             CrdtType::Rga,
             CrdtType::unordered_map("String", "u64"),
+            CrdtType::sorted_map("String", "u64"),
             CrdtType::unordered_set("String"),
             CrdtType::vector("u64"),
             CrdtType::UserStorage,
@@ -303,6 +350,7 @@ mod tests {
             CrdtType::PnCounter,
             CrdtType::Rga,
             CrdtType::unordered_map("String", "u64"),
+            CrdtType::sorted_map("String", "u64"),
             CrdtType::unordered_set("String"),
             CrdtType::vector("u64"),
             CrdtType::UserStorage,

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -462,6 +462,15 @@ impl VMHostFunctions<'_> {
     pub fn storage_index_set(&mut self, key_ptr: u64, value_ptr: u64) -> VMLogicResult<u32> {
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
         let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(value_ptr)? };
+        // Bound guest-supplied sizes like `storage_write` does, so a buggy/hostile
+        // guest can't drive unbounded host allocation through the index path.
+        let logic = self.borrow_logic();
+        if key.len() > logic.limits.max_storage_key_size.get() {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
+        if value.len() > logic.limits.max_storage_value_size.get() {
+            return Err(HostError::ValueLengthOverflow.into());
+        }
         let key = self.read_guest_memory_slice(&key)?.to_vec();
         let value = self.read_guest_memory_slice(&value)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_set", key_len = key.len(), "storage_index_set");
@@ -472,6 +481,9 @@ impl VMHostFunctions<'_> {
     /// Remove `key` from the ordered index. Returns `1` if persisted, else `0`.
     pub fn storage_index_remove(&mut self, key_ptr: u64) -> VMLogicResult<u32> {
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
+        if key.len() > self.borrow_logic().limits.max_storage_key_size.get() {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
         let key = self.read_guest_memory_slice(&key)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_del", key_len = key.len(), "storage_index_remove");
         let ok = self.with_logic_mut(|logic| logic.storage.index_del(&key));
@@ -482,6 +494,9 @@ impl VMHostFunctions<'_> {
     /// persisted, else `0`.
     pub fn storage_index_remove_prefix(&mut self, prefix_ptr: u64) -> VMLogicResult<u32> {
         let prefix = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(prefix_ptr)? };
+        if prefix.len() > self.borrow_logic().limits.max_storage_key_size.get() {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
         let prefix = self.read_guest_memory_slice(&prefix)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_del_prefix", prefix_len = prefix.len(), "storage_index_remove_prefix");
         let ok = self.with_logic_mut(|logic| logic.storage.index_del_prefix(&prefix));
@@ -504,15 +519,23 @@ impl VMHostFunctions<'_> {
     ) -> VMLogicResult<u32> {
         let lo = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(lo_ptr)? };
         let hi = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(hi_ptr)? };
+        // The bounds are index keys; cap them like any other storage key.
+        let max_key = self.borrow_logic().limits.max_storage_key_size.get();
+        if lo.len() > max_key || hi.len() > max_key {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
         let lo = self.read_guest_memory_slice(&lo)?.to_vec();
         let hi = self.read_guest_memory_slice(&hi)?.to_vec();
 
         // `n + 1`-encoded: 0 = unbounded, else `limit - 1`.
         let limit = (limit != 0).then(|| (limit - 1) as usize);
+        // Saturate rather than silently truncate `u64 -> usize` (usize is 32-bit
+        // on a wasm32 host build); a clamp to usize::MAX just means "skip all".
+        let offset = usize::try_from(offset).unwrap_or(usize::MAX);
         let pairs = self
             .borrow_logic()
             .storage
-            .index_scan(&lo, &hi, offset as usize, limit);
+            .index_scan(&lo, &hi, offset, limit);
 
         trace!(
             target: "runtime::host::storage",
@@ -538,6 +561,10 @@ impl VMHostFunctions<'_> {
     ) -> VMLogicResult<u32> {
         let lo = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(lo_ptr)? };
         let hi = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(hi_ptr)? };
+        let max_key = self.borrow_logic().limits.max_storage_key_size.get();
+        if lo.len() > max_key || hi.len() > max_key {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
         let lo = self.read_guest_memory_slice(&lo)?.to_vec();
         let hi = self.read_guest_memory_slice(&hi)?.to_vec();
 

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -456,40 +456,44 @@ impl VMHostFunctions<'_> {
     // are unhashed `collection ‖ order_key`, values are 32-byte entry ids.
     // `SortedMap` is the only caller, via the `MainStorage` adaptor.
 
-    /// Insert/overwrite `key -> value` in the ordered index. Returns `1`.
+    /// Insert/overwrite `key -> value` in the ordered index. Returns `1` if the
+    /// write was persisted, `0` otherwise (so the guest can skip stamping its
+    /// index-validity marker and rebuild instead).
     pub fn storage_index_set(&mut self, key_ptr: u64, value_ptr: u64) -> VMLogicResult<u32> {
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
         let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(value_ptr)? };
         let key = self.read_guest_memory_slice(&key)?.to_vec();
         let value = self.read_guest_memory_slice(&value)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_set", key_len = key.len(), "storage_index_set");
-        self.with_logic_mut(|logic| logic.storage.index_set(&key, &value));
-        Ok(1)
+        let ok = self.with_logic_mut(|logic| logic.storage.index_set(&key, &value));
+        Ok(ok.into())
     }
 
-    /// Remove `key` from the ordered index. Returns `1`.
+    /// Remove `key` from the ordered index. Returns `1` if persisted, else `0`.
     pub fn storage_index_remove(&mut self, key_ptr: u64) -> VMLogicResult<u32> {
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
         let key = self.read_guest_memory_slice(&key)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_del", key_len = key.len(), "storage_index_remove");
-        self.with_logic_mut(|logic| logic.storage.index_del(&key));
-        Ok(1)
+        let ok = self.with_logic_mut(|logic| logic.storage.index_del(&key));
+        Ok(ok.into())
     }
 
-    /// Remove every ordered-index key beginning with `prefix`. Returns `1`.
+    /// Remove every ordered-index key beginning with `prefix`. Returns `1` if
+    /// persisted, else `0`.
     pub fn storage_index_remove_prefix(&mut self, prefix_ptr: u64) -> VMLogicResult<u32> {
         let prefix = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(prefix_ptr)? };
         let prefix = self.read_guest_memory_slice(&prefix)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_del_prefix", prefix_len = prefix.len(), "storage_index_remove_prefix");
-        self.with_logic_mut(|logic| logic.storage.index_del_prefix(&prefix));
-        Ok(1)
+        let ok = self.with_logic_mut(|logic| logic.storage.index_del_prefix(&prefix));
+        Ok(ok.into())
     }
 
     /// Scan the ordered index over `[lo, hi)`, skipping `offset` and capped at
-    /// `limit` (`u64::MAX` = unbounded). Encodes the resulting `(key, value)`
-    /// pairs into `register_id` using a length-prefixed format the guest
-    /// decodes (`count:u32`, then per pair `klen:u32, k, vlen:u32, v`, all
-    /// little-endian). Returns `1`.
+    /// `limit`, which is `n + 1`-encoded with `0` = unbounded (a width-agnostic
+    /// sentinel — `usize::MAX` differs between the wasm32 guest and this host).
+    /// Encodes the resulting `(key, value)` pairs into `register_id` using a
+    /// length-prefixed format the guest decodes (`count:u32`, then per pair
+    /// `klen:u32, k, vlen:u32, v`, all little-endian). Returns `1`.
     pub fn storage_index_scan(
         &mut self,
         lo_ptr: u64,
@@ -503,7 +507,8 @@ impl VMHostFunctions<'_> {
         let lo = self.read_guest_memory_slice(&lo)?.to_vec();
         let hi = self.read_guest_memory_slice(&hi)?.to_vec();
 
-        let limit = (limit != u64::MAX).then_some(limit as usize);
+        // `n + 1`-encoded: 0 = unbounded, else `limit - 1`.
+        let limit = (limit != 0).then(|| (limit - 1) as usize);
         let pairs = self
             .borrow_logic()
             .storage

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -521,6 +521,40 @@ impl VMHostFunctions<'_> {
         self.with_logic_mut(|logic| logic.registers.set(logic.limits, register_id, encoded))?;
         Ok(1)
     }
+
+    /// Reverse seek: encode the single largest `(key, value)` in `[lo, hi)` into
+    /// `register_id` (same wire format as `storage_index_scan`, count 0 or 1).
+    /// Backs `SortedMap::last` as an `O(log n)` lookup. Returns `1`.
+    pub fn storage_index_last(
+        &mut self,
+        lo_ptr: u64,
+        hi_ptr: u64,
+        register_id: u64,
+    ) -> VMLogicResult<u32> {
+        let lo = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(lo_ptr)? };
+        let hi = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(hi_ptr)? };
+        let lo = self.read_guest_memory_slice(&lo)?.to_vec();
+        let hi = self.read_guest_memory_slice(&hi)?.to_vec();
+
+        let pairs: Vec<(Vec<u8>, Vec<u8>)> = self
+            .borrow_logic()
+            .storage
+            .index_last(&lo, &hi)
+            .into_iter()
+            .collect();
+
+        trace!(
+            target: "runtime::host::storage",
+            op = "index_last",
+            found = !pairs.is_empty(),
+            register_id,
+            "storage_index_last"
+        );
+
+        let encoded = encode_index_pairs(&pairs);
+        self.with_logic_mut(|logic| logic.registers.set(logic.limits, register_id, encoded))?;
+        Ok(1)
+    }
 }
 
 /// Encode ordered-index scan results into the length-prefixed wire format the

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -448,6 +448,94 @@ impl VMHostFunctions<'_> {
 
         Ok(0)
     }
+
+    // === Ordered secondary index host functions (SortedMap, core#2559) ===
+    //
+    // These target the backend's ordered index keyspace (the RocksDB
+    // `SortedIndex` column on a node, a `BTreeMap` for `InMemoryStorage`). Keys
+    // are unhashed `collection ‖ order_key`, values are 32-byte entry ids.
+    // `SortedMap` is the only caller, via the `MainStorage` adaptor.
+
+    /// Insert/overwrite `key -> value` in the ordered index. Returns `1`.
+    pub fn storage_index_set(&mut self, key_ptr: u64, value_ptr: u64) -> VMLogicResult<u32> {
+        let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
+        let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(value_ptr)? };
+        let key = self.read_guest_memory_slice(&key)?.to_vec();
+        let value = self.read_guest_memory_slice(&value)?.to_vec();
+        trace!(target: "runtime::host::storage", op = "index_set", key_len = key.len(), "storage_index_set");
+        self.with_logic_mut(|logic| logic.storage.index_set(&key, &value));
+        Ok(1)
+    }
+
+    /// Remove `key` from the ordered index. Returns `1`.
+    pub fn storage_index_remove(&mut self, key_ptr: u64) -> VMLogicResult<u32> {
+        let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
+        let key = self.read_guest_memory_slice(&key)?.to_vec();
+        trace!(target: "runtime::host::storage", op = "index_del", key_len = key.len(), "storage_index_remove");
+        self.with_logic_mut(|logic| logic.storage.index_del(&key));
+        Ok(1)
+    }
+
+    /// Remove every ordered-index key beginning with `prefix`. Returns `1`.
+    pub fn storage_index_remove_prefix(&mut self, prefix_ptr: u64) -> VMLogicResult<u32> {
+        let prefix = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(prefix_ptr)? };
+        let prefix = self.read_guest_memory_slice(&prefix)?.to_vec();
+        trace!(target: "runtime::host::storage", op = "index_del_prefix", prefix_len = prefix.len(), "storage_index_remove_prefix");
+        self.with_logic_mut(|logic| logic.storage.index_del_prefix(&prefix));
+        Ok(1)
+    }
+
+    /// Scan the ordered index over `[lo, hi)`, skipping `offset` and capped at
+    /// `limit` (`u64::MAX` = unbounded). Encodes the resulting `(key, value)`
+    /// pairs into `register_id` using a length-prefixed format the guest
+    /// decodes (`count:u32`, then per pair `klen:u32, k, vlen:u32, v`, all
+    /// little-endian). Returns `1`.
+    pub fn storage_index_scan(
+        &mut self,
+        lo_ptr: u64,
+        hi_ptr: u64,
+        offset: u64,
+        limit: u64,
+        register_id: u64,
+    ) -> VMLogicResult<u32> {
+        let lo = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(lo_ptr)? };
+        let hi = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(hi_ptr)? };
+        let lo = self.read_guest_memory_slice(&lo)?.to_vec();
+        let hi = self.read_guest_memory_slice(&hi)?.to_vec();
+
+        let limit = (limit != u64::MAX).then_some(limit as usize);
+        let pairs = self
+            .borrow_logic()
+            .storage
+            .index_scan(&lo, &hi, offset as usize, limit);
+
+        trace!(
+            target: "runtime::host::storage",
+            op = "index_scan",
+            results = pairs.len(),
+            register_id,
+            "storage_index_scan"
+        );
+
+        let encoded = encode_index_pairs(&pairs);
+        self.with_logic_mut(|logic| logic.registers.set(logic.limits, register_id, encoded))?;
+        Ok(1)
+    }
+}
+
+/// Encode ordered-index scan results into the length-prefixed wire format the
+/// guest (`calimero_sdk::env`) decodes: `count:u32`, then per pair
+/// `key_len:u32, key, value_len:u32, value` — all little-endian.
+fn encode_index_pairs(pairs: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(pairs.len() as u32).to_le_bytes());
+    for (key, value) in pairs {
+        out.extend_from_slice(&(key.len() as u32).to_le_bytes());
+        out.extend_from_slice(key);
+        out.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        out.extend_from_slice(value);
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -63,6 +63,7 @@ impl VMLogic<'_> {
                 limit: u64,
                 register_id: u64,
             ) -> u32;
+            fn storage_index_last(lo_ptr: u64, hi_ptr: u64, register_id: u64) -> u32;
 
             // Private storage functions (node-local, NOT synchronized)
             fn private_storage_read(key_ptr: u64, register_id: u64) -> u32;

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -51,6 +51,19 @@ impl VMLogic<'_> {
             fn storage_read(key_ptr: u64, register_id: u64) -> u32;
             fn storage_remove(key_ptr: u64, register_id: u64) -> u32;
 
+            // Ordered secondary index (SortedMap, core#2559) — node-local,
+            // NOT synchronized; keys are unhashed `collection ‖ order_key`.
+            fn storage_index_set(key_ptr: u64, value_ptr: u64) -> u32;
+            fn storage_index_remove(key_ptr: u64) -> u32;
+            fn storage_index_remove_prefix(prefix_ptr: u64) -> u32;
+            fn storage_index_scan(
+                lo_ptr: u64,
+                hi_ptr: u64,
+                offset: u64,
+                limit: u64,
+                register_id: u64,
+            ) -> u32;
+
             // Private storage functions (node-local, NOT synchronized)
             fn private_storage_read(key_ptr: u64, register_id: u64) -> u32;
             fn private_storage_remove(key_ptr: u64, register_id: u64) -> u32;

--- a/crates/runtime/src/store.rs
+++ b/crates/runtime/src/store.rs
@@ -14,11 +14,56 @@ pub trait Storage: Reflect {
     fn set(&mut self, key: Key, value: Value) -> Option<Value>;
     fn remove(&mut self, key: &Key) -> Option<Vec<u8>>;
     fn has(&self, key: &Key) -> bool;
+
+    // === Ordered secondary index (SortedMap, core#2559) ===
+    //
+    // A separate, byte-ordered keyspace (the backend keeps keys in sorted
+    // order, so a range scan is a native seek). Keys are the unhashed
+    // `collection ‖ order_key`; values are the entry's 32-byte id. This is the
+    // node-local, non-synced index that lets `SortedMap` answer range/prefix/
+    // page queries without scanning every entry.
+    //
+    // Default impls make the index inert: a backend that doesn't provide an
+    // ordered keyspace leaves these alone and `SortedMap` falls back to its
+    // in-memory sort (the storage adaptor gates on `index_supported()`).
+
+    /// Insert/overwrite `key -> value` in the ordered index.
+    fn index_set(&mut self, key: &[u8], value: &[u8]) {
+        let _ = (key, value);
+    }
+
+    /// Remove `key` from the ordered index.
+    fn index_del(&mut self, key: &[u8]) {
+        let _ = key;
+    }
+
+    /// Remove every index key beginning with `prefix` (used to clear one
+    /// collection's index before a rebuild).
+    fn index_del_prefix(&mut self, prefix: &[u8]) {
+        let _ = prefix;
+    }
+
+    /// Return `(key, value)` pairs in `[lo, hi)`, ascending by key, after
+    /// skipping `offset` and capped at `limit` (`None` = unbounded).
+    fn index_scan(
+        &self,
+        lo: &[u8],
+        hi: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let _ = (lo, hi, offset, limit);
+        Vec::new()
+    }
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryStorage {
     inner: BTreeMap<Key, Value>,
+    /// Ordered secondary index (see `Storage`'s index methods). A `BTreeMap`
+    /// iterates in key order, mirroring the RocksDB `SortedIndex` column the
+    /// node backs this with in production.
+    index: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
 impl Storage for InMemoryStorage {
@@ -46,6 +91,36 @@ impl Storage for InMemoryStorage {
     fn has(&self, key: &Key) -> bool {
         debug!(target: "runtime::storage::memory", key_len = key.len(), "InMemoryStorage::has");
         self.inner.contains_key(key)
+    }
+
+    fn index_set(&mut self, key: &[u8], value: &[u8]) {
+        let _ = self.index.insert(key.to_vec(), value.to_vec());
+    }
+
+    fn index_del(&mut self, key: &[u8]) {
+        let _ = self.index.remove(key);
+    }
+
+    fn index_del_prefix(&mut self, prefix: &[u8]) {
+        self.index.retain(|k, _| !k.starts_with(prefix));
+    }
+
+    fn index_scan(
+        &self,
+        lo: &[u8],
+        hi: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let ordered = self
+            .index
+            .range(lo.to_vec()..hi.to_vec())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .skip(offset);
+        match limit {
+            Some(n) => ordered.take(n).collect(),
+            None => ordered.collect(),
+        }
     }
 }
 

--- a/crates/runtime/src/store.rs
+++ b/crates/runtime/src/store.rs
@@ -55,6 +55,13 @@ pub trait Storage: Reflect {
         let _ = (lo, hi, offset, limit);
         Vec::new()
     }
+
+    /// The largest `(key, value)` in `[lo, hi)` — a reverse seek for
+    /// `SortedMap::last` (`O(log n)` instead of a forward walk to the end).
+    fn index_last(&self, lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        let _ = (lo, hi);
+        None
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -121,6 +128,13 @@ impl Storage for InMemoryStorage {
             Some(n) => ordered.take(n).collect(),
             None => ordered.collect(),
         }
+    }
+
+    fn index_last(&self, lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.index
+            .range(lo.to_vec()..hi.to_vec())
+            .next_back()
+            .map(|(k, v)| (k.clone(), v.clone()))
     }
 }
 

--- a/crates/runtime/src/store.rs
+++ b/crates/runtime/src/store.rs
@@ -27,20 +27,27 @@ pub trait Storage: Reflect {
     // ordered keyspace leaves these alone and `SortedMap` falls back to its
     // in-memory sort (the storage adaptor gates on `index_supported()`).
 
-    /// Insert/overwrite `key -> value` in the ordered index.
-    fn index_set(&mut self, key: &[u8], value: &[u8]) {
+    /// Insert/overwrite `key -> value` in the ordered index. Returns whether the
+    /// write was persisted, so the collection can avoid stamping its validity
+    /// marker (and force a rebuild instead) after a failed write.
+    fn index_set(&mut self, key: &[u8], value: &[u8]) -> bool {
         let _ = (key, value);
+        false
     }
 
-    /// Remove `key` from the ordered index.
-    fn index_del(&mut self, key: &[u8]) {
+    /// Remove `key` from the ordered index. Returns whether the write was
+    /// persisted (see [`index_set`](Self::index_set)).
+    fn index_del(&mut self, key: &[u8]) -> bool {
         let _ = key;
+        false
     }
 
     /// Remove every index key beginning with `prefix` (used to clear one
-    /// collection's index before a rebuild).
-    fn index_del_prefix(&mut self, prefix: &[u8]) {
+    /// collection's index before a rebuild). Returns whether the write was
+    /// persisted (see [`index_set`](Self::index_set)).
+    fn index_del_prefix(&mut self, prefix: &[u8]) -> bool {
         let _ = prefix;
+        false
     }
 
     /// Return `(key, value)` pairs in `[lo, hi)`, ascending by key, after
@@ -100,16 +107,19 @@ impl Storage for InMemoryStorage {
         self.inner.contains_key(key)
     }
 
-    fn index_set(&mut self, key: &[u8], value: &[u8]) {
+    fn index_set(&mut self, key: &[u8], value: &[u8]) -> bool {
         let _ = self.index.insert(key.to_vec(), value.to_vec());
+        true
     }
 
-    fn index_del(&mut self, key: &[u8]) {
+    fn index_del(&mut self, key: &[u8]) -> bool {
         let _ = self.index.remove(key);
+        true
     }
 
-    fn index_del_prefix(&mut self, prefix: &[u8]) {
+    fn index_del_prefix(&mut self, prefix: &[u8]) -> bool {
         self.index.retain(|k, _| !k.starts_with(prefix));
+        true
     }
 
     fn index_scan(

--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -586,6 +586,57 @@ fn frozen_storage_converges() {
 }
 
 // ---------------------------------------------------------------------------
+// SortedMap ordered-index path, end to end through real WASM (core#2559).
+//
+// Unlike the storage crate's unit tests (which drive the adaptor natively or via
+// a mock), this runs the compiled app through `Module::run`, so the ordered
+// reads travel the FULL host-function chain: app WASM → `MainStorage` →
+// `storage_index_set` / `storage_index_scan` host imports → the runtime's
+// `InMemoryStorage` ordered index. A correct, key-ordered result here proves the
+// Stage C host ABI works in a real WASM execution, not just in unit tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sorted_map_range_through_real_wasm() {
+    let mut c = Cluster::new(1);
+
+    // Insert deliberately out of order — each `sorted_set` maintains the index
+    // host-side via `storage_index_set`.
+    for (k, v) in [
+        ("delta", "D"),
+        ("alpha", "A"),
+        ("charlie", "C"),
+        ("bravo", "B"),
+        ("echo", "E"),
+    ] {
+        let _artifact = c.call(0, "sorted_set", json!({ "key": k, "value": v }));
+    }
+
+    // `sorted_range` reads back through `storage_index_scan` (the index-backed
+    // path). The result must be the key-ordered window [bravo, echo).
+    let range = c.query(
+        0,
+        "sorted_range",
+        json!({ "start": "bravo", "end": "echo" }),
+    );
+    let range = range.get("output").cloned().unwrap_or(range);
+    assert_eq!(
+        range,
+        json!({ "bravo": "B", "charlie": "C", "delta": "D" }),
+        "sorted_range [bravo, echo) via the host ordered index"
+    );
+
+    // Full key listing comes back ascending too.
+    let keys = c.query(0, "sorted_keys", json!({}));
+    let keys = keys.get("output").cloned().unwrap_or(keys);
+    assert_eq!(
+        keys,
+        json!(["alpha", "bravo", "charlie", "delta", "echo"]),
+        "sorted_keys ascending"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Single-writer sync coverage. These exercise the basic "one node edits, peers
 // apply the delta" path for the counter / set structures whose *concurrent*
 // same-entity tests are ignored above — so every data structure has at least

--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -634,6 +634,11 @@ fn sorted_map_range_through_real_wasm() {
         json!(["alpha", "bravo", "charlie", "delta", "echo"]),
         "sorted_keys ascending"
     );
+
+    // `last` is the reverse-seek path (`storage_index_last` host import).
+    let last = c.query(0, "sorted_last_key", json!({}));
+    let last = last.get("output").cloned().unwrap_or(last);
+    assert_eq!(last, json!("echo"), "sorted_last_key via reverse seek");
 }
 
 /// A receiving node applies SortedMap entries via the generic sync path

--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -636,6 +636,32 @@ fn sorted_map_range_through_real_wasm() {
     );
 }
 
+/// A receiving node applies SortedMap entries via the generic sync path
+/// (host-side, which does NOT touch the ordered index), so its index is stale.
+/// The next `sorted_range` query must notice the `full_hash` marker mismatch,
+/// rebuild the index from the synced entries, and return correct key-ordered
+/// results — the self-heal-after-sync path, proven through real WASM.
+#[test]
+fn sorted_map_rebuilds_index_after_sync() {
+    let mut c = Cluster::new(2);
+
+    // Node 0 writes (out of order) and broadcasts each delta; node 1 applies
+    // them via `__calimero_sync_next` (entries land host-side, index untouched).
+    for (k, v) in [("m", "M"), ("a", "A"), ("z", "Z"), ("f", "F")] {
+        let artifact = c.call(0, "sorted_set", json!({ "key": k, "value": v }));
+        c.apply(1, &artifact);
+    }
+
+    // Node 1's ordered read must rebuild its stale index, then serve the window.
+    let range = c.query(1, "sorted_range", json!({ "start": "a", "end": "z" }));
+    let range = range.get("output").cloned().unwrap_or(range);
+    assert_eq!(
+        range,
+        json!({ "a": "A", "f": "F", "m": "M" }),
+        "node 1 rebuilds its index after sync and serves the range"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Single-writer sync coverage. These exercise the basic "one node edits, peers
 // apply the delta" path for the counter / set structures whose *concurrent*

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -50,8 +50,12 @@ use sha2::{Digest, Sha256};
 /// are also covered. Doesn't catch type aliases or `use as` renames —
 /// users doing those need to either write the explicit `PrivateStorage`
 /// parameter themselves or unwind the alias.
-const TREE_BACKED_TYPES: &[(&str, usize)] =
-    &[("UnorderedMap", 2), ("UnorderedSet", 1), ("Vector", 1)];
+const TREE_BACKED_TYPES: &[(&str, usize)] = &[
+    ("UnorderedMap", 2),
+    ("SortedMap", 2),
+    ("UnorderedSet", 1),
+    ("Vector", 1),
+];
 
 /// Recursively walk `ty` and inject `PrivateStorage` on every
 /// tree-backed collection encountered — including ones nested inside

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -54,6 +54,7 @@ const TREE_BACKED_TYPES: &[(&str, usize)] = &[
     ("UnorderedMap", 2),
     ("SortedMap", 2),
     ("UnorderedSet", 1),
+    ("SortedSet", 1),
     ("Vector", 1),
 ];
 

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -560,6 +560,9 @@ fn generate_assign_deterministic_ids_impl(
             || type_str.contains("SortedMap")
             || type_str.contains("Vector")
             || type_str.contains("UnorderedSet")
+            // `SortedSet` is NOT a substring of any other entry (same reason as
+            // `SortedMap`): list it explicitly or its id stays random and diverges.
+            || type_str.contains("SortedSet")
             || type_str.contains("Counter")
             || type_str.contains("ReplicatedGrowableArray")
             || type_str.contains("UserStorage")

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -554,6 +554,10 @@ fn generate_assign_deterministic_ids_impl(
     // Helper function to check if a type is a collection that needs ID assignment
     fn is_collection_type(type_str: &str) -> bool {
         type_str.contains("UnorderedMap")
+            // `SortedMap` is NOT a substring of any other entry, so it must be
+            // listed explicitly — otherwise a top-level `SortedMap` state field
+            // keeps its `Id::random()` and diverges across nodes (CIP I9).
+            || type_str.contains("SortedMap")
             || type_str.contains("Vector")
             || type_str.contains("UnorderedSet")
             || type_str.contains("Counter")

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -548,6 +548,27 @@ pub fn storage_index_scan(
     decode_index_pairs(&buf)
 }
 
+/// The largest `(key, value)` in the ordered index over `[lo, hi)` — a reverse
+/// seek backing `SortedMap::last`.
+#[inline]
+pub fn storage_index_last(lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    let found: bool = unsafe {
+        sys::storage_index_last(
+            Ref::new(&Buffer::from(lo)),
+            Ref::new(&Buffer::from(hi)),
+            DATA_REGISTER,
+        )
+        .try_into()
+    }
+    .unwrap_or_else(expected_boolean);
+
+    if !found {
+        return None;
+    }
+    let buf = read_register(DATA_REGISTER).unwrap_or_else(expected_register);
+    decode_index_pairs(&buf).into_iter().next()
+}
+
 /// Decode the length-prefixed scan reply produced by the host's
 /// `encode_index_pairs`. Malformed/truncated input yields what was parsed so
 /// far (the host controls this buffer, so it's well-formed in practice).

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -491,6 +491,98 @@ pub fn storage_write(key: &[u8], value: &[u8]) -> bool {
     .unwrap_or_else(expected_boolean)
 }
 
+// ==================== Ordered Secondary Index (SortedMap) ====================
+//
+// Node-local, NOT synchronized. Keys are the unhashed `collection ‖ order_key`
+// so the backend keeps them in byte (= logical key) order. Only `SortedMap`
+// (via the `MainStorage` adaptor) calls these.
+
+/// Insert/overwrite `key -> value` in the ordered index.
+#[inline]
+pub fn storage_index_set(key: &[u8], value: &[u8]) {
+    let _ = unsafe {
+        sys::storage_index_set(Ref::new(&Buffer::from(key)), Ref::new(&Buffer::from(value)))
+    };
+}
+
+/// Remove `key` from the ordered index.
+#[inline]
+pub fn storage_index_remove(key: &[u8]) {
+    let _ = unsafe { sys::storage_index_remove(Ref::new(&Buffer::from(key))) };
+}
+
+/// Remove every ordered-index key beginning with `prefix`.
+#[inline]
+pub fn storage_index_remove_prefix(prefix: &[u8]) {
+    let _ = unsafe { sys::storage_index_remove_prefix(Ref::new(&Buffer::from(prefix))) };
+}
+
+/// Scan the ordered index over `[lo, hi)`, ascending, after `offset` and
+/// capped at `limit` (`None` = unbounded). Decodes the host's length-prefixed
+/// reply (`count:u32`, then per pair `klen:u32, k, vlen:u32, v`, little-endian).
+#[inline]
+pub fn storage_index_scan(
+    lo: &[u8],
+    hi: &[u8],
+    offset: usize,
+    limit: Option<usize>,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    // `usize::MAX` is the "unbounded" sentinel shared with the host.
+    let limit_raw = limit.unwrap_or(usize::MAX);
+    let found: bool = unsafe {
+        sys::storage_index_scan(
+            Ref::new(&Buffer::from(lo)),
+            Ref::new(&Buffer::from(hi)),
+            PtrSizedInt::new(offset),
+            PtrSizedInt::new(limit_raw),
+            DATA_REGISTER,
+        )
+        .try_into()
+    }
+    .unwrap_or_else(expected_boolean);
+
+    if !found {
+        return Vec::new();
+    }
+    let buf = read_register(DATA_REGISTER).unwrap_or_else(expected_register);
+    decode_index_pairs(&buf)
+}
+
+/// Decode the length-prefixed scan reply produced by the host's
+/// `encode_index_pairs`. Malformed/truncated input yields what was parsed so
+/// far (the host controls this buffer, so it's well-formed in practice).
+fn decode_index_pairs(buf: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    let take_u32 = |buf: &[u8], pos: &mut usize| -> Option<usize> {
+        let end = pos.checked_add(4)?;
+        let n = u32::from_le_bytes(buf.get(*pos..end)?.try_into().ok()?) as usize;
+        *pos = end;
+        Some(n)
+    };
+    let Some(count) = take_u32(buf, &mut pos) else {
+        return out;
+    };
+    for _ in 0..count {
+        let Some(klen) = take_u32(buf, &mut pos) else {
+            break;
+        };
+        let Some(key) = buf.get(pos..pos + klen).map(<[u8]>::to_vec) else {
+            break;
+        };
+        pos += klen;
+        let Some(vlen) = take_u32(buf, &mut pos) else {
+            break;
+        };
+        let Some(value) = buf.get(pos..pos + vlen).map(<[u8]>::to_vec) else {
+            break;
+        };
+        pos += vlen;
+        out.push((key, value));
+    }
+    out
+}
+
 // ==================== Private Storage Functions ====================
 // These functions operate on node-local storage that is NOT synchronized across nodes.
 

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -497,24 +497,32 @@ pub fn storage_write(key: &[u8], value: &[u8]) -> bool {
 // so the backend keeps them in byte (= logical key) order. Only `SortedMap`
 // (via the `MainStorage` adaptor) calls these.
 
-/// Insert/overwrite `key -> value` in the ordered index.
+/// Insert/overwrite `key -> value` in the ordered index. Returns whether the
+/// host persisted the write (so the caller can avoid stamping a stale
+/// index-validity marker on failure).
 #[inline]
-pub fn storage_index_set(key: &[u8], value: &[u8]) {
-    let _ = unsafe {
-        sys::storage_index_set(Ref::new(&Buffer::from(key)), Ref::new(&Buffer::from(value)))
-    };
+pub fn storage_index_set(key: &[u8], value: &[u8]) -> bool {
+    unsafe { sys::storage_index_set(Ref::new(&Buffer::from(key)), Ref::new(&Buffer::from(value))) }
+        .try_into()
+        .unwrap_or_else(expected_boolean)
 }
 
-/// Remove `key` from the ordered index.
+/// Remove `key` from the ordered index. Returns whether the host persisted the
+/// write (see [`storage_index_set`]).
 #[inline]
-pub fn storage_index_remove(key: &[u8]) {
-    let _ = unsafe { sys::storage_index_remove(Ref::new(&Buffer::from(key))) };
+pub fn storage_index_remove(key: &[u8]) -> bool {
+    unsafe { sys::storage_index_remove(Ref::new(&Buffer::from(key))) }
+        .try_into()
+        .unwrap_or_else(expected_boolean)
 }
 
-/// Remove every ordered-index key beginning with `prefix`.
+/// Remove every ordered-index key beginning with `prefix`. Returns whether the
+/// host persisted the write (see [`storage_index_set`]).
 #[inline]
-pub fn storage_index_remove_prefix(prefix: &[u8]) {
-    let _ = unsafe { sys::storage_index_remove_prefix(Ref::new(&Buffer::from(prefix))) };
+pub fn storage_index_remove_prefix(prefix: &[u8]) -> bool {
+    unsafe { sys::storage_index_remove_prefix(Ref::new(&Buffer::from(prefix))) }
+        .try_into()
+        .unwrap_or_else(expected_boolean)
 }
 
 /// Scan the ordered index over `[lo, hi)`, ascending, after `offset` and
@@ -527,8 +535,10 @@ pub fn storage_index_scan(
     offset: usize,
     limit: Option<usize>,
 ) -> Vec<(Vec<u8>, Vec<u8>)> {
-    // `usize::MAX` is the "unbounded" sentinel shared with the host.
-    let limit_raw = limit.unwrap_or(usize::MAX);
+    // Encode the limit as `n + 1`, with `0` = unbounded. A `MAX` sentinel would
+    // be ambiguous: `usize` is 32-bit on wasm32, so `usize::MAX` (`u32::MAX`)
+    // would not equal the host's `u64::MAX`. `0` is unambiguous on any width.
+    let limit_raw = limit.map_or(0, |n| n.saturating_add(1));
     let found: bool = unsafe {
         sys::storage_index_scan(
             Ref::new(&Buffer::from(lo)),

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -15,6 +15,8 @@ pub mod counter;
 pub use counter::{Counter, GCounter, PNCounter};
 pub mod unordered_map;
 pub use unordered_map::UnorderedMap;
+pub mod sorted_map;
+pub use sorted_map::SortedMap;
 pub mod unordered_set;
 pub use unordered_set::UnorderedSet;
 pub mod vector;

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -19,6 +19,8 @@ pub mod sorted_map;
 pub use sorted_map::SortedMap;
 pub mod unordered_set;
 pub use unordered_set::UnorderedSet;
+pub mod sorted_set;
+pub use sorted_set::SortedSet;
 pub mod vector;
 pub use vector::Vector;
 pub mod rga;

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -11,7 +11,8 @@
 
 use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
 use super::{
-    Counter, LwwRegister, ReplicatedGrowableArray, SortedMap, UnorderedMap, UnorderedSet, Vector,
+    Counter, LwwRegister, ReplicatedGrowableArray, SortedMap, SortedSet, UnorderedMap,
+    UnorderedSet, Vector,
 };
 #[cfg(test)]
 use super::{GCounter, PNCounter};
@@ -401,6 +402,48 @@ where
             let _ = self.insert(value)?;
         }
 
+        Ok(())
+    }
+}
+
+// ============================================================================
+// SortedSet
+// ============================================================================
+
+impl<T: 'static, S> CrdtMeta for SortedSet<T, S>
+where
+    S: StorageAdaptor,
+{
+    fn crdt_type() -> CrdtType {
+        CrdtType::sorted_set(std::any::type_name::<T>())
+    }
+
+    fn storage_strategy() -> StorageStrategy {
+        StorageStrategy::Structured
+    }
+
+    fn can_contain_crdts() -> bool {
+        false // Set elements are values, not CRDTs
+    }
+}
+
+impl<T, S> Mergeable for SortedSet<T, S>
+where
+    T: borsh::BorshSerialize
+        + borsh::BorshDeserialize
+        + AsRef<[u8]>
+        + Ord
+        + Clone
+        + PartialEq
+        + 'static,
+    S: StorageAdaptor,
+{
+    /// Union (add-wins) merge — identical to [`UnorderedSet`]; only iteration is
+    /// element-ordered. Order falls out of `T: Ord`, so convergence is inherited.
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        for value in other.iter()? {
+            let _ = self.insert(value)?;
+        }
         Ok(())
     }
 }

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -312,8 +312,14 @@ where
 
 impl<K, V, S> Mergeable for SortedMap<K, V, S>
 where
-    K: borsh::BorshSerialize + borsh::BorshDeserialize + AsRef<[u8]> + Ord + Clone + PartialEq,
-    V: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable,
+    K: borsh::BorshSerialize
+        + borsh::BorshDeserialize
+        + AsRef<[u8]>
+        + Ord
+        + Clone
+        + PartialEq
+        + 'static,
+    V: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable + 'static,
     S: StorageAdaptor,
 {
     /// Merge two sorted maps entry-by-entry.

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -5,11 +5,14 @@
 //! - Counter
 //! - ReplicatedGrowableArray (RGA)
 //! - UnorderedMap
+//! - SortedMap
 //! - UnorderedSet
 //! - Vector
 
 use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
-use super::{Counter, LwwRegister, ReplicatedGrowableArray, UnorderedMap, UnorderedSet, Vector};
+use super::{
+    Counter, LwwRegister, ReplicatedGrowableArray, SortedMap, UnorderedMap, UnorderedSet, Vector,
+};
 #[cfg(test)]
 use super::{GCounter, PNCounter};
 use crate::store::StorageAdaptor;
@@ -278,6 +281,55 @@ where
                 drop(self.insert(key, our_value)?);
             } else {
                 // Key only in other - add it (add-wins semantics)
+                drop(self.insert(key, other_value)?);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// SortedMap
+// ============================================================================
+
+impl<K: 'static, V: 'static, S> CrdtMeta for SortedMap<K, V, S>
+where
+    S: StorageAdaptor,
+{
+    fn crdt_type() -> CrdtType {
+        CrdtType::sorted_map(std::any::type_name::<K>(), std::any::type_name::<V>())
+    }
+
+    fn storage_strategy() -> StorageStrategy {
+        StorageStrategy::Structured // Maps decompose into entries
+    }
+
+    fn can_contain_crdts() -> bool {
+        true // Map can contain CRDT values!
+    }
+}
+
+impl<K, V, S> Mergeable for SortedMap<K, V, S>
+where
+    K: borsh::BorshSerialize + borsh::BorshDeserialize + AsRef<[u8]> + Ord + Clone + PartialEq,
+    V: borsh::BorshSerialize + borsh::BorshDeserialize + Mergeable,
+    S: StorageAdaptor,
+{
+    /// Merge two sorted maps entry-by-entry.
+    ///
+    /// Identical add-wins semantics to [`UnorderedMap`] — keys union, shared
+    /// keys recursively merge their values. Iteration order falls out of `K:
+    /// Ord` and needs no special handling at merge time, so convergence is
+    /// inherited wholesale from the map merge.
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        let other_entries = other.entries()?;
+
+        for (key, other_value) in other_entries {
+            if let Some(mut our_value) = self.get(&key)? {
+                our_value.merge(&other_value)?;
+                drop(self.insert(key, our_value)?);
+            } else {
                 drop(self.insert(key, other_value)?);
             }
         }

--- a/crates/storage/src/collections/decompose_impls.rs
+++ b/crates/storage/src/collections/decompose_impls.rs
@@ -72,8 +72,8 @@ where
 
 impl<K, V, S> Decomposable for SortedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Ord + Clone + PartialEq,
-    V: BorshSerialize + BorshDeserialize + Clone,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Ord + Clone + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + Clone + 'static,
     S: StorageAdaptor,
 {
     type Key = CompositeKey;

--- a/crates/storage/src/collections/decompose_impls.rs
+++ b/crates/storage/src/collections/decompose_impls.rs
@@ -4,7 +4,7 @@
 
 use super::composite_key::CompositeKey;
 use super::crdt_meta::{Decomposable, DecomposeError};
-use super::{UnorderedMap, Vector};
+use super::{SortedMap, UnorderedMap, Vector};
 use crate::store::StorageAdaptor;
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -51,6 +51,59 @@ where
 
         for (composite_key, value) in entries {
             // Deserialize the key from composite key bytes
+            let key = borsh::from_slice::<K>(composite_key.as_bytes()).map_err(|e| {
+                DecomposeError::StorageError(format!("Failed to deserialize key: {:?}", e))
+            })?;
+
+            drop(
+                map.insert(key, value).map_err(|e| {
+                    DecomposeError::StorageError(format!("Failed to insert: {:?}", e))
+                })?,
+            );
+        }
+
+        Ok(map)
+    }
+}
+
+// ============================================================================
+// SortedMap - Decompose into entries (sorted by key)
+// ============================================================================
+
+impl<K, V, S> Decomposable for SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + Ord + Clone + PartialEq,
+    V: BorshSerialize + BorshDeserialize + Clone,
+    S: StorageAdaptor,
+{
+    type Key = CompositeKey;
+    type Value = V;
+
+    fn decompose(&self) -> Result<Vec<(Self::Key, Self::Value)>, DecomposeError> {
+        // `entries()` already yields ascending key order, so decomposition is
+        // deterministic without an extra sort.
+        let entries = self
+            .entries()
+            .map_err(|e| DecomposeError::StorageError(format!("Failed to get entries: {:?}", e)))?;
+
+        let result = entries
+            .into_iter()
+            .map(|(k, v)| {
+                let key_bytes = borsh::to_vec(&k).map_err(|e| {
+                    DecomposeError::StorageError(format!("Failed to serialize key: {:?}", e))
+                })?;
+
+                Ok((CompositeKey::from(key_bytes), v))
+            })
+            .collect::<Result<Vec<_>, DecomposeError>>()?;
+
+        Ok(result)
+    }
+
+    fn recompose(entries: Vec<(Self::Key, Self::Value)>) -> Result<Self, DecomposeError> {
+        let mut map = SortedMap::new_internal();
+
+        for (composite_key, value) in entries {
             let key = borsh::from_slice::<K>(composite_key.as_bytes()).map_err(|e| {
                 DecomposeError::StorageError(format!("Failed to deserialize key: {:?}", e))
             })?;

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -3,8 +3,9 @@
 //! [`SortedMap`] stores its entries exactly like [`UnorderedMap`](super::UnorderedMap)
 //! — a single inner [`Collection`] of `(K, V)` pairs keyed by
 //! `compute_id(parent, key)` — so it inherits the *identical* CRDT merge
-//! semantics (add-wins keys, recursive value merge, per-key tombstones) and
-//! on-wire byte layout. Nothing extra is synced.
+//! semantics (add-wins keys, recursive value merge, per-key tombstones, and the
+//! nested-CRDT deterministic re-keying from [`super::rekey`]) and on-wire byte
+//! layout. Nothing extra is synced.
 //!
 //! What it adds is an **ordered view**. Because entry ids are
 //! `SHA256(parent ‖ key)`, entity-id order ≠ key order, and the underlying
@@ -47,6 +48,25 @@ use std::collections::BTreeMap;
 pub struct SortedMap<K, V, S: StorageAdaptor = MainStorage> {
     #[borsh(bound(serialize = "", deserialize = ""))]
     inner: Collection<(K, V), S>,
+}
+
+/// Re-key a nested sorted map (one stored as another collection's value)
+/// relative to its storage parent — mirrors [`UnorderedMap`](super::UnorderedMap)
+/// so a nested `SortedMap` value's children converge across nodes. See
+/// [`super::rekey`].
+impl<K, V, S> super::rekey::RekeyTarget for SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
+    S: StorageAdaptor,
+{
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        self.reassign_deterministic_id_under(
+            parent_id,
+            "__nested_sorted_map",
+            CrdtType::sorted_map(std::any::type_name::<K>(), std::any::type_name::<V>()),
+        );
+    }
 }
 
 impl<K, V, S> SortedMap<K, V, S>
@@ -112,6 +132,83 @@ where
         self.inner.element_mut().metadata.crdt_type = Some(crdt_type);
     }
 
+    /// Reassign the map's id + collection CRDT type to a deterministic value
+    /// keyed under `parent_id` (`None` = top-level / ROOT-relative). Shared
+    /// implementation behind the two `reassign_deterministic_id_*` entry points.
+    ///
+    /// Migration is: snapshot entries → clear (drops old-id entries) → reassign
+    /// the collection id → re-insert (each entry, and its own nested values via
+    /// `insert`'s re-key, gets a new deterministic id under the new parent). The
+    /// snapshot uses unordered iteration: re-insert order is irrelevant because
+    /// each entry's new id is a pure function of its key.
+    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
+    fn reassign_deterministic_id_keyed(
+        &mut self,
+        parent_id: Option<Id>,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) where
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
+    {
+        let new_id = super::compute_collection_id(parent_id, field_name);
+        let old_id = self.inner.id();
+
+        // If already has the correct ID, only ensure CRDT type is correct.
+        if old_id == new_id {
+            self.set_collection_crdt_type(crdt_type);
+            return;
+        }
+
+        // Snapshot all entries before migration (must do this before clearing).
+        let entries: Vec<(K, V)> = self
+            .iter_unordered()
+            .expect("failed to read entries for re-key")
+            .collect();
+
+        // Clear the collection (removes old entries with old IDs).
+        self.inner.clear().expect("failed to clear for re-key");
+
+        // Reassign the collection's ID (Collection's `_with_crdt_type` is itself
+        // just `_under(None, ..)`, so this single call covers both variants).
+        self.inner
+            .reassign_deterministic_id_under(parent_id, field_name, crdt_type);
+
+        // Re-insert all entries (they will get new IDs based on new parent ID).
+        for (key, value) in entries {
+            self.insert(key, value)
+                .expect("failed to re-insert entry during re-key");
+        }
+    }
+
+    /// Reassigns the map's ID and collection CRDT type to deterministic values.
+    pub(crate) fn reassign_deterministic_id_with_crdt_type(
+        &mut self,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) where
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
+    {
+        self.reassign_deterministic_id_keyed(None, field_name, crdt_type);
+    }
+
+    /// Like [`reassign_deterministic_id_with_crdt_type`], but keys the new id
+    /// relative to `parent_id` (for a map nested inside another entity).
+    ///
+    /// [`reassign_deterministic_id_with_crdt_type`]: Self::reassign_deterministic_id_with_crdt_type
+    pub(crate) fn reassign_deterministic_id_under(
+        &mut self,
+        parent_id: Id,
+        field_name: &str,
+        crdt_type: CrdtType,
+    ) where
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
+    {
+        self.reassign_deterministic_id_keyed(Some(parent_id), field_name, crdt_type);
+    }
+
     /// Reassigns the map's ID to a deterministic ID based on field name,
     /// migrating all existing entries to the new parent ID.
     ///
@@ -121,41 +218,15 @@ where
     ///
     /// # Arguments
     /// * `field_name` - The name of the struct field containing this map
-    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
     pub fn reassign_deterministic_id(&mut self, field_name: &str)
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
-        let crdt_type =
-            CrdtType::sorted_map(std::any::type_name::<K>(), std::any::type_name::<V>());
-
-        let new_id = super::compute_collection_id(None, field_name);
-        let old_id = self.inner.id();
-
-        // If already has the correct ID, only ensure CRDT type is correct.
-        if old_id == new_id {
-            self.set_collection_crdt_type(crdt_type);
-            return;
-        }
-
-        // Collect all entries before migration (must do this before clearing).
-        let entries: Vec<(K, V)> = self
-            .iter_unordered()
-            .expect("failed to read entries for migration")
-            .collect();
-
-        // Clear the collection (removes old entries with old IDs).
-        self.inner.clear().expect("failed to clear for migration");
-
-        // Now reassign the collection's ID with the requested CRDT type.
-        self.inner
-            .reassign_deterministic_id_with_crdt_type(field_name, crdt_type);
-
-        // Re-insert all entries (they will get new IDs based on new parent ID).
-        for (key, value) in entries {
-            self.insert(key, value)
-                .expect("failed to re-insert entry during migration");
-        }
+        self.reassign_deterministic_id_with_crdt_type(
+            field_name,
+            CrdtType::sorted_map(std::any::type_name::<K>(), std::any::type_name::<V>()),
+        );
     }
 
     /// Insert a key-value pair into the map.
@@ -169,7 +240,8 @@ where
     /// returned.
     pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreError>
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
         self.insert_with_storage_type(key, value, StorageType::Public, None)
     }
@@ -185,14 +257,25 @@ where
     pub(crate) fn insert_with_storage_type(
         &mut self,
         key: K,
-        value: V,
+        mut value: V,
         storage_type: StorageType,
         custom_id: Option<Id>,
     ) -> Result<Option<V>, StoreError>
     where
-        K: AsRef<[u8]> + PartialEq,
+        K: AsRef<[u8]> + PartialEq + 'static,
+        V: 'static,
     {
+        // Register this map type's nested-id re-key thunk, so a map stored as
+        // another collection's value (map-of-map) is re-keyed when that outer
+        // collection is itself stored (see `super::rekey`).
+        super::rekey::register_rekey::<Self>();
+
         let id = custom_id.unwrap_or_else(|| compute_id(self.inner.id(), key.as_ref()));
+
+        // Re-key any nested collections in `value` deterministically relative to
+        // this entry's (deterministic) id, so independently-created nested CRDTs
+        // converge across nodes instead of carrying per-node random ids.
+        super::rekey::rekey_nested_value(&mut value, id);
 
         if let Some(mut entry) = self.inner.get_mut(id)? {
             let (_, v) = &mut *entry;
@@ -638,15 +721,26 @@ where
 
 impl<K, V, S> Extend<(K, V)> for SortedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        // Register this map type's own re-key thunk, exactly as the other store
+        // paths do, so a map populated only via `extend`/`collect` is still
+        // re-keyed when it is itself nested as a value (map-of-map).
+        super::rekey::register_rekey::<Self>();
+
         let parent = self.inner.id();
 
-        let iter = iter.into_iter().map(|(k, v)| {
+        let iter = iter.into_iter().map(|(k, mut v)| {
             let id = compute_id(parent, k.as_ref());
+
+            // Re-key nested collections in the value relative to its entry id,
+            // matching `insert`/`VacantEntry::insert`. Without this, a nested CRDT
+            // bulk-inserted via `extend`/`collect` keeps a random internal id and
+            // two nodes that independently build the same entry never converge.
+            super::rekey::rekey_nested_value(&mut v, id);
 
             (Some(id), (k, v))
         });
@@ -657,8 +751,8 @@ where
 
 impl<K, V, S> FromIterator<(K, V)> for SortedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
-    V: BorshSerialize + BorshDeserialize,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
     S: StorageAdaptor,
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
@@ -772,7 +866,10 @@ where
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn or_insert(self, default: V) -> Result<ValueMut<'a, K, V, S>, StoreError> {
+    pub fn or_insert(self, default: V) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        V: 'static,
+    {
         match self {
             Entry::Occupied(entry) => Ok(ValueMut {
                 entry_mut: entry.entry_mut,
@@ -791,6 +888,7 @@ where
     pub fn or_insert_with<F>(self, f: F) -> Result<ValueMut<'a, K, V, S>, StoreError>
     where
         F: FnOnce() -> V,
+        V: 'static,
     {
         match self {
             Entry::Occupied(entry) => Ok(ValueMut {
@@ -818,7 +916,13 @@ where
     }
 
     /// Replaces the value in the entry and returns the old value.
-    pub fn insert(&mut self, value: V) -> V {
+    pub fn insert(&mut self, mut value: V) -> V
+    where
+        V: 'static,
+    {
+        // Re-key nested collections in the replacement value relative to this
+        // entry's (stable, deterministic) id — same reason as `VacantEntry::insert`.
+        super::rekey::rekey_nested_value(&mut value, self.entry_mut.id());
         mem::replace(&mut self.entry_mut.1, value)
     }
 
@@ -846,8 +950,16 @@ where
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn insert(self, value: V) -> Result<ValueMut<'a, K, V, S>, StoreError> {
+    pub fn insert(self, mut value: V) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        V: 'static,
+    {
         let id = compute_id(self.map.inner.id(), self.key.as_ref());
+
+        // Re-key any nested collections in `value` deterministically relative to
+        // this entry's (deterministic) id — exactly as `insert_with_storage_type`
+        // does, so a nested CRDT stored via the Entry API converges across nodes.
+        super::rekey::rekey_nested_value(&mut value, id);
 
         drop(self.map.inner.insert(Some(id), (self.key, value))?);
 
@@ -903,7 +1015,7 @@ mod tests {
 
         // Insert deliberately out of order.
         for k in ["delta", "alpha", "charlie", "bravo", "echo"] {
-            drop(map.insert(k.to_owned(), k.to_uppercase()).unwrap());
+            map.insert(k.to_owned(), k.to_uppercase()).unwrap();
         }
 
         let keys: Vec<String> = map.keys().expect("keys failed").collect();
@@ -921,7 +1033,7 @@ mod tests {
     fn test_sorted_map_range() {
         let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
         for k in ["a", "b", "c", "d", "e", "f"] {
-            drop(map.insert(k.to_owned(), k.to_owned()).unwrap());
+            map.insert(k.to_owned(), k.to_owned()).unwrap();
         }
 
         // Half-open range [b, e).
@@ -953,7 +1065,7 @@ mod tests {
     fn test_sorted_map_prefix() {
         let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
         for k in ["user:alice", "user:bob", "post:1", "user:carol", "post:2"] {
-            drop(map.insert(k.to_owned(), String::new()).unwrap());
+            map.insert(k.to_owned(), String::new()).unwrap();
         }
 
         let users: Vec<String> = map
@@ -1004,7 +1116,7 @@ mod tests {
         assert!(map.last().unwrap().is_none());
 
         for k in ["m", "a", "z", "f"] {
-            drop(map.insert(k.to_owned(), k.to_owned()).unwrap());
+            map.insert(k.to_owned(), k.to_owned()).unwrap();
         }
 
         assert_eq!(map.first().unwrap().unwrap().0, "a");
@@ -1039,7 +1151,7 @@ mod tests {
     fn test_sorted_map_remove_updates_order() {
         let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
         for k in ["a", "b", "c", "d"] {
-            drop(map.insert(k.to_owned(), k.to_owned()).unwrap());
+            map.insert(k.to_owned(), k.to_owned()).unwrap();
         }
 
         drop(map.remove("b").unwrap());
@@ -1115,7 +1227,7 @@ mod tests {
     #[test]
     fn test_entry_occupied_is_used_in_match() {
         let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
-        drop(map.insert("k".to_owned(), "v".to_owned()).unwrap());
+        map.insert("k".to_owned(), "v".to_owned()).unwrap();
 
         let value = match map.entry("k".to_owned()).unwrap() {
             Entry::Occupied(e) => e.get().clone(),

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -337,14 +337,26 @@ where
         // converge across nodes instead of carrying per-node random ids.
         super::rekey::rekey_nested_value(&mut value, id);
 
-        if let Some(mut entry) = self.inner.get_mut(id)? {
-            let (_, v) = &mut *entry;
-
-            // A value-only update doesn't change the key set, so the ordered
-            // index entry stays correct; we deliberately don't stamp the marker
-            // here (the post-write `full_hash` isn't available until the guard
-            // drops), so the next ordered read rebuilds once. Rare path.
-            return Ok(Some(mem::replace(v, value)));
+        if self.inner.contains(id)? {
+            // Value-only update. Scope the guard in its own block so its
+            // write-back refreshes the collection's `full_hash` before we read
+            // it below. (`value` is moved only on this returning path, so the
+            // fall-through new-key path keeps ownership of it.)
+            let old = {
+                let mut entry = self
+                    .inner
+                    .get_mut(id)?
+                    .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
+                let (_, v) = &mut *entry;
+                mem::replace(v, value)
+            };
+            // The key set didn't change, so the ordered index is still correct —
+            // restamp the marker to the new `full_hash` so the next ordered read
+            // stays a seek instead of forcing a needless O(n) rebuild.
+            if S::index_supported() {
+                self.stamp_index_marker();
+            }
+            return Ok(Some(old));
         }
 
         // Capture the order key before `key` is moved, so we can warm the index
@@ -1664,6 +1676,42 @@ mod tests {
         assert_eq!(
             forward, shuffled,
             "SortedMap entity hash diverged on shuffled insertion order"
+        );
+    }
+
+    // A value-only update (re-`insert` on an existing key) doesn't change the key
+    // set, so the ordered index stays correct and the validity marker must remain
+    // current — otherwise every value update would force a needless O(n) rebuild
+    // on the next ordered read.
+    #[test]
+    fn value_only_update_keeps_index_marker_current() {
+        crate::env::reset_for_testing();
+        let mut map: SortedMap<String, String, Indexed> = SortedMap::new();
+        map.insert("a".to_owned(), "1".to_owned()).unwrap();
+        map.insert("b".to_owned(), "2".to_owned()).unwrap();
+
+        // Warm + validate the index, then confirm the marker is current.
+        assert!(map.ensure_index().unwrap());
+        assert!(map.index_marker_current());
+
+        // Re-insert an existing key with a new value (the key set is unchanged).
+        drop(map.insert("a".to_owned(), "99".to_owned()).unwrap());
+        assert!(
+            map.index_marker_current(),
+            "value-only update left the index marker stale, forcing a needless rebuild"
+        );
+
+        // The read is still correct without a rebuild.
+        let got: Vec<(String, String)> = map
+            .range("a".to_owned()..="b".to_owned())
+            .unwrap()
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                ("a".to_owned(), "99".to_owned()),
+                ("b".to_owned(), "2".to_owned())
+            ]
         );
     }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -59,7 +59,7 @@ use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::error::StorageError;
 use crate::index::Index;
 use crate::store::{Key, MainStorage};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A map collection that keeps its entries ordered by key, enabling range and
 /// prefix queries plus pagination.
@@ -517,18 +517,43 @@ where
             == Some(&self.current_full_hash()[..])
     }
 
-    /// Rebuild the ordered index for this collection from the authoritative
-    /// entry set (one `O(n)` scan), then stamp the validity marker. Used when a
-    /// remote sync (or an untracked local edit) left the index stale.
+    /// Reconcile the ordered index with the authoritative entry set, then stamp
+    /// the validity marker. Used when a remote sync (or an untracked local edit)
+    /// left the index stale.
+    ///
+    /// Rather than clear-and-rebuild, this diffs the desired key set (from the
+    /// entries) against the current index and writes only the difference — so a
+    /// sync that touched a few keys in a large map costs `O(changed)` index
+    /// writes, not `O(n)`. (Reading the entries to learn their keys is still
+    /// `O(n)`: keys are co-stored with values under hashed ids, so there's no
+    /// cheaper way to discover them — the irreducible floor from core#2559.)
     fn rebuild_index(&self) -> Result<(), StoreError>
     where
         K: AsRef<[u8]>,
     {
         let collection = self.inner.id();
-        S::index_clear(collection);
-        for (k, _v) in self.iter_unordered()? {
-            S::index_put(collection, k.as_ref(), compute_id(collection, k.as_ref()));
+
+        // Desired keys = the authoritative entry set (the O(n) read floor).
+        let desired: BTreeSet<Vec<u8>> = self
+            .iter_unordered()?
+            .map(|(k, _v)| k.as_ref().to_vec())
+            .collect();
+
+        // Current index keys.
+        let existing: BTreeSet<Vec<u8>> =
+            S::index_range(collection, Bound::Unbounded, Bound::Unbounded, 0, None)
+                .into_iter()
+                .map(|(order_key, _id)| order_key)
+                .collect();
+
+        // Drop stale keys, add missing ones — only the diff is written.
+        for order_key in existing.difference(&desired) {
+            S::index_remove(collection, order_key);
         }
+        for order_key in desired.difference(&existing) {
+            S::index_put(collection, order_key, compute_id(collection, order_key));
+        }
+
         self.stamp_index_marker();
         Ok(())
     }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -14,33 +14,42 @@
 //! secondary index keyed by `collection ‖ order_key` (unhashed, so the backend's
 //! byte order is the logical key order) in a dedicated storage column.
 //!
-//! ## Performance
+//! # Complexity (on a node, with the index-backing `MainStorage`)
 //!
-//! With an index-backing adaptor (`MainStorage` on a node), the index is
-//! maintained incrementally on `insert`/`remove`/`clear` and validated by a
-//! `full_hash` marker:
+//! | Operation | Cost |
+//! |---|---|
+//! | [`range`](SortedMap::range) / [`prefix`](SortedMap::prefix) | `O(log n + k)` (seek; only the `k` matches' values load) |
+//! | [`page`](SortedMap::page)`(offset, limit)` | `O(offset + limit)` |
+//! | [`first`](SortedMap::first) / [`last`](SortedMap::last) | `O(log n)` (forward / reverse seek) |
+//! | [`get`](SortedMap::get) / [`insert`](SortedMap::insert) / [`remove`](SortedMap::remove) | `O(1)` point op **+ an index write + a marker read/write** |
+//! | [`entries`](SortedMap::entries) / [`keys`](SortedMap::keys) / [`values`](SortedMap::values) | `O(n)` (they return everything) |
+//! | post-sync rebuild (first ordered read after a sync) | `O(n)` reads, `O(changed)` writes |
 //!
-//! - [`range`](SortedMap::range) / [`prefix`](SortedMap::prefix) — `O(log n + k)`
-//!   (native seek; only the `k` matching values are loaded).
-//! - [`page`](SortedMap::page) — `O(offset + limit)`.
-//! - [`first`](SortedMap::first) / [`last`](SortedMap::last) — `O(log n)`
-//!   (forward / reverse seek to the smallest / largest key).
-//! - [`entries`](SortedMap::entries) / [`keys`](SortedMap::keys) /
-//!   [`values`](SortedMap::values) — `O(n)` (they return everything).
+//! The index is maintained incrementally on `insert`/`remove`/`clear` and
+//! validated by a `full_hash` marker, so a read right after a *local* write is
+//! still a seek. Only a **remote sync** (which mutates entries host-side without
+//! going through `insert`) leaves the index stale; the next ordered read notices
+//! the marker mismatch and rebuilds once, then resumes seeking.
 //!
-//! Local writes keep the index warm, so a read right after a write is still a
-//! seek. Only a **remote sync** (which mutates entries host-side without going
-//! through `insert`) leaves the index stale; the next ordered read notices the
-//! marker mismatch and rebuilds once (`O(n)`), then resumes seeking.
+//! # When to use `SortedMap` vs [`UnorderedMap`](super::UnorderedMap)
 //!
-//! ## CRDT-safety and the fallback
+//! **Default to [`UnorderedMap`](super::UnorderedMap)** — it has no per-write
+//! index overhead and no extra disk. Use `SortedMap` *only* when you genuinely
+//! need key order: range/prefix queries, pagination, sorted iteration, or
+//! min/max. The fast ordered reads above are paid for on every write (the extra
+//! index + marker writes), in extra storage per key, and by the post-sync
+//! rebuild — wasted if you only ever point-access the map. `SortedMap` is the
+//! `BTreeMap` to `UnorderedMap`'s `HashMap`.
+//!
+//! # CRDT-safety and the fallback
 //!
 //! The index is *not* synced — it is a derived materialised view of the
 //! authoritative (synced) entry set, so there is no extra merge path: order is a
 //! pure function of `K: Ord`, and each node rebuilds its own index from the
 //! entries it has. Adaptors that don't back an ordered keyspace (e.g.
 //! `PrivateStorage`) transparently fall back to an **in-memory sort** of the
-//! entries on each ordered read — correct, just `O(n log n)` instead of a seek.
+//! entries on each ordered read — correct, just `O(n log n)` instead of a seek
+//! (so under private storage `SortedMap` has no speed advantage).
 
 use core::borrow::Borrow;
 use core::fmt;

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -1,0 +1,1126 @@
+//! An ordered key-value map supporting range and prefix queries.
+//!
+//! [`SortedMap`] stores its entries exactly like [`UnorderedMap`](super::UnorderedMap)
+//! — a single inner [`Collection`] of `(K, V)` pairs keyed by
+//! `compute_id(parent, key)` — so it inherits the *identical* CRDT merge
+//! semantics (add-wins keys, recursive value merge, per-key tombstones) and
+//! on-wire byte layout. Nothing extra is synced.
+//!
+//! What it adds is an **ordered view**. Because entry ids are
+//! `SHA256(parent ‖ key)`, entity-id order ≠ key order, and the underlying
+//! store cannot seek by key (see core#2559). `SortedMap` therefore materialises
+//! the key order *in memory* on each ordered read: it reads the entries once and
+//! sorts them by `K: Ord`. The order is a pure function of the key set, so every
+//! replica derives the same order with **zero extra merge logic** — that is what
+//! makes the ordering CRDT-safe.
+//!
+//! This deliberately does not pretend to do sub-linear disk seeks (impossible
+//! while keys are hashed). Its value is ergonomic: it encapsulates and amortises
+//! the `keys.sort()` dance apps used to write by hand, and exposes
+//! [`range`](SortedMap::range), [`prefix`](SortedMap::prefix),
+//! [`page`](SortedMap::page) and sorted [`entries`](SortedMap::entries) /
+//! [`keys`](SortedMap::keys) / [`values`](SortedMap::values) directly.
+
+use core::borrow::Borrow;
+use core::fmt;
+use core::ops::{Deref, DerefMut, RangeBounds};
+use std::mem;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::ser::SerializeMap;
+use serde::Serialize;
+
+use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor};
+use crate::address::Id;
+use crate::collections::error::StoreError;
+use crate::entities::{ChildInfo, Data, Element, StorageType};
+use crate::error::StorageError;
+use crate::store::MainStorage;
+use std::collections::BTreeMap;
+
+/// A map collection that keeps its entries ordered by key, enabling range and
+/// prefix queries plus pagination.
+///
+/// See the [module documentation](self) for the storage model and the
+/// CRDT-safety argument.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct SortedMap<K, V, S: StorageAdaptor = MainStorage> {
+    #[borsh(bound(serialize = "", deserialize = ""))]
+    inner: Collection<(K, V), S>,
+}
+
+impl<K, V, S> SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Create a new sorted map with a random ID.
+    ///
+    /// Use this for nested collections stored as values in other maps. Merge
+    /// happens by the parent map's key, so the nested collection's ID doesn't
+    /// affect sync semantics.
+    ///
+    /// For top-level state fields, use [`new_with_field_name`](Self::new_with_field_name).
+    pub fn new() -> Self {
+        Self::new_internal()
+    }
+
+    /// Create a new sorted map with a deterministic ID derived from `field_name`.
+    ///
+    /// Use this for top-level state fields (the `#[app::state]` macro does this
+    /// automatically).
+    ///
+    /// # Example
+    /// ```ignore
+    /// let items = SortedMap::<String, String>::new_with_field_name("items");
+    /// ```
+    pub fn new_with_field_name(field_name: &str) -> Self {
+        Self::new_with_field_name_internal(None, field_name)
+    }
+}
+
+impl<K, V, S> SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Create a new sorted map (internal).
+    pub(super) fn new_internal() -> Self {
+        Self {
+            inner: Collection::new(None),
+        }
+    }
+
+    /// Create a new sorted map with a deterministic ID (internal).
+    pub(super) fn new_with_field_name_internal(
+        parent_id: Option<crate::address::Id>,
+        field_name: &str,
+    ) -> Self {
+        Self {
+            inner: Collection::new_with_field_name_and_crdt_type(
+                parent_id,
+                field_name,
+                CrdtType::sorted_map(std::any::type_name::<K>(), std::any::type_name::<V>()),
+            ),
+        }
+    }
+
+    /// Updates the CRDT type metadata on the map collection itself.
+    pub(crate) fn set_collection_crdt_type(&mut self, crdt_type: CrdtType) {
+        self.inner.element_mut().metadata.crdt_type = Some(crdt_type);
+    }
+
+    /// Reassigns the map's ID to a deterministic ID based on field name,
+    /// migrating all existing entries to the new parent ID.
+    ///
+    /// Called by the `#[app::state]` macro after `init()` returns so every
+    /// top-level collection ends up with a deterministic ID regardless of how it
+    /// was created in `init()`.
+    ///
+    /// # Arguments
+    /// * `field_name` - The name of the struct field containing this map
+    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
+    pub fn reassign_deterministic_id(&mut self, field_name: &str)
+    where
+        K: AsRef<[u8]> + PartialEq,
+    {
+        let crdt_type =
+            CrdtType::sorted_map(std::any::type_name::<K>(), std::any::type_name::<V>());
+
+        let new_id = super::compute_collection_id(None, field_name);
+        let old_id = self.inner.id();
+
+        // If already has the correct ID, only ensure CRDT type is correct.
+        if old_id == new_id {
+            self.set_collection_crdt_type(crdt_type);
+            return;
+        }
+
+        // Collect all entries before migration (must do this before clearing).
+        let entries: Vec<(K, V)> = self
+            .iter_unordered()
+            .expect("failed to read entries for migration")
+            .collect();
+
+        // Clear the collection (removes old entries with old IDs).
+        self.inner.clear().expect("failed to clear for migration");
+
+        // Now reassign the collection's ID with the requested CRDT type.
+        self.inner
+            .reassign_deterministic_id_with_crdt_type(field_name, crdt_type);
+
+        // Re-insert all entries (they will get new IDs based on new parent ID).
+        for (key, value) in entries {
+            self.insert(key, value)
+                .expect("failed to re-insert entry during migration");
+        }
+    }
+
+    /// Insert a key-value pair into the map.
+    ///
+    /// Returns the previous value for `key` if one existed.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreError>
+    where
+        K: AsRef<[u8]> + PartialEq,
+    {
+        self.insert_with_storage_type(key, value, StorageType::Public, None)
+    }
+
+    /// Insert a key-value pair with the specified `StorageType` and optional
+    /// custom `Id`.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub(crate) fn insert_with_storage_type(
+        &mut self,
+        key: K,
+        value: V,
+        storage_type: StorageType,
+        custom_id: Option<Id>,
+    ) -> Result<Option<V>, StoreError>
+    where
+        K: AsRef<[u8]> + PartialEq,
+    {
+        let id = custom_id.unwrap_or_else(|| compute_id(self.inner.id(), key.as_ref()));
+
+        if let Some(mut entry) = self.inner.get_mut(id)? {
+            let (_, v) = &mut *entry;
+
+            return Ok(Some(mem::replace(v, value)));
+        }
+
+        let _ignored = self
+            .inner
+            .insert_with_storage_type(Some(id), (key, value), storage_type)?;
+
+        Ok(None)
+    }
+
+    /// Get the number of entries in the map.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the map contains no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Get the value for a key in the map.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn get<Q>(&self, key: &Q) -> Result<Option<V>, StoreError>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + AsRef<[u8]> + ?Sized,
+    {
+        let id = compute_id(self.inner.id(), key.as_ref());
+
+        Ok(self.inner.get(id)?.map(|(_, v)| v))
+    }
+
+    /// Returns a mutable `ValueMut` guard for the value at `key`.
+    ///
+    /// Modifications are written back to storage when the guard is dropped.
+    /// Mutating a value never changes the key set, so the ordering is unaffected.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn get_mut<'a, Q>(
+        &'a mut self,
+        key: &Q,
+    ) -> Result<Option<ValueMut<'a, K, V, S>>, StoreError>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + AsRef<[u8]> + ?Sized,
+    {
+        let id = compute_id(self.inner.id(), key.as_ref());
+
+        let entry_option = self.inner.get_mut(id)?;
+
+        Ok(entry_option.map(|entry_mut| ValueMut { entry_mut }))
+    }
+
+    /// Gets the given key's corresponding entry for in-place manipulation.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn entry<'a>(&'a mut self, key: K) -> Result<Entry<'a, K, V, S>, StoreError>
+    where
+        K: PartialEq + AsRef<[u8]>,
+    {
+        let id = compute_id(self.inner.id(), key.as_ref());
+
+        if self.inner.contains(id)? {
+            let entry_mut = self
+                .inner
+                .get_mut(id)?
+                .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
+
+            Ok(Entry::Occupied(OccupiedEntry { entry_mut }))
+        } else {
+            Ok(Entry::Vacant(VacantEntry { map: self, key }))
+        }
+    }
+
+    /// Check if the map contains a key.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn contains<Q>(&self, key: &Q) -> Result<bool, StoreError>
+    where
+        K: Borrow<Q> + PartialEq,
+        Q: PartialEq + AsRef<[u8]> + ?Sized,
+    {
+        let id = compute_id(self.inner.id(), key.as_ref());
+
+        self.inner.contains(id)
+    }
+
+    /// Remove a key from the map, returning the value if it previously existed.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn remove<Q>(&mut self, key: &Q) -> Result<Option<V>, StoreError>
+    where
+        K: Borrow<Q>,
+        Q: PartialEq + AsRef<[u8]> + ?Sized,
+    {
+        let id = compute_id(self.inner.id(), key.as_ref());
+
+        let Some(entry) = self.inner.get_mut(id)? else {
+            return Ok(None);
+        };
+
+        entry.remove().map(|(_, v)| Some(v))
+    }
+
+    /// Clear the map, removing all entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, or a child
+    /// [`Element`](crate::entities::Element) cannot be found, an error will be
+    /// returned.
+    pub fn clear(&mut self) -> Result<(), StoreError> {
+        self.inner.clear()
+    }
+
+    /// Iterate entries in storage (hash) order — *not* key order.
+    ///
+    /// This is the building block the ordered readers sort. Kept private so the
+    /// public surface only ever exposes key-ordered iteration; merge and
+    /// migration paths that don't care about order use it to avoid the `K: Ord`
+    /// bound.
+    fn iter_unordered(&self) -> Result<impl Iterator<Item = (K, V)> + '_, StoreError> {
+        let collection_id = self.inner.id();
+        Ok(self.inner.entries()?.filter_map(move |result| match result {
+            Ok(entry) => Some(entry),
+            Err(error) => {
+                tracing::error!(
+                    target: "calimero_storage::iter_drop",
+                    %collection_id,
+                    %error,
+                    collection_type = "SortedMap",
+                    "ITER_DROP: parent's child list advertises an id whose entry could not be loaded — \
+                     likely entry-before-parent ordering race or storage inconsistency. \
+                     Caller will see a truncated iteration."
+                );
+                None
+            }
+        }).fuse())
+    }
+}
+
+impl<K, V, S> SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + Ord,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Materialise every `(K, V)` pair sorted ascending by key.
+    ///
+    /// This is the single full scan that backs every ordered reader. See the
+    /// [module docs](self) for why the order must be derived in memory rather
+    /// than seeked.
+    fn sorted_pairs(&self) -> Result<Vec<(K, V)>, StoreError> {
+        let mut pairs: Vec<(K, V)> = self.iter_unordered()?.collect();
+        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(pairs)
+    }
+
+    /// Iterate all entries in ascending key order.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn entries(&self) -> Result<impl Iterator<Item = (K, V)>, StoreError> {
+        Ok(self.sorted_pairs()?.into_iter())
+    }
+
+    /// Iterate all keys in ascending order.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn keys(&self) -> Result<impl Iterator<Item = K>, StoreError> {
+        Ok(self.sorted_pairs()?.into_iter().map(|(k, _)| k))
+    }
+
+    /// Iterate all values in ascending key order.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn values(&self) -> Result<impl Iterator<Item = V>, StoreError> {
+        Ok(self.sorted_pairs()?.into_iter().map(|(_, v)| v))
+    }
+
+    /// Iterate the entries whose keys fall within `range`, in ascending order.
+    ///
+    /// Accepts any [`RangeBounds<K>`], e.g. `a..b`, `a..=b`, `..b`, `c..`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// // entries with keys in ["m", "t")
+    /// for (k, v) in map.range("m".to_owned().."t".to_owned())? { /* ... */ }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn range<R>(&self, range: R) -> Result<impl Iterator<Item = (K, V)>, StoreError>
+    where
+        R: RangeBounds<K>,
+    {
+        // Filter to the range *before* sorting so the sort cost scales with the
+        // number of matches `m`, not the whole map `n`: O(n) scan + O(m log m).
+        let mut pairs: Vec<(K, V)> = self
+            .iter_unordered()?
+            .filter(|(k, _)| range.contains(k))
+            .collect();
+        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(pairs.into_iter())
+    }
+
+    /// Iterate the entries whose key bytes start with `prefix`, in ascending
+    /// order.
+    ///
+    /// Useful for hierarchical keys such as `"user:"` or `"2026-05:"`. Relies on
+    /// `K`'s byte representation ([`AsRef<[u8]>`]) matching its sort order — true
+    /// for `String`/`&str` and other lexicographically-ordered byte keys.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn prefix(&self, prefix: &[u8]) -> Result<impl Iterator<Item = (K, V)>, StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        // Filter by prefix before sorting: O(n) scan + O(m log m) on matches.
+        let prefix = prefix.to_vec();
+        let mut pairs: Vec<(K, V)> = self
+            .iter_unordered()?
+            .filter(|(k, _)| k.as_ref().starts_with(&prefix))
+            .collect();
+        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(pairs.into_iter())
+    }
+
+    /// Return a page of `limit` entries starting at `offset`, in ascending key
+    /// order. The canonical way to paginate without loading the whole map into
+    /// the caller.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn page(&self, offset: usize, limit: usize) -> Result<Vec<(K, V)>, StoreError> {
+        Ok(self
+            .sorted_pairs()?
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect())
+    }
+
+    /// The entry with the smallest key, if any.
+    ///
+    /// A single O(n) min-pass — it does **not** sort the whole map.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn first(&self) -> Result<Option<(K, V)>, StoreError> {
+        Ok(self.iter_unordered()?.min_by(|(a, _), (b, _)| a.cmp(b)))
+    }
+
+    /// The entry with the largest key, if any.
+    ///
+    /// A single O(n) max-pass — it does **not** sort the whole map.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn last(&self) -> Result<Option<(K, V)>, StoreError> {
+        Ok(self.iter_unordered()?.max_by(|(a, _), (b, _)| a.cmp(b)))
+    }
+}
+
+// Implement Data for SortedMap by delegating to its inner Collection.
+impl<K, V, S> Data for SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn collections(&self) -> BTreeMap<String, Vec<ChildInfo>> {
+        self.inner.collections()
+    }
+
+    fn element(&self) -> &Element {
+        self.inner.element()
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        self.inner.element_mut()
+    }
+}
+
+impl<K, V, S> Eq for SortedMap<K, V, S>
+where
+    K: Eq + Ord + BorshSerialize + BorshDeserialize,
+    V: Eq + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+}
+
+impl<K, V, S> PartialEq for SortedMap<K, V, S>
+where
+    K: Ord + BorshSerialize + BorshDeserialize,
+    V: PartialEq + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::unwrap_used, reason = "'tis fine")]
+    fn eq(&self, other: &Self) -> bool {
+        let l = self.entries().unwrap();
+        let r = other.entries().unwrap();
+
+        l.eq(r)
+    }
+}
+
+impl<K, V, S> Ord for SortedMap<K, V, S>
+where
+    K: Ord + BorshSerialize + BorshDeserialize,
+    V: Ord + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::unwrap_used, reason = "'tis fine")]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let l = self.entries().unwrap();
+        let r = other.entries().unwrap();
+
+        l.cmp(r)
+    }
+}
+
+impl<K, V, S> PartialOrd for SortedMap<K, V, S>
+where
+    K: Ord + BorshSerialize + BorshDeserialize,
+    V: PartialOrd + Ord + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let l = self.entries().ok()?;
+        let r = other.entries().ok()?;
+
+        l.partial_cmp(r)
+    }
+}
+
+impl<K, V, S> fmt::Debug for SortedMap<K, V, S>
+where
+    K: Ord + fmt::Debug + BorshSerialize + BorshDeserialize,
+    V: fmt::Debug + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            f.debug_struct("SortedMap")
+                .field("entries", &self.inner)
+                .finish()
+        } else {
+            f.debug_map().entries(self.entries().unwrap()).finish()
+        }
+    }
+}
+
+impl<K, V, S> Default for SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn default() -> Self {
+        Self::new_internal()
+    }
+}
+
+impl<K, V, S> Serialize for SortedMap<K, V, S>
+where
+    K: Ord + BorshSerialize + BorshDeserialize + Serialize,
+    V: BorshSerialize + BorshDeserialize + Serialize,
+    S: StorageAdaptor,
+{
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: serde::Serializer,
+    {
+        let len = self.len().map_err(serde::ser::Error::custom)?;
+
+        let mut seq = serializer.serialize_map(Some(len))?;
+
+        // Entries are emitted in ascending key order — a `SortedMap` serialises
+        // to a deterministically-ordered JSON object.
+        for (k, v) in self.entries().map_err(serde::ser::Error::custom)? {
+            seq.serialize_entry(&k, &v)?;
+        }
+
+        seq.end()
+    }
+}
+
+impl<K, V, S> Extend<(K, V)> for SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        let parent = self.inner.id();
+
+        let iter = iter.into_iter().map(|(k, v)| {
+            let id = compute_id(parent, k.as_ref());
+
+            (Some(id), (k, v))
+        });
+
+        self.inner.extend(iter);
+    }
+}
+
+impl<K, V, S> FromIterator<(K, V)> for SortedMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]>,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut map = SortedMap::new_internal();
+
+        map.extend(iter);
+
+        map
+    }
+}
+
+/// A mutable guard for a value in a [`SortedMap`].
+///
+/// Changes are written back to storage when this guard is dropped.
+#[derive(Debug)]
+pub struct ValueMut<'a, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    entry_mut: EntryMut<'a, (K, V), S>,
+}
+
+impl<K, V, S> Deref for ValueMut<'_, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entry_mut.deref().1
+    }
+}
+
+impl<K, V, S> DerefMut for ValueMut<'_, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entry_mut.deref_mut().1
+    }
+}
+
+/// A view into a single entry in a [`SortedMap`], which may either be occupied
+/// or vacant. Returned by [`SortedMap::entry`].
+#[derive(Debug)]
+pub enum Entry<'a, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// An occupied entry.
+    Occupied(OccupiedEntry<'a, K, V, S>),
+    /// A vacant entry.
+    Vacant(VacantEntry<'a, K, V, S>),
+}
+
+/// A view into an occupied entry in a [`SortedMap`].
+#[derive(Debug)]
+pub struct OccupiedEntry<'a, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    entry_mut: EntryMut<'a, (K, V), S>,
+}
+
+/// A view into a vacant entry in a [`SortedMap`].
+pub struct VacantEntry<'a, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    map: &'a mut SortedMap<K, V, S>,
+    key: K,
+}
+
+// Hand-written so it doesn't pull in `SortedMap: Debug` (which requires `K: Ord`
+// for its sorted iteration). The vacant entry only meaningfully has a key.
+impl<K, V, S> fmt::Debug for VacantEntry<'_, K, V, S>
+where
+    K: fmt::Debug + BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VacantEntry")
+            .field("key", &self.key)
+            .finish()
+    }
+}
+
+impl<'a, K, V, S> Entry<'a, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Ensures a value is in the entry by inserting the default if empty, and
+    /// returns a mutable `ValueMut` guard to the value.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn or_insert(self, default: V) -> Result<ValueMut<'a, K, V, S>, StoreError> {
+        match self {
+            Entry::Occupied(entry) => Ok(ValueMut {
+                entry_mut: entry.entry_mut,
+            }),
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the result of `f` if empty,
+    /// and returns a mutable `ValueMut` guard to the value.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn or_insert_with<F>(self, f: F) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        F: FnOnce() -> V,
+    {
+        match self {
+            Entry::Occupied(entry) => Ok(ValueMut {
+                entry_mut: entry.entry_mut,
+            }),
+            Entry::Vacant(entry) => entry.insert(f()),
+        }
+    }
+}
+
+impl<K, V, S> OccupiedEntry<'_, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Gets a reference to the value in the entry.
+    pub fn get(&self) -> &V {
+        &self.entry_mut.1
+    }
+
+    /// Gets a mutable reference to the value in the entry.
+    pub fn get_mut(&mut self) -> &mut V {
+        &mut self.entry_mut.1
+    }
+
+    /// Replaces the value in the entry and returns the old value.
+    pub fn insert(&mut self, value: V) -> V {
+        mem::replace(&mut self.entry_mut.1, value)
+    }
+
+    /// Removes the entry from the map and returns the removed value.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn remove(self) -> Result<V, StoreError> {
+        self.entry_mut.remove().map(|(_, v)| v)
+    }
+}
+
+impl<'a, K, V, S> VacantEntry<'a, K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Inserts a new value into the entry and returns a mutable `ValueMut`
+    /// guard to the new value.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn insert(self, value: V) -> Result<ValueMut<'a, K, V, S>, StoreError> {
+        let id = compute_id(self.map.inner.id(), self.key.as_ref());
+
+        drop(self.map.inner.insert(Some(id), (self.key, value))?);
+
+        let entry_mut = self
+            .map
+            .inner
+            .get_mut(id)?
+            .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
+
+        Ok(ValueMut { entry_mut })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::collections::sorted_map::Entry;
+    use crate::collections::{Root, SortedMap};
+    use crate::store::MainStorage;
+
+    #[test]
+    fn test_sorted_map_basic_operations() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+
+        assert!(map
+            .insert("key".to_owned(), "value".to_owned())
+            .expect("insert failed")
+            .is_none());
+
+        assert_eq!(
+            map.get("key").expect("get failed").as_deref(),
+            Some("value")
+        );
+
+        assert_eq!(
+            map.insert("key".to_owned(), "value2".to_owned())
+                .expect("insert failed")
+                .as_deref(),
+            Some("value")
+        );
+
+        assert_eq!(
+            map.remove("key")
+                .expect("error while removing key")
+                .as_deref(),
+            Some("value2")
+        );
+        assert_eq!(map.get("key").expect("get failed"), None);
+    }
+
+    #[test]
+    fn test_sorted_map_iterates_in_key_order_regardless_of_insertion_order() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+
+        // Insert deliberately out of order.
+        for k in ["delta", "alpha", "charlie", "bravo", "echo"] {
+            drop(map.insert(k.to_owned(), k.to_uppercase()).unwrap());
+        }
+
+        let keys: Vec<String> = map.keys().expect("keys failed").collect();
+        assert_eq!(keys, vec!["alpha", "bravo", "charlie", "delta", "echo"]);
+
+        let entries: Vec<(String, String)> = map.entries().expect("entries failed").collect();
+        assert_eq!(entries.first().unwrap().0, "alpha");
+        assert_eq!(entries.last().unwrap().0, "echo");
+
+        let values: Vec<String> = map.values().expect("values failed").collect();
+        assert_eq!(values, vec!["ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO"]);
+    }
+
+    #[test]
+    fn test_sorted_map_range() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        for k in ["a", "b", "c", "d", "e", "f"] {
+            drop(map.insert(k.to_owned(), k.to_owned()).unwrap());
+        }
+
+        // Half-open range [b, e).
+        let got: Vec<String> = map
+            .range("b".to_owned().."e".to_owned())
+            .expect("range failed")
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(got, vec!["b", "c", "d"]);
+
+        // Inclusive range [b, e].
+        let got: Vec<String> = map
+            .range("b".to_owned()..="e".to_owned())
+            .expect("range failed")
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(got, vec!["b", "c", "d", "e"]);
+
+        // Unbounded start ..c.
+        let got: Vec<String> = map
+            .range(.."c".to_owned())
+            .expect("range failed")
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(got, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_sorted_map_prefix() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        for k in ["user:alice", "user:bob", "post:1", "user:carol", "post:2"] {
+            drop(map.insert(k.to_owned(), String::new()).unwrap());
+        }
+
+        let users: Vec<String> = map
+            .prefix(b"user:")
+            .expect("prefix failed")
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(users, vec!["user:alice", "user:bob", "user:carol"]);
+
+        let posts: Vec<String> = map
+            .prefix(b"post:")
+            .expect("prefix failed")
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(posts, vec!["post:1", "post:2"]);
+    }
+
+    #[test]
+    fn test_sorted_map_pagination() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        for i in 0..10u32 {
+            // Zero-pad so lexicographic order matches numeric order.
+            map.insert(format!("k{i:02}"), i).unwrap();
+        }
+
+        let page0 = map.page(0, 3).expect("page failed");
+        assert_eq!(
+            page0.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+            vec!["k00", "k01", "k02"]
+        );
+
+        let page1 = map.page(3, 3).expect("page failed");
+        assert_eq!(
+            page1.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+            vec!["k03", "k04", "k05"]
+        );
+
+        // Last partial page.
+        let page3 = map.page(9, 3).expect("page failed");
+        assert_eq!(page3.len(), 1);
+        assert_eq!(page3[0].0, "k09");
+    }
+
+    #[test]
+    fn test_sorted_map_first_last() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        assert!(map.first().unwrap().is_none());
+        assert!(map.last().unwrap().is_none());
+
+        for k in ["m", "a", "z", "f"] {
+            drop(map.insert(k.to_owned(), k.to_owned()).unwrap());
+        }
+
+        assert_eq!(map.first().unwrap().unwrap().0, "a");
+        assert_eq!(map.last().unwrap().unwrap().0, "z");
+    }
+
+    #[test]
+    fn test_sorted_map_entry_api() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+
+        {
+            let mut guard = map
+                .entry("key1".to_owned())
+                .expect("entry failed")
+                .or_insert("value1".to_owned())
+                .expect("or_insert failed");
+            assert_eq!(*guard, "value1");
+            *guard = "updated".to_owned();
+        }
+        assert_eq!(map.get("key1").unwrap().as_deref(), Some("updated"));
+
+        // or_insert on occupied keeps the existing value.
+        let guard = map
+            .entry("key1".to_owned())
+            .expect("entry failed")
+            .or_insert("ignored".to_owned())
+            .expect("or_insert failed");
+        assert_eq!(*guard, "updated");
+    }
+
+    #[test]
+    fn test_sorted_map_remove_updates_order() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        for k in ["a", "b", "c", "d"] {
+            drop(map.insert(k.to_owned(), k.to_owned()).unwrap());
+        }
+
+        drop(map.remove("b").unwrap());
+
+        let keys: Vec<String> = map.keys().unwrap().collect();
+        assert_eq!(keys, vec!["a", "c", "d"]);
+        assert_eq!(map.len().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_sorted_map_get_mut_preserves_order() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        for k in ["b", "a", "c"] {
+            map.insert(k.to_owned(), 0u32).unwrap();
+        }
+
+        {
+            let mut guard = map.get_mut("a").unwrap().expect("key not found");
+            *guard = 42;
+        }
+
+        let entries: Vec<(String, u32)> = map.entries().unwrap().collect();
+        assert_eq!(
+            entries,
+            vec![
+                ("a".to_owned(), 42),
+                ("b".to_owned(), 0),
+                ("c".to_owned(), 0)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_deterministic_sorted_map_ids() {
+        crate::env::reset_for_testing();
+
+        let map1: SortedMap<String, String> = SortedMap::new_with_field_name("items");
+        let map2: SortedMap<String, String> = SortedMap::new_with_field_name("items");
+
+        assert_eq!(
+            <SortedMap<String, String> as crate::entities::Data>::id(&map1),
+            <SortedMap<String, String> as crate::entities::Data>::id(&map2),
+            "Maps with same field name should have same ID"
+        );
+
+        let map3: SortedMap<String, String> = SortedMap::new_with_field_name("products");
+        assert_ne!(
+            <SortedMap<String, String> as crate::entities::Data>::id(&map1),
+            <SortedMap<String, String> as crate::entities::Data>::id(&map3),
+            "Maps with different field names should have different IDs"
+        );
+    }
+
+    #[test]
+    fn test_reassign_deterministic_id_preserves_sorted_entries() {
+        crate::env::reset_for_testing();
+
+        let mut map = SortedMap::<String, String>::new();
+        map.insert("beta".to_owned(), "two".to_owned())
+            .expect("insert beta failed");
+        map.insert("alpha".to_owned(), "one".to_owned())
+            .expect("insert alpha failed");
+
+        let old_id = <SortedMap<String, String> as crate::entities::Data>::id(&map);
+        map.reassign_deterministic_id("items");
+        let new_id = <SortedMap<String, String> as crate::entities::Data>::id(&map);
+
+        assert_ne!(old_id, new_id);
+        let keys: Vec<String> = map.keys().expect("keys failed").collect();
+        assert_eq!(keys, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_entry_occupied_is_used_in_match() {
+        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        drop(map.insert("k".to_owned(), "v".to_owned()).unwrap());
+
+        let value = match map.entry("k".to_owned()).unwrap() {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(_) => panic!("expected occupied"),
+        };
+        assert_eq!(value, "v");
+    }
+}

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -8,19 +8,40 @@
 //! layout. Nothing extra is synced.
 //!
 //! What it adds is an **ordered view**. Because entry ids are
-//! `SHA256(parent ‖ key)`, entity-id order ≠ key order, and the underlying
-//! store cannot seek by key (see core#2559). `SortedMap` therefore materialises
-//! the key order *in memory* on each ordered read: it reads the entries once and
-//! sorts them by `K: Ord`. The order is a pure function of the key set, so every
-//! replica derives the same order with **zero extra merge logic** — that is what
-//! makes the ordering CRDT-safe.
+//! `SHA256(parent ‖ key)`, entity-id order ≠ key order, and the entity store
+//! cannot seek by key (see core#2559). `SortedMap` solves this with a
+//! **node-local, derived, non-synced ordered index** — a database-style
+//! secondary index keyed by `collection ‖ order_key` (unhashed, so the backend's
+//! byte order is the logical key order) in a dedicated storage column.
 //!
-//! This deliberately does not pretend to do sub-linear disk seeks (impossible
-//! while keys are hashed). Its value is ergonomic: it encapsulates and amortises
-//! the `keys.sort()` dance apps used to write by hand, and exposes
-//! [`range`](SortedMap::range), [`prefix`](SortedMap::prefix),
-//! [`page`](SortedMap::page) and sorted [`entries`](SortedMap::entries) /
-//! [`keys`](SortedMap::keys) / [`values`](SortedMap::values) directly.
+//! ## Performance
+//!
+//! With an index-backing adaptor (`MainStorage` on a node), the index is
+//! maintained incrementally on `insert`/`remove`/`clear` and validated by a
+//! `full_hash` marker:
+//!
+//! - [`range`](SortedMap::range) / [`prefix`](SortedMap::prefix) — `O(log n + k)`
+//!   (native seek; only the `k` matching values are loaded).
+//! - [`page`](SortedMap::page) — `O(limit)`.
+//! - [`first`](SortedMap::first) — `O(log n)` (seek to smallest);
+//!   [`last`](SortedMap::last) — forward-skip (loads only the last value; a
+//!   reverse seek is a future optimisation).
+//! - [`entries`](SortedMap::entries) / [`keys`](SortedMap::keys) /
+//!   [`values`](SortedMap::values) — `O(n)` (they return everything).
+//!
+//! Local writes keep the index warm, so a read right after a write is still a
+//! seek. Only a **remote sync** (which mutates entries host-side without going
+//! through `insert`) leaves the index stale; the next ordered read notices the
+//! marker mismatch and rebuilds once (`O(n)`), then resumes seeking.
+//!
+//! ## CRDT-safety and the fallback
+//!
+//! The index is *not* synced — it is a derived materialised view of the
+//! authoritative (synced) entry set, so there is no extra merge path: order is a
+//! pure function of `K: Ord`, and each node rebuilds its own index from the
+//! entries it has. Adaptors that don't back an ordered keyspace (e.g.
+//! `PrivateStorage`) transparently fall back to an **in-memory sort** of the
+//! entries on each ordered read — correct, just `O(n log n)` instead of a seek.
 
 use core::borrow::Borrow;
 use core::fmt;
@@ -728,25 +749,59 @@ where
 
     /// The entry with the smallest key, if any.
     ///
-    /// A single O(n) min-pass — it does **not** sort the whole map.
+    /// Index-backed: a seek to the first key, `O(log n)`. Falls back to a single
+    /// `O(n)` min-pass when the adaptor doesn't back the index.
     ///
     /// # Errors
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn first(&self) -> Result<Option<(K, V)>, StoreError> {
+    pub fn first(&self) -> Result<Option<(K, V)>, StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        if self.ensure_index()? {
+            let hits = S::index_range(
+                self.inner.id(),
+                Bound::Unbounded,
+                Bound::Unbounded,
+                0,
+                Some(1),
+            );
+            return Ok(self.resolve_hits(hits)?.into_iter().next());
+        }
         Ok(self.iter_unordered()?.min_by(|(a, _), (b, _)| a.cmp(b)))
     }
 
     /// The entry with the largest key, if any.
     ///
-    /// A single O(n) max-pass — it does **not** sort the whole map.
+    /// Index-backed via a forward skip to the last entry (only that one value is
+    /// loaded); falls back to a single `O(n)` max-pass otherwise. (A reverse
+    /// seek would make this `O(log n)` — a future optimisation; the forward skip
+    /// still avoids loading every value.)
     ///
     /// # Errors
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn last(&self) -> Result<Option<(K, V)>, StoreError> {
+    pub fn last(&self) -> Result<Option<(K, V)>, StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        if self.ensure_index()? {
+            let n = self.inner.len()?;
+            let Some(offset) = n.checked_sub(1) else {
+                return Ok(None);
+            };
+            let hits = S::index_range(
+                self.inner.id(),
+                Bound::Unbounded,
+                Bound::Unbounded,
+                offset,
+                Some(1),
+            );
+            return Ok(self.resolve_hits(hits)?.into_iter().next());
+        }
         Ok(self.iter_unordered()?.max_by(|(a, _), (b, _)| a.cmp(b)))
     }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -22,10 +22,9 @@
 //!
 //! - [`range`](SortedMap::range) / [`prefix`](SortedMap::prefix) — `O(log n + k)`
 //!   (native seek; only the `k` matching values are loaded).
-//! - [`page`](SortedMap::page) — `O(limit)`.
-//! - [`first`](SortedMap::first) — `O(log n)` (seek to smallest);
-//!   [`last`](SortedMap::last) — forward-skip (loads only the last value; a
-//!   reverse seek is a future optimisation).
+//! - [`page`](SortedMap::page) — `O(offset + limit)`.
+//! - [`first`](SortedMap::first) / [`last`](SortedMap::last) — `O(log n)`
+//!   (forward / reverse seek to the smallest / largest key).
 //! - [`entries`](SortedMap::entries) / [`keys`](SortedMap::keys) /
 //!   [`values`](SortedMap::values) — `O(n)` (they return everything).
 //!
@@ -800,10 +799,9 @@ where
 
     /// The entry with the largest key, if any.
     ///
-    /// Index-backed via a forward skip to the last entry (only that one value is
-    /// loaded); falls back to a single `O(n)` max-pass otherwise. (A reverse
-    /// seek would make this `O(log n)` — a future optimisation; the forward skip
-    /// still avoids loading every value.)
+    /// Index-backed: a reverse seek to the last key, `O(log n)` (only that one
+    /// value is loaded). Falls back to a single `O(n)` max-pass when the adaptor
+    /// doesn't back the index.
     ///
     /// # Errors
     ///
@@ -814,18 +812,10 @@ where
         K: AsRef<[u8]>,
     {
         if self.ensure_index()? {
-            let n = self.inner.len()?;
-            let Some(offset) = n.checked_sub(1) else {
-                return Ok(None);
+            return match S::index_last(self.inner.id()) {
+                Some((_order_key, id)) => self.inner.get(id),
+                None => Ok(None),
             };
-            let hits = S::index_range(
-                self.inner.id(),
-                Bound::Unbounded,
-                Bound::Unbounded,
-                offset,
-                Some(1),
-            );
-            return Ok(self.resolve_hits(hits)?.into_iter().next());
         }
         Ok(self.iter_unordered()?.max_by(|(a, _), (b, _)| a.cmp(b)))
     }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -1612,4 +1612,58 @@ mod tests {
             vec!["a", "b"]
         );
     }
+
+    // The node-level "same DAG heads, different root hash" split-brain manifests
+    // when two replicas of the SAME collection hold identical entries yet compute
+    // different entity hashes. The CRDT-law tests in tests/crdt_contract.rs
+    // compare *logical* content (`entries()`); this pins the stronger property
+    // the synced merkle root depends on — a SortedMap's `full_hash` is a pure
+    // function of its (deterministically-keyed) entries, not of the order they
+    // were inserted. (The on-disk ordered index is node-local and never enters
+    // this hash; only the entity tree does, exactly as for `UnorderedMap`.)
+    #[test]
+    fn entity_hash_is_insertion_order_independent() {
+        use crate::collections::LwwRegister;
+        use crate::entities::Data;
+        use crate::index::Index;
+        use crate::logical_clock::HybridTimestamp;
+
+        type Map = SortedMap<String, LwwRegister<String>, MainStorage>;
+
+        // Pin the register's timestamp + node so the value's content hash is
+        // fixed; the only thing varying across builds is the insertion order.
+        fn reg(v: &str) -> LwwRegister<String> {
+            LwwRegister::new_with_metadata(v.to_owned(), HybridTimestamp::zero(), [7; 32])
+        }
+
+        // Build the SAME logical map under the SAME deterministic id ("scores")
+        // in a caller-chosen order and return its `full_hash`. Resetting first
+        // makes each build an independent replica of the same collection.
+        fn hash_for(order: &[&str]) -> [u8; 32] {
+            crate::env::reset_for_testing();
+            let mut m: Map = SortedMap::new_with_field_name("scores");
+            for k in order {
+                drop(m.insert((*k).to_owned(), reg(k)).unwrap());
+            }
+            let id = <Map as Data>::id(&m);
+            Index::<MainStorage>::get_hashes_for(id)
+                .expect("hash lookup must not error")
+                .expect("a populated collection has index hashes")
+                .0
+        }
+
+        let forward = hash_for(&["alpha", "bravo", "charlie", "delta"]);
+        let reverse = hash_for(&["delta", "charlie", "bravo", "alpha"]);
+        let shuffled = hash_for(&["charlie", "alpha", "delta", "bravo"]);
+
+        assert_eq!(
+            forward, reverse,
+            "SortedMap entity hash diverged on reversed insertion order — the \
+             signature of a 'same DAG heads, different root hash' split-brain"
+        );
+        assert_eq!(
+            forward, shuffled,
+            "SortedMap entity hash diverged on shuffled insertion order"
+        );
+    }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -24,7 +24,7 @@
 
 use core::borrow::Borrow;
 use core::fmt;
-use core::ops::{Deref, DerefMut, RangeBounds};
+use core::ops::{Bound, Deref, DerefMut, RangeBounds};
 use std::mem;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -36,7 +36,8 @@ use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::error::StorageError;
-use crate::store::MainStorage;
+use crate::index::Index;
+use crate::store::{Key, MainStorage};
 use std::collections::BTreeMap;
 
 /// A map collection that keeps its entries ordered by key, enabling range and
@@ -48,6 +49,16 @@ use std::collections::BTreeMap;
 pub struct SortedMap<K, V, S: StorageAdaptor = MainStorage> {
     #[borsh(bound(serialize = "", deserialize = ""))]
     inner: Collection<(K, V), S>,
+}
+
+/// Convert a `RangeBounds` endpoint into the byte-bound the ordered index
+/// speaks, using `K`'s order-preserving `AsRef<[u8]>` form.
+fn bound_bytes<K: AsRef<[u8]>>(bound: Bound<&K>) -> Bound<Vec<u8>> {
+    match bound {
+        Bound::Included(k) => Bound::Included(k.as_ref().to_vec()),
+        Bound::Excluded(k) => Bound::Excluded(k.as_ref().to_vec()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
 }
 
 /// Re-key a nested sorted map (one stored as another collection's value)
@@ -280,12 +291,28 @@ where
         if let Some(mut entry) = self.inner.get_mut(id)? {
             let (_, v) = &mut *entry;
 
+            // A value-only update doesn't change the key set, so the ordered
+            // index entry stays correct; we deliberately don't stamp the marker
+            // here (the post-write `full_hash` isn't available until the guard
+            // drops), so the next ordered read rebuilds once. Rare path.
             return Ok(Some(mem::replace(v, value)));
         }
+
+        // Capture the order key before `key` is moved, so we can warm the index
+        // for this new key after the write (only when the adaptor backs it).
+        let order_key = S::index_supported().then(|| key.as_ref().to_vec());
+        let collection = self.inner.id();
 
         let _ignored = self
             .inner
             .insert_with_storage_type(Some(id), (key, value), storage_type)?;
+
+        if let Some(order_key) = order_key {
+            // Done after the inner write so the collection's `full_hash` already
+            // reflects this insert when we stamp the validity marker.
+            S::index_put(collection, &order_key, id);
+            self.stamp_index_marker();
+        }
 
         Ok(None)
     }
@@ -412,7 +439,17 @@ where
             return Ok(None);
         };
 
-        entry.remove().map(|(_, v)| Some(v))
+        let removed = entry.remove().map(|(_, v)| v)?;
+
+        // Keep the ordered index in step with the removal (no-op when the
+        // adaptor doesn't back it). `entry.remove()` has already recomputed the
+        // collection's `full_hash`, so the stamped marker stays valid.
+        if S::index_supported() {
+            S::index_remove(self.inner.id(), key.as_ref());
+            self.stamp_index_marker();
+        }
+
+        Ok(Some(removed))
     }
 
     /// Clear the map, removing all entries.
@@ -423,7 +460,76 @@ where
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned.
     pub fn clear(&mut self) -> Result<(), StoreError> {
-        self.inner.clear()
+        self.inner.clear()?;
+
+        if S::index_supported() {
+            S::index_clear(self.inner.id());
+            self.stamp_index_marker();
+        }
+
+        Ok(())
+    }
+
+    /// The collection's current `full_hash` (the validity signal for the
+    /// ordered index). `[0; 32]` if the collection has no index entry yet.
+    fn current_full_hash(&self) -> [u8; 32] {
+        Index::<S>::get_hashes_for(self.inner.id())
+            .ok()
+            .flatten()
+            .map(|(full, _own)| full)
+            .unwrap_or([0u8; 32])
+    }
+
+    /// Stamp the index validity marker with the collection's current
+    /// `full_hash`, claiming "the ordered index is consistent as of this hash".
+    fn stamp_index_marker(&self) {
+        let _ = S::storage_write(
+            Key::SortedIndexMeta(self.inner.id()),
+            &self.current_full_hash(),
+        );
+    }
+
+    /// `true` if the stamped marker equals the collection's current `full_hash`
+    /// — i.e. nothing has changed the entry set since the index was last built.
+    fn index_marker_current(&self) -> bool {
+        S::storage_read(Key::SortedIndexMeta(self.inner.id())).as_deref()
+            == Some(&self.current_full_hash()[..])
+    }
+
+    /// Rebuild the ordered index for this collection from the authoritative
+    /// entry set (one `O(n)` scan), then stamp the validity marker. Used when a
+    /// remote sync (or an untracked local edit) left the index stale.
+    fn rebuild_index(&self) -> Result<(), StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        let collection = self.inner.id();
+        S::index_clear(collection);
+        for (k, _v) in self.iter_unordered()? {
+            S::index_put(collection, k.as_ref(), compute_id(collection, k.as_ref()));
+        }
+        self.stamp_index_marker();
+        Ok(())
+    }
+
+    /// Ensure the ordered index is usable for this read.
+    ///
+    /// Returns `true` when the adaptor backs the index (rebuilding first if the
+    /// marker is stale), `false` when it doesn't — in which case the caller
+    /// falls back to the in-memory sort. This is the single seam that makes the
+    /// on-disk path transparent: a no-op adaptor (e.g. `PrivateStorage`, or
+    /// `MainStorage` before the host ABI lands) simply takes the fallback.
+    fn ensure_index(&self) -> Result<bool, StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        if !S::index_supported() {
+            return Ok(false);
+        }
+        if !self.index_marker_current() {
+            self.rebuild_index()?;
+        }
+        Ok(true)
     }
 
     /// Iterate entries in storage (hash) order — *not* key order.
@@ -516,9 +622,24 @@ where
     pub fn range<R>(&self, range: R) -> Result<impl Iterator<Item = (K, V)>, StoreError>
     where
         R: RangeBounds<K>,
+        K: AsRef<[u8]>,
     {
-        // Filter to the range *before* sorting so the sort cost scales with the
-        // number of matches `m`, not the whole map `n`: O(n) scan + O(m log m).
+        if self.ensure_index()? {
+            // Index-backed: RocksDB seeks to `start` and walks to `end` —
+            // O(log n + k), only the matching values are loaded.
+            let collection = self.inner.id();
+            let hits = S::index_range(
+                collection,
+                bound_bytes(range.start_bound()),
+                bound_bytes(range.end_bound()),
+                0,
+                None,
+            );
+            return Ok(self.resolve_hits(hits)?.into_iter());
+        }
+
+        // In-memory fallback (adaptor doesn't back the index): filter before
+        // sorting so cost scales with matches `m`: O(n) scan + O(m log m).
         let mut pairs: Vec<(K, V)> = self
             .iter_unordered()?
             .filter(|(k, _)| range.contains(k))
@@ -542,7 +663,13 @@ where
     where
         K: AsRef<[u8]>,
     {
-        // Filter by prefix before sorting: O(n) scan + O(m log m) on matches.
+        if self.ensure_index()? {
+            // Index-backed prefix seek — O(log n + k).
+            let hits = S::index_prefix(self.inner.id(), prefix, 0, None);
+            return Ok(self.resolve_hits(hits)?.into_iter());
+        }
+
+        // In-memory fallback: filter by prefix before sorting.
         let prefix = prefix.to_vec();
         let mut pairs: Vec<(K, V)> = self
             .iter_unordered()?
@@ -560,13 +687,43 @@ where
     ///
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
-    pub fn page(&self, offset: usize, limit: usize) -> Result<Vec<(K, V)>, StoreError> {
+    pub fn page(&self, offset: usize, limit: usize) -> Result<Vec<(K, V)>, StoreError>
+    where
+        K: AsRef<[u8]>,
+    {
+        if self.ensure_index()? {
+            // Index-backed: skip `offset` index entries and load only `limit`
+            // values — O(limit), no full materialisation.
+            let hits = S::index_range(
+                self.inner.id(),
+                Bound::Unbounded,
+                Bound::Unbounded,
+                offset,
+                Some(limit),
+            );
+            return self.resolve_hits(hits);
+        }
+
+        // In-memory fallback.
         Ok(self
             .sorted_pairs()?
             .into_iter()
             .skip(offset)
             .take(limit)
             .collect())
+    }
+
+    /// Load the `(K, V)` values for index hits, in the index's (ascending key)
+    /// order. A hit whose entry has since vanished is skipped (defensive; an
+    /// up-to-date index shouldn't contain stale ids).
+    fn resolve_hits(&self, hits: Vec<(Vec<u8>, Id)>) -> Result<Vec<(K, V)>, StoreError> {
+        let mut out = Vec::with_capacity(hits.len());
+        for (_order_key, id) in hits {
+            if let Some(kv) = self.inner.get(id)? {
+                out.push(kv);
+            }
+        }
+        Ok(out)
     }
 
     /// The entry with the smallest key, if any.
@@ -954,14 +1111,23 @@ where
     where
         V: 'static,
     {
-        let id = compute_id(self.map.inner.id(), self.key.as_ref());
+        let collection = self.map.inner.id();
+        let id = compute_id(collection, self.key.as_ref());
 
         // Re-key any nested collections in `value` deterministically relative to
         // this entry's (deterministic) id — exactly as `insert_with_storage_type`
         // does, so a nested CRDT stored via the Entry API converges across nodes.
         super::rekey::rekey_nested_value(&mut value, id);
 
+        // Capture the order key before `self.key` is moved, to warm the index.
+        let order_key = S::index_supported().then(|| self.key.as_ref().to_vec());
+
         drop(self.map.inner.insert(Some(id), (self.key, value))?);
+
+        if let Some(order_key) = order_key {
+            S::index_put(collection, &order_key, id);
+            self.map.stamp_index_marker();
+        }
 
         let entry_mut = self
             .map
@@ -1234,5 +1400,101 @@ mod tests {
             Entry::Vacant(_) => panic!("expected occupied"),
         };
         assert_eq!(value, "v");
+    }
+
+    // === Index-backed path (adaptor with `index_supported() == true`) ===
+    //
+    // The tests above run over `MainStorage`, whose index is a no-op until the
+    // host ABI lands, so they exercise the in-memory fallback. These run over
+    // `MockedStorage`, which DOES back the ordered index — so a correct result
+    // here proves the on-disk query path (insert warms the index; range/prefix/
+    // page read from it) end to end.
+    use crate::entities::Data;
+    use crate::store::{Key, MockedStorage, StorageAdaptor};
+
+    type Indexed = MockedStorage<951>;
+
+    #[test]
+    fn index_backed_queries_match_expected_order() {
+        crate::env::reset_for_testing();
+        assert!(Indexed::index_supported());
+
+        let mut map: SortedMap<String, String, Indexed> = SortedMap::new();
+        for k in ["delta", "alpha", "charlie", "bravo", "echo"] {
+            map.insert(k.to_owned(), k.to_uppercase()).unwrap();
+        }
+
+        // range — served from the index (RocksDB-style seek over the mock).
+        let r: Vec<String> = map
+            .range("alpha".to_owned().."delta".to_owned())
+            .unwrap()
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(r, vec!["alpha", "bravo", "charlie"]);
+
+        // page — index skip+take, only the page's values resolved.
+        let page = map.page(1, 2).unwrap();
+        assert_eq!(
+            page.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+            vec!["bravo", "charlie"]
+        );
+
+        // values resolve correctly through the index path.
+        assert_eq!(
+            map.range("bravo".to_owned()..="bravo".to_owned())
+                .unwrap()
+                .next()
+                .unwrap(),
+            ("bravo".to_owned(), "BRAVO".to_owned())
+        );
+    }
+
+    #[test]
+    fn index_backed_prefix_scan() {
+        crate::env::reset_for_testing();
+        let mut map: SortedMap<String, u32, Indexed> = SortedMap::new();
+        for (i, k) in ["user:alice", "post:1", "user:bob", "post:2", "user:carol"]
+            .into_iter()
+            .enumerate()
+        {
+            map.insert(k.to_owned(), i as u32).unwrap();
+        }
+
+        let users: Vec<String> = map.prefix(b"user:").unwrap().map(|(k, _)| k).collect();
+        assert_eq!(users, vec!["user:alice", "user:bob", "user:carol"]);
+    }
+
+    #[test]
+    fn read_rebuilds_stale_index_then_serves_from_it() {
+        crate::env::reset_for_testing();
+        let mut map: SortedMap<String, String, Indexed> = SortedMap::new();
+        for k in ["a", "b", "c", "d"] {
+            map.insert(k.to_owned(), k.to_owned()).unwrap();
+        }
+
+        let collection = <SortedMap<String, String, Indexed> as Data>::id(&map);
+
+        // Simulate a node whose entries exist but whose ordered index is stale —
+        // e.g. right after a remote sync applied entries host-side without going
+        // through `SortedMap::insert`: wipe the index and stamp a bogus marker.
+        Indexed::index_clear(collection);
+        let _ = Indexed::storage_write(Key::SortedIndexMeta(collection), &[0u8; 32]);
+
+        // The next ordered read must notice the marker mismatch, rebuild the
+        // index from the authoritative entries, and return correct results.
+        let keys: Vec<String> = map
+            .range("a".to_owned()..="d".to_owned())
+            .unwrap()
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(keys, vec!["a", "b", "c", "d"]);
+
+        // A second read should now hit the warm index (marker matches) and still
+        // be correct.
+        let page = map.page(0, 2).unwrap();
+        assert_eq!(
+            page.iter().map(|(k, _)| k.clone()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
     }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -41,6 +41,26 @@
 //! rebuild — wasted if you only ever point-access the map. `SortedMap` is the
 //! `BTreeMap` to `UnorderedMap`'s `HashMap`.
 //!
+//! # Key ordering contract
+//!
+//! `SortedMap` has two ordering sources that must agree:
+//!
+//! * the **on-disk index**, which seeks by `K`'s `AsRef<[u8]>` bytes (RocksDB
+//!   compares keys bytewise), and
+//! * the **in-memory fallback** / comparison impls (`PartialOrd`, `Ord`, `Eq`,
+//!   serialization), which use `K`'s [`Ord`].
+//!
+//! So `K`'s byte encoding **must be order-consistent with its `Ord`**: for all
+//! keys, `a.cmp(b) == a.as_ref().cmp(b.as_ref())`. This holds for `String`,
+//! `&str`, `Vec<u8>`, `[u8; N]` and any type whose `AsRef<[u8]>` is its
+//! lexicographic form — the only key types you can actually store (every write
+//! path bounds `K: AsRef<[u8]>`). A key whose `AsRef<[u8]>` disagrees with its
+//! `Ord` (e.g. a multi-byte integer stored little-endian, or a sign-flipped
+//! encoding) would make index-backed reads (`range`/`prefix`/`page`/`first`/
+//! `last`) and `Ord`-based reads (`entries`/`keys`/`values`) disagree — a usage
+//! error, not a supported configuration. Encode such keys big-endian (and
+//! offset-binary for signed values) so their bytes sort like their values.
+//!
 //! # CRDT-safety and the fallback
 //!
 //! The index is *not* synced — it is a derived materialised view of the
@@ -338,9 +358,13 @@ where
 
         if let Some(order_key) = order_key {
             // Done after the inner write so the collection's `full_hash` already
-            // reflects this insert when we stamp the validity marker.
-            S::index_put(collection, &order_key, id);
-            self.stamp_index_marker();
+            // reflects this insert when we stamp the validity marker. Only stamp
+            // if the index write was actually persisted — otherwise we leave the
+            // marker stale so the next ordered read rebuilds and self-heals,
+            // rather than trusting an index that's missing this key.
+            if S::index_put(collection, &order_key, id) {
+                self.stamp_index_marker();
+            }
         }
 
         Ok(None)
@@ -472,9 +496,9 @@ where
 
         // Keep the ordered index in step with the removal (no-op when the
         // adaptor doesn't back it). `entry.remove()` has already recomputed the
-        // collection's `full_hash`, so the stamped marker stays valid.
-        if S::index_supported() {
-            S::index_remove(self.inner.id(), key.as_ref());
+        // collection's `full_hash`, so the stamped marker stays valid — but only
+        // stamp if the index write landed; otherwise leave it stale to rebuild.
+        if S::index_supported() && S::index_remove(self.inner.id(), key.as_ref()) {
             self.stamp_index_marker();
         }
 
@@ -491,8 +515,7 @@ where
     pub fn clear(&mut self) -> Result<(), StoreError> {
         self.inner.clear()?;
 
-        if S::index_supported() {
-            S::index_clear(self.inner.id());
+        if S::index_supported() && S::index_clear(self.inner.id()) {
             self.stamp_index_marker();
         }
 
@@ -554,15 +577,25 @@ where
                 .map(|(order_key, _id)| order_key)
                 .collect();
 
-        // Drop stale keys, add missing ones — only the diff is written.
+        // Drop stale keys, add missing ones — only the diff is written. Track
+        // whether every write landed: if any was dropped, leave the marker stale
+        // so the next read retries the rebuild instead of trusting a partial one.
+        //
+        // `compute_id(collection, order_key)` reconstructs the *exact* entry id:
+        // an entry's id is `compute_id(collection, key.as_ref())` and the order
+        // key in `desired` is that same `key.as_ref()`, so this can't disagree
+        // with the stored entry — no need to read the entry to learn its id.
+        let mut persisted = true;
         for order_key in existing.difference(&desired) {
-            S::index_remove(collection, order_key);
+            persisted &= S::index_remove(collection, order_key);
         }
         for order_key in desired.difference(&existing) {
-            S::index_put(collection, order_key, compute_id(collection, order_key));
+            persisted &= S::index_put(collection, order_key, compute_id(collection, order_key));
         }
 
-        self.stamp_index_marker();
+        if persisted {
+            self.stamp_index_marker();
+        }
         Ok(())
     }
 
@@ -1204,8 +1237,11 @@ where
         drop(self.map.inner.insert(Some(id), (self.key, value))?);
 
         if let Some(order_key) = order_key {
-            S::index_put(collection, &order_key, id);
-            self.map.stamp_index_marker();
+            // Only stamp the validity marker if the index write landed; a dropped
+            // write leaves the marker stale so the next ordered read rebuilds.
+            if S::index_put(collection, &order_key, id) {
+                self.map.stamp_index_marker();
+            }
         }
 
         let entry_mut = self

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -25,6 +25,16 @@
 //! index overhead. Use `SortedSet` only when you need elements in order:
 //! `range(a..b)`, `prefix("user:")`, pagination, sorted iteration, or min/max.
 //! It is the `BTreeSet` to `UnorderedSet`'s `HashSet`.
+//!
+//! # Element ordering contract
+//!
+//! Like [`SortedMap`](super::SortedMap), `SortedSet` seeks the on-disk index by
+//! `V`'s `AsRef<[u8]>` bytes but falls back to (and compares with) `V`'s [`Ord`],
+//! so the two must agree: `a.cmp(b) == a.as_ref().cmp(b.as_ref())` for all
+//! elements. True for `String`/`&str`/`Vec<u8>`/`[u8; N]` and any type whose
+//! `AsRef<[u8]>` is its lexicographic form. Encode multi-byte integers
+//! big-endian (and signed values offset-binary) so their bytes sort like their
+//! values; an encoding that disagrees with `Ord` is a usage error.
 
 use core::borrow::Borrow;
 use core::fmt;
@@ -185,8 +195,12 @@ where
         let _ignored = self.inner.insert(Some(id), value)?;
 
         if let Some(order_key) = order_key {
-            S::index_put(collection, &order_key, id);
-            self.stamp_index_marker();
+            // Only stamp the validity marker if the index write landed; a dropped
+            // write leaves the marker stale so the next ordered read rebuilds and
+            // self-heals rather than trusting an index missing this element.
+            if S::index_put(collection, &order_key, id) {
+                self.stamp_index_marker();
+            }
         }
 
         Ok(true)
@@ -246,8 +260,9 @@ where
 
         let _ignored = entry.remove()?;
 
-        if S::index_supported() {
-            S::index_remove(self.inner.id(), value.as_ref());
+        // Only stamp if the index write landed; else leave the marker stale to
+        // force a rebuild on the next ordered read.
+        if S::index_supported() && S::index_remove(self.inner.id(), value.as_ref()) {
             self.stamp_index_marker();
         }
 
@@ -262,8 +277,7 @@ where
     /// will be returned.
     pub fn clear(&mut self) -> Result<(), StoreError> {
         self.inner.clear()?;
-        if S::index_supported() {
-            S::index_clear(self.inner.id());
+        if S::index_supported() && S::index_clear(self.inner.id()) {
             self.stamp_index_marker();
         }
         Ok(())
@@ -332,13 +346,19 @@ where
                 .into_iter()
                 .map(|(order_key, _id)| order_key)
                 .collect();
+        // Only stamp if every diff write landed; otherwise leave the marker
+        // stale so the next read retries the rebuild rather than trusting a
+        // partial index.
+        let mut persisted = true;
         for order_key in existing.difference(&desired) {
-            S::index_remove(collection, order_key);
+            persisted &= S::index_remove(collection, order_key);
         }
         for order_key in desired.difference(&existing) {
-            S::index_put(collection, order_key, compute_id(collection, order_key));
+            persisted &= S::index_put(collection, order_key, compute_id(collection, order_key));
         }
-        self.stamp_index_marker();
+        if persisted {
+            self.stamp_index_marker();
+        }
         Ok(())
     }
 

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -1,0 +1,686 @@
+//! An ordered set supporting range and prefix queries.
+//!
+//! [`SortedSet`] is to [`UnorderedSet`](super::UnorderedSet) what
+//! [`SortedMap`](super::SortedMap) is to [`UnorderedMap`](super::UnorderedMap):
+//! the same add-wins union CRDT and on-wire layout (a [`Collection`] of unique
+//! `V` elements keyed by `compute_id(parent, v)`), plus a **node-local, derived,
+//! non-synced ordered index** that makes range/prefix/pagination and min/max
+//! sub-linear instead of a full scan + sort. See [`SortedMap`](super::SortedMap)
+//! for the index mechanism and CRDT-safety argument — they are identical here,
+//! with the element playing the role of both key and value.
+//!
+//! # Complexity (on a node, with the index-backing `MainStorage`)
+//!
+//! | Operation | Cost |
+//! |---|---|
+//! | [`range`](SortedSet::range) / [`prefix`](SortedSet::prefix) | `O(log n + k)` |
+//! | [`page`](SortedSet::page)`(offset, limit)` | `O(offset + limit)` |
+//! | [`first`](SortedSet::first) / [`last`](SortedSet::last) | `O(log n)` |
+//! | [`insert`](SortedSet::insert) / [`remove`](SortedSet::remove) / [`contains`](SortedSet::contains) | `O(1)` point op **+ an index write + a marker read/write** |
+//! | [`iter`](SortedSet::iter) | `O(n)` (returns everything, ascending) |
+//!
+//! # When to use `SortedSet` vs [`UnorderedSet`](super::UnorderedSet)
+//!
+//! **Default to [`UnorderedSet`](super::UnorderedSet)** — it has no per-write
+//! index overhead. Use `SortedSet` only when you need elements in order:
+//! `range(a..b)`, `prefix("user:")`, pagination, sorted iteration, or min/max.
+//! It is the `BTreeSet` to `UnorderedSet`'s `HashSet`.
+
+use core::borrow::Borrow;
+use core::fmt;
+use core::ops::{Bound, RangeBounds};
+use std::collections::BTreeSet;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::ser::SerializeSeq;
+use serde::Serialize;
+
+use super::{compute_id, Collection, CrdtType};
+use crate::address::Id;
+use crate::collections::error::StoreError;
+use crate::entities::Data;
+use crate::index::Index;
+use crate::store::{Key, MainStorage, StorageAdaptor};
+
+/// A set collection that keeps its elements ordered, enabling range and prefix
+/// queries plus pagination. See the [module docs](self) and
+/// [`SortedMap`](super::SortedMap) for the storage model.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct SortedSet<V, S: StorageAdaptor = MainStorage> {
+    #[borsh(bound(serialize = "", deserialize = ""))]
+    inner: Collection<V, S>,
+}
+
+/// Convert a `RangeBounds` endpoint into the byte-bound the ordered index
+/// speaks, using `V`'s order-preserving `AsRef<[u8]>` form.
+fn bound_bytes<V: AsRef<[u8]>>(bound: Bound<&V>) -> Bound<Vec<u8>> {
+    match bound {
+        Bound::Included(v) => Bound::Included(v.as_ref().to_vec()),
+        Bound::Excluded(v) => Bound::Excluded(v.as_ref().to_vec()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+/// Re-key the set's inner collection relative to its storage parent, so
+/// independently-created nested sets converge. See [`super::rekey`].
+impl<V, S> super::rekey::RekeyTarget for SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::expect_used, reason = "fatal error if re-key migration fails")]
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        let new_id = super::compute_collection_id(Some(parent_id), "__sorted_set");
+        if self.inner.id() == new_id {
+            return; // already deterministic — idempotent
+        }
+        let elements: Vec<V> = self
+            .iter_unordered()
+            .expect("read set elements for re-key")
+            .collect();
+        self.inner.clear().expect("clear set for re-key");
+        self.inner.reassign_deterministic_id_under(
+            Some(parent_id),
+            "__sorted_set",
+            CrdtType::sorted_set(std::any::type_name::<V>()),
+        );
+        for v in elements {
+            let _ = self.insert(v).expect("re-insert set element during re-key");
+        }
+    }
+}
+
+impl<V, S> SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    /// Create a new sorted set with a random ID (for nested collections).
+    pub fn new() -> Self {
+        Self::new_internal()
+    }
+
+    /// Create a new sorted set with a deterministic ID derived from `field_name`
+    /// (for top-level state fields — the `#[app::state]` macro does this).
+    ///
+    /// # Example
+    /// ```ignore
+    /// let tags = SortedSet::<String>::new_with_field_name("tags");
+    /// ```
+    pub fn new_with_field_name(field_name: &str) -> Self {
+        Self::new_with_field_name_internal(None, field_name)
+    }
+}
+
+impl<V, S> SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn new_internal() -> Self {
+        Self {
+            inner: Collection::new(None),
+        }
+    }
+
+    pub(super) fn new_with_field_name_internal(parent_id: Option<Id>, field_name: &str) -> Self {
+        Self {
+            inner: Collection::new_with_field_name_and_crdt_type(
+                parent_id,
+                field_name,
+                CrdtType::sorted_set(std::any::type_name::<V>()),
+            ),
+        }
+    }
+
+    /// Reassigns the set's ID to a deterministic ID based on field name,
+    /// migrating elements. Called by the `#[app::state]` macro after `init()`.
+    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
+    pub fn reassign_deterministic_id(&mut self, field_name: &str)
+    where
+        V: AsRef<[u8]> + PartialEq + 'static,
+    {
+        let new_id = super::compute_collection_id(None, field_name);
+        if self.inner.id() == new_id {
+            return;
+        }
+        let elements: Vec<V> = self
+            .iter_unordered()
+            .expect("failed to read elements for migration")
+            .collect();
+        self.inner.clear().expect("failed to clear for migration");
+        self.inner.reassign_deterministic_id_with_crdt_type(
+            field_name,
+            CrdtType::sorted_set(std::any::type_name::<V>()),
+        );
+        for value in elements {
+            self.insert(value)
+                .expect("failed to re-insert element during migration");
+        }
+    }
+
+    /// Insert an element. Returns `true` if it was newly inserted, `false` if it
+    /// was already present.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn insert(&mut self, value: V) -> Result<bool, StoreError>
+    where
+        V: AsRef<[u8]> + PartialEq + 'static,
+    {
+        super::rekey::register_rekey::<Self>();
+        let collection = self.inner.id();
+        let id = compute_id(collection, value.as_ref());
+
+        if self.inner.get_mut(id)?.is_some() {
+            return Ok(false);
+        }
+
+        // Warm the ordered index for the new element (after the write, so the
+        // collection's full_hash already reflects it when we stamp the marker).
+        let order_key = S::index_supported().then(|| value.as_ref().to_vec());
+
+        let _ignored = self.inner.insert(Some(id), value)?;
+
+        if let Some(order_key) = order_key {
+            S::index_put(collection, &order_key, id);
+            self.stamp_index_marker();
+        }
+
+        Ok(true)
+    }
+
+    /// The number of elements.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the set is empty.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Whether the set contains `value`.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn contains<Q>(&self, value: &Q) -> Result<bool, StoreError>
+    where
+        V: Borrow<Q>,
+        Q: PartialEq + ?Sized + AsRef<[u8]>,
+    {
+        let id = compute_id(self.inner.id(), value.as_ref());
+        self.inner.contains(id)
+    }
+
+    /// Remove `value`, returning `true` if it was present.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn remove<Q>(&mut self, value: &Q) -> Result<bool, StoreError>
+    where
+        V: Borrow<Q>,
+        Q: PartialEq + AsRef<[u8]> + ?Sized,
+    {
+        let id = compute_id(self.inner.id(), value.as_ref());
+
+        let Some(entry) = self.inner.get_mut(id)? else {
+            return Ok(false);
+        };
+
+        let _ignored = entry.remove()?;
+
+        if S::index_supported() {
+            S::index_remove(self.inner.id(), value.as_ref());
+            self.stamp_index_marker();
+        }
+
+        Ok(true)
+    }
+
+    /// Clear the set.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn clear(&mut self) -> Result<(), StoreError> {
+        self.inner.clear()?;
+        if S::index_supported() {
+            S::index_clear(self.inner.id());
+            self.stamp_index_marker();
+        }
+        Ok(())
+    }
+
+    /// Iterate elements in storage (hash) order — *not* element order. The
+    /// building block the ordered readers sort; kept private.
+    fn iter_unordered(&self) -> Result<impl Iterator<Item = V> + '_, StoreError> {
+        let collection_id = self.inner.id();
+        Ok(self.inner.entries()?.filter_map(move |result| match result {
+            Ok(item) => Some(item),
+            Err(error) => {
+                tracing::error!(
+                    target: "calimero_storage::iter_drop",
+                    %collection_id,
+                    %error,
+                    collection_type = "SortedSet",
+                    "ITER_DROP: parent's child list advertises an id whose entry could not be loaded — \
+                     likely entry-before-parent ordering race or storage inconsistency. \
+                     Caller will see a truncated iteration."
+                );
+                None
+            }
+        }).fuse())
+    }
+
+    // === Ordered secondary index plumbing (mirrors SortedMap) ===
+
+    /// The collection's current `full_hash` (the index validity signal).
+    fn current_full_hash(&self) -> [u8; 32] {
+        Index::<S>::get_hashes_for(self.inner.id())
+            .ok()
+            .flatten()
+            .map(|(full, _own)| full)
+            .unwrap_or([0u8; 32])
+    }
+
+    /// Stamp the index validity marker with the current `full_hash`.
+    fn stamp_index_marker(&self) {
+        let _ = S::storage_write(
+            Key::SortedIndexMeta(self.inner.id()),
+            &self.current_full_hash(),
+        );
+    }
+
+    /// `true` if the stamped marker equals the current `full_hash`.
+    fn index_marker_current(&self) -> bool {
+        S::storage_read(Key::SortedIndexMeta(self.inner.id())).as_deref()
+            == Some(&self.current_full_hash()[..])
+    }
+
+    /// Reconcile the index with the authoritative element set, then stamp the
+    /// marker — writes only the diff (`O(changed)` writes; the entry read is
+    /// `O(n)`). Used when a remote sync left the index stale.
+    fn rebuild_index(&self) -> Result<(), StoreError>
+    where
+        V: AsRef<[u8]>,
+    {
+        let collection = self.inner.id();
+        let desired: BTreeSet<Vec<u8>> = self
+            .iter_unordered()?
+            .map(|v| v.as_ref().to_vec())
+            .collect();
+        let existing: BTreeSet<Vec<u8>> =
+            S::index_range(collection, Bound::Unbounded, Bound::Unbounded, 0, None)
+                .into_iter()
+                .map(|(order_key, _id)| order_key)
+                .collect();
+        for order_key in existing.difference(&desired) {
+            S::index_remove(collection, order_key);
+        }
+        for order_key in desired.difference(&existing) {
+            S::index_put(collection, order_key, compute_id(collection, order_key));
+        }
+        self.stamp_index_marker();
+        Ok(())
+    }
+
+    /// Ensure the index is usable; returns `true` when the adaptor backs it
+    /// (rebuilding if stale), `false` → caller uses the in-memory sort fallback.
+    fn ensure_index(&self) -> Result<bool, StoreError>
+    where
+        V: AsRef<[u8]>,
+    {
+        if !S::index_supported() {
+            return Ok(false);
+        }
+        if !self.index_marker_current() {
+            self.rebuild_index()?;
+        }
+        Ok(true)
+    }
+
+    /// Resolve index hits (`order_key, entry_id`) back to elements, in order.
+    fn resolve_hits(&self, hits: Vec<(Vec<u8>, Id)>) -> Result<Vec<V>, StoreError> {
+        let mut out = Vec::with_capacity(hits.len());
+        for (_order_key, id) in hits {
+            if let Some(v) = self.inner.get(id)? {
+                out.push(v);
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl<V, S> SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize + Ord + AsRef<[u8]>,
+    S: StorageAdaptor,
+{
+    /// All elements in their order-defined cache view. The shared sorted helper.
+    fn sorted_elements(&self) -> Result<Vec<V>, StoreError> {
+        let mut elems: Vec<V> = self.iter_unordered()?.collect();
+        elems.sort();
+        Ok(elems)
+    }
+
+    /// Iterate all elements in ascending order.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn iter(&self) -> Result<impl Iterator<Item = V>, StoreError> {
+        if self.ensure_index()? {
+            let hits = S::index_range(self.inner.id(), Bound::Unbounded, Bound::Unbounded, 0, None);
+            return Ok(self.resolve_hits(hits)?.into_iter());
+        }
+        Ok(self.sorted_elements()?.into_iter())
+    }
+
+    /// Iterate the elements within `range`, ascending.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn range<R>(&self, range: R) -> Result<impl Iterator<Item = V>, StoreError>
+    where
+        R: RangeBounds<V>,
+    {
+        if self.ensure_index()? {
+            let hits = S::index_range(
+                self.inner.id(),
+                bound_bytes(range.start_bound()),
+                bound_bytes(range.end_bound()),
+                0,
+                None,
+            );
+            return Ok(self.resolve_hits(hits)?.into_iter());
+        }
+        let mut elems: Vec<V> = self
+            .iter_unordered()?
+            .filter(|v| range.contains(v))
+            .collect();
+        elems.sort();
+        Ok(elems.into_iter())
+    }
+
+    /// Iterate the elements whose bytes start with `prefix`, ascending.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn prefix(&self, prefix: &[u8]) -> Result<impl Iterator<Item = V>, StoreError> {
+        if self.ensure_index()? {
+            let hits = S::index_prefix(self.inner.id(), prefix, 0, None);
+            return Ok(self.resolve_hits(hits)?.into_iter());
+        }
+        let prefix = prefix.to_vec();
+        let mut elems: Vec<V> = self
+            .iter_unordered()?
+            .filter(|v| v.as_ref().starts_with(&prefix))
+            .collect();
+        elems.sort();
+        Ok(elems.into_iter())
+    }
+
+    /// A page of `limit` elements starting at `offset`, ascending.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn page(&self, offset: usize, limit: usize) -> Result<Vec<V>, StoreError> {
+        if self.ensure_index()? {
+            let hits = S::index_range(
+                self.inner.id(),
+                Bound::Unbounded,
+                Bound::Unbounded,
+                offset,
+                Some(limit),
+            );
+            return self.resolve_hits(hits);
+        }
+        Ok(self
+            .sorted_elements()?
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect())
+    }
+
+    /// The smallest element, if any (`O(log n)` seek).
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn first(&self) -> Result<Option<V>, StoreError> {
+        if self.ensure_index()? {
+            let hits = S::index_range(
+                self.inner.id(),
+                Bound::Unbounded,
+                Bound::Unbounded,
+                0,
+                Some(1),
+            );
+            return Ok(self.resolve_hits(hits)?.into_iter().next());
+        }
+        Ok(self.sorted_elements()?.into_iter().next())
+    }
+
+    /// The largest element, if any (`O(log n)` reverse seek).
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn last(&self) -> Result<Option<V>, StoreError> {
+        if self.ensure_index()? {
+            return match S::index_last(self.inner.id()) {
+                Some((_order_key, id)) => self.inner.get(id),
+                None => Ok(None),
+            };
+        }
+        Ok(self.sorted_elements()?.into_iter().next_back())
+    }
+}
+
+impl<V, S> Eq for SortedSet<V, S>
+where
+    V: Eq + Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+}
+
+impl<V, S> PartialEq for SortedSet<V, S>
+where
+    V: Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::unwrap_used, reason = "'tis fine")]
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().unwrap().eq(other.iter().unwrap())
+    }
+}
+
+impl<V, S> Ord for SortedSet<V, S>
+where
+    V: Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::unwrap_used, reason = "'tis fine")]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.iter().unwrap().cmp(other.iter().unwrap())
+    }
+}
+
+impl<V, S> PartialOrd for SortedSet<V, S>
+where
+    V: Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<V, S> fmt::Debug for SortedSet<V, S>
+where
+    V: Ord + AsRef<[u8]> + fmt::Debug + BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            f.debug_struct("SortedSet")
+                .field("items", &self.inner)
+                .finish()
+        } else {
+            f.debug_set().entries(self.iter().unwrap()).finish()
+        }
+    }
+}
+
+impl<V, S> Default for SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    fn default() -> Self {
+        Self::new_internal()
+    }
+}
+
+impl<V, S> Serialize for SortedSet<V, S>
+where
+    V: Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize + Serialize,
+    S: StorageAdaptor,
+{
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: serde::Serializer,
+    {
+        let len = self.len().map_err(serde::ser::Error::custom)?;
+        let mut seq = serializer.serialize_seq(Some(len))?;
+        // Elements are emitted in ascending order.
+        for v in self.iter().map_err(serde::ser::Error::custom)? {
+            seq.serialize_element(&v)?;
+        }
+        seq.end()
+    }
+}
+
+impl<V, S> Extend<V> for SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    S: StorageAdaptor,
+{
+    fn extend<I: IntoIterator<Item = V>>(&mut self, iter: I) {
+        for v in iter {
+            // Go through `insert` so the ordered index is maintained.
+            let _ = self.insert(v);
+        }
+    }
+}
+
+impl<V, S> FromIterator<V> for SortedSet<V, S>
+where
+    V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    S: StorageAdaptor,
+{
+    fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+        let mut set = SortedSet::new_internal();
+        set.extend(iter);
+        set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::collections::{Root, SortedSet};
+    use crate::store::MainStorage;
+
+    #[test]
+    fn test_sorted_set_basic_and_order() {
+        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+
+        for v in ["delta", "alpha", "charlie", "bravo"] {
+            assert!(set.insert(v.to_owned()).expect("insert failed"));
+        }
+        // duplicate
+        assert!(!set.insert("alpha".to_owned()).expect("insert failed"));
+
+        assert!(set.contains("bravo").expect("contains failed"));
+        assert!(!set.contains("zulu").expect("contains failed"));
+        assert_eq!(set.len().unwrap(), 4);
+
+        let items: Vec<String> = set.iter().expect("iter failed").collect();
+        assert_eq!(items, vec!["alpha", "bravo", "charlie", "delta"]);
+    }
+
+    #[test]
+    fn test_sorted_set_range_prefix_page_first_last() {
+        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        for v in ["user:alice", "user:bob", "post:1", "user:carol", "post:2"] {
+            set.insert(v.to_owned()).unwrap();
+        }
+
+        let users: Vec<String> = set.prefix(b"user:").unwrap().collect();
+        assert_eq!(users, vec!["user:alice", "user:bob", "user:carol"]);
+
+        let range: Vec<String> = set
+            .range("post:2".to_owned().."user:bob".to_owned())
+            .unwrap()
+            .collect();
+        assert_eq!(range, vec!["post:2", "user:alice"]);
+
+        let page = set.page(1, 2).unwrap();
+        assert_eq!(page, vec!["post:2", "user:alice"]);
+
+        assert_eq!(set.first().unwrap().unwrap(), "post:1");
+        assert_eq!(set.last().unwrap().unwrap(), "user:carol");
+    }
+
+    #[test]
+    fn test_sorted_set_remove_updates_order() {
+        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        for v in ["a", "b", "c", "d"] {
+            set.insert(v.to_owned()).unwrap();
+        }
+        assert!(set.remove("b").unwrap());
+        assert!(!set.remove("zzz").unwrap());
+
+        let items: Vec<String> = set.iter().unwrap().collect();
+        assert_eq!(items, vec!["a", "c", "d"]);
+    }
+
+    #[test]
+    fn test_sorted_set_clear() {
+        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        set.insert("x".to_owned()).unwrap();
+        set.insert("y".to_owned()).unwrap();
+        set.clear().unwrap();
+        assert_eq!(set.len().unwrap(), 0);
+        assert!(!set.contains("x").unwrap());
+    }
+}

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1,4 +1,31 @@
 //! This module provides functionality for the unordered map data structure.
+//!
+//! [`UnorderedMap`] is the **default** key-value collection: point-lookup and
+//! full-scan only, with **no iteration-order guarantee** (entries come back in
+//! hashed entity-id order, not key order). Add-wins CRDT merge — keys union,
+//! shared keys merge their values recursively.
+//!
+//! # Complexity (on a node)
+//!
+//! | Operation | Cost |
+//! |---|---|
+//! | `get` / `insert` / `remove` / `contains` | `O(1)` point lookup |
+//! | `len` | `O(1)` |
+//! | `entries` / `keys` / `values` | `O(n)`, **unordered** |
+//!
+//! There is no separate index to maintain, so writes are as cheap as the
+//! storage engine allows and no extra disk is used per key.
+//!
+//! # `UnorderedMap` vs [`SortedMap`](super::SortedMap)
+//!
+//! **Default to `UnorderedMap`.** Reach for [`SortedMap`](super::SortedMap)
+//! *only* when you need keys in order — `range(a..b)`, `prefix("user:")`,
+//! pagination, sorted iteration, or min/max. `SortedMap` answers those in
+//! `O(log n + k)` via a maintained on-disk index, but pays for it on every
+//! write (an extra index write + a validity-marker read/write), in extra disk
+//! per key, and with an `O(n)` index rebuild on the first ordered read after a
+//! sync. If you only ever point-access a map, that index is pure overhead — use
+//! `UnorderedMap`. It is the `HashMap` to `SortedMap`'s `BTreeMap`.
 
 use core::borrow::Borrow;
 use core::fmt;

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -1,4 +1,31 @@
 //! This module provides functionality for the unordered set data structure.
+//!
+//! [`UnorderedSet`] is the **default** set collection: membership and full-scan
+//! only, with **no iteration-order guarantee** (elements come back in hashed
+//! entity-id order, not value order). Add-wins union CRDT — elements are never
+//! lost once added.
+//!
+//! # Complexity (on a node)
+//!
+//! | Operation | Cost |
+//! |---|---|
+//! | `insert` / `contains` / `remove` | `O(1)` point lookup |
+//! | `len` | `O(1)` |
+//! | `iter` | `O(n)`, **unordered** |
+//!
+//! There is no separate index to maintain, so writes are as cheap as the
+//! storage engine allows and no extra disk is used per element.
+//!
+//! # `UnorderedSet` vs [`SortedSet`](super::SortedSet)
+//!
+//! **Default to `UnorderedSet`.** Reach for [`SortedSet`](super::SortedSet)
+//! *only* when you need elements in order — `range(a..b)`, `prefix("user:")`,
+//! pagination, sorted iteration, or min/max. `SortedSet` answers those in
+//! `O(log n + k)` via a maintained on-disk index, but pays for it on every write
+//! (an extra index write + a validity-marker read/write), in extra disk per
+//! element, and with an `O(n)` index rebuild on the first ordered read after a
+//! sync. If you only ever test membership, that index is pure overhead — use
+//! `UnorderedSet`. It is the `HashSet` to `SortedSet`'s `BTreeSet`.
 
 use core::borrow::Borrow;
 use core::fmt;

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -182,6 +182,40 @@ pub fn storage_write(key: Key, value: &[u8]) -> bool {
     imp::storage_write(key, value)
 }
 
+// === Ordered secondary index (SortedMap, core#2559) ===
+//
+// Raw-byte ordered keyspace (the backend keeps keys sorted, so a range scan is
+// a native seek). Keys are the unhashed `collection ‖ order_key`. Node-local,
+// NOT synced. Only the `MainStorage` adaptor routes here; `PrivateStorage` and
+// the test mocks have their own index handling.
+
+/// Insert/overwrite `key -> value` in the ordered index.
+pub fn storage_index_set(key: &[u8], value: &[u8]) {
+    imp::storage_index_set(key, value);
+}
+
+/// Remove `key` from the ordered index.
+pub fn storage_index_remove(key: &[u8]) {
+    imp::storage_index_remove(key);
+}
+
+/// Remove every ordered-index key beginning with `prefix`.
+pub fn storage_index_remove_prefix(prefix: &[u8]) {
+    imp::storage_index_remove_prefix(prefix);
+}
+
+/// Scan the ordered index over `[lo, hi)`, ascending, after `offset`, capped at
+/// `limit` (`None` = unbounded). Returns `(key, value)` pairs.
+#[must_use]
+pub fn storage_index_scan(
+    lo: &[u8],
+    hi: &[u8],
+    offset: usize,
+    limit: Option<usize>,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    imp::storage_index_scan(lo, hi, offset, limit)
+}
+
 /// Reads data from node-local (private) persistent storage.
 ///
 /// Private storage is **NOT synchronised across nodes** — entries
@@ -403,6 +437,28 @@ mod calimero_vm {
         env::private_storage_write(&key.to_bytes(), value)
     }
 
+    /// Ordered-index ops (raw composite keys, no hashing — order must survive).
+    pub(super) fn storage_index_set(key: &[u8], value: &[u8]) {
+        env::storage_index_set(key, value);
+    }
+
+    pub(super) fn storage_index_remove(key: &[u8]) {
+        env::storage_index_remove(key);
+    }
+
+    pub(super) fn storage_index_remove_prefix(prefix: &[u8]) {
+        env::storage_index_remove_prefix(prefix);
+    }
+
+    pub(super) fn storage_index_scan(
+        lo: &[u8],
+        hi: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        env::storage_index_scan(lo, hi, offset, limit)
+    }
+
     /// Fills the buffer with random bytes.
     pub(super) fn random_bytes(buf: &mut [u8]) {
         env::random_bytes(buf)
@@ -539,6 +595,51 @@ mod mocked {
         } else {
             DefaultStore::storage_write(key, value)
         }
+    }
+
+    // Native ordered-index backend. A process-local `BTreeMap` standing in for
+    // the node's RocksDB `SortedIndex` column — enough for native tests; the
+    // node provides the durable, cross-run backing once wired. Keys are the raw
+    // composite `collection ‖ order_key`, so `BTreeMap` order == key order.
+    thread_local! {
+        static INDEX: RefCell<std::collections::BTreeMap<Vec<u8>, Vec<u8>>> =
+            const { RefCell::new(std::collections::BTreeMap::new()) };
+    }
+
+    pub(super) fn storage_index_set(key: &[u8], value: &[u8]) {
+        INDEX.with(|index| {
+            let _ = index.borrow_mut().insert(key.to_vec(), value.to_vec());
+        });
+    }
+
+    pub(super) fn storage_index_remove(key: &[u8]) {
+        INDEX.with(|index| {
+            let _ = index.borrow_mut().remove(key);
+        });
+    }
+
+    pub(super) fn storage_index_remove_prefix(prefix: &[u8]) {
+        INDEX.with(|index| index.borrow_mut().retain(|k, _| !k.starts_with(prefix)));
+    }
+
+    pub(super) fn storage_index_scan(
+        lo: &[u8],
+        hi: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        INDEX.with(|index| {
+            let matched: Vec<(Vec<u8>, Vec<u8>)> = index
+                .borrow()
+                .range(lo.to_vec()..hi.to_vec())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            let ordered = matched.into_iter().skip(offset);
+            match limit {
+                Some(n) => ordered.take(n).collect(),
+                None => ordered.collect(),
+            }
+        })
     }
 
     // Why these don't consult `RUNTIME_ENV` like their main-storage
@@ -703,5 +804,7 @@ mod mocked {
         crate::store::mocked::STORAGE.with(|storage| {
             storage.borrow_mut().clear();
         });
+        // Clear the native ordered-index mock too.
+        INDEX.with(|index| index.borrow_mut().clear());
     }
 }

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -216,6 +216,13 @@ pub fn storage_index_scan(
     imp::storage_index_scan(lo, hi, offset, limit)
 }
 
+/// The largest `(key, value)` in the ordered index over `[lo, hi)` (reverse
+/// seek; backs `SortedMap::last`).
+#[must_use]
+pub fn storage_index_last(lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    imp::storage_index_last(lo, hi)
+}
+
 /// Reads data from node-local (private) persistent storage.
 ///
 /// Private storage is **NOT synchronised across nodes** — entries
@@ -459,6 +466,10 @@ mod calimero_vm {
         env::storage_index_scan(lo, hi, offset, limit)
     }
 
+    pub(super) fn storage_index_last(lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        env::storage_index_last(lo, hi)
+    }
+
     /// Fills the buffer with random bytes.
     pub(super) fn random_bytes(buf: &mut [u8]) {
         env::random_bytes(buf)
@@ -639,6 +650,16 @@ mod mocked {
                 Some(n) => ordered.take(n).collect(),
                 None => ordered.collect(),
             }
+        })
+    }
+
+    pub(super) fn storage_index_last(lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        INDEX.with(|index| {
+            index
+                .borrow()
+                .range(lo.to_vec()..hi.to_vec())
+                .next_back()
+                .map(|(k, v)| (k.clone(), v.clone()))
         })
     }
 

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -189,19 +189,26 @@ pub fn storage_write(key: Key, value: &[u8]) -> bool {
 // NOT synced. Only the `MainStorage` adaptor routes here; `PrivateStorage` and
 // the test mocks have their own index handling.
 
-/// Insert/overwrite `key -> value` in the ordered index.
-pub fn storage_index_set(key: &[u8], value: &[u8]) {
-    imp::storage_index_set(key, value);
+/// Insert/overwrite `key -> value` in the ordered index. Returns whether the
+/// backend persisted the write (so `SortedMap` can skip stamping a stale
+/// validity marker and rebuild on the next read instead).
+#[must_use]
+pub fn storage_index_set(key: &[u8], value: &[u8]) -> bool {
+    imp::storage_index_set(key, value)
 }
 
-/// Remove `key` from the ordered index.
-pub fn storage_index_remove(key: &[u8]) {
-    imp::storage_index_remove(key);
+/// Remove `key` from the ordered index. Returns whether the write was
+/// persisted (see [`storage_index_set`]).
+#[must_use]
+pub fn storage_index_remove(key: &[u8]) -> bool {
+    imp::storage_index_remove(key)
 }
 
-/// Remove every ordered-index key beginning with `prefix`.
-pub fn storage_index_remove_prefix(prefix: &[u8]) {
-    imp::storage_index_remove_prefix(prefix);
+/// Remove every ordered-index key beginning with `prefix`. Returns whether the
+/// write was persisted (see [`storage_index_set`]).
+#[must_use]
+pub fn storage_index_remove_prefix(prefix: &[u8]) -> bool {
+    imp::storage_index_remove_prefix(prefix)
 }
 
 /// Scan the ordered index over `[lo, hi)`, ascending, after `offset`, capped at
@@ -445,16 +452,16 @@ mod calimero_vm {
     }
 
     /// Ordered-index ops (raw composite keys, no hashing — order must survive).
-    pub(super) fn storage_index_set(key: &[u8], value: &[u8]) {
-        env::storage_index_set(key, value);
+    pub(super) fn storage_index_set(key: &[u8], value: &[u8]) -> bool {
+        env::storage_index_set(key, value)
     }
 
-    pub(super) fn storage_index_remove(key: &[u8]) {
-        env::storage_index_remove(key);
+    pub(super) fn storage_index_remove(key: &[u8]) -> bool {
+        env::storage_index_remove(key)
     }
 
-    pub(super) fn storage_index_remove_prefix(prefix: &[u8]) {
-        env::storage_index_remove_prefix(prefix);
+    pub(super) fn storage_index_remove_prefix(prefix: &[u8]) -> bool {
+        env::storage_index_remove_prefix(prefix)
     }
 
     pub(super) fn storage_index_scan(
@@ -617,20 +624,23 @@ mod mocked {
             const { RefCell::new(std::collections::BTreeMap::new()) };
     }
 
-    pub(super) fn storage_index_set(key: &[u8], value: &[u8]) {
+    pub(super) fn storage_index_set(key: &[u8], value: &[u8]) -> bool {
         INDEX.with(|index| {
             let _ = index.borrow_mut().insert(key.to_vec(), value.to_vec());
         });
+        true
     }
 
-    pub(super) fn storage_index_remove(key: &[u8]) {
+    pub(super) fn storage_index_remove(key: &[u8]) -> bool {
         INDEX.with(|index| {
             let _ = index.borrow_mut().remove(key);
         });
+        true
     }
 
-    pub(super) fn storage_index_remove_prefix(prefix: &[u8]) {
+    pub(super) fn storage_index_remove_prefix(prefix: &[u8]) -> bool {
         INDEX.with(|index| index.borrow_mut().retain(|k, _| !k.starts_with(prefix)));
+        true
     }
 
     pub(super) fn storage_index_scan(

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -365,6 +365,9 @@ pub fn merge_by_crdt_type(
         // the container merge is the same add-wins structural pass.
         CrdtType::SortedMap { .. } => merge_unordered_map(existing, incoming),
         CrdtType::UnorderedSet { .. } => merge_unordered_set(existing, incoming),
+        // SortedSet stores/merges exactly like UnorderedSet (union; ordering is a
+        // read-time concern derived from `T: Ord`).
+        CrdtType::SortedSet { .. } => merge_unordered_set(existing, incoming),
         CrdtType::Vector { .. } => merge_vector(existing, incoming),
 
         // UserStorage - LWW per user (same as LwwRegister)
@@ -397,7 +400,7 @@ pub fn merge_by_crdt_type(
 /// - `GCounter`, `PnCounter` - max per executor
 /// - `Rga` - interleave by timestamp
 /// - `LwwRegister` - LWW using metadata timestamps  
-/// - `UnorderedMap`, `SortedMap`, `UnorderedSet`, `Vector` - structural merge
+/// - `UnorderedMap`, `SortedMap`, `UnorderedSet`, `SortedSet`, `Vector` - structural merge
 /// - `UserStorage` - LWW per user
 /// - `FrozenStorage` - first-write-wins
 ///

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -360,6 +360,10 @@ pub fn merge_by_crdt_type(
 
         // Collections - with type info we can merge them
         CrdtType::UnorderedMap { .. } => merge_unordered_map(existing, incoming),
+        // SortedMap stores and merges exactly like UnorderedMap (entries sync
+        // separately; ordering is a read-time concern derived from `K: Ord`), so
+        // the container merge is the same add-wins structural pass.
+        CrdtType::SortedMap { .. } => merge_unordered_map(existing, incoming),
         CrdtType::UnorderedSet { .. } => merge_unordered_set(existing, incoming),
         CrdtType::Vector { .. } => merge_vector(existing, incoming),
 
@@ -393,7 +397,7 @@ pub fn merge_by_crdt_type(
 /// - `GCounter`, `PnCounter` - max per executor
 /// - `Rga` - interleave by timestamp
 /// - `LwwRegister` - LWW using metadata timestamps  
-/// - `UnorderedMap`, `UnorderedSet`, `Vector` - structural merge
+/// - `UnorderedMap`, `SortedMap`, `UnorderedSet`, `Vector` - structural merge
 /// - `UserStorage` - LWW per user
 /// - `FrozenStorage` - first-write-wins
 ///

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -237,6 +237,115 @@ impl StorageAdaptor for MainStorage {
     fn storage_write(key: Key, value: &[u8]) -> bool {
         storage_write(key, value)
     }
+
+    // Ordered index, routed to the env layer (host functions in wasm, the
+    // RocksDB `SortedIndex` column on a node, an in-memory ordered map in
+    // native tests). Composite keys are `collection_id ‖ order_key` (unhashed),
+    // so the backend's byte order is the logical key order.
+    //
+    // NOTE: `index_supported()` is intentionally NOT overridden yet — it stays
+    // `false`, so `SortedMap` keeps using its in-memory sort and these methods
+    // are dormant until the node backs `Column::SortedIndex`. Flipping
+    // `index_supported()` to `true` is the single switch that activates them.
+
+    fn index_put(collection: Id, order_key: &[u8], entry: Id) {
+        crate::env::storage_index_set(&index_key(collection, order_key), entry.as_bytes());
+    }
+
+    fn index_remove(collection: Id, order_key: &[u8]) {
+        crate::env::storage_index_remove(&index_key(collection, order_key));
+    }
+
+    fn index_clear(collection: Id) {
+        crate::env::storage_index_remove_prefix(collection.as_bytes());
+    }
+
+    fn index_range(
+        collection: Id,
+        start: core::ops::Bound<Vec<u8>>,
+        end: core::ops::Bound<Vec<u8>>,
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Id)> {
+        use core::ops::Bound::{Excluded, Included, Unbounded};
+        let prefix = collection.as_bytes();
+        // env scan is `[lo, hi)`; translate the inclusive/exclusive bounds into
+        // byte bounds (append 0x00 to make an inclusive end / exclusive start).
+        let lo = match start {
+            Included(k) => index_key(collection, &k),
+            Excluded(k) => {
+                let mut b = index_key(collection, &k);
+                b.push(0);
+                b
+            }
+            Unbounded => prefix.to_vec(),
+        };
+        let hi = match end {
+            Excluded(k) => index_key(collection, &k),
+            Included(k) => {
+                let mut b = index_key(collection, &k);
+                b.push(0);
+                b
+            }
+            Unbounded => prefix_upper_bound(prefix),
+        };
+        decode_index_hits(
+            prefix,
+            crate::env::storage_index_scan(&lo, &hi, offset, limit),
+        )
+    }
+
+    fn index_prefix(
+        collection: Id,
+        prefix: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Id)> {
+        let coll = collection.as_bytes();
+        let lo = index_key(collection, prefix);
+        let hi = prefix_upper_bound(&lo);
+        decode_index_hits(
+            coll,
+            crate::env::storage_index_scan(&lo, &hi, offset, limit),
+        )
+    }
+}
+
+/// Build the ordered-index composite key `collection_id ‖ order_key`.
+fn index_key(collection: Id, order_key: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(32 + order_key.len());
+    key.extend_from_slice(collection.as_bytes());
+    key.extend_from_slice(order_key);
+    key
+}
+
+/// The exclusive upper bound for a byte prefix: the smallest key that does NOT
+/// start with `prefix` (used to scan "all keys under this prefix"). For the
+/// all-`0xFF` corner (astronomically unlikely for a 32-byte id) we fall back to
+/// a longer all-`0xFF` key, which still bounds the scan.
+fn prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
+    let mut end = prefix.to_vec();
+    while let Some(&last) = end.last() {
+        if last == 0xFF {
+            let _ = end.pop();
+        } else {
+            *end.last_mut().expect("non-empty") += 1;
+            return end;
+        }
+    }
+    vec![0xFF; prefix.len() + 1]
+}
+
+/// Map raw `(composite_key, entry_id_bytes)` scan hits back to
+/// `(order_key, entry_id)` by stripping the `collection_id` prefix.
+fn decode_index_hits(prefix: &[u8], hits: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<(Vec<u8>, Id)> {
+    hits.into_iter()
+        .filter_map(|(composite, entry_bytes)| {
+            let order_key = composite.strip_prefix(prefix)?.to_vec();
+            let id: [u8; 32] = entry_bytes.as_slice().try_into().ok()?;
+            Some((order_key, Id::new(id)))
+        })
+        .collect()
 }
 
 /// Node-local (private) storage adaptor.
@@ -529,7 +638,7 @@ mod index_tests {
     use core::ops::Bound;
 
     use super::mocked::MockedStorage;
-    use super::StorageAdaptor;
+    use super::{MainStorage, StorageAdaptor};
     use crate::address::Id;
 
     // Dedicated mock scope for these tests (within calimero-storage's 0..1_000
@@ -676,6 +785,54 @@ mod index_tests {
         S::index_remove(c, b"k1");
         let after = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None);
         assert_eq!(keys(after), vec![b"k2".to_vec()]);
+    }
+
+    // `MainStorage`'s index methods build composite `collection ‖ order_key`
+    // keys and translate range bounds to byte bounds, routing through the env
+    // layer (here the native in-memory ordered mock). This pins that
+    // composite/bound/decode logic — the same code path the real host ABI and
+    // RocksDB `SortedIndex` column will exercise once `index_supported()` flips.
+    #[test]
+    #[serial_test::serial]
+    fn main_storage_index_routes_through_env() {
+        crate::env::reset_for_testing();
+        let c = Id::new([200u8; 32]);
+
+        MainStorage::index_put(c, b"charlie", Id::new([3; 32]));
+        MainStorage::index_put(c, b"alpha", Id::new([1; 32]));
+        MainStorage::index_put(c, b"bravo", Id::new([2; 32]));
+
+        // Full scan resolves order keys and entry ids, ascending.
+        let all = MainStorage::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None);
+        assert_eq!(
+            all,
+            vec![
+                (b"alpha".to_vec(), Id::new([1; 32])),
+                (b"bravo".to_vec(), Id::new([2; 32])),
+                (b"charlie".to_vec(), Id::new([3; 32])),
+            ]
+        );
+
+        // Half-open range [alpha, charlie).
+        let r = MainStorage::index_range(
+            c,
+            Bound::Included(b"alpha".to_vec()),
+            Bound::Excluded(b"charlie".to_vec()),
+            0,
+            None,
+        );
+        assert_eq!(keys(r), vec![b"alpha".to_vec(), b"bravo".to_vec()]);
+
+        // Prefix scan must not bleed into other keys.
+        MainStorage::index_put(c, b"al", Id::new([9; 32]));
+        let pre = MainStorage::index_prefix(c, b"al", 0, None);
+        assert_eq!(keys(pre), vec![b"al".to_vec(), b"alpha".to_vec()]);
+
+        // Clear drops the whole collection's index.
+        MainStorage::index_clear(c);
+        assert!(
+            MainStorage::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None).is_empty()
+        );
     }
 
     #[test]

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -351,11 +351,11 @@ fn index_key(collection: Id, order_key: &[u8]) -> Vec<u8> {
 /// a longer all-`0xFF` key, which still bounds the scan.
 fn prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
     let mut end = prefix.to_vec();
-    while let Some(&last) = end.last() {
-        if last == 0xFF {
+    while let Some(last) = end.last_mut() {
+        if *last == 0xFF {
             let _ = end.pop();
         } else {
-            *end.last_mut().expect("non-empty") += 1;
+            *last += 1;
             return end;
         }
     }
@@ -548,7 +548,12 @@ pub mod mocked {
                 bytes[i] = 0;
             } else {
                 bytes[i] += 1;
-                let arr: [u8; 32] = bytes.try_into().expect("32-byte id");
+                // `bytes` started as a 32-byte id and is only mutated in place,
+                // so the length is invariably 32; fall back to `Unbounded` rather
+                // than panic if that ever fails to hold.
+                let Ok(arr) = <[u8; 32]>::try_from(bytes) else {
+                    return Bound::Unbounded;
+                };
                 return Bound::Excluded((scope, Id::new(arr), Vec::new()));
             }
         }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -141,20 +141,29 @@ pub trait StorageAdaptor: 'static {
     }
 
     /// Insert/update `collection ‖ order_key -> entry` in the ordered index.
-    /// Idempotent by `(collection, order_key)`.
-    fn index_put(collection: Id, order_key: &[u8], entry: Id) {
+    /// Idempotent by `(collection, order_key)`. Returns whether the write was
+    /// persisted, so `SortedMap` can avoid stamping a stale validity marker (and
+    /// rebuild on the next read instead) when a write is dropped. The inert
+    /// default reports `false`; it is never reached on the stamping path because
+    /// that path is gated on [`index_supported`](Self::index_supported).
+    fn index_put(collection: Id, order_key: &[u8], entry: Id) -> bool {
         let _ = (collection, order_key, entry);
+        false
     }
 
     /// Remove `collection ‖ order_key` from the ordered index. No-op if absent.
-    fn index_remove(collection: Id, order_key: &[u8]) {
+    /// Returns whether the write was persisted (see [`index_put`](Self::index_put)).
+    fn index_remove(collection: Id, order_key: &[u8]) -> bool {
         let _ = (collection, order_key);
+        false
     }
 
     /// Drop every index entry for `collection`. Used when rebuilding the index
-    /// from scratch (e.g. after a remote sync changed the entry set).
-    fn index_clear(collection: Id) {
+    /// from scratch (e.g. after a remote sync changed the entry set). Returns
+    /// whether the write was persisted (see [`index_put`](Self::index_put)).
+    fn index_clear(collection: Id) -> bool {
         let _ = collection;
+        false
     }
 
     /// Return `(order_key, entry_id)` pairs for `collection` whose order key
@@ -255,16 +264,16 @@ impl StorageAdaptor for MainStorage {
         true
     }
 
-    fn index_put(collection: Id, order_key: &[u8], entry: Id) {
-        crate::env::storage_index_set(&index_key(collection, order_key), entry.as_bytes());
+    fn index_put(collection: Id, order_key: &[u8], entry: Id) -> bool {
+        crate::env::storage_index_set(&index_key(collection, order_key), entry.as_bytes())
     }
 
-    fn index_remove(collection: Id, order_key: &[u8]) {
-        crate::env::storage_index_remove(&index_key(collection, order_key));
+    fn index_remove(collection: Id, order_key: &[u8]) -> bool {
+        crate::env::storage_index_remove(&index_key(collection, order_key))
     }
 
-    fn index_clear(collection: Id) {
-        crate::env::storage_index_remove_prefix(collection.as_bytes());
+    fn index_clear(collection: Id) -> bool {
+        crate::env::storage_index_remove_prefix(collection.as_bytes())
     }
 
     fn index_range(
@@ -591,28 +600,31 @@ pub mod mocked {
             true
         }
 
-        fn index_put(collection: Id, order_key: &[u8], entry: Id) {
+        fn index_put(collection: Id, order_key: &[u8], entry: Id) -> bool {
             INDEX.with(|index| {
                 let _ = index
                     .borrow_mut()
                     .insert((SCOPE, collection, order_key.to_vec()), entry);
             });
+            true
         }
 
-        fn index_remove(collection: Id, order_key: &[u8]) {
+        fn index_remove(collection: Id, order_key: &[u8]) -> bool {
             INDEX.with(|index| {
                 let _ = index
                     .borrow_mut()
                     .remove(&(SCOPE, collection, order_key.to_vec()));
             });
+            true
         }
 
-        fn index_clear(collection: Id) {
+        fn index_clear(collection: Id) -> bool {
             INDEX.with(|index| {
                 index
                     .borrow_mut()
                     .retain(|(scope, coll, _), _| !(*scope == SCOPE && *coll == collection));
             });
+            true
         }
 
         fn index_range(

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -479,7 +479,8 @@ pub use mocked::MockedStorage;
 /// from their own tests — see `calimero_node::sync::*_tests`.
 #[cfg(any(test, not(target_arch = "wasm32")))]
 pub mod mocked {
-    use core::cell::RefCell;
+    use core::cell::{Cell, RefCell};
+    use core::ops::Bound;
     use std::collections::BTreeMap;
 
     use super::{IterableStorage, Key, StorageAdaptor};
@@ -488,34 +489,61 @@ pub mod mocked {
     /// The scope of the storage system, which allows for multiple storage
     /// systems to be used in parallel.
     type Scope = usize;
+    /// Composite key of the mock's ordered index: `(scope, collection, order_key)`.
+    type IndexKey = (Scope, Id, Vec<u8>);
 
     thread_local! {
         pub(crate) static STORAGE: RefCell<BTreeMap<(Scope, Key), Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
         /// Ordered secondary index for the mock: `(scope, collection, order_key) -> entry_id`.
         /// `BTreeMap` iterates in key order, so within a `(scope, collection)`
-        /// the entries come back sorted by `order_key` — mirroring the RocksDB
-        /// `Column::SortedIndex` behaviour the real adaptor will provide.
-        static INDEX: RefCell<BTreeMap<(Scope, Id, Vec<u8>), Id>> = const { RefCell::new(BTreeMap::new()) };
+        /// the entries come back sorted by `order_key` — faithfully modelling the
+        /// RocksDB `Column::SortedIndex` the real adaptor uses, including its
+        /// seek-based (sub-linear) range/prefix/last behaviour.
+        static INDEX: RefCell<BTreeMap<IndexKey, Id>> = const { RefCell::new(BTreeMap::new()) };
+        /// Counts index entries *examined* by the most recent ordered query.
+        /// Lets tests prove range/page/last touch `O(window)` items, not `O(n)`.
+        static INDEX_ITEMS: Cell<usize> = const { Cell::new(0) };
     }
 
-    /// `true` if `key` satisfies the `[start, end)` bounds.
-    fn within(
-        key: &[u8],
-        start: &core::ops::Bound<Vec<u8>>,
-        end: &core::ops::Bound<Vec<u8>>,
-    ) -> bool {
-        use core::ops::Bound::{Excluded, Included, Unbounded};
-        let lo = match start {
-            Included(s) => key >= s.as_slice(),
-            Excluded(s) => key > s.as_slice(),
-            Unbounded => true,
-        };
-        let hi = match end {
-            Included(e) => key <= e.as_slice(),
-            Excluded(e) => key < e.as_slice(),
-            Unbounded => true,
-        };
-        lo && hi
+    /// Reset the "items examined" counter (call before an instrumented query).
+    pub fn reset_index_items() {
+        INDEX_ITEMS.with(|c| c.set(0));
+    }
+
+    /// How many index entries the last ordered query examined.
+    #[must_use]
+    pub fn index_items_examined() -> usize {
+        INDEX_ITEMS.with(Cell::get)
+    }
+
+    fn bump_examined() {
+        INDEX_ITEMS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// `true` if `key` is below the end bound `[.., end)`.
+    fn within_end(key: &[u8], end: &Bound<Vec<u8>>) -> bool {
+        match end {
+            Bound::Included(e) => key <= e.as_slice(),
+            Bound::Excluded(e) => key < e.as_slice(),
+            Bound::Unbounded => true,
+        }
+    }
+
+    /// The exclusive `BTreeMap` upper bound just past every key of `collection`
+    /// (the next collection id), so a `.range(..)` can be a true seek that ends
+    /// at the collection boundary. `Unbounded` if `collection` is all-`0xFF`.
+    fn collection_upper(scope: Scope, collection: Id) -> Bound<IndexKey> {
+        let mut bytes = collection.as_bytes().to_vec();
+        for i in (0..bytes.len()).rev() {
+            if bytes[i] == 0xFF {
+                bytes[i] = 0;
+            } else {
+                bytes[i] += 1;
+                let arr: [u8; 32] = bytes.try_into().expect("32-byte id");
+                return Bound::Excluded((scope, Id::new(arr), Vec::new()));
+            }
+        }
+        Bound::Unbounded
     }
 
     /// In-memory mocked storage backend, scoped by a const generic so
@@ -589,25 +617,36 @@ pub mod mocked {
 
         fn index_range(
             collection: Id,
-            start: core::ops::Bound<Vec<u8>>,
-            end: core::ops::Bound<Vec<u8>>,
+            start: Bound<Vec<u8>>,
+            end: Bound<Vec<u8>>,
             offset: usize,
             limit: Option<usize>,
         ) -> Vec<(Vec<u8>, Id)> {
+            // Seek to the start bound (a `BTreeMap::range` is a logarithmic
+            // descent), then walk forward, stopping at the collection boundary
+            // or the end bound — `take_while` over a lazy range only touches
+            // O(seek + items walked), and `skip(offset).take(limit)` bounds that
+            // to O(offset + limit). NOT a full scan.
+            let lo: Bound<IndexKey> = match start {
+                Bound::Included(s) => Bound::Included((SCOPE, collection, s)),
+                Bound::Excluded(s) => Bound::Excluded((SCOPE, collection, s)),
+                Bound::Unbounded => Bound::Included((SCOPE, collection, Vec::new())),
+            };
             INDEX.with(|index| {
-                // BTreeMap iterates in ascending key order, so filtering the
-                // `(SCOPE, collection)` slice already yields order-key order.
-                let matched: Vec<(Vec<u8>, Id)> = index
-                    .borrow()
-                    .iter()
-                    .filter(|((scope, coll, _), _)| *scope == SCOPE && *coll == collection)
-                    .filter(|((_, _, key), _)| within(key, &start, &end))
-                    .map(|((_, _, key), entry)| (key.clone(), *entry))
-                    .collect();
-                let ordered = matched.into_iter().skip(offset);
+                let index = index.borrow();
+                let walked = index
+                    .range((lo, Bound::Unbounded))
+                    .take_while(|((scope, coll, key), _)| {
+                        *scope == SCOPE && *coll == collection && within_end(key, &end)
+                    })
+                    .map(|((_, _, key), entry)| {
+                        bump_examined();
+                        (key.clone(), *entry)
+                    })
+                    .skip(offset);
                 match limit {
-                    Some(n) => ordered.take(n).collect(),
-                    None => ordered.collect(),
+                    Some(n) => walked.take(n).collect(),
+                    None => walked.collect(),
                 }
             })
         }
@@ -618,32 +657,40 @@ pub mod mocked {
             offset: usize,
             limit: Option<usize>,
         ) -> Vec<(Vec<u8>, Id)> {
+            let lo: Bound<IndexKey> = Bound::Included((SCOPE, collection, prefix.to_vec()));
             INDEX.with(|index| {
-                let matched: Vec<(Vec<u8>, Id)> = index
-                    .borrow()
-                    .iter()
-                    .filter(|((scope, coll, _), _)| *scope == SCOPE && *coll == collection)
-                    .filter(|((_, _, key), _)| key.starts_with(prefix))
-                    .map(|((_, _, key), entry)| (key.clone(), *entry))
-                    .collect();
-                let ordered = matched.into_iter().skip(offset);
+                let index = index.borrow();
+                let walked = index
+                    .range((lo, Bound::Unbounded))
+                    .take_while(|((scope, coll, key), _)| {
+                        *scope == SCOPE && *coll == collection && key.starts_with(prefix)
+                    })
+                    .map(|((_, _, key), entry)| {
+                        bump_examined();
+                        (key.clone(), *entry)
+                    })
+                    .skip(offset);
                 match limit {
-                    Some(n) => ordered.take(n).collect(),
-                    None => ordered.collect(),
+                    Some(n) => walked.take(n).collect(),
+                    None => walked.collect(),
                 }
             })
         }
 
         fn index_last(collection: Id) -> Option<(Vec<u8>, Id)> {
+            let lo: Bound<IndexKey> = Bound::Included((SCOPE, collection, Vec::new()));
+            let hi = collection_upper(SCOPE, collection);
             INDEX.with(|index| {
-                // BTreeMap iterates ascending; the last entry for this
-                // (scope, collection) is the largest order key.
+                // `BTreeMap::range` is double-ended, so `next_back()` is a
+                // reverse seek to the largest key — O(log n), one item examined.
                 index
                     .borrow()
-                    .iter()
-                    .filter(|((scope, coll, _), _)| *scope == SCOPE && *coll == collection)
+                    .range((lo, hi))
                     .next_back()
-                    .map(|((_, _, key), entry)| (key.clone(), *entry))
+                    .map(|((_, _, key), entry)| {
+                        bump_examined();
+                        (key.clone(), *entry)
+                    })
             })
         }
     }
@@ -891,6 +938,67 @@ mod index_tests {
                 None
             )),
             vec![b"y".to_vec()]
+        );
+    }
+
+    // Empirical proof of the documented Big-O: build a large collection and
+    // assert (via the mock's "items examined" counter, which faithfully models
+    // the RocksDB seek) that bounded reads touch O(window) index entries, not
+    // O(n). A full scan, by contrast, touches all n — the control.
+    #[test]
+    #[serial_test::serial]
+    fn ordered_reads_are_sublinear() {
+        use super::mocked;
+
+        let c = coll(42);
+        let n = 500usize;
+        for i in 0..n {
+            S::index_put(c, format!("k{i:04}").as_bytes(), entry(0));
+        }
+
+        // last → a single reverse-seek item.
+        mocked::reset_index_items();
+        assert!(S::index_last(c).is_some());
+        assert_eq!(
+            mocked::index_items_examined(),
+            1,
+            "last must examine 1 item, not n"
+        );
+
+        // page(0, 10) → 10 items.
+        mocked::reset_index_items();
+        let page = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, Some(10));
+        assert_eq!(page.len(), 10);
+        assert_eq!(
+            mocked::index_items_examined(),
+            10,
+            "page(0,10) must examine 10 items, not n"
+        );
+
+        // range [k0100, k0105) → 5 items (a tight window).
+        mocked::reset_index_items();
+        let window = S::index_range(
+            c,
+            Bound::Included(b"k0100".to_vec()),
+            Bound::Excluded(b"k0105".to_vec()),
+            0,
+            None,
+        );
+        assert_eq!(window.len(), 5);
+        assert_eq!(
+            mocked::index_items_examined(),
+            5,
+            "range window must examine only the matches, not n"
+        );
+
+        // Control: a full scan examines all n — confirming the counter is real.
+        mocked::reset_index_items();
+        let all = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None);
+        assert_eq!(all.len(), n);
+        assert_eq!(
+            mocked::index_items_examined(),
+            n,
+            "full scan examines all n (the counter isn't trivially small)"
         );
     }
 }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -106,6 +106,62 @@ pub trait StorageAdaptor: 'static {
     fn participates_in_sync() -> bool {
         true
     }
+
+    // === Ordered secondary index (SortedMap, core#2559) ===
+    //
+    // A node-local, derived, NON-synced index keyed by
+    // `collection_id ‖ order_key` (unhashed, so the backend's byte order is
+    // the logical key order). It lets `SortedMap` answer range/prefix/page
+    // queries in `O(log n + k)` instead of scanning + sorting every entry.
+    //
+    // Adaptors that can't provide an ordered keyspace leave these at their
+    // defaults: `index_supported()` stays `false` and `SortedMap` transparently
+    // falls back to its in-memory sort. So this is purely additive — no
+    // existing adaptor behaviour changes.
+
+    /// Whether this adaptor backs the ordered secondary index. When `false`
+    /// (the default), `SortedMap` ignores the index methods and sorts in
+    /// memory. `MainStorage` (RocksDB) and the test mocks override to `true`.
+    fn index_supported() -> bool {
+        false
+    }
+
+    /// Insert/update `collection ‖ order_key -> entry` in the ordered index.
+    /// Idempotent by `(collection, order_key)`.
+    fn index_put(collection: Id, order_key: &[u8], entry: Id) {
+        let _ = (collection, order_key, entry);
+    }
+
+    /// Remove `collection ‖ order_key` from the ordered index. No-op if absent.
+    fn index_remove(collection: Id, order_key: &[u8]) {
+        let _ = (collection, order_key);
+    }
+
+    /// Return `(order_key, entry_id)` pairs for `collection` whose order key
+    /// falls within `[start, end)` (per the `Bound`s), ascending, after
+    /// skipping `offset` and capped at `limit` (`None` = unbounded).
+    fn index_range(
+        collection: Id,
+        start: core::ops::Bound<Vec<u8>>,
+        end: core::ops::Bound<Vec<u8>>,
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Id)> {
+        let _ = (collection, start, end, offset, limit);
+        Vec::new()
+    }
+
+    /// Return `(order_key, entry_id)` pairs for `collection` whose order key
+    /// starts with `prefix`, ascending, after `offset`, capped at `limit`.
+    fn index_prefix(
+        collection: Id,
+        prefix: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Id)> {
+        let _ = (collection, prefix, offset, limit);
+        Vec::new()
+    }
 }
 
 /// Storage iteration support for GC and snapshots.
@@ -281,6 +337,7 @@ pub mod mocked {
     use std::collections::BTreeMap;
 
     use super::{IterableStorage, Key, StorageAdaptor};
+    use crate::address::Id;
 
     /// The scope of the storage system, which allows for multiple storage
     /// systems to be used in parallel.
@@ -288,6 +345,31 @@ pub mod mocked {
 
     thread_local! {
         pub(crate) static STORAGE: RefCell<BTreeMap<(Scope, Key), Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
+        /// Ordered secondary index for the mock: `(scope, collection, order_key) -> entry_id`.
+        /// `BTreeMap` iterates in key order, so within a `(scope, collection)`
+        /// the entries come back sorted by `order_key` — mirroring the RocksDB
+        /// `Column::SortedIndex` behaviour the real adaptor will provide.
+        static INDEX: RefCell<BTreeMap<(Scope, Id, Vec<u8>), Id>> = const { RefCell::new(BTreeMap::new()) };
+    }
+
+    /// `true` if `key` satisfies the `[start, end)` bounds.
+    fn within(
+        key: &[u8],
+        start: &core::ops::Bound<Vec<u8>>,
+        end: &core::ops::Bound<Vec<u8>>,
+    ) -> bool {
+        use core::ops::Bound::{Excluded, Included, Unbounded};
+        let lo = match start {
+            Included(s) => key >= s.as_slice(),
+            Excluded(s) => key > s.as_slice(),
+            Unbounded => true,
+        };
+        let hi = match end {
+            Included(e) => key <= e.as_slice(),
+            Excluded(e) => key < e.as_slice(),
+            Unbounded => true,
+        };
+        lo && hi
     }
 
     /// In-memory mocked storage backend, scoped by a const generic so
@@ -330,6 +412,73 @@ pub mod mocked {
                     .is_some()
             })
         }
+
+        fn index_supported() -> bool {
+            true
+        }
+
+        fn index_put(collection: Id, order_key: &[u8], entry: Id) {
+            INDEX.with(|index| {
+                let _ = index
+                    .borrow_mut()
+                    .insert((SCOPE, collection, order_key.to_vec()), entry);
+            });
+        }
+
+        fn index_remove(collection: Id, order_key: &[u8]) {
+            INDEX.with(|index| {
+                let _ = index
+                    .borrow_mut()
+                    .remove(&(SCOPE, collection, order_key.to_vec()));
+            });
+        }
+
+        fn index_range(
+            collection: Id,
+            start: core::ops::Bound<Vec<u8>>,
+            end: core::ops::Bound<Vec<u8>>,
+            offset: usize,
+            limit: Option<usize>,
+        ) -> Vec<(Vec<u8>, Id)> {
+            INDEX.with(|index| {
+                // BTreeMap iterates in ascending key order, so filtering the
+                // `(SCOPE, collection)` slice already yields order-key order.
+                let matched: Vec<(Vec<u8>, Id)> = index
+                    .borrow()
+                    .iter()
+                    .filter(|((scope, coll, _), _)| *scope == SCOPE && *coll == collection)
+                    .filter(|((_, _, key), _)| within(key, &start, &end))
+                    .map(|((_, _, key), entry)| (key.clone(), *entry))
+                    .collect();
+                let ordered = matched.into_iter().skip(offset);
+                match limit {
+                    Some(n) => ordered.take(n).collect(),
+                    None => ordered.collect(),
+                }
+            })
+        }
+
+        fn index_prefix(
+            collection: Id,
+            prefix: &[u8],
+            offset: usize,
+            limit: Option<usize>,
+        ) -> Vec<(Vec<u8>, Id)> {
+            INDEX.with(|index| {
+                let matched: Vec<(Vec<u8>, Id)> = index
+                    .borrow()
+                    .iter()
+                    .filter(|((scope, coll, _), _)| *scope == SCOPE && *coll == collection)
+                    .filter(|((_, _, key), _)| key.starts_with(prefix))
+                    .map(|((_, _, key), entry)| (key.clone(), *entry))
+                    .collect();
+                let ordered = matched.into_iter().skip(offset);
+                match limit {
+                    Some(n) => ordered.take(n).collect(),
+                    None => ordered.collect(),
+                }
+            })
+        }
     }
 
     // MockedStorage supports iteration for testing
@@ -344,5 +493,189 @@ pub mod mocked {
                     .collect()
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod index_tests {
+    use core::ops::Bound;
+
+    use super::mocked::MockedStorage;
+    use super::StorageAdaptor;
+    use crate::address::Id;
+
+    // Dedicated mock scope for these tests (within calimero-storage's 0..1_000
+    // band). Each test uses a distinct collection id so the shared thread-local
+    // index never bleeds across tests.
+    type S = MockedStorage<950>;
+
+    fn coll(tag: u8) -> Id {
+        Id::new([tag; 32])
+    }
+
+    fn entry(tag: u8) -> Id {
+        Id::new([0x80 | tag; 32])
+    }
+
+    fn keys(pairs: Vec<(Vec<u8>, Id)>) -> Vec<Vec<u8>> {
+        pairs.into_iter().map(|(k, _)| k).collect()
+    }
+
+    #[test]
+    fn adaptors_advertise_index_support() {
+        // The mock backs the ordered index; the default-trait adaptor does not
+        // (so a SortedMap over it transparently falls back to its in-memory
+        // sort). `MainStorage` gets a real backend in a later stage.
+        assert!(S::index_supported());
+        assert!(!DefaultIndexAdaptor::index_supported());
+    }
+
+    // A bare adaptor that takes every `StorageAdaptor` default — used to pin
+    // that `index_supported()` defaults to `false`.
+    struct DefaultIndexAdaptor;
+    impl StorageAdaptor for DefaultIndexAdaptor {
+        fn storage_read(_: super::Key) -> Option<Vec<u8>> {
+            None
+        }
+        fn storage_remove(_: super::Key) -> bool {
+            false
+        }
+        fn storage_write(_: super::Key, _: &[u8]) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn put_then_range_returns_sorted_pairs() {
+        let c = coll(1);
+        // Insert out of order.
+        S::index_put(c, b"delta", entry(4));
+        S::index_put(c, b"alpha", entry(1));
+        S::index_put(c, b"charlie", entry(3));
+        S::index_put(c, b"bravo", entry(2));
+
+        let all = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None);
+        assert_eq!(
+            keys(all),
+            vec![
+                b"alpha".to_vec(),
+                b"bravo".to_vec(),
+                b"charlie".to_vec(),
+                b"delta".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn range_respects_bounds() {
+        let c = coll(2);
+        for k in ["a", "b", "c", "d", "e"] {
+            S::index_put(c, k.as_bytes(), entry(0));
+        }
+
+        // [b, e)
+        let half_open = S::index_range(
+            c,
+            Bound::Included(b"b".to_vec()),
+            Bound::Excluded(b"e".to_vec()),
+            0,
+            None,
+        );
+        assert_eq!(
+            keys(half_open),
+            vec![b"b".to_vec(), b"c".to_vec(), b"d".to_vec()]
+        );
+
+        // (b, e]
+        let excl_incl = S::index_range(
+            c,
+            Bound::Excluded(b"b".to_vec()),
+            Bound::Included(b"e".to_vec()),
+            0,
+            None,
+        );
+        assert_eq!(
+            keys(excl_incl),
+            vec![b"c".to_vec(), b"d".to_vec(), b"e".to_vec()]
+        );
+    }
+
+    #[test]
+    fn range_offset_and_limit_paginate() {
+        let c = coll(3);
+        for i in 0..10u8 {
+            S::index_put(c, format!("k{i:02}").as_bytes(), entry(i));
+        }
+
+        let page = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 3, Some(3));
+        assert_eq!(
+            keys(page),
+            vec![b"k03".to_vec(), b"k04".to_vec(), b"k05".to_vec()]
+        );
+    }
+
+    #[test]
+    fn prefix_scan_matches_only_prefix() {
+        let c = coll(4);
+        for k in ["user:alice", "user:bob", "post:1", "user:carol", "post:2"] {
+            S::index_put(c, k.as_bytes(), entry(0));
+        }
+
+        let users = S::index_prefix(c, b"user:", 0, None);
+        assert_eq!(
+            keys(users),
+            vec![
+                b"user:alice".to_vec(),
+                b"user:bob".to_vec(),
+                b"user:carol".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn remove_drops_from_index_and_resolves_entry_ids() {
+        let c = coll(5);
+        S::index_put(c, b"k1", entry(1));
+        S::index_put(c, b"k2", entry(2));
+
+        // entry ids resolve correctly
+        let pairs = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None);
+        assert_eq!(
+            pairs,
+            vec![(b"k1".to_vec(), entry(1)), (b"k2".to_vec(), entry(2))]
+        );
+
+        S::index_remove(c, b"k1");
+        let after = S::index_range(c, Bound::Unbounded, Bound::Unbounded, 0, None);
+        assert_eq!(keys(after), vec![b"k2".to_vec()]);
+    }
+
+    #[test]
+    fn index_is_isolated_per_collection() {
+        let a = coll(6);
+        let b = coll(7);
+        S::index_put(a, b"x", entry(1));
+        S::index_put(b, b"y", entry(2));
+
+        assert_eq!(
+            keys(S::index_range(
+                a,
+                Bound::Unbounded,
+                Bound::Unbounded,
+                0,
+                None
+            )),
+            vec![b"x".to_vec()]
+        );
+        assert_eq!(
+            keys(S::index_range(
+                b,
+                Bound::Unbounded,
+                Bound::Unbounded,
+                0,
+                None
+            )),
+            vec![b"y".to_vec()]
+        );
     }
 }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -285,8 +285,16 @@ impl StorageAdaptor for MainStorage {
     ) -> Vec<(Vec<u8>, Id)> {
         use core::ops::Bound::{Excluded, Included, Unbounded};
         let prefix = collection.as_bytes();
-        // env scan is `[lo, hi)`; translate the inclusive/exclusive bounds into
-        // byte bounds (append 0x00 to make an inclusive end / exclusive start).
+        // The env scan is the half-open `[lo, hi)`. We translate the logical
+        // inclusive/exclusive bounds by appending a single `0x00` byte. This is
+        // exact for *all* byte keys — including keys that themselves contain or
+        // end in `0x00` — because no byte string `x` satisfies `k < x < k‖0x00`:
+        // any `x` that starts with `k` and is longer is `>= k‖0x00`, and any `x`
+        // that diverges from `k` before `k` ends is either `< k` or `> k‖0x00`.
+        //   - Included end  `<= k`  ⇒ hi = k‖0x00 (admits k, excludes the next key).
+        //   - Excluded start `> k`  ⇒ lo = k‖0x00 (drops k, admits the next key).
+        // (A `prefix_upper_bound`-style successor would be WRONG for an inclusive
+        // *end*: succ([5]) = [6] would wrongly admit [5,0] > [5].)
         let lo = match start {
             Included(k) => index_key(collection, &k),
             Excluded(k) => {

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -182,6 +182,13 @@ pub trait StorageAdaptor: 'static {
         let _ = (collection, prefix, offset, limit);
         Vec::new()
     }
+
+    /// Return the `(order_key, entry_id)` with the largest order key in
+    /// `collection` — a reverse seek for `SortedMap::last` (`O(log n)`).
+    fn index_last(collection: Id) -> Option<(Vec<u8>, Id)> {
+        let _ = collection;
+        None
+    }
 }
 
 /// Storage iteration support for GC and snapshots.
@@ -308,6 +315,16 @@ impl StorageAdaptor for MainStorage {
             coll,
             crate::env::storage_index_scan(&lo, &hi, offset, limit),
         )
+    }
+
+    fn index_last(collection: Id) -> Option<(Vec<u8>, Id)> {
+        let prefix = collection.as_bytes();
+        let lo = prefix.to_vec();
+        let hi = prefix_upper_bound(prefix);
+        let (composite, entry_bytes) = crate::env::storage_index_last(&lo, &hi)?;
+        let order_key = composite.strip_prefix(prefix)?.to_vec();
+        let id: [u8; 32] = entry_bytes.as_slice().try_into().ok()?;
+        Some((order_key, Id::new(id)))
     }
 }
 
@@ -614,6 +631,19 @@ pub mod mocked {
                     Some(n) => ordered.take(n).collect(),
                     None => ordered.collect(),
                 }
+            })
+        }
+
+        fn index_last(collection: Id) -> Option<(Vec<u8>, Id)> {
+            INDEX.with(|index| {
+                // BTreeMap iterates ascending; the last entry for this
+                // (scope, collection) is the largest order key.
+                index
+                    .borrow()
+                    .iter()
+                    .filter(|((scope, coll, _), _)| *scope == SCOPE && *coll == collection)
+                    .next_back()
+                    .map(|((_, _, key), entry)| (key.clone(), *entry))
             })
         }
     }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -28,6 +28,16 @@ pub enum Key {
     /// for actions that pre-date the current writer set. Tag `3` to keep the
     /// existing `Index`/`Entry`/`SyncState` byte layout stable.
     RotationLog(Id),
+
+    /// Validity marker for a `SortedMap`'s ordered secondary index (core#2559).
+    ///
+    /// Stores the collection's `full_hash` at the moment its `Column::SortedIndex`
+    /// entries were last (re)built. An ordered read compares this to the
+    /// collection's current `full_hash`: equal ⇒ the index is current and can be
+    /// queried directly; different (a local write or a remote sync changed the
+    /// entry set) ⇒ rebuild the index once, then serve. Node-local, not synced.
+    /// Tag `4` keeps the existing byte layout stable.
+    SortedIndexMeta(Id),
 }
 
 impl Key {
@@ -50,6 +60,10 @@ impl Key {
             }
             Self::RotationLog(id) => {
                 bytes[0] = 3;
+                bytes[1..33].copy_from_slice(id.as_bytes());
+            }
+            Self::SortedIndexMeta(id) => {
+                bytes[0] = 4;
                 bytes[1..33].copy_from_slice(id.as_bytes());
             }
         }
@@ -135,6 +149,12 @@ pub trait StorageAdaptor: 'static {
     /// Remove `collection ‖ order_key` from the ordered index. No-op if absent.
     fn index_remove(collection: Id, order_key: &[u8]) {
         let _ = (collection, order_key);
+    }
+
+    /// Drop every index entry for `collection`. Used when rebuilding the index
+    /// from scratch (e.g. after a remote sync changed the entry set).
+    fn index_clear(collection: Id) {
+        let _ = collection;
     }
 
     /// Return `(order_key, entry_id)` pairs for `collection` whose order key
@@ -430,6 +450,14 @@ pub mod mocked {
                 let _ = index
                     .borrow_mut()
                     .remove(&(SCOPE, collection, order_key.to_vec()));
+            });
+        }
+
+        fn index_clear(collection: Id) {
+            INDEX.with(|index| {
+                index
+                    .borrow_mut()
+                    .retain(|(scope, coll, _), _| !(*scope == SCOPE && *coll == collection));
             });
         }
 

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -238,15 +238,15 @@ impl StorageAdaptor for MainStorage {
         storage_write(key, value)
     }
 
-    // Ordered index, routed to the env layer (host functions in wasm, the
-    // RocksDB `SortedIndex` column on a node, an in-memory ordered map in
-    // native tests). Composite keys are `collection_id ‖ order_key` (unhashed),
-    // so the backend's byte order is the logical key order.
-    //
-    // NOTE: `index_supported()` is intentionally NOT overridden yet — it stays
-    // `false`, so `SortedMap` keeps using its in-memory sort and these methods
-    // are dormant until the node backs `Column::SortedIndex`. Flipping
-    // `index_supported()` to `true` is the single switch that activates them.
+    // Ordered index, routed to the env layer (host functions in wasm reaching
+    // the node's RocksDB `SortedIndex` column via `ContextStorage`; an
+    // in-memory ordered map in native tests). Composite keys are
+    // `collection_id ‖ order_key` (unhashed), so the backend's byte order is the
+    // logical key order — making range/prefix/pagination a native seek.
+
+    fn index_supported() -> bool {
+        true
+    }
 
     fn index_put(collection: Id, order_key: &[u8], entry: Id) {
         crate::env::storage_index_set(&index_key(collection, order_key), entry.as_bytes());

--- a/crates/storage/src/tests/merge_dispatch.rs
+++ b/crates/storage/src/tests/merge_dispatch.rs
@@ -201,6 +201,10 @@ fn test_is_builtin_crdt_classification() {
         "UnorderedMap is builtin"
     );
     assert!(
+        is_builtin_crdt(&CrdtType::sorted_map("String", "u64")),
+        "SortedMap is builtin"
+    );
+    assert!(
         is_builtin_crdt(&CrdtType::unordered_set("String")),
         "UnorderedSet is builtin"
     );
@@ -278,6 +282,11 @@ fn test_collections_return_incoming() {
         &existing,
         &incoming,
     );
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), incoming);
+
+    // SortedMap - same structured-storage dispatch as UnorderedMap
+    let result = merge_by_crdt_type(&CrdtType::sorted_map("String", "u64"), &existing, &incoming);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), incoming);
 

--- a/crates/storage/src/tests/merge_dispatch.rs
+++ b/crates/storage/src/tests/merge_dispatch.rs
@@ -209,6 +209,10 @@ fn test_is_builtin_crdt_classification() {
         "UnorderedSet is builtin"
     );
     assert!(
+        is_builtin_crdt(&CrdtType::sorted_set("String")),
+        "SortedSet is builtin"
+    );
+    assert!(
         is_builtin_crdt(&CrdtType::vector("u64")),
         "Vector is builtin"
     );
@@ -292,6 +296,11 @@ fn test_collections_return_incoming() {
 
     // UnorderedSet - returns incoming for structured storage
     let result = merge_by_crdt_type(&CrdtType::unordered_set("String"), &existing, &incoming);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), incoming);
+
+    // SortedSet - same structured-storage dispatch as UnorderedSet
+    let result = merge_by_crdt_type(&CrdtType::sorted_set("String"), &existing, &incoming);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), incoming);
 

--- a/crates/storage/tests/crdt_contract.rs
+++ b/crates/storage/tests/crdt_contract.rs
@@ -458,3 +458,160 @@ fn rga_satisfies_crdt_laws() {
         eq,
     );
 }
+
+// `SortedMap` stores and merges exactly like `UnorderedMap` (same inner
+// collection, add-wins keys, recursive value merge); only its *iteration* is
+// key-ordered. These tests pin that the merge laws hold through the
+// `SortedMap` surface, and — separately — that the ordering invariant survives
+// a merge regardless of merge direction.
+#[test]
+fn sorted_map_with_lww_register_satisfies_crdt_laws() {
+    use calimero_storage::collections::{LwwRegister, SortedMap};
+    use calimero_storage::logical_clock::HybridTimestamp;
+    use calimero_storage::store::MainStorage;
+
+    // Disjoint keys per replica: add-wins union, deterministic per builder.
+    // Pin the register's HLC/node so repeat builder calls are byte-identical
+    // (the `assert_mergeable_laws` determinism contract).
+    fn fresh(key: &str, node: [u8; 32]) -> SortedMap<String, LwwRegister<String>, MainStorage> {
+        let mut m = SortedMap::new();
+        m.insert(
+            key.to_owned(),
+            LwwRegister::new_with_metadata(key.to_uppercase(), HybridTimestamp::zero(), node),
+        )
+        .unwrap();
+        m
+    }
+
+    let eq = |a: &SortedMap<String, LwwRegister<String>, MainStorage>,
+              b: &SortedMap<String, LwwRegister<String>, MainStorage>| {
+        // `entries()` is already key-sorted, so a direct positional compare is
+        // a sufficient equality check.
+        let a_entries: Vec<(String, String)> = a
+            .entries()
+            .unwrap()
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect();
+        let b_entries: Vec<(String, String)> = b
+            .entries()
+            .unwrap()
+            .map(|(k, v)| (k, v.get().clone()))
+            .collect();
+        a_entries == b_entries
+    };
+
+    assert_mergeable_laws(
+        || fresh("alice", [11; 32]),
+        || fresh("bob", [22; 32]),
+        || fresh("carol", [33; 32]),
+        eq,
+    );
+}
+
+// Shared-key + per-replica executor conflict — proves `SortedMap` inherits
+// `UnorderedMap`'s recursive merge into a nested `Counter` on the same key.
+#[test]
+fn sorted_map_with_counter_shared_key_conflict() {
+    use calimero_storage::collections::{Counter, SortedMap};
+    use calimero_storage::env;
+    use calimero_storage::store::MainStorage;
+
+    let make = |executor: [u8; 32],
+                private_key: &'static str,
+                shared_count: usize,
+                private_count: usize| {
+        move || {
+            env::with_executor_id(executor, || {
+                let mut m = SortedMap::new();
+
+                let mut shared = Counter::<false, MainStorage>::new();
+                for _ in 0..shared_count {
+                    shared.increment().unwrap();
+                }
+                m.insert("shared".to_owned(), shared).unwrap();
+
+                let mut private = Counter::<false, MainStorage>::new();
+                for _ in 0..private_count {
+                    private.increment().unwrap();
+                }
+                m.insert(private_key.to_owned(), private).unwrap();
+                m
+            })
+        }
+    };
+
+    let eq = |a: &SortedMap<String, Counter, MainStorage>,
+              b: &SortedMap<String, Counter, MainStorage>| {
+        let a_entries: Vec<(String, u64)> = a
+            .entries()
+            .unwrap()
+            .map(|(k, v)| (k, v.value().unwrap()))
+            .collect();
+        let b_entries: Vec<(String, u64)> = b
+            .entries()
+            .unwrap()
+            .map(|(k, v)| (k, v.value().unwrap()))
+            .collect();
+        a_entries == b_entries
+    };
+
+    assert_mergeable_laws(
+        make([11; 32], "alice", 2, 1),
+        make([22; 32], "bob", 3, 1),
+        make([33; 32], "carol", 5, 1),
+        eq,
+    );
+}
+
+// Convergence is necessary but not sufficient for a *sorted* map: the merged
+// state must also iterate in key order, in both merge directions. Insert keys
+// out of order on each replica, merge, and assert the result is sorted and
+// direction-independent.
+#[test]
+fn sorted_map_iteration_is_sorted_after_merge() {
+    use calimero_storage::collections::{LwwRegister, SortedMap};
+    use calimero_storage::logical_clock::HybridTimestamp;
+    use calimero_storage::store::MainStorage;
+
+    fn replica(
+        keys: &[&str],
+        node: [u8; 32],
+    ) -> SortedMap<String, LwwRegister<String>, MainStorage> {
+        let mut m = SortedMap::new();
+        for k in keys {
+            m.insert(
+                (*k).to_owned(),
+                LwwRegister::new_with_metadata((*k).to_owned(), HybridTimestamp::zero(), node),
+            )
+            .unwrap();
+        }
+        m
+    }
+
+    let keys_of = |m: &SortedMap<String, LwwRegister<String>, MainStorage>| -> Vec<String> {
+        m.keys().unwrap().collect()
+    };
+
+    // Deliberately scrambled insertion order, partially overlapping key sets.
+    let mut ab = replica(&["m", "a", "z"], [1; 32]);
+    let b = replica(&["b", "a", "q"], [2; 32]);
+    ab.merge(&b).unwrap();
+
+    let mut ba = replica(&["b", "a", "q"], [2; 32]);
+    let a = replica(&["m", "a", "z"], [1; 32]);
+    ba.merge(&a).unwrap();
+
+    let expected = vec![
+        "a".to_owned(),
+        "b".to_owned(),
+        "m".to_owned(),
+        "q".to_owned(),
+        "z".to_owned(),
+    ];
+    assert_eq!(keys_of(&ab), expected, "merge(a, b) must be sorted");
+    assert_eq!(
+        keys_of(&ba),
+        expected,
+        "merge(b, a) must be sorted and identical to merge(a, b)"
+    );
+}

--- a/crates/storage/tests/crdt_contract.rs
+++ b/crates/storage/tests/crdt_contract.rs
@@ -615,3 +615,63 @@ fn sorted_map_iteration_is_sorted_after_merge() {
         "merge(b, a) must be sorted and identical to merge(a, b)"
     );
 }
+
+// `SortedSet` — same add-wins union as `UnorderedSet`, but iterated in element
+// order. Pin the merge laws through its surface, and that the merged set is
+// sorted regardless of merge direction.
+#[test]
+fn sorted_set_satisfies_crdt_laws() {
+    use calimero_storage::collections::SortedSet;
+    use calimero_storage::store::MainStorage;
+
+    fn fresh(items: &[&str]) -> SortedSet<String, MainStorage> {
+        let mut s = SortedSet::new();
+        for item in items {
+            let _ = s.insert((*item).to_owned()).unwrap();
+        }
+        s
+    }
+
+    // `iter()` is already ascending, so a direct positional compare suffices.
+    let eq = |a: &SortedSet<String, MainStorage>, b: &SortedSet<String, MainStorage>| {
+        let a_items: Vec<_> = a.iter().unwrap().collect();
+        let b_items: Vec<_> = b.iter().unwrap().collect();
+        a_items == b_items
+    };
+
+    assert_mergeable_laws(
+        || fresh(&["alice", "bob"]),
+        || fresh(&["bob", "carol"]),
+        || fresh(&["dave"]),
+        eq,
+    );
+}
+
+#[test]
+fn sorted_set_iteration_is_sorted_after_merge() {
+    use calimero_storage::collections::SortedSet;
+    use calimero_storage::store::MainStorage;
+
+    fn replica(items: &[&str]) -> SortedSet<String, MainStorage> {
+        let mut s = SortedSet::new();
+        for v in items {
+            let _ = s.insert((*v).to_owned()).unwrap();
+        }
+        s
+    }
+
+    let mut ab = replica(&["m", "a", "z"]);
+    ab.merge(&replica(&["b", "a", "q"])).unwrap();
+    let mut ba = replica(&["b", "a", "q"]);
+    ba.merge(&replica(&["m", "a", "z"])).unwrap();
+
+    let expected = vec![
+        "a".to_owned(),
+        "b".to_owned(),
+        "m".to_owned(),
+        "q".to_owned(),
+        "z".to_owned(),
+    ];
+    assert_eq!(ab.iter().unwrap().collect::<Vec<_>>(), expected);
+    assert_eq!(ba.iter().unwrap().collect::<Vec<_>>(), expected);
+}

--- a/crates/store/impl/rocksdb/src/lib.rs
+++ b/crates/store/impl/rocksdb/src/lib.rs
@@ -181,6 +181,37 @@ impl Database<'_> for RocksDB {
         Ok(Iter::new(DBIterator { ready: true, iter }))
     }
 
+    fn last_in_range(
+        &self,
+        col: Column,
+        lo: Slice<'_>,
+        hi: Slice<'_>,
+    ) -> EyreResult<Option<(Vec<u8>, Vec<u8>)>> {
+        let cf_handle = self.try_cf_handle(col)?;
+        let mut iter = self.db.raw_iterator_cf(cf_handle);
+
+        // `seek_for_prev(hi)` lands on the largest key <= hi; `hi` is the
+        // exclusive upper bound, so step back past any key == hi to reach the
+        // largest key strictly < hi. One seek + a step or two — O(log n).
+        iter.seek_for_prev(hi.as_ref());
+        while iter.valid() {
+            // Copy the key out before any mutation drops the borrow.
+            let Some(key) = iter.key().map(<[u8]>::to_vec) else {
+                break;
+            };
+            if key.as_slice() >= hi.as_ref() {
+                iter.prev();
+                continue;
+            }
+            if key.as_slice() < lo.as_ref() {
+                return Ok(None);
+            }
+            let value = iter.value().map(<[u8]>::to_vec).unwrap_or_default();
+            return Ok(Some((key, value)));
+        }
+        Ok(None)
+    }
+
     fn approximate_size(&self, col: Column, start: Slice<'_>, end: Slice<'_>) -> EyreResult<u64> {
         let cf_handle = self.try_cf_handle(col)?;
         // `get_approximate_sizes_cf` samples SST metadata — no scan,

--- a/crates/store/impl/rocksdb/src/lib.rs
+++ b/crates/store/impl/rocksdb/src/lib.rs
@@ -212,6 +212,15 @@ impl Database<'_> for RocksDB {
         Ok(None)
     }
 
+    fn delete_range(&self, col: Column, lo: Slice<'_>, hi: Slice<'_>) -> EyreResult<()> {
+        let cf_handle = self.try_cf_handle(col)?;
+        // A single range tombstone over `[lo, hi)` — no per-key delete, no scan,
+        // and no unbounded in-memory key buffer.
+        self.db
+            .delete_range_cf(cf_handle, lo.as_ref(), hi.as_ref())?;
+        Ok(())
+    }
+
     fn approximate_size(&self, col: Column, start: Slice<'_>, end: Slice<'_>) -> EyreResult<u64> {
         let cf_handle = self.try_cf_handle(col)?;
         // `get_approximate_sizes_cf` samples SST metadata — no scan,

--- a/crates/store/impl/rocksdb/src/tests.rs
+++ b/crates/store/impl/rocksdb/src/tests.rs
@@ -234,3 +234,52 @@ fn test_approximate_size_scopes_to_range() {
         "in-range ({in_range}) must not exceed full-range ({full_range})"
     );
 }
+
+#[test]
+fn test_delete_range_drops_only_in_range_keys() {
+    // The native range tombstone backing `SortedMap::clear`'s index drop must
+    // delete exactly `[lo, hi)` and leave neighbouring prefixes untouched.
+    let dir = TempDir::new("_calimero_store_delete_range").expect("tempdir");
+    let dir_path = dir.path().to_owned().try_into().expect("path conversion");
+    let config = StoreConfig::new(dir_path);
+    let db = RocksDB::open(&config).expect("db open");
+
+    // Three prefixes; we'll wipe only the middle one (0x20).
+    for p in [0x10_u8, 0x20, 0x30] {
+        for i in 0..8u8 {
+            let key = [p, i];
+            db.put(
+                Column::SortedIndex,
+                Slice::from(&key[..]),
+                Slice::from(&[i][..]),
+            )
+            .expect("put");
+        }
+    }
+
+    db.delete_range(
+        Column::SortedIndex,
+        Slice::from(&[0x20_u8][..]),
+        Slice::from(&[0x21_u8][..]),
+    )
+    .expect("delete_range");
+
+    // The 0x20 bucket is gone…
+    for i in 0..8u8 {
+        assert!(
+            !db.has(Column::SortedIndex, Slice::from(&[0x20_u8, i][..]))
+                .expect("has 0x20"),
+            "0x20 key {i} should have been deleted"
+        );
+    }
+    // …while the neighbours survive untouched.
+    for (p, label) in [(0x10_u8, "0x10"), (0x30, "0x30")] {
+        for i in 0..8u8 {
+            assert!(
+                db.has(Column::SortedIndex, Slice::from(&[p, i][..]))
+                    .expect("has neighbour"),
+                "{label} key {i} must survive a neighbouring range delete"
+            );
+        }
+    }
+}

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -101,6 +101,33 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
         Ok(last)
     }
 
+    /// Delete every key in `col` over `[lo, hi)` in one shot. Used to drop a
+    /// `SortedMap`'s whole index slice on `clear()` without materialising the
+    /// key set in memory first.
+    ///
+    /// The default buffers the in-range keys and deletes them one by one (so
+    /// backends without a native range delete still work); RocksDB overrides
+    /// this with `delete_range_cf`, a single range tombstone — `O(1)` write,
+    /// no per-key I/O and no unbounded buffer.
+    fn delete_range(&self, col: Column, lo: Slice<'_>, hi: Slice<'_>) -> EyreResult<()> {
+        let mut iter = self.iter(col)?;
+        let hi_bytes: Vec<u8> = hi.as_ref().to_vec();
+        let mut keys: Vec<Vec<u8>> = Vec::new();
+        let mut pos = iter.seek(lo)?.map(|k| k.as_ref().to_vec());
+        while let Some(key) = pos {
+            if key.as_slice() >= hi_bytes.as_slice() {
+                break;
+            }
+            keys.push(key);
+            pos = iter.next()?.map(|k| k.as_ref().to_vec());
+        }
+        drop(iter);
+        for key in keys {
+            self.delete(col, Slice::from(&key))?;
+        }
+        Ok(())
+    }
+
     /// Best-effort estimate of on-disk bytes stored in `col` for keys in
     /// `[start, end)`. Used by usage-reporting endpoints to measure
     /// per-group / per-context storage cheaply (RocksDB returns a real

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -74,6 +74,33 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
         self.iter(col)
     }
 
+    /// The largest `(key, value)` in `col` over `[lo, hi)` — i.e. a reverse
+    /// seek to the last key in the range. Used for `SortedMap::last` (an
+    /// `O(log n)` "max key" lookup instead of a forward walk to the end).
+    ///
+    /// The default does a forward `O(n)` scan keeping the last in-range entry,
+    /// so backends without reverse iteration still work; RocksDB overrides this
+    /// with `seek_for_prev` for a true `O(log n)` seek.
+    fn last_in_range(
+        &self,
+        col: Column,
+        lo: Slice<'_>,
+        hi: Slice<'_>,
+    ) -> EyreResult<Option<(Vec<u8>, Vec<u8>)>> {
+        let mut iter = self.iter(col)?;
+        let mut last: Option<(Vec<u8>, Vec<u8>)> = None;
+        let mut pos = iter.seek(lo)?.map(|k| k.as_ref().to_vec());
+        while let Some(key) = pos {
+            if key.as_slice() >= hi.as_ref() {
+                break;
+            }
+            let value = iter.read()?.as_ref().to_vec();
+            last = Some((key, value));
+            pos = iter.next()?.map(|k| k.as_ref().to_vec());
+        }
+        Ok(last)
+    }
+
     /// Best-effort estimate of on-disk bytes stored in `col` for keys in
     /// `[start, end)`. Used by usage-reporting endpoints to measure
     /// per-group / per-context storage cheaply (RocksDB returns a real

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -32,6 +32,13 @@ pub enum Column {
     /// tombstone — sync-and-auto-follow stop on the node where the user
     /// opted out, while peers see no change.
     ContextLocal,
+    /// Node-local secondary index for `SortedMap` collections. NOT
+    /// synchronized across nodes — it is a derived materialised view of the
+    /// synced entity set, maintained locally as entries are written/applied.
+    /// Keys are `collection_id(32) ‖ order_key_bytes` (unhashed, so RocksDB's
+    /// byte order = key order), values are the entry's 32-byte id. Enables
+    /// `O(log n + k)` range/prefix/pagination over `SortedMap` (core#2559).
+    SortedIndex,
 }
 
 pub trait Database<'a>: Debug + Send + Sync + 'static {

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -73,6 +73,13 @@ impl Store {
         self.db.delete(col, Slice::from(key))
     }
 
+    /// Delete every raw key in `col` over `[lo, hi)` in one shot (a native
+    /// range tombstone on RocksDB). Used to drop a whole index slice on
+    /// `clear()` without buffering the key set.
+    pub fn raw_delete_range(&self, col: Column, lo: &[u8], hi: &[u8]) -> EyreResult<()> {
+        self.db.delete_range(col, Slice::from(lo), Slice::from(hi))
+    }
+
     /// Collect up to `max` `(key, value)` pairs in `col` over `[lo, hi)`,
     /// ascending by key (the backend's native order). One forward seek + walk,
     /// stopping after `max` items (`None` = unbounded) so a bounded query

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -73,14 +73,20 @@ impl Store {
         self.db.delete(col, Slice::from(key))
     }
 
-    /// Collect `(key, value)` pairs in `col` over `[lo, hi)`, ascending by key
-    /// (the backend's native order). One forward seek + walk.
+    /// Collect up to `max` `(key, value)` pairs in `col` over `[lo, hi)`,
+    /// ascending by key (the backend's native order). One forward seek + walk,
+    /// stopping after `max` items (`None` = unbounded) so a bounded query
+    /// (`page`/`range` with a limit) walks `O(max)` rather than the whole range.
     pub fn raw_scan(
         &self,
         col: Column,
         lo: &[u8],
         hi: &[u8],
+        max: Option<usize>,
     ) -> EyreResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        if max == Some(0) {
+            return Ok(Vec::new());
+        }
         let mut iter = self.db.iter(col)?;
         let mut out = Vec::new();
         // Copy the key bytes out of each borrow before reading the value /
@@ -92,6 +98,9 @@ impl Store {
             }
             let value = iter.read()?.as_ref().to_vec();
             out.push((key, value));
+            if max.is_some_and(|m| out.len() >= m) {
+                break;
+            }
             pos = iter.next()?.map(|k| k.as_ref().to_vec());
         }
         Ok(out)

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -105,4 +105,15 @@ impl Store {
         }
         Ok(out)
     }
+
+    /// The largest `(key, value)` in `col` over `[lo, hi)` (a reverse seek —
+    /// `O(log n)` on RocksDB). Used for `SortedMap::last`.
+    pub fn raw_last(
+        &self,
+        col: Column,
+        lo: &[u8],
+        hi: &[u8],
+    ) -> EyreResult<Option<(Vec<u8>, Vec<u8>)>> {
+        self.db.last_in_range(col, Slice::from(lo), Slice::from(hi))
+    }
 }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -54,4 +54,46 @@ impl Store {
         self.db
             .approximate_size(col, Slice::from(start), Slice::from(end))
     }
+
+    // === Raw, untyped column access (ordered secondary index, core#2559) ===
+    //
+    // The typed `Handle`/`Entry` API requires fixed-size `KeyComponents`. The
+    // `SortedMap` ordered index needs *variable-length* keys in byte order, so
+    // these write/iterate raw bytes directly against a column. Intended for the
+    // node-local `Column::SortedIndex`; the keys are unhashed so the backend's
+    // byte order is the logical key order, making a range scan a native seek.
+
+    /// Write a raw `key -> value` to `col`.
+    pub fn raw_put(&self, col: Column, key: &[u8], value: &[u8]) -> EyreResult<()> {
+        self.db.put(col, Slice::from(key), Slice::from(value))
+    }
+
+    /// Delete a raw `key` from `col`.
+    pub fn raw_delete(&self, col: Column, key: &[u8]) -> EyreResult<()> {
+        self.db.delete(col, Slice::from(key))
+    }
+
+    /// Collect `(key, value)` pairs in `col` over `[lo, hi)`, ascending by key
+    /// (the backend's native order). One forward seek + walk.
+    pub fn raw_scan(
+        &self,
+        col: Column,
+        lo: &[u8],
+        hi: &[u8],
+    ) -> EyreResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        let mut iter = self.db.iter(col)?;
+        let mut out = Vec::new();
+        // Copy the key bytes out of each borrow before reading the value /
+        // advancing, so we never hold the iterator borrow across calls.
+        let mut pos = iter.seek(Slice::from(lo))?.map(|k| k.as_ref().to_vec());
+        while let Some(key) = pos {
+            if key.as_slice() >= hi {
+                break;
+            }
+            let value = iter.read()?.as_ref().to_vec();
+            out.push((key, value));
+            pos = iter.next()?.map(|k| k.as_ref().to_vec());
+        }
+        Ok(out)
+    }
 }

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -29,6 +29,19 @@ wasm_imports! {
         fn storage_remove(key: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;
         fn storage_write(key: Ref<Buffer<'_>>, value: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;
         // --
+        // Ordered secondary index (SortedMap, core#2559) — node-local, NOT
+        // synchronized. Keys are the unhashed `collection ‖ order_key`.
+        fn storage_index_set(key: Ref<Buffer<'_>>, value: Ref<Buffer<'_>>) -> Bool;
+        fn storage_index_remove(key: Ref<Buffer<'_>>) -> Bool;
+        fn storage_index_remove_prefix(prefix: Ref<Buffer<'_>>) -> Bool;
+        fn storage_index_scan(
+            lo: Ref<Buffer<'_>>,
+            hi: Ref<Buffer<'_>>,
+            offset: PtrSizedInt,
+            limit: PtrSizedInt,
+            register_id: RegisterId
+        ) -> Bool;
+        // --
         // Private storage functions (node-local, NOT synchronized)
         fn private_storage_read(key: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;
         fn private_storage_remove(key: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -41,6 +41,7 @@ wasm_imports! {
             limit: PtrSizedInt,
             register_id: RegisterId
         ) -> Bool;
+        fn storage_index_last(lo: Ref<Buffer<'_>>, hi: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;
         // --
         // Private storage functions (node-local, NOT synchronized)
         fn private_storage_read(key: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -201,9 +201,9 @@ fn normalize_generic_type(
             Ok(TypeRef::list(item_type))
         }
         // Collection types - normalize to semantic ABI types
-        "BTreeMap" | "HashMap" | "UnorderedMap" | "IndexMap" | "AuthoredMap" => {
+        "BTreeMap" | "HashMap" | "UnorderedMap" | "SortedMap" | "IndexMap" | "AuthoredMap" => {
             // All map types -> map<K, V> (normalize to semantic type)
-            // UnorderedMap and AuthoredMap preserve CRDT type metadata
+            // UnorderedMap, SortedMap and AuthoredMap preserve CRDT type metadata
             if args.args.len() != 2 {
                 return Err(NormalizeError::TypePathError(format!(
                     "invalid {ident_str} type - expected 2 type arguments"
@@ -229,9 +229,10 @@ fn normalize_generic_type(
             let _key_type = normalize_type(key_ty, wasm32, resolver)?;
             let value_type = normalize_type(value_ty, wasm32, resolver)?;
 
-            // Preserve CRDT type for UnorderedMap / AuthoredMap
+            // Preserve CRDT type for UnorderedMap / SortedMap / AuthoredMap
             let crdt_type = match ident_str.as_str() {
                 "UnorderedMap" => Some(CrdtCollectionType::UnorderedMap),
+                "SortedMap" => Some(CrdtCollectionType::SortedMap),
                 "AuthoredMap" => Some(CrdtCollectionType::AuthoredMap),
                 _ => None,
             };

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -299,6 +299,7 @@ fn normalize_generic_type(
         | "Vector"
         | "AuthoredVector"
         | "UnorderedSet"
+        | "SortedSet"
         | "FrozenValue" => {
             // These CRDT wrappers unwrap to their inner type for ABI purposes
             // but we preserve the CRDT type so deserializers know the format
@@ -386,6 +387,17 @@ fn normalize_generic_type(
                         },
                         crdt_type: Some(CrdtCollectionType::UnorderedSet),
                         inner_type: None, // Inner type is in List.items
+                    })
+                }
+                "SortedSet" => {
+                    // SortedSet<T> -> List<T> (ascending); same shape as
+                    // UnorderedSet, marker records that iteration is ordered.
+                    Ok(TypeRef::Collection {
+                        collection: CollectionType::List {
+                            items: Box::new(inner_type),
+                        },
+                        crdt_type: Some(CrdtCollectionType::SortedSet),
+                        inner_type: None,
                     })
                 }
                 "FrozenValue" => {

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -195,6 +195,9 @@ pub enum CrdtCollectionType {
     AuthoredMap,
     /// UnorderedSet: Set with CRDT metadata
     UnorderedSet,
+    /// SortedSet: Set iterated in ascending element order (range/prefix queries);
+    /// same add-wins union merge as `UnorderedSet`
+    SortedSet,
     /// ReplicatedGrowableArray: String with character-level CRDT
     ReplicatedGrowableArray,
     /// AuthoredVector: List with per-element author identity

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -187,6 +187,9 @@ pub enum CrdtCollectionType {
     Vector,
     /// UnorderedMap: Map with element IDs and CRDT metadata
     UnorderedMap,
+    /// SortedMap: Map iterated in ascending key order (range/prefix queries);
+    /// same add-wins merge as `UnorderedMap`
+    SortedMap,
     /// AuthoredMap: Map with per-entry author identity (insert is open;
     /// update/remove gated by stored owner == executor)
     AuthoredMap,

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -92,8 +92,10 @@
         "counter",
         "vector",
         "unordered_map",
+        "sorted_map",
         "authored_map",
         "unordered_set",
+        "sorted_set",
         "replicated_growable_array",
         "authored_vector"
       ]

--- a/tools/merodb/src/abi.rs
+++ b/tools/merodb/src/abi.rs
@@ -196,6 +196,13 @@ pub fn infer_schema_from_database(
                                     crdt_type: Some(CrdtCollectionType::UnorderedSet),
                                     inner_type: None,
                                 },
+                                CrdtType::SortedSet { .. } => TypeRef::Collection {
+                                    collection: CollectionType::List {
+                                        items: Box::new(TypeRef::string()),
+                                    },
+                                    crdt_type: Some(CrdtCollectionType::SortedSet),
+                                    inner_type: None,
+                                },
                                 CrdtType::Vector { .. } => TypeRef::Collection {
                                     collection: CollectionType::List {
                                         items: Box::new(TypeRef::string()),

--- a/tools/merodb/src/abi.rs
+++ b/tools/merodb/src/abi.rs
@@ -177,6 +177,18 @@ pub fn infer_schema_from_database(
                                         inner_type: None,
                                     }
                                 }
+                                CrdtType::SortedMap { .. } => {
+                                    // Same shape as UnorderedMap; the marker records that
+                                    // iteration is key-ordered.
+                                    TypeRef::Collection {
+                                        collection: CollectionType::Map {
+                                            key: Box::new(TypeRef::string()),
+                                            value: Box::new(TypeRef::string()),
+                                        },
+                                        crdt_type: Some(CrdtCollectionType::SortedMap),
+                                        inner_type: None,
+                                    }
+                                }
                                 CrdtType::UnorderedSet { .. } => TypeRef::Collection {
                                     collection: CollectionType::List {
                                         items: Box::new(TypeRef::string()),


### PR DESCRIPTION
Closes #2559.

Adds the two key-ordered collections the SDK was missing — completing the quartet:

| | Unordered (`HashMap`/`HashSet`) | Sorted (`BTreeMap`/`BTreeSet`) |
|---|---|---|
| **Map** | `UnorderedMap` | **`SortedMap`** |
| **Set** | `UnorderedSet` | **`SortedSet`** |

Both maintain key order, unlocking **range queries, prefix scans, pagination, and min/max** without a full scan, retiring the manual `keys.sort()` workarounds (e.g. `scenario-crdt-native-v2`).

## Design

- **Same storage + CRDT as the unordered siblings.** Entries are the identical `Collection` of `(K, V)` / `V` keyed by `compute_id(parent, key)`, so add-wins merge, tombstones, and the #2538 nested-CRDT re-keying are inherited — nothing extra is synced.
- **A node-local, derived, *non-synced* ordered index** — a database-style secondary index in a dedicated RocksDB column (`Column::SortedIndex`), keyed by `collection ‖ order_key` *unhashed*, so the backend's byte order **is** the logical key order and a range is a native seek. Order is a pure function of `K: Ord`, so each node rebuilds its own index from the authoritative (synced) entries — there is **no extra merge path** and **no changes to the sync-critical `interface.rs`** (the index logic lives entirely inside the collection, like every other type).
- **Self-healing across sync.** Local writes keep the index warm and stamp a `full_hash` validity marker; a remote sync (which mutates entries host-side) leaves it stale, and the next ordered read rebuilds once (diffing, so only changed keys are written) then resumes seeking.
- **Transparent fallback.** Adaptors without an ordered keyspace (e.g. `PrivateStorage`) fall back to an in-memory sort — correct, just `O(n log n)`.

## Complexity (on a node)

| Operation | Cost |
|---|---|
| `range` / `prefix` | `O(log n + k)` |
| `page(offset, limit)` | `O(offset + limit)` |
| `first` / `last` | `O(log n)` (forward / reverse seek) |
| `get` / `insert` / `remove` | `O(1)` point op + index write + marker read/write |
| `entries`/`keys`/`values` / `iter` | `O(n)` |
| post-sync rebuild | `O(n)` reads, `O(changed)` writes |

`SortedMap`/`SortedSet` are the `BTreeMap`/`BTreeSet`: **default to the unordered types** (no per-write index overhead, no extra disk) and reach for the sorted ones only when you genuinely need ordering. This trade-off is documented at the top of each collection file.

## What's in here

- **Collections**: `crates/storage/src/collections/sorted_map.rs`, `sorted_set.rs` — full API (`range`/`prefix`/`page`/`keys`/`values`/`entries`/`first`/`last` + the standard map/set ops), `Entry` API, `Serialize`/`Eq`/`Ord`/`Extend`/`FromIterator`, `RekeyTarget`.
- **CRDT/ABI**: first-class `CrdtType::SortedMap`/`SortedSet` (primitives), `CrdtMeta`+`Mergeable`, `Decomposable`, merge dispatch, `CrdtCollectionType::SortedMap`/`SortedSet` (wasm-abi + normalize), SDK macros (`is_collection_type` + private-storage substitution), and the merodb ABI display.
- **Storage engine**: `Column::SortedIndex` + raw variable-length column ops (`Store::raw_put`/`raw_delete`/`raw_scan` with an offset+limit early-stop, `raw_last` reverse seek via `Database::last_in_range`/RocksDB `seek_for_prev`).
- **Host ABI**: the index ops wired through the full WASM boundary — `runtime::store::Storage` (+ `InMemoryStorage`), 5 host functions (`storage_index_set`/`remove`/`remove_prefix`/`scan`/`last`), `sys` externs, `sdk::env` wrappers, `storage::env` dispatch, `MainStorage` routing, and `ContextStorage` backing it over RocksDB (a second `Store` handle, scoped per context).
- **Apps**: new `apps/sorted-kv-store` example; `SortedMap`/`SortedSet` fields in the conformance apps (emit the ABI markers) and `scaffolding-e2e`.

## Verification

- **516 storage** + **12 CRDT-law (`crdt_contract`)** + **10 primitives** tests green; whole workspace builds.
- **Real WASM** (`crates/runtime/tests/crdt_conformance.rs`): drives the compiled `scaffolding-e2e` through `Module::run`, proving the ordered reads work through the actual host functions (`sorted_range`/`sorted_keys`/`sorted_last_key`) **and** that a receiving node rebuilds its index after a 2-node sync.
- **Asymptotic proof** (`ordered_reads_are_sublinear`): the (now faithful, seek-based) mock counts index entries examined — `last`=1, `page(0,10)`=10, a tight range window = its matches, vs `n` for a full scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface across storage, context execution, and WASM host boundaries; synced CRDT data paths are intended to match unordered types, but index staleness/rebuild and key byte-order contracts affect correctness of ordered reads.
> 
> **Overview**
> Adds **`SortedMap`** and **`SortedSet`** — key/element-ordered CRDT collections with the same add-wins merge as `UnorderedMap`/`UnorderedSet`, plus **`range`**, **`prefix`**, **`page`**, and **`first`/`last`** without full scans.
> 
> The ordering comes from a **node-local, non-synced** secondary index (`Column::SortedIndex`, unhashed `collection ‖ order_key`) maintained on writes and validated with a **`full_hash` marker**; after remote sync the next ordered read **diff-rebuilds** the index. Storage adaptors without an ordered keyspace (e.g. private storage) **sort in memory** instead.
> 
> The change threads through **primitives/ABI**, **merge dispatch**, **SDK macros** (deterministic collection IDs + private-storage substitution), **`StorageAdaptor` / `MainStorage`**, five new **WASM host imports** (`storage_index_*`), **`ContextStorage`** (per-context index keys + range delete), **`sdk::env`**, and a new **`apps/sorted-kv-store`** example plus conformance/e2e coverage including **real WASM** range/keys/last and post-sync rebuild tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3d8135f0891f7e2592bac3ae24de35728225ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->