### PR TITLE
feat(sdk): reject unknown JSON-RPC method arguments (#1646)

### DIFF
--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -775,54 +775,67 @@ fn nested_counter_single_writer_syncs() {
 // must fail loudly instead of being silently dropped.
 // ---------------------------------------------------------------------------
 
-/// `set(key, value)` called with an extra `bogus` field must error rather than
-/// silently ignore it; the same call without the extra field still succeeds.
+/// Assert a call carrying an undeclared field fails with an "unknown field"
+/// deserialize error naming that field. Uses the same `run()` helper as every
+/// other test here (it bails when `outcome.returns` is `Err`, surfacing the
+/// app's deserialize panic), so no manual borrowing of `Cluster` internals.
+fn assert_unknown_field_rejected(c: &mut Cluster, method: &str, params: Value, field: &str) {
+    let module = c.module;
+    let err = run(module, &mut c.nodes[0], method, params)
+        .expect_err("call with an unknown argument must fail, not silently ignore it");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("unknown field") && msg.contains(field),
+        "expected an unknown-field deserialize error mentioning `{field}`, got: {msg}"
+    );
+}
+
+/// A multi-arg (`set`) and a single-arg (`add_frozen`) method each reject an
+/// extra field, while the same calls without it still succeed — i.e. the fix is
+/// not specific to multi-field input structs.
 #[test]
 fn unknown_argument_is_rejected() {
     let mut c = Cluster::new(1);
     let module = c.module;
-    let executor = c.nodes[0].executor;
 
-    // Extra `bogus` field: rejected by `deny_unknown_fields`.
-    let bad = to_json_vec(&json!({"key": "k", "value": "v", "bogus": "x"})).unwrap();
-    let outcome = module
-        .run(
-            CTX.into(),
-            executor.into(),
-            "set",
-            &bad,
-            &mut c.nodes[0].store,
-            None,
-            None,
-        )
-        .expect("host should not trap — the app panics with a deserialize error");
-    let err = outcome
-        .returns
-        .expect_err("call with an unknown argument must fail, not silently ignore it");
-    let msg = format!("{err:?}");
-    assert!(
-        msg.contains("unknown field") && msg.contains("bogus"),
-        "expected an unknown-field deserialize error mentioning `bogus`, got: {msg}"
+    assert_unknown_field_rejected(
+        &mut c,
+        "set",
+        json!({"key": "k", "value": "v", "bogus": "x"}),
+        "bogus",
+    );
+    assert_unknown_field_rejected(
+        &mut c,
+        "add_frozen",
+        json!({"value": "v", "bogus": "x"}),
+        "bogus",
     );
 
     // The declared arguments alone still deserialize and execute fine.
-    let ok = to_json_vec(&json!({"key": "k", "value": "v"})).unwrap();
-    let outcome = module
-        .run(
-            CTX.into(),
-            executor.into(),
-            "set",
-            &ok,
-            &mut c.nodes[0].store,
-            None,
-            None,
-        )
-        .expect("valid call should run");
-    assert!(
-        outcome.returns.is_ok(),
-        "valid arguments must still succeed, got: {:?}",
-        outcome.returns
-    );
+    run(
+        module,
+        &mut c.nodes[0],
+        "set",
+        json!({"key": "k", "value": "v"}),
+    )
+    .expect("valid multi-arg call should run");
+    run(module, &mut c.nodes[0], "add_frozen", json!({"value": "v"}))
+        .expect("valid single-arg call should run");
+}
+
+/// KNOWN LIMITATION: a method with no declared arguments takes the
+/// `args.is_empty()` branch in the macro (`crates/sdk/macros/src/logic/method.rs`),
+/// which emits no input struct and never reads the payload — so extra JSON
+/// fields sent to it are still silently ignored, `deny_unknown_fields`
+/// notwithstanding. This test pins that behavior so a future change to the
+/// no-arg branch is a deliberate, reviewed decision rather than an accident.
+#[test]
+fn extra_fields_to_zero_arg_method_are_ignored() {
+    let mut c = Cluster::new(1);
+    let module = c.module;
+    // `entries` declares no arguments; the surplus field is not rejected.
+    run(module, &mut c.nodes[0], "entries", json!({"bogus": "x"}))
+        .expect("zero-arg method ignores its payload (documented limitation)");
 }
 
 #[test]

--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -769,6 +769,62 @@ fn nested_counter_single_writer_syncs() {
     assert_converged("nested_counter_single", &roots);
 }
 
+// ---------------------------------------------------------------------------
+// Argument validation (core#1646): the macro-generated input struct now uses
+// serde `deny_unknown_fields`, so passing an argument a method does not declare
+// must fail loudly instead of being silently dropped.
+// ---------------------------------------------------------------------------
+
+/// `set(key, value)` called with an extra `bogus` field must error rather than
+/// silently ignore it; the same call without the extra field still succeeds.
+#[test]
+fn unknown_argument_is_rejected() {
+    let mut c = Cluster::new(1);
+    let module = c.module;
+    let executor = c.nodes[0].executor;
+
+    // Extra `bogus` field: rejected by `deny_unknown_fields`.
+    let bad = to_json_vec(&json!({"key": "k", "value": "v", "bogus": "x"})).unwrap();
+    let outcome = module
+        .run(
+            CTX.into(),
+            executor.into(),
+            "set",
+            &bad,
+            &mut c.nodes[0].store,
+            None,
+            None,
+        )
+        .expect("host should not trap — the app panics with a deserialize error");
+    let err = outcome
+        .returns
+        .expect_err("call with an unknown argument must fail, not silently ignore it");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("unknown field") && msg.contains("bogus"),
+        "expected an unknown-field deserialize error mentioning `bogus`, got: {msg}"
+    );
+
+    // The declared arguments alone still deserialize and execute fine.
+    let ok = to_json_vec(&json!({"key": "k", "value": "v"})).unwrap();
+    let outcome = module
+        .run(
+            CTX.into(),
+            executor.into(),
+            "set",
+            &ok,
+            &mut c.nodes[0].store,
+            None,
+            None,
+        )
+        .expect("valid call should run");
+    assert!(
+        outcome.returns.is_ok(),
+        "valid arguments must still succeed, got: {:?}",
+        outcome.returns
+    );
+}
+
 #[test]
 fn unordered_set_single_writer_syncs() {
     let mut c = Cluster::new(3);

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -74,7 +74,7 @@ impl ToTokens for PublicLogicMethod<'_> {
 
             quote_spanned! {name.span()=>
                 #[derive(::calimero_sdk::serde::Deserialize)]
-                #[serde(crate = "::calimero_sdk::serde")]
+                #[serde(crate = "::calimero_sdk::serde", deny_unknown_fields)]
                 struct #input_ident #input_lifetime {
                     #(
                         #args


### PR DESCRIPTION
Closes #1646.

## Problem

Calling an app method with **extra** JSON arguments that the method doesn't declare silently dropped them. For `set(value: String)`:

```json
{ "value": "hello", "other_arg": "oops" }
```

`other_arg` was discarded, `set("hello")` ran, and the call returned success. A typo'd or stale argument name passed unnoticed — exactly the class of app-dev bug the issue asks us to catch early.

### Root cause

The only place method args are matched against the signature is the `#[app::logic]` macro expansion (`crates/sdk/macros/src/logic/method.rs`), which generates a `#[derive(Deserialize)]` struct of the declared params and `serde_json::from_slice`s into it. serde's default is to **ignore** unknown fields.

## Fix

Add `deny_unknown_fields` to that generated struct:

```rust
#[derive(::calimero_sdk::serde::Deserialize)]
#[serde(crate = "::calimero_sdk::serde", deny_unknown_fields)]
struct Input { … }
```

An undeclared field now fails deserialization, which the existing match arm turns into `env::panic_str`, propagating back as an execution error. Because the check lives in the guest-side macro wrapper, it covers **every** call path uniformly — JSON-RPC, `merod call`, and internal `ctx_client.execute` — with no server-side change.

## Before / After

| | Before | After |
|---|---|---|
| `{"value":"hello","other_arg":"oops"}` | drops `other_arg`, returns success | errors: `unknown field 'other_arg', expected 'value'` |
| `{"value":"hello"}` | success | success (unchanged) |

## Test

`crates/runtime/tests/crdt_conformance.rs::unknown_argument_is_rejected` drives the **real compiled wasm** through `Module::run`:
- `set` with an extra `bogus` field → asserts an "unknown field" error.
- `set` with only declared `key`/`value` → asserts it still succeeds.

Passing locally (`test result: ok. 1 passed`).

## ⚠️ Compatibility

This is a **behavioral change**: any client that previously sent extra fields (knowingly or not) will now get an error. That's the intent of #1646, but worth a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral breaking change for any client sending extra JSON fields; limited to argument deserialization, not auth or storage.
> 
> **Overview**
> App method calls with **undeclared JSON arguments** now **fail at deserialize time** instead of silently ignoring extra fields. The `#[app::logic]` macro adds **`deny_unknown_fields`** on the generated input struct, so typos or stale parameter names surface as **unknown field** errors on every call path (JSON-RPC, `merod call`, internal execute).
> 
> **Conformance tests** drive real WASM: multi- and single-arg methods reject a `bogus` field while valid payloads still run. A separate test **documents** that **zero-arg** methods still skip payload validation (no input struct), so extra fields there remain ignored until that macro branch changes.
> 
> **Compatibility:** clients that relied on silently dropped extra fields will now see errors — intentional for #1646.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22b6b01b60e6dc0c82691a32dcc0ee2a4b74068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->