### PR TITLE
fix(sync): persistence-gate divergence alarms + active recovery

### DIFF
--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -13,6 +13,16 @@ use crate::NodeManager;
 /// loop reports the full count regardless.
 const MAX_DUMP_CHILDREN: usize = 64;
 
+/// How many consecutive heartbeats the SAME same-DAG/different-root divergence
+/// must survive before it is escalated from `warn!` to `error!` (and an active
+/// recovery sync is kicked). Heartbeats fire every `HASH_HEARTBEAT_FREQUENCY_S`
+/// (30s), so `2` means a divergence must persist *unchanged* for ≥1 full
+/// interval (~30–60s) — long enough that the background periodic sync has had a
+/// chance to heal it — before it's treated as a genuinely stuck split-brain.
+/// A first observation, or one whose hashes are still moving (sync making
+/// progress), stays at `warn!` and never trips a log-scanning CI gate.
+const DIVERGENCE_PERSIST_THRESHOLD: u32 = 2;
+
 pub(super) fn handle_hash_heartbeat(
     manager: &mut NodeManager,
     ctx: &mut actix::Context<NodeManager>,
@@ -81,6 +91,9 @@ pub(super) fn handle_hash_heartbeat(
                             );
                         }
                         if live_hash == their_root_hash {
+                            // Converged once the cache caught up — drop any
+                            // streak so a later transient starts fresh at WARN.
+                            let _ = manager.divergence_streak.remove(&(context_id, source));
                             return;
                         }
                     }
@@ -103,15 +116,59 @@ pub(super) fn handle_hash_heartbeat(
 
             // #2319: surface divergence as a metric (`sync_root_hash_divergence_detected_total`)
             // so vmagent can alert on the rate without grepping logs —
-            // with the determinism fixes this should stay near zero.
+            // with the determinism fixes this should stay near zero. Counted on
+            // EVERY observation, independent of the log-level gating below, so
+            // the rate stays faithful.
             let _new = manager.divergence_detected.inc();
+
+            // Persistence gate: a divergence is only escalated to ERROR once the
+            // SAME (our, their) hash pair has survived
+            // `DIVERGENCE_PERSIST_THRESHOLD` consecutive heartbeats. A first
+            // observation — or one whose hashes are still moving, i.e. sync is
+            // making progress — is almost always a concurrent sync apply that
+            // landed mid-flight and self-heals next tick; logging that at ERROR
+            // turns a benign, recoverable event into a hard failure for
+            // log-scanning CI on unrelated work. The streak resets on any hash
+            // change (progress) and is cleared on convergence.
+            let count = match manager.divergence_streak.get(&(context_id, source)) {
+                Some(prev) if prev.our_hash == our_hash && prev.their_hash == their_root_hash => {
+                    prev.count.saturating_add(1)
+                }
+                _ => 1,
+            };
+            let _ = manager.divergence_streak.insert(
+                (context_id, source),
+                crate::manager::DivergenceMark {
+                    our_hash,
+                    their_hash: their_root_hash,
+                    count,
+                },
+            );
+
+            if count < DIVERGENCE_PERSIST_THRESHOLD {
+                warn!(
+                    %context_id,
+                    ?source,
+                    our_hash = ?our_hash,
+                    their_hash = ?their_root_hash,
+                    count,
+                    "Divergence detected (same DAG heads, different root) — transient: a \
+                     sync apply is likely in flight; expecting periodic sync to reconcile"
+                );
+                return;
+            }
+
+            // Persisted unchanged across >= DIVERGENCE_PERSIST_THRESHOLD
+            // heartbeats: background sync has NOT healed it — a genuinely stuck
+            // split-brain worth alarming and the triage dump below.
             error!(
                 %context_id,
                 ?source,
                 our_hash = ?our_hash,
                 their_hash = ?their_root_hash,
+                count,
                 dag_heads = ?their_dag_heads,
-                "DIVERGENCE DETECTED: Same DAG heads but different root hash!"
+                "DIVERGENCE DETECTED: Same DAG heads but different root hash (persisted across heartbeats)!"
             );
             // #2319 triage aid — dump ROOT's self summary + children
             // list so a future flake can be triaged by diffing the two
@@ -194,14 +251,33 @@ pub(super) fn handle_hash_heartbeat(
                     );
                 }
             }
-            warn!(
-                %context_id,
-                ?source,
-                their_heads = ?their_dag_heads,
-                "Divergence detected - periodic sync will recover"
-            );
+            // Active recovery on the FIRST escalation: kick a sync now rather
+            // than waiting for the next periodic tick. We can't trigger the
+            // signed anchor-pull (`reconcile_after_divergence`) from here — the
+            // peer's gossiped root hash is unauthenticated, so pulling canonical
+            // state off it would be a poisoning vector — but a plain HC sync is
+            // the same path periodic sync uses, just sooner. Only on the exact
+            // threshold tick so a still-stuck divergence keeps ERRORing without
+            // re-spawning a sync every heartbeat.
+            if count == DIVERGENCE_PERSIST_THRESHOLD {
+                let node_client = manager.clients.node.clone();
+                let _ignored = ctx.spawn(
+                    async move {
+                        if let Err(e) = node_client.sync(Some(&context_id), None).await {
+                            warn!(%context_id, ?e, "Persistent-divergence recovery sync failed to start");
+                        }
+                    }
+                    .into_actor(manager),
+                );
+            }
             return;
         }
+
+        // Reaching here means we are NOT in a same-DAG / different-root
+        // divergence with this peer (converged, or a plain behind/ahead head
+        // difference handled below) — drop any stale streak so a future
+        // transient starts fresh at WARN rather than inheriting an old count.
+        let _ = manager.divergence_streak.remove(&(context_id, source));
 
         if our_context.root_hash != their_root_hash {
             let heads_we_dont_have: Vec<_> = their_heads_set.difference(&our_heads_set).collect();

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -15,6 +15,24 @@ use crate::{NodeClients, NodeManagers, NodeState};
 
 mod startup;
 
+/// Per-(context, peer) record of a *persisting* same-DAG / different-root
+/// divergence observed by the hash-heartbeat. Lets the handler tell a
+/// transient, self-healing divergence (the common case — a concurrent sync
+/// apply mid-flight, logged at WARN) from one that is genuinely stuck across
+/// successive heartbeats (escalated to ERROR + an active recovery sync).
+///
+/// `count` increments only while the SAME (our, their) hash pair recurs — if
+/// either hash moves, sync is making progress and the streak resets to 1. The
+/// entry is cleared when the pair converges. Touched only synchronously by
+/// `handlers::network_event::heartbeat::handle_hash_heartbeat` on the manager
+/// actor, so a plain `HashMap` (no lock) suffices.
+#[derive(Debug, Clone)]
+pub(crate) struct DivergenceMark {
+    pub(crate) our_hash: calimero_primitives::hash::Hash,
+    pub(crate) their_hash: calimero_primitives::hash::Hash,
+    pub(crate) count: u32,
+}
+
 /// Main node orchestrator.
 ///
 /// **SRP Applied**: Clear separation of:
@@ -70,6 +88,15 @@ pub struct NodeManager {
     /// alert on divergence rate without grepping logs; with the #2319
     /// determinism fixes this should stay near zero.
     pub(crate) divergence_detected: Counter,
+    /// Per-(context, peer) persistence tracker for same-DAG / different-root
+    /// divergence (#2319 follow-up). The hash-heartbeat escalates to `error!`
+    /// (and an active recovery sync) only after the SAME divergence survives
+    /// `DIVERGENCE_PERSIST_THRESHOLD` consecutive heartbeats; a first/changing
+    /// observation logs at `warn!`. Keeps a transient mid-sync divergence from
+    /// tripping log-scanning CI (`--e2e-mode`) on unrelated work while still
+    /// surfacing a genuinely stuck split-brain. See [`DivergenceMark`].
+    pub(crate) divergence_streak:
+        HashMap<(calimero_primitives::context::ContextId, libp2p::PeerId), DivergenceMark>,
     /// Per-namespace timestamp of the last beacon-*triggered* governance
     /// sync (#2367). Caps beacon-divergence syncs to one per namespace
     /// per `NS_BEACON_SYNC_DEBOUNCE` window — beacons arrive every ~5s
@@ -116,6 +143,7 @@ impl NodeManager {
             state_delta_tx,
             sync_session_tx,
             divergence_detected,
+            divergence_streak: HashMap::new(),
             ns_beacon_sync_debounce: Arc::new(Mutex::new(HashMap::new())),
         }
     }

--- a/crates/node/src/sync/reconciler.rs
+++ b/crates/node/src/sync/reconciler.rs
@@ -396,7 +396,14 @@ impl Reconciler {
             );
             true
         } else {
-            tracing::warn!(
+            // ERROR, not WARN: this is the authoritative "recovery ran and
+            // FAILED" signal. We pulled canonical state from a *trusted anchor*
+            // and the root STILL doesn't match the *signed* expected hash — a
+            // confirmed, non-transient split-brain (unlike the heartbeat's
+            // unauthenticated peer-hash observation, which is gated to WARN
+            // until it persists). When this fires it is genuinely
+            // operator-investigation territory and should page / fail CI.
+            tracing::error!(
                 %context_id,
                 %anchor_peer,
                 op_kind,
@@ -404,7 +411,7 @@ impl Reconciler {
                 actual_root_hash = %hex::encode(actual_root_hash),
                 "reconcile-after-divergence: post-adoption hash does NOT match signed expected — \
                  either the anchor served non-canonical state or local apply diverged again; \
-                 operator-investigation territory until pre-adoption rejection lands"
+                 recovery from a trusted anchor failed, confirmed split-brain"
             );
             false
         }


### PR DESCRIPTION
## Problem

The hash-heartbeat logs `DIVERGENCE DETECTED: Same DAG heads but different root hash` at **ERROR** on the *first* observation, then returns relying on periodic sync (the comment literally says *"periodic sync will recover"*). But in the common case that condition is a **concurrent sync apply that landed mid-flight** and self-heals on the next tick. Logging a benign, recoverable event at ERROR makes it:
- **untrustworthy** as an alarm (it fires constantly, so a real one is lost in noise), and
- a **hard CI failure**: `merobox --e2e-mode` scans node logs for ERROR, so a transient divergence on one run fails that PR — even on completely unrelated work (this is what failed #2604, which passed clean on a re-run).

It also has **no active recovery** on this path — it only logs and hopes the background periodic sync heals it (which, per the #2512 family, it doesn't always).

## Change — make the alarm trustworthy, and add the missing recovery

**1. Persistence-gate the level (heartbeat.rs + manager.rs).** New per-`(context, peer)` tracker (`divergence_streak` / `DivergenceMark`). Escalate to `error!` only once the **same** `(our, their)` hash pair survives `DIVERGENCE_PERSIST_THRESHOLD` (2) consecutive heartbeats (~30–60s at the 30s cadence) — the genuinely-stuck, #2512 sticky-loop signature. A first observation, or one whose hashes are still moving (sync making progress), logs at `warn!`. Streak resets on any hash change, cleared on convergence. The `sync_root_hash_divergence_detected_total` metric still counts **every** observation, so the alert rate is unchanged.

**2. Add active recovery.** On the first escalation, kick a sync immediately instead of waiting for the next periodic tick. (We can't trigger the *signed* anchor-pull `reconcile_after_divergence` from here — the peer's gossiped root hash is unauthenticated, so pulling canonical state off it would be a poisoning vector — but a plain HC sync is the same path periodic sync uses, just sooner.)

**3. Authoritative ERROR where recovery demonstrably failed (reconciler.rs).** `verify_post_reconcile_root_hash`'s post-adoption mismatch goes `warn!` → `error!`. That path runs *after* pulling canonical state from a **trusted anchor** and comparing against the **signed** expected hash — so a mismatch is the unambiguous *"recovery ran and failed"* signal (a confirmed split-brain), with no waiting.

## Net effect
- Transient mid-sync divergence → **WARN** (visible, metered, doesn't fail unrelated CI).
- Genuinely stuck, or recovery-failed, divergence → **ERROR** (a confirmed, actionable split-brain).

**No hashing / CRDT-merge logic is touched** — this only governs *when* the alarm escalates and adds an active recovery nudge. It is detection-hardening: it makes a real divergence a trustworthy, reproducible signal to root-cause at the source, and stops transient ones from failing CI.

## Trade-off (called out for review)
Because the heartbeat ERROR now needs ~60s of persistence and many e2e tests are shorter, a *real* stuck divergence inside a brief test may surface only as WARN within that window — so `--e2e-mode` wouldn't fail on it there. The reconciler half (3) partially covers this (it ERRORs immediately on recovery failure, no waiting) but only on the signed-op path. Tunable via `DIVERGENCE_PERSIST_THRESHOLD` if a tighter window is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync observability and recovery triggers (log levels, streak state, extra sync spawns) without touching CRDT/hash logic; mis-tuned thresholds could delay real split-brain detection in short tests.
> 
> **Overview**
> Hash-heartbeat handling for **same DAG heads, different root** no longer logs **ERROR** on the first sighting. A per-`(context, peer)` **`divergence_streak`** (with **`DivergenceMark`**) counts consecutive heartbeats where the **same** `(our_hash, their_hash)` pair repeats; until **`DIVERGENCE_PERSIST_THRESHOLD`** (2, ~30–60s), it stays **`warn!`** and returns early. The streak resets when hashes change or the peer converges; **`sync_root_hash_divergence_detected_total`** still increments on every observation.
> 
> Once the threshold is hit, it **`error!`**s (with persistence wording), keeps the triage dump, and **spawns an immediate `node_client.sync`** on that tick only—not signed anchor reconcile, since gossiped roots are unauthenticated.
> 
> In **`reconciler`**, a post–anchor-pull root that still disagrees with the **signed** expected hash is upgraded from **`warn!`** to **`error!`** as the definitive “recovery failed” signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae105524f3a4b7dda82e2da2b1daf6a2e1912af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->