### PR TITLE
fix(network): drop unsafe 'static forgery in stream encoder (#2632)

### DIFF
--- a/crates/network/primitives/src/stream/codec.rs
+++ b/crates/network/primitives/src/stream/codec.rs
@@ -2,7 +2,6 @@
 #[path = "codec_test.rs"]
 mod tests;
 
-use core::slice;
 use std::borrow::Cow;
 use std::io::Error as IoError;
 
@@ -63,11 +62,14 @@ impl<'a> Encoder<Message<'a>> for MessageCodec {
     type Error = CodecError;
 
     fn encode(&mut self, item: Message<'a>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let data = item.data.as_ref();
-        let data = Bytes::from_static(
-            // safety: `LengthDelimitedCodec: Encoder` must prepend the length, so it copies `data`
-            unsafe { slice::from_raw_parts(data.as_ptr(), data.len()) },
-        );
+        // Hand the length codec owned bytes: an already-owned payload moves in for free,
+        // a borrowed one is copied once (which the length-prefix codec would do anyway).
+        // This avoids fabricating a `'static` borrow whose soundness would hinge on
+        // `LengthDelimitedCodec` copying before it returns — an unenforced cross-crate invariant.
+        let data = match item.data {
+            Cow::Borrowed(data) => Bytes::copy_from_slice(data),
+            Cow::Owned(data) => Bytes::from(data),
+        };
         self.length_codec
             .encode(data, dst)
             .map_err(CodecError::StdIo)


### PR DESCRIPTION
## Summary

Closes #2632.

`MessageCodec::encode` (`crates/network/primitives/src/stream/codec.rs`) fabricated a `'static` slice from a borrowed buffer via `unsafe slice::from_raw_parts` wrapped in `Bytes::from_static`. Its soundness depended entirely on the inner `LengthDelimitedCodec: Encoder` **copying** the payload into `dst` before returning — an unenforced cross-crate `tokio_util` implementation detail, not a guaranteed contract. A future `tokio_util` change that retained the `Bytes` (e.g. a zero-copy path) would turn this into a use-after-free of the borrowed buffer, since the `Bytes` is tied to `'a` (a `Cow` borrow), not `'static`.

## Fix

Hand the length codec genuinely owned `Bytes` instead of forging a `'static` borrow:

```rust
let data = match item.data {
    Cow::Borrowed(data) => Bytes::copy_from_slice(data),
    Cow::Owned(data) => Bytes::from(data),
};
```

This removes the `unsafe` and the cross-crate soundness dependency entirely.

- **`Cow::Owned`** moves the `Vec` into `Bytes` with **zero copies**.
- **`Cow::Borrowed`** copies once — which the length-prefix codec was going to do anyway, so it's not a new copy in practice.

Also drops the now-unused `use core::slice;`.

## Verification

- `cargo fmt --check` clean
- `cargo test -p calimero-network-primitives` — 14 passed, incl. codec round-trip tests (`test_encoding_decoding`, `test_multiple_objects_stream`)
- `cargo clippy -p calimero-network-primitives` clean (no more `unsafe`)

_Found during security review (finding #41)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted safety fix in framing encode with equivalent copy behavior for borrowed payloads; no auth or protocol semantics change.
> 
> **Overview**
> **Replaces an unsafe `'static` slice forgery** in `MessageCodec::encode` with owned `Bytes` built from `Cow::Borrowed` (one copy) or `Cow::Owned` (move, no extra copy).
> 
> The old path relied on `LengthDelimitedCodec` always copying borrowed payload before return — not a guaranteed contract — so a zero-copy `tokio_util` change could have caused use-after-free on borrowed buffers. The unused `core::slice` import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a48c658dc56c220fa38f310e0b40cbc1e64e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->