### PR TITLE
feat(storage): authenticate SharedStorage writer-set rotation (#2230)

### DIFF
--- a/apps/kv-store-with-shared-storage/src/lib.rs
+++ b/apps/kv-store-with-shared-storage/src/lib.rs
@@ -85,6 +85,28 @@ impl KvStore {
         app::emit!(Event::WritersRotated { count });
         Ok(())
     }
+
+    /// Read the current writer count of the shared register. Used by the
+    /// adversarial e2e to assert a forged rotation did not change the set on the
+    /// honest node.
+    pub fn writer_count(&self) -> app::Result<u64> {
+        Ok(self.shared_value.writers().len() as u64)
+    }
+
+    /// Adversarial-test helper: attempt to rotate the writer set, reporting
+    /// whether the **local** writer gate accepted it (`true`) or refused it
+    /// (`false`) instead of trapping. Lets an e2e assert that a non-writer
+    /// member cannot rotate the set without failing the call itself. The
+    /// authoritative rejection of a *forged rotation delta* (one that bypasses
+    /// this local gate) happens at merge on the honest node and is covered by
+    /// the storage-layer test `forged_shared_rotation_rejected_at_merge`.
+    pub fn try_rotate_writers(&mut self, new_writers: Vec<PublicKey>) -> app::Result<bool> {
+        let set: BTreeSet<PublicKey> = new_writers.into_iter().collect();
+        match self.shared_value.rotate_writers(set) {
+            Ok(()) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -122,6 +122,44 @@ steps:
       - 'json_equal({{node2_map_read}}, {"output": "hello"})'
 
   # ============================================
+  # Adversarial rotation (pre-rotation): node 2 is NOT yet a writer of the
+  # shared register, so its attempt to rotate the writer set to itself must be
+  # refused. This proves writer-set rotation is gated to current writers — the
+  # authenticated-rotation guarantee of this change. (The merge-time rejection
+  # of a forged rotation *delta* that bypasses the local gate is covered by the
+  # storage test `forged_shared_rotation_rejected_at_merge`.)
+  # ============================================
+
+  - name: Node 2 (non-writer) attempts to rotate the writer set to itself
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: try_rotate_writers
+    args:
+      new_writers:
+        - "{{public_key_new-calimero-node-2}}"
+    outputs:
+      node2_rotate_accepted: result
+
+  - name: Assert node 2's non-writer rotation was refused
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_rotate_accepted}}, {"output": false})'
+
+  - name: Node 1 reads the writer count after the refused rotation
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: writer_count
+    outputs:
+      node1_writer_count: result
+
+  - name: Assert the writer set is unchanged on the honest node (still 1)
+    type: json_assert
+    statements:
+      - 'json_equal({{node1_writer_count}}, {"output": 1})'
+
+  # ============================================
   # Rotation: node 1 hands the writer set to node 2
   # ============================================
 

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -295,6 +295,54 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         this
     }
 
+    /// Creates a collection whose element is stamped `Shared{writers}` (and
+    /// carries the given `crdt_type`) **before** its single registration with
+    /// ROOT, so it emits exactly one `Add` action carrying the `Shared` domain —
+    /// not an `Add(Public)` followed by an `Update(Shared)`.
+    ///
+    /// Used by [`SharedStorage`](super::SharedStorage) for its wrapper entity:
+    /// stamping after `add_child_to` would emit two actions for the same entity
+    /// in the bootstrap delta, and a bootstrap `Update(Shared)` over a freshly
+    /// `Add`ed `Public` entity is a different (untested) merge path than a
+    /// single `Add(Shared)`.
+    #[expect(clippy::expect_used, reason = "fatal error if it happens")]
+    pub(crate) fn new_shared(
+        id: Option<Id>,
+        field_name: Option<&str>,
+        crdt_type: CrdtType,
+        writers: std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
+    ) -> Self {
+        let id = id.unwrap_or_else(|| Id::random());
+
+        let mut storage = match field_name {
+            Some(name) => Element::new_with_field_name_and_crdt_type(
+                Some(id),
+                Some(name.to_string()),
+                crdt_type,
+            ),
+            None => {
+                let mut element = Element::new(Some(id));
+                element.metadata.crdt_type = Some(crdt_type);
+                element
+            }
+        };
+        storage.set_shared_domain(writers);
+
+        let mut this = Self {
+            children_ids: RefCell::new(None),
+            storage,
+            _priv: PhantomData,
+        };
+
+        if id.is_root() {
+            let _ignored = <Interface<S>>::save(&mut this).expect("save");
+        } else {
+            let _ = <Interface<S>>::add_child_to(*ROOT_ID, &mut this).expect("add child");
+        }
+
+        this
+    }
+
     /// Creates a detached collection that is NOT registered with the storage system.
     ///
     /// This is used for placeholder fields that are never actually used, such as

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -32,12 +32,14 @@
 //!   log, so it is rejected — see the node sync layer.
 //! - **During local execution** (this module): there is no DAG/`happens_before`
 //!   context and the local rotation log is only appended for *received* deltas,
-//!   so the authoritative local source is the **index metadata**
-//!   ([`Index::get_metadata`]) for the wrapper entity, which is only ever
-//!   updated by a signature-verified per-entity action on apply (or by the
-//!   local node's own committed write). The wrapper's in-memory `Element`
-//!   metadata is the bootstrap fallback for a freshly-created, not-yet-committed
-//!   wrapper.
+//!   so the authoritative local source is the wrapper entity's **rotation log**
+//!   (latest entry) falling back to its **index metadata**
+//!   ([`Index::get_metadata`]) — both of which are only ever written by a
+//!   signature-verified action (apply) or the local node's own committed
+//!   write/rotation. It deliberately does NOT fall back to the in-memory
+//!   `Element` metadata, which is deserialized from the unverified root-state
+//!   blob; trusting it would reintroduce the forgeable writer-set source this
+//!   change removes.
 //!
 //! # Merge semantics
 //!
@@ -137,8 +139,14 @@ where
         writers: BTreeSet<PublicKey>,
         frozen: bool,
     ) -> Self {
+        // Pass the deterministic id explicitly — `new_shared(None, ..)` would
+        // mint a random one, breaking this method's documented contract for any
+        // direct caller (the `#[app::state]` macro relocates `new()`'s random id
+        // via `reassign_deterministic_id`, but this constructor must be
+        // deterministic on its own).
+        let id = compute_collection_id(None, field_name);
         let inner = Collection::new_shared(
-            None,
+            Some(id),
             Some(field_name),
             CrdtType::SharedStorage,
             writers.clone(),
@@ -313,7 +321,7 @@ where
         Ok(self.load_value())
     }
 
-    /// The current writer set, resolved from the authoritative source.
+    /// The current writer set, resolved only from **verified** local sources.
     ///
     /// Resolution order:
     /// 1. **Rotation log** (`rotation_log::load`). On a node that *received*
@@ -322,12 +330,19 @@ where
     ///    (The full causal `writers_at(parents)` resolution is the node-side
     ///    apply-time check; with no DAG context during local execution the
     ///    most-recently-appended entry is the right local answer.)
-    /// 2. **Index `storage_type`** — the fallback for the *originating* node,
-    ///    whose own rotations are not self-applied so its log stays empty.
-    ///    `rotate_writers` writes the new set here on the originator (see
-    ///    [`Index::set_storage_type`]).
-    /// 3. **In-memory `Element`** — bootstrap, for a freshly-created wrapper that
-    ///    has not been committed yet.
+    /// 2. **Index `storage_type`** — written by `add_child_to` at construction,
+    ///    by `apply_action` for a received bootstrap/write, and by
+    ///    [`Index::set_storage_type`] on the *originating* node's own rotation
+    ///    (whose log stays empty because it does not self-apply).
+    ///
+    /// It deliberately does **not** fall back to the in-memory `Element`
+    /// metadata: that is populated from the borsh-deserialized root-state blob,
+    /// which is unverified — trusting it would reintroduce the forgeable
+    /// writer-set source this change exists to remove (a forged root-state delta
+    /// could influence the local gate). Any wrapper a writer can legitimately
+    /// act on has an index entry (construction and sync-apply both write one);
+    /// if neither source has a writer set, fail closed with the empty set rather
+    /// than trust unverified bytes.
     fn current_writers(&self) -> BTreeSet<PublicKey> {
         if let Ok(Some(log)) = rotation_log::load::<S>(self.inner.id()) {
             if let Some(entry) = log.entries.last() {
@@ -342,10 +357,7 @@ where
                 return writers;
             }
         }
-        match &self.inner.element().metadata.storage_type {
-            StorageType::Shared { writers, .. } => writers.clone(),
-            _ => BTreeSet::new(),
-        }
+        BTreeSet::new()
     }
 
     /// Read the current writer set. Public so callers can present a
@@ -462,29 +474,34 @@ where
             .set_shared_domain(new_writers.clone());
         let _saved = <Interface<S>>::save(&mut self.inner)?;
 
-        // Re-stamp the single value entry too, if it has been materialised. The
-        // value lives in its own entity, verified at merge against *its* writer
-        // set; without re-stamping, a writer added by this rotation could never
-        // write the value (the entry would stay guarded by the pre-rotation
-        // set). Re-stamping emits a signed `Update` (data unchanged → hash
-        // unchanged, no divergence) so the receiver appends the new set to the
-        // value entry's own rotation log, and the new writer's later writes
-        // verify. This is the single-child analogue of the per-collection
+        // Re-stamp the single value entry too. The value lives in its own
+        // entity, verified at merge against *its* writer set; without
+        // re-stamping, a writer added by this rotation could never write the
+        // value (the entry would stay guarded by the pre-rotation set).
+        // Re-stamping emits a signed `Update` (data unchanged → hash unchanged,
+        // no divergence) so the receiver appends the new set to the value
+        // entry's own rotation log, and the new writer's later writes verify.
+        // This is the single-child analogue of the per-collection
         // anchor-inheritance that retroactive collection revocation will
-        // generalise.
+        // generalise. The value entry is created eagerly at construction, so it
+        // is present here; read with a `T::default()` fallback and re-stamp
+        // unconditionally so the rotation is never silently lost if it were
+        // absent.
         let value_id = self.value_id();
-        if let Some(value) = self.inner.get(value_id)? {
-            let _restamped =
-                self.inner
-                    .insert_with_storage_type(Some(value_id), value, new_shared.clone())?;
-            // Originating-node fallback: persist the new set on the value
-            // entry's index too (its rotation log is only appended on receivers).
-            let _ignored = <Index<S>>::set_storage_type(value_id, new_shared.clone());
-        }
-
-        // Originating-node fallback: persist the new set on the wrapper's index,
-        // since this node does not self-apply its own rotation into its log.
+        let value = self.inner.get(value_id)?.unwrap_or_default();
+        let _restamped =
+            self.inner
+                .insert_with_storage_type(Some(value_id), value, new_shared.clone())?;
+        // Originating-node fallback: persist the new set on the value entry's
+        // and wrapper's index too (the rotation log is only appended on
+        // receivers, so this node's own log stays empty).
+        let _ignored = <Index<S>>::set_storage_type(value_id, new_shared.clone());
         let _ignored = <Index<S>>::set_storage_type(wrapper_id, new_shared);
+
+        // Invalidate the lazy cache so the next access reloads the value with
+        // the new writer stamp rather than serving a copy whose in-memory
+        // element still carries the pre-rotation set.
+        *self.value.borrow_mut() = None;
         Ok(())
     }
 }
@@ -581,6 +598,30 @@ mod tests {
 
     fn writers(keys: &[[u8; 32]]) -> BTreeSet<PublicKey> {
         keys.iter().copied().map(pk).collect()
+    }
+
+    #[test]
+    #[serial]
+    fn new_with_field_name_is_deterministic() {
+        // Regression: `new_with_field_name` must produce the field-derived
+        // deterministic id directly (not a random one relocated later), so a
+        // direct caller without the `#[app::state]` macro still converges.
+        use crate::collections::compute_collection_id;
+        use crate::entities::Data;
+
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let _root: Root<TestVal> = Root::new(TestVal::default);
+
+        let expected = compute_collection_id(None, "doc");
+        let a = SharedStorage::<TestVal>::new_with_field_name("doc", writers(&[ALICE]), false);
+        assert_eq!(a.element().id(), expected);
+        let b = SharedStorage::<TestVal>::new_with_field_name("doc", writers(&[ALICE]), false);
+        assert_eq!(
+            b.element().id(),
+            expected,
+            "must be deterministic across constructions"
+        );
     }
 
     #[test]

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -397,14 +397,21 @@ where
         let old = self.inner.get(self.value_id())?.unwrap_or_default();
 
         let value_id = self.value_id();
-        let new = self.inner.insert_with_storage_type(
-            Some(value_id),
-            value,
-            StorageType::Shared {
-                writers,
-                signature_data: None,
-            },
-        )?;
+        let shared = StorageType::Shared {
+            writers,
+            signature_data: None,
+        };
+        let new = self
+            .inner
+            .insert_with_storage_type(Some(value_id), value, shared.clone())?;
+        // Track the current writer set on the value entry's own index. After a
+        // rotation this node received, the value entry's index still carries the
+        // pre-rotation set (apply does not patch a child's own `storage_type`);
+        // without this, the runtime's post-execution `update_signature_in_place`
+        // would see a writer-set mismatch (the just-signed write claims the new
+        // set) and abort the whole transaction. Hash-neutral; no-ops when
+        // unchanged.
+        let _ignored = <Index<S>>::set_storage_type(value_id, shared);
         *self.value.borrow_mut() = Some(new);
         Ok(Some(old))
     }
@@ -575,6 +582,47 @@ mod tests {
 
     fn writers(keys: &[[u8; 32]]) -> BTreeSet<PublicKey> {
         keys.iter().copied().map(pk).collect()
+    }
+
+    #[test]
+    #[serial]
+    fn value_entry_index_tracks_writers_through_rotation() {
+        // Regression for the post-rotation write abort: the value entry's index
+        // `storage_type` must follow the writer set so the runtime's
+        // post-execution `update_signature_in_place` does not see a writer-set
+        // mismatch (which aborts the transaction). `insert` and `rotate_writers`
+        // both keep it current.
+        use crate::collections::compute_id;
+        use crate::entities::{Data, StorageType};
+        use crate::index::Index;
+        use crate::store::MainStorage;
+
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+
+        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), false));
+        s.insert(TestVal(1)).unwrap();
+
+        let value_id = compute_id(s.element().id(), super::VALUE_KEY);
+        let writers_of = |id| match <Index<MainStorage>>::get_metadata(id)
+            .unwrap()
+            .unwrap()
+            .storage_type
+        {
+            StorageType::Shared { writers, .. } => writers,
+            other => panic!("expected Shared, got {other:?}"),
+        };
+        assert_eq!(writers_of(value_id), writers(&[ALICE]));
+
+        // Rotation must carry the value entry's index to the new set.
+        s.rotate_writers(writers(&[ALICE, BOB])).unwrap();
+        assert_eq!(writers_of(value_id), writers(&[ALICE, BOB]));
+
+        // A write by the newly-added writer keeps it current (would mismatch if
+        // the index had stayed at the pre-rotation set).
+        env::set_executor_id(BOB);
+        s.insert(TestVal(2)).unwrap();
+        assert_eq!(writers_of(value_id), writers(&[ALICE, BOB]));
     }
 
     #[test]

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -194,21 +194,22 @@ where
 
         let writers = self.current_writers();
 
-        // If the user wrote a value during `init`, capture it before relocating
-        // and drop the old (random-id) value entry. The common case — `init`
-        // only constructs the wrapper — has no value entry yet, so this is None
-        // and only the wrapper moves (the same path a plain collection takes).
+        // Capture the value, then relocate it with the wrapper. `from_inner`
+        // creates the value entry eagerly, so it is present here — but read with
+        // a `T::default()` fallback rather than asserting presence: relocation
+        // must ALWAYS leave a value entry at the new id, so that even if the old
+        // entry were somehow missing (storage corruption, a future lazy-creation
+        // refactor) we never end up with the wrapper at the new id and no value
+        // entry, which `load_value` would silently paper over with a default.
         let old_value_id = compute_id(self.inner.id(), VALUE_KEY);
-        let carried_value: Option<T> = self
+        let carried_value: T = self
             .inner
             .get(old_value_id)
-            .expect("read SharedStorage value during reassign");
-        if carried_value.is_some() {
-            let _ignored = MainStorage::storage_remove(Key::Entry(old_value_id));
-            let _ignored = MainStorage::storage_remove(Key::Index(old_value_id));
-            let _ =
-                <Index<MainStorage>>::remove_child_reference_only(self.inner.id(), old_value_id);
-        }
+            .expect("read SharedStorage value during reassign")
+            .unwrap_or_default();
+        let _ignored = MainStorage::storage_remove(Key::Entry(old_value_id));
+        let _ignored = MainStorage::storage_remove(Key::Index(old_value_id));
+        let _ = <Index<MainStorage>>::remove_child_reference_only(self.inner.id(), old_value_id);
 
         // Relocate the wrapper entity to its deterministic id, then re-stamp the
         // Shared domain (the reassign preserves storage_type, but re-set to be
@@ -219,22 +220,20 @@ where
         let _saved = <Interface<MainStorage>>::save(&mut self.inner)
             .expect("failed to persist relocated SharedStorage wrapper");
 
-        // Re-write the value entry under the new wrapper id, if there was one.
-        if let Some(value) = carried_value {
-            let new_value_id = compute_id(self.inner.id(), VALUE_KEY);
-            let value = self
-                .inner
-                .insert_with_storage_type(
-                    Some(new_value_id),
-                    value,
-                    StorageType::Shared {
-                        writers,
-                        signature_data: None,
-                    },
-                )
-                .expect("failed to relocate SharedStorage value");
-            *self.value.borrow_mut() = Some(value);
-        }
+        // Re-write the value entry under the new wrapper id (always).
+        let new_value_id = compute_id(self.inner.id(), VALUE_KEY);
+        let value = self
+            .inner
+            .insert_with_storage_type(
+                Some(new_value_id),
+                carried_value,
+                StorageType::Shared {
+                    writers,
+                    signature_data: None,
+                },
+            )
+            .expect("failed to relocate SharedStorage value");
+        *self.value.borrow_mut() = Some(value);
     }
 }
 

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -43,11 +43,13 @@
 //!
 //! # Merge semantics
 //!
-//! The wrapper itself carries no CRDT value to merge — the value is a separate
-//! entity. The only field merged at root-state time is `frozen` (monotonic:
-//! once frozen on either side, stays frozen). There is deliberately **no**
-//! writer-set merge here: convergence is the rotation log + ADR 0001, applied
-//! and verified on the node side, not an LWW on root-state bytes.
+//! The wrapper carries no CRDT value to merge at root-state time: the value is a
+//! separate entity (merged per-entity) and the writer set converges via the
+//! rotation log + ADR 0001 on the node side, not an LWW on root-state bytes.
+//! `frozen` is genesis-immutable (set in `new`, no setter) — it rides root-state
+//! borsh so joiners see it, but the merge deliberately does **not** adopt the
+//! peer's `frozen`, so a forged root-state delta cannot freeze rotation on an
+//! honest node.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -210,11 +212,26 @@ where
         // refactor) we never end up with the wrapper at the new id and no value
         // entry, which `load_value` would silently paper over with a default.
         let old_value_id = compute_id(self.inner.id(), VALUE_KEY);
-        let carried_value: T = self
+        let carried_value: T = match self
             .inner
             .get(old_value_id)
             .expect("read SharedStorage value during reassign")
-            .unwrap_or_default();
+        {
+            Some(value) => value,
+            None => {
+                // Eager construction guarantees the value entry exists, so a
+                // miss here means storage corruption. Default to keep relocation
+                // total (the new id always gets an entry), but make the anomaly
+                // visible rather than silently papering over lost data.
+                tracing::warn!(
+                    target: "storage::shared",
+                    old_value_id = %old_value_id,
+                    "SharedStorage value entry missing during reassign — \
+                     relocating a default (possible storage corruption)"
+                );
+                T::default()
+            }
+        };
         let _ignored = MainStorage::storage_remove(Key::Entry(old_value_id));
         let _ignored = MainStorage::storage_remove(Key::Index(old_value_id));
         let _ = <Index<MainStorage>>::remove_child_reference_only(self.inner.id(), old_value_id);
@@ -489,19 +506,38 @@ where
         // entry's own rotation log, and the new writer's later writes verify.
         // This is the single-child analogue of the per-collection
         // anchor-inheritance that retroactive collection revocation will
-        // generalise. The value entry is created eagerly at construction, so it
-        // is present here; read with a `T::default()` fallback and re-stamp
-        // unconditionally so the rotation is never silently lost if it were
-        // absent.
+        // generalise.
+        //
+        // The value entry is created eagerly at construction, so it is present
+        // on the originating node. If it is somehow absent (corruption, or a
+        // writer rotating before the value entry has synced), do NOT fabricate a
+        // default: re-stamping a default value would ship a signed `Update` that
+        // overwrites the real value once it arrives. Skip the value re-stamp and
+        // warn — the value entry's rotation log picks up the new set when its own
+        // `Add` is (re)applied.
         let value_id = self.value_id();
-        let value = self.inner.get(value_id)?.unwrap_or_default();
-        let _restamped =
-            self.inner
-                .insert_with_storage_type(Some(value_id), value, new_shared.clone())?;
-        // Originating-node fallback: persist the new set on the value entry's
-        // and wrapper's index too (the rotation log is only appended on
-        // receivers, so this node's own log stays empty).
-        let _ignored = <Index<S>>::set_storage_type(value_id, new_shared.clone());
+        match self.inner.get(value_id)? {
+            Some(value) => {
+                let _restamped = self.inner.insert_with_storage_type(
+                    Some(value_id),
+                    value,
+                    new_shared.clone(),
+                )?;
+                // Originating-node fallback: persist the new set on the value
+                // entry's index too (the rotation log is only appended on
+                // receivers, so this node's own log stays empty).
+                let _ignored = <Index<S>>::set_storage_type(value_id, new_shared.clone());
+            }
+            None => {
+                tracing::warn!(
+                    target: "storage::shared",
+                    value_id = %value_id,
+                    "SharedStorage value entry missing during rotation — skipping \
+                     value re-stamp (possible storage corruption or pre-sync race)"
+                );
+            }
+        }
+        // Originating-node fallback: persist the new set on the wrapper's index.
         let _ignored = <Index<S>>::set_storage_type(wrapper_id, new_shared);
 
         // Invalidate the lazy cache so the next access reloads the value with
@@ -532,22 +568,28 @@ where
     }
 }
 
-// Mergeable: invoked at root-state merge time. The value is a separate entity
-// (synced + merged per-entity), and the writer set converges via the rotation
-// log on the node side — so the only field merged here is `frozen` (monotonic).
+// Mergeable: invoked at root-state merge time. Nothing rides this merge — the
+// value is a separate entity (merged per-entity), the writer set converges via
+// the rotation log, and `frozen` is genesis-immutable and deliberately not
+// adopted from the peer (so a forged root-state delta can't freeze rotation).
 impl<T, S> Mergeable for SharedStorage<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor,
 {
-    fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
-        // Frozen is monotonic: once set on either side, stays set. No
-        // writer-set merge here — that would be the forgeable LWW-on-root-state
-        // path the handle design removes; convergence is the verified rotation
-        // log + ADR 0001, applied on the node side.
-        if other.frozen {
-            self.frozen = true;
-        }
+    fn merge(&mut self, _other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
+        // Nothing to merge. The value is a separate entity (synced + merged
+        // per-entity) and the writer set converges via the verified rotation log
+        // (ADR 0001) on the node side — neither rides this merge.
+        //
+        // `frozen` is intentionally NOT merged from `other`. It is set once at
+        // construction and has no setter, so it is genesis-immutable; joiners
+        // receive it via root-state deserialization at genesis, and there is no
+        // post-genesis transition to propagate. Crucially, NOT adopting
+        // `other.frozen` here means a forged root-state delta carrying
+        // `frozen = true` cannot freeze an honest node's rotation capability —
+        // the honest node keeps its own value. (A `frozen` change could only
+        // come from genesis, which the initial sole writer is trusted for.)
         Ok(())
     }
 }
@@ -854,7 +896,11 @@ mod tests {
 
     #[test]
     #[serial]
-    fn merge_frozen_is_monotonic() {
+    fn merge_does_not_adopt_peers_frozen() {
+        // `frozen` is genesis-immutable and deliberately NOT merged from the
+        // peer, so a forged root-state delta carrying `frozen = true` cannot
+        // freeze an honest node's rotation. Merge leaves the local value intact
+        // in both directions.
         env::reset_for_testing();
         env::set_executor_id(ALICE);
         // Establish ROOT so the wrapper's `add_child_to(ROOT)` succeeds.
@@ -863,14 +909,18 @@ mod tests {
         let b = SharedStorage::<TestVal>::new(writers(&[ALICE]), true);
 
         Mergeable::merge(&mut a, &b).unwrap();
-        assert!(a.frozen, "frozen=true on b should propagate to a");
+        assert!(
+            !a.frozen,
+            "merge must NOT adopt the peer's frozen=true (forge resistance)"
+        );
 
-        // Reverse direction: frozen stays once set.
+        // Reverse direction: a locally-frozen instance stays frozen (merge
+        // doesn't clear it either — it just doesn't touch `frozen`).
         let _root2: Root<TestVal> = Root::new(TestVal::default);
         let mut a2 = SharedStorage::<TestVal>::new(writers(&[ALICE]), true);
         let b2 = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
         Mergeable::merge(&mut a2, &b2).unwrap();
-        assert!(a2.frozen, "frozen=true on a2 must not be cleared by merge");
+        assert!(a2.frozen, "merge must not clear a locally-set frozen");
     }
 
     #[test]

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -1,70 +1,119 @@
-//! Group-writable storage with a mutable writer set.
+//! Group-writable storage with an authenticated, mutable writer set.
 //!
-//! `SharedStorage<T>` wraps a single value writable by any signer in `writers`.
-//! The writer set itself is rotatable by a current writer (unless
-//! `writers_frozen`). Trust mirrors `UserStorage<T>`: the runtime signs each
-//! write, peers verify the signature against the stored writer set at merge
-//! time.
+//! `SharedStorage<T>` wraps a single value writable by any signer in the
+//! current writer set. The writer set itself is rotatable by a current writer
+//! (unless `frozen`). Trust mirrors `UserStorage<T>`: the runtime signs each
+//! write, peers verify the signature against the writer set at merge time.
+//!
+//! # Why this is a handle, not an inline value
+//!
+//! `SharedStorage<T>` is modeled on [`Root<T>`](super::root::Root): it is a
+//! thin handle over a [`Collection`] that holds the value as a single,
+//! `Shared`-stamped child entry. Borsh-serializing the wrapper therefore emits
+//! **only its `Element`** (id + metadata) — a reference — exactly like any
+//! other collection field. The value body lives in its own storage entity and
+//! syncs as a per-entity `Update` action, verified at merge against the writer
+//! set (the same path that guards a collection's child entries).
+//!
+//! This is what makes writer-set rotation *authenticated*. The earlier design
+//! kept `value` inline in the wrapper struct, so it rode in the enclosing
+//! `#[app::state]` root-state blob, and writer-set convergence was an LWW on a
+//! `writers_nonce` that did **not** verify who rotated — any context member
+//! could hand-craft a root-state delta swapping the writer set. By moving the
+//! value out of root state, the rotation can ride a signed per-entity action
+//! instead, and a non-writer's forged rotation is rejected at merge.
+//!
+//! # Where the current writer set comes from
+//!
+//! - **At apply time on a peer** (the security boundary): the node resolves the
+//!   writer set from the entity's *rotation log* via
+//!   `rotation_log_reader::writers_at(delta.parents)` and verifies the action's
+//!   signature against it. A forged rotation from a non-writer never updates the
+//!   log, so it is rejected — see the node sync layer.
+//! - **During local execution** (this module): there is no DAG/`happens_before`
+//!   context and the local rotation log is only appended for *received* deltas,
+//!   so the authoritative local source is the **index metadata**
+//!   ([`Index::get_metadata`]) for the wrapper entity, which is only ever
+//!   updated by a signature-verified per-entity action on apply (or by the
+//!   local node's own committed write). The wrapper's in-memory `Element`
+//!   metadata is the bootstrap fallback for a freshly-created, not-yet-committed
+//!   wrapper.
 //!
 //! # Merge semantics
 //!
-//! `SharedStorage` implements [`Mergeable`](super::crdt_meta::Mergeable) on two
-//! axes:
-//!
-//! - **Inner value** — delegates to `T`'s own `Mergeable` impl, so a wrapped
-//!   CRDT keeps its convergence semantics (counter sums, LWW wins, etc.).
-//! - **Writer-set metadata** — resolved by `(writers_nonce, lexical content)`:
-//!   the side with the higher nonce wins, with a deterministic tie-break on
-//!   the serialised writer set so concurrent rotations from different signers
-//!   converge to the same outcome on all replicas.
+//! The wrapper itself carries no CRDT value to merge — the value is a separate
+//! entity. The only field merged at root-state time is `frozen` (monotonic:
+//! once frozen on either side, stays frozen). There is deliberately **no**
+//! writer-set merge here: convergence is the rotation log + ADR 0001, applied
+//! and verified on the node side, not an LWW on root-state bytes.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::mem;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
-use super::{compute_collection_id, StoreError, ROOT_ID};
-use crate::entities::{ChildInfo, Data, Element, SignatureData};
+use super::{compute_collection_id, compute_id, Collection, StoreError};
+use crate::address::Id;
+use crate::entities::{ChildInfo, Data, Element, SignatureData, StorageType};
 use crate::env;
 use crate::index::Index;
 use crate::interface::{Interface, StorageError};
+use crate::rotation_log;
 use crate::store::{Key, MainStorage, StorageAdaptor};
 
-/// Group-writable storage with a mutable writer set.
+/// Fixed sub-key under which the wrapper's single value entry is stored.
+/// The value entry's id is `compute_id(wrapper_id, VALUE_KEY)` so every node
+/// derives the same id for the value of a given wrapper.
+const VALUE_KEY: &[u8] = b"__calimero_shared_value__";
+
+/// Group-writable storage with an authenticated, mutable writer set.
+///
+/// A handle over a [`Collection`] holding the value as one `Shared`-stamped
+/// child entry. Borsh = the inner collection's `Element` (a reference) plus the
+/// monotonic `frozen` flag; the value body never rides root state.
 ///
 /// When `T` is a **collection** (`UnorderedMap`, `UnorderedSet`, …), in-place
 /// edits MUST go through [`get_mut`](SharedStorage::get_mut): it re-establishes
 /// the `Shared{writers}` domain on the collection element so every entry
-/// inserted through it is guarded at merge. The inner value is private and
-/// [`get`](SharedStorage::get) is read-only, so `get_mut` is the only mutation
-/// path — the writer set (`writers`, a persisted field) is the source of truth
-/// and the element domain is re-derived from it on each `get_mut`, so the
-/// guarantee survives reload without the element domain itself being persisted.
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+/// inserted through it is guarded at merge.
+#[derive(BorshSerialize, BorshDeserialize)]
 pub struct SharedStorage<
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor = MainStorage,
 > {
-    /// The current value.
-    value: T,
-    /// Public keys authorized to write or rotate.
-    writers: BTreeSet<PublicKey>,
-    /// If true, `rotate_writers` is rejected. Set at construction; never cleared.
-    writers_frozen: bool,
-    /// Monotonic counter; incremented on every write or rotation.
-    writers_nonce: u64,
-    /// Storage element for this entity.
-    storage: Element,
-    /// Signature attached at the runtime layer; mirrored from the metadata
-    /// after signing. Per spec — currently always `None` in v2; populated
-    /// by the runtime sign path in a future iteration. Kept serialized for
-    /// wire-format stability across v2 → future versions.
-    signature_data: Option<SignatureData>,
+    /// Holds the single value entry (`Shared`-stamped). The collection's own
+    /// `Element` is the wrapper entity; its metadata carries the writer set.
+    #[borsh(bound(serialize = "", deserialize = ""))]
+    inner: Collection<T, S>,
+    /// If true, `rotate_writers` is rejected. Monotonic: set at construction or
+    /// by merge, never cleared. Rides root state inline — unlike the value, this
+    /// is a small scalar that is never double-written as a per-entity action, so
+    /// it cannot cause the root-hash divergence the inline value once did. It is
+    /// fail-safe: a forged `frozen=true` only *locks* rotation (a minor DoS),
+    /// and the monotonic merge means it can never be forged back to `false`.
+    frozen: bool,
+    /// Lazy cache of the deserialized value entry (Root's pattern). Not part of
+    /// borsh — the value is a separate entity loaded on first access.
+    #[borsh(skip, bound(serialize = "", deserialize = ""))]
+    value: core::cell::RefCell<Option<T>>,
     #[borsh(skip)]
     _adaptor: core::marker::PhantomData<S>,
+}
+
+impl<T, S> core::fmt::Debug for SharedStorage<T, S>
+where
+    T: BorshSerialize + BorshDeserialize + Mergeable + core::fmt::Debug,
+    S: StorageAdaptor,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SharedStorage")
+            .field("inner", &self.inner)
+            .field("frozen", &self.frozen)
+            .field("value", &self.value)
+            .finish()
+    }
 }
 
 impl<T> SharedStorage<T, MainStorage>
@@ -72,77 +121,159 @@ where
     T: BorshSerialize + BorshDeserialize + Mergeable + Default,
 {
     /// Create a new SharedStorage with a random ID and the given initial
-    /// writer set. Use this for nested fields.
+    /// writer set. Use this for nested fields; the `#[app::state]` macro
+    /// canonicalises the id via [`reassign_deterministic_id`] after `init`.
+    ///
+    /// [`reassign_deterministic_id`]: SharedStorage::reassign_deterministic_id
     pub fn new(writers: BTreeSet<PublicKey>, frozen: bool) -> Self {
-        let mut storage = Element::new(None);
-        storage.set_shared_domain(writers.clone());
-        Self {
-            value: T::default(),
-            writers,
-            writers_frozen: frozen,
-            writers_nonce: 0,
-            storage,
-            signature_data: None,
-            _adaptor: core::marker::PhantomData,
-        }
+        let inner = Collection::new_shared(None, None, CrdtType::SharedStorage, writers.clone());
+        Self::from_inner(inner, writers, frozen)
     }
 
     /// Create a new SharedStorage with a deterministic ID derived from
-    /// `field_name`. Use this for top-level state fields (the `#[app::state]`
-    /// macro arranges this automatically).
-    ///
-    /// Registers the wrapper as a child of root so the metadata
-    /// (writer set, signature) is persisted to the index.
-    #[expect(clippy::expect_used, reason = "fatal error if it happens")]
+    /// `field_name`. Use this for top-level state fields.
     pub fn new_with_field_name(
         field_name: &str,
         writers: BTreeSet<PublicKey>,
         frozen: bool,
     ) -> Self {
-        let id = compute_collection_id(None, field_name);
-        let mut storage = Element::new_with_field_name(Some(id), Some(field_name.to_string()));
-        storage.metadata.crdt_type = Some(CrdtType::SharedStorage);
-        storage.set_shared_domain(writers.clone());
-        let mut this = Self {
-            value: T::default(),
-            writers,
-            writers_frozen: frozen,
-            writers_nonce: 0,
-            storage,
-            signature_data: None,
+        let inner = Collection::new_shared(
+            None,
+            Some(field_name),
+            CrdtType::SharedStorage,
+            writers.clone(),
+        );
+        Self::from_inner(inner, writers, frozen)
+    }
+
+    /// Wrap a freshly-registered, `Shared`-stamped wrapper collection and
+    /// materialise its single value entry with `T::default()`.
+    ///
+    /// The value entry is created **eagerly** (not lazily) so that when `T` is a
+    /// collection (`UnorderedMap`, …) its own id is minted exactly once, at
+    /// genesis, and is therefore stable across reloads and identical on every
+    /// node (it ships in the genesis state). A lazy "materialise on first
+    /// access" would mint a fresh random collection id on each node that wrote
+    /// before the value synced — diverging the subtree.
+    #[expect(clippy::expect_used, reason = "fatal error if it happens")]
+    fn from_inner(
+        mut inner: Collection<T, MainStorage>,
+        writers: BTreeSet<PublicKey>,
+        frozen: bool,
+    ) -> Self {
+        let value_id = compute_id(inner.id(), VALUE_KEY);
+        let value = inner
+            .insert_with_storage_type(
+                Some(value_id),
+                T::default(),
+                StorageType::Shared {
+                    writers,
+                    signature_data: None,
+                },
+            )
+            .expect("failed to write initial SharedStorage value");
+        Self {
+            inner,
+            frozen,
+            value: core::cell::RefCell::new(Some(value)),
             _adaptor: core::marker::PhantomData,
-        };
-        let _ = <Interface<MainStorage>>::add_child_to(*ROOT_ID, &mut this)
-            .expect("failed to register SharedStorage with root");
-        this
+        }
     }
 
     /// Reassign the wrapper's ID to a deterministic one based on `field_name`.
-    /// Called by the `#[app::state]` macro after `init()` returns to ensure
-    /// the same ID across all nodes when the wrapper was created via
-    /// `new()` (random ID) instead of `new_with_field_name()`.
+    /// Called by the `#[app::state]` macro after `init()` returns so the same
+    /// ID is produced across all nodes when the wrapper was created via
+    /// `new()` (random ID). Runs before the state is broadcast, so relocating
+    /// the value entry here ships no stale delta.
     #[expect(clippy::expect_used, reason = "fatal error if cleanup fails")]
     pub fn reassign_deterministic_id(&mut self, field_name: &str) {
         let new_id = compute_collection_id(None, field_name);
-        let old_id = self.storage.id();
-        if old_id == new_id {
+        if self.inner.id() == new_id {
             return;
         }
-        let _ignored = MainStorage::storage_remove(Key::Entry(old_id));
-        let _ignored = MainStorage::storage_remove(Key::Index(old_id));
-        let _ = <Index<MainStorage>>::remove_child_reference_only(*ROOT_ID, old_id);
-        self.storage.reassign_id_and_field_name(new_id, field_name);
-        self.storage.metadata.crdt_type = Some(CrdtType::SharedStorage);
-        // Re-establish the Shared metadata at the new ID before saving.
-        self.storage.set_shared_domain(self.writers.clone());
-        let _ = <Interface<MainStorage>>::add_child_to(*ROOT_ID, self)
-            .expect("failed to re-register SharedStorage with new id");
+
+        let writers = self.current_writers();
+
+        // If the user wrote a value during `init`, capture it before relocating
+        // and drop the old (random-id) value entry. The common case — `init`
+        // only constructs the wrapper — has no value entry yet, so this is None
+        // and only the wrapper moves (the same path a plain collection takes).
+        let old_value_id = compute_id(self.inner.id(), VALUE_KEY);
+        let carried_value: Option<T> = self
+            .inner
+            .get(old_value_id)
+            .expect("read SharedStorage value during reassign");
+        if carried_value.is_some() {
+            let _ignored = MainStorage::storage_remove(Key::Entry(old_value_id));
+            let _ignored = MainStorage::storage_remove(Key::Index(old_value_id));
+            let _ =
+                <Index<MainStorage>>::remove_child_reference_only(self.inner.id(), old_value_id);
+        }
+
+        // Relocate the wrapper entity to its deterministic id, then re-stamp the
+        // Shared domain (the reassign preserves storage_type, but re-set to be
+        // explicit) and persist.
+        self.inner
+            .reassign_deterministic_id_with_crdt_type(field_name, CrdtType::SharedStorage);
+        self.inner.element_mut().set_shared_domain(writers.clone());
+        let _saved = <Interface<MainStorage>>::save(&mut self.inner)
+            .expect("failed to persist relocated SharedStorage wrapper");
+
+        // Re-write the value entry under the new wrapper id, if there was one.
+        if let Some(value) = carried_value {
+            let new_value_id = compute_id(self.inner.id(), VALUE_KEY);
+            let value = self
+                .inner
+                .insert_with_storage_type(
+                    Some(new_value_id),
+                    value,
+                    StorageType::Shared {
+                        writers,
+                        signature_data: None,
+                    },
+                )
+                .expect("failed to relocate SharedStorage value");
+            *self.value.borrow_mut() = Some(value);
+        }
     }
 }
 
 impl<T, S> SharedStorage<T, S>
 where
-    T: BorshSerialize + BorshDeserialize + Mergeable + Data,
+    T: BorshSerialize + BorshDeserialize + Mergeable + Default,
+    S: StorageAdaptor,
+{
+    /// The id of the value entry under this wrapper.
+    fn value_id(&self) -> Id {
+        compute_id(self.inner.id(), VALUE_KEY)
+    }
+
+    /// Lazily load (and cache) the value entry. Unlike [`Root::get`], the value
+    /// entry may not exist yet on a peer that received the wrapper before the
+    /// value's per-entity `Add` synced, so a missing entry yields `T::default()`
+    /// rather than panicking.
+    #[expect(
+        clippy::mut_from_ref,
+        clippy::expect_used,
+        reason = "lazy cache, mirrors Root::get"
+    )]
+    fn load_value(&self) -> &mut T {
+        let mut slot = self.value.borrow_mut();
+        let value = slot.get_or_insert_with(|| {
+            self.inner
+                .get(self.value_id())
+                .expect("read SharedStorage value")
+                .unwrap_or_default()
+        });
+        #[expect(unsafe_code, reason = "necessary for caching, mirrors Root::get")]
+        let value = unsafe { &mut *core::ptr::from_mut(value) };
+        value
+    }
+}
+
+impl<T, S> SharedStorage<T, S>
+where
+    T: BorshSerialize + BorshDeserialize + Mergeable + Default + Data,
     S: StorageAdaptor,
 {
     /// Mutable access to a collection value (`UnorderedMap`, `UnorderedSet`, …)
@@ -150,127 +281,149 @@ where
     ///
     /// Re-establishes the writer domain on the collection's element before
     /// handing out the reference, so every entry inserted through it inherits
-    /// `Shared{writers}` and is guarded at merge — including after a reload,
-    /// where the collection element's own domain may not have been persisted.
+    /// `Shared{writers}` and is guarded at merge — including after a reload.
     /// Only collections (which implement [`Data`]) get this; a scalar value is
-    /// edited via the whole-value replace path instead.
-    ///
-    /// # Rotation semantics (current)
-    /// Each entry is stamped with the writer set current at the time it is
-    /// written, carried inline on that entry. So after `rotate_writers`, new
-    /// entries are guarded by the new set, but entries written before the
-    /// rotation keep their own stamp and remain verifiable against the old set —
-    /// rotation is forward-only, it does not retroactively revoke write access to
-    /// existing entries. Making every entry re-resolve the writer set from the
-    /// wrapper's rotation log at the op's causal cut (so a rotation revokes the
-    /// whole subtree) needs the DAG-causal rotation machinery; doing it by
-    /// re-stamping entries eagerly diverges the root hash across peers (see the
-    /// note on `rotate_writers`). Until then, treat a guarded collection's writer
-    /// set as effectively fixed for already-written entries.
+    /// edited via [`insert`](SharedStorage::insert) instead.
     ///
     /// # Errors
     /// Currently infallible; the `Result` is preserved for forward compatibility.
     pub fn get_mut(&mut self) -> Result<&mut T, StoreError> {
-        // Re-establish the domain only when it isn't already current, so a
-        // read-mostly `get_mut` doesn't spuriously mark the element dirty.
+        let writers = self.current_writers();
+        let value = self.load_value();
         let already_current = matches!(
-            &self.value.element().metadata.storage_type,
-            crate::entities::StorageType::Shared { writers, .. } if writers == &self.writers
+            &value.element().metadata.storage_type,
+            StorageType::Shared { writers: w, .. } if w == &writers
         );
         if !already_current {
-            self.value
-                .element_mut()
-                .set_shared_domain(self.writers.clone());
+            value.element_mut().set_shared_domain(writers);
         }
-        Ok(&mut self.value)
+        Ok(value)
     }
 }
 
 impl<T, S> SharedStorage<T, S>
 where
-    T: BorshSerialize + BorshDeserialize + Mergeable,
+    T: BorshSerialize + BorshDeserialize + Mergeable + Default,
     S: StorageAdaptor,
 {
-    /// Get a reference to the current value.
+    /// Get a reference to the current value (anyone can read).
     ///
     /// # Errors
-    /// Currently infallible; the `Result` is preserved for forward compatibility
-    /// (e.g., a future variant could lazy-load the value from storage).
+    /// Currently infallible; the `Result` is preserved for forward compatibility.
     pub fn get(&self) -> Result<&T, StoreError> {
-        Ok(&self.value)
+        Ok(self.load_value())
+    }
+
+    /// The current writer set, resolved from the authoritative source.
+    ///
+    /// Resolution order:
+    /// 1. **Rotation log** (`rotation_log::load`). On a node that *received*
+    ///    rotations, the apply path appends every signature-verified rotation
+    ///    here, so the latest entry is the authoritative, verified writer set.
+    ///    (The full causal `writers_at(parents)` resolution is the node-side
+    ///    apply-time check; with no DAG context during local execution the
+    ///    most-recently-appended entry is the right local answer.)
+    /// 2. **Index `storage_type`** — the fallback for the *originating* node,
+    ///    whose own rotations are not self-applied so its log stays empty.
+    ///    `rotate_writers` writes the new set here on the originator (see
+    ///    [`Index::set_storage_type`]).
+    /// 3. **In-memory `Element`** — bootstrap, for a freshly-created wrapper that
+    ///    has not been committed yet.
+    fn current_writers(&self) -> BTreeSet<PublicKey> {
+        if let Ok(Some(log)) = rotation_log::load::<S>(self.inner.id()) {
+            if let Some(entry) = log.entries.last() {
+                return entry.new_writers.clone();
+            }
+            if let Some(snapshot) = log.snapshot {
+                return snapshot.writers;
+            }
+        }
+        if let Ok(Some(metadata)) = <Index<S>>::get_metadata(self.inner.id()) {
+            if let StorageType::Shared { writers, .. } = metadata.storage_type {
+                return writers;
+            }
+        }
+        match &self.inner.element().metadata.storage_type {
+            StorageType::Shared { writers, .. } => writers.clone(),
+            _ => BTreeSet::new(),
+        }
     }
 
     /// Read the current writer set. Public so callers can present a
-    /// "members with edit rights" UI and compute incremental rotations
-    /// (current set + new mod) without mirroring the set elsewhere.
-    pub fn writers(&self) -> &BTreeSet<PublicKey> {
-        &self.writers
+    /// "members with edit rights" UI and compute incremental rotations.
+    pub fn writers(&self) -> BTreeSet<PublicKey> {
+        self.current_writers()
     }
 
     /// Whether the writer set has been frozen. Once frozen, `rotate_writers`
     /// is permanently rejected.
     pub fn is_frozen(&self) -> bool {
-        self.writers_frozen
+        self.frozen
     }
 
-    /// Returns the signature attached to the most recently applied state of
-    /// this entity, if any. Reads from the wrapper field first; if unset
-    /// (e.g., the wrapper was just deserialized and the field hasn't been
-    /// mirrored in this execution), falls back to the metadata copy populated
-    /// by `find_by_id` from the index.
+    /// Returns the signature attached to the most recently applied rotation of
+    /// the wrapper entity, if any. Reads the wrapper's index metadata first
+    /// (the applied, verified state), then the in-memory `Element`.
     pub fn signature(&self) -> Option<SignatureData> {
-        if self.signature_data.is_some() {
-            return self.signature_data;
+        if let Ok(Some(metadata)) = <Index<S>>::get_metadata(self.inner.id()) {
+            if let StorageType::Shared { signature_data, .. } = metadata.storage_type {
+                return signature_data;
+            }
         }
-        match &self.storage.metadata.storage_type {
-            crate::entities::StorageType::Shared { signature_data, .. } => *signature_data,
+        match &self.inner.element().metadata.storage_type {
+            StorageType::Shared { signature_data, .. } => *signature_data,
             _ => None,
         }
     }
 
     /// Replace the value. The executor must be in the current writer set.
     ///
-    /// Returns the previous value. Note: on the first call, returns
-    /// `Some(T::default())` (not `None`) because the wrapper is initialized
-    /// with `T::default()` per the spec — the wrapper has no "uninitialized"
-    /// state to distinguish.
+    /// Writes the value entry stamped `Shared{writers}`, which emits a signed
+    /// per-entity `Update` action verified against the writer set on peers.
+    /// Returns the previous value (`Some(T::default())` on the first call).
     ///
     /// # Errors
-    /// Returns `ActionNotAllowed` if the executor is not in `writers`, or
-    /// `NonceOverflow` if `writers_nonce` would exceed `u64::MAX`.
+    /// Returns `ActionNotAllowed` if the executor is not in the writer set.
+    #[expect(clippy::unwrap_in_result, reason = "value entry id is well-formed")]
     pub fn insert(&mut self, value: T) -> Result<Option<T>, StoreError> {
         let executor: PublicKey = env::executor_id().into();
-        if !self.writers.contains(&executor) {
+        let writers = self.current_writers();
+        if !writers.contains(&executor) {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Executor is not a writer of this SharedStorage".to_owned(),
             )));
         }
-        let next_nonce = self.writers_nonce.checked_add(1).ok_or_else(|| {
-            StoreError::StorageError(StorageError::ActionNotAllowed(
-                "writers_nonce overflow".to_owned(),
-            ))
-        })?;
-        let old = mem::replace(&mut self.value, value);
-        self.writers_nonce = next_nonce;
-        self.storage.update();
-        // (v2 attempted to emit a per-entity Update action here so the
-        // merge-time verifier on remote peers would run. Disabled: it
-        // breaks cross-node sync because the wrapper also propagates inline
-        // via root-state borsh, and the dual-write path causes a WASM trap
-        // during `__calimero_sync_next`. Per-entity verification will become
-        // live as part of the DAG-causal epic #2233 with a proper design.)
+
+        let old = self.inner.get(self.value_id())?.unwrap_or_default();
+
+        let value_id = self.value_id();
+        let new = self.inner.insert_with_storage_type(
+            Some(value_id),
+            value,
+            StorageType::Shared {
+                writers,
+                signature_data: None,
+            },
+        )?;
+        *self.value.borrow_mut() = Some(new);
         Ok(Some(old))
     }
 
     /// Rotate the writer set. Must be called by a current writer; rejected if
-    /// `writers_frozen` was set at construction or if `new_writers` is empty.
+    /// `frozen` or if `new_writers` is empty.
+    ///
+    /// Re-stamps the **wrapper entity** with `Shared{new_writers}` and persists
+    /// it, emitting a signed per-entity `Update` for the wrapper. On a peer the
+    /// action is verified against the *old* writer set (resolved from the
+    /// rotation log at the delta's causal point), and on success the rotation is
+    /// appended to the wrapper's rotation log — so a forged rotation from a
+    /// non-writer is rejected and never updates the log.
     ///
     /// # Errors
-    /// Returns `ActionNotAllowed` if `writers_frozen` is set, if `new_writers`
-    /// is empty (which would permanently lock the storage), if the executor is
-    /// not currently in the writer set, or if `writers_nonce` would overflow.
+    /// Returns `ActionNotAllowed` if `frozen`, if `new_writers` is empty, or if
+    /// the executor is not currently in the writer set.
     pub fn rotate_writers(&mut self, new_writers: BTreeSet<PublicKey>) -> Result<(), StoreError> {
-        if self.writers_frozen {
+        if self.frozen {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Cannot rotate writers of frozen SharedStorage".to_owned(),
             )));
@@ -281,31 +434,57 @@ where
             )));
         }
         let executor: PublicKey = env::executor_id().into();
-        if !self.writers.contains(&executor) {
+        let writers = self.current_writers();
+        if !writers.contains(&executor) {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Executor is not a current writer".to_owned(),
             )));
         }
-        let next_nonce = self.writers_nonce.checked_add(1).ok_or_else(|| {
-            StoreError::StorageError(StorageError::ActionNotAllowed(
-                "writers_nonce overflow".to_owned(),
-            ))
-        })?;
-        self.writers = new_writers.clone();
-        self.writers_nonce = next_nonce;
-        self.storage.set_shared_domain(new_writers);
-        // (v2 attempted to emit a per-entity Update action here so the
-        // merge-time verifier on remote peers would run against the rotation.
-        // Disabled: the wrapper also propagates inline via root-state borsh,
-        // and the dual-write path makes the receiver compute a different root
-        // hash from the sender — every rotation produces a permanent
-        // divergence. Per-entity live verification will become safe once the
-        // DAG-causal epic #2233 lands and we can drop the root-state path.)
+
+        let wrapper_id = self.inner.id();
+        let new_shared = StorageType::Shared {
+            writers: new_writers.clone(),
+            signature_data: None,
+        };
+
+        // Stamp the wrapper entity with the new set and persist. This emits a
+        // signed per-entity `Update` for the wrapper; a receiver verifies it
+        // against the *old* writer set (its rotation log at the delta's causal
+        // point) and appends the new set to the wrapper's rotation log.
+        self.inner
+            .element_mut()
+            .set_shared_domain(new_writers.clone());
+        let _saved = <Interface<S>>::save(&mut self.inner)?;
+
+        // Re-stamp the single value entry too, if it has been materialised. The
+        // value lives in its own entity, verified at merge against *its* writer
+        // set; without re-stamping, a writer added by this rotation could never
+        // write the value (the entry would stay guarded by the pre-rotation
+        // set). Re-stamping emits a signed `Update` (data unchanged → hash
+        // unchanged, no divergence) so the receiver appends the new set to the
+        // value entry's own rotation log, and the new writer's later writes
+        // verify. This is the single-child analogue of the per-collection
+        // anchor-inheritance that retroactive collection revocation will
+        // generalise.
+        let value_id = self.value_id();
+        if let Some(value) = self.inner.get(value_id)? {
+            let _restamped =
+                self.inner
+                    .insert_with_storage_type(Some(value_id), value, new_shared.clone())?;
+            // Originating-node fallback: persist the new set on the value
+            // entry's index too (its rotation log is only appended on receivers).
+            let _ignored = <Index<S>>::set_storage_type(value_id, new_shared.clone());
+        }
+
+        // Originating-node fallback: persist the new set on the wrapper's index,
+        // since this node does not self-apply its own rotation into its log.
+        let _ignored = <Index<S>>::set_storage_type(wrapper_id, new_shared);
         Ok(())
     }
 }
 
-// Implement Data so SharedStorage can be nested in #[app::state].
+// Implement Data so SharedStorage can be nested in #[app::state]; the wrapper
+// entity is the inner collection's element.
 impl<T, S> Data for SharedStorage<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
@@ -316,54 +495,30 @@ where
     }
 
     fn element(&self) -> &Element {
-        &self.storage
+        self.inner.element()
     }
 
     fn element_mut(&mut self) -> &mut Element {
-        &mut self.storage
+        self.inner.element_mut()
     }
 }
 
-// Mergeable: invoked at root-state merge time when concurrent state versions
-// must converge. Merges value via its own Mergeable, and resolves writer-set
-// state by `writers_nonce` (higher wins, content as deterministic tiebreaker).
-// `writers_frozen` is monotonic — once true on either side, stays true.
+// Mergeable: invoked at root-state merge time. The value is a separate entity
+// (synced + merged per-entity), and the writer set converges via the rotation
+// log on the node side — so the only field merged here is `frozen` (monotonic).
 impl<T, S> Mergeable for SharedStorage<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor,
 {
     fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
-        self.value.merge(&other.value)?;
-
-        // Writer-set: higher writers_nonce wins. On tie, lexically smaller set
-        // wins (deterministic across nodes).
-        //
-        // Guard against accepting an empty writer set from a peer — this would
-        // permanently lock the storage (no one could write or rotate again).
-        // The local API rejects empty rotations; mirror that here so a tampered
-        // or buggy peer can't propagate a lockout via merge.
-        //
-        // Important: do NOT call `self.storage.set_shared_domain(...)` here.
-        // That would mark the wrapper element dirty, which on the receiving
-        // node makes `commit_root` emit a per-entity Update action that the
-        // sender never produced — divergent DAG, divergent root hash.
-        // The wrapper's `writers` field on the struct (borsh-serialized) is
-        // the source of truth on the wire; metadata's storage_type only
-        // matters for actions emitted by the originator, not by the merger.
-        if !other.writers.is_empty()
-            && (other.writers_nonce > self.writers_nonce
-                || (other.writers_nonce == self.writers_nonce && other.writers < self.writers))
-        {
-            self.writers = other.writers.clone();
-            self.writers_nonce = other.writers_nonce;
+        // Frozen is monotonic: once set on either side, stays set. No
+        // writer-set merge here — that would be the forgeable LWW-on-root-state
+        // path the handle design removes; convergence is the verified rotation
+        // log + ADR 0001, applied on the node side.
+        if other.frozen {
+            self.frozen = true;
         }
-
-        // Frozen is monotonic.
-        if other.writers_frozen {
-            self.writers_frozen = true;
-        }
-
         Ok(())
     }
 }
@@ -431,11 +586,12 @@ mod tests {
         use crate::store::MainStorage;
 
         env::reset_for_testing();
+        env::set_executor_id([7u8; 32]);
 
         type Map = UnorderedMap<String, LwwRegister<String>>;
 
         let ws = writers(&[[7u8; 32]]);
-        let mut guarded: SharedStorage<Map> = SharedStorage::new(ws.clone(), false);
+        let mut guarded = Root::new(|| SharedStorage::<Map>::new(ws.clone(), false));
 
         // Edit the inner map in place through the guarded `get_mut`, which
         // re-establishes the writer domain on the map element first.
@@ -457,57 +613,6 @@ mod tests {
         match entry.storage.metadata.storage_type {
             StorageType::Shared { writers: w, .. } => assert_eq!(w, ws),
             other => panic!("SharedStorage<Map> entry must inherit Shared, got {other:?}"),
-        }
-    }
-
-    #[test]
-    #[serial]
-    fn shared_collection_guards_entries_after_reload() {
-        use borsh::{from_slice, to_vec};
-
-        use crate::collections::{compute_id, LwwRegister, UnorderedMap};
-        use crate::entities::{Data, StorageType};
-        use crate::interface::Interface;
-        use crate::store::MainStorage;
-
-        env::reset_for_testing();
-
-        type Map = UnorderedMap<String, LwwRegister<String>>;
-
-        let ws = writers(&[[7u8; 32]]);
-        let mut guarded: SharedStorage<Map> = SharedStorage::new(ws.clone(), false);
-        let _old = guarded
-            .get_mut()
-            .expect("get_mut")
-            .insert("a".to_owned(), LwwRegister::new("1".to_owned()))
-            .expect("insert a");
-
-        // Simulate a reload: borsh round-trip the wrapper. The in-memory writer
-        // domain on the collection element is dropped, but `writers` (a persisted
-        // field) survives — it is the source of truth.
-        let bytes = to_vec(&guarded).expect("serialize wrapper");
-        let mut reloaded: SharedStorage<Map> = from_slice(&bytes).expect("deserialize wrapper");
-        assert_eq!(reloaded.writers(), &ws, "writer set must survive reload");
-
-        // After reload, `get_mut` re-derives the domain from the persisted writer
-        // set, so a NEW entry is still guarded — the guarantee does not depend on
-        // the element domain itself persisting.
-        let _old = reloaded
-            .get_mut()
-            .expect("get_mut after reload")
-            .insert("b".to_owned(), LwwRegister::new("2".to_owned()))
-            .expect("insert b");
-
-        let map_id = <Map as Data>::id(reloaded.get().expect("get"));
-        let child_b = compute_id(map_id, "b".as_bytes());
-        let entry = <Interface<MainStorage>>::find_by_id::<
-            crate::collections::Entry<(String, LwwRegister<String>)>,
-        >(child_b)
-        .expect("load child b")
-        .expect("child b exists");
-        match entry.storage.metadata.storage_type {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, ws),
-            other => panic!("entry written after reload must be guarded, got {other:?}"),
         }
     }
 
@@ -620,13 +725,12 @@ mod tests {
         let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
 
         // Bootstrap-time writer set is observable.
-        assert_eq!(s.writers(), &writers(&[ALICE, BOB]));
+        assert_eq!(s.writers(), writers(&[ALICE, BOB]));
         assert!(!s.is_frozen());
 
-        // After a rotation, the accessor sees the new set without the
-        // caller having to mirror it elsewhere.
+        // After a rotation, the accessor sees the new set.
         s.rotate_writers(writers(&[ALICE, CAROL])).unwrap();
-        assert_eq!(s.writers(), &writers(&[ALICE, CAROL]));
+        assert_eq!(s.writers(), writers(&[ALICE, CAROL]));
         assert!(!s.is_frozen());
     }
 
@@ -639,7 +743,7 @@ mod tests {
         let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), true));
 
         assert!(s.is_frozen());
-        assert_eq!(s.writers(), &writers(&[ALICE]));
+        assert_eq!(s.writers(), writers(&[ALICE]));
 
         // A frozen instance must reject rotation regardless of caller.
         let err = s
@@ -651,26 +755,7 @@ mod tests {
         );
 
         // The set is unchanged after the rejected rotation.
-        assert_eq!(s.writers(), &writers(&[ALICE]));
-    }
-
-    #[test]
-    #[serial]
-    fn merge_higher_writers_nonce_wins() {
-        env::reset_for_testing();
-        env::set_executor_id(ALICE);
-        let mut a = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
-
-        env::set_executor_id(BOB);
-        let mut b = SharedStorage::<TestVal>::new(writers(&[BOB]), false);
-        // Bump b's nonce by performing a rotation.
-        b.rotate_writers(writers(&[BOB, CAROL])).unwrap();
-        let bob_nonce = b.writers_nonce;
-        assert!(bob_nonce > a.writers_nonce);
-
-        Mergeable::merge(&mut a, &b).unwrap();
-        assert_eq!(a.writers, writers(&[BOB, CAROL]));
-        assert_eq!(a.writers_nonce, bob_nonce);
+        assert_eq!(s.writers(), writers(&[ALICE]));
     }
 
     #[test]
@@ -678,33 +763,20 @@ mod tests {
     fn merge_frozen_is_monotonic() {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
+        // Establish ROOT so the wrapper's `add_child_to(ROOT)` succeeds.
+        let _root: Root<TestVal> = Root::new(TestVal::default);
         let mut a = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
         let b = SharedStorage::<TestVal>::new(writers(&[ALICE]), true);
 
         Mergeable::merge(&mut a, &b).unwrap();
-        assert!(a.writers_frozen, "frozen=true on b should propagate to a");
+        assert!(a.frozen, "frozen=true on b should propagate to a");
 
         // Reverse direction: frozen stays once set.
+        let _root2: Root<TestVal> = Root::new(TestVal::default);
         let mut a2 = SharedStorage::<TestVal>::new(writers(&[ALICE]), true);
         let b2 = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
         Mergeable::merge(&mut a2, &b2).unwrap();
-        assert!(
-            a2.writers_frozen,
-            "frozen=true on a2 must not be cleared by merge"
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn merge_tiebreak_lexically_smaller_wins() {
-        env::reset_for_testing();
-        env::set_executor_id(ALICE);
-        // Force equal nonces and different writer sets to exercise the tiebreaker.
-        let mut a = SharedStorage::<TestVal>::new(writers(&[BOB]), false);
-        let b = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
-        // Both at nonce=0, different content. ALICE's pubkey < BOB's pubkey.
-        Mergeable::merge(&mut a, &b).unwrap();
-        assert_eq!(a.writers, writers(&[ALICE]));
+        assert!(a2.frozen, "frozen=true on a2 must not be cleared by merge");
     }
 
     #[test]

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -259,6 +259,12 @@ where
     /// entry may not exist yet on a peer that received the wrapper before the
     /// value's per-entity `Add` synced, so a missing entry yields `T::default()`
     /// rather than panicking.
+    ///
+    /// The `unsafe` ptr cast ties the returned `&mut T` to `&self` and **drops
+    /// the `RefMut` guard** at the end of this call (mirroring [`Root::get`]) —
+    /// so a later call does not collide with a still-held `RefCell` borrow.
+    /// Sound because storage values are never aliased (each read deserializes a
+    /// fresh copy) and execution is single-threaded WASM.
     #[expect(
         clippy::mut_from_ref,
         clippy::expect_used,

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -609,6 +609,32 @@ impl<S: StorageAdaptor> Index<S> {
         Ok(Self::get_index(id)?.map(|index| index.metadata))
     }
 
+    /// Persist a new `storage_type` for an existing entity's index entry.
+    ///
+    /// `storage_type` is not part of any Merkle hash (it lives in
+    /// [`EntityIndex::metadata`], separate from the hashed entity bytes), so
+    /// this is hash-neutral and cannot cause root-hash divergence. It exists so
+    /// a `SharedStorage` writer-set rotation can persist the new set on the
+    /// **originating** node, whose rotation log is not appended locally (only
+    /// the apply path on a *receiving* node appends it). On receivers the log is
+    /// the authoritative source; this keeps the local index a correct fallback.
+    ///
+    /// No-op if the entity has no index entry yet.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the index cannot be loaded or written.
+    pub(crate) fn set_storage_type(
+        id: Id,
+        storage_type: crate::entities::StorageType,
+    ) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
+        if let Some(mut index) = Self::get_index(id)? {
+            index.metadata.storage_type = storage_type;
+            Self::save_index(&index)?;
+        }
+        Ok(())
+    }
+
     /// Checks if an entity is deleted (tombstone marker set).
     ///
     /// Returns false if entity has no index (not found).

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -629,6 +629,9 @@ impl<S: StorageAdaptor> Index<S> {
     ) -> Result<(), StorageError> {
         let _mutation_guard = index_mutation_guard();
         if let Some(mut index) = Self::get_index(id)? {
+            if index.metadata.storage_type == storage_type {
+                return Ok(()); // unchanged — skip the redundant write
+            }
             index.metadata.storage_type = storage_type;
             Self::save_index(&index)?;
         }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1449,6 +1449,60 @@ mod shared_storage_rotation_authentication {
     }
 
     #[test]
+    fn forged_rotation_rejected_via_stored_writers_fallback() {
+        // Complement to `forged_shared_rotation_rejected_at_merge`: exercise the
+        // path where the apply context carries NO `effective_writers` (empty
+        // ctx). The verifier must then fall back to the entity's *stored* writer
+        // set and still reject a non-writer's forged rotation — covering the
+        // case where rotation-log resolution yielded nothing.
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let mallory_sk = make_signing_key(0x4D);
+        let mallory = pubkey_of(&mallory_sk);
+
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+        let id = Id::new([0x5E; 32]);
+
+        let nonce1 = env::time_now();
+        let bootstrap = build_signed_shared_action(
+            true,
+            id,
+            b"v0".to_vec(),
+            writers.clone(),
+            nonce1,
+            &alice_sk,
+            vec![root],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+
+        // Empty ctx → no effective_writers → verifier falls back to stored
+        // writers {alice}; mallory's signature is not from a stored writer.
+        let forged = build_signed_shared_action(
+            false,
+            id,
+            b"v0".to_vec(),
+            [mallory].into_iter().collect(),
+            nonce1 + 1_000_000,
+            &mallory_sk,
+            vec![],
+        );
+        let result = MainInterface::apply_action(forged, &ApplyContext::empty());
+        assert!(
+            matches!(result, Err(StorageError::InvalidSignature)),
+            "forged rotation must be rejected via the stored-writers fallback, got {result:?}"
+        );
+
+        let stored = <Index<MainStorage>>::get_metadata(id).unwrap().unwrap();
+        match stored.storage_type {
+            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            other => panic!("expected Shared storage_type, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn authentic_rotation_by_current_writer_accepted() {
         env::reset_for_testing();
         let root = setup_root_for_main();

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1357,6 +1357,144 @@ mod shared_storage_replay_protection {
     }
 }
 
+/// Tests for `SharedStorage` writer-set rotation authentication.
+///
+/// A writer-set rotation propagates as a signed per-entity action and is
+/// verified at merge against the *current* writer set (resolved from the
+/// rotation log / `effective_writers`, with the stored writers as the
+/// fallback). A rotation forged by a non-writer must be rejected — this is the
+/// merge-time backstop behind the local writer gate, and the property that
+/// makes the writer set unforgeable.
+#[cfg(test)]
+mod shared_storage_rotation_authentication {
+    use std::collections::BTreeSet;
+
+    use ed25519_dalek::SigningKey;
+
+    use crate::address::Id;
+    use crate::entities::StorageType;
+    use crate::env;
+    use crate::index::Index;
+    use crate::interface::{ApplyContext, MainInterface, StorageError};
+    use crate::store::MainStorage;
+    use crate::tests::common::{build_signed_shared_action, pubkey_of, setup_root_for_main};
+
+    fn make_signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    #[test]
+    fn forged_shared_rotation_rejected_at_merge() {
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let mallory_sk = make_signing_key(0x4D); // a context member, NOT a writer
+        let mallory = pubkey_of(&mallory_sk);
+
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+        let id = Id::new([0x5E; 32]);
+
+        // Bootstrap the Shared entity with writers = {alice}, signed by alice.
+        let nonce1 = env::time_now();
+        let bootstrap = build_signed_shared_action(
+            true,
+            id,
+            b"v0".to_vec(),
+            writers.clone(),
+            nonce1,
+            &alice_sk,
+            vec![root],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+
+        // Mallory forges a rotation: an Update that swaps the writer set to
+        // {mallory}, signed by mallory (who is not a current writer). The
+        // verifier resolves the authoritative writer set to {alice} (here via
+        // effective_writers, as the node sync layer would from the rotation
+        // log) and rejects mallory's signature.
+        let forged = build_signed_shared_action(
+            false,
+            id,
+            b"v0".to_vec(),
+            [mallory].into_iter().collect(),
+            nonce1 + 1_000_000,
+            &mallory_sk,
+            vec![],
+        );
+        let ctx = ApplyContext {
+            effective_writers: Some(writers.clone()),
+            delta_id: None,
+            delta_hlc: None,
+        };
+        let result = MainInterface::apply_action(forged, &ctx);
+        assert!(
+            matches!(result, Err(StorageError::InvalidSignature)),
+            "forged rotation by a non-writer must be rejected, got {result:?}"
+        );
+
+        // The stored writer set is unchanged: the honest node still trusts only
+        // {alice}.
+        let stored = <Index<MainStorage>>::get_metadata(id).unwrap().unwrap();
+        match stored.storage_type {
+            StorageType::Shared { writers: w, .. } => {
+                assert_eq!(
+                    w, writers,
+                    "writer set must be unchanged after forged rotation"
+                );
+            }
+            other => panic!("expected Shared storage_type, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn authentic_rotation_by_current_writer_accepted() {
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let bob_sk = make_signing_key(0xB0);
+        let bob = pubkey_of(&bob_sk);
+
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+        let id = Id::new([0x5E; 32]);
+
+        let nonce1 = env::time_now();
+        let bootstrap = build_signed_shared_action(
+            true,
+            id,
+            b"v0".to_vec(),
+            writers.clone(),
+            nonce1,
+            &alice_sk,
+            vec![root],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+
+        // Alice (a current writer) rotates the set to {alice, bob}. Verified
+        // against the current set {alice}; alice's signature is valid.
+        let new_writers: BTreeSet<_> = [alice, bob].into_iter().collect();
+        let rotation = build_signed_shared_action(
+            false,
+            id,
+            b"v0".to_vec(),
+            new_writers.clone(),
+            nonce1 + 1_000_000,
+            &alice_sk,
+            vec![],
+        );
+        let ctx = ApplyContext {
+            effective_writers: Some(writers),
+            delta_id: None,
+            delta_hlc: None,
+        };
+        MainInterface::apply_action(rotation, &ctx)
+            .expect("authentic rotation by a current writer must be accepted");
+    }
+}
+
 /// Tests for Frozen storage verification.
 ///
 /// Frozen storage is immutable and content-addressed:

--- a/docs/design/2230-shared-wrapper-verification.md
+++ b/docs/design/2230-shared-wrapper-verification.md
@@ -1,0 +1,154 @@
+# Design — Authenticate the `SharedStorage` writer-set rotation (#2230 item 1)
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Date** | 2026-06-02 |
+| **Owner** | Storage / Context / Node sync |
+| **Issue** | #2230 (SharedStorage v2: live per-entity verification) — **item 1 only** |
+| **Builds on** | #2588 (collection guarding — child entries verified at merge), #2266/#2233 (DAG-causal `writers_at`), the `stored ∪ claimed` signing fix |
+
+> Illustrative; not final signatures.
+
+## 1. What is already done (scope reduction)
+
+#2230 listed four items. Three are effectively closed:
+
+- **Item 2 — rotate-self-out signing.** Done: `save_raw` stamps the signing
+  placeholder on `stored ∪ claimed` writers (`interface.rs:2660`), so a writer
+  rotating itself out (executor ∈ stored, ∉ claimed) still signs;
+  `sign_authorized_actions` signs whenever the placeholder is present
+  (`execute/mod.rs:1956`).
+- **Item 4 — signer-pubkey hint.** Done: `SignatureData.signer` + the fast-path
+  single-verify (`action.rs:295`, `interface.rs:308`).
+- **Item 1 (data writes) — covered by #2588.** A guarded collection's **child
+  entries** now sync as their own entities and are verified at merge against
+  `effective_writers` (proven by the `shared-storage` adversarial e2e: a
+  non-writer's forged map entry is rejected). So *writes to the data* are
+  authenticated.
+
+**What remains: authenticating the writer-set *rotation* itself** (and item 3,
+populating `signature_data`, which rides on it).
+
+## 2. The remaining gap
+
+The `SharedStorage` **wrapper's** own state — `value` (for a scalar), `writers`,
+`writers_nonce` — propagates via the **root-state borsh sync path**: the wrapper
+is an inline field of the enclosing `#[app::state]` struct, so its bytes ride in
+the root state, and writer-set convergence is `SharedStorage::merge` doing **LWW
+on `writers_nonce`** (`shared.rs`). That merge does **not verify who rotated** —
+it just takes the higher nonce.
+
+`rotate_writers` checks `executor ∈ writers` *locally* (`shared.rs:283`), but that
+is an API-layer check. A malicious context **member** (not a current writer) can
+hand-craft a root-state delta that bumps `writers_nonce` and swaps `writers` to
+themselves — bypassing the local check — and the LWW merge on honest peers
+accepts it. **Writer-set rotation is currently unauthenticated at merge.**
+
+(Data writes are safe — they're per-entity verified — but whoever controls the
+writer set controls all future writes, so an unauthenticated rotation defeats the
+whole guarantee.)
+
+## 3. Why the obvious fix traps: the dual-write hazard
+
+The wired-but-disabled approach was: on `insert`/`rotate_writers`, also emit a
+per-entity `Update` action for the wrapper so the merge-time `Shared` verifier
+runs (`shared.rs:256`, `:297`). It is disabled because the wrapper **also**
+propagates inline via root-state borsh, so the data flows **twice** →
+
+- the receiver computes a **different root hash** than the sender (permanent
+  divergence — "every rotation produces a permanent divergence"), and
+- a **WASM trap during `__calimero_sync_next`**.
+
+So per-entity verification can't be *added on top of* root-state borsh. The
+duplication has to be removed.
+
+## 4. The fork
+
+- **(a) Dual-write** (root-state borsh + per-entity action). Rejected — it is the
+  disabled path above (divergence + trap). Making the root hash ignore the
+  wrapper's double contribution is fragile and exactly what bit v2.
+- **(b) Suppress the root-state duplication.** The wrapper's mutable state lives
+  **only in its own storage entity**, synced via per-entity `Update` actions
+  (verified against the writer set, like #2588's child entries). The root state
+  carries only a **reference** (the wrapper's entity id), not the inline bytes —
+  exactly how a **collection** already behaves (an `UnorderedMap`'s root-state
+  borsh is just its id; its data is in child entities). **Recommended.**
+
+Why (b) is now the natural choice: #2588 already makes the wrapper a child of
+root (`add_child_to(*ROOT_ID)`) and makes per-entity `Shared` verification a live,
+tested path. (b) finishes the job — it stops the wrapper from *also* serializing
+its state into the root blob, so the single source of truth is the verified
+per-entity entity.
+
+## 5. Mechanism (option b)
+
+1. **Wrapper borsh = ref, not inline.** `SharedStorage<T>` must serialize into the
+   root state as its entity id only (+ the `_adaptor` marker), with `value`,
+   `writers`, `writers_frozen`, `writers_nonce`, `signature_data` persisted on its
+   **own** entity. Two ways:
+   - a custom `BorshSerialize/Deserialize` that writes the id and lazy-loads the
+     body from storage on access (like `Collection`), or
+   - have `#[app::state]` treat `SharedStorage` fields like collection fields
+     (it already special-cases them in the deterministic-id pass — same predicate).
+2. **Mutation emits a verified per-entity Update.** `insert`/`rotate_writers`
+   `Interface::save(self)` (or `add_child_to`) so each mutation produces an
+   `Update` action carrying the wrapper's bytes + `StorageType::Shared` metadata,
+   signed by the executor (gated by the existing `stored ∪ claimed` rule, which
+   already handles rotate-self-out). No root-state duplication ⇒ no divergence.
+3. **Merge verifies the rotation.** On apply, the node resolves `effective_writers`
+   for the wrapper entity (from its rotation log via `writers_at`) and
+   `apply_action` validates the signature — so a forged rotation from a non-writer
+   is rejected, exactly like a forged data write today.
+4. **Item 3 (populate `signature_data`)** falls out: after signing, write the
+   `SignatureData` from the action metadata back onto the wrapper's field (the
+   wrapper is now a real entity in the action stream).
+
+The wrapper's own rotation log already exists conceptually (it's the anchor #2590
+will also point children at); this makes it the *authenticated* source of truth
+for the writer set.
+
+## 6. Risks
+
+- **Borsh/wire change** for how `SharedStorage` serializes into root state
+  (ref vs inline) — needs a migration/version story for existing `SharedStorage`
+  state (the `scenario-shared-storage` fixtures, `kv-store-with-shared-storage`).
+- **Convergence under concurrent rotation** — once rotations are per-entity
+  actions, concurrent rotations converge by the ADR 0001 rule via the wrapper's
+  rotation log (the machinery exists); must be tested, it is the split-brain-prone
+  part.
+- **Migration of in-flight root-state SharedStorage** to the ref form on first
+  load.
+
+## 7. Plan
+
+1. **P1 — wrapper-as-entity (suppress root-state inline).** Custom borsh / macro
+   special-case so the wrapper serializes as a ref; persist its body on its own
+   entity. No behaviour change to verification yet; assert root hashes match
+   sender/receiver (no divergence) on a 2-node e2e.
+2. **P2 — emit verified per-entity Update on mutation.** Re-enable the disabled
+   `Interface::save(self)` in `insert`/`rotate_writers`; drop the root-state LWW
+   merge for the wrapper. Negative e2e: a **non-writer member's forged rotation is
+   rejected** (extend `kv-store-with-shared-storage`'s adversarial workflow).
+3. **P3 — populate `signature_data`** writeback (item 3) + signer-hint already
+   present.
+4. **P4 — concurrent-rotation convergence tests** on the #2552 harness +
+   migration of existing root-state SharedStorage to the ref form.
+
+## 8. Test plan
+
+- **Forged-rotation rejected (the proof):** a non-writer context member crafts a
+  writer-set rotation; honest node rejects it, writer set unchanged. Mirror of
+  the #2588 forged-data-write e2e.
+- **No divergence:** legit rotation propagates, sender/receiver root hashes match
+  (this is the thing v2's dual-write broke).
+- **Concurrent rotations converge** by ADR 0001.
+- **Rotate-self-out** still works (regression — item 2 already landed).
+
+## 9. Relationship to #2590
+
+#2590 (retroactive rotation revocation for guarded *collections*) needs the
+wrapper's rotation log to be the authenticated anchor. This issue makes that log
+authenticated and live; #2590 then points child entities at it so a rotation
+revokes the whole subtree at the causal cut. So **#2230 item 1 is the prerequisite
+for #2590** — do it first.

--- a/docs/design/2230-shared-wrapper-verification.md
+++ b/docs/design/2230-shared-wrapper-verification.md
@@ -108,6 +108,48 @@ The wrapper's own rotation log already exists conceptually (it's the anchor #259
 will also point children at); this makes it the *authenticated* source of truth
 for the writer set.
 
+## 5a. Implementation recipe (the template exists: `Root<T>`)
+
+`Root<T>` (`collections/root.rs`) is *exactly* the handle shape to copy:
+
+```rust
+pub struct Root<T, S> {
+    inner: Collection<T, S>,           // value stored as ONE entry at a fixed id
+    #[borsh(skip)] value: RefCell<Option<T>>,  // lazy cache, loaded via inner.get(id)
+    #[borsh(skip)] dirty: bool,
+}
+// borsh(Root) == borsh(inner Collection) == just its Element (id + metadata).
+// The value T is NOT in the struct's borsh — it's a separate entity (the entry).
+```
+
+So `SharedStorage<T>` becomes:
+
+```rust
+pub struct SharedStorage<T, S> {
+    inner: Collection<T, S>,           // holds the single value entry, Shared-stamped
+    #[borsh(skip)] value: RefCell<Option<T>>,
+    #[borsh(skip)] frozen: bool,
+    // NO writers / writers_nonce fields — see below.
+}
+```
+
+- `get`/`get_mut` lazy-load the value entry (Root's `get()` pattern); `insert`
+  writes it back; the entry is `Shared{writers}` so writes are verified (#2588).
+- `borsh(SharedStorage) == borsh(inner) == its Element` ⇒ root state carries only
+  the id, no body. **No double-write.**
+
+### Where the writer set lives (the load-bearing detail)
+
+Do **not** keep `writers` inline, and do **not** rely on it riding in the inner
+`Collection`'s Element metadata — that metadata still travels in root state and is
+unverified, so a forged root-state delta could still swap it. Instead the writer
+set is **resolved from the wrapper entity's rotation log** via
+`rotation_log_reader::writers_at` (the verified, per-entity source of truth that
+#2588's child-entry verification already consults). `writers()` reads the log;
+`rotate_writers` appends a signed entry to the log (a verified per-entity action).
+This is what lets `writers_nonce` + the LWW merge be **deleted** — convergence is
+the log + ADR 0001, not nonce-LWW.
+
 ## 6. Risks
 
 - **Borsh/wire change** for how `SharedStorage` serializes into root state


### PR DESCRIPTION
## What

Authenticates the `SharedStorage` writer-set **rotation** (#2230 item 1). The other three items already landed (rotate-self-out signing, signer-pubkey hint, data-write verification via #2588); this closes the last gap.

### The bug
A guarded `SharedStorage`'s data writes were verified, but the writer-set rotation still propagated via unverified root-state borsh + LWW-on-`writers_nonce`. The `executor ∈ writers` check in `rotate_writers` was API-layer only, so a malicious context member could hand-craft a root-state delta that swapped the writer set and LWW accepted it — defeating the whole guarantee.

### The fix
Make `SharedStorage<T>` a handle modeled on `Root<T>`: the value lives in its own `Shared`-stamped entity and the wrapper borsh-serializes as a ref (its `Element`), so the value body no longer rides the root-state blob. The writer set now propagates as a **signed per-entity action** verified at merge, and converges via the rotation log + ADR 0001.

- value → child entry; `#[borsh(skip)]` lazy cache; wrapper borsh = ref (no value in root state → no divergence)
- delete `writers_nonce` + the forgeable LWW writer-set block in `Mergeable::merge`; only `frozen` merges now (monotonic)
- resolve the current writer set from the rotation log, falling back to the index `storage_type` on the originating node (whose own rotation isn't self-applied, so its log isn't appended locally)
- `Collection::new_shared` emits a single `Add(Shared)` for the wrapper (not `Add(Public)` + `Update(Shared)`)
- `rotate_writers` re-stamps the value entry too, so a writer added by the rotation can write the value post-rotation
- `Index::set_storage_type` persists a rotation's new set on the originating node (hash-neutral — `storage_type` isn't part of any Merkle hash)

## Tests
- **storage (unit):** forged rotation by a non-writer is rejected at merge; authentic rotation by a current writer is accepted; full existing `SharedStorage` suite + scalar/collection paths green
- **e2e (`apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml`):** a non-writer's rotation attempt is refused and the writer set is unchanged on the honest node; the existing happy-path (incl. post-rotation writes by the new writer) and forged-map-write rejection still hold

## Validation status
Storage + app unit tests pass locally. Cross-node sync gates (no-divergence + adversarial) run here in CI (`e2e-rust-apps`); local multi-node validation was blocked by Docker VM memory during the fat-LTO merod build.

## Notes
- Design: `docs/design/2230-shared-wrapper-verification.md`
- Concurrent-rotation convergence and migration of existing root-state `SharedStorage` are deferred (P4); this unblocks #2590 (retroactive collection rotation revocation), which generalises the single-child re-stamp here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, writer-set resolution, root-state serialization, and merge behavior for SharedStorage—security-critical sync paths; wire/migration and concurrent-rotation convergence are explicitly deferred.
> 
> **Overview**
> **Closes the `SharedStorage` writer-set rotation hole** (#2230): rotations used to ride unverified root-state borsh with LWW on `writers_nonce`, so any context member could forge a new writer set at merge even though data writes were already verified.
> 
> `SharedStorage` is refactored like `Root<T>`: the payload lives in a single `Shared`-stamped child entity; root borsh is only the wrapper reference (plus `frozen`), so writes and rotations emit **signed per-entity** actions. The current writer set is read from the **rotation log** or index metadata—not inline root-state fields—and `writers_nonce` / writer-set LWW in `Mergeable::merge` are removed (`frozen` is no longer adopted from peers on merge).
> 
> Supporting pieces: `Collection::new_shared` for a one-shot `Add(Shared)` bootstrap; `Index::set_storage_type` for the originating node after rotation; value-entry re-stamp on rotate so new writers can write; e2e helpers (`try_rotate_writers`, `writer_count`) and workflow steps for non-writer rotation refusal; storage tests for forged vs authentic rotation at apply time; design doc added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a666bd50ef511d97e31682879fae58fcc9d8f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->