### PR TITLE
fix(storage): auto-converge custom struct CRDT values via deterministic re-key (#2577)

### DIFF
--- a/apps/team-metrics-custom/Cargo.toml
+++ b/apps/team-metrics-custom/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 calimero-sdk.workspace = true

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -51,6 +51,32 @@ impl Mergeable for TeamStats {
     }
 }
 
+/// Deterministic re-keying for a HAND-WRITTEN CRDT-value struct (#2577).
+///
+/// `#[derive(Mergeable)]` generates this for you. When you implement `Mergeable`
+/// by hand (as above), you MUST also implement `RekeyTarget`, or this struct —
+/// stored as an `UnorderedMap` value — is last-writer-wins'd as an opaque blob
+/// and its counters silently lose concurrent increments. Re-key each nested
+/// collection field under a field-namespaced child of the entry id so every
+/// replica derives identical ids and the counters converge as child entities.
+impl calimero_storage::collections::rekey::RekeyTarget for TeamStats {
+    fn rekey_relative_to(&mut self, parent_id: calimero_storage::address::Id) {
+        use calimero_storage::collections::rekey::field_child_id;
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.wins,
+            field_child_id(parent_id, "wins")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.losses,
+            field_child_id(parent_id, "losses")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.draws,
+            field_child_id(parent_id, "draws")
+        );
+    }
+}
+
 /// Application state
 #[app::state(emits = MetricsEvent)]
 pub struct TeamMetricsApp {

--- a/apps/team-metrics-custom/tests/converge.rs
+++ b/apps/team-metrics-custom/tests/converge.rs
@@ -33,6 +33,11 @@ fn team_stats_converge_to_summed_value_custom() {
     env::reset_environment();
     register_crdt_merge_for_test::<TeamMetricsApp>();
     calimero_sdk::event::register::<TeamMetricsApp>();
+    // `#[app::state]`-generated: registers re-key thunks for the value types of
+    // the root's collection fields. `teams: UnorderedMap<String, TeamStats>` →
+    // `TeamStats` is registered (and its hand-written `RekeyTarget` impl used).
+    // This is the WASM-load / TestHost-bridge path; we call it directly here.
+    // (One level deep — see `generate_rekey_register_method` for the scope.)
     TeamMetricsApp::__calimero_register_rekey();
 
     let a: Store = Default::default();

--- a/apps/team-metrics-custom/tests/converge.rs
+++ b/apps/team-metrics-custom/tests/converge.rs
@@ -1,0 +1,79 @@
+//! #2577 end-to-end for the HAND-WRITTEN `Mergeable` + manual `RekeyTarget` app.
+//! Two replicas concurrently record wins for the same team; the counters must
+//! SUM (not be lost to LWW). Own integration binary for isolation.
+
+#![allow(clippy::unwrap_used)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use calimero_storage::collections::Root;
+use calimero_storage::env::{self, RuntimeEnv};
+use calimero_storage::interface::ApplyContext;
+use calimero_storage::register_crdt_merge_for_test;
+use calimero_storage::store::Key;
+use team_metrics_custom::TeamMetricsApp;
+
+type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
+
+fn env_for(s: &Store, ex: [u8; 32]) -> RuntimeEnv {
+    let r = s.clone();
+    let reader = Rc::new(move |k: &Key| r.borrow().get(&k.to_bytes()).cloned());
+    let w = s.clone();
+    let writer =
+        Rc::new(move |k: Key, v: &[u8]| w.borrow_mut().insert(k.to_bytes(), v.to_vec()).is_some());
+    let rm = s.clone();
+    let remover = Rc::new(move |k: &Key| rm.borrow_mut().remove(&k.to_bytes()).is_some());
+    RuntimeEnv::new(reader, writer, remover, [7u8; 32], ex)
+}
+
+#[test]
+fn team_stats_converge_to_summed_value_custom() {
+    env::reset_environment();
+    register_crdt_merge_for_test::<TeamMetricsApp>();
+    calimero_sdk::event::register::<TeamMetricsApp>();
+    TeamMetricsApp::__calimero_register_rekey();
+
+    let a: Store = Default::default();
+    let b: Store = Default::default();
+    env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::new(TeamMetricsApp::init).commit();
+    });
+    *b.borrow_mut() = a.borrow().clone();
+
+    let da = env::with_runtime_env(env_for(&a, [1; 32]), || {
+        let mut app = Root::<TeamMetricsApp>::fetch().unwrap();
+        let _ = app.record_win("liverpool".into());
+        app.commit();
+        env::take_last_artifact().unwrap()
+    });
+    let db = env::with_runtime_env(env_for(&b, [2; 32]), || {
+        let mut app = Root::<TeamMetricsApp>::fetch().unwrap();
+        let _ = app.record_win("liverpool".into());
+        app.commit();
+        env::take_last_artifact().unwrap()
+    });
+
+    let (ha, wa) = env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::<TeamMetricsApp>::sync(&db, &ApplyContext::empty()).unwrap();
+        let app = Root::<TeamMetricsApp>::fetch().unwrap();
+        (env::root_hash(), app.get_wins("liverpool".into()).unwrap())
+    });
+    let (hb, wb) = env::with_runtime_env(env_for(&b, [2; 32]), || {
+        Root::<TeamMetricsApp>::sync(&da, &ApplyContext::empty()).unwrap();
+        let app = Root::<TeamMetricsApp>::fetch().unwrap();
+        (env::root_hash(), app.get_wins("liverpool".into()).unwrap())
+    });
+
+    println!("wins a={wa} b={wb}; converged={}", ha == hb);
+    assert_eq!(
+        wa, 2,
+        "replica A: both replicas' wins must survive (no LWW data loss)"
+    );
+    assert_eq!(
+        wb, 2,
+        "replica B: both replicas' wins must survive (no LWW data loss)"
+    );
+    assert_eq!(ha, hb, "replicas must converge to the same root hash");
+}

--- a/apps/team-metrics-macro/Cargo.toml
+++ b/apps/team-metrics-macro/Cargo.toml
@@ -7,7 +7,9 @@ repository.workspace = true
 license.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+# `rlib` (alongside the wasm `cdylib`) lets the convergence integration test in
+# `tests/` import the app type; harmless for the wasm build.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 calimero-sdk.workspace = true

--- a/apps/team-metrics-macro/tests/converge.rs
+++ b/apps/team-metrics-macro/tests/converge.rs
@@ -1,0 +1,83 @@
+//! #2577 end-to-end: the REAL `#[app::state]` + `#[derive(Mergeable)]` app, with
+//! NO hand-written rekey code — only the macro-generated `RekeyTarget` impl and
+//! `__calimero_register_rekey()` registration. Two replicas concurrently record
+//! wins for the same team; the counters must SUM (not be lost to LWW).
+//!
+//! Own integration binary so it runs isolated from process-global state.
+
+#![allow(clippy::unwrap_used)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use calimero_storage::collections::Root;
+use calimero_storage::env::{self, RuntimeEnv};
+use calimero_storage::interface::ApplyContext;
+use calimero_storage::register_crdt_merge_for_test;
+use calimero_storage::store::Key;
+use team_metrics_macro::TeamMetricsApp;
+
+type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
+
+fn env_for(s: &Store, ex: [u8; 32]) -> RuntimeEnv {
+    let r = s.clone();
+    let reader = Rc::new(move |k: &Key| r.borrow().get(&k.to_bytes()).cloned());
+    let w = s.clone();
+    let writer =
+        Rc::new(move |k: Key, v: &[u8]| w.borrow_mut().insert(k.to_bytes(), v.to_vec()).is_some());
+    let rm = s.clone();
+    let remover = Rc::new(move |k: &Key| rm.borrow_mut().remove(&k.to_bytes()).is_some());
+    RuntimeEnv::new(reader, writer, remover, [7u8; 32], ex)
+}
+
+#[test]
+fn team_stats_converge_to_summed_value() {
+    env::reset_environment();
+    // Exactly what the WASM module load / TestHost bridge do:
+    register_crdt_merge_for_test::<TeamMetricsApp>();
+    calimero_sdk::event::register::<TeamMetricsApp>(); // record_win emits events
+    TeamMetricsApp::__calimero_register_rekey(); // macro-generated (#2577)
+
+    let a: Store = Default::default();
+    let b: Store = Default::default();
+    env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::new(TeamMetricsApp::init).commit();
+    });
+    *b.borrow_mut() = a.borrow().clone();
+
+    let da = env::with_runtime_env(env_for(&a, [1; 32]), || {
+        let mut app = Root::<TeamMetricsApp>::fetch().unwrap();
+        let _ = app.record_win("liverpool".into());
+        app.commit();
+        env::take_last_artifact().unwrap()
+    });
+    let db = env::with_runtime_env(env_for(&b, [2; 32]), || {
+        let mut app = Root::<TeamMetricsApp>::fetch().unwrap();
+        let _ = app.record_win("liverpool".into());
+        app.commit();
+        env::take_last_artifact().unwrap()
+    });
+
+    let (ha, wa) = env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::<TeamMetricsApp>::sync(&db, &ApplyContext::empty()).unwrap();
+        let app = Root::<TeamMetricsApp>::fetch().unwrap();
+        (env::root_hash(), app.get_wins("liverpool".into()).unwrap())
+    });
+    let (hb, wb) = env::with_runtime_env(env_for(&b, [2; 32]), || {
+        Root::<TeamMetricsApp>::sync(&da, &ApplyContext::empty()).unwrap();
+        let app = Root::<TeamMetricsApp>::fetch().unwrap();
+        (env::root_hash(), app.get_wins("liverpool".into()).unwrap())
+    });
+
+    println!("wins a={wa} b={wb}; converged={}", ha == hb);
+    assert_eq!(
+        wa, 2,
+        "replica A: both replicas' wins must survive (no LWW data loss)"
+    );
+    assert_eq!(
+        wb, 2,
+        "replica B: both replicas' wins must survive (no LWW data loss)"
+    );
+    assert_eq!(ha, hb, "replicas must converge to the same root hash");
+}

--- a/crates/sdk/macros/src/mergeable.rs
+++ b/crates/sdk/macros/src/mergeable.rs
@@ -52,6 +52,11 @@ pub fn derive(input: DeriveInput) -> TokenStream {
         return errs.to_compile_error();
     }
 
+    let rekey_body: TokenStream = match &input.data {
+        Data::Struct(s) => generate_struct_rekey(&s.fields),
+        _ => quote! {},
+    };
+
     quote! {
         impl #impl_generics ::calimero_storage::collections::Mergeable
             for #ident #ty_generics #where_clause
@@ -67,6 +72,58 @@ pub fn derive(input: DeriveInput) -> TokenStream {
                 ::core::result::Result::Ok(())
             }
         }
+
+        // Deterministic re-keying for use as a CRDT collection VALUE. When this
+        // struct is stored as a map/set/vector value under a deterministic entry
+        // id, each field's nested collection ids are re-keyed under a
+        // field-namespaced child of that id — so every replica derives identical
+        // ids and the nested CRDTs converge as child entities instead of the
+        // whole struct blob being last-writer-wins'd (the #2577 data loss).
+        // `rekey_field_if_supported!` autoref-dispatches: a real re-key for
+        // fields whose type implements `RekeyTarget` (collections, nested CRDT
+        // structs), a no-op for leaf fields (e.g. `LwwRegister`).
+        impl #impl_generics ::calimero_storage::collections::rekey::RekeyTarget
+            for #ident #ty_generics #where_clause
+        {
+            fn rekey_relative_to(
+                &mut self,
+                parent_id: ::calimero_storage::address::Id,
+            ) {
+                #rekey_body
+            }
+        }
+    }
+}
+
+fn generate_struct_rekey(fields: &Fields) -> TokenStream {
+    match fields {
+        Fields::Named(named) => {
+            let calls = named.named.iter().map(|f| {
+                let name = f.ident.as_ref().expect("named field has ident");
+                let name_str = name.to_string();
+                quote! {
+                    ::calimero_storage::rekey_field_if_supported!(
+                        &mut self.#name,
+                        ::calimero_storage::collections::rekey::field_child_id(parent_id, #name_str)
+                    );
+                }
+            });
+            quote! { #(#calls)* }
+        }
+        Fields::Unnamed(unnamed) => {
+            let calls = unnamed.unnamed.iter().enumerate().map(|(i, _)| {
+                let idx = syn::Index::from(i);
+                let name_str = i.to_string();
+                quote! {
+                    ::calimero_storage::rekey_field_if_supported!(
+                        &mut self.#idx,
+                        ::calimero_storage::collections::rekey::field_child_id(parent_id, #name_str)
+                    );
+                }
+            });
+            quote! { #(#calls)* }
+        }
+        Fields::Unit => quote! {},
     }
 }
 

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -682,9 +682,12 @@ fn generate_rekey_register_method(
         collect_type_paths(&field.ty, &mut types);
     }
 
-    // Dedup by token string: the same value type can appear in several fields
-    // (e.g. two `UnorderedMap<String, TeamStats>`), and `register_rekey_pub` is
-    // already idempotent — so emit one registration call per distinct type.
+    // Dedup by token string (syntactic, not semantic): the same value type can
+    // appear in several fields (e.g. two `UnorderedMap<String, TeamStats>`), so
+    // collapse identically-written types to one registration call. Types written
+    // differently but equal (`TeamStats` vs `crate::TeamStats`) still emit two
+    // calls — harmless: they share a `TypeId`, and `register_rekey_pub` is
+    // idempotent (`or_insert`), so the registry holds one entry either way.
     let mut seen = std::collections::HashSet::new();
     let calls = types
         .iter()

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -655,7 +655,16 @@ fn generate_registration_hook(
 /// We register EVERY type token found in each field (the collection itself, its
 /// key/value types, and so on). `register_rekey_if_supported!` autoref-dispatches
 /// to a real registration only for `RekeyTarget` types and is a safe no-op for
-/// leaves (`String`, `u64`, `LwwRegister<_>`, …), so over-collecting is harmless.
+/// leaves (`String`, `u64`, `LwwRegister<_>`, …), so over-collecting (including
+/// key types) is harmless.
+///
+/// SCOPE — one level of custom-struct nesting. This registers the value types of
+/// the ROOT state's collection fields. Built-in collections self-register in
+/// their constructors, so any depth of *built-in* nesting works. But a custom
+/// struct reachable only through ANOTHER custom struct's collection (state →
+/// `Map<_, Outer>` → `Map<_, Inner>`, where both are app structs) is not
+/// registered here, so `Inner` would still be LWW'd. Deep custom nesting is the
+/// follow-up; today's apps don't hit it.
 fn generate_rekey_register_method(
     ident: &Ident,
     generics: &Generics,

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -48,14 +48,22 @@ impl ToTokens for StateImpl<'_> {
         // Generate Mergeable implementation
         let merge_impl = generate_mergeable_impl(ident, generics, orig);
 
+        // Re-key registration for nested CRDT-value types (#2577): so a custom
+        // struct stored as a collection value has its nested collections given
+        // deterministic ids and converges instead of being LWW'd as a blob.
+        // The method holds the registrations; the wasm load hook, the native
+        // test bridge, and `register_crdt_merge_for_test` all call it.
+        let rekey_register_method = generate_rekey_register_method(ident, generics, orig);
+        let rekey_call = quote! { <#ident #ty_generics>::__calimero_register_rekey(); };
+
         // Generate registration hook
-        let registration_hook = generate_registration_hook(ident, &ty_generics);
+        let registration_hook = generate_registration_hook(ident, &ty_generics, &rekey_call);
 
         // Generate deterministic ID assignment method
         let assign_ids_impl = generate_assign_deterministic_ids_impl(ident, generics, orig);
 
         // Generate the in-process test-harness bridge (native-only)
-        let test_state_impl = generate_test_state_impl(ident, generics, orig);
+        let test_state_impl = generate_test_state_impl(ident, generics, orig, &rekey_call);
 
         quote! {
             // State is always persisted via borsh (init save, root-state merge,
@@ -82,6 +90,9 @@ impl ToTokens for StateImpl<'_> {
 
             // Auto-generated registration hook
             #registration_hook
+
+            // Auto-generated nested-value re-key registration (#2577)
+            #rekey_register_method
 
             // Auto-generated deterministic ID assignment
             #assign_ids_impl
@@ -520,7 +531,11 @@ fn generate_mergeable_impl(
 ///    typed merge itself (separate address space), so it hands the
 ///    bytes to this export, which deserializes as `T`, runs
 ///    `Mergeable::merge`, returns serialized bytes.
-fn generate_registration_hook(ident: &Ident, ty_generics: &syn::TypeGenerics<'_>) -> TokenStream {
+fn generate_registration_hook(
+    ident: &Ident,
+    ty_generics: &syn::TypeGenerics<'_>,
+    rekey_call: &TokenStream,
+) -> TokenStream {
     quote! {
         // ============================================================================
         // AUTO-GENERATED WASM Export — WASM-Internal Registration Hook
@@ -536,6 +551,9 @@ fn generate_registration_hook(ident: &Ident, ty_generics: &syn::TypeGenerics<'_>
         #[no_mangle]
         pub extern "C" fn __calimero_register_merge() {
             ::calimero_storage::register_crdt_merge::<#ident #ty_generics>();
+            // Register nested CRDT-value-type re-key thunks (#2577) so struct
+            // values converge instead of being last-writer-wins'd as a blob.
+            #rekey_call
         }
 
         // ============================================================================
@@ -629,10 +647,83 @@ fn generate_registration_hook(ident: &Ident, ty_generics: &syn::TypeGenerics<'_>
 /// Only emitted for struct states. Enum states have no
 /// `__assign_deterministic_ids` method (no fields), and a CRDT root is always a
 /// struct in practice, so an enum-root app simply has no `TestHost` bridge.
+/// Generate `__calimero_register_rekey()` — registers a re-key thunk for every
+/// type that appears in a state field, so a custom struct stored as a collection
+/// VALUE gets its nested collections deterministically re-keyed (and thus
+/// converges) instead of being last-writer-wins'd as an opaque blob (#2577).
+///
+/// We register EVERY type token found in each field (the collection itself, its
+/// key/value types, and so on). `register_rekey_if_supported!` autoref-dispatches
+/// to a real registration only for `RekeyTarget` types and is a safe no-op for
+/// leaves (`String`, `u64`, `LwwRegister<_>`, …), so over-collecting is harmless.
+fn generate_rekey_register_method(
+    ident: &Ident,
+    generics: &Generics,
+    orig: &StructOrEnumItem,
+) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let fields = match orig {
+        StructOrEnumItem::Struct(s) => &s.fields,
+        StructOrEnumItem::Enum(_) => return quote! {},
+    };
+
+    let mut types: Vec<Type> = Vec::new();
+    for field in fields.iter() {
+        collect_type_paths(&field.ty, &mut types);
+    }
+
+    let calls = types.iter().map(|ty| {
+        quote! { ::calimero_storage::register_rekey_if_supported!(#ty); }
+    });
+
+    quote! {
+        impl #impl_generics #ident #ty_generics #where_clause {
+            /// Registers nested CRDT-value re-key thunks. Called at WASM module
+            /// load and by the native test bridge; idempotent. Not for direct use.
+            #[doc(hidden)]
+            pub fn __calimero_register_rekey() {
+                #(#calls)*
+            }
+        }
+    }
+}
+
+/// Recursively collect every `Type::Path` node reachable from `ty` (the type
+/// itself plus its generic arguments, tuple/reference/array elements), so the
+/// registration above can offer each to `register_rekey_if_supported!`.
+fn collect_type_paths(ty: &Type, out: &mut Vec<Type>) {
+    match ty {
+        Type::Path(tp) => {
+            out.push(ty.clone());
+            if let Some(seg) = tp.path.segments.last() {
+                if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                    for arg in &args.args {
+                        if let syn::GenericArgument::Type(inner) = arg {
+                            collect_type_paths(inner, out);
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(r) => collect_type_paths(&r.elem, out),
+        Type::Paren(p) => collect_type_paths(&p.elem, out),
+        Type::Group(g) => collect_type_paths(&g.elem, out),
+        Type::Array(a) => collect_type_paths(&a.elem, out),
+        Type::Tuple(t) => {
+            for elem in &t.elems {
+                collect_type_paths(elem, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn generate_test_state_impl(
     ident: &Ident,
     generics: &Generics,
     orig: &StructOrEnumItem,
+    rekey_call: &TokenStream,
 ) -> TokenStream {
     if matches!(orig, StructOrEnumItem::Enum(_)) {
         return quote! {};
@@ -655,6 +746,8 @@ fn generate_test_state_impl(
                 // unless the `testing` feature is enabled), so this bridge
                 // compiles even for example apps without `TestHost` tests.
                 ::calimero_storage::register_crdt_merge_for_test::<#ident #ty_generics>();
+                // Register nested CRDT-value-type re-key thunks (#2577).
+                #rekey_call
 
                 let root = ::calimero_storage::collections::Root::new(|| {
                     let mut state = build();

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -673,9 +673,16 @@ fn generate_rekey_register_method(
         collect_type_paths(&field.ty, &mut types);
     }
 
-    let calls = types.iter().map(|ty| {
-        quote! { ::calimero_storage::register_rekey_if_supported!(#ty); }
-    });
+    // Dedup by token string: the same value type can appear in several fields
+    // (e.g. two `UnorderedMap<String, TeamStats>`), and `register_rekey_pub` is
+    // already idempotent — so emit one registration call per distinct type.
+    let mut seen = std::collections::HashSet::new();
+    let calls = types
+        .iter()
+        .filter(|ty| seen.insert(ty.to_token_stream().to_string()))
+        .map(|ty| {
+            quote! { ::calimero_storage::register_rekey_if_supported!(#ty); }
+        });
 
     quote! {
         impl #impl_generics #ident #ty_generics #where_clause {

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -358,11 +358,38 @@ pub fn mergeable_derive(input: TokenStream) -> TokenStream {
         }
     });
 
+    // Per-field deterministic re-key (#2577). When this struct is stored as a
+    // collection VALUE under a deterministic entry id, each field's nested
+    // collection ids are re-keyed under a field-namespaced child of that id — so
+    // every replica derives identical ids and the nested CRDTs converge as child
+    // entities, instead of the whole struct blob being LWW'd (silent data loss).
+    // `rekey_field_if_supported!` autoref-dispatches to a real re-key for
+    // `RekeyTarget` fields (collections, nested CRDT structs) and a no-op for
+    // leaves (e.g. `LwwRegister`).
+    let rekey_calls = named_fields.iter().map(|field| {
+        let field_name = field.ident.as_ref().unwrap();
+        let field_name_str = field_name.to_string();
+        quote! {
+            ::calimero_storage::rekey_field_if_supported!(
+                &mut self.#field_name,
+                ::calimero_storage::collections::rekey::field_child_id(parent_id, #field_name_str)
+            );
+        }
+    });
+
     let expanded = quote! {
         impl #impl_generics calimero_storage::collections::Mergeable for #name #ty_generics #where_clause {
             fn merge(&mut self, other: &Self) -> Result<(), calimero_storage::collections::crdt_meta::MergeError> {
                 #(#merge_calls)*
                 Ok(())
+            }
+        }
+
+        impl #impl_generics ::calimero_storage::collections::rekey::RekeyTarget
+            for #name #ty_generics #where_clause
+        {
+            fn rekey_relative_to(&mut self, parent_id: ::calimero_storage::address::Id) {
+                #(#rekey_calls)*
             }
         }
     };

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -57,3 +57,7 @@ required-features = ["testing"]
 [[test]]
 name = "merge_registry_integration"
 required-features = ["testing"]
+
+[[test]]
+name = "rekey_record"
+required-features = ["testing"]

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -32,7 +32,7 @@ pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageStrategy
 pub mod composite_key;
 mod crdt_impls;
 mod decompose_impls;
-pub(crate) mod rekey;
+pub mod rekey;
 pub use composite_key::CompositeKey;
 pub mod nested;
 pub use nested::{get_nested, insert_nested, insert_nested_decomposable, NestedConfig};

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -44,12 +44,35 @@ use std::sync::{LazyLock, RwLock};
 
 use crate::address::Id;
 
-/// Implemented by collection types that carry nested collection ids needing
-/// deterministic re-keying relative to their storage parent.
-pub(crate) trait RekeyTarget: Any {
+/// Implemented by types that carry nested collection ids needing deterministic
+/// re-keying relative to their storage parent.
+///
+/// Built-in collections implement this and self-register in their constructors.
+/// Application structs used as CRDT values (e.g. an `UnorderedMap` value that is
+/// a `#[derive(Mergeable)]` struct of counters) get a generated impl that
+/// re-keys each field under a field-namespaced child id, so every replica
+/// derives identical nested ids and the children converge as entities instead of
+/// the whole struct blob being last-writer-wins'd. `pub` so generated impls can
+/// live in application crates.
+pub trait RekeyTarget: Any {
     /// Re-key this value's nested collection ids relative to `parent_id` (the
     /// deterministic entity id under which this value is stored). Idempotent.
     fn rekey_relative_to(&mut self, parent_id: Id);
+}
+
+/// Derive a deterministic per-field child id from a parent entity id and a field
+/// name, so sibling fields (e.g. two counters) get distinct namespaces and never
+/// collide. Public for macro-generated `RekeyTarget` impls.
+#[must_use]
+pub fn field_child_id(parent_id: Id, field_name: &str) -> Id {
+    super::compute_collection_id(Some(parent_id), field_name)
+}
+
+/// Public re-export so the autoref macros (which expand in application crates)
+/// can name the registration entry point without exposing the registry itself.
+#[doc(hidden)]
+pub fn register_rekey_pub<T: RekeyTarget + 'static>() {
+    register_rekey::<T>();
 }
 
 type RekeyThunk = fn(&mut dyn Any, Id);
@@ -100,4 +123,61 @@ pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
     if let Some(thunk) = thunk {
         thunk(value, parent_id);
     }
+}
+
+/// Re-key a struct field's value if its concrete type implements [`RekeyTarget`],
+/// else expand to a no-op — without a trait bound at the call site. Resolved via
+/// autoref specialization, which requires a CONCRETE type, so this is a macro
+/// (a generic fn would resolve the no-op branch once, for all types). Generated
+/// `RekeyTarget` impls call it per field.
+///
+/// `$value` must be a `&mut` place of the field; `$parent` an [`Id`].
+#[macro_export]
+macro_rules! rekey_field_if_supported {
+    ($value:expr, $parent:expr) => {{
+        struct __RkProbe<'a, T: ?::core::marker::Sized>(&'a mut T);
+        trait __RkViaRekey {
+            fn __rk_go(self, p: $crate::address::Id);
+        }
+        impl<'a, T: $crate::collections::rekey::RekeyTarget + 'static> __RkViaRekey
+            for __RkProbe<'a, T>
+        {
+            fn __rk_go(self, p: $crate::address::Id) {
+                $crate::collections::rekey::RekeyTarget::rekey_relative_to(self.0, p);
+            }
+        }
+        trait __RkViaNoop {
+            fn __rk_go(self, p: $crate::address::Id);
+        }
+        impl<'a, T: ?::core::marker::Sized> __RkViaNoop for &__RkProbe<'a, T> {
+            fn __rk_go(self, _p: $crate::address::Id) {}
+        }
+        __RkProbe($value).__rk_go($parent)
+    }};
+}
+
+/// Register a value type's re-key thunk if it implements [`RekeyTarget`], else a
+/// no-op. Generated registration code calls this for each collection-field value
+/// type so app structs auto-register before any insert. Macro (not fn) for the
+/// same autoref-on-concrete-type reason as [`rekey_field_if_supported`].
+#[macro_export]
+macro_rules! register_rekey_if_supported {
+    ($t:ty) => {{
+        struct __RgProbe<T>(::core::marker::PhantomData<T>);
+        trait __RgViaReg {
+            fn __rg_go(self);
+        }
+        impl<T: $crate::collections::rekey::RekeyTarget + 'static> __RgViaReg for __RgProbe<T> {
+            fn __rg_go(self) {
+                $crate::collections::rekey::register_rekey_pub::<T>();
+            }
+        }
+        trait __RgViaNoop {
+            fn __rg_go(self);
+        }
+        impl<T> __RgViaNoop for &__RgProbe<T> {
+            fn __rg_go(self) {}
+        }
+        __RgProbe::<$t>(::core::marker::PhantomData).__rg_go()
+    }};
 }

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -132,6 +132,13 @@ pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
 /// `RekeyTarget` impls call it per field.
 ///
 /// `$value` must be a `&mut` place of the field; `$parent` an [`Id`].
+///
+/// **`'static` requirement.** The "real re-key" arm only fires for
+/// `$value: RekeyTarget + 'static`; a `RekeyTarget` type holding a non-`'static`
+/// borrow would silently take the no-op arm. This is not a concern for any
+/// stored CRDT type (`Counter`, `UnorderedMap`, generated record structs — all
+/// owned), but a future `RekeyTarget` impl with borrowed data must be `'static`
+/// to be re-keyed here.
 #[macro_export]
 macro_rules! rekey_field_if_supported {
     ($value:expr, $parent:expr) => {{

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -54,6 +54,12 @@ use crate::address::Id;
 /// derives identical nested ids and the children converge as entities instead of
 /// the whole struct blob being last-writer-wins'd. `pub` so generated impls can
 /// live in application crates.
+///
+/// The `Any` supertrait requires `'static` (you cannot impl `Any` — and thus
+/// `RekeyTarget` — for a type holding a non-`'static` borrow; that's a compile
+/// error at the impl site, E0478). So every `RekeyTarget` type satisfies the
+/// `+ 'static` bound the dispatch macros below want — there is no way to write a
+/// non-`'static` impl that would silently take the no-op arm.
 pub trait RekeyTarget: Any {
     /// Re-key this value's nested collection ids relative to `parent_id` (the
     /// deterministic entity id under which this value is stored). Idempotent.
@@ -77,6 +83,12 @@ pub fn register_rekey_pub<T: RekeyTarget + 'static>() {
 
 type RekeyThunk = fn(&mut dyn Any, Id);
 
+// Process-global and append-only: there is deliberately NO reset path. A thunk
+// is a pure function of its type, so re-registration is idempotent and stale
+// entries are impossible — clearing would only add a footgun. Consequence for
+// tests: once a type is registered it stays registered for the whole binary, so
+// a test that needs the "unregistered" path must use a DISTINCT type (see
+// `tests/rekey_record.rs`'s `FixedStats` vs `UnfixedStats`).
 static REGISTRY: LazyLock<RwLock<HashMap<TypeId, RekeyThunk>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
@@ -133,12 +145,11 @@ pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
 ///
 /// `$value` must be a `&mut` place of the field; `$parent` an [`Id`].
 ///
-/// **`'static` requirement.** The "real re-key" arm only fires for
-/// `$value: RekeyTarget + 'static`; a `RekeyTarget` type holding a non-`'static`
-/// borrow would silently take the no-op arm. This is not a concern for any
-/// stored CRDT type (`Counter`, `UnorderedMap`, generated record structs — all
-/// owned), but a future `RekeyTarget` impl with borrowed data must be `'static`
-/// to be re-keyed here.
+/// The "real re-key" arm fires for `$value: RekeyTarget + 'static`. That bound
+/// is always satisfied by any `RekeyTarget` type: the trait's `Any` supertrait
+/// *requires* `'static`, so a non-`'static` `RekeyTarget` impl can't even be
+/// written (compile error at the impl site). There is therefore no
+/// "non-`'static` type silently takes the no-op arm" hazard here.
 ///
 /// **Each expansion MUST stay in its own block.** The autoref machinery defines
 /// local helper traits/structs; the surrounding `{{ … }}` scopes them per

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -139,6 +139,14 @@ pub(crate) fn rekey_nested_value<V: 'static>(value: &mut V, parent_id: Id) {
 /// stored CRDT type (`Counter`, `UnorderedMap`, generated record structs — all
 /// owned), but a future `RekeyTarget` impl with borrowed data must be `'static`
 /// to be re-keyed here.
+///
+/// **Each expansion MUST stay in its own block.** The autoref machinery defines
+/// local helper traits/structs; the surrounding `{{ … }}` scopes them per
+/// invocation, so repeated calls in one `rekey_relative_to` body don't collide.
+/// If a refactor ever flattened these into a shared scope, the duplicate names
+/// would shadow and could make the no-op arm win silently — which would stop
+/// re-keying and regress to the #2577 data loss with NO compile error. Keep the
+/// block.
 #[macro_export]
 macro_rules! rekey_field_if_supported {
     ($value:expr, $parent:expr) => {{

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -141,6 +141,21 @@ pub fn with_runtime_env<R>(env: RuntimeEnv, f: impl FnOnce() -> R) -> R {
     mocked::with_runtime_env(env, f)
 }
 
+/// Returns the root hash recorded by the most recent native `commit` (test use).
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn root_hash() -> Option<[u8; 32]> {
+    mocked::root_hash()
+}
+
+/// Returns (and clears) the `StorageDelta` artifact from the most recent native
+/// `commit` (test use).
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn take_last_artifact() -> Option<Vec<u8>> {
+    mocked::take_last_artifact()
+}
+
 /// Commits the root hash to the runtime.
 ///
 #[expect(clippy::missing_const_for_fn, reason = "Cannot be const here")]
@@ -576,6 +591,7 @@ mod mocked {
         static ROOT_HASH: RefCell<Option<[u8; 32]>> = const { RefCell::new(None) };
         static NATIVE_HLC: RefCell<LogicalClock> = RefCell::new(LogicalClock::new(|buf| rand::thread_rng().fill_bytes(buf)));
         static RUNTIME_ENV: RefCell<Option<RuntimeEnv>> = const { RefCell::new(None) };
+        static LAST_ARTIFACT: RefCell<Option<Vec<u8>>> = const { RefCell::new(None) };
     }
 
     /// The default storage system.
@@ -588,10 +604,23 @@ mod mocked {
     type DefaultPrivateStore = MockedStorage<{ usize::MAX - 1 }>;
 
     /// Commits the root hash to the runtime.
-    pub(super) fn commit(root_hash: &[u8; 32], _artifact: &[u8]) {
+    pub(super) fn commit(root_hash: &[u8; 32], artifact: &[u8]) {
         ROOT_HASH.with(|rh| {
             let _ = rh.borrow_mut().replace(*root_hash);
         });
+        LAST_ARTIFACT.with(|a| {
+            *a.borrow_mut() = Some(artifact.to_vec());
+        });
+    }
+
+    /// Returns the root hash recorded by the most recent [`commit`].
+    pub(super) fn root_hash() -> Option<[u8; 32]> {
+        ROOT_HASH.with(|rh| *rh.borrow())
+    }
+
+    /// Returns (and clears) the artifact recorded by the most recent [`commit`].
+    pub(super) fn take_last_artifact() -> Option<Vec<u8>> {
+        LAST_ARTIFACT.with(|a| a.borrow_mut().take())
     }
 
     /// Reads data from persistent storage.
@@ -848,6 +877,9 @@ mod mocked {
         });
         // Clear the native ordered-index mock too.
         INDEX.with(|index| index.borrow_mut().clear());
+        LAST_ARTIFACT.with(|a| {
+            *a.borrow_mut() = None;
+        });
     }
 
     /// Resets the environment state for testing (legacy `#[cfg(test)]` alias).

--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -191,9 +191,17 @@ fn unregistered_value_loses_data_pre_fix() {
     // loss and not partial survival — so a different future regression (e.g.
     // both replicas read 0, or one reads 2) trips this instead of passing
     // silently:
-    //   - they still converge (deterministic HLC tiebreak), so both agree,
+    //   - they still converge, so both agree;
     //   - to the WRONG value: exactly one replica's single increment survives
     //     (1), the other's is dropped — the data loss #2577 fixes.
+    //
+    // Why `== 1` is deterministic (not flaky): each replica increments under a
+    // DISTINCT executor id ([1;32] vs [2;32]). Root-blob LWW breaks ties by
+    // executor id, so exactly one whole `UnfixedStats` blob wins on both sides —
+    // never a tie that drops both (→0) or keeps both (→2). The increment value
+    // is always 1 (each replica did exactly one). If this ever reads 0 or 2,
+    // that's a real change in the tiebreak/serialization worth investigating,
+    // which is exactly what this guard is for.
     assert!(
         converged,
         "LWW replicas still converge — to the wrong value"

--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -1,14 +1,13 @@
-//! De-risk probe for #2577: prove that giving a custom struct value's nested
-//! collections DETERMINISTIC ids (via a `RekeyTarget` impl + registration) makes
-//! concurrent same-key writes converge to the CORRECT value (counter sums),
-//! instead of last-writer-wins'ing the struct blob and losing data.
+//! #2577 storage-level probe: a custom struct stored as a collection VALUE
+//! converges to the CORRECT value (counters sum) IFF its nested collections get
+//! deterministic ids — via a `RekeyTarget` impl + registration. The positive
+//! test proves the fix; the negative test documents the pre-fix data loss (an
+//! unregistered value type is last-writer-wins'd as a blob).
 //!
-//! `TeamStats` here impls `RekeyTarget` BY HAND and is registered explicitly via
-//! the `register_rekey_if_supported!` / `rekey_field_if_supported!` autoref
-//! macros — exactly what `#[derive(Mergeable)]` + `#[app::state]` will generate.
-//!
-//! Own integration binary (not a `src/tests` module) so it runs isolated from
-//! the unit-test suite, which shares process-global state (the rekey registry).
+//! Own integration binary (gated `required-features = ["testing"]` in Cargo) so
+//! it runs isolated from the unit-test suite, which shares the process-global
+//! rekey registry. The two structs are DISTINCT types because that registry has
+//! no reset — registering one must not affect the other.
 
 #![cfg(feature = "testing")]
 #![allow(clippy::unwrap_used)]
@@ -28,57 +27,80 @@ use calimero_storage::store::Key;
 use calimero_storage::{
     register_crdt_merge_for_test, register_rekey_if_supported, rekey_field_if_supported,
 };
+use serial_test::serial;
 
+/// A struct that implements `RekeyTarget` (what the macro generates). When
+/// registered, its nested counters get deterministic ids and converge.
 #[derive(BorshSerialize, BorshDeserialize, Default)]
 #[borsh(crate = "calimero_sdk::borsh")]
-struct TeamStats {
+struct FixedStats {
     wins: Counter,
-    losses: Counter,
 }
 
-impl Mergeable for TeamStats {
+impl Mergeable for FixedStats {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
-        self.wins.merge(&other.wins)?;
-        self.losses.merge(&other.losses)
+        self.wins.merge(&other.wins)
     }
 }
 
-// What the macro will generate: re-key each collection field under a
-// field-namespaced child of the entry id, so every replica derives identical
-// ids and the nested counters converge as child entities.
-impl RekeyTarget for TeamStats {
+impl RekeyTarget for FixedStats {
     fn rekey_relative_to(&mut self, parent_id: Id) {
         rekey_field_if_supported!(&mut self.wins, field_child_id(parent_id, "wins"));
-        rekey_field_if_supported!(&mut self.losses, field_child_id(parent_id, "losses"));
     }
 }
 
+/// Same shape, but NOT a `RekeyTarget` and never registered — i.e. the pre-fix
+/// world. Its nested counter keeps a per-replica-random id, so the blob differs
+/// and concurrent writes are last-writer-wins'd (data loss).
 #[derive(BorshSerialize, BorshDeserialize, Default)]
 #[borsh(crate = "calimero_sdk::borsh")]
-struct App {
-    teams: UnorderedMap<String, TeamStats>,
+struct UnfixedStats {
+    wins: Counter,
 }
 
-impl Mergeable for App {
+impl Mergeable for UnfixedStats {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
-        self.teams.merge(&other.teams)
+        self.wins.merge(&other.wins)
     }
 }
 
-impl App {
-    fn record_win(&mut self, team: &str) {
-        let mut s = self.teams.get(team).unwrap().unwrap_or_default();
-        s.wins.increment().unwrap();
-        self.teams.insert(team.to_owned(), s).unwrap();
-    }
-    fn wins(&self, team: &str) -> u64 {
-        self.teams
-            .get(team)
-            .unwrap()
-            .map(|s| s.wins.value().unwrap())
-            .unwrap_or(0)
-    }
+/// Root app generic over the value type, so one driver exercises both.
+trait TeamApp: BorshSerialize + BorshDeserialize + Default + Mergeable + 'static {
+    fn record_win(&mut self, team: &str);
+    fn wins(&self, team: &str) -> u64;
 }
+
+macro_rules! team_app {
+    ($app:ident, $val:ty) => {
+        #[derive(BorshSerialize, BorshDeserialize, Default)]
+        #[borsh(crate = "calimero_sdk::borsh")]
+        struct $app {
+            teams: UnorderedMap<String, $val>,
+        }
+        impl Mergeable for $app {
+            fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+                self.teams.merge(&other.teams)
+            }
+        }
+        impl TeamApp for $app {
+            fn record_win(&mut self, team: &str) {
+                let mut s = self.teams.get(team).unwrap().unwrap_or_default();
+                s.wins.increment().unwrap();
+                self.teams.insert(team.to_owned(), s).unwrap();
+            }
+            fn wins(&self, team: &str) -> u64 {
+                self.teams
+                    .get(team)
+                    .unwrap()
+                    .map(|s| s.wins.value().unwrap())
+                    .unwrap_or(0)
+            }
+        }
+    };
+}
+
+team_app!(FixedApp, FixedStats);
+team_app!(UnfixedApp, UnfixedStats);
 
 type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
 
@@ -93,52 +115,82 @@ fn env_for(s: &Store, ex: [u8; 32]) -> RuntimeEnv {
     RuntimeEnv::new(reader, writer, remover, [7u8; 32], ex)
 }
 
-#[test]
-fn deterministic_rekey_makes_struct_value_counters_converge() {
-    env::reset_environment();
-    register_crdt_merge_for_test::<App>();
-    // What the macro will emit for each collection-field value type. Autoref
-    // makes this a no-op for non-RekeyTarget value types (proven below).
-    register_rekey_if_supported!(TeamStats);
-    register_rekey_if_supported!(String); // leaf value type: must be a safe no-op
-
+/// Two replicas each record one win for the same team under their own executor
+/// id, exchange deltas, and we read back each replica's win count + root hash.
+/// Returns `(wins_a, wins_b, converged)`.
+fn drive<T: TeamApp>() -> (u64, u64, bool) {
     let a: Store = Default::default();
     let b: Store = Default::default();
     env::with_runtime_env(env_for(&a, [1; 32]), || {
-        Root::new(App::default).commit();
+        Root::new(T::default).commit();
     });
     *b.borrow_mut() = a.borrow().clone();
 
     let da = env::with_runtime_env(env_for(&a, [1; 32]), || {
-        let mut app = Root::<App>::fetch().unwrap();
+        let mut app = Root::<T>::fetch().unwrap();
         app.record_win("liverpool");
         app.commit();
         env::take_last_artifact().unwrap()
     });
     let db = env::with_runtime_env(env_for(&b, [2; 32]), || {
-        let mut app = Root::<App>::fetch().unwrap();
+        let mut app = Root::<T>::fetch().unwrap();
         app.record_win("liverpool");
         app.commit();
         env::take_last_artifact().unwrap()
     });
 
     let (ha, wa) = env::with_runtime_env(env_for(&a, [1; 32]), || {
-        Root::<App>::sync(&db, &ApplyContext::empty()).unwrap();
+        Root::<T>::sync(&db, &ApplyContext::empty()).unwrap();
         (
             env::root_hash(),
-            Root::<App>::fetch().unwrap().wins("liverpool"),
+            Root::<T>::fetch().unwrap().wins("liverpool"),
         )
     });
     let (hb, wb) = env::with_runtime_env(env_for(&b, [2; 32]), || {
-        Root::<App>::sync(&da, &ApplyContext::empty()).unwrap();
+        Root::<T>::sync(&da, &ApplyContext::empty()).unwrap();
         (
             env::root_hash(),
-            Root::<App>::fetch().unwrap().wins("liverpool"),
+            Root::<T>::fetch().unwrap().wins("liverpool"),
         )
     });
+    (wa, wb, ha == hb)
+}
 
-    println!("wins a={wa} b={wb}; converged={}", ha == hb);
+#[test]
+#[serial]
+fn registered_rekey_makes_struct_value_counters_converge() {
+    env::reset_environment();
+    register_crdt_merge_for_test::<FixedApp>();
+    // What the macro emits for each collection-field value type. Autoref makes
+    // it a no-op for leaf value types (proven by passing `String`).
+    register_rekey_if_supported!(FixedStats);
+    register_rekey_if_supported!(String);
+
+    let (wa, wb, converged) = drive::<FixedApp>();
+    println!("FIXED   wins a={wa} b={wb} converged={converged}");
     assert_eq!(wa, 2, "replica A: both increments must survive");
     assert_eq!(wb, 2, "replica B: both increments must survive");
-    assert_eq!(ha, hb, "replicas must converge to the same root hash");
+    assert!(converged, "replicas must converge to the same root hash");
+}
+
+#[test]
+#[serial]
+fn unregistered_value_loses_data_pre_fix() {
+    // Regression guard / documentation of the bug #2577 fixes: with no rekey
+    // registration (the pre-fix world), the struct value is LWW'd as a blob and
+    // concurrent increments are lost. If a future change makes the data survive
+    // WITHOUT rekey (e.g. a serialization change), this assertion fires so we
+    // re-examine whether the rekey machinery is still doing the work.
+    env::reset_environment();
+    register_crdt_merge_for_test::<UnfixedApp>();
+    // Deliberately NO `register_rekey_if_supported!(UnfixedStats)`.
+
+    let (wa, wb, converged) = drive::<UnfixedApp>();
+    println!("UNFIXED wins a={wa} b={wb} converged={converged}");
+    assert!(
+        wa < 2 && wb < 2,
+        "without rekey the struct value is LWW'd — increments must be lost \
+         (got a={wa} b={wb}); if this fails, the deterministic-rekey fix may no \
+         longer be what makes #2577 converge"
+    );
 }

--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -1,0 +1,144 @@
+//! De-risk probe for #2577: prove that giving a custom struct value's nested
+//! collections DETERMINISTIC ids (via a `RekeyTarget` impl + registration) makes
+//! concurrent same-key writes converge to the CORRECT value (counter sums),
+//! instead of last-writer-wins'ing the struct blob and losing data.
+//!
+//! `TeamStats` here impls `RekeyTarget` BY HAND and is registered explicitly via
+//! the `register_rekey_if_supported!` / `rekey_field_if_supported!` autoref
+//! macros — exactly what `#[derive(Mergeable)]` + `#[app::state]` will generate.
+//!
+//! Own integration binary (not a `src/tests` module) so it runs isolated from
+//! the unit-test suite, which shares process-global state (the rekey registry).
+
+#![cfg(feature = "testing")]
+#![allow(clippy::unwrap_used)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::address::Id;
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::rekey::{field_child_id, RekeyTarget};
+use calimero_storage::collections::{Counter, Mergeable, Root, UnorderedMap};
+use calimero_storage::env::{self, RuntimeEnv};
+use calimero_storage::interface::ApplyContext;
+use calimero_storage::store::Key;
+use calimero_storage::{
+    register_crdt_merge_for_test, register_rekey_if_supported, rekey_field_if_supported,
+};
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct TeamStats {
+    wins: Counter,
+    losses: Counter,
+}
+
+impl Mergeable for TeamStats {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.wins.merge(&other.wins)?;
+        self.losses.merge(&other.losses)
+    }
+}
+
+// What the macro will generate: re-key each collection field under a
+// field-namespaced child of the entry id, so every replica derives identical
+// ids and the nested counters converge as child entities.
+impl RekeyTarget for TeamStats {
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        rekey_field_if_supported!(&mut self.wins, field_child_id(parent_id, "wins"));
+        rekey_field_if_supported!(&mut self.losses, field_child_id(parent_id, "losses"));
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct App {
+    teams: UnorderedMap<String, TeamStats>,
+}
+
+impl Mergeable for App {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.teams.merge(&other.teams)
+    }
+}
+
+impl App {
+    fn record_win(&mut self, team: &str) {
+        let mut s = self.teams.get(team).unwrap().unwrap_or_default();
+        s.wins.increment().unwrap();
+        self.teams.insert(team.to_owned(), s).unwrap();
+    }
+    fn wins(&self, team: &str) -> u64 {
+        self.teams
+            .get(team)
+            .unwrap()
+            .map(|s| s.wins.value().unwrap())
+            .unwrap_or(0)
+    }
+}
+
+type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
+
+fn env_for(s: &Store, ex: [u8; 32]) -> RuntimeEnv {
+    let r = s.clone();
+    let reader = Rc::new(move |k: &Key| r.borrow().get(&k.to_bytes()).cloned());
+    let w = s.clone();
+    let writer =
+        Rc::new(move |k: Key, v: &[u8]| w.borrow_mut().insert(k.to_bytes(), v.to_vec()).is_some());
+    let rm = s.clone();
+    let remover = Rc::new(move |k: &Key| rm.borrow_mut().remove(&k.to_bytes()).is_some());
+    RuntimeEnv::new(reader, writer, remover, [7u8; 32], ex)
+}
+
+#[test]
+fn deterministic_rekey_makes_struct_value_counters_converge() {
+    env::reset_environment();
+    register_crdt_merge_for_test::<App>();
+    // What the macro will emit for each collection-field value type. Autoref
+    // makes this a no-op for non-RekeyTarget value types (proven below).
+    register_rekey_if_supported!(TeamStats);
+    register_rekey_if_supported!(String); // leaf value type: must be a safe no-op
+
+    let a: Store = Default::default();
+    let b: Store = Default::default();
+    env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::new(App::default).commit();
+    });
+    *b.borrow_mut() = a.borrow().clone();
+
+    let da = env::with_runtime_env(env_for(&a, [1; 32]), || {
+        let mut app = Root::<App>::fetch().unwrap();
+        app.record_win("liverpool");
+        app.commit();
+        env::take_last_artifact().unwrap()
+    });
+    let db = env::with_runtime_env(env_for(&b, [2; 32]), || {
+        let mut app = Root::<App>::fetch().unwrap();
+        app.record_win("liverpool");
+        app.commit();
+        env::take_last_artifact().unwrap()
+    });
+
+    let (ha, wa) = env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::<App>::sync(&db, &ApplyContext::empty()).unwrap();
+        (
+            env::root_hash(),
+            Root::<App>::fetch().unwrap().wins("liverpool"),
+        )
+    });
+    let (hb, wb) = env::with_runtime_env(env_for(&b, [2; 32]), || {
+        Root::<App>::sync(&da, &ApplyContext::empty()).unwrap();
+        (
+            env::root_hash(),
+            Root::<App>::fetch().unwrap().wins("liverpool"),
+        )
+    });
+
+    println!("wins a={wa} b={wb}; converged={}", ha == hb);
+    assert_eq!(wa, 2, "replica A: both increments must survive");
+    assert_eq!(wb, 2, "replica B: both increments must survive");
+    assert_eq!(ha, hb, "replicas must converge to the same root hash");
+}

--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -187,10 +187,22 @@ fn unregistered_value_loses_data_pre_fix() {
 
     let (wa, wb, converged) = drive::<UnfixedApp>();
     println!("UNFIXED wins a={wa} b={wb} converged={converged}");
+    // Tight assertions document the EXACT pre-fix failure mode — LWW, not total
+    // loss and not partial survival — so a different future regression (e.g.
+    // both replicas read 0, or one reads 2) trips this instead of passing
+    // silently:
+    //   - they still converge (deterministic HLC tiebreak), so both agree,
+    //   - to the WRONG value: exactly one replica's single increment survives
+    //     (1), the other's is dropped — the data loss #2577 fixes.
     assert!(
-        wa < 2 && wb < 2,
-        "without rekey the struct value is LWW'd — increments must be lost \
-         (got a={wa} b={wb}); if this fails, the deterministic-rekey fix may no \
-         longer be what makes #2577 converge"
+        converged,
+        "LWW replicas still converge — to the wrong value"
+    );
+    assert_eq!(wa, wb, "converged replicas must agree on the (wrong) value");
+    assert_eq!(
+        wa, 1,
+        "without rekey, LWW keeps exactly one replica's increment (not summed \
+         to 2, not lost to 0); if this changes, re-examine whether deterministic \
+         rekey is still what makes #2577 converge"
     );
 }


### PR DESCRIPTION
Fixes #2577.

Custom structs used as collection values (the `UnorderedMap<String, TeamStats>` pattern, where `TeamStats` wraps `Counter`s) silently **lost data** on concurrent same-key writes. Root cause (confirmed by code trace + probes): a `Collection` serializes only its **id handle** (`children_ids` is `#[borsh(skip)]`), so such a struct is stored as an opaque blob of handles. Its nested collections got **per-replica-random ids**, the blobs differed, and sync **LWW-overwrote** them — the inner counters never merged. The custom `Mergeable` impl was inert (it runs on empty shells), so the loss was silent.

### Fix: deterministic re-keying (no merge-callback needed)

Give such a struct's nested collections **deterministic ids**, so every replica derives identical handles, the blob matches, and the nested CRDTs converge as child entities — exactly how a root `#[app::state]` struct's collection fields already converge.

- **`#[derive(Mergeable)]`** (both the `calimero-sdk-macros` and `calimero-storage-macros` derives — apps use the latter) now also generates a `RekeyTarget` impl that re-keys each field under a field-namespaced child of the entry id.
- **`#[app::state]`** generates `__calimero_register_rekey()` — called at WASM module load and from the native `TestHost` bridge — registering a re-key thunk for every value type appearing in a state field.
- The dispatch uses two **autoref-specialization macros** (`rekey_field_if_supported!` / `register_rekey_if_supported!`): real re-key/registration for `RekeyTarget` types, a compile-time no-op for leaves (`String`, `LwwRegister<_>`, …) — so no trait bound is forced on value types and existing apps are unaffected. (Autoref needs a *concrete* type, hence macros, not generic fns.)
- **Hand-written `Mergeable`** structs must add a manual `RekeyTarget` — one worked example + doc comment in `apps/team-metrics-custom`.

### Validation

- `apps/team-metrics-{macro,custom}` two-replica convergence tests: wins **sum to 2** (was 1) — the real apps, no hand-written rekey on the derive path.
- No regressions: storage lib (530 pass), WASM `crdt_conformance` (14 pass, rebuilds the fixture with the new codegen), representative apps build.
- A storage integration probe (`crates/storage/tests/rekey_record.rs`) isolates the mechanism.

### Notes for review

- **Two `Mergeable` derives** exist (`sdk-macros` + `storage-macros`); both are patched. Worth deciding whether to consolidate.
- **Deep nesting** (custom struct → collection → *custom* struct) currently registers only one level from the root; built-in collections self-register, so nested *built-ins* are fine. Flagged as a follow-up.
- This is the fix that makes the convergence harness's `#[ignore]`d `.invariant()` tests in #2578 pass; when both land, #2578's `converge_app` should also call `T::__calimero_register_rekey()`.
- Includes the native env test getters (`root_hash()` / `take_last_artifact()`) the probes need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes CRDT sync/convergence for collection values, macro-generated registration at WASM load, and a process-global rekey registry—incorrect re-key or registration could still cause silent data loss or divergence.
> 
> **Overview**
> Fixes **#2577**: custom structs stored as map values (e.g. `UnorderedMap<String, TeamStats>`) no longer lose concurrent counter updates to whole-value LWW. The change wires **deterministic re-keying** so nested collections under each entry get field-namespaced ids every replica agrees on.
> 
> **Storage & macros:** `RekeyTarget` and `field_child_id` are public; `rekey_field_if_supported!` / `register_rekey_if_supported!` dispatch via autoref. Both `#[derive(Mergeable)]` paths (SDK + storage-macros) now emit `RekeyTarget`. `#[app::state]` adds `__calimero_register_rekey()` and hooks it from WASM `__calimero_register_merge`, the native `TestHost` bridge, and tests. **team-metrics-custom** documents a manual `RekeyTarget` when `Mergeable` is hand-written.
> 
> **Tests & tooling:** Native `env::root_hash()` / `take_last_artifact()` support two-replica sync tests; `team-metrics-*` gain `rlib` + `tests/converge.rs`; `rekey_record.rs` proves registered vs unregistered behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657f90a3217e745f225efe3e44d49001b290a994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->