### PR TITLE
fix(node): drain governance-pending buffer on sync apply paths

### DIFF
--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3428,6 +3428,14 @@ impl SyncManager {
             self.node_client.notify_namespace_op_applied(namespace_id);
         }
 
+        // Parity with the gossip apply path: a governance op we just learned
+        // may unblock a state delta buffered as `Unknown`. Run whenever this
+        // catch-up returned ops, not only on a fresh apply — see
+        // `drain_governance_pending_after_sync`.
+        if ops_count > 0 {
+            self.drain_governance_pending_after_sync().await;
+        }
+
         debug!(
             %context_id,
             %their_identity,
@@ -3436,6 +3444,37 @@ impl SyncManager {
             ops_applied = applied,
             "governance catch-up complete"
         );
+    }
+
+    /// Release any state deltas parked in the governance-pending buffer after
+    /// a governance-sync path applied (or re-confirmed) ops.
+    ///
+    /// The gossip apply path (`network_event/namespace.rs`) already drains the
+    /// governance-pending buffer when a namespace op applies, but the
+    /// **sync/backfill** apply paths here did not — a parity gap. A late
+    /// joiner's first post-join state delta is buffered as
+    /// `MembershipStatus::Unknown` until the local node learns the joiner's
+    /// membership op; when that op arrives via sync (beacon-triggered
+    /// governance sync or catch-up backfill) rather than gossip, nothing
+    /// re-evaluated the buffer, so the delta sat there forever and the two
+    /// nodes' context root hashes never reconverged.
+    ///
+    /// Deliberately *not* gated on a fresh `Applied` outcome: the awaited op
+    /// may already be present locally (e.g. deduplicated on read, #2327) yet
+    /// no drain has ever fired for it. Re-evaluating membership is the correct
+    /// trigger, and the call is cheap — `drain_all_governance_pending` returns
+    /// immediately when no context holds buffered deltas.
+    async fn drain_governance_pending_after_sync(&self) {
+        let drain_input = crate::handlers::state_delta::StateDeltaContext {
+            node_clients: crate::state::NodeClients {
+                context: self.context_client.clone(),
+                node: self.node_client.clone(),
+            },
+            node_state: self.node_state.clone(),
+            network_client: self.network_client.clone(),
+            sync_timeout: self.sync_config.timeout,
+        };
+        crate::handlers::state_delta::drain_all_governance_pending(&drain_input).await;
     }
 
     /// Handle a namespace backfill request: look up full `SignedNamespaceOp`
@@ -4221,9 +4260,10 @@ impl SyncManager {
                 payload: MessagePayload::NamespaceBackfillResponse { deltas },
                 ..
             })) => {
+                let ops_received = deltas.len();
                 info!(
                     namespace_id = %hex::encode(namespace_id),
-                    ops = deltas.len(),
+                    ops = ops_received,
                     "received namespace governance ops from peer"
                 );
                 use calimero_context_client::messages::NamespaceApplyOutcome;
@@ -4333,6 +4373,16 @@ impl SyncManager {
                 // tick which has no such constraint).
                 for report in pending_divergences {
                     self.reconcile_after_divergence(report).await;
+                }
+
+                // Parity with the gossip apply path: releasing buffered
+                // state deltas waiting on a membership op we just backfilled.
+                // This is the path the late-joiner reverse-sync hit — the
+                // joiner's first post-join write was buffered as `Unknown`
+                // and the membership op that unblocks it arrived here, via
+                // backfill, never via gossip, so nothing drained the buffer.
+                if ops_received > 0 {
+                    self.drain_governance_pending_after_sync().await;
                 }
             }
             _ => {


### PR DESCRIPTION
## Problem

The `group-late-joiner` e2e is flaky. It fails only on the **reverse-direction** step — *"Wait for node-2 post-join write to sync"* — where the late joiner (node-2) writes a key and node-1 must pull it. The two nodes get stuck at different context root hashes and never reconverge within 60s:

```
e2e-node-1: 27Kmx…   ← pre-write root, never advances (emitted 115×)
e2e-node-2: CxC6yT…  ← its own post-join write head (emitted 112×)
```

## Root cause

When node-2's post-join state delta arrives at node-1, the cross-DAG check returns `MembershipStatus::Unknown { needed: 1 }` (node-1's governance DAG hasn't yet caught up to node-2's membership op), so node-1 **buffers** the delta:

```
cross-DAG check: governance state behind position; buffering delta until catchup  needed_count=1
```

The gossip apply path (`network_event/namespace.rs`) drains the governance-pending buffer whenever a namespace op applies. But the **sync/backfill** apply paths — `sync_namespace_from_peer` and `request_governance_catchup_from_peer` — only fired the FSM notify (`notify_namespace_op_applied`) and **never drained the buffer**. A parity gap.

In the failing run node-1 *did* learn and apply the membership op via sync (its readiness beacon `applied_through` advances **1 → 2**), but because that happened on the sync path, nothing re-evaluated the buffered delta. node-1's storage tree even merges node-2's data via HashComparison (`root_hash_verified=true`), yet the **DAG head / context root never advances** because the state delta that would advance it stays parked in the buffer. Permanent split-brain.

It's flaky because it's a race on *how* node-1 learns node-2's membership op: via gossip (drains, converges) vs. via sync/backfill (no drain, stuck).

## Fix

Add a shared `SyncManager::drain_governance_pending_after_sync` helper and call it from both sync apply paths, giving them parity with the gossip path.

Gated on ops-received rather than a fresh `Applied` outcome: the awaited op may already be present locally (deduplicated on read, #2327) yet have never triggered a drain. Re-evaluating membership is the correct trigger, and the drain self-cancels cheaply when no context holds buffered deltas.

All four `apply_signed_namespace_op` sites (2 gossip pre-existing, 2 sync new) now drain.

## Verification

- `cargo fmt --check`, `cargo check`, `cargo clippy -p calimero-node` clean (no new warnings)
- `cargo test -p calimero-node --lib` — **238 passed, 0 failed**
- Log-proven sufficiency: node-1's `applied_through` reaching 2 confirms the membership op was applied; the only missing link was the drain trigger, which this adds. The existing `group-late-joiner.yml` e2e is the integration regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync and state-delta convergence paths for namespace governance; behavior change is narrow (drain when ops received) but affects multi-node membership catch-up timing.
> 
> **Overview**
> **Fixes a parity gap** where namespace governance ops applied over **sync/backfill** did not drain the governance-pending buffer, unlike the gossip apply path in `network_event/namespace.rs`.
> 
> When a peer’s state delta is held as `MembershipStatus::Unknown` until a joiner’s membership op is learned, that op can arrive via beacon-triggered catch-up or namespace backfill instead of gossip. Without a drain, buffered deltas never replay and context root hashes can stay split (flaky `group-late-joiner` reverse-sync).
> 
> Adds `SyncManager::drain_governance_pending_after_sync`, which builds a `StateDeltaContext` and calls `drain_all_governance_pending`. It runs after **`request_governance_catchup_from_peer`** and **`sync_namespace_from_peer`** whenever the response included at least one op—not only on newly `Applied` outcomes, so deduplicated ops still trigger re-evaluation when no prior drain ran.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e166f1a487f4e74536a22c4a518dd17e539549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->