### PR TITLE
fix(storage): serialize Merkle index read-modify-writes (concurrent execute/sync race)

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -43,6 +43,77 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
+// Cross-thread serialization for index read-modify-write (core#2571).
+//
+// The Merkle index mutators below (`add_child_to`, the hash recomputes, the
+// child-removal path) read an index entry, mutate it in memory, then write it
+// back. On the native node a local write (the execute path, under
+// `context.lock()`) and a sync apply (the dedicated `SyncSessionActor`, #2316)
+// run on DIFFERENT threads with no shared lock — so two concurrent
+// read-modify-writes on the same parent index entry lose one update. The lost
+// update drops a child from a collection's `children` list while that child's
+// `Key::Entry` still exists; the collection's `full_hash` then diverges from
+// every peer's and HashComparison can never reconcile it (the same-DAG-heads /
+// different-root split-brain that loops `wait_for_sync` to timeout).
+//
+// Serializing the read-modify-writes makes each one atomic: a caller always
+// reads the CURRENT list and appends its child, so no concurrent add is lost
+// regardless of interleave. The guard is reentrant — a single logical operation
+// nests these calls on one thread — and native-only: WASM app execution is
+// single-threaded, so there is no race and the guard compiles out to nothing.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod mutation_lock {
+    use std::cell::Cell;
+    use std::sync::{Mutex, MutexGuard};
+
+    static LOCK: Mutex<()> = Mutex::new(());
+    thread_local! {
+        static DEPTH: Cell<u32> = const { Cell::new(0) };
+    }
+
+    /// Held for the duration of an index read-modify-write. The global lock is
+    /// released only when the OUTERMOST guard on this thread drops, so nested
+    /// mutators (e.g. `add_child_to` → `recalculate_ancestor_hashes_for`) don't
+    /// self-deadlock.
+    #[must_use]
+    pub(crate) struct Guard(#[allow(dead_code)] Option<MutexGuard<'static, ()>>);
+
+    pub(crate) fn guard() -> Guard {
+        DEPTH.with(|depth| {
+            let current = depth.get();
+            depth.set(current + 1);
+            if current == 0 {
+                // Recover from a poisoned lock: a panic mid-mutation never
+                // leaves a half-written index entry (each `save_index` is a
+                // single store write), so the protected data stays consistent
+                // and the lock is safe to keep using.
+                Guard(Some(
+                    LOCK.lock().unwrap_or_else(|poison| poison.into_inner()),
+                ))
+            } else {
+                Guard(None)
+            }
+        })
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+            // The held `MutexGuard` (outermost guard only) drops here.
+        }
+    }
+}
+
+/// Acquire the reentrant index-mutation guard. Native serializes concurrent
+/// read-modify-writes; WASM is single-threaded so this is a no-op.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn index_mutation_guard() -> mutation_lock::Guard {
+    mutation_lock::guard()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn index_mutation_guard() {}
+
 /// RAII scope that defers ancestor-hash recomputation for a specific
 /// `StorageAdaptor`.
 ///
@@ -308,6 +379,10 @@ pub struct Index<S: StorageAdaptor>(PhantomData<S>);
 impl<S: StorageAdaptor> Index<S> {
     /// Adds a child to a parent's collection.
     pub(crate) fn add_child_to(parent_id: Id, child: ChildInfo) -> Result<(), StorageError> {
+        // Serialize the read-modify-write so a concurrent local-write / sync
+        // apply on the same parent can't lose a child (core#2571).
+        let _mutation_guard = index_mutation_guard();
+
         // Get or create parent index
         let mut parent_index = Self::get_index(parent_id)?.unwrap_or_else(|| EntityIndex {
             id: parent_id,
@@ -398,6 +473,7 @@ impl<S: StorageAdaptor> Index<S> {
     /// # Errors
     /// Returns `StorageError` if index cannot be loaded or saved.
     pub fn add_root(root: ChildInfo) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
         let mut index = Self::get_index(root.id())?.unwrap_or_else(|| EntityIndex {
             id: root.id(),
             parent_id: None,
@@ -526,6 +602,7 @@ impl<S: StorageAdaptor> Index<S> {
 
     /// Marks an entity as deleted (sets tombstone).
     pub(crate) fn mark_deleted(id: Id, deleted_at: u64) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
         if let Some(mut index) = Self::get_index(id)? {
             index.deleted_at = Some(deleted_at);
 
@@ -648,6 +725,7 @@ impl<S: StorageAdaptor> Index<S> {
     /// defer scope is active, and from `DeferredAncestorScope::drop`
     /// when flushing a deferred set.
     pub(crate) fn recalculate_ancestor_hashes_for_now(id: Id) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
         let mut current_id = id;
 
         while let Some(parent_id) = Self::get_parent_id(current_id)? {
@@ -706,6 +784,7 @@ impl<S: StorageAdaptor> Index<S> {
     /// Uses tombstone-based deletion. To move a child to a different parent,
     /// just add it to the new parent instead.
     pub(crate) fn remove_child_from(parent_id: Id, child_id: Id) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
         Self::delete_entity_and_create_tombstone(child_id)?;
         Self::update_parent_after_child_removal(parent_id, child_id)?;
         Self::recalculate_ancestor_hashes_for(parent_id)?;
@@ -745,6 +824,7 @@ impl<S: StorageAdaptor> Index<S> {
         parent_id: Id,
         child_id: Id,
     ) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
         let mut parent_index =
             Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
 
@@ -788,6 +868,10 @@ impl<S: StorageAdaptor> Index<S> {
         merkle_hash: [u8; 32],
         updated_at: Option<UpdatedAt>,
     ) -> Result<[u8; 32], StorageError> {
+        // RMW on this entity's index entry — serialize against a concurrent
+        // `add_child_to` on the same entry so neither clobbers the other
+        // (core#2571).
+        let _mutation_guard = index_mutation_guard();
         let mut index = Self::get_index(id)?.ok_or(StorageError::IndexNotFound(id))?;
         let old_own_hash = index.own_hash;
         let old_full_hash = index.full_hash;

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -61,6 +61,14 @@ thread_local! {
 // regardless of interleave. The guard is reentrant — a single logical operation
 // nests these calls on one thread — and native-only: WASM app execution is
 // single-threaded, so there is no race and the guard compiles out to nothing.
+//
+// Why ONE global lock rather than a per-entity/per-context lock: it is
+// deadlock-free by construction (a single lock has no acquisition order to
+// invert), whereas locking individual entries would let two threads grab a
+// parent and an ancestor in opposite orders during the ancestor-hash walk and
+// deadlock. Index mutations are microsecond-scale in-memory + one store write,
+// so global serialization is cheap; a per-context lock keyed by the
+// `RuntimeEnv` context is a safe future optimization if contention ever shows.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod mutation_lock {
     use std::cell::Cell;
@@ -75,6 +83,12 @@ pub(crate) mod mutation_lock {
     /// released only when the OUTERMOST guard on this thread drops, so nested
     /// mutators (e.g. `add_child_to` → `recalculate_ancestor_hashes_for`) don't
     /// self-deadlock.
+    ///
+    /// Like a `MutexGuard`, this must reach its `Drop`. `std::mem::forget`-ing
+    /// it leaks the held lock AND leaves this thread's reentrancy `DEPTH`
+    /// elevated forever, so the thread would never re-acquire the lock and
+    /// concurrent mutations from other threads would stop being serialized.
+    /// Don't `mem::forget` it (same hazard as `DeferredAncestorScope`).
     #[must_use]
     pub(crate) struct Guard(#[allow(dead_code)] Option<MutexGuard<'static, ()>>);
 
@@ -83,10 +97,14 @@ pub(crate) mod mutation_lock {
             let current = depth.get();
             depth.set(current + 1);
             if current == 0 {
-                // Recover from a poisoned lock: a panic mid-mutation never
-                // leaves a half-written index entry (each `save_index` is a
-                // single store write), so the protected data stays consistent
-                // and the lock is safe to keep using.
+                // Recover from poisoning rather than propagate. The lock only
+                // SERIALIZES access — it adds no transactionality, and the
+                // storage layer has none either, so a panic mid-mutation can
+                // leave the index partially updated whether or not this lock
+                // exists (that is the pre-existing, lock-free behaviour). What
+                // recovery buys is that one thread's panic doesn't permanently
+                // brick every other thread's index writes; surfacing the panic
+                // is the panicking caller's job, not this guard's.
                 Guard(Some(
                     LOCK.lock().unwrap_or_else(|poison| poison.into_inner()),
                 ))
@@ -98,8 +116,11 @@ pub(crate) mod mutation_lock {
 
     impl Drop for Guard {
         fn drop(&mut self) {
+            // Release the lock (outermost guard only) BEFORE clearing depth, so
+            // the "DEPTH > 0 ⇒ this thread holds the lock" invariant never
+            // momentarily inverts.
+            drop(self.0.take());
             DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
-            // The held `MutexGuard` (outermost guard only) drops here.
         }
     }
 }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -423,6 +423,11 @@ impl<S: StorageAdaptor> Interface<S> {
             ));
         }
 
+        // RMW on this entity's index entry (read → patch storage_type → save).
+        // Serialize against a concurrent index mutation on the same entry so the
+        // signature patch and a concurrent `add_child_to` can't clobber each
+        // other (core#2571).
+        let _mutation_guard = crate::index::index_mutation_guard();
         let Some(mut index) = <Index<S>>::get_index(id)? else {
             return Ok(false);
         };

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -104,6 +104,8 @@ pub mod tests {
     pub mod collections;
     /// Common test utilities and data structures.
     pub mod common;
+    /// Concurrency race reproduction (core#2571).
+    pub mod concurrency;
     /// Comprehensive CRDT behavior tests.
     pub mod crdt;
     /// Delta creation and commit tests.

--- a/crates/storage/src/tests/concurrency.rs
+++ b/crates/storage/src/tests/concurrency.rs
@@ -1,0 +1,207 @@
+//! Concurrency reproduction harness for core#2571.
+//!
+//! The opaque-leaf sync-regression smoke test (Round 2) intermittently
+//! split-brains: two nodes settle on stable-but-different Merkle root hashes and
+//! HashComparison re-merges the same collection entity forever. Every
+//! single-threaded reproduction converges, which points at a **concurrency
+//! race**: in production a local write (the execute path) and a HashComparison
+//! apply (the dedicated `SyncSessionActor`, #2316) run on different tasks and
+//! both mutate the same collection's Merkle `children` index.
+//!
+//! `Index::add_child_to` is a read-modify-write on the parent's index entry
+//! (`get_index` → mutate the `children` Vec → `save_index`). With two
+//! concurrent writers and no per-parent lock, that is a lost-update window: one
+//! writer's freshly-added child is overwritten by the other's stale snapshot.
+//! A collection that loses a child from its `children` list (while the child's
+//! `Key::Entry` still exists) produces a `full_hash` that no peer can match —
+//! the irreconcilable divergence HashComparison loops on.
+//!
+//! These tests drive that race against a **shared, cross-thread** storage
+//! backend (the production `MockedStorage` is `thread_local!`, so it can't model
+//! two actors hitting one RocksDB).
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+use crate::address::Id;
+use crate::entities::{ChildInfo, Metadata};
+use crate::index::Index;
+use crate::store::{Key, StorageAdaptor};
+
+/// Process-global key/value store shared across threads, standing in for the
+/// single RocksDB column two actors concurrently read/write in production. Each
+/// `storage_*` call locks independently — exactly the granularity that leaves a
+/// read-modify-write across two calls unprotected.
+fn shared_store() -> &'static Mutex<BTreeMap<Key, Vec<u8>>> {
+    static STORE: OnceLock<Mutex<BTreeMap<Key, Vec<u8>>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn reset_shared_store() {
+    shared_store().lock().unwrap().clear();
+}
+
+/// A `StorageAdaptor` backed by the cross-thread [`shared_store`].
+struct SharedStore;
+
+impl StorageAdaptor for SharedStore {
+    fn storage_read(key: Key) -> Option<Vec<u8>> {
+        shared_store().lock().unwrap().get(&key).cloned()
+    }
+
+    fn storage_remove(key: Key) -> bool {
+        shared_store().lock().unwrap().remove(&key).is_some()
+    }
+
+    fn storage_write(key: Key, value: &[u8]) -> bool {
+        shared_store()
+            .lock()
+            .unwrap()
+            .insert(key, value.to_vec())
+            .is_some()
+    }
+}
+
+/// Deterministic distinct child id: group byte + 2-byte counter.
+fn child_id(group: u8, i: u16) -> Id {
+    let mut bytes = [0u8; 32];
+    bytes[0] = group;
+    bytes[1] = (i >> 8) as u8;
+    bytes[2] = (i & 0xff) as u8;
+    Id::new(bytes)
+}
+
+/// **core#2571 root-cause repro.** Two threads concurrently `add_child_to` the
+/// same parent collection (the execute path vs. the HashComparison apply path).
+/// Every inserted child has a distinct id, so a correct children index must end
+/// up with ALL of them. The read-modify-write race drops some: the parent's
+/// `children` list ends shorter than the number of inserts, which in production
+/// is the collection entity whose `full_hash` can no longer match the peer.
+#[test]
+fn concurrent_add_child_to_loses_children() {
+    reset_shared_store();
+
+    let parent = Id::new([1u8; 32]);
+    Index::<SharedStore>::add_root(ChildInfo::new(parent, [0u8; 32], Metadata::new(1, 1)))
+        .expect("seed parent index");
+
+    const PER_THREAD: u16 = 300;
+
+    let t_execute = std::thread::spawn(move || {
+        for i in 0..PER_THREAD {
+            let id = child_id(0xAA, i);
+            Index::<SharedStore>::add_child_to(
+                parent,
+                ChildInfo::new(
+                    id,
+                    [i as u8; 32],
+                    Metadata::new(100 + i as u64, 100 + i as u64),
+                ),
+            )
+            .expect("execute add_child_to");
+        }
+    });
+    let t_sync = std::thread::spawn(move || {
+        for i in 0..PER_THREAD {
+            let id = child_id(0xBB, i);
+            Index::<SharedStore>::add_child_to(
+                parent,
+                ChildInfo::new(
+                    id,
+                    [i as u8; 32],
+                    Metadata::new(200 + i as u64, 200 + i as u64),
+                ),
+            )
+            .expect("sync add_child_to");
+        }
+    });
+    t_execute.join().unwrap();
+    t_sync.join().unwrap();
+
+    let children = Index::<SharedStore>::get_children_of(parent).expect("read children");
+    let expected = (PER_THREAD as usize) * 2;
+
+    assert_eq!(
+        children.len(),
+        expected,
+        "lost-update race: parent's children index holds {} of {} concurrently-added \
+         children — a collection that loses children from its Merkle index produces a \
+         full_hash no peer can match (core#2571 HashComparison sticky-loop)",
+        children.len(),
+        expected,
+    );
+}
+
+/// The direct symptom of the race: a parent that received its children
+/// concurrently ends with a DIFFERENT `full_hash` than one that received the
+/// exact same children serially. In production the "serial" node is the writer
+/// (local execute, single-threaded) and the "concurrent" node is the one whose
+/// `SyncSessionActor` apply raced its own execute path — so their collection
+/// hashes never match and HashComparison can't heal it.
+#[test]
+fn concurrent_children_index_diverges_from_serial_full_hash() {
+    // The exact same set of children, with identical ids/metadata.
+    let children: Vec<ChildInfo> = (0..200u16)
+        .map(|i| {
+            ChildInfo::new(
+                child_id(0xCC, i),
+                [i as u8; 32],
+                Metadata::new(100 + i as u64, 100 + i as u64),
+            )
+        })
+        .collect();
+
+    let parent = Id::new([2u8; 32]);
+
+    // Baseline: add all children serially (the single-threaded writer).
+    reset_shared_store();
+    Index::<SharedStore>::add_root(ChildInfo::new(parent, [9u8; 32], Metadata::new(1, 1)))
+        .expect("seed parent");
+    for c in &children {
+        Index::<SharedStore>::add_child_to(parent, c.clone()).expect("serial add");
+    }
+    let (serial_full, _) = Index::<SharedStore>::get_hashes_for(parent)
+        .expect("hashes")
+        .expect("present");
+    let serial_len = Index::<SharedStore>::get_children_of(parent).unwrap().len();
+    assert_eq!(
+        serial_len,
+        children.len(),
+        "serial baseline must keep all children"
+    );
+
+    // Concurrent: two threads split the same children set.
+    reset_shared_store();
+    Index::<SharedStore>::add_root(ChildInfo::new(parent, [9u8; 32], Metadata::new(1, 1)))
+        .expect("seed parent");
+    let (first, second): (Vec<_>, Vec<_>) = children
+        .iter()
+        .cloned()
+        .enumerate()
+        .partition(|(i, _)| i % 2 == 0);
+    let first: Vec<ChildInfo> = first.into_iter().map(|(_, c)| c).collect();
+    let second: Vec<ChildInfo> = second.into_iter().map(|(_, c)| c).collect();
+    let h1 = std::thread::spawn(move || {
+        for c in &first {
+            Index::<SharedStore>::add_child_to(parent, c.clone()).expect("t1 add");
+        }
+    });
+    let h2 = std::thread::spawn(move || {
+        for c in &second {
+            Index::<SharedStore>::add_child_to(parent, c.clone()).expect("t2 add");
+        }
+    });
+    h1.join().unwrap();
+    h2.join().unwrap();
+    let (concurrent_full, _) = Index::<SharedStore>::get_hashes_for(parent)
+        .expect("hashes")
+        .expect("present");
+
+    assert_eq!(
+        hex::encode(serial_full),
+        hex::encode(concurrent_full),
+        "core#2571: a collection whose children were added concurrently computed a \
+         different full_hash than one that received the identical children serially — \
+         this is the divergent collection hash HashComparison re-merges forever",
+    );
+}

--- a/crates/storage/src/tests/concurrency.rs
+++ b/crates/storage/src/tests/concurrency.rs
@@ -23,6 +23,8 @@
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
+use serial_test::serial;
+
 use crate::address::Id;
 use crate::entities::{ChildInfo, Metadata};
 use crate::index::Index;
@@ -60,6 +62,13 @@ impl StorageAdaptor for SharedStore {
             .insert(key, value.to_vec())
             .is_some()
     }
+
+    // These tests drive `Index::add_child_to` directly and assert on the index
+    // children list; they don't exercise the delta stream. Opt out of it so a
+    // stray `Action::Compare` push can't touch thread-local delta state.
+    fn participates_in_sync() -> bool {
+        false
+    }
 }
 
 /// Deterministic distinct child id: group byte + 2-byte counter.
@@ -77,7 +86,12 @@ fn child_id(group: u8, i: u16) -> Id {
 /// up with ALL of them. The read-modify-write race drops some: the parent's
 /// `children` list ends shorter than the number of inserts, which in production
 /// is the collection entity whose `full_hash` can no longer match the peer.
+///
+/// `#[serial]`: both tests in this module share the process-global
+/// [`shared_store`], so they must not run concurrently with each other (one's
+/// `reset_shared_store` would clear the other's data mid-run).
 #[test]
+#[serial]
 fn concurrent_add_child_to_loses_children() {
     reset_shared_store();
 
@@ -139,6 +153,7 @@ fn concurrent_add_child_to_loses_children() {
 /// `SyncSessionActor` apply raced its own execute path — so their collection
 /// hashes never match and HashComparison can't heal it.
 #[test]
+#[serial]
 fn concurrent_children_index_diverges_from_serial_full_hash() {
     // The exact same set of children, with identical ids/metadata.
     let children: Vec<ChildInfo> = (0..200u16)


### PR DESCRIPTION
Closes #2571.

## Problem

The opaque-leaf sync-regression smoke test (Round 2) intermittently split-brains: two nodes settle on stable-but-different Merkle root hashes and HashComparison re-merges the same collection entity forever until `wait_for_sync` times out. Mostly green on `master`, but reproduced there at `c47e7446`.

## Root cause — a lost-update race on the Merkle index

On the native node:
- the **execute** path (local writes) runs under `context.lock()`, and
- the dedicated **`SyncSessionActor`** (#2316) applies HashComparison results,

on **different threads with no shared lock**. Both do a read-modify-write on a collection's `children` index entry: `get_index` → mutate the `children` Vec → `save_index`. Concurrent RMW loses one update — a child is dropped from the `children` list while its `Key::Entry` still exists. That collection's `full_hash` then diverges from every peer's, and HashComparison can never reconcile it (the same-DAG-heads / different-root split-brain).

This was confirmed by deep log analysis of a failing run (one `UnorderedMap` collection entity re-merged 35× while leaves converged) and by a deterministic harness: every *single-threaded* reproduction converges; only the concurrent one diverges.

## Fix

A **native-only reentrant guard** that serializes the index read-modify-writes (`crates/storage/src/index.rs`). Each guarded call re-reads the current list and appends, so no concurrent add is lost regardless of interleave. Properties:
- **Reentrant** — a single logical operation nests these calls on one thread (`add_child_to` → `recalculate_ancestor_hashes_for` → …) without self-deadlock.
- **Native-only** — WASM app execution is single-threaded, so the guard compiles out to nothing; no new dependency, no wasm impact.
- **Complete** — applied to every index-entry RMW path: `add_child_to`, `add_root`, `mark_deleted`, `recalculate_ancestor_hashes_for_now`, `remove_child_from`, `update_parent_after_child_removal`, `update_hash_for`, and the one direct `save_index` RMW in `Interface::update_signature_in_place`.

A single global lock can't deadlock (no lock-ordering cycle); it's only ever held across synchronous index ops (never across `.await`).

## Tests

New deterministic concurrency repro — `crates/storage/src/tests/concurrency.rs` — driving two threads against a shared cross-thread storage backend (the production `MockedStorage` is `thread_local!`):
- `concurrent_add_child_to_loses_children` — **fails pre-fix** (keeps ~half of 600 concurrently-added children), passes post-fix.
- `concurrent_children_index_diverges_from_serial_full_hash` — **fails pre-fix** (concurrent vs serial `full_hash` differ), passes post-fix.

## Verification

- Repro tests fail without the fix, pass with it.
- `cargo test -p calimero-storage --lib`: 520 passed, 0 failed (no deadlock/regression).
- `cargo test -p calimero-node --test sync_sim`: 308 passed, 0 failed (the other side of the race; opaque-leaf/HC guards intact).
- `cargo build --workspace` green; wasm build green (no-op guard path); `cargo fmt --check` clean.

## Note for reviewers

The guard is a *global* index-mutation lock, so index writes serialize across all contexts. That's correct and the ops are microsecond-scale; a per-context lock keyed by the `RuntimeEnv` context is a clean future optimization if contention ever shows up. The fix is intentionally at the storage layer (fixes the race at its root, self-contained, defense-in-depth for any concurrent storage caller) rather than serializing the HC apply under `context.lock()` at the node layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Merkle index mutation hot paths used by execute and sync; a global lock serializes all native index writes (correctness fix with possible contention, mitigated by reentrancy and short critical sections).
> 
> **Overview**
> Fixes intermittent **sync split-brain** (core#2571) where local execute and `SyncSessionActor` HashComparison apply could **lose updates** on the same Merkle index entry because `get_index` → mutate `children` → `save_index` was not atomic across threads.
> 
> On **native only**, adds a **reentrant global `index_mutation_guard`** and wraps every index read-modify-write path (`add_child_to`, root/tombstone/hash/ancestor walks, child removal, `update_hash_for`, and `update_signature_in_place`). **WASM** keeps a no-op guard. New **`tests/concurrency`** uses a cross-thread shared store to repro missing children and divergent `full_hash` pre-fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a929efb55fe6e292b49d728c16d94eb7d9c0304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->