### PR TITLE
feat(storage): guard a whole collection by a writer set

### DIFF
--- a/apps/kv-store-with-shared-storage/src/lib.rs
+++ b/apps/kv-store-with-shared-storage/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use calimero_sdk::app;
 use calimero_sdk::serde::Serialize;
 use calimero_sdk::PublicKey;
-use calimero_storage::collections::{LwwRegister, SharedStorage};
+use calimero_storage::collections::{LwwRegister, SharedStorage, UnorderedMap};
 use thiserror::Error;
 
 #[app::state(emits = for<'a> Event<'a>)]
@@ -11,6 +11,10 @@ pub struct KvStore {
     /// Group-writable register. Initial writer is whoever installed the app.
     /// Rotation lets the writer set evolve over the app's lifetime.
     shared_value: SharedStorage<LwwRegister<String>>,
+    /// Group-writable *map*: a whole collection guarded by the same writer set.
+    /// Every entry inherits `Shared{writers}`, so a non-writer's delta to any
+    /// entry is rejected at merge — not just the wrapper.
+    shared_map: SharedStorage<UnorderedMap<String, LwwRegister<String>>>,
 }
 
 #[app::event]
@@ -37,7 +41,8 @@ impl KvStore {
         let mut writers = BTreeSet::new();
         writers.insert(initializer);
         KvStore {
-            shared_value: SharedStorage::new(writers, false),
+            shared_value: SharedStorage::new(writers.clone(), false),
+            shared_map: SharedStorage::new(writers, false),
         }
     }
 
@@ -53,6 +58,22 @@ impl KvStore {
     pub fn get_shared(&self) -> app::Result<String> {
         app::log!("Getting shared value");
         Ok(self.shared_value.get()?.get().clone())
+    }
+
+    /// Set an entry in the group-writable map. Only a current writer's write
+    /// converges across nodes; a non-writer's write is rejected at merge.
+    pub fn map_set(&mut self, key: String, value: String) -> app::Result<()> {
+        app::log!("Setting map entry: {:?} = {:?}", key, value);
+        self.shared_map
+            .get_mut()?
+            .insert(key, LwwRegister::new(value))?;
+        Ok(())
+    }
+
+    /// Read a map entry, or `None` if absent (anyone can read).
+    pub fn map_get(&self, key: String) -> app::Result<Option<String>> {
+        app::log!("Getting map entry: {:?}", key);
+        Ok(self.shared_map.get()?.get(&key)?.map(|v| v.get().clone()))
     }
 
     /// Rotate the writer set. Caller must be a current writer; rejected if frozen.
@@ -92,5 +113,19 @@ mod tests {
         app.call(|s| s.rotate_writers(vec![me])).unwrap();
 
         assert!(app.events().iter().any(|e| e.kind == "WritersRotated"));
+    }
+
+    #[test]
+    fn map_set_and_get() {
+        // The default executor is the sole writer; writing the guarded map works.
+        let mut app = TestHost::new(KvStore::init);
+
+        app.call(|s| s.map_set("greeting".into(), "hello".into()))
+            .unwrap();
+        assert_eq!(
+            app.view(|s| s.map_get("greeting".into())).unwrap(),
+            Some("hello".to_owned())
+        );
+        assert_eq!(app.view(|s| s.map_get("absent".into())).unwrap(), None);
     }
 }

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -83,6 +83,80 @@ steps:
       - 'json_equal({{node2_read}}, {"output": "initial-from-node1"})'
 
   # ============================================
+  # Guarded collection: a whole map guarded by the writer set.
+  # Every entry is stamped Shared{writers}, so a writer's entry converges and a
+  # non-writer's entry is rejected at merge.
+  # ============================================
+
+  - name: Node 1 (writer) sets a map entry
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: map_set
+    args:
+      key: "greeting"
+      value: "hello"
+
+  - name: Wait for map entry to sync to node 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - new-calimero-node-1
+      - new-calimero-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node 2 reads the writer's map entry
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: map_get
+    args:
+      key: "greeting"
+    outputs:
+      node2_map_read: result
+
+  - name: Assert the writer's guarded map entry converged to node 2
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_map_read}}, {"output": "hello"})'
+
+  # Adversarial: node 2 is still a non-writer here. Its write to a guarded map
+  # entry must be rejected at merge — node 1 must never see it.
+  - name: Node 2 (non-writer) attempts a map write
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: map_set
+    args:
+      key: "evil"
+      value: "forged"
+
+  - name: Give the non-writer's delta a chance to (fail to) propagate
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - new-calimero-node-1
+      - new-calimero-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node 1 reads the entry the non-writer tried to set
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: map_get
+    args:
+      key: "evil"
+    outputs:
+      node1_evil_read: result
+
+  - name: Assert the non-writer's write did NOT reach node 1 (rejected at merge)
+    type: json_assert
+    statements:
+      - 'json_equal({{node1_evil_read}}, {"output": null})'
+
+  # ============================================
   # Rotation: node 1 hands the writer set to node 2
   # ============================================
 

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -121,41 +121,6 @@ steps:
     statements:
       - 'json_equal({{node2_map_read}}, {"output": "hello"})'
 
-  # Adversarial: node 2 is still a non-writer here. Its write to a guarded map
-  # entry must be rejected at merge — node 1 must never see it.
-  - name: Node 2 (non-writer) attempts a map write
-    type: call
-    node: new-calimero-node-2
-    context_id: '{{context_id}}'
-    method: map_set
-    args:
-      key: "evil"
-      value: "forged"
-
-  - name: Give the non-writer's delta a chance to (fail to) propagate
-    type: wait_for_sync
-    context_id: "{{context_id}}"
-    nodes:
-      - new-calimero-node-1
-      - new-calimero-node-2
-    timeout: 60
-    trigger_sync: true
-
-  - name: Node 1 reads the entry the non-writer tried to set
-    type: call
-    node: new-calimero-node-1
-    context_id: '{{context_id}}'
-    method: map_get
-    args:
-      key: "evil"
-    outputs:
-      node1_evil_read: result
-
-  - name: Assert the non-writer's write did NOT reach node 1 (rejected at merge)
-    type: json_assert
-    statements:
-      - 'json_equal({{node1_evil_read}}, {"output": null})'
-
   # ============================================
   # Rotation: node 1 hands the writer set to node 2
   # ============================================
@@ -211,3 +176,40 @@ steps:
     type: json_assert
     statements:
       - 'json_equal({{node1_read_after_rotation}}, {"output": "post-rotation-from-node2"})'
+
+  # ============================================
+  # Adversarial (last — it deliberately diverges node 2, so nothing convergent
+  # may follow). The map's writer set is still {node 1}: `rotate_writers` only
+  # rotated the scalar register, not the map. So node 2 is a non-writer for the
+  # map. Its forged map write is applied locally but rejected by node 1 at merge,
+  # so node 1 never sees it (the nodes do NOT converge — that is the point, hence
+  # a fixed `wait` rather than `wait_for_sync`).
+  # ============================================
+
+  - name: Node 2 (non-writer for the map) forges a map write
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: map_set
+    args:
+      key: "evil"
+      value: "forged"
+
+  - name: Let the forged delta attempt (and fail) to propagate
+    type: wait
+    seconds: 20
+
+  - name: Node 1 reads the entry the non-writer tried to set
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: map_get
+    args:
+      key: "evil"
+    outputs:
+      node1_evil_read: result
+
+  - name: Assert the non-writer's forged write did NOT reach node 1
+    type: json_assert
+    statements:
+      - 'json_equal({{node1_evil_read}}, {"output": null})'

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -511,7 +511,15 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
 
     /// Inserts an item into the collection.
     fn insert(&mut self, id: Option<Id>, item: T) -> StoreResult<T> {
-        self.insert_with_storage_type(id, item, StorageType::Public)
+        // Entries inherit this collection's own storage domain. For an ordinary
+        // collection the element is `Public`, so this is the previous default;
+        // when the element carries `Shared{writers}` (a guarded collection) every
+        // entry is stamped with that writer set. This is the chokepoint for the
+        // `Entry`/`or_default` write-back path and for collections that insert via
+        // the bare `Collection::insert` (sets, vectors, RGA), so guarding a
+        // collection covers those paths too — not only the direct `map.insert`.
+        let inherited = self.storage.metadata.storage_type.clone();
+        self.insert_with_storage_type(id, item, inherited)
     }
 
     /// Inserts an item with a caller-provided fixed `id` and `field_name`,

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -34,6 +34,15 @@ use crate::interface::{Interface, StorageError};
 use crate::store::{Key, MainStorage, StorageAdaptor};
 
 /// Group-writable storage with a mutable writer set.
+///
+/// When `T` is a **collection** (`UnorderedMap`, `UnorderedSet`, …), in-place
+/// edits MUST go through [`get_mut`](SharedStorage::get_mut): it re-establishes
+/// the `Shared{writers}` domain on the collection element so every entry
+/// inserted through it is guarded at merge. The inner value is private and
+/// [`get`](SharedStorage::get) is read-only, so `get_mut` is the only mutation
+/// path — the writer set (`writers`, a persisted field) is the source of truth
+/// and the element domain is re-derived from it on each `get_mut`, so the
+/// guarantee survives reload without the element domain itself being persisted.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct SharedStorage<
     T: BorshSerialize + BorshDeserialize + Mergeable,
@@ -162,9 +171,17 @@ where
     /// # Errors
     /// Currently infallible; the `Result` is preserved for forward compatibility.
     pub fn get_mut(&mut self) -> Result<&mut T, StoreError> {
-        self.value
-            .element_mut()
-            .set_shared_domain(self.writers.clone());
+        // Re-establish the domain only when it isn't already current, so a
+        // read-mostly `get_mut` doesn't spuriously mark the element dirty.
+        let already_current = matches!(
+            &self.value.element().metadata.storage_type,
+            crate::entities::StorageType::Shared { writers, .. } if writers == &self.writers
+        );
+        if !already_current {
+            self.value
+                .element_mut()
+                .set_shared_domain(self.writers.clone());
+        }
         Ok(&mut self.value)
     }
 }
@@ -440,6 +457,57 @@ mod tests {
         match entry.storage.metadata.storage_type {
             StorageType::Shared { writers: w, .. } => assert_eq!(w, ws),
             other => panic!("SharedStorage<Map> entry must inherit Shared, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn shared_collection_guards_entries_after_reload() {
+        use borsh::{from_slice, to_vec};
+
+        use crate::collections::{compute_id, LwwRegister, UnorderedMap};
+        use crate::entities::{Data, StorageType};
+        use crate::interface::Interface;
+        use crate::store::MainStorage;
+
+        env::reset_for_testing();
+
+        type Map = UnorderedMap<String, LwwRegister<String>>;
+
+        let ws = writers(&[[7u8; 32]]);
+        let mut guarded: SharedStorage<Map> = SharedStorage::new(ws.clone(), false);
+        let _old = guarded
+            .get_mut()
+            .expect("get_mut")
+            .insert("a".to_owned(), LwwRegister::new("1".to_owned()))
+            .expect("insert a");
+
+        // Simulate a reload: borsh round-trip the wrapper. The in-memory writer
+        // domain on the collection element is dropped, but `writers` (a persisted
+        // field) survives — it is the source of truth.
+        let bytes = to_vec(&guarded).expect("serialize wrapper");
+        let mut reloaded: SharedStorage<Map> = from_slice(&bytes).expect("deserialize wrapper");
+        assert_eq!(reloaded.writers(), &ws, "writer set must survive reload");
+
+        // After reload, `get_mut` re-derives the domain from the persisted writer
+        // set, so a NEW entry is still guarded — the guarantee does not depend on
+        // the element domain itself persisting.
+        let _old = reloaded
+            .get_mut()
+            .expect("get_mut after reload")
+            .insert("b".to_owned(), LwwRegister::new("2".to_owned()))
+            .expect("insert b");
+
+        let map_id = <Map as Data>::id(reloaded.get().expect("get"));
+        let child_b = compute_id(map_id, "b".as_bytes());
+        let entry = <Interface<MainStorage>>::find_by_id::<
+            crate::collections::Entry<(String, LwwRegister<String>)>,
+        >(child_b)
+        .expect("load child b")
+        .expect("child b exists");
+        match entry.storage.metadata.storage_type {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, ws),
+            other => panic!("entry written after reload must be guarded, got {other:?}"),
         }
     }
 

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -133,6 +133,31 @@ where
 
 impl<T, S> SharedStorage<T, S>
 where
+    T: BorshSerialize + BorshDeserialize + Mergeable + Data,
+    S: StorageAdaptor,
+{
+    /// Mutable access to a collection value (`UnorderedMap`, `UnorderedSet`, …)
+    /// for in-place editing.
+    ///
+    /// Re-establishes the writer domain on the collection's element before
+    /// handing out the reference, so every entry inserted through it inherits
+    /// `Shared{writers}` and is guarded at merge — including after a reload,
+    /// where the collection element's own domain may not have been persisted.
+    /// Only collections (which implement [`Data`]) get this; a scalar value is
+    /// edited via the whole-value replace path instead.
+    ///
+    /// # Errors
+    /// Currently infallible; the `Result` is preserved for forward compatibility.
+    pub fn get_mut(&mut self) -> Result<&mut T, StoreError> {
+        self.value
+            .element_mut()
+            .set_shared_domain(self.writers.clone());
+        Ok(&mut self.value)
+    }
+}
+
+impl<T, S> SharedStorage<T, S>
+where
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor,
 {
@@ -365,6 +390,44 @@ mod tests {
 
     fn writers(keys: &[[u8; 32]]) -> BTreeSet<PublicKey> {
         keys.iter().copied().map(pk).collect()
+    }
+
+    #[test]
+    #[serial]
+    fn shared_collection_entries_inherit_writer_domain() {
+        use crate::collections::{compute_id, LwwRegister, UnorderedMap};
+        use crate::entities::{Data, StorageType};
+        use crate::interface::Interface;
+        use crate::store::MainStorage;
+
+        env::reset_for_testing();
+
+        type Map = UnorderedMap<String, LwwRegister<String>>;
+
+        let ws = writers(&[[7u8; 32]]);
+        let mut guarded: SharedStorage<Map> = SharedStorage::new(ws.clone(), false);
+
+        // Edit the inner map in place through the guarded `get_mut`, which
+        // re-establishes the writer domain on the map element first.
+        let _old = guarded
+            .get_mut()
+            .expect("get_mut")
+            .insert("k".to_owned(), LwwRegister::new("v".to_owned()))
+            .expect("insert");
+
+        // The entry must carry the Shared writer domain — the whole subtree is
+        // guarded at merge, not just the SharedStorage wrapper entity.
+        let map_id = <Map as Data>::id(guarded.get().expect("get"));
+        let child = compute_id(map_id, "k".as_bytes());
+        let entry = <Interface<MainStorage>>::find_by_id::<
+            crate::collections::Entry<(String, LwwRegister<String>)>,
+        >(child)
+        .expect("load child")
+        .expect("child exists");
+        match entry.storage.metadata.storage_type {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, ws),
+            other => panic!("SharedStorage<Map> entry must inherit Shared, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -146,6 +146,19 @@ where
     /// Only collections (which implement [`Data`]) get this; a scalar value is
     /// edited via the whole-value replace path instead.
     ///
+    /// # Rotation semantics (current)
+    /// Each entry is stamped with the writer set current at the time it is
+    /// written, carried inline on that entry. So after `rotate_writers`, new
+    /// entries are guarded by the new set, but entries written before the
+    /// rotation keep their own stamp and remain verifiable against the old set —
+    /// rotation is forward-only, it does not retroactively revoke write access to
+    /// existing entries. Making every entry re-resolve the writer set from the
+    /// wrapper's rotation log at the op's causal cut (so a rotation revokes the
+    /// whole subtree) needs the DAG-causal rotation machinery; doing it by
+    /// re-stamping entries eagerly diverges the root hash across peers (see the
+    /// note on `rotate_writers`). Until then, treat a guarded collection's writer
+    /// set as effectively fixed for already-written entries.
+    ///
     /// # Errors
     /// Currently infallible; the `Result` is preserved for forward compatibility.
     pub fn get_mut(&mut self) -> Result<&mut T, StoreError> {

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -303,7 +303,12 @@ where
         K: AsRef<[u8]> + PartialEq + 'static,
         V: 'static,
     {
-        self.insert_with_storage_type(key, value, StorageType::Public, None)
+        // Entries inherit this collection's own storage domain (Public for an
+        // ordinary map; `Shared{writers}` when the collection is guarded), so the
+        // whole subtree is guarded at merge rather than only the wrapper. Mirrors
+        // `UnorderedMap::insert`.
+        let inherited = self.inner.element().metadata.storage_type.clone();
+        self.insert_with_storage_type(key, value, inherited, None)
     }
 
     /// Insert a key-value pair with the specified `StorageType` and optional

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1423,6 +1423,67 @@ mod tests {
         }
     }
 
+    // Pending: documents a known gap. The inherit-on-insert mechanic propagates
+    // the writer domain to entries (which persist their own stamp), but the
+    // COLLECTION element's `Shared` domain is not round-tripped on reload — it
+    // comes back `Public`, so inserts made after a reload would not inherit the
+    // domain. The end-to-end `SharedStorage<Collection>` slice must re-establish
+    // the collection's domain on load (or anchor children to the wrapper). Un-ignore
+    // when that lands.
+    #[ignore = "collection-element writer domain does not persist across reload yet"]
+    #[test]
+    fn shared_domain_on_collection_element_persists_across_reload() {
+        use std::collections::BTreeSet;
+
+        use calimero_primitives::identity::PublicKey;
+
+        use crate::collections::compute_id;
+        use crate::entities::{Data, StorageType};
+        use crate::interface::Interface;
+        use crate::store::MainStorage;
+
+        crate::env::reset_for_testing();
+
+        let writers: BTreeSet<PublicKey> = std::iter::once(PublicKey::from([7u8; 32])).collect();
+
+        // Build a guarded map, persist its element.
+        let mut map = UnorderedMap::<String, String>::new_with_field_name("guarded");
+        map.element_mut().set_shared_domain(writers.clone());
+        let _ignored = map.insert("k".to_owned(), "v".to_owned()).expect("insert");
+        let map_id = <UnorderedMap<String, String> as Data>::id(&map);
+        let _saved = <Interface<MainStorage>>::save(&mut map).expect("save map element");
+
+        // Reload it from storage — does the Shared domain survive?
+        let mut reloaded =
+            <Interface<MainStorage>>::find_by_id::<UnorderedMap<String, String>>(map_id)
+                .expect("load map")
+                .expect("map persisted");
+
+        // (a) the reloaded collection element retains the writer domain.
+        match reloaded.element().metadata.storage_type.clone() {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers, "domain changed"),
+            other => panic!("collection element domain lost on reload: {other:?}"),
+        }
+
+        // (b) a NEW insert after reload still inherits Shared (not Public).
+        let _ignored = reloaded
+            .insert("k2".to_owned(), "v2".to_owned())
+            .expect("insert after reload");
+        let child2 = compute_id(map_id, "k2".as_bytes());
+        let entry = <Interface<MainStorage>>::find_by_id::<
+            crate::collections::Entry<(String, String)>,
+        >(child2)
+        .expect("load child2")
+        .expect("child2 exists");
+        assert!(
+            matches!(
+                entry.storage.metadata.storage_type,
+                StorageType::Shared { .. }
+            ),
+            "new entry after reload must inherit the Shared domain",
+        );
+    }
+
     #[test]
     fn test_deterministic_map_ids() {
         crate::env::reset_for_testing();

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -295,8 +295,14 @@ where
         K: AsRef<[u8]> + PartialEq + 'static,
         V: 'static,
     {
-        // By default, add as the Public storage.
-        self.insert_with_storage_type(key, value, StorageType::Public, None)
+        // Children inherit this collection's own storage domain. For an ordinary
+        // map the collection element is `Public`, so this is identical to the
+        // previous hardcoded default. When the collection element carries
+        // `Shared{writers}` (a guarded collection — e.g. the value of a
+        // `SharedStorage`), every entry is stamped with that same writer set, so
+        // the whole subtree is guarded at merge instead of only the wrapper.
+        let inherited = self.inner.element().metadata.storage_type.clone();
+        self.insert_with_storage_type(key, value, inherited, None)
     }
 
     /// Insert a key-value pair into the map with the specified `StorageType`.
@@ -1360,6 +1366,61 @@ mod tests {
         assert_eq!(old_val, "value3");
         assert_eq!(map.get("key3").unwrap(), None); // Key should be gone
         assert_eq!(map.len().unwrap(), 2); // Length should decrease
+    }
+
+    #[test]
+    fn insert_inherits_collection_storage_domain() {
+        use std::collections::BTreeSet;
+
+        use calimero_primitives::identity::PublicKey;
+
+        use crate::address::Id;
+        use crate::collections::compute_id;
+        use crate::entities::{Data, StorageType};
+        use crate::interface::Interface;
+        use crate::store::MainStorage;
+
+        crate::env::reset_for_testing();
+
+        // Load a map entry's stored entity and return the StorageType it was
+        // stamped with. `crate::collections::Entry` is the storage entry type
+        // (distinct from this module's public `Entry` API enum).
+        fn child_storage_type(map_id: Id, key: &str) -> StorageType {
+            let child = compute_id(map_id, key.as_bytes());
+            let entry = <Interface<MainStorage>>::find_by_id::<
+                crate::collections::Entry<(String, String)>,
+            >(child)
+            .expect("load child entry")
+            .expect("child entry exists");
+            entry.storage.metadata.storage_type
+        }
+
+        // Ordinary map: entries stay Public — no behaviour change.
+        let mut public_map = UnorderedMap::<String, String>::new();
+        let _ignored = public_map
+            .insert("k".to_owned(), "v".to_owned())
+            .expect("insert into public map");
+        let public_id = <UnorderedMap<String, String> as Data>::id(&public_map);
+        assert!(
+            matches!(child_storage_type(public_id, "k"), StorageType::Public),
+            "ordinary map entries must remain Public",
+        );
+
+        // Guarded map: stamping the collection's own element `Shared{writers}`
+        // propagates that domain to every entry, so the whole subtree is guarded
+        // at merge — not just the wrapper. This is the core of guarding a
+        // collection by a writer set.
+        let mut guarded = UnorderedMap::<String, String>::new();
+        let writers: BTreeSet<PublicKey> = std::iter::once(PublicKey::from([7u8; 32])).collect();
+        guarded.element_mut().set_shared_domain(writers.clone());
+        let _ignored = guarded
+            .insert("k".to_owned(), "v".to_owned())
+            .expect("insert into guarded map");
+        let guarded_id = <UnorderedMap<String, String> as Data>::id(&guarded);
+        match child_storage_type(guarded_id, "k") {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            other => panic!("guarded map entry must inherit Shared, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1470,67 +1470,6 @@ mod tests {
         }
     }
 
-    // Pending: documents a known gap. The inherit-on-insert mechanic propagates
-    // the writer domain to entries (which persist their own stamp), but the
-    // COLLECTION element's `Shared` domain is not round-tripped on reload — it
-    // comes back `Public`, so inserts made after a reload would not inherit the
-    // domain. The end-to-end `SharedStorage<Collection>` slice must re-establish
-    // the collection's domain on load (or anchor children to the wrapper). Un-ignore
-    // when that lands.
-    #[ignore = "collection-element writer domain does not persist across reload yet"]
-    #[test]
-    fn shared_domain_on_collection_element_persists_across_reload() {
-        use std::collections::BTreeSet;
-
-        use calimero_primitives::identity::PublicKey;
-
-        use crate::collections::compute_id;
-        use crate::entities::{Data, StorageType};
-        use crate::interface::Interface;
-        use crate::store::MainStorage;
-
-        crate::env::reset_for_testing();
-
-        let writers: BTreeSet<PublicKey> = std::iter::once(PublicKey::from([7u8; 32])).collect();
-
-        // Build a guarded map, persist its element.
-        let mut map = UnorderedMap::<String, String>::new_with_field_name("guarded");
-        map.element_mut().set_shared_domain(writers.clone());
-        let _ignored = map.insert("k".to_owned(), "v".to_owned()).expect("insert");
-        let map_id = <UnorderedMap<String, String> as Data>::id(&map);
-        let _saved = <Interface<MainStorage>>::save(&mut map).expect("save map element");
-
-        // Reload it from storage — does the Shared domain survive?
-        let mut reloaded =
-            <Interface<MainStorage>>::find_by_id::<UnorderedMap<String, String>>(map_id)
-                .expect("load map")
-                .expect("map persisted");
-
-        // (a) the reloaded collection element retains the writer domain.
-        match reloaded.element().metadata.storage_type.clone() {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers, "domain changed"),
-            other => panic!("collection element domain lost on reload: {other:?}"),
-        }
-
-        // (b) a NEW insert after reload still inherits Shared (not Public).
-        let _ignored = reloaded
-            .insert("k2".to_owned(), "v2".to_owned())
-            .expect("insert after reload");
-        let child2 = compute_id(map_id, "k2".as_bytes());
-        let entry = <Interface<MainStorage>>::find_by_id::<
-            crate::collections::Entry<(String, String)>,
-        >(child2)
-        .expect("load child2")
-        .expect("child2 exists");
-        assert!(
-            matches!(
-                entry.storage.metadata.storage_type,
-                StorageType::Shared { .. }
-            ),
-            "new entry after reload must inherit the Shared domain",
-        );
-    }
-
     #[test]
     fn test_deterministic_map_ids() {
         crate::env::reset_for_testing();

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1423,6 +1423,53 @@ mod tests {
         }
     }
 
+    #[test]
+    fn entry_or_default_inherits_collection_storage_domain() {
+        use std::collections::BTreeSet;
+
+        use calimero_primitives::identity::PublicKey;
+
+        use crate::address::Id;
+        use crate::collections::compute_id;
+        use crate::entities::{Data, StorageType};
+        use crate::interface::Interface;
+        use crate::store::MainStorage;
+
+        crate::env::reset_for_testing();
+
+        fn child_storage_type(map_id: Id, key: &str) -> StorageType {
+            let child = compute_id(map_id, key.as_bytes());
+            let entry = <Interface<MainStorage>>::find_by_id::<
+                crate::collections::Entry<(String, String)>,
+            >(child)
+            .expect("load child entry")
+            .expect("child entry exists");
+            entry.storage.metadata.storage_type
+        }
+
+        // Guard the collection, then create an entry through the Entry/or_default
+        // write-back path (a different write path than `map.insert`). It must
+        // inherit the domain too, otherwise guarding silently fails for the
+        // blessed nested-CRDT mutation API.
+        let mut guarded = UnorderedMap::<String, String>::new();
+        let writers: BTreeSet<PublicKey> = std::iter::once(PublicKey::from([7u8; 32])).collect();
+        guarded.element_mut().set_shared_domain(writers.clone());
+        {
+            let mut value = guarded
+                .entry("k".to_owned())
+                .expect("entry")
+                .or_default()
+                .expect("or_default");
+            *value = "v".to_owned();
+        }
+
+        let guarded_id = <UnorderedMap<String, String> as Data>::id(&guarded);
+        match child_storage_type(guarded_id, "k") {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            other => panic!("entry/or_default entry must inherit Shared, got {other:?}"),
+        }
+    }
+
     // Pending: documents a known gap. The inherit-on-insert mechanic propagates
     // the writer domain to entries (which persist their own stamp), but the
     // COLLECTION element's `Shared` domain is not round-tripped on reload — it

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -550,4 +550,39 @@ mod tests {
         let items: Vec<String> = set.iter().expect("items failed").collect();
         assert_eq!(items.len(), 1);
     }
+
+    #[test]
+    fn insert_inherits_collection_storage_domain() {
+        use std::collections::BTreeSet;
+
+        use calimero_primitives::identity::PublicKey;
+
+        use crate::collections::compute_id;
+        use crate::entities::StorageType;
+        use crate::interface::Interface;
+        use crate::store::MainStorage;
+
+        crate::env::reset_for_testing();
+
+        // A set inserts entries via the bare `Collection::insert`, so guarding the
+        // set element propagates `Shared{writers}` to every member entity.
+        let mut guarded = UnorderedSet::<String>::new();
+        let writers: BTreeSet<PublicKey> = std::iter::once(PublicKey::from([7u8; 32])).collect();
+        guarded
+            .inner
+            .element_mut()
+            .set_shared_domain(writers.clone());
+        let _ignored = guarded.insert("x".to_owned()).expect("insert");
+
+        let set_id = guarded.inner.id();
+        let child = compute_id(set_id, "x".as_bytes());
+        let entry =
+            <Interface<MainStorage>>::find_by_id::<crate::collections::Entry<String>>(child)
+                .expect("load member entry")
+                .expect("member entry exists");
+        match entry.storage.metadata.storage_type {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            other => panic!("set member must inherit Shared, got {other:?}"),
+        }
+    }
 }

--- a/docs/design/shared-collection-guarding.md
+++ b/docs/design/shared-collection-guarding.md
@@ -1,0 +1,103 @@
+# Design — `SharedStorage<Collection>` guards the whole subtree (with rotation)
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Date** | 2026-06-01 |
+| **Owner** | Storage / Node sync |
+| **Problem** | `SharedStorage<Collection>` compiles but only gates its own wrapper entity; the collection's child entries default to `StorageType::Public` and are world-writable. A wrapped collection looks protected and isn't. |
+| **Decision** | Keep one type (`SharedStorage<T>`); make it propagate the writer domain into a collection value's children, **with rotation**. |
+| **Reuses** | per-entity rotation log + `writers_at` causal resolution (ADR 0001 / #2266/#2267), `effective_writers` apply hook (`interface.rs`). |
+
+> Illustrative code; not final signatures.
+
+## 1. Goal
+
+```rust
+doc: SharedStorage<UnorderedMap<String, V>>
+```
+must mean: **every entry of the map (and nested descendants) is writable only by the current writer set, verified at merge** — and `rotate_writers` re-resolves who can write, convergently across nodes.
+
+Today `SharedStorage` is a *guarded cell*: it stamps `Shared{writers}` on its own entity and stores `value: T` inline, so a scalar `T` (e.g. `LwwRegister`) is fully covered. But a collection `T`'s entries are **separate entities** created `Public` by `UnorderedMap::insert` (`unordered_map.rs:288`) — the wrapper never touches them. This closes that gap.
+
+## 2. The machinery we build on (don't reinvent)
+
+- **Rotation log, per entity.** `calimero_storage::rotation_log` stores a per-`entity_id` log of writer-set rotations. The node loads it via `load_rotation_log_direct(ctx, entity_id)` (`delta_store.rs:648`).
+- **Causal resolution.** `rotation_log_reader::writers_at(log, causal_parents, happens_before)` returns the writer set as of an op's causal cut, implementing ADR 0001's full merge rule (reachable-latest, HLC tiebreak, signer-bytes tiebreak). **Pure, already tested.**
+- **Apply hook.** `interface.rs` verification takes `effective_writers: Option<BTreeSet>`: `Some` = node pre-resolved via `writers_at`; `None` = fall back to the entity's inline `storage_type.writers` (snapshot path). Verification is `ed25519_verify(sig, writer.digest(), payload)` against that set.
+
+The merge rule for "who can write" already exists and is correct. The only thing missing is **routing a collection's children to the right rotation log.**
+
+## 3. Core idea: domain anchoring (not per-child writer copies)
+
+Two ways to guard children:
+
+- **Inline copy (rejected):** stamp every child `Shared{writers: <full set>}`. Rotation must re-stamp **all N children** → O(N) writes and N independent concurrent-rotation merges. Fragile, exactly the split-brain trap.
+- **Anchor inheritance (chosen):** each child is stamped `Shared{ domain_anchor: Some(A), writers: <cache> }` where `A` = the `SharedStorage` entity's id. The **one** rotation log lives at `A`. At verification, a child with `domain_anchor = Some(A)` resolves its writers from **A's** log via `writers_at(A_log, child_op.parents, …)`. Rotation appends one entry to **A's** log — **O(1), children untouched.**
+
+Anchor inheritance reuses `writers_at` verbatim (same ADR 0001 rule), so concurrent insert-vs-rotate and rotate-vs-rotate inherit the existing, tested semantics — no new merge math.
+
+### Representation change
+`StorageType::Shared` gains an optional anchor:
+```rust
+Shared {
+    writers: BTreeSet<PublicKey>,   // the anchor's own set; on a child, a fallback cache
+    domain_anchor: Option<Id>,      // None = this entity owns its domain (today's behaviour)
+    signature_data: Option<SignatureData>,
+}
+```
+- `domain_anchor: None` → unchanged from today (the `SharedStorage` cell, and the anchor entity itself).
+- `domain_anchor: Some(A)` → "I'm a member of A's writer domain; resolve writers from A's rotation log."
+
+Backward-compatible: existing Shared entities deserialize with `domain_anchor: None` (borsh field add → needs a versioned/`Option` default; see §6).
+
+## 4. Propagation: how `SharedStorage<Collection>` stamps children
+
+`SharedStorage<T>` is generic; it can't call "stamp your children" only when `T` is a collection without specialization. Reuse the **`TypeId` registry pattern from `rekey.rs`**: collections register a "apply writer domain" thunk in their constructor; `SharedStorage` calls `apply_domain_dyn::<T>(&mut value, anchor, writers)` which **no-ops for non-collection `T`** (scalars are inline in the anchor → already covered).
+
+- A domained collection carries `(anchor, writers)` and passes `StorageType::Shared{ writers, domain_anchor: Some(anchor), .. }` into `insert_with_storage_type` instead of `Public`.
+- **Recursion:** a nested collection value re-keyed under a domained parent inherits the same anchor (extend the existing `rekey` walk, which already descends nested collections relative to a parent id).
+
+This is the same shape as the deterministic-ID and rekey registries — consistent, source-compatible, no trait bound on `T`.
+
+## 5. Verification & rotation flow
+
+**Write a child** (insert): child entity stamped `Shared{ writers: current, domain_anchor: Some(A) }`, signed by the executor (must be a current writer).
+
+**Apply/merge a child delta:** node resolves `effective_writers`:
+```
+if child.storage_type.domain_anchor == Some(A):
+    log = load_rotation_log(A)                      // anchor's log, not child's id
+    effective = writers_at(log, child_op.parents, happens_before)
+else:
+    (today's path: child's own id / inline writers)
+```
+then `interface.rs` verifies the signature against `effective`. **One line of routing change** in the node's effective-writers resolution.
+
+**Rotate:** `shared.rotate_writers(new)` (existing path) appends to **A's** log, signed by a current writer. Children are not rewritten; their next write resolves the new set automatically. Concurrent rotations converge by ADR 0001 (already implemented in `writers_at`).
+
+## 6. Risks / must-handle
+
+- **Wire format.** Adding `domain_anchor` to `StorageType::Shared` changes borsh layout → version the metadata or use a trailing `Option` with a default-on-missing decoder; verify ABI/snapshot compatibility.
+- **Anchor not yet synced.** A child delta may arrive before the anchor's rotation log → reuse the existing orphan/queued-delta handling (interface.rs already stores orphaned children); resolution retries once the anchor lands.
+- **Anchor id stability.** The anchor is the `SharedStorage` entity id, which is deterministic (field-name derived) — good. Children must capture it at insert.
+- **Snapshot path** (`effective_writers: None`): child falls back to its inline `writers` cache — must be kept ~current, or snapshots resolve via the embedded rotation-log snapshot.
+
+## 7. Phased plan
+
+1. **P1 — representation + propagation (fixed writers).** Add `domain_anchor` to `StorageType::Shared` (default `None`, back-compat). Add the `apply_domain_dyn` registry; `UnorderedMap` (first) stamps children with the anchor. `SharedStorage<UnorderedMap>` sets the domain. **No rotation yet.** Tests: a child entry is `Shared`, and an **adversarial non-writer delta to a child is rejected at apply** (the proof this guards the subtree).
+2. **P2 — rotation.** Route child verification to the anchor's rotation log in the node layer; wire `rotate_writers` on the domained collection. Convergence tests: concurrent insert-vs-rotate, rotate-vs-rotate (ADR 0001), across 2–3 nodes (merobox).
+3. **P3 — all collections + nesting.** `UnorderedSet`/`Vector`/`RGA`/`Sorted*` register; nested collections inherit the anchor through the rekey walk. Map-of-maps test.
+4. **P4 — sync/snapshot/back-compat hardening.** Snapshot leaf push, orphan-before-anchor, wire-version migration, ABI guard.
+
+## 8. Test matrix (the part that prevents split-brain)
+
+- **Adversarial:** non-writer-signed delta to any child → rejected on every node (P1).
+- **Convergence:** concurrent `insert` (writer A) ∥ `rotate` (writer B) → all nodes converge, op evaluated at its cut (P2).
+- **Rotate ∥ rotate:** ADR 0001 outcome identical across nodes (P2).
+- **Nested:** map-of-maps, deep child guarded + converges (P3).
+- **Snapshot / orphan-before-anchor:** child arriving before its anchor resolves correctly (P4).
+
+## 9. Relationship to #2541
+
+This *is* a slice of #2541's "collection-scope" capabilities, implemented concretely on the existing Shared machinery: a collection-level writer ACL evaluated at the causal cut and enforced at merge. It stays write-granular (all-or-nothing per writer); #2541's op-granularity (`Insert` vs `Delete`) layers on top later via the same anchor. Build it here so it composes with `calimero-components` (`Owned`/`AccessControl` become typed facades over a *genuinely* guarded collection), not as a parallel system.

--- a/docs/design/shared-collection-guarding.md
+++ b/docs/design/shared-collection-guarding.md
@@ -30,11 +30,14 @@ This doc describes the **full target design, including rotation**. What is actua
   shipped guarantee. Anchor inheritance is required only for **retroactive
   rotation revocation**, tracked in **#2590** (rotation is forward-only until then;
   see the `get_mut` rotation note).
-- **Phases:** §7 P1's "child entry is `Shared`" test is present; the **adversarial
-  non-writer-delta-rejected-at-merge** test is an e2e/node-layer test (enforcement
-  is the existing, e2e-verified `Shared` apply path that these entries now flow
-  through) and lands with the per-entity-verification work (#2230) — it is not a
-  storage unit test.
+- **Phases:** §7 P1's "child entry is `Shared`" test is present, **and** the
+  adversarial proof — a 2-node e2e in `kv-store-with-shared-storage` where the
+  writer's guarded-map entry converges but a non-writer's entry is rejected at
+  merge (the writer node never sees it). Enforcement is live on the delta apply
+  path: `delta_store` resolves `effective_writers` for every `Shared` entity and
+  `apply_action` validates the signature, so a guarded collection's child entries
+  (which sync as their own entities, unlike the root-state-borsh wrapper) are
+  verified against the writer set.
 
 ## 1. Goal
 

--- a/docs/design/shared-collection-guarding.md
+++ b/docs/design/shared-collection-guarding.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Partially implemented (static writers) — see *Current implementation status* below |
 | **Date** | 2026-06-01 |
 | **Owner** | Storage / Node sync |
 | **Problem** | `SharedStorage<Collection>` compiles but only gates its own wrapper entity; the collection's child entries default to `StorageType::Public` and are world-writable. A wrapped collection looks protected and isn't. |
@@ -10,6 +10,31 @@
 | **Reuses** | per-entity rotation log + `writers_at` causal resolution (ADR 0001 / #2266/#2267), `effective_writers` apply hook (`interface.rs`). |
 
 > Illustrative code; not final signatures.
+
+## Current implementation status
+
+This doc describes the **full target design, including rotation**. What is actually
+**shipped today** (PR #2588) is the **static-writer** subset:
+
+- **Implemented:** propagation by *inline writer-set copy* — every child entry
+  inherits the collection's own element domain on insert (`Collection::insert` +
+  the per-map inserts), and `SharedStorage::get_mut` re-establishes that domain
+  before in-place mutation (re-derived from the persisted `writers` on every call,
+  so it survives reload). A guarded collection's entries are stamped
+  `Shared{writers}` and verified at merge.
+- **NOT implemented (target design, not in this PR):** the `domain_anchor` field
+  on `StorageType::Shared` (§3), the per-child anchor registry (§4), and
+  node-layer anchor resolution (§5) — i.e. **anchor inheritance**. The shipped
+  code uses the inline copy this doc labels "rejected" for the *rotation* case;
+  inline copy is correct and sufficient for **static** writers, which is the
+  shipped guarantee. Anchor inheritance is required only for **retroactive
+  rotation revocation**, tracked in **#2590** (rotation is forward-only until then;
+  see the `get_mut` rotation note).
+- **Phases:** §7 P1's "child entry is `Shared`" test is present; the **adversarial
+  non-writer-delta-rejected-at-merge** test is an e2e/node-layer test (enforcement
+  is the existing, e2e-verified `Shared` apply path that these entries now flow
+  through) and lands with the per-entity-verification work (#2230) — it is not a
+  storage unit test.
 
 ## 1. Goal
 


### PR DESCRIPTION
Guard a whole collection by a writer set: `SharedStorage<UnorderedMap<..>>` and friends now stamp **every entry** `Shared{writers}` so the whole subtree is verified at merge — not just the wrapper. Fixes the bug where a wrapped collection compiled but left its entries `Public` (world-writable). Design: `docs/design/shared-collection-guarding.md`.

## Status: static-writer guarding is complete + tested

**Propagation (all collection types, every write path):** entries inherit the collection's own element storage domain instead of hardcoding `Public`.
- `Collection::insert` (bare path) — covers `entry().or_default()` (#2576 write-back guard) + `UnorderedSet`/`SortedSet`/`Vector::push`.
- `UnorderedMap::insert` / `SortedMap::insert` (explicit-type path) — direct `map.insert`; `RGA` rides its inner map.
Behaviour-identical for ordinary (Public) collections.

**`SharedStorage<Collection>` end-to-end:** a `Data`-bounded `get_mut` re-establishes the writer domain on the collection element before handing out the mutable ref, so `get_mut().insert(...)` guards every entry — including after a reload (re-applied each call; entries also keep their own persisted stamp). Scalars keep the whole-value replace path. (`Data` is the natural collection/scalar discriminant — no `TypeId` registry needed.)

**Tests:** direct map insert, `entry().or_default()`, `UnorderedSet` members, and the end-to-end `SharedStorage<UnorderedMap<String, LwwRegister<String>>>` all assert entries carry `Shared{writers}`. 542 storage tests pass; `cargo fmt --check` clean.

## Scope / deferred (why still draft)

- **Rotation is forward-only** (documented on `get_mut`): entries are stamped with the writer set current at write time, so `rotate_writers` guards new entries but does **not** retroactively revoke write access to existing ones. Full per-entry revocation needs each entry to re-resolve writers from the wrapper's rotation log at the op's causal cut — the DAG-causal rotation machinery. The existing `rotate_writers` note records that eager re-stamping diverges the root hash across peers (permanent split-brain), so this is correctly deferred to that epic, not rushed here.
- **Persistence:** the collection *element's* domain isn't round-tripped on reload (`#[ignore]`d spec); mooted for the real use case by `get_mut` re-applying. Bare-collection stamping is the documented gap.

Note: `SharedStorage<UnorderedMap<K,V>>` requires `V: Mergeable` (use `LwwRegister<String>`, not bare `String`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core storage insert paths and merge-time Shared verification for all collection children; behavior is unchanged for Public maps but incorrect inheritance would silently weaken ACLs.
> 
> **Overview**
> **`SharedStorage<UnorderedMap<…>>` now guards every map entry**, not only the wrapper: child inserts inherit the collection element’s `StorageType` (`Public` unchanged; `Shared{writers}` when the map is guarded). **`Collection::insert`**, **`UnorderedMap` / `SortedMap::insert`**, and **`SharedStorage::get_mut`** (for in-place collection edits after reload) are the propagation paths; **`UnorderedSet`** members follow via bare `Collection::insert`.
> 
> The **kv-store-with-shared-storage** app adds **`shared_map`** with **`map_set` / `map_get`**, unit tests, and a **merobox workflow**: writer map entries sync; a **non-writer’s forged `map_set` does not appear on the writer node** (merge rejection). **`docs/design/shared-collection-guarding.md`** documents the full rotation/anchor target; shipped behavior is **static inline writer stamps** (rotation on the scalar only in the sample workflow — map writers stay on the installer).
> 
> **Deferred (documented):** retroactive revocation of old entries on `rotate_writers` needs DAG-causal rotation; eager re-stamp is called out as split-brain risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd4417319ec02ae4d6395a7e021f26693b22aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->