### PR TITLE
fix(sync): persist signed DeleteRef so HC/LevelWise converge User/Shared clears

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -2033,11 +2033,27 @@ pub(crate) fn persist_signed_signatures(
     // the user a chance to retry.
     let result: eyre::Result<()> = with_runtime_env(env, || {
         for action in actions {
-            let (id, storage_type) = match action {
+            let (id, storage_type, is_delete) = match action {
                 Action::Add { id, metadata, .. } | Action::Update { id, metadata, .. } => {
-                    (*id, metadata.storage_type.clone())
+                    (*id, metadata.storage_type.clone(), false)
                 }
-                Action::DeleteRef { .. } | Action::Compare { .. } => continue,
+                // DeleteRef carries a real signature too (signed by
+                // `sign_authorized_actions`). Persist it onto the now-tombstoned
+                // index entry — `update_signature_in_place` RMWs the index, which
+                // survives the delete — so HashComparison can later ship a
+                // *verifiable* signed DeleteRef for the cleared entity (otherwise
+                // a User/Shared clear can't converge via HC, only via the delta
+                // stream). The tombstone's owner/writer set is unchanged by the
+                // delete, so the in-place patch's identity guard still matches.
+                // Marked `is_delete` so a persist failure is BEST-EFFORT (see
+                // the `Err` arm): unlike Add/Update, a missed tombstone
+                // signature only degrades HC clear-convergence — the deletion
+                // still propagates via the delta stream — so it must NOT abort
+                // the transaction.
+                Action::DeleteRef { id, metadata, .. } => {
+                    (*id, metadata.storage_type.clone(), true)
+                }
+                Action::Compare { .. } => continue,
             };
             // Only Shared/User with a REAL signature need the
             // re-persist. Public/Frozen don't carry signatures.
@@ -2077,6 +2093,21 @@ pub(crate) fn persist_signed_signatures(
                         %id,
                         "skipped signature persist — entity missing from local index \
                          (raced a delete?)"
+                    );
+                }
+                Err(e) if is_delete => {
+                    // BEST-EFFORT for deletes: a failed tombstone
+                    // signature-persist only means this DeleteRef can't
+                    // ship verifiably via HashComparison — the deletion
+                    // still converges via the delta stream. Never abort
+                    // the transaction over it (the strict path below is
+                    // for Add/Update, where a placeholder would make a
+                    // *live* entity unverifiable on peers).
+                    warn!(
+                        %id,
+                        error = ?e,
+                        "skipped persisting signed DeleteRef signature; HC clear-convergence \
+                         degraded for this entity (delta-stream propagation unaffected)"
                     );
                 }
                 Err(e) => {

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1472,8 +1472,9 @@ mod update_signature_in_place_tests {
     use calimero_primitives::identity::PublicKey;
 
     use crate::address::Id;
-    use crate::entities::{SignatureData, StorageType};
+    use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
     use crate::error::StorageError;
+    use crate::index::Index;
     use crate::interface::Interface;
     use crate::store::MockedStorage;
 
@@ -1595,6 +1596,58 @@ mod update_signature_in_place_tests {
         assert!(
             matches!(result, Ok(false)),
             "valid signed input on missing entity should return Ok(false); got {result:?}"
+        );
+    }
+
+    #[test]
+    fn patches_signature_on_tombstoned_entity() {
+        // Caveat-#2 mechanism: a signed `DeleteRef`'s signature must land on the
+        // (tombstoned) index entry so HashComparison can later ship a *verifiable*
+        // deletion for the cleared entity. The index survives the delete (only
+        // `Key::Entry` is removed), so `update_signature_in_place` patches it in
+        // place — which is what `persist_signed_signatures` now relies on for
+        // DeleteRef actions.
+        type S = MockedStorage<3013>;
+        let owner = PublicKey::from([0xCD; 32]);
+        let id = Id::new([0x25; 32]);
+
+        // Seed a User-owned entity in the index, then tombstone it.
+        let mut md = Metadata::new(1, 1);
+        md.storage_type = StorageType::User {
+            owner,
+            signature_data: None,
+        };
+        <Index<S>>::add_root(ChildInfo::new(id, [0u8; 32], md)).expect("seed entity");
+        <Index<S>>::mark_deleted(id, 100).expect("tombstone");
+        assert!(
+            <Index<S>>::is_deleted(id).unwrap(),
+            "entity must be tombstoned before the patch"
+        );
+
+        // Patch the signed signature onto the tombstone.
+        let real_sig = [0xEF; 64];
+        let result = <Interface<S>>::update_signature_in_place(id, user_signed(owner, real_sig));
+        assert!(
+            matches!(result, Ok(true)),
+            "patch on a tombstoned entity should succeed; got {result:?}"
+        );
+
+        // The tombstone now carries the real signature for HashComparison to ship,
+        // and remains tombstoned.
+        let idx = <Index<S>>::get_index(id).unwrap().unwrap();
+        match idx.metadata.storage_type {
+            StorageType::User {
+                signature_data: Some(sd),
+                ..
+            } => assert_eq!(
+                sd.signature, real_sig,
+                "tombstone must retain the signed signature"
+            ),
+            other => panic!("expected User with signature, got {other:?}"),
+        }
+        assert!(
+            <Index<S>>::is_deleted(id).unwrap(),
+            "entity stays tombstoned after the signature patch"
         );
     }
 }

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1462,7 +1462,7 @@ mod verify_snapshot_entity_signature_tests {
 }
 
 /// Tests for `Interface::update_signature_in_place` API-boundary
-/// validation. Uses `MockedStorage<3008..3012>` — keep disjoint from
+/// validation. Uses `MockedStorage<3008..=3013>` — keep disjoint from
 /// `verify_ancestor_integrity_tests` (3001-3004) and
 /// `verify_snapshot_entity_signature_tests` (3005-3007).
 #[cfg(test)]

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1611,7 +1611,13 @@ mod update_signature_in_place_tests {
         let owner = PublicKey::from([0xCD; 32]);
         let id = Id::new([0x25; 32]);
 
-        // Seed a User-owned entity in the index, then tombstone it.
+        // Seed a User-owned entity in the index, then tombstone it. It starts
+        // with `signature_data: None` on purpose — that's the state a freshly
+        // `save_raw`-persisted entity is in before the signer runs. The patch
+        // below supplies `Some(real_sig)`; `update_signature_in_place`'s
+        // identity guard keys on the owner/writer set (unchanged here), NOT on
+        // whether `signature_data` was previously `Some`/`None`, so a
+        // None -> Some patch is the intended flow and is accepted.
         let mut md = Metadata::new(1, 1);
         md.storage_type = StorageType::User {
             owner,


### PR DESCRIPTION
Closes #2592.

Follow-up to #2584 / #2594 (clear-tombstone propagation for HashComparison + LevelWise). Those converge **Public** clears; this extends it to **User/Shared** (signed) entities.

`persist_signed_signatures` skipped `DeleteRef`, so the real signature `sign_authorized_actions` produces for a delete was never written to the tombstone — only to the broadcast delta. HC/LevelWise read the tombstone metadata to build their `EntityDeletion`, so for User/Shared they shipped metadata whose signature didn't match the delete payload; the peer's verify rejected it (safe no-op) and the clear couldn't converge via the HC/LevelWise fallback (only via the delta stream).

Fix: handle `DeleteRef` in `persist_signed_signatures` — `update_signature_in_place` patches the surviving (tombstoned) index entry, so it retains the verifiable signed signature. **Best-effort**: a failed tombstone-persist only degrades HC/LevelWise clear-convergence (the deletion still propagates via the delta stream), so it must NOT abort the transaction — unlike Add/Update. (The version bundled into #2584 aborted via `return Err`; that was a latent bug, fixed here.)

Reverted from #2584 along with two other add-ons after a frozen-rga regression — but reverting this one alone did NOT fix frozen-rga, and #2594 (LevelWise) proved green standalone, so the regression was the *symmetric/leaf-internal* change (#2591), not this. Re-applied standalone here for e2e verification.

Storage test `patches_signature_on_tombstoned_entity` pins the mechanism. 54 context + storage suites green; build + fmt clean. **Do not merge until frozen-rga is confirmed green on this branch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync signature persistence and transaction abort semantics for signed deletes; incorrect behavior could affect HashComparison clear convergence but delta-stream deletion remains the fallback.
> 
> **Overview**
> Extends **`persist_signed_signatures`** so signed **`DeleteRef`** actions for **User/Shared** entities write the real signature onto the **surviving tombstone index** via `update_signature_in_place`, enabling **HashComparison / LevelWise** to propagate clears with verifiable deletion metadata (not only the delta stream).
> 
> **Delete** persist failures are **best-effort**: they log a warning and do **not** abort the transaction, unlike Add/Update (where a failed persist would leave live entities with placeholder signatures). This fixes a latent bug where aborting on tombstone persist failure was too strict.
> 
> Adds storage test **`patches_signature_on_tombstoned_entity`** and widens the mocked storage scope comment to `3008..=3013`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f703eb33f9f9f382035c664deda7aff90a5f9bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->