### PR TITLE
feat(context): bound context & application caches with safe eviction

### DIFF
--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, warn};
 use super::execute::execute;
 use super::execute::storage::{ContextPrivateStorage, ContextStorage};
 use crate::handlers::execute::{persist_signed_signatures, sign_authorized_actions};
-use crate::{ContextManager, ContextMeta};
+use crate::{evict_application_if_full, evict_idle_context_if_full, ContextManager, ContextMeta};
 use calimero_governance_store::governance_broadcast::ObserveDelivery;
 
 impl Handler<CreateContextRequest> for ContextManager {
@@ -50,6 +50,13 @@ impl Handler<CreateContextRequest> for ContextManager {
             let (_, sk) = self.node_namespace_identity(&group_id)?;
             Some(PrivateKey::from(sk))
         });
+
+        // Make room before `Prepared::new` inserts the freshly created context
+        // and its application — done here (rather than inside the `mem::transmute`
+        // entry loop below) where `self.contexts`/`self.applications` are
+        // borrow-free. Both are no-ops while below their caps.
+        evict_idle_context_if_full(&mut self.contexts);
+        evict_application_if_full(&mut self.applications);
 
         let prepared = match Prepared::new(
             &self.node_client,

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -51,13 +51,6 @@ impl Handler<CreateContextRequest> for ContextManager {
             Some(PrivateKey::from(sk))
         });
 
-        // Make room before `Prepared::new` inserts the freshly created context
-        // and its application — done here (rather than inside the `mem::transmute`
-        // entry loop below) where `self.contexts`/`self.applications` are
-        // borrow-free. Both are no-ops while below their caps.
-        evict_idle_context_if_full(&mut self.contexts);
-        evict_application_if_full(&mut self.applications);
-
         let prepared = match Prepared::new(
             &self.node_client,
             &self.context_client,
@@ -223,6 +216,28 @@ impl Prepared<'_> {
 
         let identity_secret = identity_secret.unwrap_or_else(|| PrivateKey::random(&mut rng));
 
+        // Resolve the application (fetching on a cache miss) *before* evicting,
+        // so a failed lookup never wastes an eviction — evict only once the
+        // insert is guaranteed to happen.
+        let application = match applications.get(&effective_app_id) {
+            Some(existing) => existing.clone(),
+            None => {
+                let fetched = node_client
+                    .get_application(&effective_app_id)?
+                    .ok_or_eyre("application not found")?;
+                evict_application_if_full(applications);
+                applications
+                    .entry(effective_app_id)
+                    .or_insert(fetched)
+                    .clone()
+            }
+        };
+
+        // Make room for the freshly created context. Placed after the
+        // membership/capability validation above (so failed auth never drains
+        // the cache) and immediately before the derivation loop that inserts.
+        evict_idle_context_if_full(contexts);
+
         let mut context = None;
         for _ in 0..5 {
             let context_secret = if let Some(seed) = seed {
@@ -264,25 +279,12 @@ impl Prepared<'_> {
 
         let identity = identity_secret.public_key();
 
-        let application = match applications.entry(effective_app_id) {
-            btree_map::Entry::Vacant(vacant) => {
-                let application = node_client
-                    .get_application(&effective_app_id)?
-                    .ok_or_eyre("application not found")?;
-
-                vacant.insert(application)
-            }
-            btree_map::Entry::Occupied(occupied) => occupied.into_mut(),
-        };
-
         let meta = Context::new(context_id, effective_app_id, Hash::default());
 
         let context = entry.insert(ContextMeta {
             meta,
             lock: Arc::new(Mutex::new(context_id)),
         });
-
-        let application = application.clone();
 
         Ok(Self {
             external_config,

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -2,7 +2,6 @@ use calimero_governance_store::{
     CapabilitiesRepository, GroupKeyring, MetaRepository, MigrationsRepository, NamespaceRepository,
 };
 use std::borrow::Cow;
-use std::collections::btree_map;
 // Removed: NonZeroUsize (replaced with CausalDelta)
 use std::time::Instant;
 
@@ -48,7 +47,7 @@ use crate::error::ContextError;
 use crate::handlers::update_application::{
     create_storage_callbacks, update_application_id, update_application_with_migration,
 };
-use crate::ContextManager;
+use crate::{evict_application_if_full, ContextManager};
 use calimero_governance_store::metrics::ExecutionLabels;
 
 pub mod storage;
@@ -978,16 +977,21 @@ impl ContextManager {
                 return Ok(CachedOrBlob::Cached(cached.clone()));
             }
 
-            let app = match act.applications.entry(application_id) {
-                btree_map::Entry::Vacant(vacant) => {
-                    let Some(app) = act.node_client.get_application(&application_id)? else {
-                        bail!(ExecuteError::ApplicationNotInstalled { application_id });
-                    };
-
-                    vacant.insert(app)
-                }
-                btree_map::Entry::Occupied(occupied) => occupied.into_mut(),
-            };
+            // Fetch on a cache miss *before* evicting (so a not-installed app
+            // never wastes an eviction), then cap the cache before inserting.
+            // This `get_module` path is the dominant `applications` insert site
+            // on a long-running node, so it must honour the cap too.
+            if !act.applications.contains_key(&application_id) {
+                let Some(app) = act.node_client.get_application(&application_id)? else {
+                    bail!(ExecuteError::ApplicationNotInstalled { application_id });
+                };
+                evict_application_if_full(&mut act.applications);
+                let _ = act.applications.insert(application_id, app);
+            }
+            let app = act
+                .applications
+                .get(&application_id)
+                .expect("application just inserted or already cached");
 
             let blob = app
                 .resolve_service_blob(service_name.as_deref())

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -29,7 +29,7 @@ use eyre::bail;
 use tracing::{debug, error, info};
 
 use crate::handlers::execute::storage::ContextStorage;
-use crate::ContextManager;
+use crate::{evict_application_if_full, ContextManager};
 
 impl Handler<UpdateApplicationRequest> for ContextManager {
     type Result = ActorResponse<Self, <UpdateApplicationRequest as Message>::Result>;
@@ -165,6 +165,11 @@ impl Handler<UpdateApplicationRequest> for ContextManager {
         );
 
         ActorResponse::r#async(task.into_actor(self).map_ok(move |application, act, _ctx| {
+            // Honour MAX_CACHED_APPLICATIONS on this insert site too — only
+            // evict when we're actually adding a new entry.
+            if !act.applications.contains_key(&application_id) {
+                evict_application_if_full(&mut act.applications);
+            }
             let _ignored = act
                 .applications
                 .entry(application_id)

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -177,6 +177,12 @@ struct ContextMeta {
 /// exceed the cap temporarily; it self-corrects as in-flight operations
 /// finish. The over-cap count is bounded by the number of contexts executing
 /// concurrently, which node concurrency already limits.
+///
+/// The victim is the first *idle* entry in `ContextId` (key) order, not the
+/// least-recently-used one — deliberately, matching the compiled-`modules`
+/// cap. A wrong guess only costs a re-fetch from the authoritative datastore,
+/// so true LRU isn't worth the access-tracking overhead; it remains a possible
+/// follow-up if profiling ever shows churn on a hot context.
 fn evict_idle_context_if_full(contexts: &mut BTreeMap<ContextId, ContextMeta>) {
     if contexts.len() < MAX_CACHED_CONTEXTS {
         return;
@@ -214,6 +220,16 @@ fn evict_application_if_full(applications: &mut BTreeMap<ApplicationId, Applicat
     if let Some((id, _)) = applications.pop_first() {
         tracing::debug!(application = %id, "evicted application from cache (at capacity)");
     }
+
+    // Each insert site evicts exactly once before adding one entry, so the map
+    // should never sit more than one over the cap here. A larger overage means
+    // an insert site bypassed this helper — catch it in dev.
+    debug_assert!(
+        applications.len() <= MAX_CACHED_APPLICATIONS,
+        "applications cache over cap after eviction ({} > {MAX_CACHED_APPLICATIONS}); \
+         an insert site likely bypassed evict_application_if_full",
+        applications.len(),
+    );
 }
 
 /// The central actor responsible for managing the lifecycle of all contexts.
@@ -557,81 +573,89 @@ impl ContextManager {
         &mut self,
         context_id: &ContextId,
     ) -> eyre::Result<Option<&ContextMeta>> {
-        // On a cache miss we're about to insert below, so make room first.
-        // Done before taking the `entry` borrow since eviction needs its own
-        // `&mut self.contexts`. A miss that turns out to be a non-existent
-        // context just wastes one (harmless) eviction.
-        if !self.contexts.contains_key(context_id) {
+        // Cache miss: fetch first, so a lookup for a non-existent context never
+        // triggers (and wastes) an eviction. Only once we know the context
+        // exists do we make room and insert. Kept as a self-contained block so
+        // its borrows end before the single returning borrow taken below (the
+        // borrow checker can't return a reference through a split hit/miss
+        // match otherwise).
+        let was_cached = self.contexts.contains_key(context_id);
+        if !was_cached {
+            let Some(context) = self.context_client.get_context(context_id)? else {
+                return Ok(None);
+            };
+
             evict_idle_context_if_full(&mut self.contexts);
-        }
 
-        let entry = self.contexts.entry(*context_id);
-
-        match entry {
-            btree_map::Entry::Occupied(mut occupied) => {
-                // CRITICAL FIX: Always reload dag_heads from database to get latest state
-                // The dag_heads can be updated by delta_store when receiving network deltas,
-                // but the cached Context object won't reflect these changes.
-                // This was causing all deltas to use genesis as parent instead of actual dag_heads.
-                let handle = self.datastore.handle();
-                let key = calimero_store::key::ContextMeta::new(*context_id);
-
-                if let Some(meta) = handle.get(&key)? {
-                    let cached = occupied.get_mut();
-
-                    // Update dag_heads if they changed in DB
-                    if cached.meta.dag_heads != meta.dag_heads {
-                        tracing::debug!(
-                            %context_id,
-                            old_heads_count = cached.meta.dag_heads.len(),
-                            new_heads_count = meta.dag_heads.len(),
-                            "Refreshing dag_heads from database (cache was stale)"
-                        );
-                        cached.meta.dag_heads = meta.dag_heads;
-                    }
-
-                    // Also update root_hash in case it changed
-                    cached.meta.root_hash = meta.root_hash.into();
-
-                    // Refresh application_id too. A LazyOnAccess upgrade (or
-                    // a cascade target-application change) rewrites the
-                    // context's bound application in the DB out-of-band of
-                    // this in-memory cache. Callers (notably the execute
-                    // path's post-lazy-upgrade re-fetch) resolve the WASM
-                    // module from `application_id`; if the cache still holds
-                    // the pre-upgrade id, the method runs the OLD module
-                    // against the freshly-migrated (new-shaped) state — a
-                    // borsh "Not all bytes read" panic. Keeping app_id in
-                    // lockstep with the DB closes that window.
-                    let db_application_id = meta.application.application_id();
-                    if cached.meta.application_id != db_application_id {
-                        tracing::debug!(
-                            %context_id,
-                            old_application_id = %cached.meta.application_id,
-                            new_application_id = %db_application_id,
-                            "Refreshing application_id from database (cache was stale)"
-                        );
-                        cached.meta.application_id = db_application_id;
-                    }
-                }
-
-                Ok(Some(occupied.into_mut()))
-            }
-            btree_map::Entry::Vacant(vacant) => {
-                let Some(context) = self.context_client.get_context(context_id)? else {
-                    return Ok(None);
-                };
-
-                let lock = Arc::new(Mutex::new(*context_id));
-
-                let item = vacant.insert(ContextMeta {
+            let lock = Arc::new(Mutex::new(*context_id));
+            let _ = self.contexts.insert(
+                *context_id,
+                ContextMeta {
                     meta: context,
                     lock,
-                });
+                },
+            );
+        }
 
-                Ok(Some(item))
+        let btree_map::Entry::Occupied(mut occupied) = self.contexts.entry(*context_id) else {
+            // Unreachable: the entry was either already cached or just inserted
+            // above, and this actor processes messages serially.
+            debug_assert!(false, "context entry vanished between insert and lookup");
+            return Ok(None);
+        };
+
+        // For an already-cached entry, reload from the DB to pick up
+        // out-of-band changes. A freshly fetched-and-inserted entry is already
+        // current, so skip the redundant read.
+        if was_cached {
+            // CRITICAL FIX: Always reload dag_heads from database to get latest state
+            // The dag_heads can be updated by delta_store when receiving network deltas,
+            // but the cached Context object won't reflect these changes.
+            // This was causing all deltas to use genesis as parent instead of actual dag_heads.
+            let handle = self.datastore.handle();
+            let key = calimero_store::key::ContextMeta::new(*context_id);
+
+            if let Some(meta) = handle.get(&key)? {
+                let cached = occupied.get_mut();
+
+                // Update dag_heads if they changed in DB
+                if cached.meta.dag_heads != meta.dag_heads {
+                    tracing::debug!(
+                        %context_id,
+                        old_heads_count = cached.meta.dag_heads.len(),
+                        new_heads_count = meta.dag_heads.len(),
+                        "Refreshing dag_heads from database (cache was stale)"
+                    );
+                    cached.meta.dag_heads = meta.dag_heads;
+                }
+
+                // Also update root_hash in case it changed
+                cached.meta.root_hash = meta.root_hash.into();
+
+                // Refresh application_id too. A LazyOnAccess upgrade (or
+                // a cascade target-application change) rewrites the
+                // context's bound application in the DB out-of-band of
+                // this in-memory cache. Callers (notably the execute
+                // path's post-lazy-upgrade re-fetch) resolve the WASM
+                // module from `application_id`; if the cache still holds
+                // the pre-upgrade id, the method runs the OLD module
+                // against the freshly-migrated (new-shaped) state — a
+                // borsh "Not all bytes read" panic. Keeping app_id in
+                // lockstep with the DB closes that window.
+                let db_application_id = meta.application.application_id();
+                if cached.meta.application_id != db_application_id {
+                    tracing::debug!(
+                        %context_id,
+                        old_application_id = %cached.meta.application_id,
+                        new_application_id = %db_application_id,
+                        "Refreshing application_id from database (cache was stale)"
+                    );
+                    cached.meta.application_id = db_application_id;
+                }
             }
         }
+
+        Ok(Some(occupied.into_mut()))
     }
 }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -127,6 +127,19 @@ impl Default for ContextManagerConfig {
     }
 }
 
+/// Upper bound on the number of contexts kept in the in-memory hot cache
+/// (`ContextManager::contexts`). A safety valve against unbounded growth on
+/// long-running nodes that access many distinct contexts — NOT a hard limit:
+/// the cache may briefly exceed it when every entry is live (see
+/// [`evict_idle_context_if_full`]). The datastore remains authoritative, so an
+/// evicted context is simply re-fetched on next access.
+const MAX_CACHED_CONTEXTS: usize = 1024;
+
+/// Upper bound on cached application metadata (`ContextManager::applications`).
+/// Mirrors the compiled-`modules` cap (`MAX_CACHED_MODULES`); application
+/// metadata is a pure cache over the datastore, so eviction is harmless.
+const MAX_CACHED_APPLICATIONS: usize = 256;
+
 /// A metadata container for a single, in-memory context.
 ///
 /// It holds the context's core properties and an asynchronous mutex (`lock`).
@@ -137,6 +150,70 @@ impl Default for ContextManagerConfig {
 struct ContextMeta {
     meta: Context,
     lock: Arc<Mutex<ContextId>>,
+}
+
+/// Evict one *idle* context to keep `contexts` under [`MAX_CACHED_CONTEXTS`].
+///
+/// Call this immediately before inserting a *new* (not-yet-cached) context. It
+/// is a no-op while the cache is below the cap.
+///
+/// # Why eviction must be gated on the lock being idle
+///
+/// Each [`ContextMeta`] carries a per-context `lock: Arc<Mutex<ContextId>>`
+/// that serializes all operations on that context. The guard is handed out as
+/// an *owned* guard (`try_lock_owned`/`lock_owned`) and is held outside the
+/// actor across the entire WASM execution — it can even be passed back in as
+/// `ContextAtomic::Held(..)`. An outstanding guard therefore holds a clone of
+/// the `Arc`, so a context with an in-flight operation always has
+/// `Arc::strong_count(&lock) >= 2`. An idle, evictable entry is exactly
+/// `strong_count == 1` (only the cache holds it).
+///
+/// If we evicted a *live* entry, the next `get_or_fetch_context` would mint a
+/// brand-new `Arc<Mutex>` for that context. Two concurrent operations would
+/// then serialize on *different* mutexes — breaking the invariant and
+/// corrupting state. Hence we only ever evict `strong_count == 1` entries.
+///
+/// If every entry is live, no eviction happens and the cache is allowed to
+/// exceed the cap temporarily; it self-corrects as in-flight operations
+/// finish. The over-cap count is bounded by the number of contexts executing
+/// concurrently, which node concurrency already limits.
+fn evict_idle_context_if_full(contexts: &mut BTreeMap<ContextId, ContextMeta>) {
+    if contexts.len() < MAX_CACHED_CONTEXTS {
+        return;
+    }
+
+    let victim = contexts
+        .iter()
+        .find(|(_, meta)| Arc::strong_count(&meta.lock) == 1)
+        .map(|(id, _)| *id);
+
+    match victim {
+        Some(id) => {
+            let _ = contexts.remove(&id);
+            tracing::debug!(context = %id, "evicted idle context from cache (at capacity)");
+        }
+        None => tracing::debug!(
+            cap = MAX_CACHED_CONTEXTS,
+            len = contexts.len(),
+            "context cache at capacity but all entries live; deferring eviction"
+        ),
+    }
+}
+
+/// Evict one application to keep `applications` under
+/// [`MAX_CACHED_APPLICATIONS`]. Call before inserting a new application.
+///
+/// Application metadata carries no per-entry lock, so this is a plain
+/// first-entry-by-key-order eviction — identical to the compiled-`modules`
+/// cap. A no-op while below the cap.
+fn evict_application_if_full(applications: &mut BTreeMap<ApplicationId, Application>) {
+    if applications.len() < MAX_CACHED_APPLICATIONS {
+        return;
+    }
+
+    if let Some((id, _)) = applications.pop_first() {
+        tracing::debug!(application = %id, "evicted application from cache (at capacity)");
+    }
 }
 
 /// The central actor responsible for managing the lifecycle of all contexts.
@@ -156,11 +233,20 @@ pub struct ContextManager {
 
     /// An in-memory cache of active contexts (`ContextId` -> `ContextMeta`).
     /// This serves as a hot cache to avoid expensive disk I/O for frequently accessed contexts.
+    ///
+    /// Size-capped to `MAX_CACHED_CONTEXTS` so long-running nodes that touch
+    /// many distinct contexts don't grow this map without bound. Eviction is
+    /// gated on the per-context lock being idle — see
+    /// [`evict_idle_context_if_full`] for why that gate is load-bearing for
+    /// correctness, not just hygiene.
     // todo! potentially make this a dashmap::DashMap
-    // todo! use cached::TimedSizedCache with a gc task
     contexts: BTreeMap<ContextId, ContextMeta>,
     /// An in-memory cache of application metadata (`ApplicationId` -> `Application`).
     /// Caching this prevents repeated fetching and parsing of application details.
+    ///
+    /// Size-capped to `MAX_CACHED_APPLICATIONS` via [`evict_application_if_full`]
+    /// (a plain by-key-order eviction, mirroring the compiled-`modules` cap)
+    /// since application metadata is a pure cache over the datastore.
     ///
     /// # Note
     /// Even when 2 applications point to the same bytecode,
@@ -471,6 +557,14 @@ impl ContextManager {
         &mut self,
         context_id: &ContextId,
     ) -> eyre::Result<Option<&ContextMeta>> {
+        // On a cache miss we're about to insert below, so make room first.
+        // Done before taking the `entry` borrow since eviction needs its own
+        // `&mut self.contexts`. A miss that turns out to be a non-existent
+        // context just wastes one (harmless) eviction.
+        if !self.contexts.contains_key(context_id) {
+            evict_idle_context_if_full(&mut self.contexts);
+        }
+
         let entry = self.contexts.entry(*context_id);
 
         match entry {
@@ -538,5 +632,138 @@ impl ContextManager {
                 Ok(Some(item))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod cache_eviction_tests {
+    use std::str::FromStr as _;
+
+    use super::*;
+    use calimero_primitives::hash::Hash;
+
+    /// Distinct `ContextId` per index (two bytes cover well beyond the cap).
+    fn cid(i: usize) -> ContextId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = (i & 0xff) as u8;
+        bytes[1] = ((i >> 8) & 0xff) as u8;
+        ContextId::from(bytes)
+    }
+
+    /// An entry whose lock is held by nobody → `strong_count == 1` (evictable).
+    fn idle_meta(id: ContextId) -> ContextMeta {
+        ContextMeta {
+            meta: Context::new(id, ApplicationId::from([0u8; 32]), Hash::default()),
+            lock: Arc::new(Mutex::new(id)),
+        }
+    }
+
+    /// An entry with an outstanding owned guard → `strong_count == 2` (live,
+    /// MUST NOT be evicted). The returned guard must be kept alive by the test.
+    fn live_meta(id: ContextId) -> (ContextMeta, OwnedMutexGuard<ContextId>) {
+        let lock = Arc::new(Mutex::new(id));
+        let guard = lock.clone().try_lock_owned().expect("fresh lock is free");
+        let meta = ContextMeta {
+            meta: Context::new(id, ApplicationId::from([0u8; 32]), Hash::default()),
+            lock,
+        };
+        (meta, guard)
+    }
+
+    #[test]
+    fn no_eviction_below_cap() {
+        let mut contexts = BTreeMap::new();
+        for i in 0..(MAX_CACHED_CONTEXTS - 1) {
+            let _ = contexts.insert(cid(i), idle_meta(cid(i)));
+        }
+        evict_idle_context_if_full(&mut contexts);
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS - 1);
+    }
+
+    #[test]
+    fn evicts_one_idle_entry_at_cap() {
+        let mut contexts = BTreeMap::new();
+        for i in 0..MAX_CACHED_CONTEXTS {
+            let _ = contexts.insert(cid(i), idle_meta(cid(i)));
+        }
+        evict_idle_context_if_full(&mut contexts);
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS - 1);
+    }
+
+    #[test]
+    fn never_evicts_a_live_entry() {
+        let mut contexts = BTreeMap::new();
+        let mut guards = Vec::new();
+
+        // Every entry live except a single idle one (the lowest key, so it's
+        // also the first candidate eviction would consider by key order).
+        let idle_id = cid(0);
+        let _ = contexts.insert(idle_id, idle_meta(idle_id));
+        for i in 1..MAX_CACHED_CONTEXTS {
+            let (meta, guard) = live_meta(cid(i));
+            let _ = contexts.insert(cid(i), meta);
+            guards.push(guard);
+        }
+
+        evict_idle_context_if_full(&mut contexts);
+
+        // The idle entry is gone; every live entry survives.
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS - 1);
+        assert!(!contexts.contains_key(&idle_id));
+        for i in 1..MAX_CACHED_CONTEXTS {
+            assert!(contexts.contains_key(&cid(i)), "live entry {i} was evicted");
+        }
+        drop(guards);
+    }
+
+    #[test]
+    fn no_eviction_when_all_entries_live() {
+        let mut contexts = BTreeMap::new();
+        let mut guards = Vec::new();
+        for i in 0..MAX_CACHED_CONTEXTS {
+            let (meta, guard) = live_meta(cid(i));
+            let _ = contexts.insert(cid(i), meta);
+            guards.push(guard);
+        }
+
+        // Cache is at cap but nothing is evictable → it stays over/at cap
+        // rather than corrupting a live context's lock identity.
+        evict_idle_context_if_full(&mut contexts);
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS);
+        drop(guards);
+    }
+
+    fn app(i: usize) -> Application {
+        use calimero_primitives::application::{ApplicationBlob, ApplicationSource};
+        use calimero_primitives::blobs::BlobId;
+        let id = ApplicationId::from([i as u8; 32]);
+        Application::new(
+            id,
+            ApplicationBlob {
+                bytecode: BlobId::from([0u8; 32]),
+                compiled: BlobId::from([0u8; 32]),
+            },
+            0,
+            ApplicationSource::from_str("http://example.test").expect("valid url"),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn application_cap_evicts_at_cap_only() {
+        let mut apps = BTreeMap::new();
+        for i in 0..(MAX_CACHED_APPLICATIONS - 1) {
+            let a = app(i);
+            let _ = apps.insert(a.id, a);
+        }
+        // Below cap → no-op.
+        evict_application_if_full(&mut apps);
+        assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS - 1);
+
+        // Fill to cap, then eviction drops exactly one.
+        let a = app(MAX_CACHED_APPLICATIONS - 1);
+        let _ = apps.insert(a.id, a);
+        evict_application_if_full(&mut apps);
+        assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS - 1);
     }
 }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -198,11 +198,30 @@ fn evict_idle_context_if_full(contexts: &mut BTreeMap<ContextId, ContextMeta>) {
             let _ = contexts.remove(&id);
             tracing::debug!(context = %id, "evicted idle context from cache (at capacity)");
         }
-        None => tracing::debug!(
-            cap = MAX_CACHED_CONTEXTS,
-            len = contexts.len(),
-            "context cache at capacity but all entries live; deferring eviction"
-        ),
+        None => {
+            // Over-cap with every entry live is a *legitimate* designed state
+            // here (unlike the applications cap, which has no live-gating and
+            // can always drain to cap — hence its debug_assert). So we don't
+            // assert; instead we make a *significant* overage observable in
+            // production, since it signals sustained high concurrency on this
+            // node. The map drains back toward the cap as live ops finish and
+            // subsequent inserts each evict one freed entry.
+            let len = contexts.len();
+            if len > MAX_CACHED_CONTEXTS + MAX_CACHED_CONTEXTS / 10 {
+                tracing::warn!(
+                    cap = MAX_CACHED_CONTEXTS,
+                    len,
+                    "context cache significantly over capacity and all entries \
+                     live; deferring eviction (sustained high concurrency?)"
+                );
+            } else {
+                tracing::debug!(
+                    cap = MAX_CACHED_CONTEXTS,
+                    len,
+                    "context cache at capacity but all entries live; deferring eviction"
+                );
+            }
+        }
     }
 }
 
@@ -211,7 +230,14 @@ fn evict_idle_context_if_full(contexts: &mut BTreeMap<ContextId, ContextMeta>) {
 ///
 /// Application metadata carries no per-entry lock, so this is a plain
 /// first-entry-by-key-order eviction — identical to the compiled-`modules`
-/// cap. A no-op while below the cap.
+/// cap. Like that cap it is NOT usage-aware: `ApplicationId`s are hashes, so
+/// the lowest key is effectively random rather than "least useful", and an
+/// evicted entry is simply re-fetched from the node on next use. A no-op while
+/// below the cap.
+///
+/// Callers guard on `!contains_key(id)` before calling, and `pop_first` only
+/// removes a key already present, so the entry about to be inserted is never
+/// itself the victim.
 fn evict_application_if_full(applications: &mut BTreeMap<ApplicationId, Application>) {
     if applications.len() < MAX_CACHED_APPLICATIONS {
         return;


### PR DESCRIPTION
Closes #2023.

## Problem
`ContextManager.contexts` and `.applications` (`crates/context/src/lib.rs`) are unbounded `BTreeMap`s. Contexts accumulate on every access via `get_or_fetch_context` with no eviction, TTL, or size cap, so long-running nodes that touch many distinct contexts leak metadata indefinitely. (The stale `cached::TimedSizedCache` TODO is removed here.)

## Why not the LRU from the issue
The issue's proposed eviction would introduce a **correctness bug**. Each `ContextMeta` holds a per-context `lock: Arc<Mutex<ContextId>>` that serializes all ops on that context. It's handed out as an **owned** guard (`try_lock_owned`/`lock_owned`) that escapes the actor and is held across the entire WASM execution — it can even be passed back as `ContextAtomic::Held(..)`. If the cache evicts a *live* entry, the next `get_or_fetch_context` mints a **brand-new** `Arc<Mutex>`, so two concurrent ops on that context would serialize on *different* mutexes → state corruption.

## Approach
Size-cap both maps, evicting before insert at every insert site (`get_or_fetch_context` + `create_context`). No new dependency, no GC task.

- **`evict_idle_context_if_full`** — at cap, evicts only an entry with `Arc::strong_count(&lock) == 1` (no outstanding guard). An in-flight op always holds a clone of the `Arc` → `count >= 2` → never evicted. If *every* entry is live, it evicts nothing and lets the cache run temporarily over cap rather than corrupt a live context's lock identity. Self-corrects as ops finish; over-cap is bounded by node concurrency. The datastore stays authoritative, so eviction only ever costs a re-fetch.
- **`evict_application_if_full`** — applications carry no lock, so this is a plain by-key-order `pop_first()` at cap, mirroring the existing `MAX_CACHED_MODULES` cap.
- Caps: `MAX_CACHED_CONTEXTS = 1024`, `MAX_CACHED_APPLICATIONS = 256` (safety valves, not hard SLAs).

## Tests
5 unit tests (`cache_eviction_tests`), all passing:
- `no_eviction_below_cap`, `evicts_one_idle_entry_at_cap`
- `never_evicts_a_live_entry` — a held guard is skipped even when first by key order
- `no_eviction_when_all_entries_live` — proves over-cap-rather-than-corrupt
- `application_cap_evicts_at_cap_only`

`cargo check`, `cargo test --lib`, `cargo fmt --check`, `cargo clippy` clean on the new code.

## Deferred (intentional)
- **Prometheus cache metrics** (the `Metrics` struct lives in `calimero-governance-store` — a counter there would balloon this into a cross-crate change). Evictions log at debug for now.
- **TTL/GC task** — the size cap bounds memory and `ContextMeta` is tiny; a background GC task isn't worth the complexity.

Per the re-triage on #2023, this also argues for **relabeling P1 → P2**: memory urgency dropped once compiled `modules` were size-capped, and the real work here is the correctness gate, not the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Context eviction correctness depends on `Arc::strong_count` gating; a bug could break per-context locking, though the change is heavily documented and unit-tested.
> 
> **Overview**
> Adds **size caps** to `ContextManager`'s in-memory `contexts` (1024) and `applications` (256) caches so long-running nodes don't grow those maps without bound. Eviction runs **only immediately before a successful insert**, and failed lookups or auth checks no longer drain the cache first.
> 
> **Context eviction** (`evict_idle_context_if_full`) removes a single idle entry only when `Arc::strong_count` on that context's per-context mutex is 1—so in-flight WASM work (which holds an owned lock and bumps the count) is never evicted. If every entry is live, the map may run temporarily over cap instead of minting a new `Arc<Mutex>` for the same context (which would break per-context serialization). **`get_or_fetch_context`** is refactored to load from the store on miss, then evict, then insert; cache hits still refresh `dag_heads`, `root_hash`, and `application_id` from the DB.
> 
> **Application eviction** (`evict_application_if_full`) is a simple `pop_first()` at cap (mirroring compiled `modules`), wired into create context, `get_module`, and non-migration `update_application`. Unit tests cover both eviction policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce506c6a6de120fc65d956bd855f322ced54934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->