### PR TITLE
feat(wasm-abi): SharedStorage CrdtCollectionType variant + collection_category classifier

### DIFF
--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -434,9 +434,13 @@ fn normalize_generic_type(
                 inner_type: None,
             })
         }
-        // SharedStorage<T> is a single-slot wrapper: the writer set lives in
-        // metadata and is not part of the user-facing data shape, so it
-        // normalizes to its inner T.
+        // SharedStorage<T> is a single-slot value guarded by a writer-set ACL
+        // (writers + per-write nonce in metadata). The user-facing data shape is
+        // the inner T, but we surface it as a Collection carrying
+        // `crdt_type = SharedStorage` + the inner type (mirroring the LwwRegister
+        // single-value shape) so the writer-ACL is visible to the schema and the
+        // migration identity-downgrade diff. Previously this unwrapped to bare T,
+        // making a `SharedStorage -> UnorderedMap` downgrade invisible.
         "SharedStorage" => {
             if args.args.is_empty() {
                 return Err(NormalizeError::TypePathError(
@@ -449,7 +453,12 @@ fn normalize_generic_type(
                     "invalid storage argument".to_owned(),
                 ));
             };
-            normalize_type(ty, wasm32, resolver)
+            let inner_type = normalize_type(ty, wasm32, resolver)?;
+            Ok(TypeRef::Collection {
+                collection: CollectionType::Record { fields: vec![] },
+                crdt_type: Some(CrdtCollectionType::SharedStorage),
+                inner_type: Some(Box::new(inner_type)),
+            })
         }
         _ => Err(NormalizeError::TypePathError(format!(
             "unknown generic type: {ident}"

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -240,7 +240,9 @@ pub fn collection_category(ty: &CrdtCollectionType) -> CollectionCategory {
         CrdtCollectionType::LwwRegister
         | CrdtCollectionType::Vector
         | CrdtCollectionType::UnorderedMap
-        | CrdtCollectionType::UnorderedSet => Convergent,
+        | CrdtCollectionType::UnorderedSet
+        | CrdtCollectionType::SortedMap
+        | CrdtCollectionType::SortedSet => Convergent,
         CrdtCollectionType::Counter | CrdtCollectionType::ReplicatedGrowableArray => Replayable,
         CrdtCollectionType::AuthoredMap
         | CrdtCollectionType::AuthoredVector
@@ -599,7 +601,7 @@ mod tests {
         use CollectionCategory::{Convergent, IdentityGated, Replayable};
         use CrdtCollectionType::{
             AuthoredMap, AuthoredVector, Counter, LwwRegister, ReplicatedGrowableArray,
-            SharedStorage, UnorderedMap, UnorderedSet, Vector,
+            SharedStorage, SortedMap, SortedSet, UnorderedMap, UnorderedSet, Vector,
         };
 
         // Convergent: key/index/content-addressed — a migrate that rebuilds them
@@ -608,6 +610,8 @@ mod tests {
         assert_eq!(collection_category(&Vector), Convergent);
         assert_eq!(collection_category(&UnorderedMap), Convergent);
         assert_eq!(collection_category(&UnorderedSet), Convergent);
+        assert_eq!(collection_category(&SortedMap), Convergent);
+        assert_eq!(collection_category(&SortedSet), Convergent);
 
         // Replayable: per-executor / per-position state that converges only if the
         // migrate body replays it deterministically (increment_for / insert_at_ts).

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -202,6 +202,50 @@ pub enum CrdtCollectionType {
     ReplicatedGrowableArray,
     /// AuthoredVector: List with per-element author identity
     AuthoredVector,
+    /// SharedStorage: single-slot value guarded by a writer-set ACL (writers +
+    /// per-write nonce in metadata). Identity-gated like the `Authored*` types.
+    SharedStorage,
+}
+
+/// Identity-derivation category of a CRDT collection.
+///
+/// The authoritative classifier for the migration-safety rail (the core upgrade
+/// gate and `calimero abi diff`). It captures how a `#[app::migrate]` that
+/// rebuilds the collection behaves cross-node, and whether changing a field's
+/// type silently strips provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollectionCategory {
+    /// Key/index/content-addressed (`LwwRegister`, `Vector`, `UnorderedMap`,
+    /// `UnorderedSet`). A migrate may rebuild them freely; they carry no
+    /// per-entry provenance.
+    Convergent,
+    /// Per-executor / per-position (`Counter`, `ReplicatedGrowableArray`).
+    /// Converges only if the migrate body replays it deterministically.
+    Replayable,
+    /// Ownership / writer-set derived from `env::executor_id()` (`AuthoredMap`,
+    /// `AuthoredVector`, `SharedStorage`). A naive rebuild diverges, and a
+    /// downgrade to a non-identity-gated type silently strips authorship / ACL.
+    IdentityGated,
+}
+
+/// Classify a CRDT collection type by how its identity is derived.
+///
+/// This is the single source of truth for the migration-safety rail. The match is
+/// intentionally exhaustive (no wildcard): adding a [`CrdtCollectionType`] variant
+/// without categorising it here is a compile error, so the taxonomy cannot
+/// silently drift.
+pub fn collection_category(ty: &CrdtCollectionType) -> CollectionCategory {
+    use CollectionCategory::{Convergent, IdentityGated, Replayable};
+    match ty {
+        CrdtCollectionType::LwwRegister
+        | CrdtCollectionType::Vector
+        | CrdtCollectionType::UnorderedMap
+        | CrdtCollectionType::UnorderedSet => Convergent,
+        CrdtCollectionType::Counter | CrdtCollectionType::ReplicatedGrowableArray => Replayable,
+        CrdtCollectionType::AuthoredMap
+        | CrdtCollectionType::AuthoredVector
+        | CrdtCollectionType::SharedStorage => IdentityGated,
+    }
 }
 
 /// Collection types
@@ -549,6 +593,33 @@ impl TypeRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn collection_category_classifies_every_crdt_type() {
+        use CollectionCategory::{Convergent, IdentityGated, Replayable};
+        use CrdtCollectionType::{
+            AuthoredMap, AuthoredVector, Counter, LwwRegister, ReplicatedGrowableArray,
+            SharedStorage, UnorderedMap, UnorderedSet, Vector,
+        };
+
+        // Convergent: key/index/content-addressed — a migrate that rebuilds them
+        // converges cross-node, and they carry no per-entry provenance to strip.
+        assert_eq!(collection_category(&LwwRegister), Convergent);
+        assert_eq!(collection_category(&Vector), Convergent);
+        assert_eq!(collection_category(&UnorderedMap), Convergent);
+        assert_eq!(collection_category(&UnorderedSet), Convergent);
+
+        // Replayable: per-executor / per-position state that converges only if the
+        // migrate body replays it deterministically (increment_for / insert_at_ts).
+        assert_eq!(collection_category(&Counter), Replayable);
+        assert_eq!(collection_category(&ReplicatedGrowableArray), Replayable);
+
+        // Identity-gated: ownership/writer-set is derived from env::executor_id(),
+        // so a naive rebuild diverges and a downgrade silently strips provenance.
+        assert_eq!(collection_category(&AuthoredMap), IdentityGated);
+        assert_eq!(collection_category(&AuthoredVector), IdentityGated);
+        assert_eq!(collection_category(&SharedStorage), IdentityGated);
+    }
 
     #[test]
     fn test_manifest_serialization() {

--- a/crates/wasm-abi/tests/normalize.rs
+++ b/crates/wasm-abi/tests/normalize.rs
@@ -471,6 +471,39 @@ fn test_authored_collections_preserve_crdt_type() {
 }
 
 #[test]
+fn test_shared_storage_preserves_crdt_type() {
+    use calimero_wasm_abi::schema::{CollectionType, CrdtCollectionType};
+
+    let resolver = MockResolver::new();
+
+    // `SharedStorage<String>` is a single-slot wrapper: one value `T` guarded by a
+    // writer set that lives in storage metadata. It must surface as a Collection
+    // carrying `crdt_type = SharedStorage` plus the inner type — mirroring the
+    // LwwRegister single-value shape — so a schema diff can SEE a
+    // `SharedStorage -> UnorderedMap` identity downgrade. Previously it unwrapped to
+    // bare `T`, making the writer-ACL invisible to the schema.
+    let normalized = normalize_type(&parse_type("SharedStorage<String>"), true, &resolver).unwrap();
+    match normalized {
+        TypeRef::Collection {
+            collection,
+            crdt_type,
+            inner_type,
+        } => {
+            assert_eq!(crdt_type, Some(CrdtCollectionType::SharedStorage));
+            assert!(
+                matches!(collection, CollectionType::Record { .. }),
+                "SharedStorage must surface as a single-slot Record collection"
+            );
+            assert!(
+                inner_type.is_some(),
+                "SharedStorage must preserve its inner value type"
+            );
+        }
+        other => panic!("expected Collection variant, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_sdk_identity_newtypes_normalize_to_fixed_bytes() {
     // `BlobId` / `ContextId` / `ApplicationId` are SDK identity newtypes from
     // `calimero_primitives`, exposed to apps via `calimero_sdk`. They are

--- a/crates/wasm-abi/tests/schema_validation.rs
+++ b/crates/wasm-abi/tests/schema_validation.rs
@@ -36,6 +36,47 @@ fn test_schema_validation_basic() {
 }
 
 #[test]
+fn test_schema_validation_shared_storage_crdt_type() {
+    use calimero_wasm_abi::schema::{
+        CollectionType, CrdtCollectionType, Manifest, Method, TypeRef,
+    };
+
+    // Load the crate's own JSON Schema.
+    let schema_json = include_str!("../wasm-abi.schema.json");
+    let schema_value: Value = serde_json::from_str(schema_json).unwrap();
+    let schema = JSONSchema::compile(&schema_value).unwrap();
+
+    // A `SharedStorage<String>` field normalizes to a single-slot Record
+    // collection carrying `crdt_type: shared_storage`. The published JSON Schema
+    // must accept that string, or every manifest with a SharedStorage field fails
+    // validation against the crate's own schema.
+    let shared = TypeRef::Collection {
+        collection: CollectionType::Record { fields: vec![] },
+        crdt_type: Some(CrdtCollectionType::SharedStorage),
+        inner_type: Some(Box::new(TypeRef::string())),
+    };
+    let mut manifest = Manifest {
+        schema_version: "wasm-abi/1".to_string(),
+        ..Default::default()
+    };
+    manifest.methods.push(Method {
+        name: "shared".to_string(),
+        params: vec![],
+        returns: Some(shared),
+        returns_nullable: None,
+        errors: vec![],
+    });
+
+    let manifest_json = serde_json::to_value(&manifest).unwrap();
+    let validation_result = schema.validate(&manifest_json);
+    assert!(
+        validation_result.is_ok(),
+        "SharedStorage crdt_type must validate against wasm-abi.schema.json: {:?}",
+        validation_result.err().map(|e| e.collect::<Vec<_>>())
+    );
+}
+
+#[test]
 fn test_schema_validation_conformance() {
     // Load the schema
     let schema_json = include_str!("../wasm-abi.schema.json");

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -97,7 +97,8 @@
         "unordered_set",
         "sorted_set",
         "replicated_growable_array",
-        "authored_vector"
+        "authored_vector",
+        "shared_storage"
       ]
     },
     "CollectionType": {


### PR DESCRIPTION
## What

Foundation for the migration **no-silent-downgrade safety rail** — the shared prerequisite called out in #2534 and #2553. Two changes in `crates/wasm-abi`:

1. **`SharedStorage` is now a `CrdtCollectionType` variant.** It was the only identity-gated collection the schema couldn't see — `SharedStorage<T>` normalized to bare `T`, so a `SharedStorage → UnorderedMap` change (which strips the writer-set ACL across the whole network) was invisible to a schema diff. It now normalizes to a single-slot Collection (`Record{}` + `crdt_type: SharedStorage` + `inner_type`, mirroring the LwwRegister single-value shape), preserving the user-facing value shape while surfacing the CRDT tag.

2. **`collection_category(&CrdtCollectionType) -> CollectionCategory`** — `{Convergent, Replayable, IdentityGated}`. The single source of truth the upcoming core upgrade gate (#2534) and `calimero abi diff` (#2553) will consume to detect identity downgrades. The classifier match is **exhaustive with no wildcard**, so adding a future `CrdtCollectionType` variant without categorising it is a compile error — the taxonomy can't silently drift.

## Why

`AuthoredMap`/`AuthoredVector` already carried their `crdt_type` tag, but `SharedStorage` did not, so the schema literally couldn't represent a `SharedStorage → UnorderedMap` downgrade. This makes all three identity-gated types visible and gives the rail one shared classifier to build on.

## Safety / compatibility

- **Additive.** `CrdtCollectionType` is `#[non_exhaustive]` and has no exhaustive match arms anywhere (storage/node use a separate runtime `CrdtType`), so no Rust consumer breaks.
- **Goldens unchanged.** No conformance app uses `SharedStorage`; `state-schema.expected.json` / `abi.expected.json` are unaffected.
- The macro-side `is_collection_type` (deterministic-id assignment) is a **different taxonomy** and is intentionally left untouched.
- **Downstream note:** apps with a `SharedStorage` field now emit `crdt_type: "shared_storage"`; typed client codegen (client-js / client-py) may want a matching arm to deserialize it (additive, separate repos).

## Tests

- `collection_category_classifies_every_crdt_type` — every variant maps to the right category.
- `test_shared_storage_preserves_crdt_type` — `SharedStorage<String>` surfaces as a Collection carrying `crdt_type: SharedStorage` + inner type.
- Full `calimero-wasm-abi` suite green; clippy clean (no new warnings); `calimero-sdk` compiles.

## Unblocks

- L1 core upgrade gate rejecting identity downgrades (#2534).
- L2 `calimero abi diff` `UNSAFE_IDENTITY_DOWNGRADE` finding (#2553).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema/normalization changes in wasm-abi only; manifests for apps using SharedStorage gain a new crdt_type field without changing runtime storage logic in this PR.
> 
> **Overview**
> **`SharedStorage<T>`** no longer normalizes to bare **`T`**. It now emits a single-slot **`Collection`** (empty **`Record`**, **`crdt_type: shared_storage`**, **`inner_type`**) so ABI/schema diffs can see writer-ACL identity downgrades (e.g. **`SharedStorage` → `UnorderedMap`**).
> 
> Adds **`CrdtCollectionType::SharedStorage`**, **`CollectionCategory`** (`Convergent` / `Replayable` / `IdentityGated`), and an **exhaustive** **`collection_category()`** helper for the upcoming migration-safety rail. **`wasm-abi.schema.json`** accepts **`shared_storage`**; tests cover normalization, classification, and JSON Schema validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293592e278e03d8710f7d5537d621dea269df8ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->