### PR TITLE
feat(context): log context cache hit rate periodically (#2031)

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -6,11 +6,12 @@ use calimero_governance_store::{
 };
 use std::collections::{btree_map, BTreeMap, HashMap, HashSet};
 use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use actix::prelude::{ActorResponse, WrapFuture};
-use actix::Actor;
+use actix::{Actor, AsyncContext};
 use calimero_context_client::client::ContextClient;
 use calimero_context_client::local_governance::SignedNamespaceOp;
 use calimero_context_config::types::ContextGroupId;
@@ -139,6 +140,45 @@ const MAX_CACHED_CONTEXTS: usize = 1024;
 /// Mirrors the compiled-`modules` cap (`MAX_CACHED_MODULES`); application
 /// metadata is a pure cache over the datastore, so eviction is harmless.
 const MAX_CACHED_APPLICATIONS: usize = 256;
+
+/// How often the periodic task logs context-cache effectiveness.
+const CACHE_STATS_LOG_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Cumulative hit/miss counters for the in-memory context cache.
+///
+/// Source of truth for the periodic [`ContextManager::log_cache_stats`] line,
+/// which is emitted even when Prometheus is disabled (headless/test nodes have
+/// `metrics: None`). When a registry *is* present the same events are also
+/// mirrored into the `context.cache.*` Prometheus series; the two are kept in
+/// lockstep at the single increment site in `get_or_fetch_context`.
+///
+/// Counters are cumulative over the process lifetime — the reported hit rate is
+/// therefore a lifetime average. Windowed rates are available from Prometheus
+/// (`rate(...)`); a per-interval delta in the log line is a possible follow-up.
+#[derive(Debug, Default)]
+struct ContextCacheStats {
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl ContextCacheStats {
+    /// Record a single cache access. `hit` is the `was_cached` outcome at the
+    /// cache-aside entry point: `true` when the context was already resident,
+    /// `false` when it had to be fetched from the datastore.
+    fn record(&self, hit: bool) {
+        let counter = if hit { &self.hits } else { &self.misses };
+        let _ = counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `(hits, misses)` snapshot. Relaxed loads are fine: the counters are only
+    /// ever read for human-facing logging, never to gate control flow.
+    fn snapshot(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
+    }
+}
 
 /// A metadata container for a single, in-memory context.
 ///
@@ -317,6 +357,12 @@ pub struct ContextManager {
     /// alongside the `contexts` LRU TODO above.
     modules: BTreeMap<(ApplicationId, Option<String>), calimero_runtime::Module>,
 
+    /// Cumulative hit/miss counters for the `contexts` hot cache, driving the
+    /// periodic effectiveness log (see [`ContextCacheStats`] and
+    /// [`Self::log_cache_stats`]). Independent of `metrics` so the log line
+    /// works on nodes without a Prometheus registry.
+    cache_stats: ContextCacheStats,
+
     /// Prometheus metrics for monitoring the health and performance of the manager,
     /// such as number of active contexts, message processing latency, etc.
     metrics: Option<Metrics>,
@@ -372,6 +418,7 @@ impl ContextManager {
             contexts: BTreeMap::new(),
             applications: BTreeMap::new(),
             modules: BTreeMap::new(),
+            cache_stats: ContextCacheStats::default(),
 
             metrics: prometheus_registry.map(Metrics::new),
             active_propagators: HashSet::new(),
@@ -560,6 +607,11 @@ impl Actor for ContextManager {
     fn started(&mut self, ctx: &mut Self::Context) {
         self.recover_in_progress_upgrades(ctx);
         self.start_namespace_heartbeat(ctx);
+        // Periodically report in-memory context-cache effectiveness.
+        // Runs on the actor thread, so it reads cache state without locking.
+        let _ = ctx.run_interval(CACHE_STATS_LOG_INTERVAL, |act, _ctx| {
+            act.log_cache_stats();
+        });
         // Auto-follow handler (see the auto-follow architecture doc) — reacts to governance
         // op-apply events and emits JoinContext on behalf of members
         // with `auto_follow.contexts = true`.
@@ -594,6 +646,69 @@ impl ContextMeta {
 }
 
 impl ContextManager {
+    /// Record one context-cache access against both the always-on in-memory
+    /// counters and (when a registry is configured) the Prometheus series.
+    /// `hit` is the `was_cached` outcome at the cache-aside entry point.
+    fn record_cache_access(&self, hit: bool) {
+        self.cache_stats.record(hit);
+
+        if let Some(metrics) = &self.metrics {
+            let counter = if hit {
+                &metrics.context_cache_hits
+            } else {
+                &metrics.context_cache_misses
+            };
+            let _ = counter.inc();
+        }
+    }
+
+    /// Emit a single context-cache effectiveness line and refresh the cache-size
+    /// gauges. Driven every [`CACHE_STATS_LOG_INTERVAL`] from [`Actor::started`].
+    ///
+    /// Hits/misses are cumulative over the process lifetime, so `hit_rate` is a
+    /// lifetime average. When no accesses have happened yet the line is dropped
+    /// to `debug` to keep idle nodes quiet; an active cache logs at `info`.
+    fn log_cache_stats(&self) {
+        let (hits, misses) = self.cache_stats.snapshot();
+        let total = hits + misses;
+        let context_cache_size = self.contexts.len();
+        let application_cache_size = self.applications.len();
+
+        if let Some(metrics) = &self.metrics {
+            // i64 gauges; cache sizes are bounded by MAX_CACHED_* (≤ 1024) so the
+            // cast is always lossless.
+            metrics.context_cache_size.set(context_cache_size as i64);
+            metrics
+                .application_cache_size
+                .set(application_cache_size as i64);
+        }
+
+        // Avoid division by zero and don't spam idle nodes with "0.0%" lines.
+        if total == 0 {
+            tracing::debug!(
+                context_cache_size,
+                application_cache_size,
+                "Context cache statistics (no accesses yet)"
+            );
+            return;
+        }
+
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "hit rate is a display-only percentage; f64 has ample precision for cache counters"
+        )]
+        let hit_rate = hits as f64 / total as f64;
+
+        tracing::info!(
+            hits,
+            misses,
+            hit_rate = %format!("{:.1}%", hit_rate * 100.0),
+            context_cache_size,
+            application_cache_size,
+            "Context cache statistics"
+        );
+    }
+
     /// Retrieves context metadata, fetching from the datastore if not present in the cache.
     ///
     /// This function implements the "cache-aside" pattern. It first checks the in-memory
@@ -622,10 +737,16 @@ impl ContextManager {
         // borrow checker can't return a reference through a split hit/miss
         // match otherwise).
         let was_cached = self.contexts.contains_key(context_id);
-        if !was_cached {
+        if was_cached {
+            self.record_cache_access(true);
+        } else {
             let Some(context) = self.context_client.get_context(context_id)? else {
+                // The context exists in neither the cache nor the datastore, so
+                // this is a probe for a non-existent context rather than a cache
+                // miss — leave the effectiveness counters untouched.
                 return Ok(None);
             };
+            self.record_cache_access(false);
 
             evict_idle_context_if_full(&mut self.contexts);
 
@@ -831,5 +952,33 @@ mod cache_eviction_tests {
         let _ = apps.insert(a.id, a);
         evict_application_if_full(&mut apps);
         assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS - 1);
+    }
+
+    #[test]
+    fn cache_stats_record_and_snapshot() {
+        let stats = ContextCacheStats::default();
+        assert_eq!(stats.snapshot(), (0, 0));
+
+        stats.record(true);
+        stats.record(true);
+        stats.record(false);
+        assert_eq!(stats.snapshot(), (2, 1));
+    }
+
+    /// Mirrors the percentage math in `log_cache_stats` so the formatting
+    /// contract (one decimal, `%` suffix) is pinned without constructing a full
+    /// `ContextManager`.
+    #[test]
+    fn cache_stats_hit_rate_formatting() {
+        let stats = ContextCacheStats::default();
+        for _ in 0..3 {
+            stats.record(true);
+        }
+        stats.record(false); // 3 hits / 4 total = 75.0%
+
+        let (hits, misses) = stats.snapshot();
+        let total = hits + misses;
+        let hit_rate = hits as f64 / total as f64;
+        assert_eq!(format!("{:.1}%", hit_rate * 100.0), "75.0%");
     }
 }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -167,7 +167,7 @@ impl ContextCacheStats {
     /// `false` when it had to be fetched from the datastore.
     fn record(&self, hit: bool) {
         let counter = if hit { &self.hits } else { &self.misses };
-        let _ = counter.fetch_add(1, Ordering::Relaxed);
+        counter.fetch_add(1, Ordering::Relaxed);
     }
 
     /// `(hits, misses)` snapshot. Relaxed loads are fine: the counters are only
@@ -609,7 +609,10 @@ impl Actor for ContextManager {
         self.start_namespace_heartbeat(ctx);
         // Periodically report in-memory context-cache effectiveness.
         // Runs on the actor thread, so it reads cache state without locking.
-        let _ = ctx.run_interval(CACHE_STATS_LOG_INTERVAL, |act, _ctx| {
+        // The returned SpawnHandle is intentionally dropped: this interval
+        // runs for the actor's entire lifetime and is never cancelled (same as
+        // `start_namespace_heartbeat`).
+        ctx.run_interval(CACHE_STATS_LOG_INTERVAL, |act, _ctx| {
             act.log_cache_stats();
         });
         // Auto-follow handler (see the auto-follow architecture doc) — reacts to governance
@@ -658,7 +661,7 @@ impl ContextManager {
             } else {
                 &metrics.context_cache_misses
             };
-            let _ = counter.inc();
+            counter.inc();
         }
     }
 

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -112,26 +112,30 @@ impl Metrics {
 
         let context_cache_hits = Counter::default();
         cache_registry.register(
-            "context_hits",
+            "hits",
             "Cumulative in-memory context cache hits",
             context_cache_hits.clone(),
         );
         let context_cache_misses = Counter::default();
         cache_registry.register(
-            "context_misses",
+            "misses",
             "Cumulative in-memory context cache misses (datastore fallback)",
             context_cache_misses.clone(),
         );
         let context_cache_size = Gauge::default();
         cache_registry.register(
-            "context_size",
-            "Number of contexts currently resident in the in-memory hot cache",
+            "size",
+            "Number of contexts resident in the in-memory hot cache. \
+             Refreshed by the periodic cache-stats task (~5-minute resolution), \
+             so it may lag faster scrape intervals — use hits/misses rates for \
+             fine-grained signal",
             context_cache_size.clone(),
         );
         let application_cache_size = Gauge::default();
         cache_registry.register(
             "application_size",
-            "Number of application-metadata entries currently resident in the cache",
+            "Number of application-metadata entries resident in the cache. \
+             Refreshed by the periodic cache-stats task (~5-minute resolution)",
             application_cache_size.clone(),
         );
 
@@ -311,4 +315,47 @@ pub fn record_governance_handler_delivery(
         .governance_handler_delivery_seconds
         .get_or_create(&labels)
         .observe(elapsed_ms as f64 / 1000.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus_client::encoding::text::encode;
+
+    use super::*;
+
+    /// The `context.cache.*` series register under the expected names and the
+    /// counters/gauges round-trip through the Prometheus text encoder. Exercises
+    /// the same `inc()`/`set()` calls that `ContextManager` makes on the cache
+    /// hit/miss and periodic-log paths.
+    #[test]
+    fn context_cache_metrics_register_and_encode() {
+        let mut registry = Registry::default();
+        let metrics = Metrics::new(&mut registry);
+
+        metrics.context_cache_hits.inc();
+        metrics.context_cache_hits.inc();
+        metrics.context_cache_misses.inc();
+        metrics.context_cache_size.set(7);
+        metrics.application_cache_size.set(3);
+
+        let mut out = String::new();
+        encode(&mut out, &registry).expect("encode registry");
+
+        assert!(
+            out.contains("context_cache_hits_total 2"),
+            "missing hit counter:\n{out}"
+        );
+        assert!(
+            out.contains("context_cache_misses_total 1"),
+            "missing miss counter:\n{out}"
+        );
+        assert!(
+            out.contains("context_cache_size 7"),
+            "missing context size gauge:\n{out}"
+        );
+        assert!(
+            out.contains("context_cache_application_size 3"),
+            "missing application size gauge:\n{out}"
+        );
+    }
 }

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -11,6 +11,20 @@ use prometheus_client::registry::Registry;
 pub struct Metrics {
     pub execution_count: Family<ExecutionLabels, Gauge>,
     pub execution_duration: Family<ExecutionLabels, Histogram>,
+
+    /// Cumulative count of in-memory context-cache hits (the requested
+    /// context was already resident in `ContextManager::contexts`).
+    pub context_cache_hits: Counter,
+    /// Cumulative count of context-cache misses (the context had to be
+    /// fetched from the authoritative datastore and inserted).
+    pub context_cache_misses: Counter,
+    /// Current number of contexts resident in the in-memory hot cache.
+    /// Set from the periodic cache-stats task, so it tracks the cap
+    /// (`MAX_CACHED_CONTEXTS`) at ~5-minute resolution.
+    pub context_cache_size: Gauge,
+    /// Current number of application-metadata entries resident in the
+    /// in-memory cache. Reported alongside `context_cache_size`.
+    pub application_cache_size: Gauge,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
@@ -87,6 +101,38 @@ impl Metrics {
             "execution_duration_seconds",
             "Context runtime execution in seconds",
             execution_duration.clone(),
+        );
+
+        // Context in-memory cache effectiveness. Hits/misses are
+        // monotonic counters incremented at the cache-aside entry point
+        // (`get_or_fetch_context`); the hit *rate* is derived in PromQL as
+        // `rate(hits) / (rate(hits) + rate(misses))`. The size gauges are
+        // refreshed by the periodic cache-stats task.
+        let cache_registry = context_registry.sub_registry_with_prefix("cache");
+
+        let context_cache_hits = Counter::default();
+        cache_registry.register(
+            "context_hits",
+            "Cumulative in-memory context cache hits",
+            context_cache_hits.clone(),
+        );
+        let context_cache_misses = Counter::default();
+        cache_registry.register(
+            "context_misses",
+            "Cumulative in-memory context cache misses (datastore fallback)",
+            context_cache_misses.clone(),
+        );
+        let context_cache_size = Gauge::default();
+        cache_registry.register(
+            "context_size",
+            "Number of contexts currently resident in the in-memory hot cache",
+            context_cache_size.clone(),
+        );
+        let application_cache_size = Gauge::default();
+        cache_registry.register(
+            "application_size",
+            "Number of application-metadata entries currently resident in the cache",
+            application_cache_size.clone(),
         );
 
         let group_store_registry = context_registry.sub_registry_with_prefix("group_store");
@@ -166,6 +212,10 @@ impl Metrics {
         Self {
             execution_count,
             execution_duration,
+            context_cache_hits,
+            context_cache_misses,
+            context_cache_size,
+            application_cache_size,
         }
     }
 }


### PR DESCRIPTION
Closes #2031.

## Summary

Adds visibility into in-memory context-cache effectiveness — a follow-up to the cache cap from #2606, instrumenting the same `contexts`/`applications` hot caches.

- **`ContextCacheStats { hits, misses: AtomicU64 }`** — always-on source of truth for the periodic log line, so it works even on nodes without a Prometheus registry (`metrics: None`, e.g. headless/test).
- **Single increment chokepoint** at `get_or_fetch_context` via `record_cache_access(hit)`, reusing the existing `was_cached` flag and mirroring into Prometheus when a registry is present. Probes for non-existent contexts (the early `Ok(None)`) are deliberately **not** counted — they're not a cache-effectiveness signal.
- **`log_cache_stats()`** driven by `ctx.run_interval(300s, …)` in `Actor::started` (mirrors the existing `start_namespace_heartbeat` pattern). Idle nodes log at `debug`; active caches log `info` with hit rate (`{:.1}%`) and both cache sizes.
- **Prometheus** under `context.cache.*`: `context_hits` / `context_misses` counters plus `context_size` / `application_size` gauges. Hit *rate* is derived in PromQL (`rate(hits) / (rate(hits) + rate(misses))`) rather than exported pre-divided.

## Acceptance criteria

- [x] Cache hits/misses tracked
- [x] Stats logged every 5 minutes
- [x] Metric exported to Prometheus

## Notes

- Hit rate is **cumulative (lifetime-average)**, matching the issue's snippet. A per-interval windowed delta in the log line is a possible follow-up; windowed rates are already available from the Prometheus counters.

## Testing

- 7 unit tests pass (2 new: `cache_stats_record_and_snapshot`, `cache_stats_hit_rate_formatting`)
- `cargo fmt --check` clean; clippy adds 0 warnings over baseline
- `calimero-node` + `calimero-server` check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only metrics and logging on the existing cache-aside path; no change to eviction, locking, or datastore behavior beyond counting accesses.
> 
> **Overview**
> Adds **observability for the in-memory context and application metadata caches** in `ContextManager`, building on the existing cache caps.
> 
> **Hit/miss tracking** uses in-process `AtomicU64` counters (`ContextCacheStats`) updated only from `get_or_fetch_context` via `record_cache_access`: hits when the context is already cached, misses after a successful datastore load. Lookups that return `None` (missing context) are **not** counted. The same events increment Prometheus `context.cache.hits` / `context.cache.misses` when a registry is configured.
> 
> **Periodic reporting** runs every 5 minutes from `Actor::started` (`log_cache_stats`): lifetime hit rate at `info` when there has been traffic, `debug` when idle, plus current context/application cache sizes. Size gauges (`context.cache.size`, `context.cache.application_size`) are refreshed on that interval.
> 
> Unit tests cover counter behavior, hit-rate formatting, and Prometheus text encoding for the new series.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb8be08d725708a985967c09a743849d51c4417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->