### PR TITLE
chore: bump version to 0.11.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.10.1-rc.47"
+version = "0.11.0-rc.1"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the shared release version of all public crates from `0.10.1-rc.47` to `0.11.0-rc.1`.

Single-line change to `[workspace.metadata.workspaces].version` in `Cargo.toml` — the field `cargo-workspaces` reads when cutting a release. The `[workspace.package]` version stays `0.0.0` (applied at release time), so no other files (including `Cargo.lock`) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime, API, or dependency changes in the diff.
> 
> **Overview**
> Bumps the workspace release version in root `Cargo.toml` from **`0.10.1-rc.47`** to **`0.11.0-rc.1`** under `[workspace.metadata.workspaces].version` — the single source of truth `cargo-workspaces` and CI use when publishing public crates.
> 
> `[workspace.package].version` stays **`0.0.0`**; no other manifests or lockfile updates in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac8ad7e9e863983f0e4241bf016c6b980543b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->