### PR TITLE
feat(auth): add AuthError::TokenExpired for explicit expiry detection

### DIFF
--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -14,6 +14,7 @@ use crate::api::handlers::AuthUiStaticFiles;
 use crate::auth::validation::{sanitize_identifier, sanitize_string, ValidatedJson};
 use crate::server::AppState;
 use crate::storage::models::Key;
+use crate::AuthError;
 
 // Common response type used by all helper functions
 type ApiResponse = (StatusCode, HeaderMap, Json<serde_json::Value>);
@@ -282,7 +283,7 @@ pub async fn refresh_token_handler(
             return error_response(StatusCode::UNAUTHORIZED, "Access token still valid", None);
         }
         Err(err) => {
-            if !err.to_string().contains("expired") {
+            if !matches!(err, AuthError::TokenExpired) {
                 return error_response(
                     StatusCode::UNAUTHORIZED,
                     format!("Invalid access token: {err}"),
@@ -446,7 +447,7 @@ pub async fn validate_handler(
         Err(err) => {
             let mut error_headers = HeaderMap::new();
             // Add error type header for better client handling
-            if err.to_string().contains("expired") {
+            if matches!(err, AuthError::TokenExpired) {
                 error_headers.insert("X-Auth-Error", "token_expired".parse().unwrap());
             } else if err.to_string().contains("revoked") {
                 error_headers.insert("X-Auth-Error", "token_revoked".parse().unwrap());

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -91,7 +91,7 @@ pub async fn auth_middleware(
             let mut headers = HeaderMap::new();
 
             match err {
-                AuthError::InvalidToken(msg) if msg.contains("expired") => {
+                AuthError::TokenExpired => {
                     warn!(
                         "Token expired for {} {} (took {:?})",
                         method, path, duration
@@ -671,12 +671,12 @@ mod tests {
     #[tokio::test]
     async fn test_error_response_expired_token_format() {
         // Verify that expired token errors produce correct header format
-        let err = crate::AuthError::InvalidToken("Token has expired".to_string());
+        let err = crate::AuthError::TokenExpired;
 
         // Simulate middleware error handling
         let mut headers = HeaderMap::new();
         match &err {
-            crate::AuthError::InvalidToken(msg) if msg.contains("expired") => {
+            crate::AuthError::TokenExpired => {
                 headers.insert("X-Auth-Error", "token_expired".parse().unwrap());
             }
             _ => {}
@@ -752,11 +752,9 @@ mod tests {
         // Test that different error types map to correct HTTP status codes
 
         // Expired token -> 401 Unauthorized
-        let expired_err = crate::AuthError::InvalidToken("Token has expired".to_string());
+        let expired_err = crate::AuthError::TokenExpired;
         let status = match &expired_err {
-            crate::AuthError::InvalidToken(msg) if msg.contains("expired") => {
-                StatusCode::UNAUTHORIZED
-            }
+            crate::AuthError::TokenExpired => StatusCode::UNAUTHORIZED,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -1021,22 +1019,19 @@ mod tests {
     }
 
     #[test]
-    fn test_expired_token_message_variations() {
-        // Test various messages that indicate expiration
-        let expired_messages = vec![
-            "Token has expired",
-            "expired",
-            "token expired",
-            "JWT expired",
-        ];
-
-        for msg in expired_messages {
-            let contains_expired = msg.to_lowercase().contains("expired");
-            assert!(
-                contains_expired,
-                "Message '{msg}' should be detected as expired"
-            );
-        }
+    fn test_expired_token_detected_by_variant_not_message() {
+        // Expiry is now identified by the dedicated `TokenExpired` variant, so
+        // detection no longer depends on the wording of any error message.
+        // A generic `InvalidToken` that merely mentions "expired" must NOT be
+        // treated as an expiry.
+        assert!(matches!(
+            crate::AuthError::TokenExpired,
+            crate::AuthError::TokenExpired
+        ));
+        assert!(!matches!(
+            crate::AuthError::InvalidToken("token expired".to_string()),
+            crate::AuthError::TokenExpired
+        ));
     }
 
     #[test]

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -733,9 +733,9 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         match &err {
-            crate::AuthError::InvalidToken(msg)
-                if !msg.contains("expired") && !msg.contains("revoked") =>
-            {
+            // Expiry is now its own variant, so the generic arm no longer needs
+            // to exclude "expired" messages.
+            crate::AuthError::InvalidToken(msg) if !msg.contains("revoked") => {
                 headers.insert("X-Auth-Error", "invalid_token".parse().unwrap());
             }
             _ => {}
@@ -778,9 +778,9 @@ mod tests {
         // Generic invalid token -> 401 Unauthorized
         let generic_err = crate::AuthError::InvalidToken("Malformed".to_string());
         let status = match &generic_err {
-            crate::AuthError::InvalidToken(msg)
-                if !msg.contains("expired") && !msg.contains("revoked") =>
-            {
+            // Expiry is now its own variant, so the generic arm no longer needs
+            // to exclude "expired" messages.
+            crate::AuthError::InvalidToken(msg) if !msg.contains("revoked") => {
                 StatusCode::UNAUTHORIZED
             }
             _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -622,15 +622,16 @@ impl TokenManager {
         validation.validate_exp = true;
         validation.set_issuer(&[&self.config.issuer]);
 
+        // NB: a challenge is a short-lived auth nonce, not a Bearer access
+        // token. Its expiry is deliberately NOT mapped to `AuthError::TokenExpired`
+        // — that variant signals access-token expiry and drives the SDK's refresh
+        // flow, which makes no sense for an expired challenge.
         let token_data = decode::<ChallengeClaims>(
             token,
             &DecodingKey::from_secret(secret.as_bytes()),
             &validation,
         )
-        .map_err(|e| match e.kind() {
-            jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::TokenExpired,
-            _ => AuthError::InvalidToken(e.to_string()),
-        })?;
+        .map_err(|e| AuthError::InvalidToken(e.to_string()))?;
 
         Ok(token_data.claims)
     }

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -326,9 +326,7 @@ impl TokenManager {
         ) {
             Ok(token_data) => Ok(token_data.claims),
             Err(err) => match err.kind() {
-                jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
-                    Err(AuthError::InvalidToken("Token has expired".to_string()))
-                }
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => Err(AuthError::TokenExpired),
                 jsonwebtoken::errors::ErrorKind::InvalidToken => {
                     Err(AuthError::InvalidToken(format!("Malformed token: {err}")))
                 }

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -627,7 +627,10 @@ impl TokenManager {
             &DecodingKey::from_secret(secret.as_bytes()),
             &validation,
         )
-        .map_err(|e| AuthError::InvalidToken(e.to_string()))?;
+        .map_err(|e| match e.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::TokenExpired,
+            _ => AuthError::InvalidToken(e.to_string()),
+        })?;
 
         Ok(token_data.claims)
     }

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -35,6 +35,8 @@ pub enum AuthError {
     AuthorizationFailed(String),
     #[error("Invalid token: {0}")]
     InvalidToken(String),
+    #[error("Token has expired")]
+    TokenExpired,
     #[error("Storage error: {0}")]
     StorageError(String),
     #[error("Provider error: {0}")]

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -10,7 +10,7 @@ use eyre::Result;
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
 use mero_auth::embedded::{build_app, default_config, EmbeddedAuthApp};
-use mero_auth::AuthService;
+use mero_auth::{AuthError, AuthService};
 use tower::{Layer, Service};
 use tracing::{debug, info, warn};
 
@@ -19,10 +19,9 @@ use crate::config::ServerConfig;
 /// Build a 401 response, adding `X-Auth-Error: token_expired` if the error
 /// indicates an expired token. Centralises the logic so the Bearer and
 /// query-param paths stay in sync.
-fn unauthorized_response(err: &dyn std::fmt::Display) -> Response {
+fn unauthorized_response(err: &AuthError) -> Response {
     let mut resp = StatusCode::UNAUTHORIZED.into_response();
-    let msg = err.to_string();
-    if msg.contains("expired") {
+    if matches!(err, AuthError::TokenExpired) {
         resp.headers_mut()
             .insert("X-Auth-Error", "token_expired".parse().unwrap());
     }

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -19,6 +19,12 @@ use crate::config::ServerConfig;
 /// Build a 401 response, adding `X-Auth-Error: token_expired` if the error
 /// indicates an expired token. Centralises the logic so the Bearer and
 /// query-param paths stay in sync.
+///
+/// Only expiry is signalled here. Revoked tokens are intentionally not
+/// distinguished: revoked keys currently surface as "Key not found" because
+/// `KeyManager::get_key` filters them out, so there is no reliable revoked
+/// signal to propagate yet. Fixing that (and adding an `X-Auth-Error:
+/// token_revoked` arm) is tracked separately.
 fn unauthorized_response(err: &AuthError) -> Response {
     let mut resp = StatusCode::UNAUTHORIZED.into_response();
     if matches!(err, AuthError::TokenExpired) {


### PR DESCRIPTION
Closes #2088.

## Problem

The server's auth guard detected expired tokens by fragile string matching — searching for `"expired"` inside error messages to set the `X-Auth-Error: token_expired` header. Any wording change in the JWT verifier would silently break expiry detection, leaving the `mero-js` SDK unable to distinguish an expired token (which it can refresh) from any other 401.

## Change

Introduce an explicit `AuthError::TokenExpired` variant and pattern-match on it instead of inspecting message text.

| File | Change |
|------|--------|
| `crates/auth/src/lib.rs` | Add `TokenExpired` variant (`#[error("Token has expired")]`) |
| `crates/auth/src/auth/token/jwt.rs` | `verify_token` emits `TokenExpired` for `ErrorKind::ExpiredSignature` |
| `crates/auth/src/auth/middleware.rs` | Match the variant → `X-Auth-Error: token_expired`; tests updated |
| `crates/server/src/auth.rs` | `unauthorized_response` takes `&AuthError` and matches the variant |
| `crates/auth/src/api/handlers/auth.rs` | Refresh + validate handlers match the variant (same `AuthError` source) |

## Impact

`mero-js` reliably receives `X-Auth-Error: token_expired` to trigger automatic re-authentication; verifier wording changes can no longer break it.

Revoked-key detection still uses string matching — out of scope here; it would warrant its own variant.

## Testing

- `cargo build -p mero-auth -p calimero-server` ✅
- `cargo test -p mero-auth -p calimero-server` ✅ (60 passed)
- `cargo clippy -p mero-auth -p calimero-server --all-targets` ✅
- `cargo fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication error handling and client-visible `X-Auth-Error` headers; behavior is intentional and low blast radius but auth paths are security-sensitive.
> 
> **Overview**
> Adds a dedicated **`AuthError::TokenExpired`** variant and replaces fragile **`"expired"`** substring checks across auth and server code with **`matches!(err, AuthError::TokenExpired)`**.
> 
> **JWT verification** maps `ExpiredSignature` to `TokenExpired` for access/refresh tokens; **challenge** JWT expiry stays **`InvalidToken`** (documented) so clients do not treat nonce expiry like refreshable access tokens.
> 
> **Handlers and middleware** set **`X-Auth-Error: token_expired`** from the variant (refresh flow, validate, auth middleware). **`calimero-server`** `unauthorized_response` now takes **`&AuthError`** and only signals expiry via the variant. Tests assert expiry is detected by variant, not message wording.
> 
> **Revoked** tokens still use message matching where applicable; server comments note revoked signaling is unchanged/out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd94d8270604ac2df7edbe7a563fb0256343938d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->