### PR TITLE
refactor(apps): standardize example apps on app::Result and enforce in app::logic

### DIFF
--- a/apps/blobs/README.md
+++ b/apps/blobs/README.md
@@ -75,7 +75,7 @@ upload_file(
     blob_id: BlobId,  // Blob ID (base58 string over the wire)
     size: u64,
     mime_type: String
-) -> Result<String, String>
+) -> app::Result<String>
 ```
 
 **Process:**
@@ -99,7 +99,7 @@ let file_id = state.upload_file(
 ### Delete a File
 
 ```rust
-delete_file(file_id: String) -> Result<(), String>
+delete_file(file_id: String) -> app::Result<()>
 ```
 
 Removes the file record from storage and emits a deletion event.
@@ -107,7 +107,7 @@ Removes the file record from storage and emits a deletion event.
 ### List All Files
 
 ```rust
-list_files() -> Result<Vec<FileRecord>, String>
+list_files() -> app::Result<Vec<FileRecord>>
 ```
 
 Returns all stored files with their metadata.
@@ -115,7 +115,7 @@ Returns all stored files with their metadata.
 ### Get Specific File
 
 ```rust
-get_file(file_id: String) -> Result<FileRecord, String>
+get_file(file_id: String) -> app::Result<FileRecord>
 ```
 
 Retrieves a single file's metadata by ID.
@@ -123,7 +123,7 @@ Retrieves a single file's metadata by ID.
 ### Get Blob ID
 
 ```rust
-get_blob_id_b58(file_id: String) -> Result<BlobId, String>
+get_blob_id_b58(file_id: String) -> app::Result<BlobId>
 ```
 
 Returns the base58-encoded blob ID for a file (useful for downloading).
@@ -131,7 +131,7 @@ Returns the base58-encoded blob ID for a file (useful for downloading).
 ### Search Files
 
 ```rust
-search_files(query: String) -> Result<Vec<FileRecord>, String>
+search_files(query: String) -> app::Result<Vec<FileRecord>>
 ```
 
 Case-insensitive search by filename.
@@ -139,8 +139,8 @@ Case-insensitive search by filename.
 ### Statistics
 
 ```rust
-get_stats() -> Result<String, String>
-get_total_files_size() -> Result<u64, String>
+get_stats() -> app::Result<String>
+get_total_files_size() -> app::Result<u64>
 ```
 
 Get usage statistics and total storage.

--- a/apps/blobs/src/lib.rs
+++ b/apps/blobs/src/lib.rs
@@ -149,26 +149,21 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(String)` - The generated file ID (e.g., "file_0", "file_1")
-    /// * `Err(String)` - Error message if storage operation fails
+    /// * `Err(app::Error)` - Error if storage operation fails
     pub fn upload_file(
         &mut self,
         name: String,
         blob_id: BlobId,
         size: u64,
         mime_type: String,
-    ) -> Result<String, String> {
+    ) -> app::Result<String> {
         // Counter is a monotonic CRDT — it converges across replicas (taking
         // the per-source max on merge). Using its current value as the file ID
         // means concurrent uploads on different nodes can still pick the same
         // ID; that limitation existed with the previous bare `u64` too.
-        let next_id = self
-            .file_counter
-            .value()
-            .map_err(|e| format!("Failed to read file counter: {e:?}"))?;
+        let next_id = self.file_counter.value()?;
         let file_id = format!("file_{next_id}");
-        self.file_counter
-            .increment()
-            .map_err(|e| format!("Failed to increment file counter: {e:?}"))?;
+        self.file_counter.increment()?;
 
         let uploader = PublicKey::from(env::executor_id()).to_string();
         let timestamp = env::time_now();
@@ -194,9 +189,7 @@ impl FileShareState {
         };
 
         // Store the file record
-        self.files
-            .insert(file_id.clone(), file_record)
-            .map_err(|e| format!("Failed to store file record: {e:?}"))?;
+        self.files.insert(file_id.clone(), file_record)?;
 
         // Emit event
         app::emit!(FileShareEvent::FileUploaded {
@@ -222,22 +215,19 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(())` - File metadata successfully deleted
-    /// * `Err(String)` - Error message if file not found or deletion fails
-    pub fn delete_file(&mut self, file_id: String) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if file not found or deletion fails
+    pub fn delete_file(&mut self, file_id: String) -> app::Result<()> {
         // Retrieve the file before deleting to get its name for the event
         let file_record = self
             .files
-            .get(&file_id)
-            .map_err(|e| format!("Failed to access file: {e:?}"))?
-            .ok_or_else(|| format!("File not found: {file_id}"))?;
+            .get(&file_id)?
+            .ok_or_else(|| app::err!("File not found: {file_id}"))?;
 
         let file_name = file_record.name.clone();
 
         // Remove the file metadata from storage
         // NOTE: The underlying blob is not deleted from blob storage
-        self.files
-            .remove(&file_id)
-            .map_err(|e| format!("Failed to delete file: {e:?}"))?;
+        self.files.remove(&file_id)?;
 
         // Emit event
         app::emit!(FileShareEvent::FileDeleted {
@@ -254,14 +244,12 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(Vec<FileRecord>)` - Vector of all file records with complete metadata (not just names)
-    /// * `Err(String)` - Error message if storage operation fails (rarely occurs)
-    pub fn list_files(&self) -> Result<Vec<FileRecord>, String> {
+    /// * `Err(app::Error)` - Error if storage operation fails (rarely occurs)
+    pub fn list_files(&self) -> app::Result<Vec<FileRecord>> {
         let mut files = Vec::new();
 
-        if let Ok(entries) = self.files.entries() {
-            for (_, file_record) in entries {
-                files.push(file_record.clone());
-            }
+        for (_, file_record) in self.files.entries()? {
+            files.push(file_record.clone());
         }
 
         app::log!("Listed {} files", files.len());
@@ -276,13 +264,13 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(FileRecord)` - Complete file record with all metadata
-    /// * `Err(String)` - Error message if file not found or retrieval fails
-    pub fn get_file(&self, file_id: String) -> Result<FileRecord, String> {
-        match self.files.get(&file_id) {
-            Ok(Some(file_record)) => Ok(file_record.clone()),
-            Ok(None) => Err(format!("File not found: {file_id}")),
-            Err(e) => Err(format!("Failed to retrieve file: {e:?}")),
-        }
+    /// * `Err(app::Error)` - Error if file not found or retrieval fails
+    pub fn get_file(&self, file_id: String) -> app::Result<FileRecord> {
+        let Some(file_record) = self.files.get(&file_id)? else {
+            app::bail!("File not found: {file_id}");
+        };
+
+        Ok(file_record.clone())
     }
 
     /// Get blob ID for download (base58-encoded)
@@ -296,8 +284,8 @@ impl FileShareState {
     /// # Returns
     /// * `Ok(BlobId)` - The blob ID (base58 string over the wire, e.g.
     ///   "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
-    /// * `Err(String)` - Error message if file not found
-    pub fn get_blob_id_b58(&self, file_id: String) -> Result<BlobId, String> {
+    /// * `Err(app::Error)` - Error if file not found
+    pub fn get_blob_id_b58(&self, file_id: String) -> app::Result<BlobId> {
         let file_record = self.get_file(file_id)?;
         Ok(file_record.blob_id)
     }
@@ -309,16 +297,14 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(Vec<FileRecord>)` - Vector of matching file records (not just names), may be empty if no matches
-    /// * `Err(String)` - Error message if storage operation fails (rarely occurs)
-    pub fn search_files(&self, query: String) -> Result<Vec<FileRecord>, String> {
+    /// * `Err(app::Error)` - Error if storage operation fails (rarely occurs)
+    pub fn search_files(&self, query: String) -> app::Result<Vec<FileRecord>> {
         let mut results = Vec::new();
         let query_lower = query.to_lowercase();
 
-        if let Ok(entries) = self.files.entries() {
-            for (_, file_record) in entries {
-                if file_record.name.to_lowercase().contains(&query_lower) {
-                    results.push(file_record.clone());
-                }
+        for (_, file_record) in self.files.entries()? {
+            if file_record.name.to_lowercase().contains(&query_lower) {
+                results.push(file_record.clone());
             }
         }
 
@@ -334,14 +320,12 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(u64)` - Total size of all files in bytes (sum of file sizes)
-    /// * `Err(String)` - Error message if storage operation fails (rarely occurs)
-    pub fn get_total_files_size(&self) -> Result<u64, String> {
+    /// * `Err(app::Error)` - Error if storage operation fails (rarely occurs)
+    pub fn get_total_files_size(&self) -> app::Result<u64> {
         let mut total_size = 0u64;
 
-        if let Ok(entries) = self.files.entries() {
-            for (_, file_record) in entries {
-                total_size += file_record.size;
-            }
+        for (_, file_record) in self.files.entries()? {
+            total_size += file_record.size;
         }
 
         Ok(total_size)
@@ -351,7 +335,7 @@ impl FileShareState {
     ///
     /// # Returns
     /// * `Ok(String)` - Formatted statistics including file count, total file size (not contract storage), and owner
-    /// * `Err(String)` - Error message if storage operations fail
+    /// * `Err(app::Error)` - Error if storage operations fail
     ///
     /// # Example Output
     /// ```text
@@ -363,11 +347,8 @@ impl FileShareState {
     ///
     /// Note: "Total storage" refers to the sum of all file sizes, not the actual
     /// contract storage usage (which would include metadata overhead).
-    pub fn get_stats(&self) -> Result<String, String> {
-        let file_count = self
-            .files
-            .len()
-            .map_err(|e| format!("Failed to get file count: {e:?}"))?;
+    pub fn get_stats(&self) -> app::Result<String> {
+        let file_count = self.files.len()?;
 
         let total_size = self.get_total_files_size()?;
 

--- a/apps/collaborative-editor/README.md
+++ b/apps/collaborative-editor/README.md
@@ -47,7 +47,7 @@ Initialize a new collaborative document with a default title "Untitled Document"
 
 ### Text Operations
 
-#### `insert_text(position: usize, text: String) -> Result<(), String>`
+#### `insert_text(position: usize, text: String) -> app::Result<()>`
 Insert text at a specific position.
 
 **Parameters:**
@@ -62,7 +62,7 @@ Insert text at a specific position.
 }
 ```
 
-#### `delete_text(start: usize, end: usize) -> Result<(), String>`
+#### `delete_text(start: usize, end: usize) -> app::Result<()>`
 Delete text in a range.
 
 **Parameters:**
@@ -77,7 +77,7 @@ Delete text in a range.
 }
 ```
 
-#### `replace_text(start: usize, end: usize, text: String) -> Result<(), String>`
+#### `replace_text(start: usize, end: usize, text: String) -> app::Result<()>`
 Replace a range of text with new text (atomic operation).
 
 **Parameters:**
@@ -94,7 +94,7 @@ Replace a range of text with new text (atomic operation).
 }
 ```
 
-#### `append_text(text: String) -> Result<(), String>`
+#### `append_text(text: String) -> app::Result<()>`
 Append text to the end of the document.
 
 **Parameters:**
@@ -107,14 +107,14 @@ Append text to the end of the document.
 }
 ```
 
-#### `clear() -> Result<(), String>`
+#### `clear() -> app::Result<()>`
 Clear the entire document.
 
 ---
 
 ### Query Methods
 
-#### `get_text() -> Result<String, String>`
+#### `get_text() -> app::Result<String>`
 Get the current document text.
 
 **Returns:** The complete document as a string
@@ -126,7 +126,7 @@ Get the current document text.
 }
 ```
 
-#### `get_length() -> Result<usize, String>`
+#### `get_length() -> app::Result<usize>`
 Get the length of the document in characters.
 
 **Returns:** Number of characters
@@ -138,7 +138,7 @@ Get the length of the document in characters.
 }
 ```
 
-#### `is_empty() -> Result<bool, String>`
+#### `is_empty() -> app::Result<bool>`
 Check if the document is empty.
 
 **Returns:** True if empty, false otherwise
@@ -154,7 +154,7 @@ Check if the document is empty.
 
 ### Title Management
 
-#### `set_title(new_title: String) -> Result<(), String>`
+#### `set_title(new_title: String) -> app::Result<()>`
 Set the document title.
 
 **Parameters:**
@@ -183,7 +183,7 @@ Get the current document title.
 
 ### Statistics
 
-#### `get_stats() -> Result<String, String>`
+#### `get_stats() -> app::Result<String>`
 Get document statistics including title, length, total edits, and owner.
 
 **Returns:** Formatted statistics string

--- a/apps/collaborative-editor/src/lib.rs
+++ b/apps/collaborative-editor/src/lib.rs
@@ -121,8 +121,8 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(())` - Text successfully inserted
-    /// * `Err(String)` - Error message if position is invalid or insertion fails
-    pub fn insert_text(&mut self, position: usize, text: String) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if position is invalid or insertion fails
+    pub fn insert_text(&mut self, position: usize, text: String) -> app::Result<()> {
         let editor_id = env::executor_id();
         let editor = encode_identity(&editor_id);
 
@@ -133,13 +133,9 @@ impl EditorState {
             editor
         );
 
-        self.document
-            .insert_str(position, &text)
-            .map_err(|e| format!("Failed to insert text: {:?}", e))?;
+        self.document.insert_str(position, &text)?;
 
-        self.edit_count
-            .increment()
-            .map_err(|e| format!("Failed to increment edit count: {:?}", e))?;
+        self.edit_count.increment()?;
 
         app::emit!(EditorEvent::TextInserted {
             position,
@@ -158,20 +154,16 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(())` - Text successfully deleted
-    /// * `Err(String)` - Error message if range is invalid or deletion fails
-    pub fn delete_text(&mut self, start: usize, end: usize) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if range is invalid or deletion fails
+    pub fn delete_text(&mut self, start: usize, end: usize) -> app::Result<()> {
         let editor_id = env::executor_id();
         let editor = encode_identity(&editor_id);
 
         app::log!("Deleting text from {} to {} by {}", start, end, editor);
 
-        self.document
-            .delete_range(start, end)
-            .map_err(|e| format!("Failed to delete text: {:?}", e))?;
+        self.document.delete_range(start, end)?;
 
-        self.edit_count
-            .increment()
-            .map_err(|e| format!("Failed to increment edit count: {:?}", e))?;
+        self.edit_count.increment()?;
 
         app::emit!(EditorEvent::TextDeleted { start, end, editor });
 
@@ -182,33 +174,27 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(String)` - The current document text
-    /// * `Err(String)` - Error message if retrieval fails
-    pub fn get_text(&self) -> Result<String, String> {
-        self.document
-            .get_text()
-            .map_err(|e| format!("Failed to get text: {:?}", e))
+    /// * `Err(app::Error)` - Error if retrieval fails
+    pub fn get_text(&self) -> app::Result<String> {
+        self.document.get_text().map_err(Into::into)
     }
 
     /// Get the length of the document
     ///
     /// # Returns
     /// * `Ok(usize)` - The number of characters in the document
-    /// * `Err(String)` - Error message if retrieval fails
-    pub fn get_length(&self) -> Result<usize, String> {
-        self.document
-            .len()
-            .map_err(|e| format!("Failed to get length: {:?}", e))
+    /// * `Err(app::Error)` - Error if retrieval fails
+    pub fn get_length(&self) -> app::Result<usize> {
+        self.document.len().map_err(Into::into)
     }
 
     /// Check if the document is empty
     ///
     /// # Returns
     /// * `Ok(bool)` - True if the document is empty
-    /// * `Err(String)` - Error message if check fails
-    pub fn is_empty(&self) -> Result<bool, String> {
-        self.document
-            .is_empty()
-            .map_err(|e| format!("Failed to check if empty: {:?}", e))
+    /// * `Err(app::Error)` - Error if check fails
+    pub fn is_empty(&self) -> app::Result<bool> {
+        self.document.is_empty().map_err(Into::into)
     }
 
     /// Set the document title
@@ -218,10 +204,10 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(())` - Title successfully changed
-    /// * `Err(String)` - Error message if title is empty
-    pub fn set_title(&mut self, new_title: String) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if title is empty
+    pub fn set_title(&mut self, new_title: String) -> app::Result<()> {
         if new_title.is_empty() {
-            return Err("Title cannot be empty".to_string());
+            app::bail!("Title cannot be empty");
         }
 
         let editor_id = env::executor_id();
@@ -230,8 +216,7 @@ impl EditorState {
         let old_title = self.get_title();
 
         self.metadata
-            .insert("title".to_string(), new_title.clone().into())
-            .map_err(|e| format!("Failed to update title: {:?}", e))?;
+            .insert("title".to_string(), new_title.clone().into())?;
 
         app::log!(
             "Title changed from '{}' to '{}' by {}",
@@ -266,7 +251,7 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(String)` - Formatted statistics
-    /// * `Err(String)` - Error message if stats retrieval fails
+    /// * `Err(app::Error)` - Error if stats retrieval fails
     ///
     /// # Example Output
     /// ```text
@@ -276,12 +261,9 @@ impl EditorState {
     /// - Total edits: 15
     /// - Owner: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
     /// ```
-    pub fn get_stats(&self) -> Result<String, String> {
+    pub fn get_stats(&self) -> app::Result<String> {
         let length = self.get_length()?;
-        let total_edits = self
-            .edit_count
-            .value()
-            .map_err(|e| format!("Failed to get edit count: {:?}", e))?;
+        let total_edits = self.edit_count.value()?;
 
         let title = self.get_title();
         let owner = self
@@ -311,8 +293,8 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(())` - Text successfully replaced
-    /// * `Err(String)` - Error message if operation fails
-    pub fn replace_text(&mut self, start: usize, end: usize, text: String) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if operation fails
+    pub fn replace_text(&mut self, start: usize, end: usize, text: String) -> app::Result<()> {
         // Delete the range first
         if start < end {
             self.delete_text(start, end)?;
@@ -333,8 +315,8 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(())` - Text successfully appended
-    /// * `Err(String)` - Error message if operation fails
-    pub fn append_text(&mut self, text: String) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if operation fails
+    pub fn append_text(&mut self, text: String) -> app::Result<()> {
         let length = self.get_length()?;
         self.insert_text(length, text)
     }
@@ -343,8 +325,8 @@ impl EditorState {
     ///
     /// # Returns
     /// * `Ok(())` - Document successfully cleared
-    /// * `Err(String)` - Error message if operation fails
-    pub fn clear(&mut self) -> Result<(), String> {
+    /// * `Err(app::Error)` - Error if operation fails
+    pub fn clear(&mut self) -> app::Result<()> {
         let length = self.get_length()?;
         if length > 0 {
             self.delete_text(0, length)?;

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -78,62 +78,44 @@ impl NestedCrdtTest {
 
     // ===== Counter Operations =====
 
-    pub fn increment_counter(&mut self, key: String) -> Result<u64, String> {
-        let mut counter = self
-            .counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| Counter::new());
+    pub fn increment_counter(&mut self, key: String) -> app::Result<u64> {
+        let mut counter = self.counters.get(&key)?.unwrap_or_else(|| Counter::new());
 
-        counter
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
+        counter.increment()?;
 
-        let value = counter
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        let value = counter.value()?;
 
-        drop(
-            self.counters
-                .insert(key.clone(), counter)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.counters.insert(key.clone(), counter)?);
 
         app::emit!(TestEvent::CounterIncremented { key, value });
 
         Ok(value)
     }
 
-    pub fn get_counter(&self, key: String) -> Result<u64, String> {
+    pub fn get_counter(&self, key: String) -> app::Result<u64> {
         self.counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|c| c.value().unwrap_or(0))
-            .ok_or_else(|| "Counter not found".to_owned())
+            .ok_or_else(|| app::err!("Counter not found"))
     }
 
     // ===== LwwRegister Operations =====
 
-    pub fn set_register(&mut self, key: String, value: String) -> Result<(), String> {
+    pub fn set_register(&mut self, key: String, value: String) -> app::Result<()> {
         let register = LwwRegister::new(value.clone());
 
-        drop(
-            self.registers
-                .insert(key.clone(), register)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.registers.insert(key.clone(), register)?);
 
         app::emit!(TestEvent::RegisterSet { key, value });
 
         Ok(())
     }
 
-    pub fn get_register(&self, key: String) -> Result<String, String> {
+    pub fn get_register(&self, key: String) -> app::Result<String> {
         self.registers
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|r| r.get().clone())
-            .ok_or_else(|| "Register not found".to_owned())
+            .ok_or_else(|| app::err!("Register not found"))
     }
 
     // ===== Nested Map Operations =====
@@ -143,24 +125,15 @@ impl NestedCrdtTest {
         outer_key: String,
         inner_key: String,
         value: String,
-    ) -> Result<(), String> {
+    ) -> app::Result<()> {
         let mut inner_map = self
             .metadata
-            .get(&outer_key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&outer_key)?
             .unwrap_or_else(|| UnorderedMap::new());
 
-        drop(
-            inner_map
-                .insert(inner_key.clone(), value.clone().into())
-                .map_err(|e| format!("Inner insert failed: {:?}", e))?,
-        );
+        drop(inner_map.insert(inner_key.clone(), value.clone().into())?);
 
-        drop(
-            self.metadata
-                .insert(outer_key.clone(), inner_map)
-                .map_err(|e| format!("Outer insert failed: {:?}", e))?,
-        );
+        drop(self.metadata.insert(outer_key.clone(), inner_map)?);
 
         app::emit!(TestEvent::MetadataSet {
             outer_key,
@@ -171,96 +144,71 @@ impl NestedCrdtTest {
         Ok(())
     }
 
-    pub fn get_metadata(&self, outer_key: String, inner_key: String) -> Result<String, String> {
+    pub fn get_metadata(&self, outer_key: String, inner_key: String) -> app::Result<String> {
         self.metadata
-            .get(&outer_key)
-            .map_err(|e| format!("Outer get failed: {:?}", e))?
-            .ok_or_else(|| "Outer key not found".to_owned())?
-            .get(&inner_key)
-            .map_err(|e| format!("Inner get failed: {:?}", e))?
-            .ok_or_else(|| "Inner key not found".to_owned())
+            .get(&outer_key)?
+            .ok_or_else(|| app::err!("Outer key not found"))?
+            .get(&inner_key)?
+            .ok_or_else(|| app::err!("Inner key not found"))
             .map(|v| v.get().clone())
     }
 
     // ===== Vector Operations =====
 
-    pub fn push_metric(&mut self, value: u64) -> Result<usize, String> {
+    pub fn push_metric(&mut self, value: u64) -> app::Result<usize> {
         let mut counter = Counter::new();
         for _ in 0..value {
-            counter
-                .increment()
-                .map_err(|e| format!("Increment failed: {:?}", e))?;
+            counter.increment()?;
         }
 
-        self.metrics
-            .push(counter)
-            .map_err(|e| format!("Push failed: {:?}", e))?;
+        self.metrics.push(counter)?;
 
-        let len = self
-            .metrics
-            .len()
-            .map_err(|e| format!("Len failed: {:?}", e))?;
+        let len = self.metrics.len()?;
 
         app::emit!(TestEvent::MetricPushed { value });
 
         Ok(len)
     }
 
-    pub fn get_metric(&self, index: usize) -> Result<u64, String> {
+    pub fn get_metric(&self, index: usize) -> app::Result<u64> {
         self.metrics
-            .get(index)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .ok_or_else(|| "Index out of bounds".to_owned())?
+            .get(index)?
+            .ok_or_else(|| app::err!("Index out of bounds"))?
             .value()
-            .map_err(|e| format!("Value failed: {:?}", e))
+            .map_err(Into::into)
     }
 
-    pub fn metrics_len(&self) -> Result<usize, String> {
-        self.metrics
-            .len()
-            .map_err(|e| format!("Len failed: {:?}", e))
+    pub fn metrics_len(&self) -> app::Result<usize> {
+        self.metrics.len().map_err(Into::into)
     }
 
     // ===== Set Operations =====
 
-    pub fn add_tag(&mut self, key: String, tag: String) -> Result<(), String> {
-        let mut set = self
-            .tags
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| UnorderedSet::new());
+    pub fn add_tag(&mut self, key: String, tag: String) -> app::Result<()> {
+        let mut set = self.tags.get(&key)?.unwrap_or_else(|| UnorderedSet::new());
 
-        let _ = set
-            .insert(tag.clone())
-            .map_err(|e| format!("Insert failed: {:?}", e))?;
+        let _ = set.insert(tag.clone())?;
 
-        drop(
-            self.tags
-                .insert(key.clone(), set)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.tags.insert(key.clone(), set)?);
 
         app::emit!(TestEvent::TagAdded { key, tag });
 
         Ok(())
     }
 
-    pub fn has_tag(&self, key: String, tag: String) -> Result<bool, String> {
+    pub fn has_tag(&self, key: String, tag: String) -> app::Result<bool> {
         self.tags
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|set| set.contains(&tag).unwrap_or(false))
-            .ok_or_else(|| "Key not found".to_owned())
+            .ok_or_else(|| app::err!("Key not found"))
     }
 
-    pub fn get_tag_count(&self, key: String) -> Result<u64, String> {
+    pub fn get_tag_count(&self, key: String) -> app::Result<u64> {
         let count = self
             .tags
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .ok_or_else(|| "Key not found".to_owned())?
-            .iter()
-            .map_err(|e| format!("Iter failed: {:?}", e))?
+            .get(&key)?
+            .ok_or_else(|| app::err!("Key not found"))?
+            .iter()?
             .count();
 
         Ok(count as u64)

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -93,10 +93,11 @@ impl NestedCrdtTest {
     }
 
     pub fn get_counter(&self, key: String) -> app::Result<u64> {
-        self.counters
-            .get(&key)?
-            .map(|c| c.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Counter not found"))
+        let Some(counter) = self.counters.get(&key)? else {
+            app::bail!("Counter not found");
+        };
+
+        Ok(counter.value()?)
     }
 
     // ===== LwwRegister Operations =====
@@ -197,10 +198,11 @@ impl NestedCrdtTest {
     }
 
     pub fn has_tag(&self, key: String, tag: String) -> app::Result<bool> {
-        self.tags
-            .get(&key)?
-            .map(|set| set.contains(&tag).unwrap_or(false))
-            .ok_or_else(|| app::err!("Key not found"))
+        let Some(set) = self.tags.get(&key)? else {
+            app::bail!("Key not found");
+        };
+
+        Ok(set.contains(&tag)?)
     }
 
     pub fn get_tag_count(&self, key: String) -> app::Result<u64> {

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -339,6 +339,9 @@ fn encode_identity(identity: &[u8; 32]) -> String {
 
 fn encode_blob_id_base58(blob_id_bytes: &[u8; BLOB_ID_SIZE]) -> String {
     let mut buf = [0u8; BASE58_ENCODED_MAX_SIZE];
+    // Both unwraps are infallible for this input: a 32-byte value base58-encodes
+    // to at most 44 chars (== BASE58_ENCODED_MAX_SIZE), so `onto` never overflows
+    // the buffer, and the base58 alphabet is ASCII, so the bytes are always UTF-8.
     let len = bs58::encode(blob_id_bytes).onto(&mut buf[..]).unwrap();
     std::str::from_utf8(&buf[..len]).unwrap().to_owned()
 }
@@ -825,10 +828,11 @@ impl E2eKvStore {
     }
 
     pub fn get_g_counter(&self, key: String) -> app::Result<u64> {
-        self.crdt_counters
-            .get(&key)?
-            .map(|c| c.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("GCounter not found"))
+        let Some(counter) = self.crdt_counters.get(&key)? else {
+            app::bail!("GCounter not found");
+        };
+
+        Ok(counter.value()?)
     }
 
     // --- PN-COUNTER (supports increment AND decrement) ---
@@ -874,10 +878,11 @@ impl E2eKvStore {
     }
 
     pub fn get_pn_counter(&self, key: String) -> app::Result<i64> {
-        self.crdt_pn_counters
-            .get(&key)?
-            .map(|c| c.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("PNCounter not found"))
+        let Some(counter) = self.crdt_pn_counters.get(&key)? else {
+            app::bail!("PNCounter not found");
+        };
+
+        Ok(counter.value()?)
     }
 
     // Legacy alias for backward compatibility
@@ -983,10 +988,11 @@ impl E2eKvStore {
     }
 
     pub fn has_tag(&self, key: String, tag: String) -> app::Result<bool> {
-        self.crdt_tags
-            .get(&key)?
-            .map(|set| set.contains(&tag).unwrap_or(false))
-            .ok_or_else(|| app::err!("Key not found"))
+        let Some(set) = self.crdt_tags.get(&key)? else {
+            app::bail!("Key not found");
+        };
+
+        Ok(set.contains(&tag)?)
     }
 
     pub fn get_tag_count(&self, key: String) -> app::Result<u64> {

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -343,22 +343,22 @@ fn encode_blob_id_base58(blob_id_bytes: &[u8; BLOB_ID_SIZE]) -> String {
     std::str::from_utf8(&buf[..len]).unwrap().to_owned()
 }
 
-fn parse_blob_id_base58(blob_id_str: &str) -> Result<[u8; BLOB_ID_SIZE], String> {
-    match bs58::decode(blob_id_str).into_vec() {
-        Ok(bytes) => {
-            if bytes.len() != BLOB_ID_SIZE {
-                return Err(format!(
-                    "Invalid blob ID length: expected {} bytes, got {}",
-                    BLOB_ID_SIZE,
-                    bytes.len()
-                ));
-            }
-            let mut blob_id = [0u8; BLOB_ID_SIZE];
-            blob_id.copy_from_slice(&bytes);
-            Ok(blob_id)
-        }
-        Err(e) => Err(format!("Failed to decode blob ID '{blob_id_str}': {e}")),
+fn parse_blob_id_base58(blob_id_str: &str) -> app::Result<[u8; BLOB_ID_SIZE]> {
+    let bytes = bs58::decode(blob_id_str)
+        .into_vec()
+        .map_err(|e| app::err!("Failed to decode blob ID '{blob_id_str}': {e}"))?;
+
+    if bytes.len() != BLOB_ID_SIZE {
+        app::bail!(
+            "Invalid blob ID length: expected {} bytes, got {}",
+            BLOB_ID_SIZE,
+            bytes.len()
+        );
     }
+
+    let mut blob_id = [0u8; BLOB_ID_SIZE];
+    blob_id.copy_from_slice(&bytes);
+    Ok(blob_id)
 }
 
 fn serialize_blob_id_bytes<S>(
@@ -710,7 +710,7 @@ impl E2eKvStore {
         blob_id_str: String,
         size: u64,
         mime_type: String,
-    ) -> Result<String, String> {
+    ) -> app::Result<String> {
         let blob_id = parse_blob_id_base58(&blob_id_str)?;
 
         let current_counter = *self.file_counter.get();
@@ -739,9 +739,7 @@ impl E2eKvStore {
             uploaded_at: timestamp,
         };
 
-        self.files
-            .insert(file_id.clone(), file_record)
-            .map_err(|e| format!("Failed to store file record: {e:?}"))?;
+        self.files.insert(file_id.clone(), file_record)?;
 
         app::emit!(Event::FileUploaded {
             id: file_id.clone(),
@@ -754,18 +752,15 @@ impl E2eKvStore {
         Ok(file_id)
     }
 
-    pub fn delete_file(&mut self, file_id: String) -> Result<(), String> {
+    pub fn delete_file(&mut self, file_id: String) -> app::Result<()> {
         let file_record = self
             .files
-            .get(&file_id)
-            .map_err(|e| format!("Failed to access file: {e:?}"))?
-            .ok_or_else(|| format!("File not found: {file_id}"))?;
+            .get(&file_id)?
+            .ok_or_else(|| app::err!("File not found: {file_id}"))?;
 
         let file_name = file_record.name.clone();
 
-        self.files
-            .remove(&file_id)
-            .map_err(|e| format!("Failed to delete file: {e:?}"))?;
+        self.files.remove(&file_id)?;
 
         app::emit!(Event::FileDeleted {
             id: file_id.clone(),
@@ -776,39 +771,35 @@ impl E2eKvStore {
         Ok(())
     }
 
-    pub fn list_files(&self) -> Result<Vec<FileRecord>, String> {
+    pub fn list_files(&self) -> app::Result<Vec<FileRecord>> {
         let mut files = Vec::new();
-        if let Ok(entries) = self.files.entries() {
-            for (_, file_record) in entries {
-                files.push(file_record.clone());
-            }
+        for (_, file_record) in self.files.entries()? {
+            files.push(file_record.clone());
         }
         app::log!("Listed {} files", files.len());
         Ok(files)
     }
 
-    pub fn get_file(&self, file_id: String) -> Result<FileRecord, String> {
-        match self.files.get(&file_id) {
-            Ok(Some(file_record)) => Ok(file_record.clone()),
-            Ok(None) => Err(format!("File not found: {file_id}")),
-            Err(e) => Err(format!("Failed to retrieve file: {e:?}")),
-        }
+    pub fn get_file(&self, file_id: String) -> app::Result<FileRecord> {
+        let Some(file_record) = self.files.get(&file_id)? else {
+            app::bail!("File not found: {file_id}");
+        };
+
+        Ok(file_record.clone())
     }
 
-    pub fn get_blob_id_b58(&self, file_id: String) -> Result<String, String> {
+    pub fn get_blob_id_b58(&self, file_id: String) -> app::Result<String> {
         let file_record = self.get_file(file_id)?;
         Ok(encode_blob_id_base58(&file_record.blob_id))
     }
 
-    pub fn search_files(&self, query: String) -> Result<Vec<FileRecord>, String> {
+    pub fn search_files(&self, query: String) -> app::Result<Vec<FileRecord>> {
         let mut results = Vec::new();
         let query_lower = query.to_lowercase();
 
-        if let Ok(entries) = self.files.entries() {
-            for (_, file_record) in entries {
-                if file_record.name.to_lowercase().contains(&query_lower) {
-                    results.push(file_record.clone());
-                }
+        for (_, file_record) in self.files.entries()? {
+            if file_record.name.to_lowercase().contains(&query_lower) {
+                results.push(file_record.clone());
             }
         }
 
@@ -820,61 +811,39 @@ impl E2eKvStore {
 
     // --- G-COUNTER (grow-only) ---
 
-    pub fn increment_g_counter(&mut self, key: String) -> Result<u64, String> {
-        let mut counter = self
-            .crdt_counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(GCounter::new);
+    pub fn increment_g_counter(&mut self, key: String) -> app::Result<u64> {
+        let mut counter = self.crdt_counters.get(&key)?.unwrap_or_else(GCounter::new);
 
-        counter
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
+        counter.increment()?;
 
-        let value = counter
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        let value = counter.value()?;
 
-        drop(
-            self.crdt_counters
-                .insert(key.clone(), counter)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.crdt_counters.insert(key.clone(), counter)?);
 
         app::emit!(Event::GCounterIncremented { key, value });
         Ok(value)
     }
 
-    pub fn get_g_counter(&self, key: String) -> Result<u64, String> {
+    pub fn get_g_counter(&self, key: String) -> app::Result<u64> {
         self.crdt_counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|c| c.value().unwrap_or(0))
-            .ok_or_else(|| "GCounter not found".to_owned())
+            .ok_or_else(|| app::err!("GCounter not found"))
     }
 
     // --- PN-COUNTER (supports increment AND decrement) ---
 
-    pub fn increment_pn_counter(&mut self, key: String) -> Result<i64, String> {
+    pub fn increment_pn_counter(&mut self, key: String) -> app::Result<i64> {
         let mut counter = self
             .crdt_pn_counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .unwrap_or_else(PNCounter::new);
 
-        counter
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
+        counter.increment()?;
 
-        let value = counter
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        let value = counter.value()?;
 
-        drop(
-            self.crdt_pn_counters
-                .insert(key.clone(), counter)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.crdt_pn_counters.insert(key.clone(), counter)?);
 
         app::emit!(Event::PnCounterChanged {
             key,
@@ -884,26 +853,17 @@ impl E2eKvStore {
         Ok(value)
     }
 
-    pub fn decrement_pn_counter(&mut self, key: String) -> Result<i64, String> {
+    pub fn decrement_pn_counter(&mut self, key: String) -> app::Result<i64> {
         let mut counter = self
             .crdt_pn_counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .unwrap_or_else(PNCounter::new);
 
-        counter
-            .decrement()
-            .map_err(|e| format!("Decrement failed: {:?}", e))?;
+        counter.decrement()?;
 
-        let value = counter
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        let value = counter.value()?;
 
-        drop(
-            self.crdt_pn_counters
-                .insert(key.clone(), counter)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.crdt_pn_counters.insert(key.clone(), counter)?);
 
         app::emit!(Event::PnCounterChanged {
             key,
@@ -913,44 +873,38 @@ impl E2eKvStore {
         Ok(value)
     }
 
-    pub fn get_pn_counter(&self, key: String) -> Result<i64, String> {
+    pub fn get_pn_counter(&self, key: String) -> app::Result<i64> {
         self.crdt_pn_counters
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|c| c.value().unwrap_or(0))
-            .ok_or_else(|| "PNCounter not found".to_owned())
+            .ok_or_else(|| app::err!("PNCounter not found"))
     }
 
     // Legacy alias for backward compatibility
-    pub fn increment_counter(&mut self, key: String) -> Result<u64, String> {
+    pub fn increment_counter(&mut self, key: String) -> app::Result<u64> {
         self.increment_g_counter(key)
     }
 
-    pub fn get_counter(&self, key: String) -> Result<u64, String> {
+    pub fn get_counter(&self, key: String) -> app::Result<u64> {
         self.get_g_counter(key)
     }
 
     // NESTED CRDT - REGISTERS
 
-    pub fn set_register(&mut self, key: String, value: String) -> Result<(), String> {
+    pub fn set_register(&mut self, key: String, value: String) -> app::Result<()> {
         let register = LwwRegister::new(value.clone());
 
-        drop(
-            self.crdt_registers
-                .insert(key.clone(), register)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.crdt_registers.insert(key.clone(), register)?);
 
         app::emit!(Event::RegisterSet { key, value });
         Ok(())
     }
 
-    pub fn get_register(&self, key: String) -> Result<String, String> {
+    pub fn get_register(&self, key: String) -> app::Result<String> {
         self.crdt_registers
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|r| r.get().clone())
-            .ok_or_else(|| "Register not found".to_owned())
+            .ok_or_else(|| app::err!("Register not found"))
     }
 
     // NESTED CRDT - METADATA
@@ -960,24 +914,15 @@ impl E2eKvStore {
         outer_key: String,
         inner_key: String,
         value: String,
-    ) -> Result<(), String> {
+    ) -> app::Result<()> {
         let mut inner_map = self
             .crdt_metadata
-            .get(&outer_key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&outer_key)?
             .unwrap_or_else(UnorderedMap::new);
 
-        drop(
-            inner_map
-                .insert(inner_key.clone(), value.clone().into())
-                .map_err(|e| format!("Inner insert failed: {:?}", e))?,
-        );
+        drop(inner_map.insert(inner_key.clone(), value.clone().into())?);
 
-        drop(
-            self.crdt_metadata
-                .insert(outer_key.clone(), inner_map)
-                .map_err(|e| format!("Outer insert failed: {:?}", e))?,
-        );
+        drop(self.crdt_metadata.insert(outer_key.clone(), inner_map)?);
 
         app::emit!(Event::MetadataSet {
             outer_key,
@@ -987,94 +932,69 @@ impl E2eKvStore {
         Ok(())
     }
 
-    pub fn get_metadata(&self, outer_key: String, inner_key: String) -> Result<String, String> {
+    pub fn get_metadata(&self, outer_key: String, inner_key: String) -> app::Result<String> {
         self.crdt_metadata
-            .get(&outer_key)
-            .map_err(|e| format!("Outer get failed: {:?}", e))?
-            .ok_or_else(|| "Outer key not found".to_owned())?
-            .get(&inner_key)
-            .map_err(|e| format!("Inner get failed: {:?}", e))?
-            .ok_or_else(|| "Inner key not found".to_owned())
+            .get(&outer_key)?
+            .ok_or_else(|| app::err!("Outer key not found"))?
+            .get(&inner_key)?
+            .ok_or_else(|| app::err!("Inner key not found"))
             .map(|v| v.get().clone())
     }
 
     // NESTED CRDT - METRICS VECTOR
 
-    pub fn push_metric(&mut self, value: u64) -> Result<usize, String> {
+    pub fn push_metric(&mut self, value: u64) -> app::Result<usize> {
         let mut counter = GCounter::new();
         for _ in 0..value {
-            counter
-                .increment()
-                .map_err(|e| format!("Increment failed: {:?}", e))?;
+            counter.increment()?;
         }
 
-        self.crdt_metrics
-            .push(counter)
-            .map_err(|e| format!("Push failed: {:?}", e))?;
+        self.crdt_metrics.push(counter)?;
 
-        let len = self
-            .crdt_metrics
-            .len()
-            .map_err(|e| format!("Len failed: {:?}", e))?;
+        let len = self.crdt_metrics.len()?;
 
         app::emit!(Event::MetricPushed { value });
         Ok(len)
     }
 
-    pub fn get_metric(&self, index: usize) -> Result<u64, String> {
+    pub fn get_metric(&self, index: usize) -> app::Result<u64> {
         self.crdt_metrics
-            .get(index)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .ok_or_else(|| "Index out of bounds".to_owned())?
+            .get(index)?
+            .ok_or_else(|| app::err!("Index out of bounds"))?
             .value()
-            .map_err(|e| format!("Value failed: {:?}", e))
+            .map_err(Into::into)
     }
 
-    pub fn metrics_len(&self) -> Result<usize, String> {
-        self.crdt_metrics
-            .len()
-            .map_err(|e| format!("Len failed: {:?}", e))
+    pub fn metrics_len(&self) -> app::Result<usize> {
+        self.crdt_metrics.len().map_err(Into::into)
     }
 
     // NESTED CRDT - TAGS SET
 
-    pub fn add_tag(&mut self, key: String, tag: String) -> Result<(), String> {
-        let mut set = self
-            .crdt_tags
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(UnorderedSet::new);
+    pub fn add_tag(&mut self, key: String, tag: String) -> app::Result<()> {
+        let mut set = self.crdt_tags.get(&key)?.unwrap_or_else(UnorderedSet::new);
 
-        let _ = set
-            .insert(tag.clone())
-            .map_err(|e| format!("Insert failed: {:?}", e))?;
+        let _ = set.insert(tag.clone())?;
 
-        drop(
-            self.crdt_tags
-                .insert(key.clone(), set)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.crdt_tags.insert(key.clone(), set)?);
 
         app::emit!(Event::TagAdded { key, tag });
         Ok(())
     }
 
-    pub fn has_tag(&self, key: String, tag: String) -> Result<bool, String> {
+    pub fn has_tag(&self, key: String, tag: String) -> app::Result<bool> {
         self.crdt_tags
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&key)?
             .map(|set| set.contains(&tag).unwrap_or(false))
-            .ok_or_else(|| "Key not found".to_owned())
+            .ok_or_else(|| app::err!("Key not found"))
     }
 
-    pub fn get_tag_count(&self, key: String) -> Result<u64, String> {
+    pub fn get_tag_count(&self, key: String) -> app::Result<u64> {
         let count = self
             .crdt_tags
-            .get(&key)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .ok_or_else(|| "Key not found".to_owned())?
-            .iter()
-            .map_err(|e| format!("Iter failed: {:?}", e))?
+            .get(&key)?
+            .ok_or_else(|| app::err!("Key not found"))?
+            .iter()?
             .count();
 
         Ok(count as u64)
@@ -1082,7 +1002,7 @@ impl E2eKvStore {
 
     // RGA DOCUMENT (from collaborative-editor)
 
-    pub fn rga_insert_text(&mut self, position: usize, text: String) -> Result<(), String> {
+    pub fn rga_insert_text(&mut self, position: usize, text: String) -> app::Result<()> {
         let editor_id = env::executor_id();
         let editor = encode_identity(&editor_id);
 
@@ -1093,13 +1013,9 @@ impl E2eKvStore {
             editor
         );
 
-        self.rga_document
-            .insert_str(position, &text)
-            .map_err(|e| format!("Failed to insert text: {:?}", e))?;
+        self.rga_document.insert_str(position, &text)?;
 
-        self.rga_edit_count
-            .increment()
-            .map_err(|e| format!("Failed to increment edit count: {:?}", e))?;
+        self.rga_edit_count.increment()?;
 
         app::emit!(Event::TextInserted {
             position,
@@ -1110,46 +1026,36 @@ impl E2eKvStore {
         Ok(())
     }
 
-    pub fn rga_delete_text(&mut self, start: usize, end: usize) -> Result<(), String> {
+    pub fn rga_delete_text(&mut self, start: usize, end: usize) -> app::Result<()> {
         let editor_id = env::executor_id();
         let editor = encode_identity(&editor_id);
 
         app::log!("Deleting text from {} to {} by {}", start, end, editor);
 
-        self.rga_document
-            .delete_range(start, end)
-            .map_err(|e| format!("Failed to delete text: {:?}", e))?;
+        self.rga_document.delete_range(start, end)?;
 
-        self.rga_edit_count
-            .increment()
-            .map_err(|e| format!("Failed to increment edit count: {:?}", e))?;
+        self.rga_edit_count.increment()?;
 
         app::emit!(Event::TextDeleted { start, end, editor });
 
         Ok(())
     }
 
-    pub fn rga_get_text(&self) -> Result<String, String> {
-        self.rga_document
-            .get_text()
-            .map_err(|e| format!("Failed to get text: {:?}", e))
+    pub fn rga_get_text(&self) -> app::Result<String> {
+        self.rga_document.get_text().map_err(Into::into)
     }
 
-    pub fn rga_get_length(&self) -> Result<usize, String> {
-        self.rga_document
-            .len()
-            .map_err(|e| format!("Failed to get length: {:?}", e))
+    pub fn rga_get_length(&self) -> app::Result<usize> {
+        self.rga_document.len().map_err(Into::into)
     }
 
-    pub fn rga_is_empty(&self) -> Result<bool, String> {
-        self.rga_document
-            .is_empty()
-            .map_err(|e| format!("Failed to check if empty: {:?}", e))
+    pub fn rga_is_empty(&self) -> app::Result<bool> {
+        self.rga_document.is_empty().map_err(Into::into)
     }
 
-    pub fn rga_set_title(&mut self, new_title: String) -> Result<(), String> {
+    pub fn rga_set_title(&mut self, new_title: String) -> app::Result<()> {
         if new_title.is_empty() {
-            return Err("Title cannot be empty".to_string());
+            app::bail!("Title cannot be empty");
         }
 
         let editor_id = env::executor_id();
@@ -1158,8 +1064,7 @@ impl E2eKvStore {
         let old_title = self.rga_get_title();
 
         self.rga_metadata
-            .insert("title".to_string(), new_title.clone().into())
-            .map_err(|e| format!("Failed to update title: {:?}", e))?;
+            .insert("title".to_string(), new_title.clone().into())?;
 
         app::log!(
             "Title changed from '{}' to '{}' by {}",
@@ -1186,12 +1091,12 @@ impl E2eKvStore {
             .unwrap_or_else(|| "Untitled Document".to_string())
     }
 
-    pub fn rga_append_text(&mut self, text: String) -> Result<(), String> {
+    pub fn rga_append_text(&mut self, text: String) -> app::Result<()> {
         let length = self.rga_get_length()?;
         self.rga_insert_text(length, text)
     }
 
-    pub fn rga_clear(&mut self) -> Result<(), String> {
+    pub fn rga_clear(&mut self) -> app::Result<()> {
         let length = self.rga_get_length()?;
         if length > 0 {
             self.rga_delete_text(0, length)?;
@@ -1201,11 +1106,10 @@ impl E2eKvStore {
 
     // AUTHORED MAP
 
-    pub fn authored_insert(&mut self, key: String, value: String) -> Result<(), String> {
+    pub fn authored_insert(&mut self, key: String, value: String) -> app::Result<()> {
         let owner = bs58::encode(env::executor_id()).into_string();
         self.authored_items
-            .insert(key.clone(), value.clone().into())
-            .map_err(|e| format!("authored_insert failed: {:?}", e))?;
+            .insert(key.clone(), value.clone().into())?;
         app::emit!(Event::AuthoredInserted {
             key: key.clone(),
             value: value.clone(),
@@ -1214,10 +1118,8 @@ impl E2eKvStore {
         Ok(())
     }
 
-    pub fn authored_update(&mut self, key: String, value: String) -> Result<(), String> {
-        self.authored_items
-            .update(&key, value.clone().into())
-            .map_err(|e| format!("authored_update failed: {:?}", e))?;
+    pub fn authored_update(&mut self, key: String, value: String) -> app::Result<()> {
+        self.authored_items.update(&key, value.clone().into())?;
         app::emit!(Event::AuthoredUpdated {
             key: key.clone(),
             value: value.clone(),
@@ -1225,56 +1127,39 @@ impl E2eKvStore {
         Ok(())
     }
 
-    pub fn authored_remove(&mut self, key: String) -> Result<Option<String>, String> {
-        let result = self
-            .authored_items
-            .remove(&key)
-            .map_err(|e| format!("authored_remove failed: {:?}", e))?
-            .map(|v| v.get().clone());
+    pub fn authored_remove(&mut self, key: String) -> app::Result<Option<String>> {
+        let result = self.authored_items.remove(&key)?.map(|v| v.get().clone());
         if result.is_some() {
             app::emit!(Event::AuthoredRemoved { key: key.clone() });
         }
         Ok(result)
     }
 
-    pub fn authored_get(&self, key: String) -> Result<Option<String>, String> {
-        Ok(self
-            .authored_items
-            .get(&key)
-            .map_err(|e| format!("authored_get failed: {:?}", e))?
-            .map(|v| v.get().clone()))
+    pub fn authored_get(&self, key: String) -> app::Result<Option<String>> {
+        Ok(self.authored_items.get(&key)?.map(|v| v.get().clone()))
     }
 
-    pub fn authored_entries(&self) -> Result<BTreeMap<String, String>, String> {
+    pub fn authored_entries(&self) -> app::Result<BTreeMap<String, String>> {
         Ok(self
             .authored_items
-            .entries()
-            .map_err(|e| format!("authored_entries failed: {:?}", e))?
+            .entries()?
             .map(|(k, v)| (k, v.get().clone()))
             .collect())
     }
 
-    pub fn authored_get_owner(&self, key: String) -> Result<Option<String>, String> {
-        Ok(self
-            .authored_items
-            .owner_of(&key)
-            .map_err(|e| format!("authored_get_owner failed: {:?}", e))?
-            .map(|pk| pk.to_string()))
+    pub fn authored_get_owner(&self, key: String) -> app::Result<Option<String>> {
+        Ok(self.authored_items.owner_of(&key)?.map(|pk| pk.to_string()))
     }
 
-    pub fn authored_len(&self) -> Result<usize, String> {
-        self.authored_items
-            .len()
-            .map_err(|e| format!("authored_len failed: {:?}", e))
+    pub fn authored_len(&self) -> app::Result<usize> {
+        self.authored_items.len().map_err(Into::into)
     }
 
     // SHARED STORAGE
 
-    pub fn shared_set(&mut self, value: String) -> Result<(), String> {
+    pub fn shared_set(&mut self, value: String) -> app::Result<()> {
         let by = bs58::encode(env::executor_id()).into_string();
-        self.shared_data
-            .insert(LwwRegister::new(value.clone()))
-            .map_err(|e| format!("shared_set failed: {:?}", e))?;
+        self.shared_data.insert(LwwRegister::new(value.clone()))?;
         app::emit!(Event::SharedSet {
             value: value.clone(),
             by: by.clone(),
@@ -1282,16 +1167,11 @@ impl E2eKvStore {
         Ok(())
     }
 
-    pub fn shared_get(&self) -> Result<String, String> {
-        Ok(self
-            .shared_data
-            .get()
-            .map_err(|e| format!("shared_get failed: {:?}", e))?
-            .get()
-            .clone())
+    pub fn shared_get(&self) -> app::Result<String> {
+        Ok(self.shared_data.get()?.get().clone())
     }
 
-    pub fn shared_get_writers(&self) -> Result<Vec<String>, String> {
+    pub fn shared_get_writers(&self) -> app::Result<Vec<String>> {
         Ok(self
             .shared_data
             .writers()
@@ -1300,39 +1180,30 @@ impl E2eKvStore {
             .collect())
     }
 
-    pub fn shared_add_writer(&mut self, writer_bs58: String) -> Result<(), String> {
-        let new_writer: PublicKey = writer_bs58
-            .parse()
-            .map_err(|e| format!("Invalid public key '{}': {:?}", writer_bs58, e))?;
+    pub fn shared_add_writer(&mut self, writer_bs58: String) -> app::Result<()> {
+        let new_writer: PublicKey = writer_bs58.parse()?;
         let mut new_writers = self.shared_data.writers().clone();
         new_writers.insert(new_writer);
-        self.shared_data
-            .rotate_writers(new_writers)
-            .map_err(|e| format!("shared_add_writer failed: {:?}", e))?;
+        self.shared_data.rotate_writers(new_writers)?;
         app::emit!(Event::SharedWriterAdded {
             writer: writer_bs58.clone(),
         });
         Ok(())
     }
 
-    pub fn shared_is_writer(&self, key_bs58: String) -> Result<bool, String> {
-        let pk: PublicKey = key_bs58
-            .parse()
-            .map_err(|e| format!("Invalid public key '{}': {:?}", key_bs58, e))?;
+    pub fn shared_is_writer(&self, key_bs58: String) -> app::Result<bool> {
+        let pk: PublicKey = key_bs58.parse()?;
         Ok(self.shared_data.writers().contains(&pk))
     }
 
-    pub fn shared_is_frozen(&self) -> Result<bool, String> {
+    pub fn shared_is_frozen(&self) -> app::Result<bool> {
         Ok(self.shared_data.is_frozen())
     }
 
     // AUTHORED VECTOR
 
-    pub fn authored_vec_push(&mut self, value: String) -> Result<usize, String> {
-        let index = self
-            .authored_vec
-            .push(LwwRegister::new(value.clone()))
-            .map_err(|e| format!("authored_vec_push failed: {:?}", e))?;
+    pub fn authored_vec_push(&mut self, value: String) -> app::Result<usize> {
+        let index = self.authored_vec.push(LwwRegister::new(value.clone()))?;
         let owner = bs58::encode(env::executor_id()).into_string();
         app::emit!(Event::AuthoredVecPushed {
             index,
@@ -1342,50 +1213,32 @@ impl E2eKvStore {
         Ok(index)
     }
 
-    pub fn authored_vec_get(&self, index: usize) -> Result<Option<String>, String> {
-        Ok(self
-            .authored_vec
-            .get(index)
-            .map_err(|e| format!("authored_vec_get failed: {:?}", e))?
-            .map(|r| r.get().clone()))
+    pub fn authored_vec_get(&self, index: usize) -> app::Result<Option<String>> {
+        Ok(self.authored_vec.get(index)?.map(|r| r.get().clone()))
     }
 
-    pub fn authored_vec_update(&mut self, index: usize, value: String) -> Result<(), String> {
+    pub fn authored_vec_update(&mut self, index: usize, value: String) -> app::Result<()> {
         self.authored_vec
-            .update(index, LwwRegister::new(value.clone()))
-            .map_err(|e| format!("authored_vec_update failed: {:?}", e))?;
+            .update(index, LwwRegister::new(value.clone()))?;
         app::emit!(Event::AuthoredVecUpdated { index, value });
         Ok(())
     }
 
-    pub fn authored_vec_remove(&mut self, index: usize) -> Result<(), String> {
-        self.authored_vec
-            .tombstone(index)
-            .map_err(|e| format!("authored_vec_remove failed: {:?}", e))?;
+    pub fn authored_vec_remove(&mut self, index: usize) -> app::Result<()> {
+        self.authored_vec.tombstone(index)?;
         app::emit!(Event::AuthoredVecRemoved { index });
         Ok(())
     }
 
-    pub fn authored_vec_get_owner(&self, index: usize) -> Result<Option<String>, String> {
-        Ok(self
-            .authored_vec
-            .owner_of(index)
-            .map_err(|e| format!("authored_vec_get_owner failed: {:?}", e))?
-            .map(|pk| pk.to_string()))
+    pub fn authored_vec_get_owner(&self, index: usize) -> app::Result<Option<String>> {
+        Ok(self.authored_vec.owner_of(index)?.map(|pk| pk.to_string()))
     }
 
-    pub fn authored_vec_entries(&self) -> Result<Vec<String>, String> {
-        Ok(self
-            .authored_vec
-            .iter()
-            .map_err(|e| format!("authored_vec_entries failed: {:?}", e))?
-            .map(|r| r.get().clone())
-            .collect())
+    pub fn authored_vec_entries(&self) -> app::Result<Vec<String>> {
+        Ok(self.authored_vec.iter()?.map(|r| r.get().clone()).collect())
     }
 
-    pub fn authored_vec_len(&self) -> Result<usize, String> {
-        self.authored_vec
-            .len()
-            .map_err(|e| format!("authored_vec_len failed: {:?}", e))
+    pub fn authored_vec_len(&self) -> app::Result<usize> {
+        self.authored_vec.len().map_err(Into::into)
     }
 }

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -131,23 +131,26 @@ impl TeamMetricsApp {
     }
 
     pub fn get_wins(&self, team_id: String) -> app::Result<u64> {
-        self.teams
-            .get(&team_id)?
-            .map(|s| s.wins.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Team not found"))
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.wins.value()?)
     }
 
     pub fn get_losses(&self, team_id: String) -> app::Result<u64> {
-        self.teams
-            .get(&team_id)?
-            .map(|s| s.losses.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Team not found"))
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.losses.value()?)
     }
 
     pub fn get_draws(&self, team_id: String) -> app::Result<u64> {
-        self.teams
-            .get(&team_id)?
-            .map(|s| s.draws.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Team not found"))
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.draws.value()?)
     }
 }

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -79,120 +79,75 @@ impl TeamMetricsApp {
         }
     }
 
-    pub fn record_win(&mut self, team_id: String) -> Result<u64, String> {
-        let mut stats = self
-            .teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| TeamStats {
-                wins: Counter::new(),
-                losses: Counter::new(),
-                draws: Counter::new(),
-            });
+    pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
+            wins: Counter::new(),
+            losses: Counter::new(),
+            draws: Counter::new(),
+        });
 
-        stats
-            .wins
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
-        let total = stats
-            .wins
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        stats.wins.increment()?;
+        let total = stats.wins.value()?;
 
-        drop(
-            self.teams
-                .insert(team_id.clone(), stats)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.teams.insert(team_id.clone(), stats)?);
 
         app::emit!(MetricsEvent::WinRecorded { team_id, total });
 
         Ok(total)
     }
 
-    pub fn record_loss(&mut self, team_id: String) -> Result<u64, String> {
-        let mut stats = self
-            .teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| TeamStats {
-                wins: Counter::new(),
-                losses: Counter::new(),
-                draws: Counter::new(),
-            });
+    pub fn record_loss(&mut self, team_id: String) -> app::Result<u64> {
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
+            wins: Counter::new(),
+            losses: Counter::new(),
+            draws: Counter::new(),
+        });
 
-        stats
-            .losses
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
-        let total = stats
-            .losses
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        stats.losses.increment()?;
+        let total = stats.losses.value()?;
 
-        drop(
-            self.teams
-                .insert(team_id.clone(), stats)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.teams.insert(team_id.clone(), stats)?);
 
         app::emit!(MetricsEvent::LossRecorded { team_id, total });
 
         Ok(total)
     }
 
-    pub fn record_draw(&mut self, team_id: String) -> Result<u64, String> {
-        let mut stats = self
-            .teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| TeamStats {
-                wins: Counter::new(),
-                losses: Counter::new(),
-                draws: Counter::new(),
-            });
+    pub fn record_draw(&mut self, team_id: String) -> app::Result<u64> {
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
+            wins: Counter::new(),
+            losses: Counter::new(),
+            draws: Counter::new(),
+        });
 
-        stats
-            .draws
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
-        let total = stats
-            .draws
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        stats.draws.increment()?;
+        let total = stats.draws.value()?;
 
-        drop(
-            self.teams
-                .insert(team_id.clone(), stats)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.teams.insert(team_id.clone(), stats)?);
 
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 
         Ok(total)
     }
 
-    pub fn get_wins(&self, team_id: String) -> Result<u64, String> {
+    pub fn get_wins(&self, team_id: String) -> app::Result<u64> {
         self.teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&team_id)?
             .map(|s| s.wins.value().unwrap_or(0))
-            .ok_or_else(|| "Team not found".to_owned())
+            .ok_or_else(|| app::err!("Team not found"))
     }
 
-    pub fn get_losses(&self, team_id: String) -> Result<u64, String> {
+    pub fn get_losses(&self, team_id: String) -> app::Result<u64> {
         self.teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&team_id)?
             .map(|s| s.losses.value().unwrap_or(0))
-            .ok_or_else(|| "Team not found".to_owned())
+            .ok_or_else(|| app::err!("Team not found"))
     }
 
-    pub fn get_draws(&self, team_id: String) -> Result<u64, String> {
+    pub fn get_draws(&self, team_id: String) -> app::Result<u64> {
         self.teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&team_id)?
             .map(|s| s.draws.value().unwrap_or(0))
-            .ok_or_else(|| "Team not found".to_owned())
+            .ok_or_else(|| app::err!("Team not found"))
     }
 }

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -53,120 +53,75 @@ impl TeamMetricsApp {
         }
     }
 
-    pub fn record_win(&mut self, team_id: String) -> Result<u64, String> {
-        let mut stats = self
-            .teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| TeamStats {
-                wins: Counter::new(),
-                losses: Counter::new(),
-                draws: Counter::new(),
-            });
+    pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
+            wins: Counter::new(),
+            losses: Counter::new(),
+            draws: Counter::new(),
+        });
 
-        stats
-            .wins
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
-        let total = stats
-            .wins
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        stats.wins.increment()?;
+        let total = stats.wins.value()?;
 
-        drop(
-            self.teams
-                .insert(team_id.clone(), stats)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.teams.insert(team_id.clone(), stats)?);
 
         app::emit!(MetricsEvent::WinRecorded { team_id, total });
 
         Ok(total)
     }
 
-    pub fn record_loss(&mut self, team_id: String) -> Result<u64, String> {
-        let mut stats = self
-            .teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| TeamStats {
-                wins: Counter::new(),
-                losses: Counter::new(),
-                draws: Counter::new(),
-            });
+    pub fn record_loss(&mut self, team_id: String) -> app::Result<u64> {
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
+            wins: Counter::new(),
+            losses: Counter::new(),
+            draws: Counter::new(),
+        });
 
-        stats
-            .losses
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
-        let total = stats
-            .losses
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        stats.losses.increment()?;
+        let total = stats.losses.value()?;
 
-        drop(
-            self.teams
-                .insert(team_id.clone(), stats)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.teams.insert(team_id.clone(), stats)?);
 
         app::emit!(MetricsEvent::LossRecorded { team_id, total });
 
         Ok(total)
     }
 
-    pub fn record_draw(&mut self, team_id: String) -> Result<u64, String> {
-        let mut stats = self
-            .teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
-            .unwrap_or_else(|| TeamStats {
-                wins: Counter::new(),
-                losses: Counter::new(),
-                draws: Counter::new(),
-            });
+    pub fn record_draw(&mut self, team_id: String) -> app::Result<u64> {
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
+            wins: Counter::new(),
+            losses: Counter::new(),
+            draws: Counter::new(),
+        });
 
-        stats
-            .draws
-            .increment()
-            .map_err(|e| format!("Increment failed: {:?}", e))?;
-        let total = stats
-            .draws
-            .value()
-            .map_err(|e| format!("Value failed: {:?}", e))?;
+        stats.draws.increment()?;
+        let total = stats.draws.value()?;
 
-        drop(
-            self.teams
-                .insert(team_id.clone(), stats)
-                .map_err(|e| format!("Insert failed: {:?}", e))?,
-        );
+        drop(self.teams.insert(team_id.clone(), stats)?);
 
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 
         Ok(total)
     }
 
-    pub fn get_wins(&self, team_id: String) -> Result<u64, String> {
+    pub fn get_wins(&self, team_id: String) -> app::Result<u64> {
         self.teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&team_id)?
             .map(|s| s.wins.value().unwrap_or(0))
-            .ok_or_else(|| "Team not found".to_owned())
+            .ok_or_else(|| app::err!("Team not found"))
     }
 
-    pub fn get_losses(&self, team_id: String) -> Result<u64, String> {
+    pub fn get_losses(&self, team_id: String) -> app::Result<u64> {
         self.teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&team_id)?
             .map(|s| s.losses.value().unwrap_or(0))
-            .ok_or_else(|| "Team not found".to_owned())
+            .ok_or_else(|| app::err!("Team not found"))
     }
 
-    pub fn get_draws(&self, team_id: String) -> Result<u64, String> {
+    pub fn get_draws(&self, team_id: String) -> app::Result<u64> {
         self.teams
-            .get(&team_id)
-            .map_err(|e| format!("Get failed: {:?}", e))?
+            .get(&team_id)?
             .map(|s| s.draws.value().unwrap_or(0))
-            .ok_or_else(|| "Team not found".to_owned())
+            .ok_or_else(|| app::err!("Team not found"))
     }
 }

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -105,23 +105,26 @@ impl TeamMetricsApp {
     }
 
     pub fn get_wins(&self, team_id: String) -> app::Result<u64> {
-        self.teams
-            .get(&team_id)?
-            .map(|s| s.wins.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Team not found"))
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.wins.value()?)
     }
 
     pub fn get_losses(&self, team_id: String) -> app::Result<u64> {
-        self.teams
-            .get(&team_id)?
-            .map(|s| s.losses.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Team not found"))
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.losses.value()?)
     }
 
     pub fn get_draws(&self, team_id: String) -> app::Result<u64> {
-        self.teams
-            .get(&team_id)?
-            .map(|s| s.draws.value().unwrap_or(0))
-            .ok_or_else(|| app::err!("Team not found"))
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.draws.value()?)
     }
 }

--- a/crates/sdk/macros/src/errors.rs
+++ b/crates/sdk/macros/src/errors.rs
@@ -87,6 +87,13 @@ pub enum ParseError<'a> {
     #[error("method annotated with `#[app::init]` must be named `init`")]
     AppInitMethodNotNamedInit,
     #[error(
+        "app logic methods must return `app::Result<T>`, not `Result<T, String>` — the SDK's \
+         `From<StoreError> for app::Error` lets storage errors propagate through `?` directly.\n\n\
+         Change the return type to `app::Result<T>`, drop `.map_err(|e| format!(...))?` in favour \
+         of `?`, and use `app::bail!` / `app::err!` for custom error messages."
+    )]
+    StringErrorResult,
+    #[error(
         "`{type_name}` is not allowed here — std collections are not CRDTs and would silently \
          diverge across replicas. Use `{suggestion}` from `calimero_storage::collections` instead.\n\n\
          If you genuinely need a non-CRDT type, skip `#[app::state]` / `#[derive(Mergeable)]` \

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -241,6 +241,13 @@ impl ToTokens for PublicLogicMethod<'_> {
 /// is written with a single type argument, so it never matches the two-argument
 /// `Result<Ok, Err>` shape this looks for. Custom error types
 /// (`Result<T, MyError>`) are likewise untouched.
+///
+/// This is a purely syntactic check, so it cannot see through type aliases: a
+/// `type MyResult<T> = Result<T, String>` used as `-> MyResult<T>` is not
+/// flagged. The error type is matched only against the standard-library
+/// `String` spellings (`String`, `std::string::String`, `alloc::string::String`)
+/// so an unrelated user type whose last path segment happens to be `String`
+/// is not falsely flagged.
 fn string_error_result_span(ty: &Type) -> Option<Span> {
     let Type::Path(type_path) = ty else {
         return None;
@@ -267,12 +274,40 @@ fn string_error_result_span(ty: &Type) -> Option<Span> {
         return None;
     }
 
-    let Type::Path(err_path) = err else {
-        return None;
+    is_std_string(err).then(|| err.span())
+}
+
+/// Whether `ty` is the standard-library `String`, written either bare or with a
+/// `std`/`alloc` qualifier. A leading `::` is allowed; any other prefix (e.g.
+/// `my_crate::String`) is rejected to avoid false positives.
+fn is_std_string(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
     };
 
-    let err_segment = err_path.path.segments.last()?;
-    (err_segment.ident == "String" && err_segment.arguments.is_empty()).then(|| err.span())
+    if type_path.qself.is_some() {
+        return false;
+    }
+
+    let segments = &type_path.path.segments;
+
+    // The `String` segment itself must carry no generic arguments.
+    if !segments
+        .last()
+        .is_some_and(|segment| segment.arguments.is_empty())
+    {
+        return false;
+    }
+
+    match segments.len() {
+        1 => segments[0].ident == "String",
+        3 => {
+            (segments[0].ident == "std" || segments[0].ident == "alloc")
+                && segments[1].ident == "string"
+                && segments[2].ident == "String"
+        }
+        _ => false,
+    }
 }
 
 pub struct LogicMethodImplInput<'a, 'b> {
@@ -429,6 +464,9 @@ mod tests {
         assert!(flags(parse_quote! { Result<Vec<FileRecord>, String> }));
         assert!(flags(parse_quote! { core::result::Result<(), String> }));
         assert!(flags(parse_quote! { std::result::Result<bool, String> }));
+        // Qualified standard-library `String` spellings.
+        assert!(flags(parse_quote! { Result<(), std::string::String> }));
+        assert!(flags(parse_quote! { Result<(), alloc::string::String> }));
     }
 
     #[test]
@@ -440,6 +478,11 @@ mod tests {
         assert!(!flags(parse_quote! { Result<u64, MyError> }));
         assert!(!flags(parse_quote! { Result<u64, std::io::Error> }));
         assert!(!flags(parse_quote! { Result<u64, app::Error> }));
+        // A user type whose last segment is `String` must not be flagged.
+        assert!(!flags(parse_quote! { Result<u64, my_crate::String> }));
+        assert!(!flags(
+            parse_quote! { Result<u64, widgets::string::String> }
+        ));
     }
 
     #[test]

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -1,7 +1,10 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
-use syn::{Error as SynError, GenericParam, Ident, ImplItemFn, Path, ReturnType, Visibility};
+use syn::{
+    Error as SynError, GenericArgument, GenericParam, Ident, ImplItemFn, Path, PathArguments,
+    ReturnType, Type, Visibility,
+};
 
 use crate::errors::{Errors, ParseError};
 use crate::logic::arg::{LogicArg, LogicArgInput, LogicArgTyped, SelfType};
@@ -230,6 +233,48 @@ impl ToTokens for PublicLogicMethod<'_> {
     }
 }
 
+/// Detects a bare `Result<T, String>` return type and returns the span of the
+/// `String` error type, so app logic methods can be steered towards
+/// `app::Result<T>` (which carries `app::Error`).
+///
+/// `app::Result<T>` is left alone: it desugars to `Result<T, app::Error>` but
+/// is written with a single type argument, so it never matches the two-argument
+/// `Result<Ok, Err>` shape this looks for. Custom error types
+/// (`Result<T, MyError>`) are likewise untouched.
+fn string_error_result_span(ty: &Type) -> Option<Span> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != "Result" {
+        return None;
+    }
+
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+
+    let mut type_args = args.args.iter().filter_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    });
+
+    let _ok = type_args.next()?;
+    let err = type_args.next()?;
+    if type_args.next().is_some() {
+        // More than two type arguments — not a plain `Result<Ok, Err>`.
+        return None;
+    }
+
+    let Type::Path(err_path) = err else {
+        return None;
+    };
+
+    let err_segment = err_path.path.segments.last()?;
+    (err_segment.ident == "String" && err_segment.arguments.is_empty()).then(|| err.span())
+}
+
 pub struct LogicMethodImplInput<'a, 'b> {
     pub item: &'a ImplItemFn,
 
@@ -340,6 +385,10 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
 
         let mut ret = None;
         if let ReturnType::Type(_, ret_type) = &input.item.sig.output {
+            if let Some(span) = string_error_result_span(ret_type) {
+                errors.subsume(SynError::new(span, ParseError::StringErrorResult));
+            }
+
             match LogicTy::try_from(LogicTyInput {
                 type_: input.type_,
                 ty: ret_type,
@@ -360,5 +409,45 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
             has_refs,
             modifiers,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::{parse_quote, Type};
+
+    use super::string_error_result_span;
+
+    fn flags(ty: Type) -> bool {
+        string_error_result_span(&ty).is_some()
+    }
+
+    #[test]
+    fn flags_bare_string_error_result() {
+        assert!(flags(parse_quote! { Result<(), String> }));
+        assert!(flags(parse_quote! { Result<u64, String> }));
+        assert!(flags(parse_quote! { Result<Vec<FileRecord>, String> }));
+        assert!(flags(parse_quote! { core::result::Result<(), String> }));
+        assert!(flags(parse_quote! { std::result::Result<bool, String> }));
+    }
+
+    #[test]
+    fn ignores_app_result_and_custom_errors() {
+        // `app::Result<T>` carries a single type argument.
+        assert!(!flags(parse_quote! { app::Result<u64> }));
+        assert!(!flags(parse_quote! { Result<u64> }));
+        // Custom / non-`String` error types are fine.
+        assert!(!flags(parse_quote! { Result<u64, MyError> }));
+        assert!(!flags(parse_quote! { Result<u64, std::io::Error> }));
+        assert!(!flags(parse_quote! { Result<u64, app::Error> }));
+    }
+
+    #[test]
+    fn ignores_non_result_types() {
+        assert!(!flags(parse_quote! { u64 }));
+        assert!(!flags(parse_quote! { Option<String> }));
+        assert!(!flags(parse_quote! { String }));
+        // More than two type arguments is not a plain `Result<Ok, Err>`.
+        assert!(!flags(parse_quote! { Result<u64, String, Extra> }));
     }
 }


### PR DESCRIPTION
Closes #2543.

## Problem

Example apps declared `Result<T, String>` and hand-wrapped every storage call with `.map_err(|e| format!("...{:?}", e))?` — ~28 times in a single file. The SDK already provides `From<StoreError> for app::Error`, so returning `app::Result<T>` lets storage errors propagate through `?` with zero boilerplate.

## Changes

**Converted 6 apps** (`blobs`, `collaborative-editor`, `nested-crdt-test`, `team-metrics-macro`, `team-metrics-custom`, `scaffolding-e2e`):
- `-> Result<T, String>` → `-> app::Result<T>`
- `.map_err(|e| format!(...))?` → `?`; tail maps → `.map_err(Into::into)`
- custom messages → `app::bail!` / `app::err!`
- error-swallowing `if let Ok(entries) = ...` → proper `?` propagation
- READMEs updated to match the new signatures

The other apps (`kv-store*`, `private_data`, `sync-test`, migration/conformance fixtures) already used `app::Result`.

**Enforcement in the `#[app::logic]` macro** (the issue's "additional work"), instead of a CI grep:
- A public logic method returning a bare `Result<T, String>` now **fails to compile** with an actionable message pointing to `app::Result` + `app::bail!`/`app::err!`.
- Runs automatically at compile time for every app — no separate CI step, no second source of truth.
- Precisely scoped: `app::Result<T>` (single type arg) and custom error types pass; helper fns and trait impls (`Mergeable::merge`) are never flagged because the check only sees public logic methods.
- Covered by unit tests in `logic::method::tests`.

## Verification
- All 6 apps `cargo check` clean and `cargo fmt --check` clean against latest master
- `calimero-sdk-macros`: 48/48 tests pass (incl. 3 new), fmt-clean, no new clippy
- Integration-tested: reverting a method to `Result<T, String>` produces `error: (calimero)> app logic methods must return app::Result<T>, not Result<T, String>`, and compiles cleanly once fixed
- No other `#[app::logic]` block in the repo returns a `String` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical error-type and propagation changes in example/e2e apps plus a compile-time guard; no auth, payment, or core runtime behavior changes beyond surfacing storage errors that were previously swallowed.
> 
> **Overview**
> Example app logic and docs now use **`app::Result<T>`** instead of **`Result<T, String>`**, so storage failures propagate with **`?`** (via **`From<StoreError> for app::Error`**) instead of hand-written **`.map_err(|e| format!(...))?`**. Custom cases use **`app::bail!`** / **`app::err!`**, and patterns that ignored storage errors (**`if let Ok(entries) = ...`**) now fail the call on error.
> 
> **Six apps** are updated: **`blobs`**, **`collaborative-editor`**, **`nested-crdt-test`**, **`team-metrics-macro`**, **`team-metrics-custom`**, and **`scaffolding-e2e`** (including blob ID parsing and small comments on base58 helpers). Matching **README** API signatures were refreshed.
> 
> The **`#[app::logic]`** macro **rejects** public methods that return bare **`Result<T, String>`** at compile time, with a message pointing to **`app::Result`** and the error macros; **`app::Result<T>`** and other error types are unchanged. Unit tests cover the detector in **`logic/method`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa16a0691b4774ad83f3b4fdcfb082fc4f1b690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->