### PR TITLE
fix(runtime): stop installing a process-global panic hook (#2637)

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -978,6 +978,12 @@ mod wasm_integration_tests {
                     message.contains("storage.get panicked deliberately"),
                     "panic message must be recovered from the unwind payload, got: {message:?}"
                 );
+                // `Unknown` because the unwind payload carries no location. This
+                // guards against silently re-introducing the process-global hook
+                // (which captured a precise location). If a *non-global* location
+                // recovery mechanism is ever added on purpose, update this assertion
+                // to expect the recovered location — that is an intended improvement,
+                // not a regression.
                 assert!(
                     matches!(location, Location::Unknown),
                     "without the global hook the panic location can't be recovered; \

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -891,6 +891,103 @@ mod wasm_integration_tests {
         }
     }
 
+    /// A `Storage` whose `get` panics. Used to drive a panic from *inside* a
+    /// host function so we can exercise the runtime's per-host-call
+    /// `catch_unwind` recovery (the path that replaced the process-global
+    /// `set_hook` machinery in `logic/imports.rs`).
+    struct PanicStorage;
+
+    impl Storage for PanicStorage {
+        fn get(&self, _key: &store::Key) -> Option<store::Value> {
+            panic!("storage.get panicked deliberately");
+        }
+        fn set(&mut self, _key: store::Key, _value: store::Value) -> Option<store::Value> {
+            None
+        }
+        fn remove(&mut self, _key: &store::Key) -> Option<store::Value> {
+            None
+        }
+        fn has(&self, _key: &store::Key) -> bool {
+            false
+        }
+    }
+
+    /// A panic that originates *inside a host function* must be caught by the
+    /// runtime's per-host-call `catch_unwind` and surfaced as
+    /// `HostError::Panic { context: Host, .. }` with its message intact —
+    /// WITHOUT installing a process-global panic hook.
+    ///
+    /// The message is recovered directly from the unwind payload. Asserting
+    /// `location == Unknown` doubles as a regression guard: the deleted
+    /// `set_hook` hook captured a *precise* `Location::At { .. }`; the payload
+    /// can't carry a location, so it must now degrade to `Unknown`. A revival
+    /// of the global-hook approach would make this assertion fail.
+    #[test]
+    fn test_wasm_host_panic_recovered_without_global_hook() {
+        // The guest builds a 16-byte `{ ptr: u64, len: u64 }` buffer descriptor
+        // (the host-guest ABI; see `prepare_guest_buf_descriptor`) pointing at a
+        // 3-byte key "abc", then calls `storage_read`. The host reads the key and
+        // calls `storage.get`, which panics.
+        let wat = r#"
+            (module
+                (import "env" "storage_read" (func $storage_read (param i64 i64) (result i32)))
+                (memory (export "memory") 1)
+                (func (export "read_probe")
+                    ;; descriptor at offset 16: ptr = 100
+                    (i64.store (i32.const 16) (i64.const 100))
+                    ;; descriptor at offset 24: len = 3
+                    (i64.store (i32.const 24) (i64.const 3))
+                    ;; key bytes "abc" at offset 100
+                    (i32.store8 (i32.const 100) (i32.const 97))
+                    (i32.store8 (i32.const 101) (i32.const 98))
+                    (i32.store8 (i32.const 102) (i32.const 99))
+                    ;; storage_read(descriptor_ptr = 16, register_id = 0)
+                    (drop (call $storage_read (i64.const 16) (i64.const 0)))
+                )
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        let engine = Engine::default();
+        let module = engine.compile(&wasm).expect("Failed to compile module");
+
+        let mut storage = PanicStorage;
+        let outcome = module
+            .run(
+                [0; 32].into(),
+                [0; 32].into(),
+                "read_probe",
+                &[],
+                &mut storage,
+                None,
+                None,
+            )
+            .expect("run must return an Outcome, not propagate the unwind");
+
+        match &outcome.returns {
+            Err(FunctionCallError::HostError(HostError::Panic {
+                context,
+                message,
+                location,
+            })) => {
+                assert!(
+                    matches!(context, PanicContext::Host),
+                    "expected Host panic context, got: {context:?}"
+                );
+                assert!(
+                    message.contains("storage.get panicked deliberately"),
+                    "panic message must be recovered from the unwind payload, got: {message:?}"
+                );
+                assert!(
+                    matches!(location, Location::Unknown),
+                    "without the global hook the panic location can't be recovered; \
+                     expected Unknown, got: {location:?}"
+                );
+            }
+            other => panic!("Expected HostError::Panic, got: {other:?}"),
+        }
+    }
+
     /// Test that memory out of bounds causes a WasmTrap error (not a crash)
     #[test]
     fn test_wasm_memory_out_of_bounds() {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -1,17 +1,6 @@
-use core::cell::RefCell;
-use core::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Once;
-
 use wasmer::{Imports, Store};
 
 use super::{HostError, Location, PanicContext, VMLogic};
-
-thread_local! {
-    // https://open.spotify.com/track/7DPUuTaTZCtQ6o4Xx00qzT
-    static HOOKER: Once = const { Once::new() };
-    static PAYLOAD: RefCell<Option<(String, Location)>> = const { RefCell::new(None) };
-    static HOST_CTX: AtomicBool = const { AtomicBool::new(false) };
-}
 
 impl VMLogic<'_> {
     pub fn imports(&mut self, store: &mut Store) -> Imports {
@@ -192,24 +181,31 @@ macro_rules! _imports {
                         println!("{}", decorator);
                     };
 
-                    HOST_CTX.with(|ctx| ctx.store(true, Ordering::Relaxed));
                     let res = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
                         let (data, store) = env.data_and_store_mut();
                         let data = unsafe { &mut *(*data.get_mut()).cast::<VMLogic<'_>>() };
 
                         data.host_functions(store).$func($($arg),*)
-                    })).unwrap_or_else(|_| {
-                        let (message, location) = PAYLOAD.with(|payload| {
-                            payload.borrow_mut().take().unwrap_or_else(|| ("<no message>".to_owned(), Location::Unknown))
-                        });
+                    })).unwrap_or_else(|panic_payload| {
+                        // Recover the panic message straight from the unwind payload
+                        // rather than from a process-global panic hook. A global
+                        // `set_hook` clobbers whatever hook the host installs (crash
+                        // reporters, loggers, the test harness) in a load-order
+                        // dependent way, so we avoid it entirely. The payload carries
+                        // the message but not the source location, so the location
+                        // degrades to `Unknown` — same as the guest-panic path in
+                        // `Module::run`.
+                        let message = crate::panic_payload::panic_payload_to_string(
+                            panic_payload.as_ref(),
+                            "<no message>",
+                        );
 
                         Err(HostError::Panic {
                             context: PanicContext::Host,
                             message,
-                            location,
+                            location: Location::Unknown,
                         }.into())
                     });
-                    HOST_CTX.with(|ctx| ctx.store(false, Ordering::Relaxed));
 
                     #[cfg(feature = "host-traces")]
                     {
@@ -229,33 +225,6 @@ macro_rules! _imports {
 
             let mut store = $store;
             let logic = $logic;
-
-            HOOKER.with(|hooker| {
-                hooker.call_once(|| {
-                    let prev_hook = std::panic::take_hook();
-                    std::panic::set_hook(Box::new(move |info| {
-                        if !HOST_CTX.with(|ctx| ctx.load(Ordering::Relaxed)) {
-                            return prev_hook(info);
-                        }
-                        PAYLOAD.with(|payload| {
-                            let message = match info.payload().downcast_ref::<&'static str>() {
-                                Some(message) => *message,
-                                None => match info.payload().downcast_ref::<String>() {
-                                    Some(message) => &**message,
-                                    None => "<no message>",
-                                },
-                            };
-
-                            *payload.borrow_mut() = Some(match info.location() {
-                                Some(location) => (message.to_owned(), Location::from(location)),
-                                None => (message.to_owned(), Location::Unknown),
-                            });
-                        });
-
-                        prev_hook(info);
-                    }));
-                });
-            });
 
             let env = wasmer::FunctionEnv::new(&mut store, fragile::Fragile::new(core::ptr::from_mut(logic).cast::<()>()));
 


### PR DESCRIPTION
## What

Fixes #2637. The WASM execution macro in `crates/runtime/src/logic/imports.rs` installed a **process-global** panic hook via `std::panic::set_hook`, gated by a thread-local `Once`.

The gate was per-thread but the effect was process-wide, which meant:
- install order was nondeterministic (whichever thread ran WASM first won);
- every worker thread that ran WASM stacked another nested hook;
- the hook was never restored — it lived for the process lifetime;
- it silently clobbered (or transparently chained to) whatever panic hook the host installed afterward — crash reporters, structured loggers, the `cargo test` harness.

It existed only to recover a host-function panic's message + location into a thread-local for the `catch_unwind` path.

## How

Recover the panic message **directly from the `catch_unwind` payload** via the existing `panic_payload::panic_payload_to_string` (the same mechanism `Module::run` already uses at `lib.rs`), and delete the `set_hook` / `HOOKER` / `PAYLOAD` / `HOST_CTX` machinery entirely.

Tradeoff: the unwind payload can't carry a source location, so a host-function panic's `location` now degrades to `Location::Unknown` — matching the existing guest-panic path. In exchange, the runtime no longer mutates global process state.

## Testing

Added `test_wasm_host_panic_recovered_without_global_hook`: a WAT guest calls `storage_read` backed by a `Storage` whose `get()` panics, driving a **real** host-side panic through the per-host-call `catch_unwind`. It asserts:
- `HostError::Panic { context: Host }`,
- the panic message survives (proves payload-downcast recovery works),
- `location == Unknown`.

The location assertion is a deliberate fail-on-old regression guard: I verified that temporarily re-emitting a precise `Location::At { .. }` (simulating the deleted global hook) makes the test fail exactly on that assertion.

- ✅ 93/93 runtime lib tests pass
- ✅ `cargo fmt --check` clean
- ✅ no new clippy warnings in the runtime crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches panic handling on every WASM host import boundary; behavior change is intentional (no global hook, host panic locations become Unknown) with a targeted integration test.
> 
> **Overview**
> Removes the WASM host-import layer’s **process-global** `std::panic::set_hook` setup (thread-local `Once`, `PAYLOAD`, `HOST_CTX`) so the runtime no longer overwrites or chains against the node’s own panic hooks.
> 
> Host-function panics are still caught per call with `catch_unwind`, but the message now comes from **`panic_payload::panic_payload_to_string`** on the unwind payload—the same approach as `Module::run`—and **`HostError::Panic`** uses **`Location::Unknown`** because the payload has no source location (guest `panic` still supplies location via the guest ABI).
> 
> Adds **`test_wasm_host_panic_recovered_without_global_hook`**: a WAT guest calls `storage_read` against a `Storage` that panics in `get`, asserting **Host** context, message preservation, and **`Unknown`** location as a guard against reintroducing the global hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b5eee64f5e727a3bd34fd91d35ba460f245995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->