### PR TITLE
fix(ci): make worker nodes produce CPU profiles in fuzzy profiling

### DIFF
--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -17,18 +17,40 @@ EXIT_CODE=0
 mkdir -p "$PROFILING_OUTPUT_DIR"
 mkdir -p "${PROFILING_REPORTS_DIR:-/profiling/reports}"
 
+# Probe whether `perf` can actually record on this container. Hoisted to top
+# level so the build-time check (install_kernel_tools) and the runtime guard
+# (start_profiling) share one robust implementation instead of two divergent
+# copies.
+#
+# Profile a short `sleep 0.3`, NOT an instant `true`: at the sampling
+# frequency this captures enough samples for a usable perf to exit cleanly.
+# We decide on stderr CONTENT, not the raw exit code — profiling a
+# microsecond-lived workload makes the exit status depend on host load and
+# process ordering, which passed on the first-started, least-loaded node and
+# spuriously failed on the later, busier nodes even though perf was equally
+# usable on all of them. A kptr_restrict / perf_event_paranoid *warning*
+# about kernel-symbol resolution is benign; only a real perf_event_open or
+# kernel-tools failure is fatal.
+perf_sanity_check() {
+    local err rc
+    err=$(perf record -o /dev/null -- sleep 0.3 2>&1)
+    rc=$?
+    if printf '%s\n' "$err" | grep -qiE \
+        'operation not permitted|permission denied|perf_event_open|not found for kernel|no such file or directory|cannot (find|open|read)'; then
+        echo "[Profiling] perf sanity check failed (rc=$rc). Full stderr:"
+        printf '%s\n' "$err" | sed 's/^/[Profiling]   /'
+        return 1
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "[Profiling] perf exited $rc with no fatal error; treating as usable. stderr:"
+        printf '%s\n' "$err" | sed 's/^/[Profiling]   /'
+    fi
+    return 0
+}
+
 install_kernel_tools() {
     local kernel_version=$(uname -r)
     echo "[Profiling] Detected kernel: $kernel_version"
-
-    perf_sanity_check() {
-        local err
-        err=$(perf record -o /dev/null -- true 2>&1)
-        if [ $? -eq 0 ]; then return 0; fi
-        echo "[Profiling] perf sanity check failed. First 5 lines of stderr:"
-        echo "$err" | head -5 | sed 's/^/[Profiling]   /'
-        return 1
-    }
 
     # Happy path: the Dockerfile pre-symlinks the generic perf at
     # /usr/local/bin/perf, which takes PATH precedence over Ubuntu's
@@ -75,8 +97,8 @@ start_profiling() {
         return
     fi
     
-    if ! perf record -o /dev/null -- true 2>/dev/null; then
-        echo "[Profiling] perf not compatible, skipping CPU profiling"
+    if ! perf_sanity_check; then
+        echo "[Profiling] perf not usable, skipping CPU profiling"
         return
     fi
     

--- a/scripts/profiling/entrypoint-profiling.sh
+++ b/scripts/profiling/entrypoint-profiling.sh
@@ -31,12 +31,29 @@ mkdir -p "${PROFILING_REPORTS_DIR:-/profiling/reports}"
 # usable on all of them. A kptr_restrict / perf_event_paranoid *warning*
 # about kernel-symbol resolution is benign; only a real perf_event_open or
 # kernel-tools failure is fatal.
+#
+# Set to "true" by the first successful probe so start_profiling can skip a
+# redundant re-check after install_kernel_tools has already confirmed perf.
+PERF_USABLE=''
 perf_sanity_check() {
     local err rc
+    # A missing perf binary must read as a failure: bash reports it as
+    # "command not found" (rc=127), which none of the fatal stderr patterns
+    # below match, so without this guard the function would fall through to
+    # "usable" and the apt fallback would never fire. Short-circuit here so we
+    # also don't spawn the 0.3s probe for a binary that isn't there.
+    command -v perf >/dev/null 2>&1 || {
+        echo "[Profiling] perf not found in PATH"
+        return 1
+    }
     err=$(perf record -o /dev/null -- sleep 0.3 2>&1)
     rc=$?
+    # 'perf_event_open' is anchored to a failure context — the bare syscall
+    # name also shows up in benign informational lines on some perf builds,
+    # while the real fatal line ("...perf_event_open() ... returned ...
+    # Operation not permitted") is already caught by the permission patterns.
     if printf '%s\n' "$err" | grep -qiE \
-        'operation not permitted|permission denied|perf_event_open|not found for kernel|no such file or directory|cannot (find|open|read)'; then
+        'operation not permitted|permission denied|perf_event_open.*(fail|return|error)|not found for kernel|no such file or directory|cannot (find|open|read)'; then
         echo "[Profiling] perf sanity check failed (rc=$rc). Full stderr:"
         printf '%s\n' "$err" | sed 's/^/[Profiling]   /'
         return 1
@@ -45,6 +62,7 @@ perf_sanity_check() {
         echo "[Profiling] perf exited $rc with no fatal error; treating as usable. stderr:"
         printf '%s\n' "$err" | sed 's/^/[Profiling]   /'
     fi
+    PERF_USABLE=true
     return 0
 }
 
@@ -97,7 +115,10 @@ start_profiling() {
         return
     fi
     
-    if ! perf_sanity_check; then
+    # install_kernel_tools already probed perf at startup; only re-check if
+    # that probe didn't confirm it (PERF_USABLE unset) to avoid a redundant
+    # 0.3s probe on the happy path.
+    if [ "$PERF_USABLE" != "true" ] && ! perf_sanity_check; then
         echo "[Profiling] perf not usable, skipping CPU profiling"
         return
     fi


### PR DESCRIPTION
Closes #2373.

## Problem

In Fuzzy Load Test profiling, **CPU flamegraphs rendered only for the seed node (node-1)**; the 3 worker nodes per suite (`*-node-2/3/4`) produced no `perf-*.data`/`perf-*.log` at all — only memory flamegraphs. Reproduced every run.

## Root cause

Not a CAP_PERFMON / `perf_event_paranoid` difference (those are host-wide and identical for all containers). The defect is the perf sanity probe:

```bash
perf record -o /dev/null -- true   # gated on the exit code of profiling `true`
```

Profiling a process that exits in **microseconds** makes the probe's exit status depend on host load and process start order, not on whether perf can open events. The seed starts first and least-loaded → passes. Workers start ~6s apart, after the seed's continuous 16-min `perf record` is already running and the host is busier → the throwaway probe exits non-zero → CPU profiling is wrongly vetoed, even though those nodes can profile their own long-running merod fine. Deterministic by start order ⇒ reproduces every run.

Aggravating factors:
- The same fragile probe existed **twice** — `perf_sanity_check` (nested in `install_kernel_tools`) and an inline copy in `start_profiling`.
- `head -5` truncation buried the decisive stderr line behind a benign `kptr_restrict` warning, so the artifact alone couldn't pin it.

## Fix

`scripts/profiling/entrypoint-profiling.sh`:

- **Hoist one robust `perf_sanity_check` to top level** and use it at both sites (no more divergent copies).
- **Profile `sleep 0.3`, not instant `true`** — at the sampling frequency a usable perf captures enough samples to exit cleanly.
- **Decide on stderr content, not raw exit code** — a `kptr_restrict`/`perf_event_paranoid` warning about kernel-symbol resolution is benign; only a real `perf_event_open`/kernel-tools failure (matched by pattern) is fatal. Logs **full** stderr on genuine failure.

**Safety:** the build-time check still fails on the fatal `not found for kernel` pattern, so the apt fallback still runs; after apt installs the matching `linux-tools` the post-install check passes on all nodes. `stop_profiling` already warns on a tiny/empty `perf-*.data` if perf genuinely can't record.

## Testing

- `bash -n` passes.
- Mocked-`perf` exercise of all three paths:
  - clean (exit 0) → usable, silent ✅
  - benign kptr warning + exit 1 (the worker-node bug) → **treated as usable** ✅
  - fatal `Operation not permitted` + exit 255 → fails, full stderr logged ✅

## Scope

CI/profiling only — `scripts/profiling/entrypoint-profiling.sh` gates the `merod:edge-profiling` rebuild, so the next fuzzy run picks it up. No merod runtime impact; memory profiling and seed-node CPU profiling unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/profiling entrypoint only; no merod runtime or auth/data paths touched.
> 
> **Overview**
> **Unifies and hardens the `perf` sanity probe** in `scripts/profiling/entrypoint-profiling.sh` so fuzzy load-test **worker nodes** get CPU profiles, not only the first-started seed node.
> 
> The probe moves to a **single top-level `perf_sanity_check`**, shared by `install_kernel_tools` and `start_profiling` (replacing a nested copy plus an inline `perf record … true` guard). It records **`sleep 0.3`** instead of instant `true`, treats **fatal stderr patterns** (e.g. permission / missing kernel tools) as failure while **benign warnings** (e.g. `kptr_restrict`) can still count as usable, logs **full stderr** on real failure, and sets **`PERF_USABLE`** so `start_profiling` skips a second probe after a successful install-time check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5aac26c39847060ba8a7836cae5bc1cc63ac01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->