### PR TITLE
feat(sdk): reject extra arguments on zero-argument methods (#2600)

### DIFF
--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -823,19 +823,24 @@ fn unknown_argument_is_rejected() {
         .expect("valid single-arg call should run");
 }
 
-/// KNOWN LIMITATION: a method with no declared arguments takes the
-/// `args.is_empty()` branch in the macro (`crates/sdk/macros/src/logic/method.rs`),
-/// which emits no input struct and never reads the payload — so extra JSON
-/// fields sent to it are still silently ignored, `deny_unknown_fields`
-/// notwithstanding. This test pins that behavior so a future change to the
-/// no-arg branch is a deliberate, reviewed decision rather than an accident.
+/// A method with no declared arguments (the macro's `args.is_empty()` branch)
+/// rejects a populated JSON object — i.e. extra arguments it cannot consume —
+/// but still accepts an empty `{}` or `null` body, which carry no named
+/// arguments, so callers aren't forced to send a particular empty form
+/// (core#2600).
 #[test]
-fn extra_fields_to_zero_arg_method_are_ignored() {
+fn extra_fields_to_zero_arg_method_are_rejected() {
     let mut c = Cluster::new(1);
     let module = c.module;
-    // `entries` declares no arguments; the surplus field is not rejected.
-    run(module, &mut c.nodes[0], "entries", json!({"bogus": "x"}))
-        .expect("zero-arg method ignores its payload (documented limitation)");
+
+    // `entries` declares no arguments; a field it cannot consume is rejected.
+    assert_unknown_field_rejected(&mut c, "entries", json!({"bogus": "x"}), "bogus");
+
+    // Empty-object and null bodies carry no arguments and must still succeed.
+    run(module, &mut c.nodes[0], "entries", json!({}))
+        .expect("zero-arg method accepts an empty object body");
+    run(module, &mut c.nodes[0], "entries", json!(null))
+        .expect("zero-arg method accepts a null body");
 }
 
 #[test]

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -59,7 +59,31 @@ impl ToTokens for PublicLogicMethod<'_> {
             .any(|modifier| matches!(modifier, Modifer::Init));
 
         let input = if args.is_empty() {
-            quote! {}
+            // No declared arguments: a method that takes none must not silently
+            // accept named ones. An absent body, an empty/`null` body, or any
+            // non-object body carries no named arguments and is accepted (so
+            // callers need not send `{}`); only a populated JSON object — i.e.
+            // actual extra arguments — is rejected. Mirrors `deny_unknown_fields`
+            // on the args-bearing branch below.
+            quote_spanned! {name.span()=>
+                if let Some(input) = ::calimero_sdk::env::input() {
+                    if !input.is_empty() {
+                        if let Ok(::calimero_sdk::serde_json::Value::Object(fields)) =
+                            ::calimero_sdk::serde_json::from_slice::<
+                                ::calimero_sdk::serde_json::Value,
+                            >(&input)
+                        {
+                            if !fields.is_empty() {
+                                ::calimero_sdk::env::panic_str(&format!(
+                                    "Failed to deserialize input from JSON: method takes no \
+                                     arguments but received unknown field(s): {:?}",
+                                    fields.keys().collect::<::std::vec::Vec<_>>()
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
         } else {
             let input_ident = idents::input();
 


### PR DESCRIPTION
Closes #2600. Follow-up to #1646 / #2598.

## Gap

#2598 added `deny_unknown_fields` to the macro-generated input struct, so a method with **declared** arguments now errors on an undeclared field. But a method with **zero** arguments takes the `args.is_empty()` branch of the macro (`crates/sdk/macros/src/logic/method.rs`), which emitted no input handling and never read the payload — so extra JSON fields sent to a no-arg method were still silently ignored.

## Fix

The no-arg branch now inspects the input and rejects a **populated JSON object** (actual extra arguments), panicking with an unknown-field error that names the offending keys. It deliberately stays lenient about the forms that carry no named arguments:

| Body sent to a no-arg method | Result |
|---|---|
| absent / empty | ✅ accepted |
| `null` | ✅ accepted |
| `{}` | ✅ accepted |
| non-object (scalar/array) | ✅ accepted (carries no named args) |
| `{"bogus": "x"}` | ❌ rejected — `unknown field(s): ["bogus"]` |

This matters because `argsJson` is a required `serde_json::Value` on `ExecutionRequest`, so a legitimate no-arg JSON-RPC call sends `{}` or `null` — those must keep working. Only a body with actual fields is treated as "extra arguments". The behavior now mirrors `deny_unknown_fields` on the args-bearing branch.

### Open questions from the issue, resolved
- **Absent payload still accepted?** Yes — only a *non-empty object* errors.
- **Literal `{}` accepted?** Yes.

## Test

`crates/runtime/tests/crdt_conformance.rs` — the test that previously pinned the silent-ignore limitation is flipped to assert rejection and renamed `extra_fields_to_zero_arg_method_are_rejected`. It drives the **real compiled wasm** through `Module::run`:
- `entries` (no args) with `{"bogus":"x"}` → asserts an unknown-field error.
- `entries` with `{}` and with `null` → asserts both still succeed.

Full `crdt_conformance` suite green (20 passed).

## ⚠️ Compatibility

Same class of behavioral change as #1646: any client that was sending extra fields to a no-arg method will now get an error. That's the intent of #2600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for clients that sent spurious fields to no-arg methods; behavior is intentional and aligned with deny_unknown_fields on multi-arg methods.
> 
> **Overview**
> **Zero-argument app methods** no longer ignore extra JSON fields. The SDK macro’s `args.is_empty()` branch now parses the WASM input: **non-empty JSON objects** panic with an unknown-field style error listing the keys; **empty `{}`, `null`, absent input, and non-object bodies** still succeed so normal no-arg RPC calls are unchanged.
> 
> Conformance test **`extra_fields_to_zero_arg_method_are_rejected`** replaces the old “silent ignore” expectation: `entries` with `{"bogus":"x"}` must fail; `{}` and `null` must still run through real compiled WASM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd6ec62d11d706ba21e65327b79d61fc145b517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->