### PR TITLE
fix(sync): infer Frozen storage_type for bare HC/LevelWise leaf pushes

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -1481,6 +1481,85 @@ mod tests {
         });
     }
 
+    /// A *new* Frozen entity pushed as a bare HC leaf must land as
+    /// `StorageType::Frozen`, not `Public`.
+    ///
+    /// Frozen entities carry no wire authorization (`wire_authorization_for`
+    /// returns None for Frozen), so before the fix a freshly-received frozen
+    /// leaf defaulted to `Public` (its `crdt_type` was set to `FrozenStorage`
+    /// but `storage_type` stayed `Public`). A later real `Frozen` delta then hit
+    /// `apply_action`'s guard with `existing=Public new=Frozen` →
+    /// `ActionNotAllowed("Cannot change StorageType")`, panicking the guest's
+    /// frozen-value merge (the HC/LevelWise frozen-push split-brain, #2591).
+    /// `apply_leaf_with_crdt_merge` now infers `Frozen` from the wire-carried
+    /// `crdt_type`.
+    #[test]
+    fn apply_leaf_new_frozen_entry_lands_as_frozen_not_public() {
+        use std::sync::Arc;
+
+        use calimero_node_primitives::sync::hash_comparison::{LeafMetadata, TreeLeafData};
+        use calimero_primitives::crdt::CrdtType;
+        use calimero_storage::action::Action;
+        use calimero_storage::entities::{Metadata, StorageType};
+        use calimero_storage::interface::ApplyContext;
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::Store;
+        use sha2::{Digest, Sha256};
+
+        use crate::sync::helpers::apply_leaf_with_crdt_merge;
+
+        let context_id = ContextId::from([0xCC; 32]);
+        let identity = PublicKey::from([0u8; 32]);
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let runtime_env = create_runtime_env(&store, context_id, identity);
+
+        let root_id = Id::new(*context_id.as_ref());
+        let frozen_id = Id::new([0x77u8; 32]);
+
+        // Frozen content-addressed blob: [key_hash(32)][value][element_id(32)].
+        let value = b"freshly-pushed-frozen".to_vec();
+        let key_hash: [u8; 32] = Sha256::digest(&value).into();
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&key_hash);
+        blob.extend_from_slice(&value);
+        blob.extend_from_slice(frozen_id.as_bytes());
+
+        with_runtime_env(runtime_env.clone(), || {
+            // Context root only — the frozen entity does NOT exist locally yet.
+            Interface::<MainStorage>::apply_action(
+                Action::Update {
+                    id: root_id,
+                    data: vec![],
+                    ancestors: vec![],
+                    metadata: Metadata::default(),
+                },
+                &ApplyContext::empty(),
+            )
+            .expect("create root");
+
+            // A bare frozen leaf as HC ships it: crdt_type=FrozenStorage, the
+            // root as parent, and NO wire authorization (Frozen carries none).
+            let leaf = TreeLeafData::new(
+                *frozen_id.as_bytes(),
+                blob.clone(),
+                LeafMetadata::new(CrdtType::FrozenStorage, 100, *root_id.as_bytes())
+                    .with_parent(*root_id.as_bytes()),
+            );
+            apply_leaf_with_crdt_merge(context_id, &leaf).expect("apply new frozen leaf");
+
+            let md = Index::<MainStorage>::get_index(frozen_id)
+                .unwrap()
+                .expect("frozen entity should have been created")
+                .metadata;
+            assert!(
+                matches!(md.storage_type, StorageType::Frozen),
+                "new frozen leaf must land as Frozen, not {:?} — else a later Frozen \
+                 delta is rejected with Cannot change StorageType",
+                md.storage_type
+            );
+        });
+    }
+
     /// Characterization guard that isolates the `clear()` HashComparison
     /// split-brain to delete *propagation*, NOT resurrection.
     ///

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -314,6 +314,20 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
         metadata.storage_type = wire_auth.clone();
     } else if let Some(ref existing) = existing_index {
         metadata.storage_type = existing.metadata.storage_type.clone();
+    } else if matches!(
+        leaf.metadata.crdt_type,
+        calimero_primitives::crdt::CrdtType::FrozenStorage
+    ) {
+        // New entity, no wire authorization, but the wire-carried `crdt_type`
+        // says this is Frozen storage. Frozen entities carry no authorization
+        // (content-addressed + immutable, so `wire_authorization_for` returns
+        // None), so without this they'd fall through to the `Public` default
+        // below. A peer that then receives the real `Frozen` entity via a delta
+        // would reject the `Public -> Frozen` storage-type change in
+        // `apply_action` ("Cannot change StorageType"), panicking the guest's
+        // frozen-value merge — the HC/LevelWise frozen-push split-brain. The
+        // `crdt_type` IS on the wire, so infer `Frozen` from it.
+        metadata.storage_type = StorageType::Frozen;
     }
 
     let action = if existing_index.is_some() {


### PR DESCRIPTION
## Problem

A Frozen entity pushed via HashComparison / LevelWise as a bare leaf lands on a fresh receiver as **`Public`**, not `Frozen`. When the real `Frozen` entity later arrives via a delta, `apply_action`'s guard rejects the `Public → Frozen` storage-type change (`ActionNotAllowed("Cannot change StorageType")`) — and because the failing check runs inside the **WASM guest's** frozen-value merge (`__calimero_sync_next`), it surfaces as a guest panic and a multi-node split-brain.

Root cause: Frozen entities carry no wire authorization (`wire_authorization_for` returns `None` for `Frozen` — only `User`/`Shared` carry it). So in `apply_leaf_with_crdt_merge`, a freshly-received frozen leaf got `crdt_type = FrozenStorage` set correctly but `storage_type` left at the `Public` default (the "new entity, no wire-auth" case).

This was pinned by instrumenting the storage-type guard to embed the entity id + types into the error message (the guest panic carried it):
```
id=9bc70da3…  existing=Public  new=Frozen   ← a __frozen_storage_frozen_items child
```

## Fix

In `apply_leaf_with_crdt_merge`, when there's no wire-auth and no existing entity, **infer `storage_type = Frozen` from the wire-carried `crdt_type == FrozenStorage`** (the crdt_type *is* on the wire, so Frozen is recoverable). Public/Shared/User paths are unchanged.

## Why it matters

Latent for any Frozen entity pushed via HC/LevelWise as a bare leaf. It was surfaced deterministically by the reverted symmetric-convergence change (#2591), whose leaf-internal push newly sent frozen items down this path and broke `frozen-rga-convergence` 4×. This fix also **unblocks #2591** (the symmetric push becomes safe on top of it).

## Tests

- New unit test `apply_leaf_new_frozen_entry_lands_as_frozen_not_public` — a bare frozen leaf with no auth + no existing entity must land as `Frozen`.
- 310 sync_sim green; build + fmt clean.
- A verification run stacking this fix + the reverted #2591 change is in flight to confirm it resolves the original frozen-rga regression; result will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync apply metadata for new entities; wrong inference could still mis-classify storage, but the change is narrow, matches wire crdt_type, and is covered by a targeted unit test.
> 
> **Overview**
> HashComparison and LevelWise can apply **new** frozen entities from bare leaves that carry `CrdtType::FrozenStorage` but no wire authorization (frozen entries never get `wire_authorization_for`). **`apply_leaf_with_crdt_merge`** now sets **`StorageType::Frozen`** in that case instead of leaving **`Public`**, so a later delta cannot hit **`Cannot change StorageType`** and panic inside WASM frozen merge (#2591 split-brain).
> 
> A regression test **`apply_leaf_new_frozen_entry_lands_as_frozen_not_public`** asserts a first-time frozen HC leaf is stored as frozen, not public.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430a53c6352650b18eb075aed005468c63a8c13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->