### PR TITLE
refactor(macros): consolidate the two #[derive(Mergeable)] macros (#2580)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10315,7 +10315,6 @@ version = "0.0.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "calimero-storage-macros",
  "serial_test",
 ]
 

--- a/apps/team-metrics-macro/Cargo.toml
+++ b/apps/team-metrics-macro/Cargo.toml
@@ -14,7 +14,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
-calimero-storage-macros.workspace = true
 
 [dev-dependencies]
 # Enables `register_crdt_merge` + the native mock host so `TestHost` can drive

--- a/apps/team-metrics-macro/src/lib.rs
+++ b/apps/team-metrics-macro/src/lib.rs
@@ -10,8 +10,7 @@
 
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use calimero_storage::collections::{Counter, UnorderedMap};
-use calimero_storage_macros::Mergeable;
+use calimero_storage::collections::{Counter, Mergeable, UnorderedMap};
 
 /// Team statistics with multiple counters
 ///

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -294,105 +294,11 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-/// Derives the `Mergeable` trait for a struct.
-///
-/// This macro automatically implements the `Mergeable` trait by calling
-/// `merge()` on each field that implements `Mergeable`.
-///
-/// # Requirements
-///
-/// - All fields must implement `Mergeable`
-/// - Struct must have named fields
-///
-/// # Generated implementation
-///
-/// For each field, calls `self.field.merge(&other.field)?`
-///
-/// # Example
-///
-/// ```ignore
-/// use calimero_storage::collections::{Counter, Mergeable, ReplicatedGrowableArray, UnorderedMap};
-///
-/// #[derive(Mergeable, BorshSerialize, BorshDeserialize)]
-/// pub struct Document {
-///     content: ReplicatedGrowableArray,
-///     edit_count: Counter,
-///     metadata: UnorderedMap<String, String>,
-/// }
-///
-/// // Auto-generates:
-/// impl Mergeable for Document {
-///     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
-///         self.content.merge(&other.content)?;
-///         self.edit_count.merge(&other.edit_count)?;
-///         self.metadata.merge(&other.metadata)?;
-///         Ok(())
-///     }
-/// }
-/// ```
-#[proc_macro_derive(Mergeable)]
-pub fn mergeable_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-
-    let fields = match &input.data {
-        Data::Struct(data) => &data.fields,
-        Data::Enum(_) | Data::Union(_) => {
-            panic!("Mergeable can only be derived for structs")
-        }
-    };
-
-    let named_fields = match fields {
-        Fields::Named(fields) => &fields.named,
-        Fields::Unnamed(_) | Fields::Unit => {
-            panic!("Mergeable can only be derived for structs with named fields")
-        }
-    };
-
-    // Generate merge calls for each field
-    let merge_calls = named_fields.iter().map(|field| {
-        let field_name = field.ident.as_ref().unwrap();
-        quote! {
-            self.#field_name.merge(&other.#field_name)?;
-        }
-    });
-
-    // Per-field deterministic re-key (#2577). When this struct is stored as a
-    // collection VALUE under a deterministic entry id, each field's nested
-    // collection ids are re-keyed under a field-namespaced child of that id — so
-    // every replica derives identical ids and the nested CRDTs converge as child
-    // entities, instead of the whole struct blob being LWW'd (silent data loss).
-    // `rekey_field_if_supported!` autoref-dispatches to a real re-key for
-    // `RekeyTarget` fields (collections, nested CRDT structs) and a no-op for
-    // leaves (e.g. `LwwRegister`).
-    let rekey_calls = named_fields.iter().map(|field| {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_name_str = field_name.to_string();
-        quote! {
-            ::calimero_storage::rekey_field_if_supported!(
-                &mut self.#field_name,
-                ::calimero_storage::collections::rekey::field_child_id(parent_id, #field_name_str)
-            );
-        }
-    });
-
-    let expanded = quote! {
-        impl #impl_generics calimero_storage::collections::Mergeable for #name #ty_generics #where_clause {
-            fn merge(&mut self, other: &Self) -> Result<(), calimero_storage::collections::crdt_meta::MergeError> {
-                #(#merge_calls)*
-                Ok(())
-            }
-        }
-
-        impl #impl_generics ::calimero_storage::collections::rekey::RekeyTarget
-            for #name #ty_generics #where_clause
-        {
-            fn rekey_relative_to(&mut self, parent_id: ::calimero_storage::address::Id) {
-                #(#rekey_calls)*
-            }
-        }
-    };
-
-    TokenStream::from(expanded)
-}
+// NOTE: there is intentionally no `#[derive(Mergeable)]` here. A second, simpler
+// implementation used to live in this crate and had to be kept in sync with the
+// one in `calimero-sdk-macros` by hand (they drifted). The single canonical
+// derive now lives in `calimero-sdk-macros` (`crates/sdk/macros/src/mergeable.rs`),
+// which additionally applies forbidden-type field validation and emits friendly
+// enum/union compile errors. It is re-exported alongside the `Mergeable` trait
+// from `calimero_storage::collections`, so `use calimero_storage::collections::Mergeable;`
+// brings in both the trait and the derive.

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -29,10 +29,18 @@ pub mod lww_register;
 pub use lww_register::LwwRegister;
 pub mod crdt_meta;
 pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageStrategy};
-// The `Mergeable` derive macro (canonical impl lives in `calimero-sdk-macros`)
-// is re-exported here under the same name as the trait, serde-style, so a single
-// `use calimero_storage::collections::Mergeable;` brings in both. They occupy
-// different namespaces (trait vs. derive macro), so the shared name does not clash.
+// Re-export of the `Mergeable` *derive macro*, whose single canonical
+// implementation lives in `calimero-sdk-macros` (it shares the forbidden-type
+// field lint with `#[app::state]`, which is why it can't live in this crate's
+// macros). Exposing it here under the same name as the trait — serde-style — lets
+// a single `use calimero_storage::collections::Mergeable;` bring in both; the two
+// occupy different namespaces (trait vs. derive macro), so the shared name does
+// not clash. This relies on `calimero-storage`'s existing dependency on
+// `calimero-sdk` (the edge already points storage -> sdk; sdk does not depend on
+// storage, so there is no cycle). The path `calimero_sdk::app::Mergeable` is
+// compile-checked here: if it ever moves, this line fails to build rather than
+// silently breaking, and `tests/derive_mergeable.rs` exercises the re-exported
+// derive through this exact path.
 pub use calimero_sdk::app::Mergeable;
 pub mod composite_key;
 mod crdt_impls;

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -29,6 +29,11 @@ pub mod lww_register;
 pub use lww_register::LwwRegister;
 pub mod crdt_meta;
 pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageStrategy};
+// The `Mergeable` derive macro (canonical impl lives in `calimero-sdk-macros`)
+// is re-exported here under the same name as the trait, serde-style, so a single
+// `use calimero_storage::collections::Mergeable;` brings in both. They occupy
+// different namespaces (trait vs. derive macro), so the shared name does not clash.
+pub use calimero_sdk::app::Mergeable;
 pub mod composite_key;
 mod crdt_impls;
 mod decompose_impls;

--- a/crates/storage/tests/derive_mergeable.rs
+++ b/crates/storage/tests/derive_mergeable.rs
@@ -69,6 +69,36 @@ fn derive_supports_unit_structs() {
 // merge lives in `crates/sdk/macros/src/state.rs::tests` (the generator is a
 // private function and easier to inspect directly via TokenStream).
 
+// Locks in the serde-style single-import: `calimero_storage::collections::Mergeable`
+// resolves to BOTH the trait and the re-exported derive macro. If the canonical
+// derive's path under `calimero-sdk` ever moves, the re-export — and this module —
+// stop compiling, so the breakage is loud rather than silent.
+mod via_storage_reexport {
+    use calimero_storage::collections::{Counter, Mergeable};
+
+    #[derive(Mergeable)]
+    struct Reexported {
+        hits: Counter,
+    }
+
+    #[test]
+    fn derive_and_trait_both_resolve_through_storage_path() {
+        let mut a = Reexported {
+            hits: Counter::new(),
+        };
+        let mut b = Reexported {
+            hits: Counter::new(),
+        };
+        b.hits.increment().unwrap();
+
+        // `Mergeable::merge` here is the trait method, reached through the same
+        // single import that brought in the derive above.
+        a.merge(&b).unwrap();
+
+        assert!(a.hits.value().unwrap() >= 1);
+    }
+}
+
 #[derive(Mergeable)]
 struct BoxedField {
     boxed_counter: Box<Counter>,


### PR DESCRIPTION
Closes #2580.

## Problem

Two independent `#[derive(Mergeable)]` proc-macros existed and had to be kept in sync by hand:

- `crates/sdk/macros/src/mergeable.rs` (`calimero_sdk::app::Mergeable`) — has forbidden-type field validation, friendly enum/union `compile_error!`s, and tuple-struct support.
- `crates/storage-macros/src/lib.rs` (`calimero_storage_macros::Mergeable`) — simpler, no validation, named-fields-only `panic!`s. This was the one the example apps imported.

PR #2579 had to patch **both** to generate the new `RekeyTarget` impl — exactly the parallel maintenance that drifts (surfaced by meroreviewer).

## Change

Collapse to a single canonical derive, keeping the fuller implementation:

- **Remove** the duplicate `mergeable_derive` from `calimero-storage-macros` (keeps `AtomicUnit` + `Collection`).
- **Re-export** the surviving `calimero-sdk-macros` derive alongside the `Mergeable` *trait* from `calimero_storage::collections`, serde-style — so a single `use calimero_storage::collections::Mergeable;` brings in both. Trait and derive occupy different namespaces, so the shared name doesn't clash. No new dependency / no cycle (`calimero-storage` already depends on `calimero-sdk`).
- **Repoint** `apps/team-metrics-macro` to the single import and drop its now-unused `calimero-storage-macros` dependency.

### Before → after

| | Before | After |
|---|---|---|
| Mergeable derives | 2 independent (drift-prone) | 1 canonical |
| App import | two `use` lines (`collections::{…}` + `storage_macros::Mergeable`) | one `use calimero_storage::collections::{Counter, Mergeable, UnorderedMap};` |
| Field validation for apps | none | forbidden-type lint enforced |
| Enum/union field | raw `panic!` | clean `compile_error!` with guidance |
| Tuple structs | rejected | supported |

Net: 5 files, +11/−106.

## Verification

- `cargo build -p calimero-storage-macros -p calimero-storage -p team-metrics-macro` ✅
- `cargo test -p team-metrics-macro` ✅ (4/4 incl. convergence + rekey)
- `cargo test -p calimero-storage --test derive_mergeable --test compile_fail` ✅ (enum/hashmap rejection intact, tuple support)
- `cargo fmt --check` ✅
- No remaining `storage_macros::Mergeable` / `mergeable_derive` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time macro and import-path cleanup only; behavior stays on the fuller sdk derive with added tests, no runtime security or persistence changes.
> 
> **Overview**
> Removes the duplicate **`#[derive(Mergeable)]`** from `calimero-storage-macros` and standardizes on the **`calimero-sdk-macros`** implementation (forbidden-type lint, clearer enum/union errors, tuple structs).
> 
> **`calimero_storage::collections`** now re-exports that derive next to the **`Mergeable`** trait so one import covers both (serde-style). **`team-metrics-macro`** drops `calimero-storage-macros` and uses that single path; a storage integration test locks the re-export so a moved canonical path fails loudly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d8b03ba06385a347d3d0df97116bfec8f4f08e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->