### PR TITLE
refactor(apps): drop the drop(insert(...)) papercut (#2556) + run CI on apps/**

### DIFF
--- a/.github/workflows/ci-checks-ignored.yml
+++ b/.github/workflows/ci-checks-ignored.yml
@@ -8,6 +8,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - "crates/**"
+      - "apps/**"
       - "e2e-tests/**"
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -8,6 +8,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - "crates/**"
+      - "apps/**"
       - "e2e-tests/**"
 
 env:

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -85,7 +85,7 @@ impl NestedCrdtTest {
 
         let value = counter.value()?;
 
-        drop(self.counters.insert(key.clone(), counter)?);
+        self.counters.insert(key.clone(), counter)?;
 
         app::emit!(TestEvent::CounterIncremented { key, value });
 
@@ -105,7 +105,7 @@ impl NestedCrdtTest {
     pub fn set_register(&mut self, key: String, value: String) -> app::Result<()> {
         let register = LwwRegister::new(value.clone());
 
-        drop(self.registers.insert(key.clone(), register)?);
+        self.registers.insert(key.clone(), register)?;
 
         app::emit!(TestEvent::RegisterSet { key, value });
 
@@ -132,9 +132,9 @@ impl NestedCrdtTest {
             .get(&outer_key)?
             .unwrap_or_else(|| UnorderedMap::new());
 
-        drop(inner_map.insert(inner_key.clone(), value.clone().into())?);
+        inner_map.insert(inner_key.clone(), value.clone().into())?;
 
-        drop(self.metadata.insert(outer_key.clone(), inner_map)?);
+        self.metadata.insert(outer_key.clone(), inner_map)?;
 
         app::emit!(TestEvent::MetadataSet {
             outer_key,
@@ -188,9 +188,9 @@ impl NestedCrdtTest {
     pub fn add_tag(&mut self, key: String, tag: String) -> app::Result<()> {
         let mut set = self.tags.get(&key)?.unwrap_or_else(|| UnorderedSet::new());
 
-        let _ = set.insert(tag.clone())?;
+        set.insert(tag.clone())?;
 
-        drop(self.tags.insert(key.clone(), set)?);
+        self.tags.insert(key.clone(), set)?;
 
         app::emit!(TestEvent::TagAdded { key, tag });
 

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -89,7 +89,7 @@ impl TeamMetricsApp {
         stats.wins.increment()?;
         let total = stats.wins.value()?;
 
-        drop(self.teams.insert(team_id.clone(), stats)?);
+        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::WinRecorded { team_id, total });
 
@@ -106,7 +106,7 @@ impl TeamMetricsApp {
         stats.losses.increment()?;
         let total = stats.losses.value()?;
 
-        drop(self.teams.insert(team_id.clone(), stats)?);
+        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::LossRecorded { team_id, total });
 
@@ -123,7 +123,7 @@ impl TeamMetricsApp {
         stats.draws.increment()?;
         let total = stats.draws.value()?;
 
-        drop(self.teams.insert(team_id.clone(), stats)?);
+        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -17,7 +17,7 @@ use calimero_storage::collections::{Counter, Mergeable, UnorderedMap};
 ///
 /// This struct demonstrates CUSTOM Mergeable implementation.
 /// You have full control and can add custom logic!
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Default, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct TeamStats {
     pub wins: Counter,
@@ -80,11 +80,7 @@ impl TeamMetricsApp {
     }
 
     pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
-            wins: Counter::new(),
-            losses: Counter::new(),
-            draws: Counter::new(),
-        });
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
 
         stats.wins.increment()?;
         let total = stats.wins.value()?;
@@ -97,11 +93,7 @@ impl TeamMetricsApp {
     }
 
     pub fn record_loss(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
-            wins: Counter::new(),
-            losses: Counter::new(),
-            draws: Counter::new(),
-        });
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
 
         stats.losses.increment()?;
         let total = stats.losses.value()?;
@@ -114,11 +106,7 @@ impl TeamMetricsApp {
     }
 
     pub fn record_draw(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
-            wins: Counter::new(),
-            losses: Counter::new(),
-            draws: Counter::new(),
-        });
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
 
         stats.draws.increment()?;
         let total = stats.draws.value()?;

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -63,7 +63,7 @@ impl TeamMetricsApp {
         stats.wins.increment()?;
         let total = stats.wins.value()?;
 
-        drop(self.teams.insert(team_id.clone(), stats)?);
+        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::WinRecorded { team_id, total });
 
@@ -80,7 +80,7 @@ impl TeamMetricsApp {
         stats.losses.increment()?;
         let total = stats.losses.value()?;
 
-        drop(self.teams.insert(team_id.clone(), stats)?);
+        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::LossRecorded { team_id, total });
 
@@ -97,7 +97,7 @@ impl TeamMetricsApp {
         stats.draws.increment()?;
         let total = stats.draws.value()?;
 
-        drop(self.teams.insert(team_id.clone(), stats)?);
+        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -17,7 +17,7 @@ use calimero_storage_macros::Mergeable;
 ///
 /// This struct demonstrates #[derive(Mergeable)] - zero boilerplate!
 /// All fields are CRDTs, so the macro just calls merge on each.
-#[derive(Debug, Mergeable, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Default, Mergeable, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct TeamStats {
     pub wins: Counter,
@@ -54,11 +54,7 @@ impl TeamMetricsApp {
     }
 
     pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
-            wins: Counter::new(),
-            losses: Counter::new(),
-            draws: Counter::new(),
-        });
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
 
         stats.wins.increment()?;
         let total = stats.wins.value()?;
@@ -71,11 +67,7 @@ impl TeamMetricsApp {
     }
 
     pub fn record_loss(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
-            wins: Counter::new(),
-            losses: Counter::new(),
-            draws: Counter::new(),
-        });
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
 
         stats.losses.increment()?;
         let total = stats.losses.value()?;
@@ -88,11 +80,7 @@ impl TeamMetricsApp {
     }
 
     pub fn record_draw(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_else(|| TeamStats {
-            wins: Counter::new(),
-            losses: Counter::new(),
-            draws: Counter::new(),
-        });
+        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
 
         stats.draws.increment()?;
         let total = stats.draws.value()?;


### PR DESCRIPTION
## Summary

Two SDK-UX papercut cleanups for the example apps, plus a CI gap fix surfaced along the way.

> **Note:** this PR was rebased after #2566 merged. #2566 already did the `app::Result` conversion (**#2543**) across these and other apps, so that half is no longer part of this diff. What remains here is **#2556** (removing the `drop(insert(...))` papercut) plus the CI fix below.

## #2556 — drop the `drop(insert(...))` noise

Removes the `drop(self.x.insert(k, v)?)` wrappers in the three example apps → bare `self.x.insert(k, v)?;`.

Resolved **without** adding a `set()` method or changing the storage crate. The issue assumed `UnorderedMap::insert` is `#[must_use]`, but it is not, and the crate enables no `unused_results` lint — so `self.x.insert(k, v)?;` as a bare statement already compiles **warning-free**, exactly like `std::collections::HashMap::insert`. The fix is simply to delete the `drop(...)` wrappers; the displaced-value return is ignored as std allows. This keeps the API surface minimal (no `insert` vs `set` "which do I use?" papercut). The `let _ = set.insert(...)` in `nested-crdt-test` is normalized to a bare statement too, for consistency.

Verified: bare inserts produce **no** `unused_must_use` / `unused_results` warning in any of the three apps.

**Before**
```rust
drop(self.teams.insert(team_id.clone(), stats)?);
```
**After**
```rust
self.teams.insert(team_id.clone(), stats)?;
```

## CI — run real `ci-checks` on `apps/**` changes

While verifying this PR I found that the required **"Rust"** check is gated by a path-filter + stub pattern: `ci-checks.yml` runs the real build/test/clippy/fmt only for paths in its `paths:` list, while `ci-checks-ignored.yml` is a no-op stub reporting the same check name for everything else. `apps/**` was in **neither** real list, so PRs touching only example apps had "Rust" satisfied by the stub in ~3s — nothing was actually compiled or tested.

This adds `apps/**` to `ci-checks.yml` `paths:` and `ci-checks-ignored.yml` `paths-ignore:` (kept in sync per the note in those files). App-only PRs now run the real workspace build + tests, which already cover these apps (they are workspace members and `build-all-apps.sh` builds their wasm). You can see the effect on this PR: the real `Rust` job now runs on `big-machine` instead of only the 3s stub.

> ⚠️ Tradeoff for reviewers: `apps/**` is broad, so *any* app change (incl. README/comment-only) now triggers the full heavy build+test — likely why apps were excluded originally. If that's too costly, a follow-up could add a dedicated lightweight "build apps" job (`build-all-apps.sh` + `cargo build -p <apps>`) instead of routing app changes through the full `ci-checks`. Happy to split the CI commit into its own PR if preferred.

## Verification

- `cargo build --target wasm32-unknown-unknown` for all three apps → clean (only pre-existing `calimero-storage` `missing_docs` warnings).
- `cargo fmt --check` → clean for all three.
- Residual counts per app file: `drop(` = 0, `Result<_, String>` = 0, `.map_err` = 0, error-swallowing `.unwrap_or(...)` = 0.
- Both workflow files YAML-valid; `apps/**` present in the correct `paths:` / `paths-ignore:` block.

Closes #2556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving example-app cleanups and CI path wiring; no production auth, storage API, or merge semantics changes.
> 
> **Overview**
> Example apps no longer wrap `UnorderedMap` / nested collection updates in `drop(...)` or `let _ = ...`; they use plain `self.*.insert(...)?` and bare `set.insert(...)?` instead. **Team metrics** examples add `Default` on `TeamStats` and load missing teams with `unwrap_or_default()` instead of manual `Counter::new()` blocks.
> 
> **CI** now treats `apps/**` like `crates/**`: the real **CI** workflow runs on app changes, and the stub workflow ignores that path so the required **Rust** check is not satisfied by a no-op when only apps change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03637923bbae00affcd809f0a3e25714c4bb5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->