### PR TITLE
fix(node): atomic WriteBatch for cascade-delta persistence

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -13,7 +13,9 @@ use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_primitives::metadata::MetadataRecord;
-use calimero_store::{key, Store};
+use calimero_store::slice::Slice;
+use calimero_store::tx::Transaction;
+use calimero_store::{key, types, Store};
 use calimero_utils_actix::LazyRecipient;
 use eyre::{ContextCompat, WrapErr};
 use futures_util::Stream;
@@ -276,6 +278,67 @@ impl ContextRegistry {
             %context_id,
             dag_heads_count = dag_heads.len(),
             "Updated dag_heads in database"
+        );
+
+        Ok(())
+    }
+
+    /// Atomically persist a batch of applied DAG-delta records together with
+    /// the context's updated `dag_heads`, in a single backend write batch.
+    ///
+    /// Either every delta record *and* the new `dag_heads` land, or none do.
+    /// A per-record `put` loop followed by a separate [`update_dag_heads`]
+    /// could be interrupted partway — a serialization slip, an I/O error, a
+    /// crash — leaving some cascaded deltas persisted as `applied: true`
+    /// while `dag_heads` stayed stale. On restart, the delta-load path would
+    /// miss the unpersisted deltas and the in-memory DAG and the DB could
+    /// diverge permanently for that context. Folding the whole set into one
+    /// [`Store::apply`] (a RocksDB `WriteBatch`) closes that window: a
+    /// failure leaves the pre-cascade state untouched, so the next sync
+    /// replays cleanly.
+    ///
+    /// `deltas` pairs each delta's storage key with the record to write.
+    ///
+    /// [`update_dag_heads`]: Self::update_dag_heads
+    pub fn persist_deltas_and_dag_heads(
+        &self,
+        context_id: &ContextId,
+        deltas: &[(key::ContextDagDelta, types::ContextDagDelta)],
+        dag_heads: Vec<[u8; 32]>,
+    ) -> eyre::Result<()> {
+        let meta_key = key::ContextMeta::new(*context_id);
+
+        let Some(mut meta) = self.datastore.handle().get(&meta_key)? else {
+            eyre::bail!("Context not found: {}", context_id);
+        };
+        meta.dag_heads = dag_heads;
+
+        // Encode every value up front. A serialization failure here aborts
+        // the batch before anything is written, preserving all-or-nothing.
+        let meta_bytes: Slice<'_> = borsh::to_vec(&meta)?.into();
+        let mut delta_values: Vec<Slice<'_>> = Vec::with_capacity(deltas.len());
+        for (_, record) in deltas {
+            delta_values.push(borsh::to_vec(record)?.into());
+        }
+
+        // Build the transaction over borrowed keys + owned value bytes, then
+        // commit it as one atomic write. `ContextDagDelta` lives in the
+        // `Delta` column and `ContextMeta` in `Meta`; a RocksDB `WriteBatch`
+        // is atomic across column families, so the heads update can't land
+        // without the deltas (or vice versa).
+        let mut tx = Transaction::default();
+        for ((delta_key, _), value) in deltas.iter().zip(delta_values) {
+            tx.put(delta_key, value);
+        }
+        tx.put(&meta_key, meta_bytes);
+
+        self.datastore.apply(&tx)?;
+
+        tracing::debug!(
+            %context_id,
+            delta_count = deltas.len(),
+            dag_heads_count = meta.dag_heads.len(),
+            "Atomically persisted cascaded deltas and dag_heads"
         );
 
         Ok(())
@@ -1011,6 +1074,20 @@ impl ContextClient {
         self.registry.update_dag_heads(context_id, dag_heads)
     }
 
+    /// Atomically persist a batch of applied DAG-delta records together with
+    /// the context's updated `dag_heads`, in a single backend write batch:
+    /// either all of it lands or none does, so a mid-write failure can't
+    /// leave persisted deltas pointing past stale heads.
+    pub fn persist_deltas_and_dag_heads(
+        &self,
+        context_id: &ContextId,
+        deltas: &[(key::ContextDagDelta, types::ContextDagDelta)],
+        dag_heads: Vec<[u8; 32]>,
+    ) -> eyre::Result<()> {
+        self.registry
+            .persist_deltas_and_dag_heads(context_id, deltas, dag_heads)
+    }
+
     /// Updates the ApplicationId for a context.
     pub fn update_context_application_id(
         &self,
@@ -1652,5 +1729,178 @@ impl ContextClient {
             .expect("Mailbox not to be dropped");
 
         receiver.await.expect("Mailbox not to be dropped")
+    }
+}
+
+#[cfg(test)]
+mod atomic_persist_tests {
+    use std::sync::Arc;
+
+    use calimero_primitives::application::ApplicationId;
+    use calimero_primitives::context::ContextId;
+    use calimero_storage::logical_clock::HybridTimestamp;
+    use calimero_store::config::StoreConfig;
+    use calimero_store::db::{Column, Database, InMemoryDB};
+    use calimero_store::iter::Iter;
+    use calimero_store::slice::Slice;
+    use calimero_store::tx::Transaction;
+    use calimero_store::{key, types, Store};
+    use eyre::Result as EyreResult;
+
+    use super::ContextRegistry;
+
+    const INITIAL_HEAD: [u8; 32] = [0x00; 32];
+    const DELTA_A: [u8; 32] = [0x11; 32];
+    const DELTA_B: [u8; 32] = [0x22; 32];
+
+    fn ctx() -> ContextId {
+        ContextId::from([0x07; 32])
+    }
+
+    fn seed_meta(store: &Store, context_id: &ContextId, heads: Vec<[u8; 32]>) {
+        let key = key::ContextMeta::new(*context_id);
+        let meta = types::ContextMeta::new(
+            key::ApplicationMeta::new(ApplicationId::from([0xAA; 32])),
+            [0u8; 32],
+            heads,
+            None,
+        );
+        store
+            .clone()
+            .handle()
+            .put(&key, &meta)
+            .expect("seed context meta");
+    }
+
+    fn delta_record(
+        context_id: &ContextId,
+        id: [u8; 32],
+    ) -> (key::ContextDagDelta, types::ContextDagDelta) {
+        let key = key::ContextDagDelta::new(*context_id, id);
+        let record = types::ContextDagDelta {
+            delta_id: id,
+            parents: Vec::new(),
+            actions: vec![1, 2, 3],
+            hlc: HybridTimestamp::zero(),
+            applied: true,
+            expected_root_hash: [0u8; 32],
+            events: None,
+            author_id: None,
+            governance_position_blob: None,
+            delta_signature: None,
+        };
+        (key, record)
+    }
+
+    fn read_heads(store: &Store, context_id: &ContextId) -> Vec<[u8; 32]> {
+        store
+            .handle()
+            .get(&key::ContextMeta::new(*context_id))
+            .expect("read meta")
+            .expect("meta present")
+            .dag_heads
+    }
+
+    fn has_delta(store: &Store, context_id: &ContextId, id: [u8; 32]) -> bool {
+        store
+            .handle()
+            .get(&key::ContextDagDelta::new(*context_id, id))
+            .expect("read delta")
+            .is_some()
+    }
+
+    #[test]
+    fn persists_all_deltas_and_heads_together() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let cid = ctx();
+        seed_meta(&store, &cid, vec![INITIAL_HEAD]);
+
+        let registry = ContextRegistry::new(store.clone());
+        let deltas = [delta_record(&cid, DELTA_A), delta_record(&cid, DELTA_B)];
+
+        registry
+            .persist_deltas_and_dag_heads(&cid, &deltas, vec![DELTA_B])
+            .expect("atomic persist succeeds");
+
+        assert!(has_delta(&store, &cid, DELTA_A), "delta A persisted");
+        assert!(has_delta(&store, &cid, DELTA_B), "delta B persisted");
+        assert_eq!(read_heads(&store, &cid), vec![DELTA_B], "heads advanced");
+    }
+
+    /// A [`Database`] whose `apply` always fails, simulating a backend write
+    /// error (disk full, RocksDB I/O fault) at commit time. Every other
+    /// operation delegates to a real in-memory backend, so seeding and
+    /// assertions observe genuine state.
+    #[derive(Debug)]
+    struct FailOnApply<D> {
+        inner: D,
+    }
+
+    impl<'a, D: Database<'a>> Database<'a> for FailOnApply<D> {
+        fn open(_config: &StoreConfig) -> EyreResult<Self>
+        where
+            Self: Sized,
+        {
+            unimplemented!("test-only backend is constructed directly")
+        }
+
+        fn has(&self, col: Column, key: Slice<'_>) -> EyreResult<bool> {
+            self.inner.has(col, key)
+        }
+
+        fn get(&self, col: Column, key: Slice<'_>) -> EyreResult<Option<Slice<'_>>> {
+            self.inner.get(col, key)
+        }
+
+        fn put(&self, col: Column, key: Slice<'a>, value: Slice<'a>) -> EyreResult<()> {
+            self.inner.put(col, key, value)
+        }
+
+        fn delete(&self, col: Column, key: Slice<'_>) -> EyreResult<()> {
+            self.inner.delete(col, key)
+        }
+
+        fn iter(&self, col: Column) -> EyreResult<Iter<'_>> {
+            self.inner.iter(col)
+        }
+
+        fn apply(&self, _tx: &Transaction<'a>) -> EyreResult<()> {
+            eyre::bail!("injected apply failure")
+        }
+    }
+
+    #[test]
+    fn failed_commit_leaves_pre_cascade_state() {
+        let store = Store::new(Arc::new(FailOnApply {
+            inner: InMemoryDB::owned(),
+        }));
+        let cid = ctx();
+        seed_meta(&store, &cid, vec![INITIAL_HEAD]);
+
+        let registry = ContextRegistry::new(store.clone());
+        let deltas = [delta_record(&cid, DELTA_A), delta_record(&cid, DELTA_B)];
+
+        let err = registry
+            .persist_deltas_and_dag_heads(&cid, &deltas, vec![DELTA_B])
+            .expect_err("commit must surface the backend failure");
+        assert!(
+            err.to_string().contains("injected apply failure"),
+            "unexpected error: {err}"
+        );
+
+        // All-or-nothing: neither delta nor the advanced heads landed.
+        assert!(
+            !has_delta(&store, &cid, DELTA_A),
+            "delta A must not persist"
+        );
+        assert!(
+            !has_delta(&store, &cid, DELTA_B),
+            "delta B must not persist"
+        );
+        assert_eq!(
+            read_heads(&store, &cid),
+            vec![INITIAL_HEAD],
+            "heads must remain at pre-cascade value"
+        );
     }
 }

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -297,7 +297,11 @@ impl ContextRegistry {
     /// failure leaves the pre-cascade state untouched, so the next sync
     /// replays cleanly.
     ///
-    /// `deltas` pairs each delta's storage key with the record to write.
+    /// `deltas` pairs each delta's storage key with the record to write. An
+    /// empty `deltas` slice is valid: the batch then carries only the
+    /// `dag_heads` update (still atomic), which is how a cascade with no
+    /// newly-applied deltas advances heads — the behaviour the standalone
+    /// [`update_dag_heads`] used to provide.
     ///
     /// [`update_dag_heads`]: Self::update_dag_heads
     pub fn persist_deltas_and_dag_heads(
@@ -312,24 +316,21 @@ impl ContextRegistry {
             eyre::bail!("Context not found: {}", context_id);
         };
         meta.dag_heads = dag_heads;
+        let dag_heads_count = meta.dag_heads.len();
 
-        // Encode every value up front. A serialization failure here aborts
-        // the batch before anything is written, preserving all-or-nothing.
-        let meta_bytes: Slice<'_> = borsh::to_vec(&meta)?.into();
-        let mut delta_values: Vec<Slice<'_>> = Vec::with_capacity(deltas.len());
-        for (_, record) in deltas {
-            delta_values.push(borsh::to_vec(record)?.into());
-        }
-
-        // Build the transaction over borrowed keys + owned value bytes, then
-        // commit it as one atomic write. `ContextDagDelta` lives in the
-        // `Delta` column and `ContextMeta` in `Meta`; a RocksDB `WriteBatch`
-        // is atomic across column families, so the heads update can't land
-        // without the deltas (or vice versa).
+        // Stage every put into one transaction, then commit it as a single
+        // atomic write. Values are encoded into owned byte slices as we go;
+        // a serialization failure aborts here, before `apply`, so nothing is
+        // written. `ContextDagDelta` lives in the `Delta` column and
+        // `ContextMeta` in `Meta`; a RocksDB `WriteBatch` is atomic across
+        // column families, so the heads update can't land without the deltas
+        // (or vice versa).
         let mut tx = Transaction::default();
-        for ((delta_key, _), value) in deltas.iter().zip(delta_values) {
+        for (delta_key, record) in deltas {
+            let value: Slice<'_> = borsh::to_vec(record)?.into();
             tx.put(delta_key, value);
         }
+        let meta_bytes: Slice<'_> = borsh::to_vec(&meta)?.into();
         tx.put(&meta_key, meta_bytes);
 
         self.datastore.apply(&tx)?;
@@ -337,7 +338,7 @@ impl ContextRegistry {
         tracing::debug!(
             %context_id,
             delta_count = deltas.len(),
-            dag_heads_count = meta.dag_heads.len(),
+            dag_heads_count,
             "Atomically persisted cascaded deltas and dag_heads"
         );
 
@@ -1734,6 +1735,7 @@ impl ContextClient {
 
 #[cfg(test)]
 mod atomic_persist_tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
     use calimero_primitives::application::ApplicationId;
@@ -1765,11 +1767,8 @@ mod atomic_persist_tests {
             heads,
             None,
         );
-        store
-            .clone()
-            .handle()
-            .put(&key, &meta)
-            .expect("seed context meta");
+        let mut handle = store.handle();
+        handle.put(&key, &meta).expect("seed context meta");
     }
 
     fn delta_record(
@@ -1831,9 +1830,17 @@ mod atomic_persist_tests {
     /// error (disk full, RocksDB I/O fault) at commit time. Every other
     /// operation delegates to a real in-memory backend, so seeding and
     /// assertions observe genuine state.
+    ///
+    /// Once `armed` is set, `put` also fails. The atomic persist path must
+    /// route all writes through `apply` (one transaction) — never a direct
+    /// `put` — so arming the backend before the call under test turns any
+    /// future regression that sneaks a stray `put` in ahead of the commit
+    /// into a hard test failure rather than a silently-passing one. Seeding
+    /// runs while disarmed.
     #[derive(Debug)]
     struct FailOnApply<D> {
         inner: D,
+        armed: Arc<AtomicBool>,
     }
 
     impl<'a, D: Database<'a>> Database<'a> for FailOnApply<D> {
@@ -1853,6 +1860,10 @@ mod atomic_persist_tests {
         }
 
         fn put(&self, col: Column, key: Slice<'a>, value: Slice<'a>) -> EyreResult<()> {
+            assert!(
+                !self.armed.load(Ordering::SeqCst),
+                "atomic persist must not write via direct `put`; all writes go through `apply`"
+            );
             self.inner.put(col, key, value)
         }
 
@@ -1871,11 +1882,16 @@ mod atomic_persist_tests {
 
     #[test]
     fn failed_commit_leaves_pre_cascade_state() {
+        let armed = Arc::new(AtomicBool::new(false));
         let store = Store::new(Arc::new(FailOnApply {
             inner: InMemoryDB::owned(),
+            armed: Arc::clone(&armed),
         }));
         let cid = ctx();
         seed_meta(&store, &cid, vec![INITIAL_HEAD]);
+
+        // From here, any direct `put` is a bug — only `apply` may write.
+        armed.store(true, Ordering::SeqCst);
 
         let registry = ContextRegistry::new(store.clone());
         let deltas = [delta_record(&cid, DELTA_A), delta_record(&cid, DELTA_B)];
@@ -1887,6 +1903,8 @@ mod atomic_persist_tests {
             err.to_string().contains("injected apply failure"),
             "unexpected error: {err}"
         );
+
+        // Reads below are fine while armed (only `put` is gated).
 
         // All-or-nothing: neither delta nor the advanced heads landed.
         assert!(

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1922,6 +1922,18 @@ impl DeltaStore {
     ) -> Vec<([u8; 32], Vec<u8>)> {
         let mut forwarded_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
 
+        // Build the records to persist first, then commit them and the
+        // updated `dag_heads` as one atomic batch below. Writing each delta
+        // with its own `put` and then updating `dag_heads` separately left a
+        // window where a crash or I/O error midway persisted some cascaded
+        // deltas as `applied: true` while `dag_heads` stayed stale — on
+        // restart the delta-load path would miss the unpersisted deltas and
+        // the in-memory DAG and the DB could diverge permanently.
+        let mut records: Vec<(
+            calimero_store::key::ContextDagDelta,
+            calimero_store::types::ContextDagDelta,
+        )> = Vec::with_capacity(applied_bodies.len());
+
         if !applied_bodies.is_empty() {
             info!(
                 context_id = %self.applier.context_id,
@@ -1929,7 +1941,7 @@ impl DeltaStore {
                 "Persisting newly-applied deltas (cascades and/or Add-path parents)"
             );
 
-            let mut handle = self.applier.context_client.datastore_handle();
+            let handle = self.applier.context_client.datastore_handle();
             for (cid, applied_delta) in applied_bodies {
                 let db_key =
                     calimero_store::key::ContextDagDelta::new(self.applier.context_id, *cid);
@@ -1984,12 +1996,11 @@ impl DeltaStore {
                 }
 
                 // Preserve `events` in the DB until handler execution is
-                // confirmed by the caller (#2185). If we crash between
-                // this write and `execute_cascaded_events` succeeding,
-                // the next `load_persisted_deltas` / cascade scan will
-                // find `applied: true, events: Some(..)` and replay the
-                // handlers. `mark_events_executed` clears the column
-                // once handlers have run.
+                // confirmed by the caller. If we crash between this write
+                // and `execute_cascaded_events` succeeding, the next
+                // `load_persisted_deltas` / cascade scan will find
+                // `applied: true, events: Some(..)` and replay the handlers.
+                // `mark_events_executed` clears the column once they run.
                 let record = calimero_store::types::ContextDagDelta {
                     delta_id: *cid,
                     parents: applied_delta.parents.clone(),
@@ -1997,53 +2008,40 @@ impl DeltaStore {
                     hlc: applied_delta.hlc,
                     applied: true,
                     expected_root_hash: applied_delta.expected_root_hash,
-                    events: stored_events.clone(),
+                    events: stored_events,
                     author_id: None,
                     governance_position_blob: None,
                     delta_signature: None,
                 };
-                if let Err(e) = handle.put(&db_key, &record) {
-                    warn!(
-                        ?e,
-                        context_id = %self.applier.context_id,
-                        delta_id = ?cid,
-                        "Failed to persist applied delta to database"
-                    );
-                } else if stored_events.is_some() {
-                    info!(
-                        context_id = %self.applier.context_id,
-                        delta_id = ?cid,
-                        "Persisted applied delta - has events for handler execution"
-                    );
-                }
+                records.push((db_key, record));
             }
         }
 
-        // Update the database's `dag_heads` so sync handshakes and
-        // `broadcast_heartbeat` see the post-cascade state. Failing to
-        // do this was the original bug behind #2178.
-        //
-        // The failure is logged rather than propagated to match
-        // `get_missing_parents`'s warn-and-continue behaviour. Stale
-        // `dag_heads` is recoverable (the next sync session overwrites
-        // them). Since #2185, events are preserved in the DB record
-        // until the caller confirms handler execution, so a failure
-        // here no longer risks losing the event payloads — they still
-        // live in both the in-memory Vec we return *and* in the DB.
-        match self
-            .applier
-            .context_client
-            .update_dag_heads(&self.applier.context_id, heads.clone())
-        {
+        // Commit the delta records and the post-cascade `dag_heads` as one
+        // atomic write so sync handshakes and `broadcast_heartbeat` never
+        // observe heads that point past deltas the DB doesn't hold (and vice
+        // versa). The failure is logged rather than propagated to match
+        // `get_missing_parents`'s warn-and-continue behaviour: on failure
+        // nothing is written, so the DB stays at its pre-cascade state and
+        // the next sync replays cleanly. Events are preserved in the DB
+        // record (and in the Vec we return) until the caller confirms
+        // handler execution, so a failure here can't lose event payloads.
+        match self.applier.context_client.persist_deltas_and_dag_heads(
+            &self.applier.context_id,
+            &records,
+            heads.clone(),
+        ) {
             Ok(()) => debug!(
                 context_id = %self.applier.context_id,
                 new_heads = ?heads,
-                "Updated database dag_heads"
+                persisted_deltas = records.len(),
+                "Atomically persisted cascaded deltas and dag_heads"
             ),
             Err(e) => warn!(
                 ?e,
                 context_id = %self.applier.context_id,
-                "Failed to update dag_heads in database; next sync will correct it"
+                "Failed to persist cascaded deltas and dag_heads atomically; \
+                 DB left at pre-cascade state, next sync will correct it"
             ),
         }
 

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -123,4 +123,14 @@ impl Store {
     ) -> EyreResult<Option<(Vec<u8>, Vec<u8>)>> {
         self.db.last_in_range(col, Slice::from(lo), Slice::from(hi))
     }
+
+    /// Atomically commit a multi-key [`Transaction`](tx::Transaction) as a
+    /// single backend write. On RocksDB this is one `WriteBatch`, so either
+    /// every put/delete in `tx` lands or none do — there is no state where
+    /// part of the batch is persisted. This is the primitive callers reach
+    /// for when several keys (possibly across columns) must move together,
+    /// e.g. cascade-delta records plus their context's `dag_heads`.
+    pub fn apply(&self, tx: &tx::Transaction<'_>) -> EyreResult<()> {
+        self.db.apply(tx)
+    }
 }


### PR DESCRIPTION
## What

Makes cascade-delta persistence and the `dag_heads` update **all-or-nothing**.

Both cascade paths persisted cascaded deltas one `handle.put` at a time and then updated `dag_heads` in a separate write. If the loop failed partway (borsh error, `handle.put` I/O error, crash), the DB could end up with some cascaded deltas stored as `applied: true` and others not — and `dag_heads` stale relative to them. On restart, `load_persisted_deltas` would miss the unpersisted deltas and the in-memory DAG and the DB could **diverge permanently** for that context. Unlikely on a healthy node, but unrecoverable when it happens.

## Changes

- **`Store::apply(&self, tx: &Transaction)`** (`crates/store/src/lib.rs`) — public wrapper over the backend's transaction apply. On RocksDB this is one `WriteBatch` (`db.write`), atomic across column families. (The existing `StoreBatch` is a stub that commits per-op; `Transaction` → `db.apply` is the real atomic primitive, same path the Temporal layer's `commit()` uses.)
- **`ContextRegistry::persist_deltas_and_dag_heads`** + a `ContextClient` delegation (`crates/context/primitives/src/client/mod.rs`) — reads `ContextMeta`, sets the new heads, borsh-encodes every `ContextDagDelta` record and the meta up front (a serialization slip aborts before anything is written), then commits them in a single `Transaction`. `ContextDagDelta` lives in the `Delta` column and `ContextMeta` in `Meta`; one WriteBatch covers both, so heads can't land without the deltas (or vice versa).
- **Routed `delta_store`'s shared helper** `persist_cascaded_deltas_and_update_heads` through it — replacing the per-`put` loop + separate `update_dag_heads`. This is the single call site #2183 created, so all three cascade entry points (`add_delta_internal`, `get_missing_parents`, and the third internal caller) are now atomic. Event-preservation semantics are unchanged.

On commit failure nothing is written, so the DB stays at its pre-cascade state and the next sync replays cleanly. The failure is logged (not propagated), matching the prior warn-and-continue behaviour.

## Acceptance (from #2184)

- [x] Cascade persistence in both `add_delta_internal` and `get_missing_parents` is atomic: all cascaded deltas + `dag_heads` land, or none do.
- [x] On simulated partial-write failure, the DB reflects the pre-cascade state.

## Tests

`atomic_persist_tests` in `client/mod.rs`:
- `persists_all_deltas_and_heads_together` — happy path, all deltas + advanced heads land.
- `failed_commit_leaves_pre_cascade_state` — a `FailOnApply` backend (delegates everything but errors on `apply`) proves a failed commit leaves heads unchanged and the deltas absent.

`cargo build`, `cargo fmt --check`, clippy (lib) on the touched crates, and `calimero-store` tests all pass.

Closes #2184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core DAG/sync persistence; a regression could leave contexts inconsistent on disk, though behavior is narrowed to one atomic commit path with targeted tests.
> 
> **Overview**
> Cascade persistence no longer writes each applied DAG delta with a separate `put` and then updates `dag_heads` in another step. **All cascaded delta records and the context’s updated `dag_heads` are committed in one store transaction** (`Store::apply` / RocksDB `WriteBatch`), via new `ContextRegistry::persist_deltas_and_dag_heads` and a `ContextClient` wrapper.
> 
> The node’s shared `persist_cascaded_deltas_and_update_heads` path now **builds the batch of records first** (still preserving event payloads for handler replay) and calls that API instead of per-delta `put` plus `update_dag_heads`. On commit failure, **nothing from that cascade is written**, so the DB stays at the pre-cascade state and sync can replay.
> 
> Tests cover the happy path and a backend that fails on `apply`, asserting no partial deltas or head advance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dff0803937204d82a410ccc67530c9db80c0bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->