### PR TITLE
feat(sync): carry deletions in the comparison tree (tombstones-in-tree, #2591)

### DIFF
--- a/crates/node/primitives/src/sync/hash_comparison.rs
+++ b/crates/node/primitives/src/sync/hash_comparison.rs
@@ -186,6 +186,16 @@ pub struct TreeNode {
 
     /// Leaf data (present only for leaf nodes).
     pub leaf_data: Option<TreeLeafData>,
+
+    /// Tombstones for children removed from this (internal) node.
+    ///
+    /// A deletion is the absence of a child from `children`, which the
+    /// add-biased comparison can't observe. Carrying the tombstones here lets a
+    /// peer that still holds a child converge to the deletion (delete-wins)
+    /// during comparison — without anyone pushing the live entity. Empty for
+    /// leaf nodes. Populated by `get_local_tree_node` from the parent index's
+    /// `deleted_children` (each entry resolved to a signed `EntityDeletion`).
+    pub deleted_children: Vec<EntityDeletion>,
 }
 
 impl TreeNode {
@@ -197,6 +207,7 @@ impl TreeNode {
             hash,
             children,
             leaf_data: None,
+            deleted_children: Vec::new(),
         }
     }
 
@@ -208,6 +219,7 @@ impl TreeNode {
             hash,
             children: vec![],
             leaf_data: Some(data),
+            deleted_children: Vec::new(),
         }
     }
 
@@ -225,13 +237,15 @@ impl TreeNode {
             return false;
         }
 
-        // Check structural invariant: must have exactly one of children or data
-        // - Internal nodes: non-empty children, no leaf_data
-        // - Leaf nodes: empty children, has leaf_data
-        let has_children = !self.children.is_empty();
-        let has_data = self.leaf_data.is_some();
-        if has_children == has_data {
-            // Invalid: either both present (ambiguous) or both absent (empty)
+        // Check structural invariant: must be exactly one of internal or leaf.
+        // - Internal node: has live children OR only-tombstoned children
+        //   (a parent cleared to childless still carries `deleted_children`),
+        //   and no leaf_data.
+        // - Leaf node: has leaf_data, no children, no deleted_children.
+        let is_internal = !self.children.is_empty() || !self.deleted_children.is_empty();
+        let is_leaf = self.leaf_data.is_some();
+        if is_internal == is_leaf {
+            // Invalid: either both (ambiguous) or neither (empty).
             return false;
         }
 
@@ -1057,6 +1071,7 @@ mod tests {
             id: [1; 32],
             hash: [2; 32],
             children: vec![[3; 32]],
+            deleted_children: vec![],
             leaf_data: Some(leaf_data),
         };
         assert!(!invalid_node.is_valid());

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -388,6 +388,13 @@ pub enum MessagePayload<'a> {
         nodes: Vec<LevelNode>,
         /// Whether there are more levels below this one.
         has_more_levels: bool,
+        /// Authenticated tombstones for children of the queried parents that
+        /// this responder has deleted. Lets a holder that still has the entity
+        /// (the initiator) learn of the deletion and apply it delete-wins —
+        /// the LevelWise analogue of `TreeNode::deleted_children`. Without it a
+        /// cleared responder returns no nodes at level 0 and the initiator's
+        /// loop exits before ever seeing the deletion (holder-initiates clear).
+        deleted_children: Vec<super::hash_comparison::EntityDeletion>,
     },
 
     /// Acknowledgment of received EntityPush for bidirectional HashComparison sync.
@@ -604,6 +611,7 @@ mod tests {
             level: 0,
             nodes: nodes.clone(),
             has_more_levels: true,
+            deleted_children: vec![],
         };
 
         let encoded = borsh::to_vec(&response).expect("serialize");
@@ -614,12 +622,14 @@ mod tests {
                 level,
                 nodes: decoded_nodes,
                 has_more_levels,
+                deleted_children,
             } => {
                 assert_eq!(level, 0);
                 assert_eq!(decoded_nodes.len(), 2);
                 assert!(has_more_levels);
                 assert!(decoded_nodes[0].is_internal());
                 assert!(decoded_nodes[1].is_internal());
+                assert!(deleted_children.is_empty());
             }
             _ => panic!("wrong variant"),
         }
@@ -642,6 +652,7 @@ mod tests {
             level: 1,
             nodes,
             has_more_levels: false,
+            deleted_children: vec![],
         };
 
         let encoded = borsh::to_vec(&response).expect("serialize");
@@ -652,6 +663,7 @@ mod tests {
                 level,
                 nodes: decoded_nodes,
                 has_more_levels,
+                deleted_children: _,
             } => {
                 assert_eq!(level, 1);
                 assert_eq!(decoded_nodes.len(), 2);
@@ -670,6 +682,7 @@ mod tests {
             level: 2,
             nodes: vec![],
             has_more_levels: false,
+            deleted_children: vec![],
         };
 
         let encoded = borsh::to_vec(&response).expect("serialize");
@@ -680,10 +693,12 @@ mod tests {
                 level,
                 nodes,
                 has_more_levels,
+                deleted_children,
             } => {
                 assert_eq!(level, 2);
                 assert!(nodes.is_empty());
                 assert!(!has_more_levels);
+                assert!(deleted_children.is_empty());
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -438,6 +438,26 @@ async fn run_initiator_impl<T: SyncTransport>(
                 // Internal node: compare with local version
                 let is_this_node_root = is_root_request && remote_node.id == node_id;
 
+                // Tombstone reconciliation (symmetric clear convergence): the
+                // remote advertises children it deleted. For any we still hold
+                // live, apply the deletion (delete-wins by HLC) via the
+                // authenticated DeleteRef path — so a peer that cleared an entry
+                // converges us even when WE initiated the sync, without anyone
+                // pushing the live entity. (Our own deletions flow the other way
+                // via the remote_only → EntityDeletePush path below.)
+                if !remote_node.deleted_children.is_empty() {
+                    let applied = with_runtime_env(runtime_env.clone(), || {
+                        apply_remote_tombstones(&remote_node.deleted_children)
+                    });
+                    if applied > 0 {
+                        debug!(
+                            %context_id,
+                            applied,
+                            "applied remote deleted_children (clear convergence)"
+                        );
+                    }
+                }
+
                 let local_version = with_runtime_env(runtime_env.clone(), || {
                     get_local_tree_node(context_id, &remote_node.id, is_this_node_root)
                 })?;
@@ -1216,52 +1236,108 @@ fn get_local_tree_node(
         .map(|children| children.iter().map(|c| *c.id().as_bytes()).collect())
         .unwrap_or_default();
 
-    if children_ids.is_empty() {
-        // Leaf node
-        if let Some(entry_data) = Interface::<MainStorage>::find_by_id_raw(entity_id) {
-            let crdt_type = index.metadata.crdt_type.clone().unwrap_or_else(|| {
-                // No CRDT type ("opaque" leaf — e.g. the `Root<T>` state entry).
-                // Emit a real *leaf* (not a malformed empty `internal` node, which the
-                // peer's `TreeNode::is_valid()` rejects) carrying a synthetic LWW wire
-                // type — merge-equivalent to `None` and Merkle-hash-neutral.
-                trace!(%entity_id, "opaque leaf, synthesised LWW wire type for sync");
-                CrdtType::lww_register(OPAQUE_LEAF_CRDT_TYPE_NAME)
-            });
-            // Carry the leaf's Merkle parent_id on the wire — see the same
-            // comment in `collect_leaves_recursive` for rationale.
-            let mut metadata = LeafMetadata::new(crdt_type, index.metadata.updated_at(), [0u8; 32])
-                .with_created_at(index.metadata.created_at());
-            if let Some(parent_id) = index.parent_id() {
-                metadata = metadata.with_parent(*parent_id.as_bytes());
-            }
-            // Full ancestor chain — see the matching block in
-            // `collect_leaves_recursive` for rationale.
-            if let Ok(ancestors) = Index::<MainStorage>::get_ancestors_of(entity_id) {
-                metadata = metadata.with_ancestors(ancestors);
-            }
-            if let Some(auth) = crate::sync::helpers::wire_authorization_for(&index.metadata) {
-                metadata = metadata.with_authorization(auth);
-            }
-            let leaf_data = TreeLeafData::new(*entity_id.as_bytes(), entry_data, metadata);
-            Ok(Some(TreeNode::leaf(
-                *entity_id.as_bytes(),
-                full_hash,
-                leaf_data,
-            )))
-        } else {
-            Ok(Some(TreeNode::internal(
-                *entity_id.as_bytes(),
-                full_hash,
-                vec![],
-            )))
+    // Tombstones for children this node removed, resolved to signed
+    // `EntityDeletion`s from each child's own tombstone index. Carried on the
+    // wire so a peer that still holds the child converges to the deletion
+    // (delete-wins) during comparison — without anyone pushing the live entity.
+    let deleted_children = collect_deleted_children_wire(&index);
+
+    // A node with live children and/or tombstoned children is INTERNAL. A
+    // collection cleared to childless still carries `deleted_children`, so emit
+    // it as internal carrying the tombstones (not as a leaf) — that's what lets
+    // the deletion propagate. Behaviour is unchanged when there are no
+    // tombstones (`deleted_children` empty): the old leaf/internal split below.
+    if !children_ids.is_empty() || !deleted_children.is_empty() {
+        let mut node = TreeNode::internal(*entity_id.as_bytes(), full_hash, children_ids);
+        node.deleted_children = deleted_children;
+        return Ok(Some(node));
+    }
+
+    // No children, live or tombstoned — leaf, or empty-internal.
+    if let Some(entry_data) = Interface::<MainStorage>::find_by_id_raw(entity_id) {
+        let crdt_type = index.metadata.crdt_type.clone().unwrap_or_else(|| {
+            // No CRDT type ("opaque" leaf — e.g. the `Root<T>` state entry).
+            // Emit a real *leaf* (not a malformed empty `internal` node, which the
+            // peer's `TreeNode::is_valid()` rejects) carrying a synthetic LWW wire
+            // type — merge-equivalent to `None` and Merkle-hash-neutral.
+            trace!(%entity_id, "opaque leaf, synthesised LWW wire type for sync");
+            CrdtType::lww_register(OPAQUE_LEAF_CRDT_TYPE_NAME)
+        });
+        // Carry the leaf's Merkle parent_id on the wire — see the same
+        // comment in `collect_leaves_recursive` for rationale.
+        let mut metadata = LeafMetadata::new(crdt_type, index.metadata.updated_at(), [0u8; 32])
+            .with_created_at(index.metadata.created_at());
+        if let Some(parent_id) = index.parent_id() {
+            metadata = metadata.with_parent(*parent_id.as_bytes());
         }
+        // Full ancestor chain — see the matching block in
+        // `collect_leaves_recursive` for rationale.
+        if let Ok(ancestors) = Index::<MainStorage>::get_ancestors_of(entity_id) {
+            metadata = metadata.with_ancestors(ancestors);
+        }
+        if let Some(auth) = crate::sync::helpers::wire_authorization_for(&index.metadata) {
+            metadata = metadata.with_authorization(auth);
+        }
+        let leaf_data = TreeLeafData::new(*entity_id.as_bytes(), entry_data, metadata);
+        Ok(Some(TreeNode::leaf(
+            *entity_id.as_bytes(),
+            full_hash,
+            leaf_data,
+        )))
     } else {
         Ok(Some(TreeNode::internal(
             *entity_id.as_bytes(),
             full_hash,
-            children_ids,
+            vec![],
         )))
     }
+}
+
+/// Apply tombstones a remote node advertised in its `deleted_children`, for any
+/// entity we still hold live. Each goes through the authenticated
+/// `Action::DeleteRef` path (delete-wins by HLC; signature/nonce verified for
+/// User/Shared, safe no-op when it loses or fails auth). Returns the count
+/// applied. Must be called inside a `with_runtime_env` scope.
+pub(crate) fn apply_remote_tombstones(deletions: &[EntityDeletion]) -> u64 {
+    let mut applied = 0u64;
+    for deletion in deletions {
+        let action = calimero_storage::action::Action::DeleteRef {
+            id: Id::new(deletion.id),
+            deleted_at: deletion.deleted_at,
+            metadata: deletion.metadata.clone(),
+        };
+        if Interface::<MainStorage>::apply_action(
+            action,
+            &calimero_storage::interface::ApplyContext::empty(),
+        )
+        .is_ok()
+        {
+            applied += 1;
+        }
+    }
+    applied
+}
+
+/// Resolve a node's `deleted_children` (child ids) to signed `EntityDeletion`s
+/// for the wire, reading each child's own tombstone index for `deleted_at` +
+/// the (signed) metadata. Entries whose child index is gone (GC'd) or not
+/// actually tombstoned are skipped.
+pub(crate) fn collect_deleted_children_wire(
+    index: &calimero_storage::index::EntityIndex,
+) -> Vec<EntityDeletion> {
+    index
+        .deleted_children()
+        .iter()
+        .filter_map(|child_id| {
+            let cidx = Index::<MainStorage>::get_index(*child_id).ok().flatten()?;
+            let deleted_at = cidx.deleted_at?;
+            Some(EntityDeletion {
+                id: *child_id.as_bytes(),
+                deleted_at,
+                metadata: cidx.metadata.clone(),
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -259,12 +259,13 @@ async fn run_initiator_impl<T: SyncTransport>(
             bail!("Expected Message, got {:?}", response);
         };
 
-        let (resp_level, mut nodes, has_more_levels) = match payload {
+        let (resp_level, mut nodes, has_more_levels, remote_deleted) = match payload {
             MessagePayload::LevelWiseResponse {
                 level: resp_level,
                 nodes,
                 has_more_levels,
-            } => (resp_level, nodes, has_more_levels),
+                deleted_children,
+            } => (resp_level, nodes, has_more_levels, deleted_children),
             MessagePayload::SnapshotError { error } => {
                 warn!(%context_id, ?error, "Peer returned error");
                 bail!("Peer error: {:?}", error);
@@ -319,9 +320,29 @@ async fn run_initiator_impl<T: SyncTransport>(
             %context_id,
             level,
             nodes_received = nodes.len(),
+            deleted_received = remote_deleted.len(),
             has_more_levels,
             "Received level response"
         );
+
+        // Apply any tombstones the responder advertised for this level FIRST —
+        // before the empty-nodes early-out below. A cleared collection returns
+        // zero live nodes but a non-empty `deleted_children`; applying here
+        // (authenticated DeleteRef, delete-wins) is what converges a clear when
+        // the holder initiates. Safe no-op when we already deleted or lose LWW.
+        if !remote_deleted.is_empty() {
+            let applied = with_runtime_env(runtime_env.clone(), || {
+                crate::sync::hash_comparison_protocol::apply_remote_tombstones(&remote_deleted)
+            });
+            stats.entities_merged += applied;
+            debug!(
+                %context_id,
+                level,
+                advertised = remote_deleted.len(),
+                applied,
+                "Applied remote tombstones from level response"
+            );
+        }
 
         if nodes.is_empty() {
             debug!(%context_id, level, "No nodes at this level, sync complete");
@@ -605,13 +626,14 @@ async fn run_responder_impl<T: SyncTransport>(
     let mut sequence_id = 0u64;
 
     // Handle the first request (already parsed by the manager)
-    let (nodes, has_more_levels) =
+    let (nodes, has_more_levels, deleted_children) =
         handle_levelwise_request(context_id, first_level, first_parent_ids, &runtime_env)?;
 
     debug!(
         %context_id,
         level = first_level,
         nodes_found = nodes.len(),
+        deleted = deleted_children.len(),
         has_more_levels,
         "Responding with first level nodes"
     );
@@ -622,6 +644,7 @@ async fn run_responder_impl<T: SyncTransport>(
             level: first_level,
             nodes,
             has_more_levels,
+            deleted_children,
         },
         next_nonce: generate_nonce(),
     };
@@ -638,7 +661,7 @@ fn handle_levelwise_request(
     level: u32,
     parent_ids: Option<Vec<[u8; 32]>>,
     runtime_env: &calimero_storage::env::RuntimeEnv,
-) -> Result<(Vec<LevelNode>, bool)> {
+) -> Result<(Vec<LevelNode>, bool, Vec<EntityDeletion>)> {
     trace!(
         %context_id,
         level,
@@ -655,7 +678,7 @@ fn handle_levelwise_request(
             "Level exceeds maximum"
         );
         // Return empty response rather than error to avoid leaking state
-        return Ok((vec![], false));
+        return Ok((vec![], false, vec![]));
     }
 
     // DoS protection: truncate parent_ids if too large
@@ -715,13 +738,14 @@ async fn run_responder_loop<T: SyncTransport>(
             InitPayload::LevelWiseRequest {
                 level, parent_ids, ..
             } => {
-                let (nodes, has_more_levels) =
+                let (nodes, has_more_levels, deleted_children) =
                     handle_levelwise_request(context_id, level, parent_ids, runtime_env)?;
 
                 debug!(
                     %context_id,
                     level,
                     nodes_found = nodes.len(),
+                    deleted = deleted_children.len(),
                     has_more_levels,
                     "Responding with level nodes"
                 );
@@ -732,6 +756,7 @@ async fn run_responder_loop<T: SyncTransport>(
                         level,
                         nodes,
                         has_more_levels,
+                        deleted_children,
                     },
                     next_nonce: generate_nonce(),
                 };
@@ -871,19 +896,20 @@ fn get_nodes_at_level(
     context_id: ContextId,
     level: usize,
     parent_ids: Option<&[[u8; 32]]>,
-) -> Result<(Vec<LevelNode>, bool)> {
+) -> Result<(Vec<LevelNode>, bool, Vec<EntityDeletion>)> {
     let mut nodes = Vec::new();
+    let mut deleted_children = Vec::new();
     let mut has_more_levels = false;
 
     let root_id = Id::new(*context_id.as_ref());
 
     // Verify root exists before proceeding
     match Index::<MainStorage>::get_index(root_id) {
-        Ok(Some(_)) => {}                      // Root exists, continue
-        Ok(None) => return Ok((nodes, false)), // Empty tree
+        Ok(Some(_)) => {}                                        // Root exists, continue
+        Ok(None) => return Ok((nodes, false, deleted_children)), // Empty tree
         Err(e) => {
             warn!(%context_id, error = %e, "Failed to get root index");
-            return Ok((nodes, false));
+            return Ok((nodes, false, deleted_children));
         }
     }
 
@@ -896,7 +922,7 @@ fn get_nodes_at_level(
         None => {
             // This shouldn't happen - deeper levels need parent_ids
             warn!(%context_id, level, "No parent_ids for level > 0");
-            return Ok((nodes, false));
+            return Ok((nodes, false, deleted_children));
         }
         Some(ids) => ids.iter().map(|id| Id::new(*id)).collect(),
     };
@@ -907,6 +933,14 @@ fn get_nodes_at_level(
             Ok(None) => continue,
             Err(_) => continue,
         };
+
+        // Tombstones for children this parent deleted ride alongside the live
+        // node list so a holder (the initiator) learns of the deletion even
+        // when the parent now has zero live children (the cleared-collection
+        // case, where the node list would otherwise be empty).
+        deleted_children.extend(
+            crate::sync::hash_comparison_protocol::collect_deleted_children_wire(&parent_index),
+        );
 
         let Some(children) = parent_index.children() else {
             continue;
@@ -1014,7 +1048,7 @@ fn get_nodes_at_level(
         }
     }
 
-    Ok((nodes, has_more_levels))
+    Ok((nodes, has_more_levels, deleted_children))
 }
 
 // =============================================================================

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -816,6 +816,48 @@ mod tests {
         );
     }
 
+    /// Symmetric convergence in ONE round when the node that still HOLDS the
+    /// entry initiates (the #2591 case). `bob` (holder) initiates against `alice`
+    /// (cleared). Alice's now-childless node carries `deleted_children=[entry]`
+    /// on the wire, so bob applies the deletion (delete-wins) during comparison
+    /// — no live entity pushed, single direction. Before tombstones-in-tree this
+    /// only converged once *alice* happened to initiate.
+    #[tokio::test]
+    async fn test_hashcomparison_clear_converges_when_holder_initiates() {
+        use crate::sync_sim::actions::StorageOp;
+
+        let ctx = shared_context();
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let mut bob = SimNode::new_in_context("bob", ctx);
+
+        let entry = EntityId::from_u64(1);
+        alice.insert_entity_with_metadata(entry, b"v1".to_vec(), EntityMetadata::default());
+        bob.insert_entity_with_metadata(entry, b"v1".to_vec(), EntityMetadata::default());
+        assert_eq!(alice.root_hash(), bob.root_hash());
+
+        alice.apply_storage_op(StorageOp::Remove { id: entry });
+        assert_eq!(alice.entity_count(), 0);
+        assert_eq!(bob.entity_count(), 1);
+
+        // The HOLDER (bob) initiates — only direction, no second pass.
+        execute_hash_comparison_sync(&mut bob, &alice)
+            .await
+            .expect("bob->alice sync ok");
+
+        assert_eq!(
+            bob.entity_count(),
+            0,
+            "bob did not converge to the deletion when it was the initiator \
+             (deleted_children not propagated)"
+        );
+        assert_eq!(alice.entity_count(), 0, "alice stays cleared");
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "roots must converge after a single sync regardless of who initiated"
+        );
+    }
+
     /// LevelWise (the wide/shallow-tree protocol) must also propagate clears.
     /// It's pull-only, so the cleared node propagates the deletion via
     /// `EntityDeletePush` when it initiates. Without it, a clear reconciled via
@@ -851,6 +893,48 @@ mod tests {
             alice.root_hash(),
             bob.root_hash(),
             "roots must converge after LevelWise clear propagation"
+        );
+    }
+
+    /// LevelWise must also converge a clear when the HOLDER initiates (#2591).
+    /// `bob` (holder) initiates against cleared `alice`. Alice returns zero live
+    /// nodes at level 0 but carries `deleted_children=[entry]` on the wire, which
+    /// bob applies (delete-wins) before its empty-nodes early-out — so the clear
+    /// converges in a single pull. Before tombstones-in-tree the empty level
+    /// response made bob exit the loop still holding the entry.
+    #[tokio::test]
+    async fn test_levelwise_clear_converges_when_holder_initiates() {
+        use crate::sync_sim::actions::StorageOp;
+
+        let ctx = shared_context();
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let mut bob = SimNode::new_in_context("bob", ctx);
+
+        let entry = EntityId::from_u64(1);
+        alice.insert_entity_with_metadata(entry, b"v1".to_vec(), EntityMetadata::default());
+        bob.insert_entity_with_metadata(entry, b"v1".to_vec(), EntityMetadata::default());
+        assert_eq!(alice.root_hash(), bob.root_hash());
+
+        alice.apply_storage_op(StorageOp::Remove { id: entry });
+        assert_eq!(alice.entity_count(), 0);
+        assert_eq!(bob.entity_count(), 1);
+
+        // The HOLDER (bob) initiates the pull.
+        execute_level_wise_sync(&mut bob, &alice)
+            .await
+            .expect("bob->alice levelwise ok");
+
+        assert_eq!(
+            bob.entity_count(),
+            0,
+            "bob did not converge to the deletion as LevelWise initiator \
+             (deleted_children not carried on the level response)"
+        );
+        assert_eq!(alice.entity_count(), 0, "alice stays cleared");
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "roots must converge after a single LevelWise pull regardless of initiator"
         );
     }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -340,6 +340,18 @@ pub struct EntityIndex {
     /// Enables proper conflict resolution (delete vs update) in distributed scenarios.
     /// Garbage collected after retention period (default: 1 day).
     pub deleted_at: Option<u64>,
+
+    /// Ids of this entity's children that have been removed (tombstoned).
+    ///
+    /// A deletion is the *absence* of a child from `children`, which the
+    /// add-biased HC/LevelWise comparison can't see. This list makes the
+    /// deletion explicit so it can be carried on the sync wire
+    /// (`TreeNode.deleted_children`): a peer that still holds the child learns
+    /// of the deletion during comparison and applies delete-wins — without
+    /// anyone pushing the live entity. The child's `deleted_at` + signed
+    /// metadata are read from the child's own tombstone index at wire-build
+    /// time, so only the id is kept here.
+    pub deleted_children: Vec<Id>,
 }
 
 impl EntityIndex {
@@ -359,6 +371,7 @@ impl EntityIndex {
             own_hash: [0; 32],
             metadata: Metadata::default(),
             deleted_at: None,
+            deleted_children: Vec::new(),
         }
     }
 
@@ -378,6 +391,15 @@ impl EntityIndex {
     #[must_use]
     pub fn children(&self) -> Option<&[ChildInfo]> {
         self.children.as_deref()
+    }
+
+    /// Ids of this entity's children that have been removed (tombstoned).
+    ///
+    /// Carried on the sync wire so a peer that still holds a child converges
+    /// to the deletion (delete-wins) without anyone pushing the live entity.
+    #[must_use]
+    pub fn deleted_children(&self) -> &[Id] {
+        &self.deleted_children
     }
 
     /// Returns the full hash (entity + all descendants).
@@ -400,6 +422,7 @@ pub struct Index<S: StorageAdaptor>(PhantomData<S>);
 impl<S: StorageAdaptor> Index<S> {
     /// Adds a child to a parent's collection.
     pub(crate) fn add_child_to(parent_id: Id, child: ChildInfo) -> Result<(), StorageError> {
+        let added_child_id = child.id();
         // Serialize the read-modify-write so a concurrent local-write / sync
         // apply on the same parent can't lose a child (core#2571).
         let _mutation_guard = index_mutation_guard();
@@ -413,6 +436,7 @@ impl<S: StorageAdaptor> Index<S> {
             own_hash: [0; 32],
             metadata: Metadata::default(),
             deleted_at: None,
+            deleted_children: Vec::new(),
         });
 
         // Get or create child index
@@ -424,6 +448,7 @@ impl<S: StorageAdaptor> Index<S> {
             own_hash: [0; 32],
             metadata: child.metadata.clone(),
             deleted_at: None,
+            deleted_children: Vec::new(),
         });
         child_index.parent_id = Some(parent_id);
         child_index.own_hash = child.merkle_hash();
@@ -481,6 +506,13 @@ impl<S: StorageAdaptor> Index<S> {
             }
         }
 
+        // A re-added (resurrected) child is live again, so it must no longer be
+        // advertised as deleted on the wire — else a peer would apply a stale
+        // delete-wins against it.
+        parent_index
+            .deleted_children
+            .retain(|id| *id != added_child_id);
+
         parent_index.full_hash =
             Self::calculate_full_hash_for_children(parent_index.own_hash, &parent_index.children)?;
         Self::save_index(&parent_index)?;
@@ -503,6 +535,7 @@ impl<S: StorageAdaptor> Index<S> {
             own_hash: [0; 32],
             metadata: root.metadata.clone(),
             deleted_at: None,
+            deleted_children: Vec::new(),
         });
         index.own_hash = root.merkle_hash();
         // Keep stored full_hash current. Without this, a root holds
@@ -856,6 +889,15 @@ impl<S: StorageAdaptor> Index<S> {
             if children.is_empty() {
                 parent_index.children = None;
             }
+        }
+
+        // Record the removal so the deletion is explicit on the sync wire
+        // (the child vanishes from `children`, which the add-biased HC/LevelWise
+        // comparison can't otherwise observe). Deduped; the per-child
+        // `deleted_at` + signed metadata are read from the child's own tombstone
+        // index at wire-build time.
+        if !parent_index.deleted_children.contains(&child_id) {
+            parent_index.deleted_children.push(child_id);
         }
 
         // Recalculate parent's hash

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -616,6 +616,7 @@ mod index__private_methods {
             own_hash: hash2,
             metadata: Metadata::default(),
             deleted_at: None,
+            deleted_children: Vec::new(),
         };
         <Index<MainStorage>>::save_index(&index).unwrap();
 
@@ -637,6 +638,7 @@ mod index__private_methods {
             own_hash: hash2,
             metadata: Metadata::default(),
             deleted_at: None,
+            deleted_children: Vec::new(),
         };
         <Index<MainStorage>>::save_index(&index).unwrap();
         assert_eq!(<Index<MainStorage>>::get_index(id).unwrap().unwrap(), index);
@@ -1088,6 +1090,7 @@ mod minimal_struct_layout_compat {
                 field_name,
             },
             deleted_at: Some(9999),
+            deleted_children: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Closes #2591.

## Problem

HashComparison and LevelWise reconcile entity trees **add-wins** during comparison. Deletions only ever rode the delta stream or an `EntityDeletePush` sent by the node that *did* the clear. So a clear converged only when the **cleared** node happened to initiate:

- **HC, holder initiates:** the cleared collection is a now-childless node; comparison sees "no children" and the holder keeps its stale copy.
- **LevelWise, holder initiates:** the cleared collection returns an empty level; the initiator hits its empty-nodes early-out and exits still holding the entry.

Either way the deletion sat unpropagated until roles flipped — an intermittent clear split-brain (the `scaffolding-e2e` clear flake lineage).

## Fix — make deletions first-class on the comparison wire

Convergence becomes symmetric in a single round regardless of initiator, **without pushing any live entity** (which would re-enter the Frozen-as-Public apply path that regressed frozen-rga before):

- **storage** — `EntityIndex` gains `deleted_children: Vec<Id>`, appended when a child is removed from its parent and cleared when the child is re-added.
- **HashComparison** — `TreeNode` carries `deleted_children: Vec<EntityDeletion>`. A now-childless cleared collection is emitted as an *internal* node carrying them. The initiator applies remote `deleted_children` via the authenticated `Action::DeleteRef` path (delete-wins by HLC; sig/nonce verified for User/Shared; safe no-op on LWW loss / auth fail).
- **LevelWise** — the level response carries `deleted_children`; the initiator applies them **before** its empty-level early-out, so a cleared collection converges on the first pull.

Tombstone resolution + application reuse the `EntityDeletion` wire type and apply path from #2584. The cleared-node-initiates direction still flows via the existing `EntityDeletePush` — this PR adds the *other* direction.

## Wire / state-format note

The `EntityIndex` borsh layout change is **additive** but there is no migration hook — nodes upgrading need fresh state. `MessagePayload::LevelWiseResponse` and `TreeNode` gain a field (older peers can't decode the new layout; this is a coordinated-upgrade change like the prior sync-wire additions).

## Tests

- `test_hashcomparison_clear_converges_when_holder_initiates` — holder initiates, converges in one HC round.
- `test_levelwise_clear_converges_when_holder_initiates` — holder initiates, converges in one LevelWise pull.
- Existing `test_{hashcomparison,levelwise}_propagates_clear_tombstone` (cleared-node-initiates) still green.
- Full `sync_sim` (312), `calimero-storage` lib (544), `calimero-node` lib (241), `calimero-node-primitives` lib (163) green; `cargo fmt --check` clean; `cargo build --workspace` clean.

## Gate

⚠️ Draft until the **frozen-rga convergence** e2e job is green on this branch (run dispatched: https://github.com/calimero-network/core/actions/runs/26806974408). The whole design exists to converge clears *without* re-treading the live-entity Frozen path that regressed frozen-rga previously; this PR stays draft until that's proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes persistent `EntityIndex` borsh layout and sync wire messages (`TreeNode`, `LevelWiseResponse`), requiring coordinated rollout; deletion apply path is security-sensitive (authenticated `DeleteRef`, delete-wins).
> 
> **Overview**
> Fixes **clear split-brain** when the node that still holds an entry initiates HashComparison or LevelWise: add-biased tree comparison could not see removals, so a cleared peer looked “empty” and the holder never learned the delete until roles flipped.
> 
> **Storage** adds `EntityIndex::deleted_children` (recorded on `remove_child_from`, cleared on re-add). **HashComparison** puts resolved `EntityDeletion` tombstones on `TreeNode::deleted_children`, treats cleared parents as **internal** nodes even with no live children, and applies remote tombstones via authenticated `DeleteRef` during traversal. **LevelWise** adds `deleted_children` on `LevelWiseResponse`, aggregates them in `get_nodes_at_level`, and applies them **before** the empty-level early-out. Wire/index layout changes need a **coordinated upgrade** (no migration hook).
> 
> New `sync_sim` tests cover holder-initiates clear for both protocols in one round, without pushing live entities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9d5f2eb05d3709c0589541540e812605f8918c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->