### PR TITLE
feat(sdk): #[app::state] emits its own borsh derives (#2545)

### DIFF
--- a/apps/abi_conformance/src/lib.rs
+++ b/apps/abi_conformance/src/lib.rs
@@ -114,8 +114,7 @@ pub enum Event {
 // generation actually has to handle them. State schemas are covered separately
 // by the `state-schema-conformance` app.
 #[app::state(emits = Event)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct AbiState {
     counters: UnorderedMap<String, LwwRegister<u32>>,
     // Key-ordered map — locks the `SortedMap` ABI collection marker.

--- a/apps/abi_conformance/src/lib.rs
+++ b/apps/abi_conformance/src/lib.rs
@@ -94,7 +94,6 @@ pub enum ConformanceError {
 
 // Events
 #[app::event]
-#[derive(Debug)]
 pub enum Event {
     Ping,
     Named(String),
@@ -114,7 +113,6 @@ pub enum Event {
 // generation actually has to handle them. State schemas are covered separately
 // by the `state-schema-conformance` app.
 #[app::state(emits = Event)]
-#[derive(Debug)]
 pub struct AbiState {
     counters: UnorderedMap<String, LwwRegister<u32>>,
     // Key-ordered map — locks the `SortedMap` ABI collection marker.

--- a/apps/blobs/src/lib.rs
+++ b/apps/blobs/src/lib.rs
@@ -90,7 +90,6 @@ pub struct FileShareState {
 
 /// Events emitted by the application
 #[app::event]
-#[derive(Debug)]
 pub enum FileShareEvent {
     /// Emitted when a file is successfully uploaded
     FileUploaded {

--- a/apps/blobs/src/lib.rs
+++ b/apps/blobs/src/lib.rs
@@ -75,8 +75,6 @@ impl calimero_storage::collections::Mergeable for FileRecord {
 
 /// Application state for the file sharing system.
 #[app::state(emits = FileShareEvent)]
-#[derive(BorshDeserialize, BorshSerialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
 pub struct FileShareState {
     /// Context owner's identity as base58-encoded public key.
     /// Set during initialization from `env::executor_id()`.
@@ -92,8 +90,7 @@ pub struct FileShareState {
 
 /// Events emitted by the application
 #[app::event]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub enum FileShareEvent {
     /// Emitted when a file is successfully uploaded
     FileUploaded {

--- a/apps/collaborative-editor/src/lib.rs
+++ b/apps/collaborative-editor/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![allow(clippy::len_without_is_empty)]
 
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::{app, env};
 use calimero_storage::collections::{Counter, LwwRegister, ReplicatedGrowableArray, UnorderedMap};
 
@@ -20,8 +19,6 @@ use calimero_storage::collections::{Counter, LwwRegister, ReplicatedGrowableArra
 /// All fields must be CRDTs to avoid divergence during concurrent updates.
 /// Using LWW merge on root state with non-CRDT fields causes data loss.
 #[app::state(emits = EditorEvent)]
-#[derive(BorshDeserialize, BorshSerialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
 pub struct EditorState {
     /// The collaborative text document using RGA CRDT
     pub document: ReplicatedGrowableArray,
@@ -36,8 +33,7 @@ pub struct EditorState {
 
 /// Events emitted by the collaborative editor
 #[app::event]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub enum EditorEvent {
     /// Emitted when the document is initialized
     DocumentCreated {

--- a/apps/collaborative-editor/src/lib.rs
+++ b/apps/collaborative-editor/src/lib.rs
@@ -33,7 +33,6 @@ pub struct EditorState {
 
 /// Events emitted by the collaborative editor
 #[app::event]
-#[derive(Debug)]
 pub enum EditorEvent {
     /// Emitted when the document is initialized
     DocumentCreated {

--- a/apps/kv-store-init/src/lib.rs
+++ b/apps/kv-store-init/src/lib.rs
@@ -8,7 +8,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct KvStoreInit {
     items: UnorderedMap<String, LwwRegister<String>>,
 }

--- a/apps/kv-store-init/src/lib.rs
+++ b/apps/kv-store-init/src/lib.rs
@@ -3,14 +3,12 @@
 use std::collections::BTreeMap;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct KvStoreInit {
     items: UnorderedMap<String, LwwRegister<String>>,
 }

--- a/apps/kv-store-with-handlers/src/lib.rs
+++ b/apps/kv-store-with-handlers/src/lib.rs
@@ -8,7 +8,6 @@ use calimero_storage::collections::{Counter, LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct KvStore {
     items: UnorderedMap<String, LwwRegister<String>>,
     handlers_called: UnorderedMap<String, LwwRegister<String>>, // Track handlers called with CRDT counter

--- a/apps/kv-store-with-handlers/src/lib.rs
+++ b/apps/kv-store-with-handlers/src/lib.rs
@@ -3,14 +3,12 @@
 use std::collections::BTreeMap;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{Counter, LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct KvStore {
     items: UnorderedMap<String, LwwRegister<String>>,
     handlers_called: UnorderedMap<String, LwwRegister<String>>, // Track handlers called with CRDT counter

--- a/apps/kv-store-with-shared-storage/src/lib.rs
+++ b/apps/kv-store-with-shared-storage/src/lib.rs
@@ -35,7 +35,7 @@ impl KvStore {
     pub fn init() -> KvStore {
         let initializer: PublicKey = calimero_sdk::env::executor_id().into();
         let mut writers = BTreeSet::new();
-        let _ = writers.insert(initializer);
+        writers.insert(initializer);
         KvStore {
             shared_value: SharedStorage::new(writers, false),
         }
@@ -44,7 +44,7 @@ impl KvStore {
     /// Set the shared value. Caller must be a current writer.
     pub fn set_shared(&mut self, value: String) -> app::Result<()> {
         app::log!("Setting shared value: {:?}", value);
-        let _ = self.shared_value.insert(LwwRegister::new(value.clone()))?;
+        self.shared_value.insert(LwwRegister::new(value.clone()))?;
         app::emit!(Event::SharedSet { value: &value });
         Ok(())
     }

--- a/apps/kv-store-with-shared-storage/src/lib.rs
+++ b/apps/kv-store-with-shared-storage/src/lib.rs
@@ -1,15 +1,13 @@
 use std::collections::BTreeSet;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::PublicKey;
 use calimero_storage::collections::{LwwRegister, SharedStorage};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct KvStore {
     /// Group-writable register. Initial writer is whoever installed the app.
     /// Rotation lets the writer set evolve over the app's lifetime.

--- a/apps/kv-store-with-shared-storage/src/lib.rs
+++ b/apps/kv-store-with-shared-storage/src/lib.rs
@@ -7,7 +7,6 @@ use calimero_storage::collections::{LwwRegister, SharedStorage};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct KvStore {
     /// Group-writable register. Initial writer is whoever installed the app.
     /// Rotation lets the writer set evolve over the app's lifetime.

--- a/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
+++ b/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
@@ -11,8 +11,7 @@ use calimero_storage::collections::{FrozenStorage, LwwRegister, UnorderedMap, Us
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct KvStore {
     // Public items, viewable by all
     items: UnorderedMap<String, LwwRegister<String>>,

--- a/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
+++ b/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
@@ -11,7 +11,6 @@ use calimero_storage::collections::{FrozenStorage, LwwRegister, UnorderedMap, Us
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct KvStore {
     // Public items, viewable by all
     items: UnorderedMap<String, LwwRegister<String>>,

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -3,15 +3,13 @@
 use std::collections::BTreeMap;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::unordered_map::Entry;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct KvStore {
     items: UnorderedMap<String, LwwRegister<String>>,
 }

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -9,7 +9,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct KvStore {
     items: UnorderedMap<String, LwwRegister<String>>,
 }

--- a/apps/migrations/migration-suite-v1/src/lib.rs
+++ b/apps/migrations/migration-suite-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct MigrationSuiteV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v1/src/lib.rs
+++ b/apps/migrations/migration-suite-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct MigrationSuiteV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v2-add-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v2-add-field/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct MigrationSuiteV2AddField {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v2-add-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v2-add-field/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct MigrationSuiteV2AddField {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v3-remove-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v3-remove-field/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 const SCHEMA_VERSION_V3: &str = "3.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct MigrationSuiteV3RemoveField {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v3-remove-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v3-remove-field/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 const SCHEMA_VERSION_V3: &str = "3.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct MigrationSuiteV3RemoveField {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v4-rename-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v4-rename-field/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V3: &str = "3.0.0";
 const SCHEMA_VERSION_V4: &str = "4.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct MigrationSuiteV4RenameField {
     items: UnorderedMap<String, LwwRegister<String>>,
     details: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v4-rename-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v4-rename-field/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V3: &str = "3.0.0";
 const SCHEMA_VERSION_V4: &str = "4.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct MigrationSuiteV4RenameField {
     items: UnorderedMap<String, LwwRegister<String>>,
     details: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v5-change-type/src/lib.rs
+++ b/apps/migrations/migration-suite-v5-change-type/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V4: &str = "4.0.0";
 const SCHEMA_VERSION_V5: &str = "5.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct MigrationSuiteV5ChangeType {
     items: UnorderedMap<String, LwwRegister<String>>,
     details: LwwRegister<String>,

--- a/apps/migrations/migration-suite-v5-change-type/src/lib.rs
+++ b/apps/migrations/migration-suite-v5-change-type/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V4: &str = "4.0.0";
 const SCHEMA_VERSION_V5: &str = "5.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct MigrationSuiteV5ChangeType {
     items: UnorderedMap<String, LwwRegister<String>>,
     details: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-map-v1/src/lib.rs
+++ b/apps/migrations/scenario-authored-map-v1/src/lib.rs
@@ -10,7 +10,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// each entry's recorded owner survives the migration identically on every
 /// node (authorship is part of the stored value, so it must round-trip).
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioAuthoredMapV1 {
     entries: AuthoredMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-map-v1/src/lib.rs
+++ b/apps/migrations/scenario-authored-map-v1/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{AuthoredMap, LwwRegister};
 
@@ -11,8 +10,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// each entry's recorded owner survives the migration identically on every
 /// node (authorship is part of the stored value, so it must round-trip).
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioAuthoredMapV1 {
     entries: AuthoredMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-map-v2/src/lib.rs
+++ b/apps/migrations/scenario-authored-map-v2/src/lib.rs
@@ -14,7 +14,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// node under LazyOnAccess), diverging the owners. Carrying the collection
 /// preserves the v1 owner stamps byte-for-byte, so every node converges.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioAuthoredMapV2 {
     entries: AuthoredMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-map-v2/src/lib.rs
+++ b/apps/migrations/scenario-authored-map-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{AuthoredMap, LwwRegister};
@@ -14,8 +14,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// node under LazyOnAccess), diverging the owners. Carrying the collection
 /// preserves the v1 owner stamps byte-for-byte, so every node converges.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioAuthoredMapV2 {
     entries: AuthoredMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-vector-v1/src/lib.rs
+++ b/apps/migrations/scenario-authored-vector-v1/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{AuthoredVector, LwwRegister};
 
@@ -8,8 +7,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// v1 state for the authored-vector migration scenario. `entries` is an
 /// `AuthoredVector` whose every element records the executor that pushed it.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioAuthoredVectorV1 {
     entries: AuthoredVector<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-vector-v1/src/lib.rs
+++ b/apps/migrations/scenario-authored-vector-v1/src/lib.rs
@@ -7,7 +7,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// v1 state for the authored-vector migration scenario. `entries` is an
 /// `AuthoredVector` whose every element records the executor that pushed it.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioAuthoredVectorV1 {
     entries: AuthoredVector<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-vector-v2/src/lib.rs
+++ b/apps/migrations/scenario-authored-vector-v2/src/lib.rs
@@ -19,7 +19,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// element values while preserving authorship — needs a migration-context gate
 /// relaxation and is tracked in #2534.)
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioAuthoredVectorV2 {
     entries: AuthoredVector<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-authored-vector-v2/src/lib.rs
+++ b/apps/migrations/scenario-authored-vector-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{AuthoredVector, LwwRegister};
@@ -19,8 +19,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// element values while preserving authorship — needs a migration-context gate
 /// relaxation and is tracked in #2534.)
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioAuthoredVectorV2 {
     entries: AuthoredVector<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-crdt-native-v1/src/lib.rs
+++ b/apps/migrations/scenario-crdt-native-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioCrdtNativeV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-crdt-native-v1/src/lib.rs
+++ b/apps/migrations/scenario-crdt-native-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioCrdtNativeV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-crdt-native-v2/src/lib.rs
+++ b/apps/migrations/scenario-crdt-native-v2/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioCrdtNativeV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-crdt-native-v2/src/lib.rs
+++ b/apps/migrations/scenario-crdt-native-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap, Vector};
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioCrdtNativeV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-field-remove-archive-v1/src/lib.rs
+++ b/apps/migrations/scenario-field-remove-archive-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::LwwRegister;
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioFieldRemoveArchiveV1 {
     name: LwwRegister<String>,
     legacy_note: LwwRegister<String>,

--- a/apps/migrations/scenario-field-remove-archive-v1/src/lib.rs
+++ b/apps/migrations/scenario-field-remove-archive-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::LwwRegister;
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioFieldRemoveArchiveV1 {
     name: LwwRegister<String>,
     legacy_note: LwwRegister<String>,

--- a/apps/migrations/scenario-field-remove-archive-v2/src/lib.rs
+++ b/apps/migrations/scenario-field-remove-archive-v2/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioFieldRemoveArchiveV2 {
     name: LwwRegister<String>,
     counter: LwwRegister<u64>,

--- a/apps/migrations/scenario-field-remove-archive-v2/src/lib.rs
+++ b/apps/migrations/scenario-field-remove-archive-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioFieldRemoveArchiveV2 {
     name: LwwRegister<String>,
     counter: LwwRegister<u64>,

--- a/apps/migrations/scenario-field-split-v1/src/lib.rs
+++ b/apps/migrations/scenario-field-split-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::LwwRegister;
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioFieldSplitV1 {
     name: LwwRegister<String>,
     address: LwwRegister<String>,

--- a/apps/migrations/scenario-field-split-v1/src/lib.rs
+++ b/apps/migrations/scenario-field-split-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::LwwRegister;
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioFieldSplitV1 {
     name: LwwRegister<String>,
     address: LwwRegister<String>,

--- a/apps/migrations/scenario-field-split-v2/src/lib.rs
+++ b/apps/migrations/scenario-field-split-v2/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioFieldSplitV2 {
     name: LwwRegister<String>,
     street: LwwRegister<String>,

--- a/apps/migrations/scenario-field-split-v2/src/lib.rs
+++ b/apps/migrations/scenario-field-split-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::LwwRegister;
@@ -8,8 +8,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioFieldSplitV2 {
     name: LwwRegister<String>,
     street: LwwRegister<String>,

--- a/apps/migrations/scenario-frozen-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-frozen-storage-v1/src/lib.rs
@@ -10,7 +10,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// (not a string) so it never needs an encode/decode codec, and is fetched back
 /// via `get_last_doc()` so no hash has to round-trip through a workflow variable.
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioFrozenStorageV1 {
     documents: FrozenStorage<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-frozen-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-frozen-storage-v1/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{FrozenStorage, LwwRegister};
 
@@ -11,8 +10,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// (not a string) so it never needs an encode/decode codec, and is fetched back
 /// via `get_last_doc()` so no hash has to round-trip through a workflow variable.
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioFrozenStorageV1 {
     documents: FrozenStorage<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-frozen-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-frozen-storage-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{FrozenStorage, LwwRegister};
@@ -17,8 +17,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// `migration_hash` (raw bytes) and fetched back via `get_migration_doc()` — no
 /// hash crosses a workflow variable and no encode/decode codec is needed.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioFrozenStorageV2 {
     documents: FrozenStorage<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-frozen-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-frozen-storage-v2/src/lib.rs
@@ -17,7 +17,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// `migration_hash` (raw bytes) and fetched back via `get_migration_doc()` — no
 /// hash crosses a workflow variable and no encode/decode codec is needed.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioFrozenStorageV2 {
     documents: FrozenStorage<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-invariant-reshuffle-v1/src/lib.rs
+++ b/apps/migrations/scenario-invariant-reshuffle-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioInvariantReshuffleV1 {
     global_count: LwwRegister<u64>,
     per_item_counts: UnorderedMap<String, LwwRegister<u64>>,

--- a/apps/migrations/scenario-invariant-reshuffle-v1/src/lib.rs
+++ b/apps/migrations/scenario-invariant-reshuffle-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioInvariantReshuffleV1 {
     global_count: LwwRegister<u64>,
     per_item_counts: UnorderedMap<String, LwwRegister<u64>>,

--- a/apps/migrations/scenario-invariant-reshuffle-v2/src/lib.rs
+++ b/apps/migrations/scenario-invariant-reshuffle-v2/src/lib.rs
@@ -23,7 +23,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 // requires every top-level field to be `Mergeable`, which collection
 // types satisfy but a plain struct of collections does not.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioInvariantReshuffleV2 {
     total: LwwRegister<u64>,
     per_item: UnorderedMap<String, LwwRegister<u64>>,

--- a/apps/migrations/scenario-invariant-reshuffle-v2/src/lib.rs
+++ b/apps/migrations/scenario-invariant-reshuffle-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
@@ -23,8 +23,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 // requires every top-level field to be `Mergeable`, which collection
 // types satisfy but a plain struct of collections does not.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioInvariantReshuffleV2 {
     total: LwwRegister<u64>,
     per_item: UnorderedMap<String, LwwRegister<u64>>,

--- a/apps/migrations/scenario-new-enum-variant-v1/src/lib.rs
+++ b/apps/migrations/scenario-new-enum-variant-v1/src/lib.rs
@@ -14,8 +14,7 @@ pub enum Status {
 }
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioNewEnumVariantV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-new-enum-variant-v1/src/lib.rs
+++ b/apps/migrations/scenario-new-enum-variant-v1/src/lib.rs
@@ -14,7 +14,6 @@ pub enum Status {
 }
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioNewEnumVariantV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-new-enum-variant-v2/src/lib.rs
+++ b/apps/migrations/scenario-new-enum-variant-v2/src/lib.rs
@@ -19,8 +19,7 @@ pub enum Status {
 }
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioNewEnumVariantV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-new-enum-variant-v2/src/lib.rs
+++ b/apps/migrations/scenario-new-enum-variant-v2/src/lib.rs
@@ -19,7 +19,6 @@ pub enum Status {
 }
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioNewEnumVariantV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-new-method-v1/src/lib.rs
+++ b/apps/migrations/scenario-new-method-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioNewMethodV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     counter: LwwRegister<u64>,

--- a/apps/migrations/scenario-new-method-v1/src/lib.rs
+++ b/apps/migrations/scenario-new-method-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioNewMethodV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     counter: LwwRegister<u64>,

--- a/apps/migrations/scenario-new-method-v2/src/lib.rs
+++ b/apps/migrations/scenario-new-method-v2/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioNewMethodV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     counter: LwwRegister<u64>,

--- a/apps/migrations/scenario-new-method-v2/src/lib.rs
+++ b/apps/migrations/scenario-new-method-v2/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioNewMethodV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     counter: LwwRegister<u64>,

--- a/apps/migrations/scenario-pure-bugfix-v1/src/lib.rs
+++ b/apps/migrations/scenario-pure-bugfix-v1/src/lib.rs
@@ -5,7 +5,6 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioPureBugfixV1 {
     items: UnorderedMap<String, LwwRegister<u64>>,
     last_sum: LwwRegister<u64>,

--- a/apps/migrations/scenario-pure-bugfix-v1/src/lib.rs
+++ b/apps/migrations/scenario-pure-bugfix-v1/src/lib.rs
@@ -1,13 +1,11 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioPureBugfixV1 {
     items: UnorderedMap<String, LwwRegister<u64>>,
     last_sum: LwwRegister<u64>,

--- a/apps/migrations/scenario-pure-bugfix-v2/src/lib.rs
+++ b/apps/migrations/scenario-pure-bugfix-v2/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
@@ -9,8 +8,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 // same types, same order. v2 differs only in the body of `sum_all_values`,
 // where the off-by-one bug has been fixed. No `#[app::migrate]` is needed.
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioPureBugfixV2 {
     items: UnorderedMap<String, LwwRegister<u64>>,
     last_sum: LwwRegister<u64>,

--- a/apps/migrations/scenario-pure-bugfix-v2/src/lib.rs
+++ b/apps/migrations/scenario-pure-bugfix-v2/src/lib.rs
@@ -8,7 +8,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 // same types, same order. v2 differs only in the body of `sum_all_values`,
 // where the off-by-one bug has been fixed. No `#[app::migrate]` is needed.
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioPureBugfixV2 {
     items: UnorderedMap<String, LwwRegister<u64>>,
     last_sum: LwwRegister<u64>,

--- a/apps/migrations/scenario-shared-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-shared-storage-v1/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::env;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::PublicKey;
@@ -15,8 +14,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// both the stored value and the writer set survive the migration identically
 /// on every node.
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioSharedStorageV1 {
     doc: SharedStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-shared-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-shared-storage-v1/src/lib.rs
@@ -34,7 +34,7 @@ impl ScenarioSharedStorageV1 {
         // Seed the writer set with the creating node so it can write.
         let mut writers = BTreeSet::new();
         let executor: PublicKey = env::executor_id().into();
-        let _ = writers.insert(executor);
+        writers.insert(executor);
         ScenarioSharedStorageV1 {
             doc: SharedStorage::new_with_field_name("doc", writers, false),
             title: LwwRegister::new("untitled".to_owned()),
@@ -48,7 +48,7 @@ impl ScenarioSharedStorageV1 {
 
     /// Replace the shared value. Only a writer may write.
     pub fn set_doc(&mut self, value: String) -> app::Result<()> {
-        let _ = self.doc.insert(value.into())?;
+        self.doc.insert(value.into())?;
         Ok(())
     }
 

--- a/apps/migrations/scenario-shared-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-shared-storage-v1/src/lib.rs
@@ -14,7 +14,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// both the stored value and the writer set survive the migration identically
 /// on every node.
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioSharedStorageV1 {
     doc: SharedStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-shared-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-shared-storage-v2/src/lib.rs
@@ -18,7 +18,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// per node under LazyOnAccess), diverging the writer sets. Carrying the
 /// wrapper preserves the v1 writer set byte-for-byte, so every node converges.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioSharedStorageV2 {
     doc: SharedStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-shared-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-shared-storage-v2/src/lib.rs
@@ -82,7 +82,7 @@ impl ScenarioSharedStorageV2 {
         // Seed the writer set with the creating node so it can write.
         let mut writers = BTreeSet::new();
         let executor: PublicKey = env::executor_id().into();
-        let _ = writers.insert(executor);
+        writers.insert(executor);
         ScenarioSharedStorageV2 {
             doc: SharedStorage::new_with_field_name("doc", writers, false),
             title: LwwRegister::new("untitled".to_owned()),
@@ -96,7 +96,7 @@ impl ScenarioSharedStorageV2 {
     }
 
     pub fn set_doc(&mut self, value: String) -> app::Result<()> {
-        let _ = self.doc.insert(value.into())?;
+        self.doc.insert(value.into())?;
         Ok(())
     }
 

--- a/apps/migrations/scenario-shared-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-shared-storage-v2/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::env;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
@@ -18,8 +18,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// per node under LazyOnAccess), diverging the writer sets. Carrying the
 /// wrapper preserves the v1 writer set byte-for-byte, so every node converges.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioSharedStorageV2 {
     doc: SharedStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-struct-to-enum-v1/src/lib.rs
+++ b/apps/migrations/scenario-struct-to-enum-v1/src/lib.rs
@@ -19,7 +19,6 @@ pub struct Status {
 }
 
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioStructToEnumV1 {
     name: LwwRegister<String>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-struct-to-enum-v1/src/lib.rs
+++ b/apps/migrations/scenario-struct-to-enum-v1/src/lib.rs
@@ -19,8 +19,7 @@ pub struct Status {
 }
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioStructToEnumV1 {
     name: LwwRegister<String>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-struct-to-enum-v2/src/lib.rs
+++ b/apps/migrations/scenario-struct-to-enum-v2/src/lib.rs
@@ -19,8 +19,7 @@ pub enum Status {
 }
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioStructToEnumV2 {
     name: LwwRegister<String>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-struct-to-enum-v2/src/lib.rs
+++ b/apps/migrations/scenario-struct-to-enum-v2/src/lib.rs
@@ -19,7 +19,6 @@ pub enum Status {
 }
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioStructToEnumV2 {
     name: LwwRegister<String>,
     status: LwwRegister<Status>,

--- a/apps/migrations/scenario-unordered-set-v1/src/lib.rs
+++ b/apps/migrations/scenario-unordered-set-v1/src/lib.rs
@@ -7,7 +7,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// v1 state for the unordered-set migration scenario. `tags` is a plain
 /// content-addressed `UnorderedSet` (no executor identity in its element ids).
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioUnorderedSetV1 {
     tags: UnorderedSet<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-unordered-set-v1/src/lib.rs
+++ b/apps/migrations/scenario-unordered-set-v1/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UnorderedSet};
 
@@ -8,8 +7,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// v1 state for the unordered-set migration scenario. `tags` is a plain
 /// content-addressed `UnorderedSet` (no executor identity in its element ids).
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioUnorderedSetV1 {
     tags: UnorderedSet<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-unordered-set-v2/src/lib.rs
+++ b/apps/migrations/scenario-unordered-set-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UnorderedSet};
@@ -14,8 +14,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// identity), so every node applying the SAME transform over the SAME old set
 /// produces a byte-identical set — even though migrate emits no sync delta.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioUnorderedSetV2 {
     tags: UnorderedSet<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-unordered-set-v2/src/lib.rs
+++ b/apps/migrations/scenario-unordered-set-v2/src/lib.rs
@@ -14,7 +14,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// identity), so every node applying the SAME transform over the SAME old set
 /// produces a byte-identical set — even though migrate emits no sync delta.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioUnorderedSetV2 {
     tags: UnorderedSet<String>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-user-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-user-storage-v1/src/lib.rs
@@ -11,7 +11,6 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// the migration identically on every node (the per-user slot key is part of
 /// the stored map, so it must round-trip).
 #[app::state]
-#[derive(Debug)]
 pub struct ScenarioUserStorageV1 {
     notes: UserStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-user-storage-v1/src/lib.rs
+++ b/apps/migrations/scenario-user-storage-v1/src/lib.rs
@@ -1,5 +1,4 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, UserStorage};
 
@@ -12,8 +11,7 @@ const SCHEMA_VERSION_V1: &str = "1.0.0";
 /// the migration identically on every node (the per-user slot key is part of
 /// the stored map, so it must round-trip).
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioUserStorageV1 {
     notes: UserStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-user-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-user-storage-v2/src/lib.rs
@@ -16,7 +16,6 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// the collection preserves the v1 slot keys byte-for-byte, so every node
 /// converges.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct ScenarioUserStorageV2 {
     notes: UserStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/migrations/scenario-user-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-user-storage-v2/src/lib.rs
@@ -1,5 +1,5 @@
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::borsh::BorshDeserialize;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::state::read_raw;
 use calimero_storage::collections::{LwwRegister, UserStorage};
@@ -16,8 +16,7 @@ const SCHEMA_VERSION_V2: &str = "2.0.0";
 /// the collection preserves the v1 slot keys byte-for-byte, so every node
 /// converges.
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct ScenarioUserStorageV2 {
     notes: UserStorage<LwwRegister<String>>,
     title: LwwRegister<String>,

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -18,7 +18,6 @@ use calimero_storage::collections::{
 };
 
 #[app::state(emits = TestEvent)]
-#[derive(Debug)]
 pub struct NestedCrdtTest {
     /// Map of counters - concurrent increments should sum
     pub counters: UnorderedMap<String, Counter>,
@@ -42,7 +41,6 @@ pub struct NestedCrdtTest {
 }
 
 #[app::event]
-#[derive(Debug)]
 pub enum TestEvent {
     CounterIncremented {
         key: String,

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -13,14 +13,12 @@
 )]
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::{
     Counter, LwwRegister, SortedMap, UnorderedMap, UnorderedSet, Vector,
 };
 
 #[app::state(emits = TestEvent)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct NestedCrdtTest {
     /// Map of counters - concurrent increments should sum
     pub counters: UnorderedMap<String, Counter>,
@@ -44,8 +42,7 @@ pub struct NestedCrdtTest {
 }
 
 #[app::event]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub enum TestEvent {
     CounterIncremented {
         key: String,

--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -65,8 +65,7 @@ use thiserror::Error;
 /// Only the hash of each secret lives here; the secret itself is
 /// node-local (see [`Secrets`]).
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct SecretGame {
     /// Mapping of game_id -> sha256(secret) hex. `LwwRegister` is a
     /// CRDT type — appropriate here because this is synced state

--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -65,7 +65,6 @@ use thiserror::Error;
 /// Only the hash of each secret lives here; the secret itself is
 /// node-local (see [`Secrets`]).
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct SecretGame {
     /// Mapping of game_id -> sha256(secret) hex. `LwwRegister` is a
     /// CRDT type — appropriate here because this is synced state

--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -280,14 +280,14 @@ impl SecretGame {
     /// Attach a private note to a game (private state).
     pub fn set_note(&self, game_id: String, note: String) -> app::Result<()> {
         let mut secrets = Secrets::private_load_or_default()?;
-        let _ = secrets.as_mut().notes.insert(game_id, note);
+        secrets.as_mut().notes.insert(game_id, note);
         Ok(())
     }
 
     /// Add a private user-defined tag.
     pub fn add_tag(&self, tag: String) -> app::Result<()> {
         let mut secrets = Secrets::private_load_or_default()?;
-        let _ = secrets.as_mut().tags.insert(tag);
+        secrets.as_mut().tags.insert(tag);
         Ok(())
     }
 

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -102,7 +102,6 @@ impl Default for PrivateSecrets {
 // MAIN STATE
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct E2eKvStore {
     // --- KV Storage ---
     /// Public replicated KV map

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -102,8 +102,7 @@ impl Default for PrivateSecrets {
 // MAIN STATE
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct E2eKvStore {
     // --- KV Storage ---
     /// Public replicated KV map

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -900,7 +900,7 @@ impl E2eKvStore {
 
         let value = counter.value()?;
 
-        drop(self.crdt_counters.insert(key.clone(), counter)?);
+        self.crdt_counters.insert(key.clone(), counter)?;
 
         app::emit!(Event::GCounterIncremented { key, value });
         Ok(value)
@@ -926,7 +926,7 @@ impl E2eKvStore {
 
         let value = counter.value()?;
 
-        drop(self.crdt_pn_counters.insert(key.clone(), counter)?);
+        self.crdt_pn_counters.insert(key.clone(), counter)?;
 
         app::emit!(Event::PnCounterChanged {
             key,
@@ -946,7 +946,7 @@ impl E2eKvStore {
 
         let value = counter.value()?;
 
-        drop(self.crdt_pn_counters.insert(key.clone(), counter)?);
+        self.crdt_pn_counters.insert(key.clone(), counter)?;
 
         app::emit!(Event::PnCounterChanged {
             key,
@@ -978,7 +978,7 @@ impl E2eKvStore {
     pub fn set_register(&mut self, key: String, value: String) -> app::Result<()> {
         let register = LwwRegister::new(value.clone());
 
-        drop(self.crdt_registers.insert(key.clone(), register)?);
+        self.crdt_registers.insert(key.clone(), register)?;
 
         app::emit!(Event::RegisterSet { key, value });
         Ok(())
@@ -1004,9 +1004,9 @@ impl E2eKvStore {
             .get(&outer_key)?
             .unwrap_or_else(UnorderedMap::new);
 
-        drop(inner_map.insert(inner_key.clone(), value.clone().into())?);
+        inner_map.insert(inner_key.clone(), value.clone().into())?;
 
-        drop(self.crdt_metadata.insert(outer_key.clone(), inner_map)?);
+        self.crdt_metadata.insert(outer_key.clone(), inner_map)?;
 
         app::emit!(Event::MetadataSet {
             outer_key,
@@ -1058,9 +1058,9 @@ impl E2eKvStore {
     pub fn add_tag(&mut self, key: String, tag: String) -> app::Result<()> {
         let mut set = self.crdt_tags.get(&key)?.unwrap_or_else(UnorderedSet::new);
 
-        let _ = set.insert(tag.clone())?;
+        set.insert(tag.clone())?;
 
-        drop(self.crdt_tags.insert(key.clone(), set)?);
+        self.crdt_tags.insert(key.clone(), set)?;
 
         app::emit!(Event::TagAdded { key, tag });
         Ok(())

--- a/apps/sorted-kv-store/src/lib.rs
+++ b/apps/sorted-kv-store/src/lib.rs
@@ -10,14 +10,12 @@
 use std::collections::BTreeMap;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
 use calimero_storage::collections::{LwwRegister, SortedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct SortedKvStore {
     items: SortedMap<String, LwwRegister<String>>,
 }

--- a/apps/sorted-kv-store/src/lib.rs
+++ b/apps/sorted-kv-store/src/lib.rs
@@ -15,7 +15,6 @@ use calimero_storage::collections::{LwwRegister, SortedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct SortedKvStore {
     items: SortedMap<String, LwwRegister<String>>,
 }

--- a/apps/sorted-set-store/src/lib.rs
+++ b/apps/sorted-set-store/src/lib.rs
@@ -9,12 +9,10 @@
 //! `HashSet`.
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::SortedSet;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct SortedSetStore {
     items: SortedSet<String>,
 }

--- a/apps/sorted-set-store/src/lib.rs
+++ b/apps/sorted-set-store/src/lib.rs
@@ -12,7 +12,6 @@ use calimero_sdk::app;
 use calimero_storage::collections::SortedSet;
 
 #[app::state(emits = for<'a> Event<'a>)]
-#[derive(Debug)]
 pub struct SortedSetStore {
     items: SortedSet<String>,
 }

--- a/apps/state-schema-conformance/src/lib.rs
+++ b/apps/state-schema-conformance/src/lib.rs
@@ -67,8 +67,7 @@ pub enum Status {
 
 // State with comprehensive Calimero collection types
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct StateSchemaConformance {
     // Maps with various value types (all using UnorderedMap with LwwRegister values)
     string_map: UnorderedMap<String, LwwRegister<String>>, // map<string, string>

--- a/apps/state-schema-conformance/src/lib.rs
+++ b/apps/state-schema-conformance/src/lib.rs
@@ -67,7 +67,6 @@ pub enum Status {
 
 // State with comprehensive Calimero collection types
 #[app::state]
-#[derive(Debug)]
 pub struct StateSchemaConformance {
     // Maps with various value types (all using UnorderedMap with LwwRegister values)
     string_map: UnorderedMap<String, LwwRegister<String>>, // map<string, string>

--- a/apps/sync-test/src/lib.rs
+++ b/apps/sync-test/src/lib.rs
@@ -8,12 +8,10 @@
 use std::collections::BTreeMap;
 
 use calimero_sdk::app;
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 #[app::state]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct SyncTest {
     /// Key-value entries written by different nodes.
     entries: UnorderedMap<String, LwwRegister<String>>,
@@ -23,7 +21,6 @@ pub struct SyncTest {
     /// Key: "inviter:invitee" (e.g., "sandi:matea"), Value: invitation payload (e.g., context_id).
     invitations: UnorderedMap<String, LwwRegister<String>>,
 }
-
 
 #[app::logic]
 impl SyncTest {
@@ -91,18 +88,19 @@ impl SyncTest {
         payload: String,
     ) -> app::Result<()> {
         let key = format!("{}:{}", inviter, invitee);
-        app::log!("[{}] creating invitation for {}: {}", inviter, invitee, payload);
+        app::log!(
+            "[{}] creating invitation for {}: {}",
+            inviter,
+            invitee,
+            payload
+        );
         self.invitations.insert(key, payload.into())?;
         Ok(())
     }
 
     /// Node B reads an invitation addressed to them.
     /// Returns None if the invitation hasn't synced yet.
-    pub fn read_invitation(
-        &self,
-        inviter: &str,
-        invitee: &str,
-    ) -> app::Result<Option<String>> {
+    pub fn read_invitation(&self, inviter: &str, invitee: &str) -> app::Result<Option<String>> {
         let key = format!("{}:{}", inviter, invitee);
         Ok(self.invitations.get(&key)?.map(|v| v.get().clone()))
     }

--- a/apps/sync-test/src/lib.rs
+++ b/apps/sync-test/src/lib.rs
@@ -11,7 +11,6 @@ use calimero_sdk::app;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
 #[app::state]
-#[derive(Debug)]
 pub struct SyncTest {
     /// Key-value entries written by different nodes.
     entries: UnorderedMap<String, LwwRegister<String>>,

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -53,7 +53,6 @@ impl Mergeable for TeamStats {
 
 /// Application state
 #[app::state(emits = MetricsEvent)]
-#[derive(Debug)]
 pub struct TeamMetricsApp {
     /// Maps team_id → team statistics
     /// TeamStats has a CUSTOM Mergeable impl with full control
@@ -61,7 +60,6 @@ pub struct TeamMetricsApp {
 }
 
 #[app::event]
-#[derive(Debug)]
 pub enum MetricsEvent {
     WinRecorded { team_id: String, total: u64 },
     LossRecorded { team_id: String, total: u64 },

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -53,8 +53,7 @@ impl Mergeable for TeamStats {
 
 /// Application state
 #[app::state(emits = MetricsEvent)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct TeamMetricsApp {
     /// Maps team_id → team statistics
     /// TeamStats has a CUSTOM Mergeable impl with full control
@@ -62,8 +61,7 @@ pub struct TeamMetricsApp {
 }
 
 #[app::event]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub enum MetricsEvent {
     WinRecorded { team_id: String, total: u64 },
     LossRecorded { team_id: String, total: u64 },

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -27,7 +27,6 @@ pub struct TeamStats {
 
 /// Application state
 #[app::state(emits = MetricsEvent)]
-#[derive(Debug)]
 pub struct TeamMetricsApp {
     /// Maps team_id → team statistics
     /// The TeamStats struct uses #[derive(Mergeable)] - no manual impl needed!
@@ -35,7 +34,6 @@ pub struct TeamMetricsApp {
 }
 
 #[app::event]
-#[derive(Debug)]
 pub enum MetricsEvent {
     WinRecorded { team_id: String, total: u64 },
     LossRecorded { team_id: String, total: u64 },

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -27,8 +27,7 @@ pub struct TeamStats {
 
 /// Application state
 #[app::state(emits = MetricsEvent)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct TeamMetricsApp {
     /// Maps team_id → team statistics
     /// The TeamStats struct uses #[derive(Mergeable)] - no manual impl needed!
@@ -36,8 +35,7 @@ pub struct TeamMetricsApp {
 }
 
 #[app::event]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub enum MetricsEvent {
     WinRecorded { team_id: String, total: u64 },
     LossRecorded { team_id: String, total: u64 },

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::len_without_is_empty)]
 
-use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::{app, ContextId};
 use calimero_storage::collections::Counter;
 
 #[app::state(emits = Event)]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug)]
 pub struct XCallExample {
     /// Counter for tracking pongs received.
     counter: Counter,

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -4,7 +4,6 @@ use calimero_sdk::{app, ContextId};
 use calimero_storage::collections::Counter;
 
 #[app::state(emits = Event)]
-#[derive(Debug)]
 pub struct XCallExample {
     /// Counter for tracking pongs received.
     counter: Counter,

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -55,6 +55,19 @@ impl ToTokens for StateImpl<'_> {
         let assign_ids_impl = generate_assign_deterministic_ids_impl(ident, generics, orig);
 
         quote! {
+            // State is always persisted via borsh (init save, root-state merge,
+            // `merge_root_state_typed::<T>`), so the macro injects the derives and
+            // the crate redirect itself — authors no longer hand-write
+            // `#[derive(BorshSerialize, BorshDeserialize)]` + `#[borsh(crate = ...)]`
+            // on every state type. The full-path derive only selects the proc-macro;
+            // the generated code still resolves the borsh runtime through `::borsh`
+            // by default, so the `crate` attribute redirecting it to the SDK re-export
+            // is load-bearing.
+            #[derive(
+                ::calimero_sdk::borsh::BorshSerialize,
+                ::calimero_sdk::borsh::BorshDeserialize,
+            )]
+            #[borsh(crate = "::calimero_sdk::borsh")]
             #orig
 
             impl #impl_generics ::calimero_sdk::state::AppState for #ident #ty_generics #where_clause {

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -317,6 +317,41 @@ impl<'a> TryFrom<StateImplInput<'a>> for StateImpl<'a> {
             }
         }
 
+        // `#[app::state]` injects the borsh derives + `#[borsh(crate = ...)]`
+        // itself. A leftover manual `BorshSerialize`/`BorshDeserialize` derive or
+        // `#[borsh(...)]` attribute would otherwise collide with the injected one
+        // and surface as a cryptic "conflicting implementations of trait
+        // `BorshSerialize`" error pointing at generated code. Catch it here and
+        // point straight at the attribute to delete.
+        let attrs = match input.item {
+            StructOrEnumItem::Struct(item) => &item.attrs,
+            StructOrEnumItem::Enum(item) => &item.attrs,
+        };
+
+        for attr in attrs {
+            if attr.path().is_ident("borsh") {
+                errors.subsume(SynError::new_spanned(
+                    attr,
+                    "remove this `#[borsh(...)]`: `#[app::state]` now injects the borsh crate attribute",
+                ));
+            } else if attr.path().is_ident("derive") {
+                let _ = attr.parse_nested_meta(|meta| {
+                    if meta.path.segments.last().is_some_and(|seg| {
+                        matches!(
+                            seg.ident.to_string().as_str(),
+                            "BorshSerialize" | "BorshDeserialize"
+                        )
+                    }) {
+                        errors.subsume(SynError::new_spanned(
+                            &meta.path,
+                            "remove this derive: `#[app::state]` now injects `BorshSerialize` and `BorshDeserialize`",
+                        ));
+                    }
+                    Ok(())
+                });
+            }
+        }
+
         match input.item {
             StructOrEnumItem::Struct(item) => {
                 validate_fields(&item.fields, &errors);

--- a/crates/sdk/tests/macros/valid_receivers.rs
+++ b/crates/sdk/tests/macros/valid_receivers.rs
@@ -1,7 +1,11 @@
 use calimero_sdk::app;
 
+// State is now required to be borsh-(de)serializable (the macro injects the
+// derives), so a bare `&'a ()` field — which can't deserialize — is replaced
+// with `PhantomData<&'a ()>` to keep the lifetime around for the receiver tests
+// below without violating the borsh contract.
 #[app::state]
-struct MyType<'a>(&'a ());
+struct MyType<'a>(::core::marker::PhantomData<&'a ()>);
 
 #[app::logic]
 impl<'a> MyType<'a> {

--- a/crates/wasm-abi/tests/abi_conformance.rs
+++ b/crates/wasm-abi/tests/abi_conformance.rs
@@ -57,8 +57,7 @@ pub enum Event {
 
 // State
 #[app::state(emits = Event)]
-#[derive(Debug, PartialEq, PartialOrd, BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "calimero_sdk::borsh")]
+#[derive(Debug, PartialEq, PartialOrd)]
 pub struct AbiState {
     counters: BTreeMap<String, u32>,
     users: Vec<UserId32>,


### PR DESCRIPTION
Closes #2545.

## Summary

State is always persisted via borsh (init save, root-state merge, `merge_root_state_typed::<T>`), so every state type repeated the same `#[derive(BorshSerialize, BorshDeserialize)]` + `#[borsh(crate = "calimero_sdk::borsh")]` incantation. `#[app::state]` now injects both itself, so authors write just:

```rust
#[app::state(emits = ...)]
#[derive(Debug)]
pub struct MyState { ... }
```

The full-path derive (`::calimero_sdk::borsh::Borsh*`) selects the proc-macro; the `crate` redirect is still load-bearing because borsh's generated code resolves the runtime through `::borsh` by default, which apps don't depend on directly.

`#[app::event]` is unchanged: it already injects `serde::Serialize` + the serde crate path, and events never use borsh in the SDK. The redundant borsh derives some event enums carried were just deleted.

## What changed

- **`crates/sdk/macros/src/state.rs`** — inject the borsh derives + crate attr before the user's item.
- **`crates/sdk/tests/macros/valid_receivers.rs`** — `&'a ()` state field → `PhantomData<&'a ()>`. Injected borsh makes "state is borsh-serializable" an enforced contract, and a bare reference can't derive `BorshDeserialize`; PhantomData keeps the `'a` for the receiver tests.
- **`apps/**`** (49 files) — removed the manual `#[derive(BorshSerialize, BorshDeserialize)]` + `#[borsh(crate = ...)]` from every state type and the redundant borsh on the 5 event enums. Borsh imports are removed where unused, narrowed to `BorshDeserialize` in the 14 migration apps whose old-schema structs still deserialize, and kept intact where standalone types still derive borsh (e.g. `abi_conformance` records).

## Breaking change — migration for out-of-tree apps

This is a breaking change for any app that keeps the manual derive: the macro now injects `BorshSerialize`/`BorshDeserialize`, so a manual derive on the same type produces a duplicate-impl error (`conflicting implementations of trait BorshSerialize`).

To migrate, on each `#[app::state]` type:
1. Drop `BorshSerialize, BorshDeserialize` from `#[derive(...)]` (keep your other derives — `Debug`, `Clone`, etc.).
2. Delete the `#[borsh(crate = "calimero_sdk::borsh")]` line.
3. Remove the `use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};` import **if** it's now unused (some apps borsh-derive non-state helper types — keep/narrow the import if so).

State is now required to be borsh-(de)serializable. A state type holding a non-borsh field (e.g. a bare reference) that previously compiled will now fail — this surfaces a latent bug, since such state could never have been persisted.

## Verification

- All workspace-member apps build for `wasm32-unknown-unknown` — zero conflicting-impl errors, zero borsh/unused-import warnings.
- `cargo fmt --check` clean; macros crate compiles; pre-commit hook green.
- ABI-safe: borsh's wire format is independent of the crate *path*, so the injected full-path derive is byte-identical to the old manual derive (no change for `abi_conformance` / `state-schema-conformance`).

## Notes

- `apps/sync-test` is an orphaned standalone app (not in the root `members`/`exclude`, `version.workspace = true` can't resolve), so it can't compile in isolation regardless of this change. The same mechanical transform was applied; it matches kv-store, which compiles clean.
- The `crates/sdk/tests/macros` trybuild suite is `#[ignore]`d (not in CI). If run with `cargo test -- --ignored`, regenerate the `compile_fail` `.stderr` snapshots with `TRYBUILD=overwrite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API for app authors (duplicate borsh on state fails compile) and stricter requirement that state fields be borsh-serializable; persistence wire format is intended unchanged.
> 
> **Overview**
> **`#[app::state]` now injects Borsh serialization** so app authors no longer repeat `BorshSerialize`/`BorshDeserialize` and `#[borsh(crate = "calimero_sdk::borsh")]` on every state type. The macro expands with the derives and SDK crate redirect; compile-time validation rejects leftover manual `#[derive(Borsh…)]` or `#[borsh(…)]` on state with a clear error instead of duplicate-impl failures.
> 
> Workspace **apps** drop those manual attributes on state (and redundant borsh on some **events**). Migration apps keep **`BorshDeserialize` only** on private legacy structs used in `read_raw` migrations. **`valid_receivers`** uses `PhantomData` instead of `&'a ()` so injected borsh rules are satisfied. Minor cleanups (e.g. `?` instead of `drop(...)`, ignored `insert` results) appear in a few apps but are not the theme of the PR.
> 
> **Breaking for out-of-tree apps:** remove manual borsh derives/attributes on `#[app::state]` types or builds will conflict. Wire format is unchanged (same borsh layout via SDK re-export).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da116322c70b66882ba5d38c217eb523e43540b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->