### PR TITLE
fix(storage): cascade re-key registration into deeply-nested custom structs (#2581)

### DIFF
--- a/crates/sdk/macros/src/mergeable.rs
+++ b/crates/sdk/macros/src/mergeable.rs
@@ -57,6 +57,17 @@ pub fn derive(input: DeriveInput) -> TokenStream {
         _ => quote! {},
     };
 
+    // Registration of THIS struct's nested value types, scanned exactly like the
+    // root `#[app::state]` does its own fields. The root only ever names the type
+    // tokens in its OWN fields, so a custom struct reachable only through another
+    // custom struct's collection is never registered there; emitting the same
+    // scan per Mergeable struct cascades registration through the whole value
+    // graph (see `RekeyTarget::register_nested_value_types`).
+    let rekey_register_body: TokenStream = match &input.data {
+        Data::Struct(s) => crate::state::rekey_register_calls(&s.fields),
+        _ => quote! {},
+    };
+
     quote! {
         impl #impl_generics ::calimero_storage::collections::Mergeable
             for #ident #ty_generics #where_clause
@@ -90,6 +101,16 @@ pub fn derive(input: DeriveInput) -> TokenStream {
                 parent_id: ::calimero_storage::address::Id,
             ) {
                 #rekey_body
+            }
+
+            // Cascade registration into the value types this struct nests, so a
+            // custom struct reachable only through this one's collections is
+            // registered too (not left to be last-writer-wins'd). Same per-field
+            // scan the root state runs; `register_rekey_if_supported!` recurses
+            // and the first-registration guard makes self-referential value
+            // graphs terminate.
+            fn register_nested_value_types() {
+                #rekey_register_body
             }
         }
     }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -677,17 +677,39 @@ fn generate_rekey_register_method(
         StructOrEnumItem::Enum(_) => return quote! {},
     };
 
+    let calls = rekey_register_calls(fields);
+
+    quote! {
+        impl #impl_generics #ident #ty_generics #where_clause {
+            /// Registers nested CRDT-value re-key thunks. Called at WASM module
+            /// load and by the native test bridge; idempotent. Not for direct use.
+            #[doc(hidden)]
+            pub fn __calimero_register_rekey() {
+                #calls
+            }
+        }
+    }
+}
+
+/// Emit one `register_rekey_if_supported!(T)` per distinct type token reachable
+/// from `fields` (each field type plus its generic args, recursively). Shared by
+/// the root `#[app::state]` scan and `#[derive(Mergeable)]`'s
+/// `register_nested_value_types` override, so a nested custom struct registers
+/// its own collection-value types the same way the root does — turning the
+/// root's one-level scan into a full walk of the reachable value graph.
+///
+/// Dedup is by token string (syntactic, not semantic): the same value type can
+/// appear in several fields (e.g. two `UnorderedMap<String, TeamStats>`), so
+/// collapse identically-written types to one call. Types written differently but
+/// equal (`TeamStats` vs `crate::TeamStats`) still emit two calls — harmless:
+/// they share a `TypeId`, and registration is idempotent (`or_insert`), so the
+/// registry holds one entry either way.
+pub(crate) fn rekey_register_calls(fields: &syn::Fields) -> TokenStream {
     let mut types: Vec<Type> = Vec::new();
     for field in fields.iter() {
         collect_type_paths(&field.ty, &mut types);
     }
 
-    // Dedup by token string (syntactic, not semantic): the same value type can
-    // appear in several fields (e.g. two `UnorderedMap<String, TeamStats>`), so
-    // collapse identically-written types to one registration call. Types written
-    // differently but equal (`TeamStats` vs `crate::TeamStats`) still emit two
-    // calls — harmless: they share a `TypeId`, and `register_rekey_pub` is
-    // idempotent (`or_insert`), so the registry holds one entry either way.
     let mut seen = std::collections::HashSet::new();
     let calls = types
         .iter()
@@ -696,22 +718,17 @@ fn generate_rekey_register_method(
             quote! { ::calimero_storage::register_rekey_if_supported!(#ty); }
         });
 
-    quote! {
-        impl #impl_generics #ident #ty_generics #where_clause {
-            /// Registers nested CRDT-value re-key thunks. Called at WASM module
-            /// load and by the native test bridge; idempotent. Not for direct use.
-            #[doc(hidden)]
-            pub fn __calimero_register_rekey() {
-                #(#calls)*
-            }
-        }
-    }
+    quote! { #(#calls)* }
 }
 
 /// Recursively collect every `Type::Path` node reachable from `ty` (the type
 /// itself plus its generic arguments, tuple/reference/array elements), so the
 /// registration above can offer each to `register_rekey_if_supported!`.
-fn collect_type_paths(ty: &Type, out: &mut Vec<Type>) {
+///
+/// Shared with `#[derive(Mergeable)]` (via [`rekey_register_calls`]), which runs
+/// the identical per-field scan so a nested custom struct registers its own
+/// value types — extending the root's one-level scan to the full graph.
+pub(crate) fn collect_type_paths(ty: &Type, out: &mut Vec<Type>) {
     match ty {
         Type::Path(tp) => {
             out.push(ty.clone());

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -82,6 +82,14 @@ pub trait RekeyTarget: Any {
     /// cascades in turn), walking the full value graph one struct at a time.
     /// The default is empty: leaf collections (`Counter`) and types with no
     /// registerable nested value carry nothing further to register.
+    ///
+    /// This is a type-level operation, so the `Self: Sized` bound is deliberate:
+    /// it is invoked ONLY on a concrete type, as `register_rekey_cascade::<T>()`,
+    /// never through a `dyn RekeyTarget` trait object (registration has no value
+    /// to dispatch on). That bound makes the method object-unsafe, so an attempt
+    /// to cascade through a trait object won't compile rather than silently
+    /// taking the no-op default. The instance-level `rekey_relative_to` stays
+    /// object-safe — it is the one called through the type-erased thunk.
     fn register_nested_value_types()
     where
         Self: Sized,
@@ -144,8 +152,9 @@ pub(crate) fn register_rekey<T: RekeyTarget + 'static>() -> bool {
     }
     // Use the entry API under the write lock (not a second `contains_key`) so
     // the insert-or-not decision is atomic: if two threads both miss the read
-    // fast-path, exactly one observes `Vacant` and reports the insertion, so
-    // the cascade can't double-walk on a startup race.
+    // fast-path for the SAME type, exactly one observes `Vacant` and returns
+    // true; the other sees `Occupied` and returns false. So the cascade fires
+    // exactly once per type — never twice for one type on a startup race.
     match REGISTRY
         .write()
         .unwrap_or_else(|e| e.into_inner())

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -64,6 +64,29 @@ pub trait RekeyTarget: Any {
     /// Re-key this value's nested collection ids relative to `parent_id` (the
     /// deterministic entity id under which this value is stored). Idempotent.
     fn rekey_relative_to(&mut self, parent_id: Id);
+
+    /// Cascade-register the re-key thunks of the value types nested in THIS
+    /// type, so they can be dispatched to when stored as collection values.
+    ///
+    /// Registration (unlike `rekey_relative_to`) does not recurse on its own:
+    /// `rekey_nested_value` dispatches by `TypeId`, so a value type that is
+    /// never registered is silently skipped (last-writer-wins'd). The root
+    /// `#[app::state]` scan only sees the type tokens written in the root
+    /// struct's own fields; a custom struct reachable only *through another
+    /// custom struct's collection* (e.g. `Map<_, Outer>` where `Outer` holds
+    /// `Map<_, Inner>`) is never named there, so without this hook `Inner`
+    /// would keep per-replica-random nested ids and lose concurrent writes.
+    ///
+    /// `#[derive(Mergeable)]` overrides this to register each of its own
+    /// collection-field value types (via `register_rekey_if_supported!`, which
+    /// cascades in turn), walking the full value graph one struct at a time.
+    /// The default is empty: leaf collections (`Counter`) and types with no
+    /// registerable nested value carry nothing further to register.
+    fn register_nested_value_types()
+    where
+        Self: Sized,
+    {
+    }
 }
 
 /// Derive a deterministic per-field child id from a parent entity id and a field
@@ -74,11 +97,22 @@ pub fn field_child_id(parent_id: Id, field_name: &str) -> Id {
     super::compute_collection_id(Some(parent_id), field_name)
 }
 
-/// Public re-export so the autoref macros (which expand in application crates)
-/// can name the registration entry point without exposing the registry itself.
+/// Register `T`'s thunk and, only on its FIRST registration, cascade into the
+/// value types `T` nests (via `T::register_nested_value_types`). This is what
+/// `register_rekey_if_supported!` dispatches to, so a single scan of the root
+/// state's fields transitively registers the whole reachable custom-struct
+/// value graph — not just one level.
+///
+/// The "first registration only" guard is load-bearing: it makes the walk
+/// terminate on self- and mutually-recursive value types (e.g.
+/// `Tree { children: UnorderedMap<_, Tree> }`). `register_rekey` reports
+/// whether THIS call inserted the thunk; we recurse only then, so an
+/// already-registered type is never re-walked.
 #[doc(hidden)]
-pub fn register_rekey_pub<T: RekeyTarget + 'static>() {
-    register_rekey::<T>();
+pub fn register_rekey_cascade<T: RekeyTarget + 'static>() {
+    if register_rekey::<T>() {
+        T::register_nested_value_types();
+    }
 }
 
 type RekeyThunk = fn(&mut dyn Any, Id);
@@ -93,8 +127,10 @@ static REGISTRY: LazyLock<RwLock<HashMap<TypeId, RekeyThunk>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Register `T`'s re-key thunk. Called from `T`'s constructor; idempotent and
-/// cheap (a read-lock hit on the common already-registered path).
-pub(crate) fn register_rekey<T: RekeyTarget + 'static>() {
+/// cheap (a read-lock hit on the common already-registered path). Returns
+/// `true` iff THIS call inserted the thunk (it was not already present), so
+/// `register_rekey_cascade` can recurse exactly once per type.
+pub(crate) fn register_rekey<T: RekeyTarget + 'static>() -> bool {
     let tid = TypeId::of::<T>();
     // Recover from a poisoned lock rather than propagating the panic: the
     // registry is an append-only map of independent fn pointers, so a thread
@@ -104,17 +140,27 @@ pub(crate) fn register_rekey<T: RekeyTarget + 'static>() {
         .unwrap_or_else(|e| e.into_inner())
         .contains_key(&tid)
     {
-        return;
+        return false;
     }
-    REGISTRY
+    // Use the entry API under the write lock (not a second `contains_key`) so
+    // the insert-or-not decision is atomic: if two threads both miss the read
+    // fast-path, exactly one observes `Vacant` and reports the insertion, so
+    // the cascade can't double-walk on a startup race.
+    match REGISTRY
         .write()
         .unwrap_or_else(|e| e.into_inner())
         .entry(tid)
-        .or_insert(|any: &mut dyn Any, parent: Id| {
-            if let Some(t) = any.downcast_mut::<T>() {
-                t.rekey_relative_to(parent);
-            }
-        });
+    {
+        std::collections::hash_map::Entry::Occupied(_) => false,
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            let _ = slot.insert(|any: &mut dyn Any, parent: Id| {
+                if let Some(t) = any.downcast_mut::<T>() {
+                    t.rekey_relative_to(parent);
+                }
+            });
+            true
+        }
+    }
 }
 
 /// Re-key any nested collections carried by `value` deterministically relative
@@ -186,6 +232,12 @@ macro_rules! rekey_field_if_supported {
 /// no-op. Generated registration code calls this for each collection-field value
 /// type so app structs auto-register before any insert. Macro (not fn) for the
 /// same autoref-on-concrete-type reason as [`rekey_field_if_supported`].
+///
+/// The real arm goes through `register_rekey_cascade`, which on a type's first
+/// registration also registers the value types IT nests
+/// ([`RekeyTarget::register_nested_value_types`]). So one call on a root field
+/// type transitively covers the whole reachable custom-struct value graph, not
+/// just one level.
 #[macro_export]
 macro_rules! register_rekey_if_supported {
     ($t:ty) => {{
@@ -195,7 +247,7 @@ macro_rules! register_rekey_if_supported {
         }
         impl<T: $crate::collections::rekey::RekeyTarget + 'static> __RgViaReg for __RgProbe<T> {
             fn __rg_go(self) {
-                $crate::collections::rekey::register_rekey_pub::<T>();
+                $crate::collections::rekey::register_rekey_cascade::<T>();
             }
         }
         trait __RgViaNoop {

--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -218,3 +218,177 @@ fn unregistered_value_loses_data_pre_fix() {
          rekey is still what makes #2577 converge"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Deep custom-struct nesting (#2581): a custom struct reachable only THROUGH
+// another custom struct's collection — `App → Map<_, Outer> → Map<_, Inner>`,
+// where both `Outer` and `Inner` are app structs.
+//
+// The root scan only names the type tokens in the ROOT struct's own fields, so
+// it registers `Outer` but never `Inner`. Pre-#2581, `Inner` therefore kept
+// per-replica-random nested ids and its `score` counter was last-writer-wins'd
+// (the exact #2577 loss, one level deeper). The fix makes `#[derive(Mergeable)]`
+// register each struct's own value types (`register_nested_value_types`) and has
+// `register_rekey_if_supported!` cascade, so registering `Outer` transitively
+// registers `Inner`.
+//
+// These tests register ONLY the root-level tokens (`Outer`, `String`) — exactly
+// what the root `#[app::state]` macro emits, NOT `Inner` — and rely on the
+// cascade to reach `Inner`. The positive path uses the derive (cascade fires);
+// the negative path uses hand-written impls WITHOUT a `register_nested_value_types`
+// override (the pre-fix derive shape), so `Inner` stays unregistered and loses
+// data. Distinct types throughout, since the rekey registry has no reset.
+
+/// Derive path: cascade should reach `Inner` via `Outer`'s generated
+/// `register_nested_value_types`.
+#[derive(BorshSerialize, BorshDeserialize, Default, Mergeable)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Inner {
+    score: Counter,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default, Mergeable)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Outer {
+    inner: UnorderedMap<String, Inner>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default, Mergeable)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct DeepApp {
+    groups: UnorderedMap<String, Outer>,
+}
+
+/// Hand-written impls mirroring the PRE-#2581 derive: a correct
+/// `rekey_relative_to` but NO `register_nested_value_types` override (so it
+/// takes the trait default no-op). `InnerManual` is consequently never
+/// registered when only the root tokens are.
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct InnerManual {
+    score: Counter,
+}
+
+impl Mergeable for InnerManual {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.score.merge(&other.score)
+    }
+}
+
+impl RekeyTarget for InnerManual {
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        rekey_field_if_supported!(&mut self.score, field_child_id(parent_id, "score"));
+    }
+    // Deliberately NO `register_nested_value_types` override — the pre-fix gap.
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct OuterManual {
+    inner: UnorderedMap<String, InnerManual>,
+}
+
+impl Mergeable for OuterManual {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.inner.merge(&other.inner)
+    }
+}
+
+impl RekeyTarget for OuterManual {
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        rekey_field_if_supported!(&mut self.inner, field_child_id(parent_id, "inner"));
+    }
+    // Deliberately NO `register_nested_value_types` override.
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct DeepAppManual {
+    groups: UnorderedMap<String, OuterManual>,
+}
+
+impl Mergeable for DeepAppManual {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.groups.merge(&other.groups)
+    }
+}
+
+// Reuse the `drive::<T>()` two-replica harness: `record_win`/`wins` navigate two
+// collection levels (`groups[team].inner[team].score`) instead of one.
+macro_rules! deep_team_app {
+    ($app:ty) => {
+        impl TeamApp for $app {
+            fn record_win(&mut self, team: &str) -> app::Result<()> {
+                let mut outer = self.groups.entry(team.to_owned())?.or_default()?;
+                let mut inner = outer.inner.entry(team.to_owned())?.or_default()?;
+                inner.score.increment()?;
+                Ok(())
+            }
+            fn wins(&self, team: &str) -> app::Result<u64> {
+                match self.groups.get(team)? {
+                    Some(outer) => match outer.inner.get(team)? {
+                        Some(inner) => Ok(inner.score.value()?),
+                        None => Ok(0),
+                    },
+                    None => Ok(0),
+                }
+            }
+        }
+    };
+}
+
+deep_team_app!(DeepApp);
+deep_team_app!(DeepAppManual);
+
+#[test]
+#[serial]
+fn cascade_registers_deeply_nested_custom_value() {
+    env::reset_environment();
+    register_crdt_merge_for_test::<DeepApp>();
+    // Register ONLY what the root `#[app::state]` scan would for
+    // `DeepApp { groups: UnorderedMap<String, Outer> }`: the value type `Outer`
+    // and the key type `String`. `Inner` is NOT named here — the cascade through
+    // `Outer::register_nested_value_types` must register it.
+    register_rekey_if_supported!(Outer);
+    register_rekey_if_supported!(String);
+
+    let (wa, wb, converged) = drive::<DeepApp>();
+    println!("DEEP-CASCADE wins a={wa} b={wb} converged={converged}");
+    assert_eq!(
+        wa, 2,
+        "replica A: both increments must survive two levels deep"
+    );
+    assert_eq!(
+        wb, 2,
+        "replica B: both increments must survive two levels deep"
+    );
+    assert!(converged, "replicas must converge to the same root hash");
+}
+
+#[test]
+#[serial]
+fn no_cascade_loses_deeply_nested_data_pre_fix() {
+    // Pre-fix shape: `OuterManual` has no `register_nested_value_types`, so
+    // registering the root tokens leaves `InnerManual` unregistered and its
+    // nested counter is LWW'd — the #2577 loss, one level deeper. Same tight
+    // `== 1` assertion (and rationale) as `unregistered_value_loses_data_pre_fix`.
+    env::reset_environment();
+    register_crdt_merge_for_test::<DeepAppManual>();
+    register_rekey_if_supported!(OuterManual);
+    register_rekey_if_supported!(String);
+    // Deliberately NO `register_rekey_if_supported!(InnerManual)`, and
+    // `OuterManual` does not cascade into it.
+
+    let (wa, wb, converged) = drive::<DeepAppManual>();
+    println!("DEEP-NOCASCADE wins a={wa} b={wb} converged={converged}");
+    assert!(
+        converged,
+        "LWW replicas still converge — to the wrong value"
+    );
+    assert_eq!(wa, wb, "converged replicas must agree on the (wrong) value");
+    assert_eq!(
+        wa, 1,
+        "without cascading registration, the deeply-nested counter is LWW'd: \
+         exactly one replica's increment survives"
+    );
+}


### PR DESCRIPTION
Closes #2581. Follow-up to #2577 / #2579.

## Problem

The deterministic re-key fix (#2579) registered re-key thunks for only **one level** of custom-struct nesting — the value types of the **root** `#[app::state]` struct's collection fields. A custom struct reachable only *through another custom struct's collection* is never registered, so `rekey_nested_value`'s `TypeId` dispatch silently no-ops and its nested collections keep per-replica-random ids → concurrent writes are silently last-writer-wins'd (the exact #2577 data loss, one level deeper).

```rust
#[derive(Mergeable)] struct Inner { score: Counter }
#[derive(Mergeable)] struct Outer { inner: UnorderedMap<String, Inner> }
#[app::state]        struct App   { groups: UnorderedMap<String, Outer> }
```

`App`'s scan registers `Outer` and `String` but **never `Inner`** (it appears only in `Outer`'s definition, not in any `App` field). So two replicas concurrently writing the same `Inner.score` lose data.

Not affected: any depth of *built-in* collection nesting (they self-register in their constructors). Only **custom-struct-inside-custom-struct** is the gap, and no current example app hits it.

## Fix (issue's approach #1: cascading registration)

Runtime re-keying (`rekey_field_if_supported!`) already recurses to any depth; only **registration** was one-level. So each `#[derive(Mergeable)]` struct now registers its own collection-field value types, and registration cascades through the value graph.

- **`crates/storage/src/collections/rekey.rs`**
  - New trait hook `RekeyTarget::register_nested_value_types()` (default no-op).
  - New `register_rekey_cascade<T>()`: registers `T`'s thunk and, **only on its first registration**, recurses into the value types `T` nests. The first-registration guard makes self-/mutually-recursive value graphs (e.g. `Tree { children: Map<_, Tree> }`) terminate.
  - `register_rekey` now reports whether *this* call inserted the thunk, decided atomically via the `Entry` API under the write lock (so a startup race can't double-walk).
  - `register_rekey_if_supported!` routes its real arm through the cascade.
- **`crates/sdk/macros/src/{state,mergeable}.rs`**
  - `#[derive(Mergeable)]` generates `register_nested_value_types()` scanning its own fields.
  - Extracted `rekey_register_calls` / made `collect_type_paths` shared, so the derive and the root `#[app::state]` scan walk types identically.

## Tests

`crates/storage/tests/rekey_record.rs` (gated `--features testing`) gains two cases on the existing two-replica `drive::<T>()` harness:
- `cascade_registers_deeply_nested_custom_value` — derive path; registers **only** the root tokens (`Outer`, `String`), and the deeply-nested counter still converges to `2`, proving the cascade reaches `Inner`.
- `no_cascade_loses_deeply_nested_data_pre_fix` — hand-written impls **without** the `register_nested_value_types` override (the pre-fix shape); the deeply-nested counter is LWW'd to `1`, documenting the bug and proving the cascade is load-bearing.

All green locally: rekey_record 4/4, storage lib 550, sdk-macros 55, `team-metrics-macro` converge 2/2, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync/convergence registration for nested CRDT values; behavior is guarded by new integration tests and first-registration recursion limits, but incorrect registration could still cause silent data loss in edge layouts.
> 
> **Overview**
> Extends **deterministic re-key registration** so custom structs nested inside other custom struct map values are registered, not only types named on the root `#[app::state]` fields. Without this, deeply nested counters could still diverge across replicas (same class of bug as #2577).
> 
> **Runtime:** `RekeyTarget` gains `register_nested_value_types()`; `register_rekey_cascade` registers a type’s thunk and, on first insert only, walks nested value types. `register_rekey` returns whether it inserted and uses an atomic `Entry` insert so concurrent startup cannot double-cascade. `register_rekey_if_supported!` now calls the cascade path.
> 
> **Macros:** `#[derive(Mergeable)]` emits `register_nested_value_types` using the same field type scan as root state; `rekey_register_calls` / `collect_type_paths` are shared with `#[app::state]`.
> 
> **Tests:** Two-replica deep nesting (`Map → Outer → Map → Inner`) proves cascade reaches `Inner` when only root tokens are registered, and that missing the override still LWWs to `1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88583348275a90de26f783276092022bbfaabedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->