### PR TITLE
feat(sdk): host-backed tracing subscriber for WASM apps (#1657)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tracing",
+ "tracing-subscriber",
  "trybuild",
 ]
 
@@ -8736,6 +8738,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/scaffolding-e2e/Cargo.toml
+++ b/apps/scaffolding-e2e/Cargo.toml
@@ -12,12 +12,16 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thiserror.workspace = true
-calimero-sdk.workspace = true
+# `tracing` feature routes `tracing` macro output (this app's and the storage
+# crate's) through the host log; exercised by `tracing_probe` + the runtime
+# `tracing_logs` integration test.
+calimero-sdk = { workspace = true, features = ["tracing"] }
 calimero-storage.workspace = true
 calimero-storage-macros.workspace = true
 sha2.workspace = true
 hex.workspace = true
 bs58.workspace = true
+tracing.workspace = true
 
 [build-dependencies]
 calimero-wasm-abi.workspace = true

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -455,6 +455,27 @@ impl E2eKvStore {
         Ok(())
     }
 
+    /// Test-only probe for the host-backed `tracing` subscriber.
+    ///
+    /// Emits one `tracing` event at each level and performs a KV insert so the
+    /// storage crate's *own* `tracing` output (e.g. `Interface::apply_action`,
+    /// `commit_root`) is exercised through the same path. When `debug` is set,
+    /// raises the level to DEBUG first so those lower-level lines pass the
+    /// filter. Driven by the runtime `tracing_logs` integration test; the
+    /// convergence tests never call it, keeping DEBUG spam out of them.
+    pub fn tracing_probe(&mut self, debug: bool) -> app::Result<()> {
+        if debug {
+            env::set_log_level(env::LevelFilter::DEBUG);
+        }
+        tracing::info!(probe = true, "tracing_probe: info line");
+        tracing::debug!(probe = true, "tracing_probe: debug line");
+        tracing::warn!("tracing_probe: warn line");
+        // Mutating storage drives the storage crate's internal `tracing`.
+        self.kv_items
+            .insert("probe_key".to_owned(), "probe_value".to_owned().into())?;
+        Ok(())
+    }
+
     /// KV set with handler triggers (for testing event-driven handlers)
     pub fn set_with_handler(&mut self, key: String, value: String) -> app::Result<()> {
         app::log!("Setting key with handler: {:?} to value: {:?}", key, value);

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -43,6 +43,7 @@ eyre.workspace = true
 owo-colors.workspace = true
 rand.workspace = true
 serde_json.workspace = true
+wasmer.workspace = true
 wat.workspace = true
 
 [features]

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -110,9 +110,22 @@ const DEFAULT_MAX_REGISTERS: u64 = 100;
 /// Default maximum register size in MiB (100 MiB).
 const DEFAULT_MAX_REGISTER_SIZE_MIB: u64 = 100;
 /// Default maximum number of log entries.
-const DEFAULT_MAX_LOGS: u64 = 100;
-/// Default maximum log message size in KiB (16 KiB).
-const DEFAULT_MAX_LOG_SIZE_KIB: u64 = 16;
+///
+/// Bounds the per-execution log buffer (worst case `max_logs * max_log_size`,
+/// i.e. ~16 MiB, held transiently in the `Outcome`). `tracing` (incl. the
+/// storage crate's, routed through the SDK's host-backed subscriber) emits
+/// many short lines, so the budget favours line *count* over per-line size —
+/// enough for an app that logs liberally and for a DEBUG session. A heavy
+/// whole-tree DEBUG trace can still exceed this; raise the limit explicitly or
+/// narrow the level/target for those.
+const DEFAULT_MAX_LOGS: u64 = 4096;
+/// Default maximum log message size in KiB.
+///
+/// A single over-long line *traps* the execution (`LogLengthOverflow`), not
+/// truncates, so this stays comfortably above any realistic log/`tracing`
+/// line (which are typically well under 1 KiB) while being far below the old
+/// 16 KiB — the buffer budget is better spent on more lines than bigger ones.
+const DEFAULT_MAX_LOG_SIZE_KIB: u64 = 4;
 /// Default maximum number of events.
 const DEFAULT_MAX_EVENTS: u64 = 100;
 /// Default maximum event kind size in bytes.
@@ -781,8 +794,8 @@ mod tests {
         assert_eq!(limits.max_registers, 100);
         assert_eq!(*limits.max_register_size.deref(), 100 << 20);
         assert_eq!(limits.max_registers_capacity, 1 << 30); // 1 GiB
-        assert_eq!(limits.max_logs, 100);
-        assert_eq!(limits.max_log_size, 16 << 10); // 16 KiB
+        assert_eq!(limits.max_logs, 4096);
+        assert_eq!(limits.max_log_size, 4 << 10); // 4 KiB
         assert_eq!(limits.max_events, 100);
         assert_eq!(limits.max_event_kind_size, 100);
         assert_eq!(limits.max_event_data_size, 16 << 10); // 16 KiB

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -112,20 +112,20 @@ const DEFAULT_MAX_REGISTER_SIZE_MIB: u64 = 100;
 /// Default maximum number of log entries.
 ///
 /// Bounds the per-execution log buffer (worst case `max_logs * max_log_size`,
-/// i.e. ~16 MiB, held transiently in the `Outcome`). `tracing` (incl. the
-/// storage crate's, routed through the SDK's host-backed subscriber) emits
-/// many short lines, so the budget favours line *count* over per-line size —
-/// enough for an app that logs liberally and for a DEBUG session. A heavy
-/// whole-tree DEBUG trace can still exceed this; raise the limit explicitly or
-/// narrow the level/target for those.
-const DEFAULT_MAX_LOGS: u64 = 4096;
+/// i.e. ~16 MiB, held transiently in the `Outcome`). Bumped 10× over the
+/// original 100 so an app that logs liberally — or surfaces `tracing` via the
+/// SDK's host-backed subscriber — has headroom. A heavy whole-tree DEBUG trace
+/// can still exceed this; raise the limit explicitly or narrow the
+/// level/target for those.
+const DEFAULT_MAX_LOGS: u64 = 1024;
 /// Default maximum log message size in KiB.
 ///
-/// A single over-long line *traps* the execution (`LogLengthOverflow`), not
-/// truncates, so this stays comfortably above any realistic log/`tracing`
-/// line (which are typically well under 1 KiB) while being far below the old
-/// 16 KiB — the buffer budget is better spent on more lines than bigger ones.
-const DEFAULT_MAX_LOG_SIZE_KIB: u64 = 4;
+/// A single over-long line *traps* the execution (`LogLengthOverflow`) rather
+/// than truncating, so this is NOT shrunk: `tracing` from dependency crates
+/// (e.g. `calimero_storage`'s merge logs) can exceed a few KiB, and trapping
+/// an execution over a log line would be a bad trade. The line-count budget is
+/// raised instead (see `DEFAULT_MAX_LOGS`).
+const DEFAULT_MAX_LOG_SIZE_KIB: u64 = 16;
 /// Default maximum number of events.
 const DEFAULT_MAX_EVENTS: u64 = 100;
 /// Default maximum event kind size in bytes.
@@ -794,8 +794,8 @@ mod tests {
         assert_eq!(limits.max_registers, 100);
         assert_eq!(*limits.max_register_size.deref(), 100 << 20);
         assert_eq!(limits.max_registers_capacity, 1 << 30); // 1 GiB
-        assert_eq!(limits.max_logs, 4096);
-        assert_eq!(limits.max_log_size, 4 << 10); // 4 KiB
+        assert_eq!(limits.max_logs, 1024);
+        assert_eq!(limits.max_log_size, 16 << 10); // 16 KiB
         assert_eq!(limits.max_events, 100);
         assert_eq!(limits.max_event_kind_size, 100);
         assert_eq!(limits.max_event_data_size, 16 << 10); // 16 KiB

--- a/crates/runtime/tests/tracing_logs.rs
+++ b/crates/runtime/tests/tracing_logs.rs
@@ -80,10 +80,13 @@ fn engine_module() -> &'static (Engine, Module) {
     static EM: OnceLock<(Engine, Module)> = OnceLock::new();
     EM.get_or_init(|| {
         // DEBUG-level storage logging on the scaffolding root (many collections)
-        // easily exceeds the 100-log default, which would trap with
-        // `LogsOverflow`. Raise the cap well past anything a single probe emits.
+        // emits far more, and larger, lines than the production defaults allow
+        // (it would trap with `LogsOverflow` / `LogLengthOverflow`). Raise both
+        // caps well past anything a single probe emits — this is a test rig, not
+        // a statement about production limits.
         let limits = VMLimits {
             max_logs: 100_000,
+            max_log_size: 1 << 20, // 1 MiB
             ..VMLimits::default()
         };
         let engine = Engine::new(wasmer::Engine::default(), limits);
@@ -124,23 +127,23 @@ fn run(method: &str, params: Value) -> Outcome {
 
 #[test]
 fn app_tracing_reaches_outcome_and_filters_by_level() {
-    // Default level is INFO: info + warn pass, debug is filtered out.
+    // Default level is WARN: warn passes, info + debug are filtered out.
     let outcome = run("tracing_probe", json!({ "debug": false }));
     let logs = outcome.logs;
 
-    let info = logs
+    let warn = logs
         .iter()
-        .find(|l| l.contains("tracing_probe: info line"))
-        .unwrap_or_else(|| panic!("missing info line; logs: {logs:#?}"));
-    assert!(info.contains("INFO"), "level rendered into line: {info:?}");
+        .find(|l| l.contains("tracing_probe: warn line"))
+        .unwrap_or_else(|| panic!("missing warn line; logs: {logs:#?}"));
+    assert!(warn.contains("WARN"), "level rendered into line: {warn:?}");
 
     assert!(
-        logs.iter().any(|l| l.contains("tracing_probe: warn line")),
-        "warn line present; logs: {logs:#?}"
+        !logs.iter().any(|l| l.contains("tracing_probe: info line")),
+        "info line must be filtered out at the WARN default; logs: {logs:#?}"
     );
     assert!(
         !logs.iter().any(|l| l.contains("tracing_probe: debug line")),
-        "debug line must be filtered out at INFO; logs: {logs:#?}"
+        "debug line must be filtered out at the WARN default; logs: {logs:#?}"
     );
 }
 

--- a/crates/runtime/tests/tracing_logs.rs
+++ b/crates/runtime/tests/tracing_logs.rs
@@ -1,0 +1,163 @@
+//! End-to-end test for the host-backed `tracing` subscriber (SDK `tracing`
+//! feature).
+//!
+//! `tracing` is a facade: with no subscriber installed in the WASM guest, its
+//! macros (`info!`/`debug!`/…) — including those inside crates the app imports,
+//! notably `calimero_storage` — are dropped before formatting. The SDK now
+//! installs a subscriber whose writer forwards each formatted line through the
+//! host `log_utf8` function, so the output lands in the execution `Outcome`.
+//!
+//! This drives a REAL compiled app (`apps/scaffolding-e2e`, built with the
+//! `tracing` feature) through the actual `Module::run` path and asserts:
+//!   * app-level `tracing` events reach `outcome.logs` with their level
+//!     rendered;
+//!   * the level filter drops events below the active level (DEBUG hidden at
+//!     the default INFO);
+//!   * raising the level to DEBUG surfaces `calimero_storage`'s OWN `tracing`
+//!     output — proving logs from a crate the app merely *imports* (not just
+//!     the app's own) reach the host.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use calimero_runtime::logic::{Outcome, VMLimits};
+use calimero_runtime::store::InMemoryStorage;
+use calimero_runtime::{Engine, Module};
+use serde_json::{json, to_vec as to_json_vec, Value};
+
+const CTX: [u8; 32] = [9u8; 32];
+const EXEC: [u8; 32] = [3u8; 32];
+
+fn workspace_root() -> PathBuf {
+    // crates/runtime/ -> ../../
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Build the scaffolding-e2e app once per test-binary run and return its wasm.
+/// Rebuilds only when the binary is missing or older than `src/lib.rs` (a
+/// coarse but adequate freshness check for a fixture).
+fn scaffolding_wasm() -> &'static [u8] {
+    static WASM: OnceLock<Vec<u8>> = OnceLock::new();
+    WASM.get_or_init(|| {
+        let app_dir = workspace_root().join("apps/scaffolding-e2e");
+        let wasm_path = app_dir.join("res/scaffolding_e2e.wasm");
+
+        let wasm_mtime = std::fs::metadata(&wasm_path)
+            .and_then(|m| m.modified())
+            .ok();
+        let src_mtime = std::fs::metadata(app_dir.join("src/lib.rs"))
+            .and_then(|m| m.modified())
+            .ok();
+        let needs_build = match (wasm_mtime, src_mtime) {
+            (Some(w), Some(s)) => w < s,
+            _ => true,
+        };
+        if needs_build {
+            let output = Command::new("bash")
+                .arg(app_dir.join("build.sh"))
+                .output()
+                .expect("failed to spawn build.sh — is bash on PATH?");
+            assert!(
+                output.status.success(),
+                "building scaffolding-e2e wasm failed:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+        std::fs::read(&wasm_path).expect("scaffolding_e2e.wasm not found after build")
+    })
+}
+
+fn engine_module() -> &'static (Engine, Module) {
+    static EM: OnceLock<(Engine, Module)> = OnceLock::new();
+    EM.get_or_init(|| {
+        // DEBUG-level storage logging on the scaffolding root (many collections)
+        // easily exceeds the 100-log default, which would trap with
+        // `LogsOverflow`. Raise the cap well past anything a single probe emits.
+        let limits = VMLimits {
+            max_logs: 100_000,
+            ..VMLimits::default()
+        };
+        let engine = Engine::new(wasmer::Engine::default(), limits);
+        let module = engine.compile(scaffolding_wasm()).expect("compile wasm");
+        (engine, module)
+    })
+}
+
+/// `init` on a fresh store, then run `method`; returns the method's `Outcome`.
+fn run(method: &str, params: Value) -> Outcome {
+    let (_, module) = engine_module();
+    let mut store = InMemoryStorage::default();
+
+    module
+        .run(
+            CTX.into(),
+            EXEC.into(),
+            "init",
+            &to_json_vec(&json!({})).unwrap(),
+            &mut store,
+            None,
+            None,
+        )
+        .expect("init failed");
+
+    module
+        .run(
+            CTX.into(),
+            EXEC.into(),
+            method,
+            &to_json_vec(&params).unwrap(),
+            &mut store,
+            None,
+            None,
+        )
+        .expect("method run failed")
+}
+
+#[test]
+fn app_tracing_reaches_outcome_and_filters_by_level() {
+    // Default level is INFO: info + warn pass, debug is filtered out.
+    let outcome = run("tracing_probe", json!({ "debug": false }));
+    let logs = outcome.logs;
+
+    let info = logs
+        .iter()
+        .find(|l| l.contains("tracing_probe: info line"))
+        .unwrap_or_else(|| panic!("missing info line; logs: {logs:#?}"));
+    assert!(info.contains("INFO"), "level rendered into line: {info:?}");
+
+    assert!(
+        logs.iter().any(|l| l.contains("tracing_probe: warn line")),
+        "warn line present; logs: {logs:#?}"
+    );
+    assert!(
+        !logs.iter().any(|l| l.contains("tracing_probe: debug line")),
+        "debug line must be filtered out at INFO; logs: {logs:#?}"
+    );
+}
+
+#[test]
+fn debug_level_surfaces_storage_crate_tracing() {
+    // Raising to DEBUG surfaces both the app's debug line AND the storage
+    // crate's own `tracing` output — the imported-dependency case.
+    let outcome = run("tracing_probe", json!({ "debug": true }));
+    let logs = outcome.logs;
+
+    assert!(
+        logs.iter().any(|l| l.contains("tracing_probe: debug line")),
+        "app debug line present at DEBUG; logs: {logs:#?}"
+    );
+    assert!(
+        logs.iter().any(|l| l.contains("calimero_storage")),
+        "expected at least one log from the storage crate's own tracing \
+         (target `calimero_storage::…`); logs: {logs:#?}"
+    );
+}

--- a/crates/runtime/tests/tracing_logs.rs
+++ b/crates/runtime/tests/tracing_logs.rs
@@ -41,9 +41,39 @@ fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
+/// Newest mtime across the app's build inputs: every `*.rs` under `src/`
+/// (recursively), plus `Cargo.toml` and `build.sh`. Returns `None` if nothing
+/// could be stat'd (forces a rebuild). Mirrors the `crdt_conformance` fixture
+/// so a change to a sibling module or the manifest doesn't leave stale wasm.
+fn newest_mtime(app_dir: &std::path::Path) -> Option<std::time::SystemTime> {
+    fn visit(dir: &std::path::Path, newest: &mut Option<std::time::SystemTime>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                visit(&path, newest);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                if let Ok(m) = entry.metadata().and_then(|m| m.modified()) {
+                    *newest = Some(newest.map_or(m, |cur| cur.max(m)));
+                }
+            }
+        }
+    }
+    let mut newest = None;
+    visit(&app_dir.join("src"), &mut newest);
+    for f in ["Cargo.toml", "build.sh"] {
+        if let Ok(m) = std::fs::metadata(app_dir.join(f)).and_then(|m| m.modified()) {
+            newest = Some(newest.map_or(m, |cur| cur.max(m)));
+        }
+    }
+    newest
+}
+
 /// Build the scaffolding-e2e app once per test-binary run and return its wasm.
-/// Rebuilds only when the binary is missing or older than `src/lib.rs` (a
-/// coarse but adequate freshness check for a fixture).
+/// Rebuilds when the binary is missing or older than ANY build input (see
+/// [`newest_mtime`]).
 fn scaffolding_wasm() -> &'static [u8] {
     static WASM: OnceLock<Vec<u8>> = OnceLock::new();
     WASM.get_or_init(|| {
@@ -53,10 +83,7 @@ fn scaffolding_wasm() -> &'static [u8] {
         let wasm_mtime = std::fs::metadata(&wasm_path)
             .and_then(|m| m.modified())
             .ok();
-        let src_mtime = std::fs::metadata(app_dir.join("src/lib.rs"))
-            .and_then(|m| m.modified())
-            .ok();
-        let needs_build = match (wasm_mtime, src_mtime) {
+        let needs_build = match (wasm_mtime, newest_mtime(&app_dir)) {
             (Some(w), Some(s)) => w < s,
             _ => true,
         };

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -18,6 +18,16 @@ calimero-primitives = { workspace = true, features = ["borsh"] }
 calimero-sdk-macros.workspace = true
 calimero-sys.workspace = true
 calimero-wasm-abi.workspace = true
+tracing = { workspace = true, optional = true }
+# Uses the `fmt` + `registry` features (both on by default); inherits the
+# workspace's feature set since `workspace = true` can't override it.
+tracing-subscriber = { workspace = true, optional = true }
+
+[features]
+# Routes `tracing` macro output (`info!`/`debug!`/… from the app and any crate
+# it imports) through the host log function. Off by default to keep the wasm
+# binary small; apps opt in with `calimero-sdk = { features = ["tracing"] }`.
+tracing = ["dep:tracing", "dep:tracing-subscriber"]
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -214,6 +214,7 @@ impl ToTokens for PublicLogicMethod<'_> {
             #[no_mangle]
             pub extern "C" fn #name() {
                 ::calimero_sdk::env::setup_panic_hook();
+                ::calimero_sdk::env::init_logging();
 
                 ::calimero_sdk::event::register::<#self_>();
 

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -66,6 +66,19 @@ pub mod ext;
 #[doc(hidden)]
 pub mod host;
 
+/// Host-backed `tracing` subscriber (cargo feature `tracing`). Routes
+/// `tracing` macro output through [`log`] so it reaches the execution outcome.
+#[cfg(feature = "tracing")]
+mod subscriber;
+
+/// Sets the maximum `tracing` level forwarded to the host (feature `tracing`).
+#[cfg(feature = "tracing")]
+pub use subscriber::set_log_level;
+/// Re-exported so apps can set the level without depending on `tracing`
+/// directly, e.g. `env::set_log_level(env::LevelFilter::DEBUG)`.
+#[cfg(feature = "tracing")]
+pub use tracing::level_filters::LevelFilter;
+
 /// Register ID used for data operations in the WASM runtime.
 #[cfg(target_arch = "wasm32")]
 const DATA_REGISTER: RegisterId = RegisterId::new(PtrSizedInt::MAX.as_usize() - 1);
@@ -161,6 +174,20 @@ pub fn setup_panic_hook() {
             )
         }
     }));
+}
+
+/// Installs the host-backed `tracing` subscriber so `tracing` macros
+/// (`info!`/`debug!`/…) emitted by the app — and by any crate it imports — are
+/// forwarded to the host log and surface in the execution outcome.
+///
+/// No-op unless the `tracing` cargo feature is enabled. Idempotent: the
+/// generated WASM exports call this at method entry (alongside
+/// [`setup_panic_hook`]), so apps get `tracing` output with no manual setup.
+/// Tune verbosity with [`set_log_level`].
+#[inline]
+pub fn init_logging() {
+    #[cfg(feature = "tracing")]
+    subscriber::init();
 }
 
 /// Marks code as unreachable for optimization purposes.

--- a/crates/sdk/src/env/subscriber.rs
+++ b/crates/sdk/src/env/subscriber.rs
@@ -1,0 +1,223 @@
+//! Host-backed `tracing` subscriber for Calimero WASM applications.
+//!
+//! `tracing` is a facade: its macros forward each event to whatever global
+//! subscriber is installed, and when none is, the events are dropped before
+//! they are even formatted. WASM guests never installed one, so
+//! `tracing::info!`/`debug!`/… — including calls inside crates the app
+//! imports — produced no output and could not be extracted.
+//!
+//! This module installs a subscriber whose writer forwards every formatted
+//! line through [`crate::env::log`] to the host, so `tracing` output lands in
+//! the execution outcome alongside `app::log!`. The level is held in a global
+//! atomic and re-read on every event, so [`set_log_level`] retunes verbosity
+//! at runtime even after the subscriber is installed.
+//!
+//! Gated behind the `tracing` cargo feature so apps that don't want the
+//! dependency (and the binary-size cost) pay nothing.
+
+use core::sync::atomic::{AtomicU8, Ordering};
+use std::io::{self, Write};
+use std::sync::Once;
+
+use tracing::level_filters::LevelFilter;
+use tracing::Level;
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{Layer, Registry};
+
+/// Maximum enabled log level, encoded as a small ordinal (0 = OFF … 5 = TRACE)
+/// so it lives in a single relaxed atomic. Read on every event by the filter,
+/// which is why the level can change after the subscriber is already global.
+static MAX_LEVEL: AtomicU8 = AtomicU8::new(LEVEL_INFO);
+
+const LEVEL_OFF: u8 = 0;
+const LEVEL_ERROR: u8 = 1;
+const LEVEL_WARN: u8 = 2;
+const LEVEL_INFO: u8 = 3;
+const LEVEL_DEBUG: u8 = 4;
+const LEVEL_TRACE: u8 = 5;
+
+/// Installs the subscriber once per WASM instance. Re-attempting is cheap and
+/// harmless: `set_global_default` would reject a second subscriber anyway, and
+/// `Once` saves rebuilding one on every method call within the same instance.
+static INIT: Once = Once::new();
+
+fn level_filter_to_u8(level: LevelFilter) -> u8 {
+    match level.into_level() {
+        None => LEVEL_OFF,
+        Some(Level::ERROR) => LEVEL_ERROR,
+        Some(Level::WARN) => LEVEL_WARN,
+        Some(Level::INFO) => LEVEL_INFO,
+        Some(Level::DEBUG) => LEVEL_DEBUG,
+        Some(Level::TRACE) => LEVEL_TRACE,
+    }
+}
+
+fn current_max() -> LevelFilter {
+    match MAX_LEVEL.load(Ordering::Relaxed) {
+        LEVEL_OFF => LevelFilter::OFF,
+        LEVEL_ERROR => LevelFilter::ERROR,
+        LEVEL_WARN => LevelFilter::WARN,
+        LEVEL_INFO => LevelFilter::INFO,
+        LEVEL_DEBUG => LevelFilter::DEBUG,
+        _ => LevelFilter::TRACE,
+    }
+}
+
+/// Sets the maximum `tracing` level forwarded to the host. Takes effect
+/// immediately, including for an already-installed subscriber, since the
+/// filter re-reads the level on each event. Pass [`LevelFilter::OFF`] to
+/// silence `tracing` output entirely.
+///
+/// Call this from your app's initializer (or a dedicated method) to control
+/// verbosity, e.g. `env::set_log_level(LevelFilter::DEBUG)`.
+pub fn set_log_level(level: LevelFilter) {
+    MAX_LEVEL.store(level_filter_to_u8(level), Ordering::Relaxed);
+}
+
+/// A `Write` sink that buffers one event's bytes and, on drop (end of the
+/// event), forwards them to the host as a single log line. `tracing`'s fmt
+/// layer calls `make_writer` once per event, writes the formatted record, then
+/// drops the writer — so one writer lifetime maps to exactly one host log.
+struct HostWriter {
+    buf: Vec<u8>,
+}
+
+impl Write for HostWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for HostWriter {
+    fn drop(&mut self) {
+        if self.buf.is_empty() {
+            return;
+        }
+        // The host frames each log entry itself, so drop the trailing newline
+        // the fmt layer appends. `from_utf8_lossy` guards against a partial
+        // multi-byte sequence (shouldn't happen, but must never panic here).
+        let line = String::from_utf8_lossy(&self.buf);
+        crate::env::log(line.trim_end_matches('\n'));
+    }
+}
+
+struct HostMakeWriter;
+
+impl MakeWriter<'_> for HostMakeWriter {
+    type Writer = HostWriter;
+
+    fn make_writer(&self) -> Self::Writer {
+        HostWriter { buf: Vec::new() }
+    }
+}
+
+/// Installs the host-backed subscriber as the global default, once.
+///
+/// Called automatically at the entry of every generated WASM export (next to
+/// `setup_panic_hook`), so apps get `tracing` output without any setup. Safe to
+/// call repeatedly.
+pub fn init() {
+    INIT.call_once(|| {
+        // `without_time`: the default fmt timer calls `SystemTime::now()`,
+        // which traps on `wasm32-unknown-unknown`. `with_ansi(false)`: no
+        // colour escapes in plain-text host logs. The level filter reads the
+        // global atomic per event so `set_log_level` stays effective.
+        let layer = tracing_subscriber::fmt::layer()
+            .with_writer(HostMakeWriter)
+            .without_time()
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.level() <= &current_max()
+            }));
+
+        let subscriber = Registry::default().with(layer);
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::level_filters::LevelFilter;
+    use tracing::{debug, info, warn};
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::{Layer, Registry};
+
+    use super::{current_max, set_log_level, HostMakeWriter};
+    use crate::env::host;
+
+    /// `MAX_LEVEL` is a process-global atomic, so these tests must not run
+    /// concurrently or one's `set_log_level` would perturb another's filter.
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Builds a fresh subscriber identical to the installed one. Tests use a
+    /// thread-local default (`with_default`) rather than the process-global
+    /// default so they don't collide when run in parallel, and they read the
+    /// host mock's captured logs directly (no full `TestHost` app needed).
+    fn test_subscriber() -> impl tracing::Subscriber + Send + Sync {
+        let layer = tracing_subscriber::fmt::layer()
+            .with_writer(HostMakeWriter)
+            .without_time()
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.level() <= &current_max()
+            }));
+        Registry::default().with(layer)
+    }
+
+    #[test]
+    fn forwards_events_to_host_with_level() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        host::reset();
+        set_log_level(LevelFilter::INFO);
+
+        tracing::subscriber::with_default(test_subscriber(), || {
+            info!(item = 7, "processing");
+        });
+
+        let logs = host::logs();
+        assert_eq!(logs.len(), 1, "exactly one host log line per event");
+        assert!(logs[0].contains("INFO"), "level is rendered: {:?}", logs[0]);
+        assert!(logs[0].contains("processing"), "message body present");
+        assert!(logs[0].contains("item=7"), "structured field present");
+        assert!(!logs[0].ends_with('\n'), "trailing newline trimmed");
+    }
+
+    #[test]
+    fn level_filters_below_threshold() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        host::reset();
+        set_log_level(LevelFilter::INFO);
+
+        tracing::subscriber::with_default(test_subscriber(), || {
+            debug!("dropped at INFO");
+            warn!("kept at INFO");
+        });
+
+        let logs = host::logs();
+        assert_eq!(logs.len(), 1, "debug dropped, warn kept");
+        assert!(logs[0].contains("kept at INFO"));
+    }
+
+    #[test]
+    fn level_change_takes_effect_immediately() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        host::reset();
+
+        tracing::subscriber::with_default(test_subscriber(), || {
+            set_log_level(LevelFilter::INFO);
+            debug!("first, dropped");
+            set_log_level(LevelFilter::DEBUG);
+            debug!("second, kept");
+        });
+
+        let logs = host::logs();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("second, kept"));
+    }
+}

--- a/crates/sdk/src/env/subscriber.rs
+++ b/crates/sdk/src/env/subscriber.rs
@@ -26,8 +26,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{Layer, Registry};
 
 /// Maximum enabled log level, encoded as a small ordinal (0 = OFF … 5 = TRACE)
-/// so it lives in a single relaxed atomic. Read on every event by the filter,
-/// which is why the level can change after the subscriber is already global.
+/// so it lives in a single atomic. Read on every event by the filter, which is
+/// why the level can change after the subscriber is already global.
 ///
 /// Defaults to WARN, not INFO: dependency crates compiled into the guest (most
 /// notably `calimero_storage`) log routine operations at INFO, so an INFO
@@ -61,7 +61,11 @@ fn level_filter_to_u8(level: LevelFilter) -> u8 {
 }
 
 fn current_max() -> LevelFilter {
-    match MAX_LEVEL.load(Ordering::Relaxed) {
+    // `Acquire`/`Release` (paired with `set_log_level`'s store) rather than
+    // `Relaxed`: in WASM the guest is single-threaded so it makes no
+    // difference, but the SDK also compiles for native test targets where a
+    // level set on one thread should be promptly visible on another.
+    match MAX_LEVEL.load(Ordering::Acquire) {
         LEVEL_OFF => LevelFilter::OFF,
         LEVEL_ERROR => LevelFilter::ERROR,
         LEVEL_WARN => LevelFilter::WARN,
@@ -78,8 +82,14 @@ fn current_max() -> LevelFilter {
 ///
 /// Call this from your app's initializer (or a dedicated method) to control
 /// verbosity, e.g. `env::set_log_level(LevelFilter::DEBUG)`.
+///
+/// Note: at DEBUG, `tracing` from *every* crate compiled into the guest is
+/// forwarded — including `calimero_storage` internals (keys, values, merge
+/// detail). Those lines land in the execution `Outcome`, so treat DEBUG as a
+/// debugging aid, not something to leave on where the `Outcome` is persisted
+/// or exposed.
 pub fn set_log_level(level: LevelFilter) {
-    MAX_LEVEL.store(level_filter_to_u8(level), Ordering::Relaxed);
+    MAX_LEVEL.store(level_filter_to_u8(level), Ordering::Release);
 }
 
 /// A `Write` sink that buffers one event's bytes and, on drop (end of the
@@ -124,6 +134,24 @@ impl MakeWriter<'_> for HostMakeWriter {
     }
 }
 
+/// Builds the host-backed subscriber. The single source of truth for its
+/// configuration so tests exercise exactly what [`init`] installs.
+///
+/// `without_time`: the default fmt timer calls `SystemTime::now()`, which traps
+/// on `wasm32-unknown-unknown`. `with_ansi(false)`: no colour escapes in
+/// plain-text host logs. The level filter reads the global atomic per event so
+/// `set_log_level` stays effective after install.
+fn build_subscriber() -> impl tracing::Subscriber + Send + Sync {
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(HostMakeWriter)
+        .without_time()
+        .with_ansi(false)
+        .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+            meta.level() <= &current_max()
+        }));
+    Registry::default().with(layer)
+}
+
 /// Installs the host-backed subscriber as the global default, once.
 ///
 /// Called automatically at the entry of every generated WASM export (next to
@@ -131,20 +159,7 @@ impl MakeWriter<'_> for HostMakeWriter {
 /// call repeatedly.
 pub fn init() {
     INIT.call_once(|| {
-        // `without_time`: the default fmt timer calls `SystemTime::now()`,
-        // which traps on `wasm32-unknown-unknown`. `with_ansi(false)`: no
-        // colour escapes in plain-text host logs. The level filter reads the
-        // global atomic per event so `set_log_level` stays effective.
-        let layer = tracing_subscriber::fmt::layer()
-            .with_writer(HostMakeWriter)
-            .without_time()
-            .with_ansi(false)
-            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
-                meta.level() <= &current_max()
-            }));
-
-        let subscriber = Registry::default().with(layer);
-        let _ = tracing::subscriber::set_global_default(subscriber);
+        let _ = tracing::subscriber::set_global_default(build_subscriber());
     });
 }
 
@@ -152,38 +167,27 @@ pub fn init() {
 mod tests {
     use tracing::level_filters::LevelFilter;
     use tracing::{debug, info, warn};
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::{Layer, Registry};
 
-    use super::{current_max, set_log_level, HostMakeWriter};
+    use super::{build_subscriber, set_log_level};
     use crate::env::host;
 
     /// `MAX_LEVEL` is a process-global atomic, so these tests must not run
     /// concurrently or one's `set_log_level` would perturb another's filter.
     static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// Builds a fresh subscriber identical to the installed one. Tests use a
-    /// thread-local default (`with_default`) rather than the process-global
-    /// default so they don't collide when run in parallel, and they read the
-    /// host mock's captured logs directly (no full `TestHost` app needed).
-    fn test_subscriber() -> impl tracing::Subscriber + Send + Sync {
-        let layer = tracing_subscriber::fmt::layer()
-            .with_writer(HostMakeWriter)
-            .without_time()
-            .with_ansi(false)
-            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
-                meta.level() <= &current_max()
-            }));
-        Registry::default().with(layer)
+    /// Serialize on `TEST_LOCK`, recovering a poisoned lock (a panicking test
+    /// shouldn't cascade-fail the rest of the module via lock poisoning).
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     #[test]
     fn forwards_events_to_host_with_level() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = lock();
         host::reset();
         set_log_level(LevelFilter::INFO);
 
-        tracing::subscriber::with_default(test_subscriber(), || {
+        tracing::subscriber::with_default(build_subscriber(), || {
             info!(item = 7, "processing");
         });
 
@@ -197,11 +201,11 @@ mod tests {
 
     #[test]
     fn level_filters_below_threshold() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = lock();
         host::reset();
         set_log_level(LevelFilter::INFO);
 
-        tracing::subscriber::with_default(test_subscriber(), || {
+        tracing::subscriber::with_default(build_subscriber(), || {
             debug!("dropped at INFO");
             warn!("kept at INFO");
         });
@@ -213,10 +217,10 @@ mod tests {
 
     #[test]
     fn level_change_takes_effect_immediately() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = lock();
         host::reset();
 
-        tracing::subscriber::with_default(test_subscriber(), || {
+        tracing::subscriber::with_default(build_subscriber(), || {
             set_log_level(LevelFilter::INFO);
             debug!("first, dropped");
             set_log_level(LevelFilter::DEBUG);

--- a/crates/sdk/src/env/subscriber.rs
+++ b/crates/sdk/src/env/subscriber.rs
@@ -28,7 +28,14 @@ use tracing_subscriber::{Layer, Registry};
 /// Maximum enabled log level, encoded as a small ordinal (0 = OFF … 5 = TRACE)
 /// so it lives in a single relaxed atomic. Read on every event by the filter,
 /// which is why the level can change after the subscriber is already global.
-static MAX_LEVEL: AtomicU8 = AtomicU8::new(LEVEL_INFO);
+///
+/// Defaults to WARN, not INFO: dependency crates compiled into the guest (most
+/// notably `calimero_storage`) log routine operations at INFO, so an INFO
+/// default would flood every execution's log buffer with internals. WARN
+/// surfaces warnings/errors out of the box; apps opt into INFO/DEBUG via
+/// [`set_log_level`] when they actually want the detail (e.g. debugging a
+/// storage divergence).
+static MAX_LEVEL: AtomicU8 = AtomicU8::new(LEVEL_WARN);
 
 const LEVEL_OFF: u8 = 0;
 const LEVEL_ERROR: u8 = 1;


### PR DESCRIPTION
Closes #1657.

## Problem

`tracing` is a facade — its macros (`info!`/`debug!`/`warn!`/…) forward each event to whatever subscriber is installed, and with **none** installed they're dropped before they're even formatted. WASM guests never installed one, so:

- App code using idiomatic `tracing` macros produced **no output**, silently.
- Worse, any crate the app *imports* that logs via `tracing` — notably **`calimero_storage`**, which is heavily instrumented (`Interface::apply_action`, `commit_root`, `merge`, HashComparison apply, index, rotation log, rekey, collections) and runs inside the guest — was completely invisible from the WASM side.

The only egress from the guest is the `log_utf8` host function (what `env::log` / `app::log!` use), so `env_logger`-style backends don't apply: there's no guest stderr and no `RUST_LOG` env to read.

## Fix

An opt-in, host-backed `tracing` subscriber whose `MakeWriter` forwards each formatted line through `log_utf8`, so `tracing` output lands in the execution `Outcome` next to `app::log!`.

- **New `calimero-sdk` `tracing` feature**, off by default (zero binary-size cost for apps that don't want it). When enabled, `#[app::logic]` exports auto-install the subscriber at method entry, alongside `setup_panic_hook` — no app setup required.
- **`env::set_log_level(LevelFilter)`** retunes verbosity at runtime: the level lives in a global atomic re-read by the filter per event, so it takes effect even after install. Default WARN — enabling the feature won't flood the buffer with dependency-crate INFO logs; apps raise it to INFO/DEBUG via `set_log_level`.
- **wasm32 gotchas handled**: `without_time()` (the default fmt timer's `SystemTime::now()` traps on `wasm32-unknown-unknown`), `with_ansi(false)`, install-once via `Once`.

### Log-limit tuning

`tracing` emits many short lines, so the per-execution log budget is redistributed to favor count over size:

| Limit | Before | After |
|---|---|---|
| `max_logs` | 100 | **1024** |
| `max_log_size` | 16 KiB | **16 KiB (unchanged)** |
| worst-case buffer | 1.6 MiB | ~16 MiB (transient, in `Outcome`) |

Per-line cap kept at 16 KiB: an over-long line *traps* the execution (`LogLengthOverflow`) rather than truncating, and dependency-crate `tracing` (e.g. `calimero_storage` merge logs) can exceed a few KiB. The budget is spent on line count instead.

## Why this matters

This makes the storage crate's own apply/merge/commit play-by-play observable from inside the guest at DEBUG — previously a blind spot exactly where many divergence/split-brain bugs live. The node already logs the *host* side of sync; this closes the *guest* side.

## Tests

- **3 SDK unit tests** — writer forwarding, level filtering, runtime level change.
- **2 runtime e2e tests** (`crates/runtime/tests/tracing_logs.rs`) driving a real compiled app (`scaffolding-e2e`, built with the feature) through `Module::run`:
  - app `tracing` reaches `Outcome.logs` with level rendered; INFO/DEBUG filtered out at the WARN default;
  - at DEBUG, `calimero_storage`'s **own** tracing surfaces (the imported-dependency case).

Verified: `wasm32-unknown-unknown` compile with the feature on; feature-off app build unchanged; no `crdt_conformance` regression; `cargo fmt` clean.

## Follow-ups (not in this PR)

- Per-target filtering (e.g. only `calimero_storage::merge` at DEBUG) so heavy storage tracing can be scoped without the global firehose — the `filter_fn` already receives full `Metadata`.
- Wiring `VMLimits` to node config so operators can raise the cap per node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises per-execution log buffer headroom and adds optional guest logging that can amplify `Outcome` size or hit `LogsOverflow` under DEBUG; feature is off by default so production wasm size/behavior is unchanged unless opted in.
> 
> **Overview**
> Adds an **opt-in** `calimero-sdk` **`tracing`** feature that installs a host-backed `tracing-subscriber` at each generated WASM export entry (`init_logging` next to `setup_panic_hook`), forwarding formatted lines through `env::log` into the execution **`Outcome`**. Apps can tune verbosity at runtime via **`env::set_log_level`** (default **WARN** to avoid flooding from dependency crates like **`calimero_storage`**).
> 
> **Runtime** default **`max_logs`** is raised from **100 → 1024** (per-line cap stays **16 KiB**; over-long lines still trap). **`scaffolding-e2e`** gains a **`tracing_probe`** method and enables the feature for tests; **`crates/runtime/tests/tracing_logs.rs`** runs real WASM through `Module::run` to assert level filtering and that storage-crate `tracing` reaches `outcome.logs` at DEBUG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac51c36bab9fabc9284c9cba12c66966b7ce413a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
