### PR TITLE
fix(storage): SharedStorage rotation review follow-ups (post-#2601)

### DIFF
--- a/apps/kv-store-with-shared-storage/src/lib.rs
+++ b/apps/kv-store-with-shared-storage/src/lib.rs
@@ -76,7 +76,15 @@ impl KvStore {
         Ok(self.shared_map.get()?.get(&key)?.map(|v| v.get().clone()))
     }
 
-    /// Rotate the writer set. Caller must be a current writer; rejected if frozen.
+    /// Rotate the writer set of the shared **register** (`shared_value`) only.
+    /// Caller must be a current writer; rejected if frozen.
+    ///
+    /// Note: this intentionally does NOT rotate `shared_map` — each
+    /// `SharedStorage` field has its own independent writer set. An app that
+    /// wants to rotate both must call rotate on each (the e2e relies on the map
+    /// staying guarded by the original set for its adversarial step). This is an
+    /// example app; production apps should name such methods per the field they
+    /// rotate to avoid surprising callers.
     pub fn rotate_writers(&mut self, new_writers: Vec<PublicKey>) -> app::Result<()> {
         app::log!("Rotating writers: {:?}", new_writers);
         let set: BTreeSet<PublicKey> = new_writers.into_iter().collect();
@@ -86,20 +94,26 @@ impl KvStore {
         Ok(())
     }
 
-    /// Read the current writer count of the shared register. Used by the
-    /// adversarial e2e to assert a forged rotation did not change the set on the
-    /// honest node.
+    /// e2e-support method (not for production). Read the current writer count of
+    /// the shared register so the adversarial workflow can assert a forged
+    /// rotation did not change the set on the honest node. It is a public
+    /// `#[app::logic]` method because the e2e drives this app as a black box over
+    /// RPC, so `#[cfg(test)]`/feature gating would make it unreachable to the
+    /// harness; a real app would not expose it.
     pub fn writer_count(&self) -> app::Result<u64> {
         Ok(self.shared_value.writers().len() as u64)
     }
 
-    /// Adversarial-test helper: attempt to rotate the writer set, reporting
-    /// whether the **local** writer gate accepted it (`true`) or refused it
-    /// (`false`) instead of trapping. Lets an e2e assert that a non-writer
-    /// member cannot rotate the set without failing the call itself. The
-    /// authoritative rejection of a *forged rotation delta* (one that bypasses
-    /// this local gate) happens at merge on the honest node and is covered by
-    /// the storage-layer test `forged_shared_rotation_rejected_at_merge`.
+    /// e2e-support method (not for production). Attempt to rotate the writer set,
+    /// reporting whether the **local** writer gate accepted it (`true`) or
+    /// refused it (`false`) instead of trapping, so the adversarial workflow can
+    /// assert a non-writer member cannot rotate without failing the RPC call
+    /// itself. Deliberately swallows the error to return a bool — not suitable
+    /// for production (a real app should propagate it). Public for the same
+    /// black-box-RPC reason as `writer_count`. The authoritative rejection of a
+    /// *forged rotation delta* (one that bypasses this local gate) happens at
+    /// merge and is covered by the storage test
+    /// `forged_shared_rotation_rejected_at_merge`.
     pub fn try_rotate_writers(&mut self, new_writers: Vec<PublicKey>) -> app::Result<bool> {
         let set: BTreeSet<PublicKey> = new_writers.into_iter().collect();
         match self.shared_value.rotate_writers(set) {

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -91,12 +91,15 @@ pub struct SharedStorage<
     /// `Element` is the wrapper entity; its metadata carries the writer set.
     #[borsh(bound(serialize = "", deserialize = ""))]
     inner: Collection<T, S>,
-    /// If true, `rotate_writers` is rejected. Monotonic: set at construction or
-    /// by merge, never cleared. Rides root state inline — unlike the value, this
-    /// is a small scalar that is never double-written as a per-entity action, so
-    /// it cannot cause the root-hash divergence the inline value once did. It is
-    /// fail-safe: a forged `frozen=true` only *locks* rotation (a minor DoS),
-    /// and the monotonic merge means it can never be forged back to `false`.
+    /// If true, `rotate_writers` is rejected. **Genesis-immutable**: set once in
+    /// `new`, no setter. It rides root-state borsh inline (so cold-join peers
+    /// learn it at genesis), but `Mergeable::merge` deliberately does NOT adopt a
+    /// peer's `frozen` — so a forged root-state delta cannot freeze an existing
+    /// honest node's rotation. The residual trust assumption is the **genesis
+    /// blob**: a cold joiner that receives a forged genesis with `frozen=true`
+    /// from a malicious provider would be locked (the accepted "minor DoS"). This
+    /// is the same genesis-provider trust the writer set itself relies on (the
+    /// initial sole writer controls genesis).
     frozen: bool,
     /// Lazy cache of the deserialized value entry (Root's pattern). Not part of
     /// borsh — the value is a separate entity loaded on first access.
@@ -353,6 +356,15 @@ where
     ///    (The full causal `writers_at(parents)` resolution is the node-side
     ///    apply-time check; with no DAG context during local execution the
     ///    most-recently-appended entry is the right local answer.)
+    ///
+    ///    Note this local gate is **best-effort under concurrent rotations**:
+    ///    "most-recently-appended" is this node's insertion order, which can
+    ///    differ from causal order if concurrent rotations arrive interleaved.
+    ///    A local `insert`/`rotate_writers` may then accept/reject against a set
+    ///    the merge-time verifier (which uses the proper causal `writers_at`)
+    ///    would resolve differently. The merge check is the security boundary;
+    ///    full local causal resolution is deferred to the concurrent-rotation
+    ///    work (P4).
     /// 2. **Index `storage_type`** — written by `add_child_to` at construction,
     ///    by `apply_action` for a received bootstrap/write, and by
     ///    [`Index::set_storage_type`] on the *originating* node's own rotation
@@ -380,6 +392,18 @@ where
                 return writers;
             }
         }
+        // Neither the rotation log nor a Shared index entry exists. A wrapper a
+        // writer can legitimately act on always has one, so this is an anomaly
+        // (missing/corrupt index, or acting before the wrapper synced). Fail
+        // closed with the empty set — but warn, since the empty set silently
+        // locks every writer out (`insert`/`rotate_writers` → ActionNotAllowed).
+        tracing::warn!(
+            target: "storage::shared",
+            wrapper_id = %self.inner.id(),
+            "SharedStorage current_writers found no rotation log or Shared index \
+             entry — failing closed with an empty writer set (missing/corrupt \
+             index, or wrapper not yet synced)"
+        );
         BTreeSet::new()
     }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1539,13 +1539,34 @@ mod shared_storage_rotation_authentication {
             &alice_sk,
             vec![],
         );
+        // Populate delta_id/delta_hlc so the rotation-log write hook fires and we
+        // can assert the rotation actually took effect (not just that it was
+        // accepted). The writer set is persisted to the rotation log, not the
+        // index `storage_type` (apply does not patch a child's own metadata) — so
+        // the log is what we assert.
+        use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+        let delta_hlc = HybridTimestamp::new(Timestamp::new(
+            NTP64(nonce1 + 1_000_000),
+            ID::from(core::num::NonZeroU128::new(1).unwrap()),
+        ));
         let ctx = ApplyContext {
             effective_writers: Some(writers),
-            delta_id: None,
-            delta_hlc: None,
+            delta_id: Some([0xD1; 32]),
+            delta_hlc: Some(delta_hlc),
         };
         MainInterface::apply_action(rotation, &ctx)
             .expect("authentic rotation by a current writer must be accepted");
+
+        // The rotation must be recorded in the wrapper's rotation log with the
+        // new writer set.
+        let log = crate::rotation_log::load::<MainStorage>(id)
+            .unwrap()
+            .expect("rotation log must exist after an accepted rotation");
+        assert_eq!(
+            log.entries.last().expect("a rotation entry").new_writers,
+            new_writers,
+            "accepted rotation must record the new writer set in the rotation log"
+        );
     }
 }
 

--- a/docs/design/2230-shared-wrapper-verification.md
+++ b/docs/design/2230-shared-wrapper-verification.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Implemented (item 1) — PR #2601, merged 2026-06-02 |
 | **Date** | 2026-06-02 |
 | **Owner** | Storage / Context / Node sync |
 | **Issue** | #2230 (SharedStorage v2: live per-entity verification) — **item 1 only** |


### PR DESCRIPTION
Follow-up to the merged #2601 (authenticate SharedStorage writer-set rotation), addressing the remaining post-merge review comments. Docs/tests/diagnostics only — no behavioral change to the merged security model.

## Changes
- **`current_writers` visibility + docs** — `tracing::warn!` when neither the rotation log nor a Shared index entry has a writer set (the fail-closed empty set silently locks every writer out, so the anomaly is now logged). Documented that local resolution via the latest log entry is **best-effort under concurrent rotations** — the causal `writers_at` resolution is the merge-time check; full local causal resolution is deferred to P4.
- **Positive-path test strengthened** — `authentic_rotation_by_current_writer_accepted` now populates `delta_id`/`delta_hlc` and asserts the rotation is recorded in the wrapper's rotation log (not just that `apply_action` returns `Ok`).
- **`frozen` docs** — updated to reflect it is genesis-immutable and not merged from peers (a forged root-state delta can't freeze an honest node), and to call out the residual genesis-blob trust assumption (same trust the writer set relies on).
- **kv-store example app docs** — `rotate_writers` documents that it rotates only the register, not the map (each `SharedStorage` field has its own writer set); `writer_count`/`try_rotate_writers` marked as e2e-support methods (public only because the e2e drives the app over RPC, so `#[cfg(test)]`/feature gating would make them unreachable to the harness).
- **Design doc** — status → Implemented (PR #2601).

## Reviewer points explained (no change)
- `load_value` unsafe ptr cast — mirrors `Root::get` (established crate-wide pattern); the cast drops the `RefMut` guard so there's no live borrow across the returned ref. A `RefMut`-returning redesign would diverge from `Root` and is a separate cross-cutting cleanup.
- `Collection::new_shared` already `.expect("add child")`s — it panics on error (the `let _ =` discards only the `bool` return, not the `Result`).
- `insert` writer check is already before any storage read; `value_id()` is pure; single-threaded execution → no TOCTOU.

## Tests
546 storage + 3 app (TestHost) unit tests green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and tracing-only changes plus test/doc updates; no changes to merge-time verification or rotation logic.
> 
> **Overview**
> Post-#2601 follow-up: **documentation, observability, and tests** only — the merged rotation authentication behavior is unchanged.
> 
> **`SharedStorage` (`shared.rs`)** — `frozen` is documented as genesis-immutable and not adopted from peers on merge (forged root-state cannot freeze an honest node), with the residual genesis-blob trust called out. `current_writers` now documents that local resolution from the latest rotation-log entry is **best-effort under concurrent rotations** (merge-time causal `writers_at` remains the security boundary; P4 deferred). When neither log nor Shared index has writers, a **`tracing::warn!`** is emitted before the existing fail-closed empty set (previously silent lock-out).
> 
> **Tests** — `authentic_rotation_by_current_writer_accepted` supplies `delta_id`/`delta_hlc` and asserts the new writer set appears in the wrapper **rotation log**, not only `Ok` from `apply_action`.
> 
> **Example app** — `rotate_writers` documents register-only rotation (map has its own writer set); `writer_count` / `try_rotate_writers` labeled e2e-only RPC helpers.
> 
> **Design doc** — #2230 item 1 status set to **Implemented** (PR #2601).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d95fccd465fae4b56ad03b43580564dd6a7682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->