### PR TITLE
fix(sync): propagate clear tombstones through LevelWise

### DIFF
--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -59,9 +59,9 @@ use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use calimero_node_primitives::sync::{
-    compare_level_nodes, create_runtime_env, InitPayload, LevelNode, MessagePayload, StreamMessage,
-    SyncProtocolExecutor, SyncTransport, TreeLeafData, MAX_LEVELWISE_DEPTH, MAX_NODES_PER_LEVEL,
-    MAX_PARENTS_PER_REQUEST, MAX_REQUESTS_PER_SESSION,
+    compare_level_nodes, create_runtime_env, EntityDeletion, InitPayload, LevelNode,
+    MessagePayload, StreamMessage, SyncProtocolExecutor, SyncTransport, TreeLeafData,
+    MAX_LEVELWISE_DEPTH, MAX_NODES_PER_LEVEL, MAX_PARENTS_PER_REQUEST, MAX_REQUESTS_PER_SESSION,
 };
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
@@ -76,7 +76,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::sync::helpers::{
     apply_leaf_with_crdt_merge, generate_nonce, get_local_root_hash_for_context,
-    is_leaf_currently_authorized,
+    is_leaf_currently_authorized, MAX_ENTITIES_PER_PUSH,
 };
 
 // =============================================================================
@@ -226,6 +226,13 @@ async fn run_initiator_impl<T: SyncTransport>(
     let mut current_parent_ids: Option<Vec<[u8; 32]>> = None;
     let clamped_max_depth = max_depth.min(MAX_LEVELWISE_DEPTH as u32);
 
+    // Deletions to propagate: entries the remote still holds that we have
+    // locally tombstoned (cleared). LevelWise is pull-only, so without this
+    // the deletion never reaches the peer and the clear can't converge via
+    // this protocol (same bug HashComparison had). Collected across levels and
+    // flushed once after the walk. Mirrors HashComparison's remote-only path.
+    let mut pending_deletions: Vec<EntityDeletion> = Vec::new();
+
     for level in 0..clamped_max_depth {
         // Build request for this level
         let request_msg = StreamMessage::Init {
@@ -362,6 +369,30 @@ async fn run_initiator_impl<T: SyncTransport>(
                 continue;
             };
 
+            // Tombstone propagation: if we hold a local tombstone for a node the
+            // remote still has (it surfaces here because it's absent from our
+            // live tree), propagate our deletion instead of pulling the remote's
+            // live copy. The peer applies it via the authenticated DeleteRef
+            // path. Mirrors HashComparison's remote-only handling.
+            let tombstone =
+                with_runtime_env(
+                    runtime_env.clone(),
+                    || match Index::<MainStorage>::get_index(calimero_storage::address::Id::new(
+                        node_id,
+                    )) {
+                        Ok(Some(idx)) => idx.deleted_at.map(|d| (d, idx.metadata.clone())),
+                        _ => None,
+                    },
+                );
+            if let Some((deleted_at, metadata)) = tombstone {
+                pending_deletions.push(EntityDeletion {
+                    id: node_id,
+                    deleted_at,
+                    metadata,
+                });
+                continue;
+            }
+
             if node.is_leaf() {
                 // Leaf: apply CRDT merge (Invariant I5)
                 if let Some(ref leaf_data) = node.leaf_data {
@@ -443,6 +474,37 @@ async fn run_initiator_impl<T: SyncTransport>(
         }
 
         current_parent_ids = Some(next_level_parents);
+    }
+
+    // Flush deletion propagation (clear convergence). Entries we cleared but the
+    // peer still holds are pushed as authenticated tombstones so the peer
+    // applies delete-wins, instead of us silently re-pulling them.
+    if !pending_deletions.is_empty() {
+        for chunk in pending_deletions.chunks(MAX_ENTITIES_PER_PUSH) {
+            let msg = StreamMessage::Init {
+                context_id,
+                party_id: identity,
+                payload: InitPayload::EntityDeletePush {
+                    context_id,
+                    deletions: chunk.to_vec(),
+                },
+                next_nonce: generate_nonce(),
+            };
+            transport.send(&msg).await?;
+
+            let ack = transport.recv().await?.ok_or_else(|| {
+                eyre::eyre!("stream closed while waiting for EntityDeletePushAck")
+            })?;
+            match ack {
+                StreamMessage::Message {
+                    payload: MessagePayload::EntityDeletePushAck { applied_count },
+                    ..
+                } => {
+                    debug!(%context_id, applied_count, "LevelWise: peer applied pushed tombstones");
+                }
+                _ => bail!("Unexpected response to EntityDeletePush"),
+            }
+        }
     }
 
     // Close the transport to signal completion
@@ -649,39 +711,88 @@ async fn run_responder_loop<T: SyncTransport>(
             break;
         };
 
-        let InitPayload::LevelWiseRequest {
-            level, parent_ids, ..
-        } = payload
-        else {
-            debug!(%context_id, "Received non-LevelWiseRequest, ending responder");
-            break;
-        };
+        match payload {
+            InitPayload::LevelWiseRequest {
+                level, parent_ids, ..
+            } => {
+                let (nodes, has_more_levels) =
+                    handle_levelwise_request(context_id, level, parent_ids, runtime_env)?;
 
-        let (nodes, has_more_levels) =
-            handle_levelwise_request(context_id, level, parent_ids, runtime_env)?;
+                debug!(
+                    %context_id,
+                    level,
+                    nodes_found = nodes.len(),
+                    has_more_levels,
+                    "Responding with level nodes"
+                );
 
-        debug!(
-            %context_id,
-            level,
-            nodes_found = nodes.len(),
-            has_more_levels,
-            "Responding with level nodes"
-        );
+                let response = StreamMessage::Message {
+                    sequence_id,
+                    payload: MessagePayload::LevelWiseResponse {
+                        level,
+                        nodes,
+                        has_more_levels,
+                    },
+                    next_nonce: generate_nonce(),
+                };
 
-        // Send response
-        let response = StreamMessage::Message {
-            sequence_id,
-            payload: MessagePayload::LevelWiseResponse {
-                level,
-                nodes,
-                has_more_levels,
-            },
-            next_nonce: generate_nonce(),
-        };
+                transport.send(&response).await?;
+                sequence_id += 1;
+                requests_handled += 1;
+            }
 
-        transport.send(&response).await?;
-        sequence_id += 1;
-        requests_handled += 1;
+            // Tombstone propagation (clear convergence) — same mechanism as
+            // HashComparison. The cleared initiator pushes authenticated
+            // deletions for entries this responder still holds; apply them via
+            // the DeleteRef path (delete-wins by HLC; sig/nonce verified for
+            // User/Shared, safe no-op on loss/auth-fail).
+            InitPayload::EntityDeletePush { deletions, .. } => {
+                let total = deletions.len();
+                trace!(%context_id, total, "Handling EntityDeletePush from initiator");
+
+                let mut applied: u32 = 0;
+                for deletion in &deletions {
+                    let action = calimero_storage::action::Action::DeleteRef {
+                        id: Id::new(deletion.id),
+                        deleted_at: deletion.deleted_at,
+                        metadata: deletion.metadata.clone(),
+                    };
+                    let result = with_runtime_env(runtime_env.clone(), || {
+                        Interface::<MainStorage>::apply_action(
+                            action,
+                            &calimero_storage::interface::ApplyContext::empty(),
+                        )
+                    });
+                    match result {
+                        Ok(_) => applied += 1,
+                        Err(e) => debug!(
+                            %context_id,
+                            id = %hex::encode(deletion.id),
+                            error = %e,
+                            "EntityDeletePush: skipped a tombstone (lost LWW or unauthorized)"
+                        ),
+                    }
+                }
+
+                let response = StreamMessage::Message {
+                    sequence_id,
+                    payload: MessagePayload::EntityDeletePushAck {
+                        applied_count: applied,
+                    },
+                    next_nonce: generate_nonce(),
+                };
+                transport.send(&response).await?;
+                sequence_id += 1;
+                requests_handled += 1;
+
+                info!(%context_id, applied, total, "Applied pushed tombstones (delete-wins)");
+            }
+
+            _ => {
+                debug!(%context_id, "Received non-LevelWiseRequest, ending responder");
+                break;
+            }
+        }
     }
 
     info!(%context_id, requests_handled, "LevelWise responder complete");

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -33,6 +33,7 @@
 
 use calimero_node::sync::{
     HashComparisonConfig, HashComparisonFirstRequest, HashComparisonProtocol, HashComparisonStats,
+    LevelWiseConfig, LevelWiseFirstRequest, LevelWiseProtocol,
 };
 use calimero_node_primitives::sync::{
     InitPayload, StreamMessage, SyncProtocolExecutor, SyncTransport,
@@ -179,6 +180,73 @@ pub async fn execute_hash_comparison_sync(
     let stats = init_result.wrap_err("initiator failed")?;
 
     Ok(stats.into())
+}
+
+/// Drive a real `LevelWiseProtocol` session between two sim nodes over an
+/// in-memory `SimStream`, mirroring `execute_hash_comparison_sync`. The
+/// responder extracts the first `LevelWiseRequest` exactly as the manager does.
+pub async fn execute_level_wise_sync(initiator: &mut SimNode, responder: &SimNode) -> Result<()> {
+    let (mut init_stream, mut resp_stream) = SimStream::pair();
+
+    let init_root = initiator.root_hash();
+    let resp_root = responder.root_hash();
+    if init_root == resp_root {
+        return Ok(());
+    }
+
+    let initiator_store = initiator.storage().store();
+    let responder_store = responder.storage().store();
+    let initiator_context = initiator.context_id();
+    let responder_context = responder.context_id();
+    let identity = PublicKey::from([0u8; 32]);
+
+    let config = LevelWiseConfig {
+        remote_root_hash: resp_root,
+        max_depth: 8,
+    };
+
+    let initiator_fut = async {
+        LevelWiseProtocol::run_initiator(
+            &mut init_stream,
+            initiator_store,
+            initiator_context,
+            identity,
+            config,
+        )
+        .await
+    };
+
+    let responder_fut = async {
+        let first_msg = resp_stream
+            .recv()
+            .await?
+            .ok_or_else(|| eyre::eyre!("Stream closed before first message"))?;
+
+        let first_request = match first_msg {
+            StreamMessage::Init {
+                payload:
+                    InitPayload::LevelWiseRequest {
+                        level, parent_ids, ..
+                    },
+                ..
+            } => LevelWiseFirstRequest { level, parent_ids },
+            _ => bail!("Expected LevelWiseRequest Init message"),
+        };
+
+        LevelWiseProtocol::run_responder(
+            &mut resp_stream,
+            responder_store,
+            responder_context,
+            identity,
+            first_request,
+        )
+        .await
+    };
+
+    let (init_result, resp_result) = tokio::join!(initiator_fut, responder_fut);
+    resp_result.wrap_err("responder failed")?;
+    let _ = init_result.wrap_err("initiator failed")?;
+    Ok(())
 }
 
 // =============================================================================
@@ -745,6 +813,44 @@ mod tests {
             alice.root_hash(),
             bob.root_hash(),
             "Merkle roots diverge: the deletion never converged (clear split-brain)"
+        );
+    }
+
+    /// LevelWise (the wide/shallow-tree protocol) must also propagate clears.
+    /// It's pull-only, so the cleared node propagates the deletion via
+    /// `EntityDeletePush` when it initiates. Without it, a clear reconciled via
+    /// LevelWise would split-brain exactly like HashComparison did.
+    #[tokio::test]
+    async fn test_levelwise_propagates_clear_tombstone() {
+        use crate::sync_sim::actions::StorageOp;
+
+        let ctx = shared_context();
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let mut bob = SimNode::new_in_context("bob", ctx);
+
+        let entry = EntityId::from_u64(1);
+        alice.insert_entity_with_metadata(entry, b"v1".to_vec(), EntityMetadata::default());
+        bob.insert_entity_with_metadata(entry, b"v1".to_vec(), EntityMetadata::default());
+        assert_eq!(alice.root_hash(), bob.root_hash());
+
+        alice.apply_storage_op(StorageOp::Remove { id: entry });
+        assert_eq!(alice.entity_count(), 0);
+        assert_eq!(bob.entity_count(), 1);
+
+        // Cleared node (alice) initiates LevelWise → propagates the deletion.
+        execute_level_wise_sync(&mut alice, &bob)
+            .await
+            .expect("alice->bob levelwise ok");
+
+        assert_eq!(
+            bob.entity_count(),
+            0,
+            "bob still holds the cleared entry: LevelWise did not propagate the tombstone"
+        );
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "roots must converge after LevelWise clear propagation"
         );
     }
 


### PR DESCRIPTION
Closes #2593.

Follow-up to #2584 (which fixed clear-tombstone propagation for HashComparison). LevelWise — selected for wide/shallow trees, e.g. a large KV map — had the same add-wins/tombstone-blind behavior: `local_missing` = pull, `remote_missing` = nothing-to-do, no `DeleteRef`. A clear reconciled via LevelWise could split-brain just like HC did.

LevelWise is pull-only, so the cleared initiator now detects `local_missing` entries it has locally tombstoned and propagates them via `EntityDeletePush` (reusing the wire message + authenticated `DeleteRef` apply already on master from #2584); the responder applies them (delete-wins by HLC). Adds a sim driver (`execute_level_wise_sync`) + `test_levelwise_propagates_clear_tombstone` driving the real `LevelWiseProtocol`.

This was originally bundled into #2584 but reverted along with two other add-ons after a `frozen-rga-convergence` e2e regression. Re-applied **standalone** here so the e2e can verify it in isolation — confirming whether LevelWise was a regression culprit (hypothesis: it was NOT; the regression was the symmetric/leaf-internal change, #2591). **Do not merge until frozen-rga is confirmed green on this branch.**

310 sync_sim green; build + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replication convergence for deletions on a production sync path; wire format reuses existing EntityDeletePush/DeleteRef from #2584, but incorrect tombstone detection could drop or mis-apply deletes.
> 
> **Overview**
> **LevelWise** was pull-only, so a local **clear** never reached a peer that still held the entry—the same split-brain that **HashComparison** had before #2584.
> 
> The **initiator** now detects nodes the remote still has where the local index is **tombstoned** during the level walk, queues **`EntityDeletion`** records, and after the walk sends **`EntityDeletePush`** (chunked) instead of re-pulling live data. The **responder** loop handles **`EntityDeletePush`** by applying authenticated **`DeleteRef`** actions and replying with **`EntityDeletePushAck`**.
> 
> Simulation adds **`execute_level_wise_sync`** and **`test_levelwise_propagates_clear_tombstone`** so the cleared node initiating LevelWise converges Bob’s store and Merkle roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db45b3313ffa4084106a17fe2fb1e813f132ee53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->