### PR TITLE
fix(sdk): narrow #[app::state] borsh guard to the crate redirect only

### DIFF
--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -318,11 +318,17 @@ impl<'a> TryFrom<StateImplInput<'a>> for StateImpl<'a> {
         }
 
         // `#[app::state]` injects the borsh derives + `#[borsh(crate = ...)]`
-        // itself. A leftover manual `BorshSerialize`/`BorshDeserialize` derive or
-        // `#[borsh(...)]` attribute would otherwise collide with the injected one
-        // and surface as a cryptic "conflicting implementations of trait
-        // `BorshSerialize`" error pointing at generated code. Catch it here and
-        // point straight at the attribute to delete.
+        // itself. A leftover manual `BorshSerialize`/`BorshDeserialize` derive, or
+        // a `#[borsh(crate = ...)]` redirect, would otherwise collide with the
+        // injected one and surface as a cryptic "conflicting implementations of
+        // trait `BorshSerialize`" error pointing at generated code. Catch those
+        // here and point straight at the attribute to delete.
+        //
+        // Only the `crate` key collides — other container-level borsh keys
+        // (`#[borsh(init = ...)]` on a struct, `#[borsh(use_discriminant = ...)]`
+        // on an enum) are legitimate and the macro does not supply them, so they
+        // must pass through. Flagging every `#[borsh(...)]` would make those
+        // attributes impossible to use on a state type.
         let attrs = match input.item {
             StructOrEnumItem::Struct(item) => &item.attrs,
             StructOrEnumItem::Enum(item) => &item.attrs,
@@ -330,12 +336,29 @@ impl<'a> TryFrom<StateImplInput<'a>> for StateImpl<'a> {
 
         for attr in attrs {
             if attr.path().is_ident("borsh") {
-                errors.subsume(SynError::new_spanned(
-                    attr,
-                    "remove this `#[borsh(...)]`: `#[app::state]` now injects the borsh crate attribute",
-                ));
+                let mut sets_crate = false;
+                if let Err(err) = attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("crate") {
+                        sets_crate = true;
+                    }
+                    // Consume `= <value>` so iteration reaches every key rather
+                    // than stopping at the first `key = value` pair.
+                    if meta.input.peek(Token![=]) {
+                        let _: TokenStream = meta.value()?.parse()?;
+                    }
+                    Ok(())
+                }) {
+                    errors.subsume(err);
+                }
+
+                if sets_crate {
+                    errors.subsume(SynError::new_spanned(
+                        attr,
+                        "remove `crate = ...` from this `#[borsh(...)]`: `#[app::state]` injects the borsh crate redirect itself",
+                    ));
+                }
             } else if attr.path().is_ident("derive") {
-                let _ = attr.parse_nested_meta(|meta| {
+                if let Err(err) = attr.parse_nested_meta(|meta| {
                     if meta.path.segments.last().is_some_and(|seg| {
                         matches!(
                             seg.ident.to_string().as_str(),
@@ -348,7 +371,9 @@ impl<'a> TryFrom<StateImplInput<'a>> for StateImpl<'a> {
                         ));
                     }
                     Ok(())
-                });
+                }) {
+                    errors.subsume(err);
+                }
             }
         }
 
@@ -746,5 +771,74 @@ mod tests {
                 "expected merge call referencing `{index}` in:\n{rendered}",
             );
         }
+    }
+
+    /// Run the `#[app::state]` input validation (which includes the
+    /// borsh-attribute guard) over `item`, returning whether it was accepted.
+    fn state_accepts(item: StructOrEnumItem) -> bool {
+        let args = StateArgs { emits: None };
+        let accepted = match StateImpl::try_from(StateImplInput {
+            item: &item,
+            args: &args,
+        }) {
+            Ok(_) => true,
+            Err(errors) => {
+                // The error accumulator panics on drop if left non-empty, so
+                // drain it (this is what the real macro entry point does on the
+                // error path) before reporting rejection.
+                let _ = errors.to_compile_error();
+                false
+            }
+        };
+        accepted
+    }
+
+    #[test]
+    fn borsh_guard_rejects_crate_redirect_only() {
+        // `try_from` reads the reserved-ident table, a thread-local the proc-macro
+        // entry point initializes; do the same for this unit test's thread.
+        crate::reserved::init();
+
+        // The macro injects the borsh derives + `#[borsh(crate = ...)]`, so a
+        // leftover manual derive or `crate` redirect must be rejected (otherwise
+        // it surfaces later as a cryptic "conflicting implementations" error).
+        assert!(
+            !state_accepts(StructOrEnumItem::Struct(parse_quote! {
+                #[borsh(crate = "calimero_sdk::borsh")]
+                pub struct S {}
+            })),
+            "`#[borsh(crate = ...)]` must be rejected — the macro injects it",
+        );
+        assert!(
+            !state_accepts(StructOrEnumItem::Struct(parse_quote! {
+                #[derive(BorshSerialize, BorshDeserialize)]
+                pub struct S {}
+            })),
+            "a manual borsh derive must be rejected — the macro injects it",
+        );
+
+        // But the macro supplies ONLY `crate`. Other legitimate container-level
+        // borsh keys it never sets must pass through, or they become impossible
+        // to use on a state type: `init` on a struct, `use_discriminant` on an
+        // enum (required by borsh for enums with explicit discriminants).
+        assert!(
+            state_accepts(StructOrEnumItem::Struct(parse_quote! {
+                #[borsh(init = "post_load")]
+                pub struct S {}
+            })),
+            "`#[borsh(init = ...)]` is legitimate and must pass through",
+        );
+        assert!(
+            state_accepts(StructOrEnumItem::Enum(parse_quote! {
+                #[borsh(use_discriminant = true)]
+                pub enum E { A = 1, B = 2 }
+            })),
+            "`#[borsh(use_discriminant = ...)]` is legitimate and must pass through",
+        );
+
+        // And the common case — no item-level borsh attribute — is accepted.
+        assert!(state_accepts(StructOrEnumItem::Struct(parse_quote! {
+            pub struct S {}
+        })));
     }
 }


### PR DESCRIPTION
## What

Follow-up to the `#[app::state]` borsh-derive auto-injection (#2545). That PR added a guard in `StateImplInput::try_from` to catch a leftover manual borsh derive / `#[borsh(crate = ...)]` and emit a clear "remove this" error instead of a cryptic *conflicting implementations of `BorshSerialize`*. As flagged in the #2545 review, the guard was too broad: it fired on **any** `#[borsh(...)]` attribute.

The macro injects **only** `#[borsh(crate = ...)]`. Other container-level borsh keys it never supplies are legitimate and were made impossible to use on a state type, with no escape hatch:

- `#[borsh(init = "…")]` on a struct (post-deserialize init hook)
- `#[borsh(use_discriminant = true)]` on an enum — **required by borsh 1.x** for enums with explicit discriminants

## Change

- Parse the `#[borsh(...)]` attribute and flag it **only when it sets `crate`**; all other keys pass through.
- Stop discarding the `parse_nested_meta` result on both the borsh and derive branches — `subsume` the error instead of swallowing a malformed-attribute parse failure (also raised in review).
- Unit test `borsh_guard_rejects_crate_redirect_only` pins the matrix: `crate` redirect and manual borsh derive **rejected**; `init` (struct) / `use_discriminant` (enum) / no-attr **accepted**.

## Impact

Latent today — no state type in the tree currently uses `borsh(init)` or an explicit-discriminant enum — so this is a correctness/robustness fix that removes a future footgun, not an active-regression fix.

## Verification

- `cargo test -p calimero-sdk-macros` — 49 pass (incl. the new guard test)
- `calimero-sdk` builds; `kv-store` builds on `wasm32-unknown-unknown --release`
- `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proc-macro validation only; relaxes an overly broad compile-time check with no runtime behavior change.
> 
> **Overview**
> Follow-up to auto-injected borsh on `#[app::state]`: validation no longer rejects **every** `#[borsh(...)]` on the state type.
> 
> The guard now parses nested `#[borsh]` keys and errors **only** when `crate = ...` is present (that collides with the macro’s injected redirect). Legitimate keys such as `#[borsh(init = ...)]` on structs and `#[borsh(use_discriminant = true)]` on enums are allowed again.
> 
> Malformed `#[borsh]` / `#[derive]` nested-meta parse failures are **subsume**d into the macro error accumulator instead of being ignored. A unit test pins reject vs accept cases (`crate` redirect and manual borsh derives rejected; `init`, `use_discriminant`, and plain types accepted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbb8165a536d1673c00c4bba4407181047a3054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->