### PR TITLE
fix(node): backfill namespace governance DAG to drain cross-DAG-buffered deltas (#2625)

### DIFF
--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -314,6 +314,28 @@ impl NodeState {
             .collect()
     }
 
+    /// Distinct `source_peer`s of the deltas currently buffered for
+    /// `context_id`, in first-seen order. Non-consuming.
+    ///
+    /// Used by the #2625 governance backfill to target the peers that
+    /// actually delivered the stuck deltas. Such a peer satisfied the delta's
+    /// governance position at send time, so it holds the full
+    /// `StoredNamespaceEntry::Signed` op (with the encrypted group payload) —
+    /// unlike an arbitrary namespace-topic subscriber, which may be a
+    /// non-member holding only the `Opaque` skeleton and would serve nothing
+    /// for the missing group op.
+    pub(crate) fn governance_pending_source_peers(&self, context_id: &ContextId) -> Vec<PeerId> {
+        let Some(entry) = self.governance_pending.get(context_id) else {
+            return Vec::new();
+        };
+        let mut seen = std::collections::HashSet::new();
+        entry
+            .iter()
+            .map(|d| d.source_peer)
+            .filter(|p| seen.insert(*p))
+            .collect()
+    }
+
     /// Check if we should buffer a delta (during snapshot sync).
     pub(crate) fn should_buffer_delta(&self, context_id: &ContextId) -> bool {
         self.sync_sessions
@@ -657,5 +679,59 @@ impl crate::sync::state_access::SyncStateAccess for NodeState {
 
     fn record_reconcile_failure(&self, context_id: ContextId) -> u32 {
         crate::sync::record_reconcile_failure(&self.reconcile_attempts, context_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_node_primitives::delta_buffer::BufferedDelta;
+    use calimero_primitives::hash::Hash;
+    use calimero_storage::logical_clock::HybridTimestamp;
+
+    use super::*;
+
+    fn buffered(id: u8, source_peer: PeerId) -> BufferedDelta {
+        BufferedDelta {
+            id: [id; 32],
+            parents: vec![],
+            hlc: HybridTimestamp::zero(),
+            payload: vec![],
+            nonce: [0u8; 12],
+            author_id: PublicKey::from([0u8; 32]),
+            root_hash: Hash::from([0u8; 32]),
+            events: None,
+            source_peer,
+            key_id: [0u8; 32],
+            governance_position: None,
+            delta_signature: None,
+            governance_drain_attempts: 0,
+            producing_app_key: None,
+        }
+    }
+
+    /// #2625: the backfill targets the peers that delivered the stuck deltas.
+    /// They must be distinct (one stream per peer) and in first-seen order
+    /// (try the earliest deliverer first).
+    #[test]
+    fn governance_pending_source_peers_dedups_and_preserves_order() {
+        let state = NodeState::new(false, NodeMode::Standard);
+        let ctx = ContextId::from([7u8; 32]);
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+
+        // Deliveries p1, p2, p1 → distinct first-seen order [p1, p2].
+        state.buffer_governance_pending(ctx, buffered(1, p1));
+        state.buffer_governance_pending(ctx, buffered(2, p2));
+        state.buffer_governance_pending(ctx, buffered(3, p1));
+
+        assert_eq!(state.governance_pending_source_peers(&ctx), vec![p1, p2]);
+    }
+
+    #[test]
+    fn governance_pending_source_peers_empty_for_unknown_context() {
+        let state = NodeState::new(false, NodeMode::Standard);
+        assert!(state
+            .governance_pending_source_peers(&ContextId::from([9u8; 32]))
+            .is_empty());
     }
 }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -497,6 +497,22 @@ impl SyncManager {
         context_id: ContextId,
         peer_id: Option<PeerId>,
     ) -> eyre::Result<(PeerId, SyncProtocol)> {
+        // #2625: release any state deltas parked in the governance-pending
+        // buffer for this context before the regular context sync runs. The
+        // cross-DAG check buffers a state delta as `Unknown` when the
+        // namespace governance op its signed position references is missing
+        // locally; the buffer normally drains when that op arrives via
+        // gossip. But in a one-directional divergence the authoring peer
+        // already applied the op and never rebroadcasts it, and our own
+        // governance DAG never registers it as a missing parent (nothing
+        // local references it except the buffered delta) — so neither the
+        // gossip-apply drain nor `resolve_namespace_pending` (which gates on
+        // `namespace_has_pending`) ever fires, and the context root stays
+        // split-brain. Pulling the namespace governance DAG here lands the
+        // op and triggers the drain. Cheap when nothing is buffered.
+        self.backfill_governance_for_pending_deltas(context_id)
+            .await;
+
         if let Some(peer_id) = peer_id {
             return self.initiate_sync(context_id, peer_id).await;
         }
@@ -3233,7 +3249,7 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
 #[async_trait::async_trait(?Send)]
 impl super::driver::SyncDriverDispatch for SyncManager {
     async fn sync_namespace_from_peer(&self, namespace_id: [u8; 32]) {
-        SyncManager::sync_namespace_from_peer(self, namespace_id).await
+        SyncManager::sync_namespace_from_peer(self, namespace_id, None).await
     }
 
     async fn initiate_namespace_join(
@@ -3481,6 +3497,94 @@ impl SyncManager {
             sync_timeout: self.sync_config.timeout,
         };
         crate::handlers::state_delta::drain_all_governance_pending(&drain_input).await;
+    }
+
+    /// #2625: when `context_id` has state deltas parked in the
+    /// governance-pending buffer, proactively pull its namespace governance
+    /// DAG so the missing governance op lands and the buffered deltas drain.
+    ///
+    /// This closes the gap left by #2589: that fix drains the buffer *when a
+    /// governance op is applied* via sync, but here the op is never delivered
+    /// to us at all. The only local record that the op exists is the buffered
+    /// delta's `governance_position`; our governance DAG has no missing-parent
+    /// entry for it, so `resolve_namespace_pending` (which gates on
+    /// `namespace_has_pending`) is a no-op and never requests it. Actively
+    /// pulling the namespace DAG is what fetches the op; `sync_namespace_from_peer`
+    /// then calls `drain_governance_pending_after_sync` once any ops arrive.
+    ///
+    /// Peer selection matters: the missing op is almost always an *encrypted
+    /// group op*, and only a group **member** stores it as a full
+    /// `StoredNamespaceEntry::Signed` (a non-member namespace subscriber holds
+    /// only the `Opaque` skeleton and serves nothing for it). So we target the
+    /// peers that actually delivered the stuck deltas first — they satisfied
+    /// the delta's governance position at send time, hence hold the `Signed`
+    /// op — and only fall back to an arbitrary mesh peer if that didn't drain
+    /// the buffer (e.g. the delta was relayed by a non-member).
+    ///
+    /// Gated on a non-empty buffer (a cheap `DashMap` length read), so the
+    /// steady-state cost on every interval tick is one map lookup.
+    async fn backfill_governance_for_pending_deltas(&self, context_id: ContextId) {
+        if !should_backfill_governance(self.node_state.governance_pending_len(&context_id)) {
+            return;
+        }
+        let store = self.context_client.datastore_handle().into_inner();
+        let Some(namespace_id) = resolve_namespace_id(&store, &context_id) else {
+            debug!(
+                %context_id,
+                "governance-pending backfill: could not resolve namespace id; skipping (#2625)"
+            );
+            return;
+        };
+        drop(store);
+        debug!(
+            %context_id,
+            namespace_id = %hex::encode(namespace_id),
+            pending = self.node_state.governance_pending_len(&context_id),
+            "governance-pending backfill: pulling namespace governance DAG to release buffered deltas (#2625)"
+        );
+
+        // Prefer the peers that delivered the stuck deltas (likely group
+        // members holding the full `Signed` op). Stop as soon as the buffer
+        // drains so we don't open redundant streams.
+        for peer in self.node_state.governance_pending_source_peers(&context_id) {
+            if !should_backfill_governance(self.node_state.governance_pending_len(&context_id)) {
+                return;
+            }
+            self.sync_namespace_from_peer(namespace_id, Some(peer))
+                .await;
+        }
+
+        // Fallback: a non-member relay may have delivered the delta, so its
+        // source peer couldn't serve the op. Try the namespace mesh — but
+        // anyone can subscribe to the `ns/<id>` topic without being a member,
+        // so prefer trusted ANCHORS (peers we've observed signing applied
+        // messages with an Owner/Admin/ReadOnlyTee identity) over arbitrary
+        // subscribers, exactly like the regular context-sync partner picker.
+        //
+        // This is a *liveness* defense, not a safety one: a malicious or
+        // non-member subscriber cannot corrupt our governance state — every
+        // op is signature-verified in `apply_signed_op` before any mutation,
+        // is content-hash idempotent, and is nonce/DAG-ordered. The worst a
+        // bad peer can do is serve nothing or stale ops; anchor-first ordering
+        // just avoids wasting backfill rounds on such peers.
+        if should_backfill_governance(self.node_state.governance_pending_len(&context_id)) {
+            let topic =
+                libp2p::gossipsub::TopicHash::from_raw(format!("ns/{}", hex::encode(namespace_id)));
+            let mut peers = self.sync_network.subscribed_peers(topic).await;
+            let _anchor_count = super::peers::partition_peers_anchor_first(
+                &mut peers,
+                &*self.state_access,
+                &self.anchor_identities_for_context(&context_id),
+            );
+            for peer in peers {
+                if !should_backfill_governance(self.node_state.governance_pending_len(&context_id))
+                {
+                    break;
+                }
+                self.sync_namespace_from_peer(namespace_id, Some(peer))
+                    .await;
+            }
+        }
     }
 
     /// Handle a namespace backfill request: look up full `SignedNamespaceOp`
@@ -4223,22 +4327,39 @@ impl SyncManager {
         )
     }
 
-    /// Pull all namespace governance ops from a mesh peer.
-    async fn sync_namespace_from_peer(&self, namespace_id: [u8; 32]) {
+    /// Pull all namespace governance ops from a peer.
+    ///
+    /// `peer = Some(p)` targets `p` explicitly; `None` picks the first mesh
+    /// peer subscribed to the namespace topic (the legacy behaviour). Callers
+    /// that know a group **member** should target it: only members store the
+    /// full [`StoredNamespaceEntry::Signed`] op (carrying the encrypted group
+    /// payload), so a non-member namespace subscriber holds only the
+    /// [`StoredNamespaceEntry::Opaque`] skeleton and `extract_signed_op`
+    /// returns `None` for it — backfilling from such a peer yields nothing for
+    /// group ops and would never release a governance-pending delta.
+    async fn sync_namespace_from_peer(&self, namespace_id: [u8; 32], peer: Option<PeerId>) {
         use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
-        let topic =
-            libp2p::gossipsub::TopicHash::from_raw(format!("ns/{}", hex::encode(namespace_id)));
-        let peers = self.sync_network.subscribed_peers(topic).await;
-        let Some(peer) = peers.first() else {
-            debug!(
-                namespace_id = %hex::encode(namespace_id),
-                "no mesh peers for namespace sync"
-            );
-            return;
+        let peer = match peer {
+            Some(p) => p,
+            None => {
+                let topic = libp2p::gossipsub::TopicHash::from_raw(format!(
+                    "ns/{}",
+                    hex::encode(namespace_id)
+                ));
+                let peers = self.sync_network.subscribed_peers(topic).await;
+                let Some(p) = peers.first().copied() else {
+                    debug!(
+                        namespace_id = %hex::encode(namespace_id),
+                        "no mesh peers for namespace sync"
+                    );
+                    return;
+                };
+                p
+            }
         };
 
-        let Ok(mut stream) = self.sync_network.open_stream(*peer).await else {
+        let Ok(mut stream) = self.sync_network.open_stream(peer).await else {
             debug!("failed to open stream for namespace sync");
             return;
         };
@@ -4396,6 +4517,43 @@ impl SyncManager {
             }
         }
     }
+}
+
+/// Pure trigger predicate for the #2625 governance-pending backfill: the
+/// interval sync should pull the namespace governance DAG iff the context
+/// has at least one delta parked in the governance-pending buffer.
+///
+/// Extracted as a free function so the trigger condition is unit-testable
+/// without standing up a `SyncManager` + network stack — the regression we
+/// guard against is silently dropping the trigger (e.g. inverting the
+/// comparison), which would let a cross-DAG-buffered delta wedge a context
+/// into permanent split-brain again.
+const fn should_backfill_governance(pending_len: usize) -> bool {
+    pending_len > 0
+}
+
+/// Resolve the namespace-root id (bytes) that owns `context_id`, walking from
+/// the context's immediate owning group up to the namespace root. Returns
+/// `None` for non-group (legacy) contexts whose `ContextGroupRef` is absent,
+/// or on a namespace-resolution error.
+///
+/// Mirrors `ContextClient::get_context_group_id` (reads `ContextGroupRef`)
+/// followed by `NamespaceRepository::resolve`, but as a free function over
+/// `&Store` so it is unit-testable. Unlike the interval-sync fallback-topic
+/// closure it does NOT best-effort fall back to the immediate group id: the
+/// #2625 backfill must pull the *correct* namespace DAG, and a wrong id would
+/// silently fail to converge rather than fetch the missing governance op.
+fn resolve_namespace_id(store: &calimero_store::Store, context_id: &ContextId) -> Option<[u8; 32]> {
+    let handle = store.handle();
+    let group_id: [u8; 32] = handle
+        .get(&calimero_store::key::ContextGroupRef::new(*context_id))
+        .ok()??;
+    NamespaceRepository::new(store)
+        .resolve(&calimero_context_config::types::ContextGroupId::from(
+            group_id,
+        ))
+        .map(|id| id.to_bytes())
+        .ok()
 }
 
 mod namespace_join;

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -176,3 +176,105 @@ fn test_max_depth_calculation() {
         );
     }
 }
+
+// =========================================================================
+// Tests for the #2625 governance-pending backfill trigger
+//
+// Regression guard for the cross-DAG governance gate buffering a root-context
+// delta that never drains → permanent split-brain (group-subgroup e2e flake).
+// `perform_interval_sync` now calls `backfill_governance_for_pending_deltas`,
+// which (a) fires only when the governance-pending buffer is non-empty
+// (`should_backfill_governance`) and (b) pulls the *correct* namespace
+// governance DAG (`resolve_namespace_id`). Both pieces are unit-tested here so
+// a future refactor that inverts the gate or mis-resolves the namespace gets
+// caught without needing the full e2e.
+// =========================================================================
+
+mod governance_backfill_trigger {
+    use std::sync::Arc;
+
+    use calimero_context::group_store::{register_context_in_group, NamespaceRepository};
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_primitives::context::ContextId;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+
+    use super::super::{resolve_namespace_id, should_backfill_governance};
+
+    fn fresh_store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    fn ctx(byte: u8) -> ContextId {
+        ContextId::from([byte; 32])
+    }
+
+    fn gid(byte: u8) -> ContextGroupId {
+        ContextGroupId::from([byte; 32])
+    }
+
+    #[test]
+    fn empty_buffer_does_not_trigger_backfill() {
+        // Steady state: no deltas parked → no namespace pull. Inverting this
+        // gate would pull the governance DAG on every interval tick for every
+        // context.
+        assert!(!should_backfill_governance(0));
+    }
+
+    #[test]
+    fn non_empty_buffer_triggers_backfill() {
+        // The bug: a delta sat buffered forever because nothing pulled the
+        // governance op it waited on. Any pending delta must arm the pull.
+        assert!(should_backfill_governance(1));
+        assert!(should_backfill_governance(42));
+    }
+
+    #[test]
+    fn resolve_namespace_id_root_group_resolves_to_itself() {
+        // The flake hit the ROOT context: its owning group IS the namespace
+        // root (no parent), so resolution returns that group's bytes.
+        let store = fresh_store();
+        let context_id = ctx(0x11);
+        let root_group = gid(0x22);
+
+        register_context_in_group(&store, &root_group, &context_id)
+            .expect("register_context_in_group");
+
+        let resolved = resolve_namespace_id(&store, &context_id);
+        assert_eq!(resolved, Some(root_group.to_bytes()));
+    }
+
+    #[test]
+    fn resolve_namespace_id_subgroup_context_resolves_to_root() {
+        // A subgroup-owned context must resolve to the namespace ROOT, not the
+        // immediate subgroup — pulling the subgroup's DAG would miss the
+        // root-level governance op and never converge.
+        let store = fresh_store();
+        let context_id = ctx(0x31);
+        let root_group = gid(0x32);
+        let subgroup = gid(0x33);
+
+        NamespaceRepository::new(&store)
+            .nest(&root_group, &subgroup)
+            .expect("nest subgroup under root");
+        register_context_in_group(&store, &subgroup, &context_id)
+            .expect("register_context_in_group");
+
+        let resolved = resolve_namespace_id(&store, &context_id);
+        assert_eq!(
+            resolved,
+            Some(root_group.to_bytes()),
+            "subgroup-owned context should resolve to the namespace root"
+        );
+    }
+
+    #[test]
+    fn resolve_namespace_id_unregistered_context_returns_none() {
+        // Legacy non-group context (no `ContextGroupRef`): nothing to pull, so
+        // resolution returns None and the backfill is skipped rather than
+        // pulling a bogus namespace.
+        let store = fresh_store();
+        let resolved = resolve_namespace_id(&store, &ctx(0x99));
+        assert_eq!(resolved, None);
+    }
+}


### PR DESCRIPTION
## What & why

Fixes the `group-subgroup` e2e flake from #2625: a root-context state delta gets buffered by the cross-DAG governance gate and **never drains**, leaving the context root in permanent split-brain.

A state delta is buffered as `MembershipStatus::Unknown` when the namespace governance op its signed position references is missing locally. That buffer is meant to drain when the op arrives — but in a one-directional divergence:

- the authoring peer already applied the op and never rebroadcasts it, and
- our own governance DAG has no missing-parent record for it (only the buffered delta references it),

so neither the gossip-apply drain nor `resolve_namespace_pending` (gated on `namespace_has_pending`) ever fires. The op is never fetched, and the delta sits forever.

This extends #2589 (which drains the buffer *when a governance op is applied*) to the case where the op is **never delivered** — by going and pulling it.

## How

- `perform_interval_sync` now calls **`backfill_governance_for_pending_deltas`** before the regular context sync. When the governance-pending buffer is non-empty, it resolves the namespace root and pulls the namespace governance DAG, which lands the missing op and triggers the existing `drain_governance_pending_after_sync`. Gated on a non-empty buffer, so steady-state cost is one `DashMap` length read per tick.

- **Member-aware peer selection.** The missing op is almost always an *encrypted group op*, and only a group **member** stores it as a full `StoredNamespaceEntry::Signed` — a non-member namespace-topic subscriber holds only the `Opaque` skeleton and serves nothing for it (`extract_signed_op` returns `None`). So the backfill:
  1. targets the peers that **delivered the stuck deltas** first (they satisfied the delta's governance position, so they hold the `Signed` op), then
  2. falls back to namespace mesh peers ordered **anchors-first** via `partition_peers_anchor_first` (the same trust signal the regular sync-partner picker uses), instead of an arbitrary `peers.first()`.

  This is a **liveness** defense only: every op is signature-verified in `apply_signed_op` before any state mutation (plus content-hash idempotency and nonce/DAG ordering), so a malicious or non-member peer can stall but **cannot corrupt** governance state.

- `sync_namespace_from_peer` gains an explicit-peer parameter; the legacy `None` path (first mesh peer) is unchanged for existing callers.

## Why correctness holds (subgroup case)

There is one governance DAG per namespace — group ops *are* namespace ops. So "group behind" reduces to "namespace DAG missing an op", which the pull fetches; and a namespace that's complete but whose derived state differs never buffers (it hits the deciding branches of `membership_status_at`, not `Unknown`). A subgroup-owned context resolves to the **namespace root** (`resolve_namespace_id`), matching what `membership_status_at` checks against — covered by a test.

## Testing

- `cargo fmt --check` ✅, `cargo check -p calimero-node` ✅
- New unit tests (7, all green):
  - trigger gate (`should_backfill_governance`) on/off
  - namespace resolution: root group → itself, subgroup → root, non-group → `None`
  - source-peer dedup + first-seen ordering
- The end-to-end repro is the existing `group-subgroup` e2e.

## Follow-up

Peer selection here is still bounded by the in-memory, restart-ephemeral `peer_identities` cache. #2642 tracks persisting an authenticated `identity↔PeerId` map so member-first dialing works on a cold cache across every sync path.

Closes #2625.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync ordering and namespace governance fetch paths on every interval tick when buffers are non-empty; mitigated by signature verification on apply and existing drain logic, but wrong namespace resolution or peer selection could waste sync rounds or delay convergence.
> 
> **Overview**
> Fixes **#2625** split-brain when cross-DAG governance gates park state deltas that never drain because the referenced namespace governance op was never gossiped and nothing registered it as a missing parent.
> 
> **Interval sync** now runs **`backfill_governance_for_pending_deltas`** before normal context sync when the governance-pending buffer is non-empty: it resolves the **namespace root** DAG id and pulls namespace governance ops so the existing post-sync drain can apply buffered deltas. Steady state stays cheap (buffer length check only).
> 
> **Peer selection** for that pull is member-aware: try distinct **`source_peer`**s from buffered deltas (first-seen order), then namespace mesh peers with **anchors-first** ordering. **`sync_namespace_from_peer`** accepts an optional explicit peer; driver/legacy callers still use `None` (first mesh peer).
> 
> Pure helpers **`should_backfill_governance`** and **`resolve_namespace_id`** plus unit tests guard the trigger gate, namespace resolution (root vs subgroup vs non-group), and source-peer dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78588a915c85a146437a17639bb3a619caaf294a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->