### PR TITLE
fix(storage): serialize entity value-write with own_hash update on merge (#2571)

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2087,6 +2087,30 @@ impl<S: StorageAdaptor> Interface<S> {
         data: &[u8],
         metadata: Metadata,
     ) -> Result<Option<(bool, [u8; 32])>, StorageError> {
+        // Serialize the WHOLE read-merge-write-rehash sequence, not just the
+        // index update. The entry-value write (`storage_write(Key::Entry(id))`)
+        // and the `own_hash` update (`Index::update_hash_for`) are two separate
+        // store writes; `own_hash = Sha256(final_data)` is computed from THIS
+        // call's merged bytes. Without a guard spanning both, a concurrent
+        // writer for the same id (the execute path vs. the dedicated sync
+        // apply, which run on different threads sharing one store) can land its
+        // value write and its own_hash update in opposite orders, leaving the
+        // stored bytes and the recorded `own_hash` from DIFFERENT writers. A
+        // peer recomputing the leaf hash from the bytes then never matches this
+        // node's advertised `own_hash`, so the parent collection's `full_hash`
+        // can't converge and HashComparison re-merges it forever (the
+        // stable-but-different root-hash split-brain). The guard is reentrant,
+        // so the nested `update_hash_for` / `add_child_to` re-acquire it on this
+        // thread without deadlock; on wasm it compiles out (single-threaded).
+        //
+        // TODO(perf): this widens the global mutation guard to span the CRDT
+        // merge (not just the microsecond index update it was scoped to), so all
+        // entity writes now serialize through one process-global lock for the
+        // duration of a merge. Revisit whether this regresses write throughput
+        // on hot collections; if so, move to a per-entity (id-keyed) lock so
+        // independent entities can merge in parallel.
+        let _mutation_guard = crate::index::index_mutation_guard();
+
         let incoming_updated_at = metadata.updated_at();
 
         // Compute incoming data hash for tracing
@@ -2305,6 +2329,19 @@ impl<S: StorageAdaptor> Interface<S> {
         // merges for `Root<T>` entries would fail with `IndexNotFound`
         // and the deferred WASM merge would be dropped, leaving the
         // receiver's root entity permanently divergent.
+        //
+        // Hold the reentrant mutation guard across the whole LWW-check →
+        // entry-write → own_hash-update sequence for the same reason as
+        // `save_internal`: the value write and the `own_hash` update are
+        // separate store writes, and a concurrent writer for this id must not
+        // interleave between them or the stored bytes and recorded `own_hash`
+        // diverge.
+        //
+        // TODO(perf): see the matching note in `save_internal` — this holds the
+        // process-global guard across the merge; revisit for a per-entity lock
+        // if it regresses write throughput.
+        let _mutation_guard = crate::index::index_mutation_guard();
+
         let last_metadata = <Index<S>>::get_metadata(id)?;
 
         // LWW guard — same shape as `save_internal`'s LWW-by-HLC

--- a/crates/storage/src/tests/concurrency.rs
+++ b/crates/storage/src/tests/concurrency.rs
@@ -444,6 +444,16 @@ fn concurrent_merge_splits_value_from_own_hash() {
 
     const ROUNDS: u16 = 40;
     const PER_THREAD: u16 = 60;
+    // `round`/`i` are stamped into the per-write payload as a single `u8`
+    // below; keep the counts inside one byte so two distinct rounds/iters can
+    // never collide on the same payload pattern. The loops are exclusive, so
+    // the largest stamped value is `count - 1`; `<= 256` (not `< 256`) is the
+    // correct bound — at `count == 256` the max index is 255, which still fits
+    // a `u8`. This byte budget guards ONLY payload uniqueness for the
+    // value-winner assertion; it has no bearing on the HLC-ordering guarantee
+    // below, which holds for any `PER_THREAD`.
+    const _: () = assert!(ROUNDS <= 256, "round as u8 would truncate");
+    const _: () = assert!(PER_THREAD <= 256, "i as u8 would truncate");
 
     for round in 0..ROUNDS {
         reset_shared_store();
@@ -453,7 +463,13 @@ fn concurrent_merge_splits_value_from_own_hash() {
 
         // Each writer churns a distinct, monotonically-newer value so every
         // Update is accepted (incoming-newer) and actually writes — maximising
-        // the interleave between the value write and the own_hash update.
+        // the interleave between the value write and the own_hash update. The
+        // two threads use interleaved-but-disjoint HLC ranges (execute = even,
+        // sync = odd) so writes are *strictly* newer rather than equal-HLC: the
+        // merge takes the `incoming_timestamp > existing` branch (the one the
+        // bug targets), not the equal-HLC content-hash tiebreak. The global
+        // maximum HLC is therefore `t_sync`'s last write, so the converged
+        // value is deterministic — asserted after the loop joins.
         let t_execute = std::thread::spawn(move || {
             for i in 0..PER_THREAD {
                 let ts = 100 + i as u64 * 2;
@@ -462,7 +478,7 @@ fn concurrent_merge_splits_value_from_own_hash() {
         });
         let t_sync = std::thread::spawn(move || {
             for i in 0..PER_THREAD {
-                let ts = 100 + i as u64 * 2;
+                let ts = 101 + i as u64 * 2;
                 update_lww_leaf(leaf, vec![0xBB, round as u8, i as u8], ts);
             }
         });
@@ -484,6 +500,23 @@ fn concurrent_merge_splits_value_from_own_hash() {
              contribution to the collection full_hash",
             hex::encode(stored_hash),
             hex::encode(own_hash),
+        );
+
+        // The converged value must be the global LWW winner, not merely
+        // self-consistent: `t_sync`'s highest HLC (101 + 2*(PER_THREAD-1))
+        // strictly exceeds every `t_execute` write (100 + 2*(PER_THREAD-1)).
+        // `lww_pick` resolves by HLC magnitude, not arrival order — a lower-ts
+        // write loses whether it arrives as `incoming` or sits as `existing` —
+        // so the leaf settles on that single highest-ts payload no matter how
+        // the two threads interleave. This is a second, independent invariant
+        // from the hash check above: it catches a "hash is self-consistent but
+        // the bytes are a stale writer's" regression the hash check can't see.
+        let expected = vec![0xBB, round as u8, (PER_THREAD - 1) as u8];
+        assert_eq!(
+            stored, expected,
+            "core#2571 (round {round}): converged on the wrong writer's value — \
+             expected the global LWW winner (t_sync's last write) but stored {:?}",
+            stored,
         );
     }
 }

--- a/crates/storage/src/tests/concurrency.rs
+++ b/crates/storage/src/tests/concurrency.rs
@@ -80,6 +80,46 @@ fn child_id(group: u8, i: u16) -> Id {
     Id::new(bytes)
 }
 
+/// Seed `root` (top of tree) and place `map` under it, single-threaded. The
+/// production execute/sync race we model is only on the concurrent leaf inserts.
+fn seed_root_and_map(root: Id, map: Id) {
+    use crate::action::Action;
+    use crate::interface::{ApplyContext, Interface};
+
+    Index::<SharedStore>::add_root(ChildInfo::new(root, [0u8; 32], Metadata::new(1, 1)))
+        .expect("seed root index");
+    // `root` is already in the index, so the ancestor ChildInfo's hash is never
+    // consulted (the ancestor loop skips present entries); `[0; 32]` is fine.
+    Interface::<SharedStore>::apply_action(
+        Action::Add {
+            id: map,
+            data: b"map-collection".to_vec(),
+            ancestors: vec![ChildInfo::new(root, [0u8; 32], Metadata::new(1, 1))],
+            metadata: Metadata::new(2, 2),
+        },
+        &ApplyContext::empty(),
+    )
+    .expect("seed map under root");
+}
+
+/// Apply a single leaf under `map` via the production `apply_action` path (the
+/// same entry point the execute and HashComparison-apply paths both use).
+fn apply_leaf_under_map(map: Id, id: Id, data: Vec<u8>, ts: u64) {
+    use crate::action::Action;
+    use crate::interface::{ApplyContext, Interface};
+
+    Interface::<SharedStore>::apply_action(
+        Action::Add {
+            id,
+            data,
+            ancestors: vec![ChildInfo::new(map, [0u8; 32], Metadata::new(2, 2))],
+            metadata: Metadata::new(ts, ts),
+        },
+        &ApplyContext::empty(),
+    )
+    .expect("apply leaf under map");
+}
+
 /// **core#2571 root-cause repro.** Two threads concurrently `add_child_to` the
 /// same parent collection (the execute path vs. the HashComparison apply path).
 /// Every inserted child has a distinct id, so a correct children index must end
@@ -219,4 +259,231 @@ fn concurrent_children_index_diverges_from_serial_full_hash() {
          different full_hash than one that received the identical children serially — \
          this is the divergent collection hash HashComparison re-merges forever",
     );
+}
+
+/// **core#2571 — negative result: the composite `apply_action` insert path is
+/// NOT the residual divergence source.**
+///
+/// #2573 made `Index::add_child_to` itself atomic (the two tests above, which
+/// call it directly, prove that). The natural next suspect was one level up:
+/// production never calls `add_child_to` in isolation — the execute path and
+/// the HashComparison apply path both go through `Interface::apply_action`,
+/// which performs a *multi-step* index read-modify-write for a single
+/// `Action::Add` of a nested entity — `add_child_to(parent, placeholder)` →
+/// `save_internal` → `add_child_to(parent, real_hash)` (interface.rs) — each
+/// step taking and releasing the #2573 guard *independently*. So the composite
+/// is not atomic against a concurrent `apply_action` on the same parent.
+///
+/// This test drives exactly that interleave: two threads concurrently
+/// `apply_action(Action::Add { leaf })` for *distinct* leaves under the same
+/// nested map, compared against a serial baseline. It **converges** (asserts
+/// equal root hashes) and is robust across many runs — because `add_child_to`
+/// re-reads and merges the live `children` list under the guard rather than
+/// overwriting it, every interleaving of pure inserts ends with the full child
+/// set. The live #2571 split-brain therefore does NOT originate in concurrent
+/// nested *inserts* at the index layer; it lies in the value-merge / re-apply
+/// path (e.g. a concurrent container `Action::Update` whose `save_internal`
+/// short-circuit on equal/stale `updated_at` skips the parent-hash recompute,
+/// or a non-idempotent CRDT value merge). Kept as a regression guard so a
+/// future change to the composite path can't silently reintroduce child loss.
+#[test]
+#[serial]
+fn concurrent_apply_action_nested_inserts_converge() {
+    let root = Id::new([0x11; 32]);
+    let map = Id::new([0x22; 32]);
+
+    // Distinct (id, data, timestamp) per leaf: distinct data ⇒ distinct
+    // own_hash, so a correct map ends with every leaf contributing to its
+    // (and the root's) Merkle hash.
+    const LEAVES: u16 = 200;
+    let leaves: Vec<(Id, Vec<u8>, u64)> = (0..LEAVES)
+        .map(|i| {
+            let mut data = vec![0u8; 8];
+            data[0] = (i >> 8) as u8;
+            data[1] = (i & 0xff) as u8;
+            (child_id(0xDD, i), data, 100 + i as u64)
+        })
+        .collect();
+
+    // Serial baseline: one writer applies every leaf.
+    reset_shared_store();
+    seed_root_and_map(root, map);
+    for (id, data, ts) in &leaves {
+        apply_leaf_under_map(map, *id, data.clone(), *ts);
+    }
+    let (serial_root, _) = Index::<SharedStore>::get_hashes_for(root)
+        .expect("root hashes")
+        .expect("root present");
+    assert_eq!(
+        Index::<SharedStore>::get_children_of(map).unwrap().len(),
+        leaves.len(),
+        "serial baseline must keep every leaf under the map",
+    );
+
+    // Concurrent: two threads split the same leaves and apply them through
+    // `apply_action` simultaneously — the execute-vs-HashComparison interleave.
+    reset_shared_store();
+    seed_root_and_map(root, map);
+    let (first, second): (Vec<_>, Vec<_>) = leaves
+        .iter()
+        .cloned()
+        .enumerate()
+        .partition(|(i, _)| i % 2 == 0);
+    let first: Vec<_> = first.into_iter().map(|(_, l)| l).collect::<Vec<_>>();
+    let second: Vec<_> = second.into_iter().map(|(_, l)| l).collect::<Vec<_>>();
+    let t_execute = std::thread::spawn(move || {
+        for (id, data, ts) in &first {
+            apply_leaf_under_map(map, *id, data.clone(), *ts);
+        }
+    });
+    let t_sync = std::thread::spawn(move || {
+        for (id, data, ts) in &second {
+            apply_leaf_under_map(map, *id, data.clone(), *ts);
+        }
+    });
+    t_execute.join().unwrap();
+    t_sync.join().unwrap();
+
+    let (concurrent_root, _) = Index::<SharedStore>::get_hashes_for(root)
+        .expect("root hashes")
+        .expect("root present");
+    let concurrent_children = Index::<SharedStore>::get_children_of(map).unwrap().len();
+
+    assert_eq!(
+        concurrent_children,
+        leaves.len(),
+        "concurrent apply_action dropped a leaf from the map's children index \
+         ({} of {}) — the collection's full_hash can no longer match a peer's",
+        concurrent_children,
+        leaves.len(),
+    );
+    assert_eq!(
+        hex::encode(serial_root),
+        hex::encode(concurrent_root),
+        "core#2571 residual: applying the identical nested leaves concurrently via \
+         apply_action produced a different ROOT full_hash than applying them serially \
+         — the same-content / different-root split-brain HashComparison cannot heal",
+    );
+}
+
+/// Seed a single LWW leaf entity `leaf` under `parent` (already a root in the
+/// index) with an initial value, single-threaded.
+fn seed_lww_leaf(parent: Id, leaf: Id, value: &[u8]) {
+    use crate::action::Action;
+    use crate::collections::crdt_meta::CrdtType;
+    use crate::interface::{ApplyContext, Interface};
+
+    let mut md = Metadata::new(1, 1);
+    md.crdt_type = Some(CrdtType::LwwRegister {
+        inner_type: "String".to_string(),
+    });
+    Interface::<SharedStore>::apply_action(
+        Action::Add {
+            id: leaf,
+            data: value.to_vec(),
+            ancestors: vec![ChildInfo::new(parent, [0u8; 32], Metadata::new(1, 1))],
+            metadata: md,
+        },
+        &ApplyContext::empty(),
+    )
+    .expect("seed lww leaf");
+}
+
+/// Apply an `Action::Update` to `leaf` carrying `value` at HLC `ts`, via the
+/// production `apply_action` → `save_internal` → CRDT-merge path.
+fn update_lww_leaf(leaf: Id, value: Vec<u8>, ts: u64) {
+    use crate::action::Action;
+    use crate::collections::crdt_meta::CrdtType;
+    use crate::interface::{ApplyContext, Interface};
+
+    let mut md = Metadata::new(ts, ts);
+    md.crdt_type = Some(CrdtType::LwwRegister {
+        inner_type: "String".to_string(),
+    });
+    Interface::<SharedStore>::apply_action(
+        Action::Update {
+            id: leaf,
+            data: value,
+            ancestors: vec![],
+            metadata: md,
+        },
+        &ApplyContext::empty(),
+    )
+    .expect("update lww leaf");
+}
+
+/// **core#2571 live-bug repro — the value/own_hash split.**
+///
+/// `save_internal` (and the CRDT-merge helper it calls) persist an entity in two
+/// unsynchronised steps: `storage_write(Key::Entry(id), merged)` for the VALUE,
+/// then `Index::update_hash_for(id, own_hash, ..)` for the recorded `own_hash`,
+/// where `own_hash = Sha256(merged)` is computed *before* the value write. #2573
+/// added the mutation guard, but it wraps only `update_hash_for` — the value
+/// write sits outside it (the code even notes "the storage layer doesn't
+/// serialize concurrent writes anyway"). So when the execute path and the
+/// HashComparison-apply path merge the SAME entity concurrently, the last VALUE
+/// write and the last `own_hash` write can come from DIFFERENT writers, leaving
+/// the stored bytes and their recorded Merkle `own_hash` inconsistent.
+///
+/// A peer that recomputes the leaf hash from the bytes gets `Sha256(value)`,
+/// while this node's index advertises a different `own_hash` — so the parent
+/// collection's `full_hash` can never match and HashComparison re-merges the
+/// container forever (the stable-but-different root-hash split-brain).
+///
+/// The invariant asserted is storage-layer, CRDT-agnostic: a present entity's
+/// stored bytes must hash to its recorded `own_hash`. Two threads concurrently
+/// `Action::Update` the same LWW leaf with churning values; the round is
+/// repeated so the non-sticky race is reliably observed.
+#[test]
+#[serial]
+fn concurrent_merge_splits_value_from_own_hash() {
+    use sha2::{Digest, Sha256};
+
+    let root = Id::new([0x31; 32]);
+    let leaf = Id::new([0x32; 32]);
+
+    const ROUNDS: u16 = 40;
+    const PER_THREAD: u16 = 60;
+
+    for round in 0..ROUNDS {
+        reset_shared_store();
+        Index::<SharedStore>::add_root(ChildInfo::new(root, [0u8; 32], Metadata::new(1, 1)))
+            .expect("seed root");
+        seed_lww_leaf(root, leaf, b"genesis");
+
+        // Each writer churns a distinct, monotonically-newer value so every
+        // Update is accepted (incoming-newer) and actually writes — maximising
+        // the interleave between the value write and the own_hash update.
+        let t_execute = std::thread::spawn(move || {
+            for i in 0..PER_THREAD {
+                let ts = 100 + i as u64 * 2;
+                update_lww_leaf(leaf, vec![0xAA, round as u8, i as u8], ts);
+            }
+        });
+        let t_sync = std::thread::spawn(move || {
+            for i in 0..PER_THREAD {
+                let ts = 100 + i as u64 * 2;
+                update_lww_leaf(leaf, vec![0xBB, round as u8, i as u8], ts);
+            }
+        });
+        t_execute.join().unwrap();
+        t_sync.join().unwrap();
+
+        let stored = SharedStore::storage_read(Key::Entry(leaf)).expect("leaf value present");
+        let stored_hash: [u8; 32] = Sha256::digest(&stored).into();
+        let (_full, own_hash) = Index::<SharedStore>::get_hashes_for(leaf)
+            .expect("leaf hashes")
+            .expect("leaf index present");
+
+        assert_eq!(
+            hex::encode(stored_hash),
+            hex::encode(own_hash),
+            "core#2571 (round {round}): the stored entity bytes hash to {} but the \
+             Merkle index records own_hash {} — concurrent merges split the value \
+             write from the own_hash update, so peers can never match this leaf's \
+             contribution to the collection full_hash",
+            hex::encode(stored_hash),
+            hex::encode(own_hash),
+        );
+    }
 }

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -3060,3 +3060,264 @@ fn test_nested_pncounter_concurrent_writers_converge() {
         hex::encode(b_root),
     );
 }
+
+/// **core#2571 live-bug repro target — the production type and shape.**
+///
+/// The sync-regression smoke split-brains on a `UnorderedMap<String,
+/// LwwRegister<String>>` collection entity: HashComparison re-merges the
+/// container forever and the two nodes settle on stable-but-different root
+/// hashes. The earlier `add_child_to` (#2573) and composite-`apply_action`
+/// (concurrency.rs) repros both converge, so the divergence is not in the index
+/// RMW for inserts — it must be in the value-merge / re-apply path for the
+/// container itself.
+///
+/// This mirrors `test_nested_counter_first_touch_concurrent_converges` but with
+/// the *production* element type (`LwwRegister<String>`) and **distinct keys**
+/// (the "concurrent bidirectional inserts" of the issue title): node A inserts
+/// `a`, node B inserts `b`, then each applies the other's delta in the opposite
+/// order. A correct CRDT map converges to `{a, b}` with an apply-order-
+/// independent Merkle root on both nodes. If the container re-apply path is the
+/// #2571 source, the two root hashes diverge here.
+#[test]
+#[serial]
+fn test_kv_map_bidirectional_distinct_key_inserts_converge() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct KvApp {
+        kv: UnorderedMap<String, LwwRegister<String>>,
+    }
+    impl Mergeable for KvApp {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.kv.merge(&other.kv)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<KvApp, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<KvApp>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let insert_kv = |key: &str, val: &str| -> Vec<Action> {
+        let mut doc = Root::<KvApp, S>::fetch().unwrap();
+        doc.kv
+            .insert(key.to_string(), LwwRegister::new(val.to_string()))
+            .unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: empty map shared by both nodes.
+    fresh([9; 32]);
+    let g = Root::<KvApp, S>::new(|| KvApp {
+        kv: UnorderedMap::new_with_field_name("kv"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    // Node A inserts key "a"; node B inserts key "b" — concurrent, distinct keys.
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = insert_kv("a", "va");
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = insert_kv("b", "vb");
+
+    let keys = || -> Vec<String> {
+        let doc = Root::<KvApp, S>::fetch().unwrap();
+        let mut ks: Vec<String> = doc.kv.entries().unwrap().map(|(k, _)| k).collect();
+        ks.sort();
+        ks
+    };
+    let materialize =
+        |exec: [u8; 32], first: &[Action], second: &[Action]| -> (Vec<String>, [u8; 32]) {
+            fresh(exec);
+            import(base.clone());
+            reset_delta_context();
+            set_current_heads(vec![base_hash]);
+            import(first.to_vec());
+            reset_delta_context();
+            set_current_heads(vec![root_hash()]);
+            import(second.to_vec());
+            (keys(), root_hash())
+        };
+
+    // node A applies [a, then b]; node B applies [b, then a] — opposite orders.
+    let (a_keys, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_keys, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_keys,
+        vec!["a".to_string(), "b".to_string()],
+        "node A must hold both keys"
+    );
+    assert_eq!(
+        b_keys,
+        vec!["a".to_string(), "b".to_string()],
+        "node B must hold both keys"
+    );
+
+    assert_eq!(
+        a_root,
+        b_root,
+        "core#2571: bidirectional distinct-key inserts into UnorderedMap<String, \
+         LwwRegister<String>> must converge to an apply-order-independent root hash: \
+         A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
+/// core#2571 variant: **same-key concurrent writes** (LWW conflict). Both nodes
+/// write key "k" with different values from different executors. LWW must pick a
+/// deterministic winner (HLC, then node-id tiebreak) on BOTH nodes, and the
+/// Merkle root must converge regardless of apply order. A divergence here is the
+/// LwwRegister value/own_hash mismatch that HashComparison re-merges forever.
+#[test]
+#[serial]
+fn test_kv_map_same_key_concurrent_writes_converge() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct KvApp {
+        kv: UnorderedMap<String, LwwRegister<String>>,
+    }
+    impl Mergeable for KvApp {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.kv.merge(&other.kv)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<KvApp, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<KvApp>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let write_k = |val: &str| -> Vec<Action> {
+        let mut doc = Root::<KvApp, S>::fetch().unwrap();
+        doc.kv
+            .insert("k".to_string(), LwwRegister::new(val.to_string()))
+            .unwrap();
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    fresh([9; 32]);
+    let g = Root::<KvApp, S>::new(|| KvApp {
+        kv: UnorderedMap::new_with_field_name("kv"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = write_k("from_a");
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = write_k("from_b");
+
+    let value_of = || -> Option<String> {
+        Root::<KvApp, S>::fetch()
+            .unwrap()
+            .kv
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|r| r.get().clone())
+    };
+    let materialize =
+        |exec: [u8; 32], first: &[Action], second: &[Action]| -> (Option<String>, [u8; 32]) {
+            fresh(exec);
+            import(base.clone());
+            reset_delta_context();
+            set_current_heads(vec![base_hash]);
+            import(first.to_vec());
+            reset_delta_context();
+            set_current_heads(vec![root_hash()]);
+            import(second.to_vec());
+            (value_of(), root_hash())
+        };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, b_val,
+        "same-key LWW winner must match on both nodes: A={a_val:?} B={b_val:?}"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "core#2571: same-key concurrent LWW writes must converge to an apply-order-\
+         independent root hash: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}


### PR DESCRIPTION
## Problem

The sync-regression smoke (e.g. run 26744325134) intermittently split-brains on a `UnorderedMap<String, LwwRegister<String>>` collection: two nodes settle on **stable-but-different** Merkle root hashes and HashComparison re-merges the same container entity forever (`root_hash_verified=false`, identical stats every tick). This is the residual of #2571 — the previous fix (#2573) closed the issue on paper but the smoke still reproduces *with #2573 present*.

## Root cause

`save_internal` (and `write_pre_merged_root_state`) persist an entity in **two unsynchronised store writes**:

```rust
let own_hash = Sha256::digest(&final_data);            // computed up front
let _ = S::storage_write(Key::Entry(id), &final_data); // VALUE write  — UNGUARDED
Index::<S>::update_hash_for(id, own_hash, …)?;         // own_hash write — #2573 guard scoped HERE only
```

#2573 added the global mutation guard but scoped it to `update_hash_for`; the value write sits outside it (the code even noted *"the storage layer doesn't serialize concurrent writes anyway"*). When the execute path and the dedicated sync-apply actor merge the **same** entity on different threads sharing one store, the last value write and the last `own_hash` write can come from **different writers**. The stored bytes then hash to one value while the index advertises another → a peer recomputing the leaf hash never matches → the parent collection's `full_hash` can't converge → the permanent split-brain HashComparison loops on.

## Fix

Take the reentrant global mutation guard at the **top** of both functions, so the whole `read → merge → value-write → own_hash-update` sequence is atomic against any concurrent writer for the same id. The guard is reentrant, so nested `update_hash_for` / `add_child_to` re-acquire it on the same thread without deadlock; on wasm it compiles out (single-threaded).

A `TODO(perf)` is left at both sites: this widens the global guard to span the CRDT merge (not just the microsecond index update), so all entity writes now serialize through one process-global lock for the merge duration — worth checking for write-throughput regression, and moving to a per-entity (id-keyed) lock if it bites.

## Tests (`crates/storage/src/tests`)

- **`concurrency.rs::concurrent_merge_splits_value_from_own_hash`** — threaded repro asserting the storage invariant `Sha256(stored bytes) == recorded own_hash`. **Red before this fix (8/8 runs), green after (10/10).**
- **Bracketing tests** proving where the bug *isn't* (and isolating it to the threaded value/own_hash split):
  - `concurrency.rs::concurrent_apply_action_nested_inserts_converge` — composite `apply_action` index inserts converge under threads.
  - `merge_integration.rs::test_kv_map_bidirectional_distinct_key_inserts_converge` and `::test_kv_map_same_key_concurrent_writes_converge` — single-threaded value merges converge in every apply order.

`calimero-storage` lib suite: 524 passed / 0 failed. `cargo fmt --check` clean.

Closes #2571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness fix for sync/Merkle convergence, but holding the global mutation guard across full CRDT merges may reduce write throughput on hot paths until per-entity locking is considered.
> 
> **Overview**
> Fixes **core#2571** by holding the reentrant **`index_mutation_guard`** for the full entity persist path in **`save_internal`** and **`write_pre_merged_root_state`**, so **CRDT merge → `Key::Entry` write → `own_hash` / Merkle index update** cannot interleave across execute vs sync-apply threads on the same id. Previously the guard only covered index updates, which could leave **stored bytes and recorded `own_hash` from different writers** and cause permanent HashComparison / root-hash split-brain.
> 
> Adds **`TODO(perf)`** notes that this widens the process-global lock across merges (possible write-throughput cost; per-entity locking suggested later).
> 
> **Tests** document and guard the failure mode: threaded **`concurrent_merge_splits_value_from_own_hash`** (value/hash invariant), plus convergence checks for nested **`apply_action`** inserts and single-threaded **`UnorderedMap<String, LwwRegister<String>>`** bidirectional / same-key scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f4f436eb349c3fd262fd01d908bc97e213207f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->