### PR TITLE
feat(sdk/macros): compile-error when a multi-writer/sync-semantic collection is used inside #[app::private]

### DIFF
--- a/crates/sdk/macros/src/errors.rs
+++ b/crates/sdk/macros/src/errors.rs
@@ -113,6 +113,15 @@ pub enum ParseError<'a> {
         type_name: &'static str,
         suggestion: &'static str,
     },
+    #[error(
+        "`{type_name}` cannot be used inside `#[app::private]` — it {explanation}\n\n\
+         A node-local private namespace has a single writer, so the multi-writer / \
+         sync-layer semantics this type models have no meaning here."
+    )]
+    PrivateIncompatibleCollection {
+        type_name: String,
+        explanation: &'static str,
+    },
 }
 
 impl AsRef<Self> for ParseError<'_> {

--- a/crates/sdk/macros/src/errors.rs
+++ b/crates/sdk/macros/src/errors.rs
@@ -119,7 +119,7 @@ pub enum ParseError<'a> {
          sync-layer semantics this type models have no meaning here."
     )]
     PrivateIncompatibleCollection {
-        type_name: String,
+        type_name: &'static str,
         explanation: &'static str,
     },
 }

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -31,9 +31,11 @@ use sha2::{Digest, Sha256};
 /// straight into the outer private blob and need no substitution.
 ///
 /// **Deliberately excluded** (using them inside `#[app::private]`
-/// is a semantic mismatch and currently produces a normal type
-/// error, since their `::new()` stays pinned to `MainStorage`; a
-/// dedicated compile-time diagnostic is tracked in #2428):
+/// is a semantic mismatch — rather than silently leaving their
+/// `::new()` pinned to `MainStorage` and letting a downstream type
+/// error surface, they're listed in `PRIVATE_INCOMPATIBLE` and
+/// rejected with a targeted compile error pointing at the primitive
+/// to use instead):
 ///
 /// - CRDT data-types (`LwwRegister`, `Counter`, `GCounter`,
 ///   `PNCounter`, `ReplicatedGrowableArray`) — CRDTs exist for
@@ -57,6 +59,154 @@ const TREE_BACKED_TYPES: &[(&str, usize)] = &[
     ("SortedSet", 1),
     ("Vector", 1),
 ];
+
+/// Calimero collections whose entire reason for existing is the
+/// *synced* multi-writer tree — CRDTs, access-control wrappers, and
+/// authored collections. Unlike the structural primitives in
+/// `TREE_BACKED_TYPES`, these can't simply be re-pointed at
+/// `PrivateStorage`: a node-local namespace has a single writer, so
+/// per-entry authorship, cross-node merge, per-user scoping, and
+/// last-write-wins reconciliation are all meaningless. Seeing one
+/// inside `#[app::private]` is a semantic mistake, not a mechanical
+/// one, so we reject it with a targeted compile error rather than
+/// silently leaving it pinned to `MainStorage` (which re-introduces
+/// the very leak `#[app::private]` is supposed to prevent).
+///
+/// Each entry pairs the type name with the tail of the sentence
+/// "`<Name>` cannot be used inside `#[app::private]` — it `<...>`",
+/// so the message tells the user *why* it's wrong and *what* to
+/// reach for instead.
+///
+/// Matched on the *last segment* of the type path, the same way
+/// `try_inject_on_path` matches `TREE_BACKED_TYPES`, so
+/// fully-qualified paths are covered too. Aliases / `use as` renames
+/// slip past — the same limitation the injection path has.
+const PRIVATE_INCOMPATIBLE: &[(&str, &str)] = &[
+    (
+        "AuthoredMap",
+        "tracks per-entry authorship for multi-writer convergence; use `UnorderedMap` instead.",
+    ),
+    (
+        "AuthoredVector",
+        "tracks per-entry authorship for multi-writer convergence; use `Vector` instead.",
+    ),
+    (
+        "Counter",
+        "is a CRDT counter for concurrent increments across nodes; use a plain integer field.",
+    ),
+    (
+        "GCounter",
+        "is a CRDT counter for concurrent increments across nodes; use a plain integer field.",
+    ),
+    (
+        "PNCounter",
+        "is a CRDT counter for concurrent increments across nodes; use a plain integer field.",
+    ),
+    (
+        "ReplicatedGrowableArray",
+        "is a collaborative-edit text CRDT; use `Vector<u8>` or a `String` field.",
+    ),
+    (
+        "SharedStorage",
+        "models single-signature shared/causal reconciliation; pointless with one writer.",
+    ),
+    (
+        "UserStorage",
+        "models per-user scoping at the sync layer; pointless in a node-local namespace.",
+    ),
+    (
+        "FrozenStorage",
+        "models cross-node immutability; redundant in single-node storage.",
+    ),
+    (
+        "LwwRegister",
+        "is a last-write-wins register for concurrent writes; just use the value type directly.",
+    ),
+];
+
+/// Recursively walk `ty` — descending through the same wrappers
+/// `inject_private_storage` does (generics, tuples, references,
+/// arrays, slices, groups, parens) — and collect every offending
+/// `PRIVATE_INCOMPATIBLE` type encountered, paired with its
+/// explanation. We collect the offending *ident* (not just the name)
+/// so the eventual `compile_error!` can be spanned right at the
+/// culprit type. Read-only twin of `inject_private_storage`: a
+/// nested `Option<AuthoredVector<T>>` is caught just as a top-level
+/// field would be.
+fn collect_private_incompatible<'t>(ty: &'t Type, found: &mut Vec<(&'t Ident, &'static str)>) {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(last) = type_path.path.segments.last() {
+                let name = last.ident.to_string();
+                if let Some(&(_, explanation)) =
+                    PRIVATE_INCOMPATIBLE.iter().find(|(n, _)| *n == name)
+                {
+                    found.push((&last.ident, explanation));
+                }
+                if let PathArguments::AngleBracketed(args) = &last.arguments {
+                    for arg in &args.args {
+                        if let GenericArgument::Type(inner) = arg {
+                            collect_private_incompatible(inner, found);
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(r) => collect_private_incompatible(&r.elem, found),
+        Type::Tuple(t) => {
+            for elem in &t.elems {
+                collect_private_incompatible(elem, found);
+            }
+        }
+        Type::Array(a) => collect_private_incompatible(&a.elem, found),
+        Type::Slice(s) => collect_private_incompatible(&s.elem, found),
+        Type::Group(g) => collect_private_incompatible(&g.elem, found),
+        Type::Paren(p) => collect_private_incompatible(&p.elem, found),
+        _ => {}
+    }
+}
+
+/// Walk every field of `item` and push a targeted compile error into
+/// `errors` for each `PRIVATE_INCOMPATIBLE` collection found — at any
+/// depth. Runs before substitution: catching the misuse up front is
+/// the whole point, and there's nothing sensible to rewrite anyway.
+fn check_private_compatible<'a>(item: &'a StructOrEnumItem, errors: &Errors<'a, StructOrEnumItem>) {
+    let mut found: Vec<(&Ident, &'static str)> = Vec::new();
+
+    let walk_fields = |fields: &'a Fields, found: &mut Vec<(&'a Ident, &'static str)>| match fields
+    {
+        Fields::Named(fields) => {
+            for field in &fields.named {
+                collect_private_incompatible(&field.ty, found);
+            }
+        }
+        Fields::Unnamed(fields) => {
+            for field in &fields.unnamed {
+                collect_private_incompatible(&field.ty, found);
+            }
+        }
+        Fields::Unit => {}
+    };
+
+    match item {
+        StructOrEnumItem::Struct(item) => walk_fields(&item.fields, &mut found),
+        StructOrEnumItem::Enum(item) => {
+            for variant in &item.variants {
+                walk_fields(&variant.fields, &mut found);
+            }
+        }
+    }
+
+    for (ident, explanation) in found {
+        errors.subsume(SynError::new_spanned(
+            ident,
+            ParseError::PrivateIncompatibleCollection {
+                type_name: ident.to_string(),
+                explanation,
+            },
+        ));
+    }
+}
 
 /// Recursively walk `ty` and inject `PrivateStorage` on every
 /// tree-backed collection encountered — including ones nested inside
@@ -337,6 +487,11 @@ impl<'a> TryFrom<PrivateImplInput<'a>> for PrivateImpl<'a> {
             errors.subsume(SynError::new_spanned(ident, ParseError::UseOfReservedIdent));
         }
 
+        // Reject multi-writer / sync-semantic Calimero collections
+        // before we attempt any substitution — they have no coherent
+        // meaning in a single-writer private namespace.
+        check_private_compatible(input.item, &errors);
+
         // Generate a default key if none provided (hash ident to avoid collisions)
         let key_bytes = input
             .args
@@ -518,6 +673,103 @@ mod tests {
             assert!(
                 !included.contains(head),
                 "{head} is in both TREE_BACKED_TYPES and an EXCLUDED_* list — pick one"
+            );
+        }
+    }
+
+    // `PRIVATE_INCOMPATIBLE` detection tests: the multi-writer /
+    // sync-semantic family must be *caught* (errored on), not just
+    // "left alone" by the rewrite. These pin the diagnostic side of
+    // the contract the rewrite tests above pin the substitution side
+    // of.
+
+    fn incompatible_names(input: Type) -> Vec<String> {
+        let mut found = Vec::new();
+        super::collect_private_incompatible(&input, &mut found);
+        found
+            .into_iter()
+            .map(|(ident, _)| ident.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn every_incompatible_type_is_detected() {
+        // Each name in the list is flagged when it appears as a field
+        // type. We construct a minimal valid instantiation per type so
+        // the parser is happy; detection keys off the ident, not the
+        // generics.
+        for (name, _) in super::PRIVATE_INCOMPATIBLE {
+            let ty: Type = syn::parse_str(&format!("{name}<String>")).expect("parse");
+            let names = incompatible_names(ty);
+            assert_eq!(
+                names,
+                vec![(*name).to_owned()],
+                "{name} must be flagged as private-incompatible"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_incompatible_type_is_detected() {
+        // Buried inside a wrapper it must still be caught — otherwise a
+        // user could smuggle the leak back in via `Option<...>`.
+        let names = incompatible_names(parse_quote!(Option<AuthoredVector<String>>));
+        assert_eq!(names, vec!["AuthoredVector".to_owned()]);
+    }
+
+    #[test]
+    fn multiple_incompatible_types_all_reported() {
+        // A tuple with two offenders flags both, so the user fixes
+        // every misuse in one compile cycle rather than whack-a-mole.
+        let names = incompatible_names(parse_quote!((Counter, AuthoredMap<String, String>)));
+        assert_eq!(names, vec!["Counter".to_owned(), "AuthoredMap".to_owned()]);
+    }
+
+    #[test]
+    fn compatible_primitive_is_not_flagged() {
+        // The supported primitives must NOT trip the incompatible
+        // check — they're handled by substitution instead.
+        assert!(incompatible_names(parse_quote!(UnorderedMap<String, String>)).is_empty());
+        assert!(incompatible_names(parse_quote!(Vector<u8>)).is_empty());
+        assert!(incompatible_names(parse_quote!(BTreeMap<String, String>)).is_empty());
+    }
+
+    #[test]
+    fn excluded_lists_match_private_incompatible() {
+        // Anti-drift: every type the rewrite tests assert is "left
+        // alone" must also be one the diagnostic rejects, and vice
+        // versa. Two lists, one truth.
+        let incompatible: std::collections::HashSet<&str> = super::PRIVATE_INCOMPATIBLE
+            .iter()
+            .map(|(n, _)| *n)
+            .collect();
+        for excluded in EXCLUDED_CRDT_TYPES
+            .iter()
+            .chain(EXCLUDED_ACCESS_CONTROL_TYPES)
+        {
+            let head = excluded.split('<').next().expect("non-empty");
+            assert!(
+                incompatible.contains(head),
+                "{head} is left-alone by the rewrite but missing from PRIVATE_INCOMPATIBLE — \
+                 it would silently fall back to MainStorage"
+            );
+        }
+        assert_eq!(
+            incompatible.len(),
+            EXCLUDED_CRDT_TYPES.len() + EXCLUDED_ACCESS_CONTROL_TYPES.len(),
+            "PRIVATE_INCOMPATIBLE names a type the exclusion lists don't — keep them in sync"
+        );
+    }
+
+    #[test]
+    fn private_incompatible_disjoint_from_tree_backed() {
+        // A type can't be both rewritten and rejected.
+        let included: std::collections::HashSet<&str> =
+            super::TREE_BACKED_TYPES.iter().map(|(n, _)| *n).collect();
+        for (name, _) in super::PRIVATE_INCOMPATIBLE {
+            assert!(
+                !included.contains(name),
+                "{name} is in both TREE_BACKED_TYPES and PRIVATE_INCOMPATIBLE — pick one"
             );
         }
     }

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -127,21 +127,29 @@ const PRIVATE_INCOMPATIBLE: &[(&str, &str)] = &[
 /// Recursively walk `ty` — descending through the same wrappers
 /// `inject_private_storage` does (generics, tuples, references,
 /// arrays, slices, groups, parens) — and collect every offending
-/// `PRIVATE_INCOMPATIBLE` type encountered, paired with its
-/// explanation. We collect the offending *ident* (not just the name)
-/// so the eventual `compile_error!` can be spanned right at the
-/// culprit type. Read-only twin of `inject_private_storage`: a
-/// nested `Option<AuthoredVector<T>>` is caught just as a top-level
-/// field would be.
-fn collect_private_incompatible<'t>(ty: &'t Type, found: &mut Vec<(&'t Ident, &'static str)>) {
+/// `PRIVATE_INCOMPATIBLE` type encountered, paired with the matching
+/// `(name, explanation)` const entry. We collect the offending
+/// *ident* (not just the name) so the eventual `compile_error!` can be
+/// spanned right at the culprit type, and carry the `&'static` name so
+/// the diagnostic reuses the const string rather than re-allocating.
+/// Read-only twin of `inject_private_storage`: a nested
+/// `Option<AuthoredVector<T>>` is caught just as a top-level field
+/// would be.
+fn collect_private_incompatible<'t>(
+    ty: &'t Type,
+    found: &mut Vec<(&'t Ident, &'static (&'static str, &'static str))>,
+) {
     match ty {
         Type::Path(type_path) => {
             if let Some(last) = type_path.path.segments.last() {
                 let name = last.ident.to_string();
-                if let Some(&(_, explanation)) =
-                    PRIVATE_INCOMPATIBLE.iter().find(|(n, _)| *n == name)
-                {
-                    found.push((&last.ident, explanation));
+                if let Some(entry) = PRIVATE_INCOMPATIBLE.iter().find(|(n, _)| *n == name) {
+                    // The whole field is already invalid — don't recurse
+                    // into its type args, or `AuthoredVector<Counter>`
+                    // would noisily report `Counter` too when the only
+                    // mistake the user made is the outer type.
+                    found.push((&last.ident, entry));
+                    return;
                 }
                 if let PathArguments::AngleBracketed(args) = &last.arguments {
                     for arg in &args.args {
@@ -166,42 +174,43 @@ fn collect_private_incompatible<'t>(ty: &'t Type, found: &mut Vec<(&'t Ident, &'
     }
 }
 
+/// Collect every `PRIVATE_INCOMPATIBLE` offender across one set of
+/// fields (a struct body, or a single enum variant).
+fn collect_incompatible_in_fields<'a>(
+    fields: &'a Fields,
+    found: &mut Vec<(&'a Ident, &'static (&'static str, &'static str))>,
+) {
+    let fields = match fields {
+        Fields::Named(fields) => &fields.named,
+        Fields::Unnamed(fields) => &fields.unnamed,
+        Fields::Unit => return,
+    };
+    for field in fields {
+        collect_private_incompatible(&field.ty, found);
+    }
+}
+
 /// Walk every field of `item` and push a targeted compile error into
 /// `errors` for each `PRIVATE_INCOMPATIBLE` collection found — at any
 /// depth. Runs before substitution: catching the misuse up front is
 /// the whole point, and there's nothing sensible to rewrite anyway.
 fn check_private_compatible<'a>(item: &'a StructOrEnumItem, errors: &Errors<'a, StructOrEnumItem>) {
-    let mut found: Vec<(&Ident, &'static str)> = Vec::new();
-
-    let walk_fields = |fields: &'a Fields, found: &mut Vec<(&'a Ident, &'static str)>| match fields
-    {
-        Fields::Named(fields) => {
-            for field in &fields.named {
-                collect_private_incompatible(&field.ty, found);
-            }
-        }
-        Fields::Unnamed(fields) => {
-            for field in &fields.unnamed {
-                collect_private_incompatible(&field.ty, found);
-            }
-        }
-        Fields::Unit => {}
-    };
+    let mut found = Vec::new();
 
     match item {
-        StructOrEnumItem::Struct(item) => walk_fields(&item.fields, &mut found),
+        StructOrEnumItem::Struct(item) => collect_incompatible_in_fields(&item.fields, &mut found),
         StructOrEnumItem::Enum(item) => {
             for variant in &item.variants {
-                walk_fields(&variant.fields, &mut found);
+                collect_incompatible_in_fields(&variant.fields, &mut found);
             }
         }
     }
 
-    for (ident, explanation) in found {
+    for (ident, &(type_name, explanation)) in found {
         errors.subsume(SynError::new_spanned(
             ident,
             ParseError::PrivateIncompatibleCollection {
-                type_name: ident.to_string(),
+                type_name,
                 explanation,
             },
         ));
@@ -743,22 +752,32 @@ mod tests {
             .iter()
             .map(|(n, _)| *n)
             .collect();
-        for excluded in EXCLUDED_CRDT_TYPES
+        let excluded: std::collections::HashSet<&str> = EXCLUDED_CRDT_TYPES
             .iter()
             .chain(EXCLUDED_ACCESS_CONTROL_TYPES)
-        {
-            let head = excluded.split('<').next().expect("non-empty");
+            // Pull just the leading identifier (everything before `<`).
+            .map(|ty| ty.split('<').next().expect("non-empty"))
+            .collect();
+
+        // Forward: every left-alone type must be rejected by the
+        // diagnostic, or it would silently fall back to MainStorage.
+        for name in &excluded {
             assert!(
-                incompatible.contains(head),
-                "{head} is left-alone by the rewrite but missing from PRIVATE_INCOMPATIBLE — \
+                incompatible.contains(name),
+                "{name} is left-alone by the rewrite but missing from PRIVATE_INCOMPATIBLE — \
                  it would silently fall back to MainStorage"
             );
         }
-        assert_eq!(
-            incompatible.len(),
-            EXCLUDED_CRDT_TYPES.len() + EXCLUDED_ACCESS_CONTROL_TYPES.len(),
-            "PRIVATE_INCOMPATIBLE names a type the exclusion lists don't — keep them in sync"
-        );
+        // Reverse: every rejected type must be a known left-alone
+        // type, so the diagnostic never names something out of thin
+        // air. The two checks together pin set equality regardless of
+        // duplicates — length alone wouldn't.
+        for name in &incompatible {
+            assert!(
+                excluded.contains(name),
+                "{name} is in PRIVATE_INCOMPATIBLE but not in any EXCLUDED_* list — keep them in sync"
+            );
+        }
     }
 
     #[test]

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -132,6 +132,7 @@ const PRIVATE_INCOMPATIBLE: &[(&str, &str)] = &[
 /// *ident* (not just the name) so the eventual `compile_error!` can be
 /// spanned right at the culprit type, and carry the `&'static` name so
 /// the diagnostic reuses the const string rather than re-allocating.
+///
 /// Read-only twin of `inject_private_storage`: a nested
 /// `Option<AuthoredVector<T>>` is caught just as a top-level field
 /// would be.
@@ -142,8 +143,9 @@ fn collect_private_incompatible<'t>(
     match ty {
         Type::Path(type_path) => {
             if let Some(last) = type_path.path.segments.last() {
-                let name = last.ident.to_string();
-                if let Some(entry) = PRIVATE_INCOMPATIBLE.iter().find(|(n, _)| *n == name) {
+                // `Ident: PartialEq<str>`, so match the name without
+                // allocating a `String` per path segment visited.
+                if let Some(entry) = PRIVATE_INCOMPATIBLE.iter().find(|(n, _)| last.ident == *n) {
                     // The whole field is already invalid — don't recurse
                     // into its type args, or `AuthoredVector<Counter>`
                     // would noisily report `Counter` too when the only
@@ -752,6 +754,14 @@ mod tests {
             .iter()
             .map(|(n, _)| *n)
             .collect();
+
+        // A duplicate name would double-report a single offender and
+        // would also be invisible to the set comparisons below.
+        assert_eq!(
+            incompatible.len(),
+            super::PRIVATE_INCOMPATIBLE.len(),
+            "PRIVATE_INCOMPATIBLE has duplicate entries"
+        );
         let excluded: std::collections::HashSet<&str> = EXCLUDED_CRDT_TYPES
             .iter()
             .chain(EXCLUDED_ACCESS_CONTROL_TYPES)

--- a/crates/sdk/tests/macros.rs
+++ b/crates/sdk/tests/macros.rs
@@ -51,4 +51,5 @@ fn all() {
     t.compile_fail("tests/macros/error_const_generic.rs");
     t.compile_fail("tests/macros/error_explicit_abi.rs");
     t.compile_fail("tests/macros/error_event_on_struct.rs");
+    t.compile_fail("tests/macros/error_private_incompatible.rs");
 }

--- a/crates/sdk/tests/macros/error_private_incompatible.rs
+++ b/crates/sdk/tests/macros/error_private_incompatible.rs
@@ -1,0 +1,28 @@
+//! Multi-writer / sync-semantic Calimero collections have no coherent
+//! meaning in a single-writer private namespace, so `#[app::private]`
+//! must reject them with a targeted diagnostic rather than silently
+//! leaving them pinned to `MainStorage` (which re-introduces the leak).
+//!
+//! The collection names below are stand-ins defined locally — the macro
+//! matches on the *last path segment ident*, so it fires the diagnostic
+//! without the real `calimero_storage` types in scope. This keeps the
+//! captured stderr to just the macro errors we're asserting on.
+
+use calimero_sdk::app;
+
+#[allow(dead_code)]
+struct AuthoredVector<T>(core::marker::PhantomData<T>);
+#[allow(dead_code)]
+struct Counter;
+#[allow(dead_code)]
+struct SharedStorage<T>(core::marker::PhantomData<T>);
+
+#[app::private]
+struct Secrets {
+    history: AuthoredVector<String>,
+    hits: Counter,
+    // Nested inside a wrapper — must still be caught.
+    shared: Option<SharedStorage<String>>,
+}
+
+fn main() {}

--- a/crates/sdk/tests/macros/error_private_incompatible.stderr
+++ b/crates/sdk/tests/macros/error_private_incompatible.stderr
@@ -1,0 +1,23 @@
+error: (calimero)> `AuthoredVector` cannot be used inside `#[app::private]` — it tracks per-entry authorship for multi-writer convergence; use `Vector` instead.
+
+       A node-local private namespace has a single writer, so the multi-writer / sync-layer semantics this type models have no meaning here.
+  --> tests/macros/error_private_incompatible.rs:22:14
+   |
+22 |     history: AuthoredVector<String>,
+   |              ^^^^^^^^^^^^^^
+
+error: (calimero)> `Counter` cannot be used inside `#[app::private]` — it is a CRDT counter for concurrent increments across nodes; use a plain integer field.
+
+       A node-local private namespace has a single writer, so the multi-writer / sync-layer semantics this type models have no meaning here.
+  --> tests/macros/error_private_incompatible.rs:23:11
+   |
+23 |     hits: Counter,
+   |           ^^^^^^^
+
+error: (calimero)> `SharedStorage` cannot be used inside `#[app::private]` — it models single-signature shared/causal reconciliation; pointless with one writer.
+
+       A node-local private namespace has a single writer, so the multi-writer / sync-layer semantics this type models have no meaning here.
+  --> tests/macros/error_private_incompatible.rs:25:20
+   |
+25 |     shared: Option<SharedStorage<String>>,
+   |                    ^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #2428.

## Problem

#2425 narrowed `#[app::private]` auto-substitution to the storage primitives (`UnorderedMap`/`SortedMap`/`UnorderedSet`/`SortedSet`/`Vector`) and deliberately dropped the multi-writer / sync-semantic family. But those types still *parsed* inside an `#[app::private]` struct — the macro just left them untouched, so their `::new()` stayed pinned to `MainStorage` and their entries silently leaked into the synced Merkle tree (the #2423 leak), even though the `#[app::private]` annotation implies the user expected privacy.

The misuse is *semantic*, not mechanical: `AuthoredVector`, `Counter`, `SharedStorage`, … model per-entry authorship, cross-node merge, per-user scoping, and LWW reconciliation — none of which have meaning in a single-writer node-local namespace. The right answer is a targeted compile error that points at the primitive the user most likely meant.

## What this does

- **`PRIVATE_INCOMPATIBLE`** — a `(name, explanation)` list covering the excluded family, each pairing the type with a one-liner on *why* it's wrong and *what* to use instead.
- **`collect_private_incompatible`** — a read-only twin of `inject_private_storage` that recurses through the same wrappers (generics, tuples, refs, arrays, slices, groups, parens), so offenders nested in `Option<…>`/`Vec<…>`/tuples are caught too. It collects the offending *ident* so the `compile_error!` is spanned right at the culprit type.
- **`check_private_compatible`** — walks every struct/enum/variant field and pushes a spanned error per offender into the existing `Errors` accumulator, before substitution runs.
- New **`ParseError::PrivateIncompatibleCollection`** variant.

### Sample diagnostic

\`\`\`
error: (calimero)> \`AuthoredVector\` cannot be used inside \`#[app::private]\` — it tracks
per-entry authorship for multi-writer convergence; use \`Vector\` instead.

       A node-local private namespace has a single writer, so the multi-writer /
       sync-layer semantics this type models have no meaning here.
\`\`\`

## Tests

- 6 unit tests in `private.rs`: per-type detection, nested detection, multi-offender reporting, primitives-not-flagged, plus two anti-drift checks keeping `PRIVATE_INCOMPATIBLE` in sync with the existing `EXCLUDED_*` test lists and disjoint from `TREE_BACKED_TYPES`.
- New trybuild compile-fail test `error_private_incompatible.rs` (+`.stderr`) asserting the message text and spans. Uses locally-named stand-in types so only the macro diagnostics surface in the captured stderr.

`cargo test -p calimero-sdk-macros` → 23 passed. `cargo fmt --check` clean; clippy clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only macro validation; no runtime behavior change for valid apps, only clearer failures for previously leaky misuse.
> 
> **Overview**
> **`#[app::private]`** now **fails at compile time** when a field uses sync- or multi-writer Calimero collections (CRDTs, `SharedStorage` / `UserStorage` / `FrozenStorage`, `AuthoredMap` / `AuthoredVector`, etc.) instead of leaving them on default **`MainStorage`** and leaking into the synced tree.
> 
> The macro maintains a **`PRIVATE_INCOMPATIBLE`** list with per-type guidance, walks field types with the same recursion as **`PrivateStorage`** injection (including nested `Option` / tuples), and emits **`ParseError::PrivateIncompatibleCollection`** with spans on the offending ident. The check runs **before** tree-backed substitution.
> 
> **Unit tests** lock detection, nesting, and list consistency with existing **`EXCLUDED_*`** / **`TREE_BACKED_TYPES`** tables; a **trybuild** test asserts diagnostic text and spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0842c2ece55c8baf6203f186cd0c21476fa3435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->