### PR TITLE
feat(sdk): Entry::or_default() write-back guard for nested CRDTs

### DIFF
--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -89,13 +89,14 @@ impl NestedCrdtTest {
     // ===== Counter Operations =====
 
     pub fn increment_counter(&mut self, key: String) -> app::Result<u64> {
-        let mut counter = self.counters.get(&key)?.unwrap_or_else(|| Counter::new());
+        // `or_default()` returns a write-back guard: the counter is re-persisted
+        // when `counter` drops at the end of this method, so there is no manual
+        // get → modify → re-insert dance.
+        let mut counter = self.counters.entry(key.clone())?.or_default()?;
 
         counter.increment()?;
 
         let value = counter.value()?;
-
-        self.counters.insert(key.clone(), counter)?;
 
         app::emit!(TestEvent::CounterIncremented { key, value });
 
@@ -177,14 +178,12 @@ impl NestedCrdtTest {
         inner_key: String,
         value: String,
     ) -> app::Result<()> {
-        let mut inner_map = self
-            .metadata
-            .get(&outer_key)?
-            .unwrap_or_else(|| UnorderedMap::new());
+        // Two levels deep: the guard yields the inner map in place and writes the
+        // whole nested CRDT back when it drops — `or_default()` composes for
+        // `Map<String, Map<String, _>>` without re-inserting either level.
+        let mut inner_map = self.metadata.entry(outer_key.clone())?.or_default()?;
 
         inner_map.insert(inner_key.clone(), value.clone().into())?;
-
-        self.metadata.insert(outer_key.clone(), inner_map)?;
 
         app::emit!(TestEvent::MetadataSet {
             outer_key,
@@ -236,11 +235,9 @@ impl NestedCrdtTest {
     // ===== Set Operations =====
 
     pub fn add_tag(&mut self, key: String, tag: String) -> app::Result<()> {
-        let mut set = self.tags.get(&key)?.unwrap_or_else(|| UnorderedSet::new());
+        let mut set = self.tags.entry(key.clone())?.or_default()?;
 
         set.insert(tag.clone())?;
-
-        self.tags.insert(key.clone(), set)?;
 
         app::emit!(TestEvent::TagAdded { key, tag });
 

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -26,8 +26,8 @@ use calimero_sdk::serde::Serialize;
 use calimero_sdk::{app, env, PublicKey};
 use calimero_storage::collections::{
     AuthoredMap, AuthoredVector, Counter, FrozenStorage, GCounter, LwwRegister, Mergeable,
-    PNCounter, ReplicatedGrowableArray, SharedStorage, SortedMap, SortedSet, UnorderedMap,
-    UnorderedSet, UserStorage, Vector,
+    ReplicatedGrowableArray, SharedStorage, SortedMap, SortedSet, UnorderedMap, UnorderedSet,
+    UserStorage, Vector,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -894,13 +894,11 @@ impl E2eKvStore {
     // --- G-COUNTER (grow-only) ---
 
     pub fn increment_g_counter(&mut self, key: String) -> app::Result<u64> {
-        let mut counter = self.crdt_counters.get(&key)?.unwrap_or_else(GCounter::new);
+        let mut counter = self.crdt_counters.entry(key.clone())?.or_default()?;
 
         counter.increment()?;
 
         let value = counter.value()?;
-
-        self.crdt_counters.insert(key.clone(), counter)?;
 
         app::emit!(Event::GCounterIncremented { key, value });
         Ok(value)
@@ -917,16 +915,11 @@ impl E2eKvStore {
     // --- PN-COUNTER (supports increment AND decrement) ---
 
     pub fn increment_pn_counter(&mut self, key: String) -> app::Result<i64> {
-        let mut counter = self
-            .crdt_pn_counters
-            .get(&key)?
-            .unwrap_or_else(PNCounter::new);
+        let mut counter = self.crdt_pn_counters.entry(key.clone())?.or_default()?;
 
         counter.increment()?;
 
         let value = counter.value()?;
-
-        self.crdt_pn_counters.insert(key.clone(), counter)?;
 
         app::emit!(Event::PnCounterChanged {
             key,
@@ -937,16 +930,11 @@ impl E2eKvStore {
     }
 
     pub fn decrement_pn_counter(&mut self, key: String) -> app::Result<i64> {
-        let mut counter = self
-            .crdt_pn_counters
-            .get(&key)?
-            .unwrap_or_else(PNCounter::new);
+        let mut counter = self.crdt_pn_counters.entry(key.clone())?.or_default()?;
 
         counter.decrement()?;
 
         let value = counter.value()?;
-
-        self.crdt_pn_counters.insert(key.clone(), counter)?;
 
         app::emit!(Event::PnCounterChanged {
             key,
@@ -999,14 +987,9 @@ impl E2eKvStore {
         inner_key: String,
         value: String,
     ) -> app::Result<()> {
-        let mut inner_map = self
-            .crdt_metadata
-            .get(&outer_key)?
-            .unwrap_or_else(UnorderedMap::new);
+        let mut inner_map = self.crdt_metadata.entry(outer_key.clone())?.or_default()?;
 
         inner_map.insert(inner_key.clone(), value.clone().into())?;
-
-        self.crdt_metadata.insert(outer_key.clone(), inner_map)?;
 
         app::emit!(Event::MetadataSet {
             outer_key,
@@ -1056,11 +1039,9 @@ impl E2eKvStore {
     // NESTED CRDT - TAGS SET
 
     pub fn add_tag(&mut self, key: String, tag: String) -> app::Result<()> {
-        let mut set = self.crdt_tags.get(&key)?.unwrap_or_else(UnorderedSet::new);
+        let mut set = self.crdt_tags.entry(key.clone())?.or_default()?;
 
         set.insert(tag.clone())?;
-
-        self.crdt_tags.insert(key.clone(), set)?;
 
         app::emit!(Event::TagAdded { key, tag });
         Ok(())

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -76,9 +76,6 @@ impl TeamMetricsApp {
     }
 
     pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
-        // `or_default()` hands back a write-back guard over the (possibly newly
-        // created) `TeamStats`; mutating it through the guard re-persists the
-        // whole struct on drop, no manual re-insert.
         let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.wins.increment()?;

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -76,12 +76,13 @@ impl TeamMetricsApp {
     }
 
     pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
+        // `or_default()` hands back a write-back guard over the (possibly newly
+        // created) `TeamStats`; mutating it through the guard re-persists the
+        // whole struct on drop, no manual re-insert.
+        let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.wins.increment()?;
         let total = stats.wins.value()?;
-
-        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::WinRecorded { team_id, total });
 
@@ -89,12 +90,10 @@ impl TeamMetricsApp {
     }
 
     pub fn record_loss(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
+        let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.losses.increment()?;
         let total = stats.losses.value()?;
-
-        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::LossRecorded { team_id, total });
 
@@ -102,12 +101,10 @@ impl TeamMetricsApp {
     }
 
     pub fn record_draw(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
+        let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.draws.increment()?;
         let total = stats.draws.value()?;
-
-        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -50,9 +50,6 @@ impl TeamMetricsApp {
     }
 
     pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
-        // `or_default()` hands back a write-back guard over the (possibly newly
-        // created) `TeamStats`; mutating it through the guard re-persists the
-        // whole struct on drop, no manual re-insert.
         let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.wins.increment()?;

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -50,12 +50,13 @@ impl TeamMetricsApp {
     }
 
     pub fn record_win(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
+        // `or_default()` hands back a write-back guard over the (possibly newly
+        // created) `TeamStats`; mutating it through the guard re-persists the
+        // whole struct on drop, no manual re-insert.
+        let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.wins.increment()?;
         let total = stats.wins.value()?;
-
-        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::WinRecorded { team_id, total });
 
@@ -63,12 +64,10 @@ impl TeamMetricsApp {
     }
 
     pub fn record_loss(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
+        let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.losses.increment()?;
         let total = stats.losses.value()?;
-
-        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::LossRecorded { team_id, total });
 
@@ -76,12 +75,10 @@ impl TeamMetricsApp {
     }
 
     pub fn record_draw(&mut self, team_id: String) -> app::Result<u64> {
-        let mut stats = self.teams.get(&team_id)?.unwrap_or_default();
+        let mut stats = self.teams.entry(team_id.clone())?.or_default()?;
 
         stats.draws.increment()?;
         let total = stats.draws.value()?;
-
-        self.teams.insert(team_id.clone(), stats)?;
 
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -58,6 +58,67 @@ pub use frozen::FrozenStorage;
 pub mod frozen_value;
 pub use frozen_value::FrozenValue;
 
+/// An owned, **read-only** view of a value returned by a collection's `get`.
+///
+/// Storage values are not resident in memory the way a `HashMap`'s are — every
+/// `get` deserializes a fresh copy from the backing store — so this cannot be a
+/// borrow like `HashMap::get`'s `&V`. Instead it owns the deserialized value and
+/// exposes it *immutably only* (`Deref`, deliberately no `DerefMut`).
+///
+/// That turns the most common storage footgun into a compile error: mutating a
+/// `get` result and forgetting to write it back used to silently discard the
+/// change (the value was a throwaway copy). Now the mutation does not compile —
+/// the borrow checker steers you to the right tool:
+///
+/// - to **mutate and persist**, use [`get_mut`] or [`entry`]`().or_default()`;
+/// - to **take an owned, mutable copy on purpose** (e.g. mutate locally and
+///   `insert` it back deliberately), call [`into_inner`](ValueRef::into_inner).
+///
+/// [`get_mut`]: UnorderedMap::get_mut
+/// [`entry`]: UnorderedMap::entry
+pub struct ValueRef<V> {
+    value: V,
+}
+
+impl<V> ValueRef<V> {
+    /// Wrap an owned value just read from storage. Internal: only collection
+    /// `get` methods mint these.
+    pub(crate) const fn new(value: V) -> Self {
+        Self { value }
+    }
+
+    /// Consume the guard and take ownership of the value.
+    ///
+    /// Use this for the deliberate read-modify-write-back pattern (mutate a copy,
+    /// then `insert` it). Prefer `get_mut`/`entry().or_default()` when you can —
+    /// they persist automatically without the manual re-insert.
+    pub fn into_inner(self) -> V {
+        self.value
+    }
+}
+
+impl<V> Deref for ValueRef<V> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<V: fmt::Debug> fmt::Debug for ValueRef<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<V: PartialEq> PartialEq for ValueRef<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<V: Eq> Eq for ValueRef<V> {}
+
 // fixme! macro expects `calimero_storage` to be in deps
 use crate as calimero_storage;
 use crate::address::Id;

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -119,6 +119,22 @@ impl<V: PartialEq> PartialEq for ValueRef<V> {
 
 impl<V: Eq> Eq for ValueRef<V> {}
 
+// Intentionally NO `Clone`/`AsRef`/`Hash`/`Borrow` impls: `ValueRef` is a
+// `Deref` guard, so `guard.clone()`, `guard.as_ref()`, `guard.hash(..)` already
+// resolve to `V`'s own methods through the deref. Adding inherent trait impls
+// here would *shadow* those — e.g. `file_record.clone()` would yield a
+// `ValueRef<FileRecord>` instead of a `FileRecord`, silently changing callers.
+// To take the value out explicitly, use [`ValueRef::into_inner`].
+
+/// Compare a guard directly against a bare `V`, so `map.get(k)?.unwrap() == v`
+/// works without unwrapping the guard first. (Operator-based, so it does not
+/// shadow any `Deref` method.)
+impl<V: PartialEq> PartialEq<V> for ValueRef<V> {
+    fn eq(&self, other: &V) -> bool {
+        &self.value == other
+    }
+}
+
 // fixme! macro expects `calimero_storage` to be in deps
 use crate as calimero_storage;
 use crate::address::Id;

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -70,9 +70,12 @@ pub use frozen_value::FrozenValue;
 /// change (the value was a throwaway copy). Now the mutation does not compile —
 /// the borrow checker steers you to the right tool:
 ///
-/// - to **mutate and persist**, use [`get_mut`] or [`entry`]`().or_default()`;
-/// - to **take an owned, mutable copy on purpose** (e.g. mutate locally and
-///   `insert` it back deliberately), call [`into_inner`](ValueRef::into_inner).
+/// - to **mutate and persist**, use [`get_mut`] or [`entry`]`().or_default()`
+///   (both write back automatically — no manual re-insert);
+/// - to **take an owned copy on purpose**, `.clone()` it (when `V: Clone`).
+///
+/// There is intentionally no public `into_inner`/unwrap: handing back an owned,
+/// mutable value with no write-back is exactly the footgun this guard closes.
 ///
 /// [`get_mut`]: UnorderedMap::get_mut
 /// [`entry`]: UnorderedMap::entry
@@ -89,10 +92,15 @@ impl<V> ValueRef<V> {
 
     /// Consume the guard and take ownership of the value.
     ///
-    /// Use this for the deliberate read-modify-write-back pattern (mutate a copy,
-    /// then `insert` it). Prefer `get_mut`/`entry().or_default()` when you can —
-    /// they persist automatically without the manual re-insert.
-    pub fn into_inner(self) -> V {
+    /// Deliberately **crate-internal**: exposing it publicly would re-open the
+    /// footgun this guard exists to close — `map.get(k)?.into_inner()` yields an
+    /// owned, mutable copy whose changes are silently dropped unless manually
+    /// re-`insert`ed. Public callers should instead mutate-and-persist via
+    /// [`get_mut`](UnorderedMap::get_mut) / [`entry`](UnorderedMap::entry)`().or_default()`,
+    /// or take an explicit owned copy with `.clone()` when `V: Clone`. The
+    /// storage crate itself uses this for the few deliberate read-modify-write
+    /// paths (e.g. CRDT merge) where a held mutable guard would conflict.
+    pub(crate) fn into_inner(self) -> V {
         self.value
     }
 }

--- a/crates/storage/src/collections/authored_map.rs
+++ b/crates/storage/src/collections/authored_map.rs
@@ -24,7 +24,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
-use super::{compute_id, StoreError, UnorderedMap};
+use super::{compute_id, StoreError, UnorderedMap, ValueRef};
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::index::Index;
 use crate::interface::StorageError;
@@ -192,7 +192,7 @@ where
     /// # Errors
     /// Returns any underlying storage error.
     pub fn get(&self, k: &K) -> Result<Option<V>, StoreError> {
-        self.inner.get(k)
+        Ok(self.inner.get(k)?.map(ValueRef::into_inner))
     }
 
     /// Returns whether `k` is present.

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -23,7 +23,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
-use super::{StoreError, Vector};
+use super::{StoreError, ValueRef, Vector};
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::index::Index;
 use crate::interface::StorageError;
@@ -162,7 +162,7 @@ where
     /// # Errors
     /// Returns any underlying storage error.
     pub fn get(&self, index: usize) -> Result<Option<V>, StoreError> {
-        self.inner.get(index)
+        Ok(self.inner.get(index)?.map(ValueRef::into_inner))
     }
 
     /// Returns the public key of the owner at `index`, if the slot exists.

--- a/crates/storage/src/collections/counter.rs
+++ b/crates/storage/src/collections/counter.rs
@@ -352,7 +352,7 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Counter<ALLOW_DECREMENT, S>
     /// Returns error if storage operation fails or if increment would overflow u64::MAX
     pub fn increment_for(&mut self, executor_id: &[u8; 32]) -> Result<(), StoreError> {
         let key = hex::encode(executor_id);
-        let current = self.positive.get(&key)?.unwrap_or(0);
+        let current = self.positive.get(&key)?.as_deref().copied().unwrap_or(0);
         let new_value = current.checked_add(1).ok_or_else(|| {
             StorageError::InvalidData(
                 "Counter increment overflow: value already at u64::MAX".to_owned(),
@@ -368,7 +368,7 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Counter<ALLOW_DECREMENT, S>
     /// Returns error if storage operation fails
     pub fn get_positive_count(&self, executor_id: &[u8; 32]) -> Result<u64, StoreError> {
         let key = hex::encode(executor_id);
-        Ok(self.positive.get(&key)?.unwrap_or(0))
+        Ok(self.positive.get(&key)?.as_deref().copied().unwrap_or(0))
     }
 }
 
@@ -417,7 +417,7 @@ impl<S: StorageAdaptor> Counter<true, S> {
     /// Returns error if storage operation fails or if decrement would overflow u64::MAX
     pub fn decrement_for(&mut self, executor_id: &[u8; 32]) -> Result<(), StoreError> {
         let key = hex::encode(executor_id);
-        let current = self.negative.get(&key)?.unwrap_or(0);
+        let current = self.negative.get(&key)?.as_deref().copied().unwrap_or(0);
         let new_value = current.checked_add(1).ok_or_else(|| {
             StorageError::InvalidData(
                 "Counter decrement overflow: value already at u64::MAX".to_owned(),
@@ -433,7 +433,7 @@ impl<S: StorageAdaptor> Counter<true, S> {
     /// Returns error if storage operation fails
     pub fn get_negative_count(&self, executor_id: &[u8; 32]) -> Result<u64, StoreError> {
         let key = hex::encode(executor_id);
-        Ok(self.negative.get(&key)?.unwrap_or(0))
+        Ok(self.negative.get(&key)?.as_deref().copied().unwrap_or(0))
     }
 
     /// Get the total count across all executors (PN-Counter only)

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -12,7 +12,7 @@
 use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
 use super::{
     Counter, LwwRegister, ReplicatedGrowableArray, SortedMap, SortedSet, UnorderedMap,
-    UnorderedSet, Vector,
+    UnorderedSet, ValueRef, Vector,
 };
 #[cfg(test)]
 use super::{GCounter, PNCounter};
@@ -156,7 +156,12 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Mergeable for Counter<ALLOW
         // Merge positive counts (both G-Counter and PN-Counter)
         // For each executor in other, take the max of their counts
         for (executor_id, other_count) in other.positive.entries()? {
-            let self_count = self.positive.get(&executor_id)?.unwrap_or(0);
+            let self_count = self
+                .positive
+                .get(&executor_id)?
+                .as_deref()
+                .copied()
+                .unwrap_or(0);
 
             // Take max for this executor (monotonic property)
             let new_count = self_count.max(other_count);
@@ -168,7 +173,12 @@ impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> Mergeable for Counter<ALLOW
         // If PN-Counter mode, also merge negative counts
         if ALLOW_DECREMENT {
             for (executor_id, other_count) in other.negative.entries()? {
-                let self_count = self.negative.get(&executor_id)?.unwrap_or(0);
+                let self_count = self
+                    .negative
+                    .get(&executor_id)?
+                    .as_deref()
+                    .copied()
+                    .unwrap_or(0);
 
                 // Take max for this executor (monotonic property)
                 let new_count = self_count.max(other_count);
@@ -275,7 +285,7 @@ where
         let other_entries = other.entries()?;
 
         for (key, other_value) in other_entries {
-            if let Some(mut our_value) = self.get(&key)? {
+            if let Some(mut our_value) = self.get(&key)?.map(ValueRef::into_inner) {
                 // Key exists in both - recursively merge values
                 // This is where nested CRDT merging happens!
                 our_value.merge(&other_value)?;
@@ -333,7 +343,7 @@ where
         let other_entries = other.entries()?;
 
         for (key, other_value) in other_entries {
-            if let Some(mut our_value) = self.get(&key)? {
+            if let Some(mut our_value) = self.get(&key)?.map(ValueRef::into_inner) {
                 our_value.merge(&other_value)?;
                 drop(self.insert(key, our_value)?);
             } else {
@@ -501,8 +511,8 @@ where
         // Merge elements at same indices
         let min_len = our_len.min(their_len);
         for i in 0..min_len {
-            if let Some(mut our_value) = self.get(i)? {
-                if let Some(their_value) = other.get(i)? {
+            if let Some(mut our_value) = self.get(i)?.map(ValueRef::into_inner) {
+                if let Some(their_value) = other.get(i)?.map(ValueRef::into_inner) {
                     // Recursively merge values at same index
                     our_value.merge(&their_value)?;
                     drop(self.update(i, our_value)?);
@@ -513,7 +523,7 @@ where
         // If other is longer, append remaining elements (LWW: take their additions)
         if their_len > our_len {
             for i in our_len..their_len {
-                if let Some(value) = other.get(i)? {
+                if let Some(value) = other.get(i)?.map(ValueRef::into_inner) {
                     self.push(value)?;
                 }
             }

--- a/crates/storage/src/collections/decompose_impls.rs
+++ b/crates/storage/src/collections/decompose_impls.rs
@@ -151,7 +151,7 @@ where
                     DecomposeError::StorageError(format!("Failed to serialize index: {:?}", e))
                 })?;
 
-                result.push((CompositeKey::from(index_bytes), value));
+                result.push((CompositeKey::from(index_bytes), value.into_inner()));
             }
         }
 
@@ -232,9 +232,30 @@ mod tests {
         let reconstructed = UnorderedMap::<String, u64>::recompose(entries).unwrap();
 
         // Verify
-        assert_eq!(reconstructed.get(&"a".to_owned()).unwrap(), Some(1u64));
-        assert_eq!(reconstructed.get(&"b".to_owned()).unwrap(), Some(2u64));
-        assert_eq!(reconstructed.get(&"c".to_owned()).unwrap(), Some(3u64));
+        assert_eq!(
+            reconstructed
+                .get(&"a".to_owned())
+                .unwrap()
+                .as_deref()
+                .copied(),
+            Some(1u64)
+        );
+        assert_eq!(
+            reconstructed
+                .get(&"b".to_owned())
+                .unwrap()
+                .as_deref()
+                .copied(),
+            Some(2u64)
+        );
+        assert_eq!(
+            reconstructed
+                .get(&"c".to_owned())
+                .unwrap()
+                .as_deref()
+                .copied(),
+            Some(3u64)
+        );
     }
 
     #[test]
@@ -266,9 +287,27 @@ mod tests {
         let reconstructed = Vector::<String>::recompose(entries).unwrap();
 
         // Verify all values are present in correct order
-        assert_eq!(reconstructed.get(0).unwrap(), Some("first".to_owned()));
-        assert_eq!(reconstructed.get(1).unwrap(), Some("second".to_owned()));
-        assert_eq!(reconstructed.get(2).unwrap(), Some("third".to_owned()));
+        assert_eq!(
+            reconstructed
+                .get(0)
+                .unwrap()
+                .map(crate::collections::ValueRef::into_inner),
+            Some("first".to_owned())
+        );
+        assert_eq!(
+            reconstructed
+                .get(1)
+                .unwrap()
+                .map(crate::collections::ValueRef::into_inner),
+            Some("second".to_owned())
+        );
+        assert_eq!(
+            reconstructed
+                .get(2)
+                .unwrap()
+                .map(crate::collections::ValueRef::into_inner),
+            Some("third".to_owned())
+        );
         assert_eq!(reconstructed.len().unwrap(), 3);
     }
 }

--- a/crates/storage/src/collections/frozen.rs
+++ b/crates/storage/src/collections/frozen.rs
@@ -154,7 +154,7 @@ where
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
     pub fn get(&self, hash: &Hash) -> Result<Option<T>, StoreError> {
-        Ok(self.inner.get(hash)?.map(|frozen_value| frozen_value.0))
+        Ok(self.inner.get(hash)?.map(|fv| fv.into_inner().0))
         //// Get the Option<FrozenValue<Vec<u8>>>
         //if let Some(frozen_value_bytes) = self.inner.get(hash)? {
         //    // `frozen_value_bytes.0` is the Vec<u8>

--- a/crates/storage/src/collections/nested.rs
+++ b/crates/storage/src/collections/nested.rs
@@ -28,7 +28,7 @@
 
 use super::composite_key::CompositeKey;
 use super::crdt_meta::{CrdtMeta, Decomposable};
-use super::{StoreError, UnorderedMap};
+use super::{StoreError, UnorderedMap, ValueRef};
 use crate::store::StorageAdaptor;
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -180,7 +180,7 @@ where
 {
     // For Phase 2.1, use standard get for all types
     // Phase 2.2 will add reconstruction logic
-    map.get(key)
+    Ok(map.get(key)?.map(ValueRef::into_inner))
 }
 
 #[cfg(test)]

--- a/crates/storage/src/collections/nested_map.rs
+++ b/crates/storage/src/collections/nested_map.rs
@@ -35,7 +35,7 @@
 //! # Ok::<(), calimero_storage::collections::error::StoreError>(())
 //! ```
 
-use super::{StoreError, UnorderedMap};
+use super::{StoreError, UnorderedMap, ValueRef};
 use crate::store::StorageAdaptor;
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -103,6 +103,7 @@ where
         // Get or create the inner map
         let mut inner_map = self
             .get(&outer_key)?
+            .map(ValueRef::into_inner)
             .unwrap_or_else(UnorderedMap::new_internal);
 
         // Insert into inner map
@@ -116,14 +117,14 @@ where
 
     fn get_nested(&self, outer_key: &K1, inner_key: &K2) -> Result<Option<V>, StoreError> {
         if let Some(inner_map) = self.get(outer_key)? {
-            inner_map.get(inner_key)
+            Ok(inner_map.get(inner_key)?.map(ValueRef::into_inner))
         } else {
             Ok(None)
         }
     }
 
     fn remove_nested(&mut self, outer_key: &K1, inner_key: &K2) -> Result<Option<V>, StoreError> {
-        let Some(mut inner_map) = self.get(outer_key)? else {
+        let Some(mut inner_map) = self.get(outer_key)?.map(ValueRef::into_inner) else {
             return Ok(None);
         };
 

--- a/crates/storage/src/collections/nested_map.rs
+++ b/crates/storage/src/collections/nested_map.rs
@@ -18,8 +18,10 @@
 //! ```rust,no_run
 //! # use calimero_storage::collections::{UnorderedMap, Root};
 //! # let mut outer_map = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
-//! // ❌ BROKEN: Get-modify-put creates blobs
-//! let mut inner_map = outer_map.get(&"doc-1".to_owned())?.unwrap();  // Gets deserialized COPY
+//! // ❌ BROKEN: Get-modify-put creates blobs. `get` now returns a read-only
+//! //    `ValueRef`, so taking an owned copy to mutate is an explicit
+//! //    `into_inner()` — the copy this anti-pattern hinges on.
+//! let mut inner_map = outer_map.get(&"doc-1".to_owned())?.unwrap().into_inner(); // deserialized COPY
 //! inner_map.insert("title".to_owned(), "New".to_owned())?;              // Modifies copy
 //! outer_map.insert("doc-1".to_owned(), inner_map)?;          // Re-serializes as blob
 //! # Ok::<(), calimero_storage::collections::error::StoreError>(())

--- a/crates/storage/src/collections/nested_map.rs
+++ b/crates/storage/src/collections/nested_map.rs
@@ -15,17 +15,20 @@
 //!
 //! # The Problem
 //!
-//! ```rust,no_run
-//! # use calimero_storage::collections::{UnorderedMap, Root};
-//! # let mut outer_map = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
-//! // ❌ BROKEN: Get-modify-put creates blobs. `get` now returns a read-only
-//! //    `ValueRef`, so taking an owned copy to mutate is an explicit
-//! //    `into_inner()` — the copy this anti-pattern hinges on.
-//! let mut inner_map = outer_map.get(&"doc-1".to_owned())?.unwrap().into_inner(); // deserialized COPY
-//! inner_map.insert("title".to_owned(), "New".to_owned())?;              // Modifies copy
-//! outer_map.insert("doc-1".to_owned(), inner_map)?;          // Re-serializes as blob
-//! # Ok::<(), calimero_storage::collections::error::StoreError>(())
+//! The old get-modify-put anti-pattern read the inner map into an owned **copy**,
+//! mutated the copy, and wrote it back as a fresh blob:
+//!
+//! ```text
+//! let mut inner = outer_map.get(&"doc-1")?.unwrap();  // deserialized COPY
+//! inner.insert("title", "New")?;                       // mutates the copy
+//! outer_map.insert("doc-1", inner)?;                   // re-serializes as a blob
 //! ```
+//!
+//! This is no longer expressible: `get` returns a read-only [`ValueRef`] guard
+//! that exposes the value only via `Deref` (no way to mutate it or move it out),
+//! so the "copy" step doesn't compile. Use the helpers below instead.
+//!
+//! [`ValueRef`]: super::ValueRef
 //!
 //! # The Solution
 //!

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -972,11 +972,16 @@ where
 
 impl<K, V, S> Default for SortedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
-    S: StorageAdaptor,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
+    S: StorageAdaptor + 'static,
 {
     fn default() -> Self {
+        // Register the nested-id re-key thunk at construction so a map first
+        // created via `default()` (e.g. `entry(k).or_default()` on a nested
+        // `Map<_, SortedMap<..>>`) is re-keyed deterministically by its parent
+        // rather than keeping a per-node random id. See `UnorderedMap`'s `Default`.
+        super::rekey::register_rekey::<Self>();
         Self::new_internal()
     }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -80,7 +80,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeMap;
 use serde::Serialize;
 
-use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor};
+use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor, ValueRef};
 use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
@@ -405,19 +405,24 @@ where
 
     /// Get the value for a key in the map.
     ///
+    /// Returns a read-only [`ValueRef`] guard (an owned copy that derefs to
+    /// `&V`). To *mutate* the stored value use [`get_mut`](Self::get_mut) or
+    /// [`entry`](Self::entry)`().or_default()`; to take an owned mutable copy on
+    /// purpose call [`ValueRef::into_inner`].
+    ///
     /// # Errors
     ///
     /// If an error occurs when interacting with the storage system, or a child
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned.
-    pub fn get<Q>(&self, key: &Q) -> Result<Option<V>, StoreError>
+    pub fn get<Q>(&self, key: &Q) -> Result<Option<ValueRef<V>>, StoreError>
     where
         K: Borrow<Q>,
         Q: PartialEq + AsRef<[u8]> + ?Sized,
     {
         let id = compute_id(self.inner.id(), key.as_ref());
 
-        Ok(self.inner.get(id)?.map(|(_, v)| v))
+        Ok(self.inner.get(id)?.map(|(_, v)| ValueRef::new(v)))
     }
 
     /// Returns a mutable `ValueMut` guard for the value at `key`.
@@ -1303,7 +1308,10 @@ mod tests {
             .is_none());
 
         assert_eq!(
-            map.get("key").expect("get failed").as_deref(),
+            map.get("key")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value")
         );
 
@@ -1450,7 +1458,10 @@ mod tests {
             assert_eq!(*guard, "value1");
             *guard = "updated".to_owned();
         }
-        assert_eq!(map.get("key1").unwrap().as_deref(), Some("updated"));
+        assert_eq!(
+            map.get("key1").unwrap().as_deref().map(String::as_str),
+            Some("updated")
+        );
 
         // or_insert on occupied keeps the existing value.
         let guard = map
@@ -1486,7 +1497,7 @@ mod tests {
             *guard += 1;
         }
 
-        assert_eq!(map.get("b").unwrap(), Some(6));
+        assert_eq!(map.get("b").unwrap().as_deref().copied(), Some(6));
         assert_eq!(map.len().unwrap(), 1);
 
         // Ordering is preserved when `or_default()` creates new keys.

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -407,8 +407,8 @@ where
     ///
     /// Returns a read-only [`ValueRef`] guard (an owned copy that derefs to
     /// `&V`). To *mutate* the stored value use [`get_mut`](Self::get_mut) or
-    /// [`entry`](Self::entry)`().or_default()`; to take an owned mutable copy on
-    /// purpose call [`ValueRef::into_inner`].
+    /// [`entry`](Self::entry)`().or_default()` (both write back automatically),
+    /// or `.clone()` the guard for an owned copy when `V: Clone`.
     ///
     /// # Errors
     ///

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -1178,6 +1178,27 @@ where
             Entry::Vacant(entry) => entry.insert(f()),
         }
     }
+
+    /// Ensures a value is in the entry by inserting `V::default()` if empty,
+    /// and returns a mutable `ValueMut` guard to the value.
+    ///
+    /// This is the blessed path for in-place mutation of nested CRDT values:
+    /// the returned guard re-persists the value to storage when it is dropped,
+    /// so there is no manual get → modify → re-insert dance. It also composes
+    /// for nested collections — `map.entry(k)?.or_default()?` yields a guard
+    /// whose nested CRDTs are deterministically re-keyed under this entry's id,
+    /// so independently first-created values converge across nodes.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn or_default(self) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        V: Default + 'static,
+    {
+        self.or_insert_with(V::default)
+    }
 }
 
 impl<K, V, S> OccupiedEntry<'_, K, V, S>
@@ -1438,6 +1459,45 @@ mod tests {
             .or_insert("ignored".to_owned())
             .expect("or_insert failed");
         assert_eq!(*guard, "updated");
+    }
+
+    #[test]
+    fn test_sorted_map_entry_or_default() {
+        let mut map = Root::new(|| SortedMap::<String, u64, MainStorage>::new());
+
+        // Vacant: inserts `u64::default()` (0), guard write-back persists the bump.
+        {
+            let mut guard = map
+                .entry("b".to_owned())
+                .expect("entry failed")
+                .or_default()
+                .expect("or_default failed");
+            assert_eq!(*guard, 0);
+            *guard += 5;
+        }
+        // Occupied: yields the existing value, not a fresh default.
+        {
+            let mut guard = map
+                .entry("b".to_owned())
+                .expect("entry failed")
+                .or_default()
+                .expect("or_default failed");
+            assert_eq!(*guard, 5);
+            *guard += 1;
+        }
+
+        assert_eq!(map.get("b").unwrap(), Some(6));
+        assert_eq!(map.len().unwrap(), 1);
+
+        // Ordering is preserved when `or_default()` creates new keys.
+        drop(
+            map.entry("a".to_owned())
+                .expect("entry failed")
+                .or_default()
+                .expect("or_default failed"),
+        );
+        let keys: Vec<String> = map.keys().unwrap().collect();
+        assert_eq!(keys, vec!["a", "b"]);
     }
 
     #[test]

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -974,7 +974,7 @@ impl<K, V, S> Default for SortedMap<K, V, S>
 where
     K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
     V: BorshSerialize + BorshDeserialize + 'static,
-    S: StorageAdaptor + 'static,
+    S: StorageAdaptor,
 {
     fn default() -> Self {
         // Register the nested-id re-key thunk at construction so a map first

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -584,7 +584,7 @@ where
 impl<V, S> Default for SortedSet<V, S>
 where
     V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
-    S: StorageAdaptor + 'static,
+    S: StorageAdaptor,
 {
     fn default() -> Self {
         // Register the nested-id re-key thunk at construction so a set first

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -583,10 +583,15 @@ where
 
 impl<V, S> Default for SortedSet<V, S>
 where
-    V: BorshSerialize + BorshDeserialize,
-    S: StorageAdaptor,
+    V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    S: StorageAdaptor + 'static,
 {
     fn default() -> Self {
+        // Register the nested-id re-key thunk at construction so a set first
+        // created via `default()` (e.g. `entry(k).or_default()` on a nested
+        // `Map<_, SortedSet<..>>`) is re-keyed deterministically by its parent
+        // rather than keeping a per-node random id. See `UnorderedMap`'s `Default`.
+        super::rekey::register_rekey::<Self>();
         Self::new_internal()
     }
 }

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -624,7 +624,7 @@ impl<K, V, S> Default for UnorderedMap<K, V, S>
 where
     K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
     V: BorshSerialize + BorshDeserialize + 'static,
-    S: StorageAdaptor + 'static,
+    S: StorageAdaptor,
 {
     fn default() -> Self {
         // Register this map type's nested-id re-key thunk at construction, so a

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -36,7 +36,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeMap;
 use serde::Serialize;
 
-use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor};
+use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor, ValueRef};
 use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
@@ -395,20 +395,26 @@ where
 
     /// Get the value for a key in the map.
     ///
+    /// Returns a read-only [`ValueRef`] guard (an owned, deserialized copy that
+    /// derefs to `&V`). Reads work transparently through it; to *mutate* the
+    /// stored value use [`get_mut`](Self::get_mut) or
+    /// [`entry`](Self::entry)`().or_default()`, and to take an owned mutable copy
+    /// on purpose call [`ValueRef::into_inner`].
+    ///
     /// # Errors
     ///
     /// If an error occurs when interacting with the storage system, or a child
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned.
     ///
-    pub fn get<Q>(&self, key: &Q) -> Result<Option<V>, StoreError>
+    pub fn get<Q>(&self, key: &Q) -> Result<Option<ValueRef<V>>, StoreError>
     where
         K: Borrow<Q>,
         Q: PartialEq + AsRef<[u8]> + ?Sized,
     {
         let id = compute_id(self.inner.id(), key.as_ref());
 
-        Ok(self.inner.get(id)?.map(|(_, v)| v))
+        Ok(self.inner.get(id)?.map(|(_, v)| ValueRef::new(v)))
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
@@ -944,11 +950,17 @@ mod tests {
             .is_none());
 
         assert_eq!(
-            map.get("key").expect("get failed").as_deref(),
+            map.get("key")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value")
         );
         assert_ne!(
-            map.get("key").expect("get failed").as_deref(),
+            map.get("key")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value2")
         );
 
@@ -964,11 +976,17 @@ mod tests {
             .is_none());
 
         assert_eq!(
-            map.get("key").expect("get failed").as_deref(),
+            map.get("key")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value2")
         );
         assert_eq!(
-            map.get("key2").expect("get failed").as_deref(),
+            map.get("key2")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value")
         );
 
@@ -997,11 +1015,17 @@ mod tests {
             .is_none());
 
         assert_eq!(
-            map.get("key1").expect("get failed").as_deref(),
+            map.get("key1")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value1")
         );
         assert_eq!(
-            map.get("key2").expect("get failed").as_deref(),
+            map.get("key2")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("value2")
         );
     }
@@ -1020,7 +1044,10 @@ mod tests {
             .is_none());
 
         assert_eq!(
-            map.get("key").expect("get failed").as_deref(),
+            map.get("key")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("new_value")
         );
     }
@@ -1148,7 +1175,10 @@ mod tests {
 
         // Verify the change was persisted
         assert_eq!(
-            map.get("key1").expect("get failed").as_deref(),
+            map.get("key1")
+                .expect("get failed")
+                .as_deref()
+                .map(String::as_str),
             Some("new_value")
         );
 
@@ -1175,7 +1205,10 @@ mod tests {
         } // Guard is dropped, "new_value1" is committed
 
         assert_eq!(map.len().unwrap(), 1);
-        assert_eq!(map.get("key1").unwrap().as_deref(), Some("new_value1"));
+        assert_eq!(
+            map.get("key1").unwrap().as_deref().map(String::as_str),
+            Some("new_value1")
+        );
 
         // Test `or_insert_with()`
         {
@@ -1189,7 +1222,10 @@ mod tests {
         } // Guard is dropped
 
         assert_eq!(map.len().unwrap(), 2);
-        assert_eq!(map.get("key2").unwrap().as_deref(), Some("value2"));
+        assert_eq!(
+            map.get("key2").unwrap().as_deref().map(String::as_str),
+            Some("value2")
+        );
     }
 
     #[test]
@@ -1214,7 +1250,10 @@ mod tests {
 
         // Make sure the value hasn't changed
         assert_eq!(map.len().unwrap(), 1);
-        assert_eq!(map.get("key1").unwrap().as_deref(), Some("value1"));
+        assert_eq!(
+            map.get("key1").unwrap().as_deref().map(String::as_str),
+            Some("value1")
+        );
 
         // Test `or_insert_with()` on an occupied entry
         let mut called = false;
@@ -1234,7 +1273,10 @@ mod tests {
 
         assert_eq!(called, false); // Verify closure was not executed
         assert_eq!(map.len().unwrap(), 1);
-        assert_eq!(map.get("key1").unwrap().as_deref(), Some("value1"));
+        assert_eq!(
+            map.get("key1").unwrap().as_deref().map(String::as_str),
+            Some("value1")
+        );
     }
 
     #[test]
@@ -1253,7 +1295,7 @@ mod tests {
             *guard += 5;
         } // Guard is dropped -> value re-persisted
 
-        assert_eq!(map.get("key1").unwrap(), Some(5));
+        assert_eq!(map.get("key1").unwrap().as_deref().copied(), Some(5));
         assert_eq!(map.len().unwrap(), 1);
 
         // Occupied: `or_default()` yields the existing value, not a fresh default.
@@ -1267,7 +1309,7 @@ mod tests {
             *guard += 1;
         } // Guard is dropped -> value re-persisted
 
-        assert_eq!(map.get("key1").unwrap(), Some(6));
+        assert_eq!(map.get("key1").unwrap().as_deref().copied(), Some(6));
         assert_eq!(map.len().unwrap(), 1);
     }
 
@@ -1284,7 +1326,10 @@ mod tests {
         } else {
             panic!("Entry should be occupied");
         }
-        assert_eq!(map.get("key1").unwrap().as_deref(), Some("updated_value1"));
+        assert_eq!(
+            map.get("key1").unwrap().as_deref().map(String::as_str),
+            Some("updated_value1")
+        );
 
         // Test `OccupiedEntry::insert()`
         let old_val = if let Ok(Entry::Occupied(mut entry)) = map.entry("key2".to_owned()) {
@@ -1293,7 +1338,10 @@ mod tests {
             panic!("Entry should be occupied");
         };
         assert_eq!(old_val, "value2");
-        assert_eq!(map.get("key2").unwrap().as_deref(), Some("updated_value2"));
+        assert_eq!(
+            map.get("key2").unwrap().as_deref().map(String::as_str),
+            Some("updated_value2")
+        );
         assert_eq!(map.len().unwrap(), 3); // Length should be unchanged
 
         // Test `OccupiedEntry::remove()`
@@ -1396,12 +1444,18 @@ mod tests {
             "Map ID should change after deterministic reassignment"
         );
         assert_eq!(
-            map.get("alpha").expect("get alpha failed").as_deref(),
+            map.get("alpha")
+                .expect("get alpha failed")
+                .as_deref()
+                .map(String::as_str),
             Some("one"),
             "alpha entry should survive reassignment"
         );
         assert_eq!(
-            map.get("beta").expect("get beta failed").as_deref(),
+            map.get("beta")
+                .expect("get beta failed")
+                .as_deref()
+                .map(String::as_str),
             Some("two"),
             "beta entry should survive reassignment"
         );

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -398,8 +398,8 @@ where
     /// Returns a read-only [`ValueRef`] guard (an owned, deserialized copy that
     /// derefs to `&V`). Reads work transparently through it; to *mutate* the
     /// stored value use [`get_mut`](Self::get_mut) or
-    /// [`entry`](Self::entry)`().or_default()`, and to take an owned mutable copy
-    /// on purpose call [`ValueRef::into_inner`].
+    /// [`entry`](Self::entry)`().or_default()` (both write back automatically),
+    /// or `.clone()` the guard for an owned copy when `V: Clone`.
     ///
     /// # Errors
     ///

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -818,6 +818,27 @@ where
             Entry::Vacant(entry) => entry.insert(f()),
         }
     }
+
+    /// Ensures a value is in the entry by inserting `V::default()` if empty,
+    /// and returns a mutable `ValueMut` guard to the value.
+    ///
+    /// This is the blessed path for in-place mutation of nested CRDT values:
+    /// the returned guard re-persists the value to storage when it is dropped,
+    /// so there is no manual get → modify → re-insert dance. It also composes
+    /// for nested collections — `map.entry(k)?.or_default()?` yields a guard
+    /// whose nested CRDTs are deterministically re-keyed under this entry's id,
+    /// so independently first-created values converge across nodes.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system, an error
+    /// will be returned.
+    pub fn or_default(self) -> Result<ValueMut<'a, K, V, S>, StoreError>
+    where
+        V: Default + 'static,
+    {
+        self.or_insert_with(V::default)
+    }
 }
 
 impl<K, V, S> OccupiedEntry<'_, K, V, S>
@@ -1214,6 +1235,40 @@ mod tests {
         assert_eq!(called, false); // Verify closure was not executed
         assert_eq!(map.len().unwrap(), 1);
         assert_eq!(map.get("key1").unwrap().as_deref(), Some("value1"));
+    }
+
+    #[test]
+    fn test_unordered_map_entry_or_default() {
+        let mut map = Root::new(|| UnorderedMap::<String, u64, MainStorage>::new());
+
+        // Vacant: `or_default()` inserts `u64::default()` (0) and the write-back
+        // guard persists the mutation made through it on drop.
+        {
+            let mut guard = map
+                .entry("key1".to_owned())
+                .expect("entry failed")
+                .or_default()
+                .expect("or_default failed");
+            assert_eq!(*guard, 0);
+            *guard += 5;
+        } // Guard is dropped -> value re-persisted
+
+        assert_eq!(map.get("key1").unwrap(), Some(5));
+        assert_eq!(map.len().unwrap(), 1);
+
+        // Occupied: `or_default()` yields the existing value, not a fresh default.
+        {
+            let mut guard = map
+                .entry("key1".to_owned())
+                .expect("entry failed")
+                .or_default()
+                .expect("or_default failed");
+            assert_eq!(*guard, 5);
+            *guard += 1;
+        } // Guard is dropped -> value re-persisted
+
+        assert_eq!(map.get("key1").unwrap(), Some(6));
+        assert_eq!(map.len().unwrap(), 1);
     }
 
     #[test]

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -622,11 +622,18 @@ where
 
 impl<K, V, S> Default for UnorderedMap<K, V, S>
 where
-    K: BorshSerialize + BorshDeserialize,
-    V: BorshSerialize + BorshDeserialize,
-    S: StorageAdaptor,
+    K: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    V: BorshSerialize + BorshDeserialize + 'static,
+    S: StorageAdaptor + 'static,
 {
     fn default() -> Self {
+        // Register this map type's nested-id re-key thunk at construction, so a
+        // map first created via `default()` — e.g. `entry(k).or_default()` on a
+        // `Map<_, Map<..>>` — is known to the re-key registry BEFORE its parent's
+        // `VacantEntry::insert` re-keys it. Without this the freshly-defaulted
+        // inner collection keeps a random id and the two nodes that first-touch
+        // it never converge. Mirrors `Counter::new_internal`'s registration.
+        super::rekey::register_rekey::<Self>();
         Self::new_internal()
     }
 }

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -376,10 +376,15 @@ where
 
 impl<V, S> Default for UnorderedSet<V, S>
 where
-    V: BorshSerialize + BorshDeserialize,
-    S: StorageAdaptor,
+    V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
+    S: StorageAdaptor + 'static,
 {
     fn default() -> Self {
+        // Register the nested-id re-key thunk at construction so a set first
+        // created via `default()` (e.g. `entry(k).or_default()` on a
+        // `Map<_, Set<..>>`) is re-keyed deterministically by its parent rather
+        // than keeping a per-node random id. See `UnorderedMap`'s `Default`.
+        super::rekey::register_rekey::<Self>();
         Self::new_internal()
     }
 }

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -377,7 +377,7 @@ where
 impl<V, S> Default for UnorderedSet<V, S>
 where
     V: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static,
-    S: StorageAdaptor + 'static,
+    S: StorageAdaptor,
 {
     fn default() -> Self {
         // Register the nested-id re-key thunk at construction so a set first

--- a/crates/storage/src/collections/user.rs
+++ b/crates/storage/src/collections/user.rs
@@ -4,7 +4,7 @@
 //! only `insert` into their own key-slot (`env::executor_id()`).
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
-use super::{StoreError, UnorderedMap};
+use super::{StoreError, UnorderedMap, ValueRef};
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::env;
 use crate::store::{MainStorage, StorageAdaptor};
@@ -147,7 +147,10 @@ where
     /// Returns a `StoreError` if the storage operation fails.
     pub fn get(&self) -> Result<Option<T>, StoreError> {
         let executor_public_key: PublicKey = env::executor_id().into();
-        self.inner.get(&executor_public_key)
+        Ok(self
+            .inner
+            .get(&executor_public_key)?
+            .map(ValueRef::into_inner))
     }
 
     /// Gets the data for a *specific* user's PublicKey.
@@ -155,7 +158,7 @@ where
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
     pub fn get_for_user(&self, user_key: &PublicKey) -> Result<Option<T>, StoreError> {
-        self.inner.get(user_key)
+        Ok(self.inner.get(user_key)?.map(ValueRef::into_inner))
     }
 
     /// Checks if data exists for the current executor.

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -219,8 +219,8 @@ where
     ///
     /// Returns a read-only [`ValueRef`] guard (an owned copy that derefs to
     /// `&V`). To *mutate* the stored value use [`update`](Self::update) or
-    /// [`get_mut`](Self::get_mut); to take an owned mutable copy on purpose call
-    /// [`ValueRef::into_inner`].
+    /// [`get_mut`](Self::get_mut), or `.clone()` the guard for an owned copy when
+    /// `V: Clone`.
     ///
     /// # Errors
     ///

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -8,7 +8,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeSeq;
 use serde::Serialize;
 
-use super::{Collection, CrdtType};
+use super::{Collection, CrdtType, ValueRef};
 use crate::collections::error::StoreError;
 use crate::entities::Data;
 use crate::store::{MainStorage, StorageAdaptor};
@@ -217,15 +217,25 @@ where
 
     /// Get the value at a specific index in the vector.
     ///
+    /// Returns a read-only [`ValueRef`] guard (an owned copy that derefs to
+    /// `&V`). To *mutate* the stored value use [`update`](Self::update) or
+    /// [`get_mut`](Self::get_mut); to take an owned mutable copy on purpose call
+    /// [`ValueRef::into_inner`].
+    ///
     /// # Errors
     ///
     /// If an error occurs when interacting with the storage system, or a child
     /// [`Element`](crate::entities::Element) cannot be found, an error will be
     /// returned. Returns an error if the index would cause arithmetic overflow.
     ///
-    pub fn get(&self, index: usize) -> Result<Option<V>, StoreError> {
+    pub fn get(&self, index: usize) -> Result<Option<ValueRef<V>>, StoreError> {
         validate_index_bounds(index)?;
-        self.inner.entries()?.nth(index).transpose()
+        Ok(self
+            .inner
+            .entries()?
+            .nth(index)
+            .transpose()?
+            .map(ValueRef::new))
     }
 
     /// Update the value at a specific index in the vector.
@@ -535,7 +545,7 @@ mod tests {
 
         let value = "test_data".to_owned();
         let _ = vector.push(value.clone()).unwrap();
-        let retrieved_value = vector.get(0).unwrap();
+        let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
         assert_eq!(retrieved_value, Some(value));
     }
 
@@ -547,7 +557,7 @@ mod tests {
         let value2 = "test_data2".to_owned();
         let _ = vector.push(value1.clone()).unwrap();
         let old = vector.update(0, value2.clone()).unwrap();
-        let retrieved_value = vector.get(0).unwrap();
+        let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
         assert_eq!(retrieved_value, Some(value2));
         assert_eq!(old, Some(value1));
     }

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -469,10 +469,15 @@ where
 
 impl<V, S> Default for Vector<V, S>
 where
-    V: BorshSerialize + BorshDeserialize,
-    S: StorageAdaptor,
+    V: BorshSerialize + BorshDeserialize + 'static,
+    S: StorageAdaptor + 'static,
 {
     fn default() -> Self {
+        // Register the nested-id re-key thunk at construction so a vector first
+        // created via `default()` (e.g. `entry(k).or_default()` on a
+        // `Map<_, Vector<..>>`) is re-keyed deterministically by its parent
+        // rather than keeping a per-node random id. See `UnorderedMap`'s `Default`.
+        super::rekey::register_rekey::<Self>();
         Self::new_internal()
     }
 }

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -470,7 +470,7 @@ where
 impl<V, S> Default for Vector<V, S>
 where
     V: BorshSerialize + BorshDeserialize + 'static,
-    S: StorageAdaptor + 'static,
+    S: StorageAdaptor,
 {
     fn default() -> Self {
         // Register the nested-id re-key thunk at construction so a vector first

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -99,7 +99,7 @@ impl JsUnorderedMap {
     ///
     /// Propagates [`StoreError`] when the underlying map read fails.
     pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
-        self.map.get(key)
+        Ok(self.map.get(key)?.map(|v| v.into_inner()))
     }
 
     /// Removes the value for `key`, returning the previous value if it existed.
@@ -234,7 +234,7 @@ impl JsVector {
     ///
     /// Returns [`StoreError`] when the underlying vector read fails.
     pub fn get(&self, index: usize) -> Result<Option<Vec<u8>>, StoreError> {
-        self.vector.get(index)
+        Ok(self.vector.get(index)?.map(|v| v.into_inner()))
     }
 
     /// Updates the value at `index`, returning the old value if it existed.

--- a/crates/storage/src/tests/collections.rs
+++ b/crates/storage/src/tests/collections.rs
@@ -78,11 +78,17 @@ fn test_unordered_map_basic_operations() {
         .is_none());
 
     assert_eq!(
-        map.get("key").expect("get failed").as_deref(),
+        map.get("key")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("value")
     );
     assert_ne!(
-        map.get("key").expect("get failed").as_deref(),
+        map.get("key")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("value2")
     );
 
@@ -98,11 +104,17 @@ fn test_unordered_map_basic_operations() {
         .is_none());
 
     assert_eq!(
-        map.get("key").expect("get failed").as_deref(),
+        map.get("key")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("value2")
     );
     assert_eq!(
-        map.get("key2").expect("get failed").as_deref(),
+        map.get("key2")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("value")
     );
 
@@ -131,11 +143,17 @@ fn test_unordered_map_insert_and_get() {
         .is_none());
 
     assert_eq!(
-        map.get("key1").expect("get failed").as_deref(),
+        map.get("key1")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("value1")
     );
     assert_eq!(
-        map.get("key2").expect("get failed").as_deref(),
+        map.get("key2")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("value2")
     );
 }
@@ -154,7 +172,10 @@ fn test_unordered_map_update_value() {
         .is_none());
 
     assert_eq!(
-        map.get("key").expect("get failed").as_deref(),
+        map.get("key")
+            .expect("get failed")
+            .as_deref()
+            .map(String::as_str),
         Some("new_value")
     );
 }
@@ -280,7 +301,7 @@ fn test_vector_get() {
 
     let value = "test_data".to_string();
     let _ = vector.push(value.clone()).unwrap();
-    let retrieved_value = vector.get(0).unwrap();
+    let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
     assert_eq!(retrieved_value, Some(value));
 }
 
@@ -292,7 +313,7 @@ fn test_vector_update() {
     let value2 = "test_data2".to_string();
     let _ = vector.push(value1.clone()).unwrap();
     let old = vector.update(0, value2.clone()).unwrap();
-    let retrieved_value = vector.get(0).unwrap();
+    let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
     assert_eq!(retrieved_value, Some(value2));
     assert_eq!(old, Some(value1));
 }

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -6,7 +6,7 @@
 
 use crate::collections::{
     Counter, LwwRegister, Mergeable, ReplicatedGrowableArray, Root, UnorderedMap, UnorderedSet,
-    Vector,
+    ValueRef, Vector,
 };
 use crate::env;
 use crate::merge::{clear_merge_registry, merge_root_state, register_crdt_merge};
@@ -222,7 +222,12 @@ fn test_merge_with_nested_map() {
 
     // Simulate node 2 - add title field
     let mut state2: AppWithNestedMap = borsh::from_slice(&bytes1).unwrap();
-    let mut doc = state2.documents.get(&"doc-1".to_string()).unwrap().unwrap();
+    let mut doc = state2
+        .documents
+        .get(&"doc-1".to_string())
+        .unwrap()
+        .unwrap()
+        .into_inner();
     doc.insert(
         "title".to_string(),
         LwwRegister::new("My Title".to_string()),
@@ -238,7 +243,8 @@ fn test_merge_with_nested_map() {
         .documents
         .get(&"doc-1".to_string())
         .unwrap()
-        .unwrap();
+        .unwrap()
+        .into_inner();
     doc.insert("owner".to_string(), LwwRegister::new("Alice".to_string()))
         .unwrap();
     state1_modified
@@ -662,7 +668,12 @@ fn test_merge_map_of_counters() {
 
     // Node 2: Increment the same counter (from same base)
     let mut state2: AppWithCounters = borsh::from_slice(&bytes1).unwrap();
-    let mut counter2 = state2.scores.get(&"player1".to_string()).unwrap().unwrap();
+    let mut counter2 = state2
+        .scores
+        .get(&"player1".to_string())
+        .unwrap()
+        .unwrap()
+        .into_inner();
     counter2.increment().unwrap(); // value = 3
     state2
         .scores
@@ -808,11 +819,11 @@ fn test_merge_vector_of_counters() {
     let mut state2: AppWithVectorCounters = borsh::from_slice(&bytes1).unwrap();
 
     // Increment both counters on node 2
-    let mut c = state2.metrics.get(0).unwrap().unwrap();
+    let mut c = state2.metrics.get(0).unwrap().unwrap().into_inner();
     c.increment().unwrap(); // was 2, now 3
     state2.metrics.update(0, c).unwrap();
 
-    let mut c = state2.metrics.get(1).unwrap().unwrap();
+    let mut c = state2.metrics.get(1).unwrap().unwrap().into_inner();
     c.increment().unwrap();
     c.increment().unwrap(); // was 1, now 3
     state2.metrics.update(1, c).unwrap();
@@ -885,7 +896,12 @@ fn test_merge_map_of_sets() {
     // Node 2: Add more tags to Alice (concurrent)
     let mut state2: AppWithSetTags = borsh::from_slice(&bytes1).unwrap();
 
-    let mut alice_tags2 = state2.user_tags.get(&"alice".to_string()).unwrap().unwrap();
+    let mut alice_tags2 = state2
+        .user_tags
+        .get(&"alice".to_string())
+        .unwrap()
+        .unwrap()
+        .into_inner();
     alice_tags2.insert("crdt".to_string()).unwrap();
     alice_tags2.insert("distributed".to_string()).unwrap();
     state2
@@ -2165,6 +2181,7 @@ fn test_nested_counter_in_map_concurrent_increments_converge() {
             .counters
             .get(&"k".to_string())
             .unwrap()
+            .map(ValueRef::into_inner)
             .unwrap_or_else(Counter::new);
         ctr.increment().unwrap();
         doc.counters.insert("k".to_string(), ctr).unwrap();
@@ -2310,6 +2327,7 @@ fn test_nested_counter_first_touch_concurrent_converges() {
             .counters
             .get(&"k".to_string())
             .unwrap()
+            .map(ValueRef::into_inner)
             .unwrap_or_else(Counter::new);
         ctr.increment().unwrap();
         doc.counters.insert("k".to_string(), ctr).unwrap();
@@ -2839,6 +2857,7 @@ fn test_nested_set_first_touch_concurrent_converges() {
             .tags
             .get(&"k".to_string())
             .unwrap()
+            .map(ValueRef::into_inner)
             .unwrap_or_else(UnorderedSet::new);
         let _ = set.insert(tag.to_string()).unwrap();
         doc.tags.insert("k".to_string(), set).unwrap();
@@ -2998,6 +3017,7 @@ fn test_nested_pncounter_single_writer_converges() {
         .counters
         .get(&"bal".to_string())
         .unwrap()
+        .map(ValueRef::into_inner)
         .unwrap_or_else(Counter::<true>::new);
     ctr.increment().unwrap();
     ctr.increment().unwrap();
@@ -3123,6 +3143,7 @@ fn test_nested_pncounter_concurrent_writers_converge() {
             .counters
             .get(&"bal".to_string())
             .unwrap()
+            .map(ValueRef::into_inner)
             .unwrap_or_else(Counter::<true>::new);
         ctr.increment().unwrap();
         ctr.increment().unwrap();
@@ -3144,6 +3165,7 @@ fn test_nested_pncounter_concurrent_writers_converge() {
             .counters
             .get(&"bal".to_string())
             .unwrap()
+            .map(ValueRef::into_inner)
             .unwrap_or_else(Counter::<true>::new);
         ctr.increment().unwrap();
         doc.counters.insert("bal".to_string(), ctr).unwrap();

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -2523,6 +2523,138 @@ fn test_nested_counter_first_touch_via_entry_api_converges() {
     );
 }
 
+/// Same first-touch nested-counter convergence as the `or_insert_with` test
+/// above, but the value is created via `map.entry(k).or_default()`. `or_default`
+/// delegates to `or_insert_with(V::default)` and so funnels through the same
+/// `VacantEntry::insert` re-keying path — this guards that the convenience
+/// wrapper does not regress the nested-CRDT re-keying that makes independently
+/// first-created values converge across nodes.
+#[test]
+#[serial]
+fn test_nested_counter_first_touch_via_or_default_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct NestedCounters {
+        counters: UnorderedMap<String, Counter>,
+    }
+    impl Mergeable for NestedCounters {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.counters.merge(&other.counters)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<NestedCounters, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<NestedCounters>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    let incr_create_via_or_default = || {
+        let mut doc = Root::<NestedCounters, S>::fetch().unwrap();
+        // First touch through `or_default()`: vacant -> insert Counter::default().
+        {
+            let mut guard = doc
+                .counters
+                .entry("k".to_string())
+                .unwrap()
+                .or_default()
+                .unwrap();
+            guard.increment().unwrap();
+        }
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: EMPTY map (no "k"); only the map container is shared.
+    fresh([9; 32]);
+    let g = Root::<NestedCounters, S>::new(|| NestedCounters {
+        counters: UnorderedMap::new_with_field_name("counters"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = incr_create_via_or_default();
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = incr_create_via_or_default();
+
+    let value_of = || -> u64 {
+        Root::<NestedCounters, S>::fetch()
+            .unwrap()
+            .counters
+            .get(&"k".to_string())
+            .unwrap()
+            .map(|c| c.value().unwrap())
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, 2,
+        "node A: or_default()-created 'k' counters must merge to 2 (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: or_default()-created 'k' counters must merge to 2 (got {b_val})"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "or_default() first-touch nested-counter root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
 /// Same first-touch nested-counter convergence, but the value is bulk-inserted
 /// via `Extend` (`map.extend([(k, counter)])`) — the path `collect()` /
 /// `FromIterator` also funnels through. `Extend::extend` was a third store path

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -2541,6 +2541,147 @@ fn test_nested_counter_first_touch_via_entry_api_converges() {
     );
 }
 
+/// First-touch convergence when the `or_default()` value is itself a *nested
+/// collection* (`Map<String, Map<String, Counter>>`), created on two nodes
+/// independently. This is the case the app `set_metadata`/`add_tag` handlers
+/// exercise. It guards against the re-key-registration ordering hazard: the
+/// inner map's re-key thunk is registered by its own `insert`/`extend`, so a
+/// freshly `or_default()`-minted inner collection must still end up with a
+/// deterministic id (else the two nodes' inner maps are distinct entities and
+/// their counters never sum).
+#[test]
+#[serial]
+fn test_nested_map_first_touch_via_or_default_converges() {
+    use crate::action::Action;
+    use crate::address::Id;
+    use crate::delta::{commit_causal_delta, reset_delta_context, set_current_heads, StorageDelta};
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, Interface};
+    use crate::store::MainStorage;
+
+    #[derive(BorshSerialize, BorshDeserialize)]
+    struct NestedMaps {
+        outer: UnorderedMap<String, UnorderedMap<String, Counter>>,
+    }
+    impl Mergeable for NestedMaps {
+        fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+            self.outer.merge(&other.outer)
+        }
+    }
+
+    type S = MainStorage;
+    let root_hash = || {
+        Index::<S>::get_hashes_for(Id::root())
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32])
+    };
+    let capture = |data: Vec<u8>| -> Vec<Action> {
+        Interface::<S>::save_raw(Id::root(), data, Metadata::default()).unwrap();
+        commit_causal_delta(&root_hash())
+            .unwrap()
+            .expect("op must produce a delta")
+            .actions
+    };
+    let import = |actions: Vec<Action>| {
+        let payload = borsh::to_vec(&StorageDelta::Actions(actions)).unwrap();
+        Root::<NestedMaps, S>::sync(&payload, &ApplyContext::empty()).unwrap();
+    };
+    let fresh = |exec: [u8; 32]| {
+        env::reset_for_testing();
+        reset_delta_context();
+        register_crdt_merge::<NestedMaps>();
+        set_current_heads(vec![[0; 32]]);
+        env::set_executor_id(exec);
+    };
+    // First touch through `or_default()` at BOTH levels: vacant outer -> default
+    // inner map; vacant inner -> default Counter; then increment.
+    let touch_via_or_default = || {
+        let mut doc = Root::<NestedMaps, S>::fetch().unwrap();
+        {
+            let mut inner = doc
+                .outer
+                .entry("k".to_string())
+                .unwrap()
+                .or_default()
+                .unwrap();
+            let mut ctr = inner.entry("c".to_string()).unwrap().or_default().unwrap();
+            ctr.increment().unwrap();
+        }
+        let data = borsh::to_vec(&*doc).unwrap();
+        drop(doc);
+        capture(data)
+    };
+
+    // Genesis: EMPTY outer map; only the container is shared.
+    fresh([9; 32]);
+    let g = Root::<NestedMaps, S>::new(|| NestedMaps {
+        outer: UnorderedMap::new_with_field_name("outer"),
+    });
+    let g_data = borsh::to_vec(&*g).unwrap();
+    drop(g);
+    let base = capture(g_data);
+    let base_hash = root_hash();
+
+    fresh([1; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_a = touch_via_or_default();
+
+    fresh([2; 32]);
+    import(base.clone());
+    reset_delta_context();
+    set_current_heads(vec![base_hash]);
+    let delta_b = touch_via_or_default();
+
+    let value_of = || -> u64 {
+        Root::<NestedMaps, S>::fetch()
+            .unwrap()
+            .outer
+            .get(&"k".to_string())
+            .unwrap()
+            .and_then(|inner| {
+                inner
+                    .get(&"c".to_string())
+                    .unwrap()
+                    .map(|c| c.value().unwrap())
+            })
+            .unwrap_or(0)
+    };
+    let materialize = |exec: [u8; 32], first: &[Action], second: &[Action]| -> (u64, [u8; 32]) {
+        fresh(exec);
+        import(base.clone());
+        reset_delta_context();
+        set_current_heads(vec![base_hash]);
+        import(first.to_vec());
+        reset_delta_context();
+        set_current_heads(vec![root_hash()]);
+        import(second.to_vec());
+        (value_of(), root_hash())
+    };
+
+    let (a_val, a_root) = materialize([1; 32], &delta_a, &delta_b);
+    let (b_val, b_root) = materialize([2; 32], &delta_b, &delta_a);
+
+    assert_eq!(
+        a_val, 2,
+        "node A: or_default()-created nested-map counter must merge to 2 (got {a_val})"
+    );
+    assert_eq!(
+        b_val, 2,
+        "node B: or_default()-created nested-map counter must merge to 2 (got {b_val})"
+    );
+    assert_eq!(
+        a_root,
+        b_root,
+        "or_default() first-touch nested-MAP root must converge regardless of apply order: A={} B={}",
+        hex::encode(a_root),
+        hex::encode(b_root),
+    );
+}
+
 /// Same first-touch nested-counter convergence as the `or_insert_with` test
 /// above, but the value is created via `map.entry(k).or_default()`. `or_default`
 /// delegates to `or_insert_with(V::default)` and so funnels through the same

--- a/crates/storage/src/tests/nested_crdt_merge.rs
+++ b/crates/storage/src/tests/nested_crdt_merge.rs
@@ -30,14 +30,14 @@ fn test_nested_map_merge_different_inner_keys() {
     let mut map2 = map1; // Placeholder
 
     // Node 1: Update title field
-    let mut inner1 = map1.get(&"doc-1".to_string()).unwrap().unwrap();
+    let mut inner1 = map1.get(&"doc-1".to_string()).unwrap().unwrap().into_inner();
     inner1
         .insert("title".to_string(), "Updated Title".to_string())
         .unwrap();
     map1.insert("doc-1".to_string(), inner1).unwrap();
 
     // Node 2: Add owner field (concurrent modification)
-    let mut inner2 = map2.get(&"doc-1".to_string()).unwrap().unwrap();
+    let mut inner2 = map2.get(&"doc-1".to_string()).unwrap().unwrap().into_inner();
     inner2
         .insert("owner".to_string(), "Alice".to_string())
         .unwrap();
@@ -87,12 +87,12 @@ fn test_map_of_counters_merge() {
     let mut map2 = map1.clone();
 
     // Node 1: Increment counter1
-    let mut c = map1.get(&"counter1".to_string()).unwrap().unwrap();
+    let mut c = map1.get(&"counter1".to_string()).unwrap().unwrap().into_inner();
     c.increment().unwrap(); // value = 3
     map1.insert("counter1".to_string(), c).unwrap();
 
     // Node 2: Also increment counter1 (concurrent)
-    let mut c = map2.get(&"counter1".to_string()).unwrap().unwrap();
+    let mut c = map2.get(&"counter1".to_string()).unwrap().unwrap().into_inner();
     c.increment().unwrap(); // value = 3
     map2.insert("counter1".to_string(), c).unwrap();
 
@@ -122,14 +122,14 @@ fn test_map_of_lww_registers_merge() {
     std::thread::sleep(std::time::Duration::from_millis(1));
 
     // Node 1: Update title
-    let mut title1 = map1.get(&"title".to_string()).unwrap().unwrap();
+    let mut title1 = map1.get(&"title".to_string()).unwrap().unwrap().into_inner();
     title1.set("From Node 1".to_string());
     map1.insert("title".to_string(), title1).unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(1));
 
     // Node 2: Update title (concurrent, later timestamp)
-    let mut title2 = map2.get(&"title".to_string()).unwrap().unwrap();
+    let mut title2 = map2.get(&"title".to_string()).unwrap().unwrap().into_inner();
     title2.set("From Node 2".to_string());
     map2.insert("title".to_string(), title2).unwrap();
 
@@ -166,14 +166,14 @@ fn test_three_level_nesting_merge() {
     let mut map2 = map1.clone();
 
     // Node 1: Update title field
-    let mut inner1 = map1.get(&"doc-1".to_string()).unwrap().unwrap();
+    let mut inner1 = map1.get(&"doc-1".to_string()).unwrap().unwrap().into_inner();
     inner1
         .insert("title".to_string(), LwwRegister::new("Title 1".to_string()))
         .unwrap();
     map1.insert("doc-1".to_string(), inner1).unwrap();
 
     // Node 2: Add owner field (concurrent)
-    let mut inner2 = map2.get(&"doc-1".to_string()).unwrap().unwrap();
+    let mut inner2 = map2.get(&"doc-1".to_string()).unwrap().unwrap().into_inner();
     inner2
         .insert("owner".to_string(), LwwRegister::new("Alice".to_string()))
         .unwrap();


### PR DESCRIPTION
Closes #2542.

## Summary
Completes the in-place mutation path for nested CRDT values so app authors stop hand-writing the `get → modify → re-insert` dance.

Adds `Entry::or_default()` to both `UnorderedMap` and `SortedMap`. It inserts `V::default()` when the entry is vacant and returns the existing `ValueMut` write-back guard, which re-persists the value on drop (deterministically re-keying nested CRDTs under the entry's id). The guard plumbing and re-keying already existed behind `or_insert`/`or_insert_with`, so `or_default()` is a thin `or_insert_with(V::default)` wrapper — and it composes for nested collections (`Map<String, Map<String, _>>`) for free.

The blessed path is now:
```rust
let mut counter = self.counters.entry(key.clone())?.or_default()?;
counter.increment()?;
let value = counter.value()?;
```

## Changes
- **SDK** (`crates/storage/src/collections/`): add `or_default()` to `unordered_map.rs` and `sorted_map.rs`, with unit tests (vacant insert + write-back, occupied keep-existing, SortedMap ordering preserved).
- **Apps** rewritten onto `entry().or_default()`:
  - `nested-crdt-test`: `increment_counter`, `set_metadata` (two levels deep), `add_tag`
  - `team-metrics-custom`, `team-metrics-macro`: `record_win` / `record_loss` / `record_draw`

## Testing
- `cargo test -p calimero-storage --lib entry` → 11 passed (incl. both new `or_default` tests)
- `nested-crdt-test` / `team-metrics-custom` / `team-metrics-macro` `TestHost` unit tests pass (5 / 2 / 2)
- No new unused-import warnings; `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking `get` return types across storage collections plus CRDT identity/re-key and convergence behavior; incorrect usage could cause silent divergence before this change and compile breaks after.
> 
> **Overview**
> This PR finishes the **in-place nested CRDT mutation** story: **`Entry::or_default()`** on `UnorderedMap` and `SortedMap` (vacant → `V::default()`, returns **`ValueMut`** that **write-backs on drop**, including deterministic **re-key** for nested collections). Apps (`nested-crdt-test`, `scaffolding-e2e`, team-metrics apps) replace **`get` → modify → `insert`** with **`entry(...).or_default()?`**.
> 
> **`get`** on core maps/vectors now returns **`ValueRef<V>`** — an owned, **read-only** guard (`Deref` only, no public `into_inner`) so mutating a fetched copy without persisting becomes a **compile error**. Internal merge/decompose paths use crate-private **`into_inner`** / **`as_deref`**.
> 
> **`Default`** for maps/sets/vectors registers **re-key** at construction so values first created via **`or_default()`** converge across nodes. New **integration tests** cover first-touch convergence for nested counters and **`Map<String, Map<String, Counter>>`** via **`or_default()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab22012b65ae902cfc9fd8944703446ef97c3460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->