### PR TITLE
fix(storage): adapt rekey_record test to the ValueRef get() API (unblocks master CI)

### DIFF
--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -16,6 +16,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::address::Id;
 use calimero_storage::collections::crdt_meta::MergeError;
@@ -66,8 +67,8 @@ impl Mergeable for UnfixedStats {
 
 /// Root app generic over the value type, so one driver exercises both.
 trait TeamApp: BorshSerialize + BorshDeserialize + Default + Mergeable + 'static {
-    fn record_win(&mut self, team: &str);
-    fn wins(&self, team: &str) -> u64;
+    fn record_win(&mut self, team: &str) -> app::Result<()>;
+    fn wins(&self, team: &str) -> app::Result<u64>;
 }
 
 macro_rules! team_app {
@@ -83,17 +84,20 @@ macro_rules! team_app {
             }
         }
         impl TeamApp for $app {
-            fn record_win(&mut self, team: &str) {
-                let mut s = self.teams.get(team).unwrap().unwrap_or_default();
-                s.wins.increment().unwrap();
-                self.teams.insert(team.to_owned(), s).unwrap();
+            fn record_win(&mut self, team: &str) -> app::Result<()> {
+                // `app::Result` + `?`, exactly as real apps write methods (see
+                // apps/team-metrics-custom). The `entry().or_default()` handle is
+                // write-back-guarded (core#2576): the increment persists when the
+                // guard drops — no explicit re-insert.
+                let mut stats = self.teams.entry(team.to_owned())?.or_default()?;
+                stats.wins.increment()?;
+                Ok(())
             }
-            fn wins(&self, team: &str) -> u64 {
-                self.teams
-                    .get(team)
-                    .unwrap()
-                    .map(|s| s.wins.value().unwrap())
-                    .unwrap_or(0)
+            fn wins(&self, team: &str) -> app::Result<u64> {
+                match self.teams.get(team)? {
+                    Some(s) => Ok(s.wins.value()?),
+                    None => Ok(0),
+                }
             }
         }
     };
@@ -128,13 +132,13 @@ fn drive<T: TeamApp>() -> (u64, u64, bool) {
 
     let da = env::with_runtime_env(env_for(&a, [1; 32]), || {
         let mut app = Root::<T>::fetch().unwrap();
-        app.record_win("liverpool");
+        app.record_win("liverpool").unwrap();
         app.commit();
         env::take_last_artifact().unwrap()
     });
     let db = env::with_runtime_env(env_for(&b, [2; 32]), || {
         let mut app = Root::<T>::fetch().unwrap();
-        app.record_win("liverpool");
+        app.record_win("liverpool").unwrap();
         app.commit();
         env::take_last_artifact().unwrap()
     });
@@ -143,14 +147,14 @@ fn drive<T: TeamApp>() -> (u64, u64, bool) {
         Root::<T>::sync(&db, &ApplyContext::empty()).unwrap();
         (
             env::root_hash(),
-            Root::<T>::fetch().unwrap().wins("liverpool"),
+            Root::<T>::fetch().unwrap().wins("liverpool").unwrap(),
         )
     });
     let (hb, wb) = env::with_runtime_env(env_for(&b, [2; 32]), || {
         Root::<T>::sync(&da, &ApplyContext::empty()).unwrap();
         (
             env::root_hash(),
-            Root::<T>::fetch().unwrap().wins("liverpool"),
+            Root::<T>::fetch().unwrap().wins("liverpool").unwrap(),
         )
     });
     (wa, wb, ha == hb)


### PR DESCRIPTION
## master is red — quick unblock

`crates/storage/tests/rekey_record.rs` (added by #2579) uses the pre-#2576 `map.get().unwrap_or_default()` / `map.insert()` idiom. #2579 branched **before** #2576 (`Entry::or_default()` + `ValueRef`-returning `get()`), so its own CI never saw the conflict — but #2579 merged **after** #2576. Result: master's `testing`-feature build fails with `the trait bound ValueRef<FixedStats>: Default is not satisfied`.

The workspace build (`cargo build --workspace --all-targets --tests`) enables `calimero-storage`'s `testing` feature via the example apps' dev-deps, so **this is currently failing the `Rust` check on every open PR.**

## Fix

Switch the test fixtures to the current idiom — `app::Result` + `?` with `entry().or_default()` — exactly how real apps write methods (`apps/team-metrics-custom/src/lib.rs`). One file, no behaviour change:
- `FixedApp` (registered re-key) still converges to **2**,
- `UnfixedApp` (no re-key) still loses data to **1**.

```
test result: ok. 2 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that mirror existing app patterns; no production logic or security surface is modified.
> 
> **Overview**
> Updates **`rekey_record`** integration test fixtures so they compile and behave like production apps after the **ValueRef / `Entry::or_default()`** API (#2576).
> 
> The shared **`TeamApp`** trait now returns **`app::Result`** for **`record_win`** and **`wins`**. **`record_win`** uses **`teams.entry(...)? .or_default()?`** and **`wins.increment()?`** instead of **`get` + `unwrap_or_default` + `insert`**, relying on write-back when the entry guard drops. **`wins`** uses **`get`?** and **`wins.value()?`** instead of nested **`unwrap`s**. Call sites in **`drive`** unwrap those results so the two convergence tests (**registered rekey → 2**, **unregistered → 1**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc1a3a4a5d5d06ec0aaf22353645eba76295168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->