### PR TITLE
feat(api): expose per-context sync status via JSON-RPC (#2027)

### DIFF
--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -780,6 +780,30 @@ impl NodeClient {
         &self.sync_client
     }
 
+    /// Read the best-effort sync-status snapshot for `context_id`.
+    ///
+    /// Round-trips through `NodeManager`, which owns the run-loop-published
+    /// snapshot map. `Ok(None)` means the sync run-loop has no record for the
+    /// context — it was created locally, or just joined and has not been
+    /// dispatched yet. The snapshot is advisory (see
+    /// [`SyncStatusSnapshot`](crate::SyncStatusSnapshot)); use it for UX, not
+    /// control flow.
+    pub async fn sync_status(
+        &self,
+        context_id: ContextId,
+    ) -> eyre::Result<Option<crate::SyncStatusSnapshot>> {
+        let (tx, rx) = oneshot::channel();
+        self.node_manager
+            .send(NodeMessage::GetSyncStatus {
+                context_id,
+                outcome: tx,
+            })
+            .await
+            .map_err(|_| eyre::eyre!("node manager mailbox dropped"))?;
+        rx.await
+            .map_err(|_| eyre::eyre!("sync status response channel dropped"))
+    }
+
     pub async fn sync(
         &self,
         context_id: Option<&ContextId>,

--- a/crates/node/primitives/src/lib.rs
+++ b/crates/node/primitives/src/lib.rs
@@ -9,6 +9,8 @@ pub mod join_bundle;
 pub use join_bundle::JoinBundle;
 pub mod messages;
 pub mod sync;
+pub mod sync_status;
+pub use sync_status::{SyncPhase, SyncStatusSnapshot};
 pub mod topic_manager;
 pub use topic_manager::TopicManager;
 

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -53,4 +53,14 @@ pub enum NodeMessage {
     /// claim "FSM observes every monotonic advance regardless of
     /// origin" only held for the receive path until #2237 follow-up.
     ForwardNamespaceOpApplied { namespace_id: [u8; 32] },
+    /// Read the best-effort sync-status snapshot the sync run-loop has
+    /// recorded for a context. Routed through `NodeClient -> NodeManager`
+    /// because the snapshot lives on the node-crate-private `NodeState`,
+    /// which the server layer cannot name directly. `outcome` carries
+    /// `None` when the run-loop has no record for the context (never
+    /// synced — e.g. created locally or just joined).
+    GetSyncStatus {
+        context_id: ContextId,
+        outcome: oneshot::Sender<Option<crate::SyncStatusSnapshot>>,
+    },
 }

--- a/crates/node/primitives/src/sync_status.rs
+++ b/crates/node/primitives/src/sync_status.rs
@@ -11,12 +11,14 @@
 //! lock-free map and read out-of-band, so a reader may observe a value that is
 //! a few hundred milliseconds stale. It is meant for UX ("syncing, please
 //! wait" vs "stuck"), not for control flow.
-
-use serde::{Deserialize, Serialize};
+//!
+//! These types are passed in-process only (run-loop publisher → `NodeManager`
+//! → `NodeClient`); the wire-facing shape lives in `calimero-server-primitives`
+//! (`jsonrpc::SyncState`), which the server handler maps onto. So there are
+//! deliberately no `serde` derives here.
 
 /// A snapshot of where a context is in the sync lifecycle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct SyncStatusSnapshot {
     /// Coarse phase the sync manager last recorded for this context.
     pub phase: SyncPhase,
@@ -30,27 +32,19 @@ pub struct SyncStatusSnapshot {
     pub last_error: Option<String>,
 }
 
-impl SyncStatusSnapshot {
-    /// A context with no recorded activity — neither syncing nor backing off.
-    #[must_use]
-    pub const fn idle() -> Self {
-        Self {
-            phase: SyncPhase::Idle,
-            failure_count: 0,
-            last_error: None,
-        }
-    }
-}
-
 /// Coarse sync phase. Deliberately small: finer-grained snapshot progress
 /// (page percent, bytes) can be layered on later without changing the
-/// distinction this enum exists to make — running vs idle vs wedged.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-#[serde(tag = "state", rename_all = "camelCase")]
+/// distinction this enum exists to make — running vs settled vs wedged.
+///
+/// Note this phase is derived purely from the run-loop's `SyncState` and is
+/// blind to whether the context is initialized. In particular the benign
+/// "no peers / peer not materialised" outcome clears the in-flight marker
+/// without recording a failure, so it lands here as [`SyncPhase::Idle`]; it is
+/// the *reader* (which also knows `is_initialized`) that resolves an
+/// uninitialized-yet-idle context to "waiting for peers".
+#[derive(Clone, Copy, Debug)]
 pub enum SyncPhase {
-    /// No attempt is in flight and none is gated behind backoff. Either the
-    /// context is already initialized, or it has just joined and the run-loop
-    /// has not dispatched its first attempt yet.
+    /// No attempt is in flight and none is gated behind backoff.
     Idle,
     /// A sync attempt is currently in flight (snapshot or delta exchange).
     Syncing,

--- a/crates/node/primitives/src/sync_status.rs
+++ b/crates/node/primitives/src/sync_status.rs
@@ -1,0 +1,64 @@
+//! Best-effort, point-in-time view of a context's state-sync progress.
+//!
+//! A node that has joined a context but not yet received its initial state
+//! reports `root_hash == [0; 32]` and rejects execution with
+//! `ExecuteError::Uninitialized`. That single error can't tell a client
+//! whether sync is actively running, waiting for a peer to appear, or wedged
+//! after repeated failures. This snapshot surfaces the sync manager's own
+//! per-context bookkeeping so the distinction is observable.
+//!
+//! The data is advisory: it is published from the sync run-loop on a
+//! lock-free map and read out-of-band, so a reader may observe a value that is
+//! a few hundred milliseconds stale. It is meant for UX ("syncing, please
+//! wait" vs "stuck"), not for control flow.
+
+use serde::{Deserialize, Serialize};
+
+/// A snapshot of where a context is in the sync lifecycle.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncStatusSnapshot {
+    /// Coarse phase the sync manager last recorded for this context.
+    pub phase: SyncPhase,
+    /// Consecutive failed sync attempts. Resets to 0 on the next success.
+    /// A non-zero value with `phase == BackingOff` is the "stuck" signal.
+    pub failure_count: u32,
+    /// The error from the most recent failed attempt, if any. Carries the
+    /// reason behind a `BackingOff` phase (e.g. "No peers to sync with"),
+    /// which is what lets a client distinguish "waiting for a peer" from a
+    /// genuine protocol failure.
+    pub last_error: Option<String>,
+}
+
+impl SyncStatusSnapshot {
+    /// A context with no recorded activity — neither syncing nor backing off.
+    #[must_use]
+    pub const fn idle() -> Self {
+        Self {
+            phase: SyncPhase::Idle,
+            failure_count: 0,
+            last_error: None,
+        }
+    }
+}
+
+/// Coarse sync phase. Deliberately small: finer-grained snapshot progress
+/// (page percent, bytes) can be layered on later without changing the
+/// distinction this enum exists to make — running vs idle vs wedged.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "camelCase")]
+pub enum SyncPhase {
+    /// No attempt is in flight and none is gated behind backoff. Either the
+    /// context is already initialized, or it has just joined and the run-loop
+    /// has not dispatched its first attempt yet.
+    Idle,
+    /// A sync attempt is currently in flight (snapshot or delta exchange).
+    Syncing,
+    /// The last attempt finished without success and the next retry is gated
+    /// behind exponential backoff. `retry_in_secs` is the manager's best
+    /// estimate of the remaining wait; it is `0` once a retry is due.
+    BackingOff {
+        /// Estimated seconds until the next retry is eligible.
+        retry_in_secs: u64,
+    },
+}

--- a/crates/node/src/handlers.rs
+++ b/crates/node/src/handlers.rs
@@ -56,6 +56,16 @@ impl Handler<NodeMessage> for NodeManager {
                     "Removed pending specialized node invite"
                 );
             }
+            NodeMessage::GetSyncStatus {
+                context_id,
+                outcome,
+            } => {
+                // Synchronous read off the lock-free `sync_status` map; reply
+                // directly on the oneshot. A dropped receiver (caller gave up)
+                // is fine to ignore — this is a pure observability query.
+                let snapshot = self.state.sync_status_snapshot(&context_id);
+                let _ = outcome.send(snapshot);
+            }
             NodeMessage::ForwardNamespaceOpApplied { namespace_id } => {
                 // Forward the publisher-side signal to the readiness FSM.
                 // Mirrors `addr.do_send(NamespaceOpApplied { namespace_id })`

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
+use calimero_node_primitives::SyncStatusSnapshot;
 use calimero_primitives::identity::PublicKey;
 use calimero_primitives::{blobs::BlobId, context::ContextId};
 use dashmap::DashMap;
@@ -157,6 +158,12 @@ pub(crate) struct NodeState {
     /// - Cooldown computed as exponential backoff capped at 30 min;
     ///   see [`reconcile_cooldown`] in `sync::manager`.
     pub(crate) reconcile_attempts: Arc<DashMap<ContextId, ReconcileAttempt>>,
+    /// Per-context, best-effort sync-progress snapshot published by the sync
+    /// run-loop and read out-of-band (JSON-RPC `sync_status`). Lets a client
+    /// blocked on `Uninitialized` tell "syncing" from "stuck" instead of
+    /// guessing. Advisory only — see [`SyncStatusSnapshot`] — and absent for
+    /// contexts the run-loop has never touched.
+    pub(crate) sync_status: Arc<DashMap<ContextId, SyncStatusSnapshot>>,
 }
 
 /// Per-context backoff state for the reconcile-after-divergence path.
@@ -204,7 +211,23 @@ impl NodeState {
             governance_pending: Arc::new(DashMap::new()),
             peer_identities: Arc::new(DashMap::new()),
             reconcile_attempts: Arc::new(DashMap::new()),
+            sync_status: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Shared handle to the sync-status map, for the run-loop publisher.
+    pub(crate) fn sync_status_handle(&self) -> Arc<DashMap<ContextId, SyncStatusSnapshot>> {
+        self.sync_status.clone()
+    }
+
+    /// Read the latest sync-status snapshot for a context, if the run-loop has
+    /// recorded one. `None` means the context has had no sync activity (e.g.
+    /// it was created locally, or just joined and not yet dispatched).
+    pub(crate) fn sync_status_snapshot(
+        &self,
+        context_id: &ContextId,
+    ) -> Option<SyncStatusSnapshot> {
+        self.sync_status.get(context_id).map(|s| s.value().clone())
     }
 
     /// Record that `peer_id` has successfully delivered a message

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -474,6 +474,7 @@ impl SyncManager {
         let tracker = super::session::SessionTracker::new(
             self.sync_config.session_deadline,
             self.sync_config.interval,
+            self.node_state.sync_status_handle(),
         );
 
         let driver = super::driver::SyncDriver::new(

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -18,9 +18,12 @@
 //! helpers with a single typed `SessionTracker`.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 
+use calimero_node_primitives::{SyncPhase, SyncStatusSnapshot};
 use calimero_primitives::context::ContextId;
+use dashmap::DashMap;
 use tokio::time::Instant;
 use tracing::{debug, info, warn};
 
@@ -79,6 +82,13 @@ pub(super) struct SessionTracker {
     /// outcome, AND the minimum between successful syncs before the
     /// next attempt is considered (subject to a `force` override).
     dispatch_backoff: Duration,
+    /// Lock-free mirror of the per-context sync phase, published after
+    /// every `SyncState` transition so an out-of-band reader (the
+    /// JSON-RPC `sync_status` endpoint) can distinguish "syncing" from
+    /// "stuck" without reaching into this run-loop-owned tracker. The
+    /// tracker is the sole writer; readers only ever see committed
+    /// snapshots. Shares the `Arc` held by `NodeState::sync_status`.
+    status_sink: Arc<DashMap<ContextId, SyncStatusSnapshot>>,
 }
 
 /// Outcome of [`SessionTracker::dispatch_decision`].
@@ -136,7 +146,11 @@ impl SessionTracker {
     /// per-session timeout the `SyncSessionActor` enforces.
     /// `dispatch_backoff` is `sync_config.interval` — the minimum
     /// between dispatch attempts and successful syncs.
-    pub(super) fn new(session_deadline: Duration, dispatch_backoff: Duration) -> Self {
+    pub(super) fn new(
+        session_deadline: Duration,
+        dispatch_backoff: Duration,
+        status_sink: Arc<DashMap<ContextId, SyncStatusSnapshot>>,
+    ) -> Self {
         const SESSION_WEDGE_GRACE_MULTIPLIER: u32 = 2;
         Self {
             state: HashMap::new(),
@@ -148,7 +162,39 @@ impl SessionTracker {
             full_window_started: Instant::now(),
             session_wedge_grace: session_deadline * SESSION_WEDGE_GRACE_MULTIPLIER,
             dispatch_backoff,
+            status_sink,
         }
+    }
+
+    /// Recompute and publish the observable sync-status snapshot for `ctx`
+    /// from its current `SyncState`. Called after every transition so the
+    /// out-of-band reader sees a fresh phase. Cheap: one map lookup plus a
+    /// `DashMap` insert. A context with no tracked state is left absent
+    /// (the reader treats absence as "no sync activity recorded").
+    fn publish_status(&self, ctx: &ContextId) {
+        let Some(state) = self.state.get(ctx) else {
+            return;
+        };
+        let phase = match state.last_sync() {
+            // `last_sync == None` is the in-progress marker the tracker uses.
+            None => SyncPhase::Syncing,
+            Some(last) if state.failure_count() > 0 => {
+                // Mirror `dispatch_decision`'s eligibility floor so the
+                // reported wait matches when the next attempt actually fires.
+                let minimum = self.dispatch_backoff.max(state.backoff_delay());
+                let retry_in_secs = minimum.saturating_sub(last.elapsed()).as_secs();
+                SyncPhase::BackingOff { retry_in_secs }
+            }
+            Some(_) => SyncPhase::Idle,
+        };
+        let _prev = self.status_sink.insert(
+            *ctx,
+            SyncStatusSnapshot {
+                phase,
+                failure_count: state.failure_count(),
+                last_error: state.last_error().map(ToOwned::to_owned),
+            },
+        );
     }
 
     /// `session_wedge_grace` exposed for the caller's wedge warn-log
@@ -264,6 +310,7 @@ impl SessionTracker {
         } else if let Some(existing) = self.state.get_mut(&ctx) {
             let _ignored = existing.take_last_sync();
         }
+        self.publish_status(&ctx);
     }
 
     /// Apply a `SyncSessionResult` from the result channel. Clears
@@ -365,9 +412,7 @@ impl SessionTracker {
                         // the next tick pick a different peer is the
                         // graceful recovery.
                         s.on_not_materialized();
-                        return;
-                    }
-                    if err.downcast_ref::<NoPeersAvailable>().is_some() {
+                    } else if err.downcast_ref::<NoPeersAvailable>().is_some() {
                         // Transient: no co-member is connected for this
                         // context right now (empty mesh + no namespace
                         // fallback). This is a connectivity condition,
@@ -385,17 +430,17 @@ impl SessionTracker {
                              waiting for a co-member, not a failure"
                         );
                         s.on_not_materialized();
-                        return;
+                    } else {
+                        s.on_failure(err.to_string());
+                        warn!(
+                            %context_id,
+                            ?took,
+                            error = %err,
+                            failure_count = s.failure_count(),
+                            backoff_secs = s.backoff_delay().as_secs(),
+                            "Sync failed, applying exponential backoff"
+                        );
                     }
-                    s.on_failure(err.to_string());
-                    warn!(
-                        %context_id,
-                        ?took,
-                        error = %err,
-                        failure_count = s.failure_count(),
-                        backoff_secs = s.backoff_delay().as_secs(),
-                        "Sync failed, applying exponential backoff"
-                    );
                 }
                 Err(ref timeout_err) => {
                     s.on_failure(timeout_err.to_string());
@@ -409,6 +454,9 @@ impl SessionTracker {
                 }
             },
         }
+        // The mutable `s` borrow above is released; publish the settled phase
+        // so the out-of-band reader observes success/idle/backoff immediately.
+        self.publish_status(&context_id);
     }
 
     /// Wedge-watchdog tick. Returns contexts whose initiator was
@@ -446,6 +494,7 @@ impl SessionTracker {
                         .to_owned(),
                 );
             }
+            self.publish_status(ctx);
         }
         self.initiator_dispatched_at
             .retain(|_, dispatched_at| dispatched_at.elapsed() < grace);
@@ -540,7 +589,11 @@ mod tests {
     fn tracker() -> SessionTracker {
         // Use small but realistic durations so the `force` override
         // tests have a meaningful "minimum".
-        SessionTracker::new(Duration::from_secs(30), Duration::from_secs(5))
+        SessionTracker::new(
+            Duration::from_secs(30),
+            Duration::from_secs(5),
+            Arc::new(DashMap::new()),
+        )
     }
 
     // -----------------------------------------------------------------
@@ -1318,5 +1371,72 @@ mod tests {
             s.last_sync().is_none(),
             "second record_dispatch_succeeded must clear last_sync"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // publish_status — the observable sync-status snapshot
+    // -----------------------------------------------------------------
+
+    fn tracker_with_sink() -> (SessionTracker, Arc<DashMap<ContextId, SyncStatusSnapshot>>) {
+        let sink = Arc::new(DashMap::new());
+        let t = SessionTracker::new(
+            Duration::from_secs(30),
+            Duration::from_secs(5),
+            Arc::clone(&sink),
+        );
+        (t, sink)
+    }
+
+    #[test]
+    fn publish_status_reports_syncing_while_in_flight() {
+        let (mut t, sink) = tracker_with_sink();
+        // A dispatched first sync leaves the in-progress marker set.
+        t.record_dispatch_succeeded(ctx(1), true);
+        let snap = sink.get(&ctx(1)).expect("status published on dispatch");
+        assert!(matches!(snap.phase, SyncPhase::Syncing));
+        assert_eq!(snap.failure_count, 0);
+        assert!(snap.last_error.is_none());
+    }
+
+    #[test]
+    fn publish_status_reports_idle_after_success() {
+        let (mut t, sink) = tracker_with_sink();
+        let mut s = SyncState::new();
+        s.on_success(
+            libp2p::PeerId::random(),
+            super::super::tracking::SyncProtocol::DagCatchup,
+        );
+        let _ = t.state.insert(ctx(1), s);
+        t.publish_status(&ctx(1));
+        let snap = sink.get(&ctx(1)).expect("status published");
+        assert!(matches!(snap.phase, SyncPhase::Idle));
+        assert_eq!(snap.failure_count, 0);
+        assert!(snap.last_error.is_none());
+    }
+
+    #[test]
+    fn publish_status_reports_backing_off_after_failure() {
+        let (mut t, sink) = tracker_with_sink();
+        let mut s = SyncState::new();
+        s.on_failure("No peers to sync with".to_owned());
+        let _ = t.state.insert(ctx(1), s);
+        t.publish_status(&ctx(1));
+        let snap = sink.get(&ctx(1)).expect("status published");
+        match snap.phase {
+            // backoff_delay(2^1=2s) is below the 5s dispatch floor, so the
+            // reported wait is the floor minus the (near-zero) elapsed time.
+            SyncPhase::BackingOff { retry_in_secs } => assert!(retry_in_secs <= 5),
+            other => panic!("expected BackingOff, got {other:?}"),
+        }
+        assert_eq!(snap.failure_count, 1);
+        assert_eq!(snap.last_error.as_deref(), Some("No peers to sync with"));
+    }
+
+    #[test]
+    fn publish_status_absent_for_untracked_context() {
+        let (t, sink) = tracker_with_sink();
+        // No state recorded for this context → nothing to publish.
+        t.publish_status(&ctx(9));
+        assert!(sink.get(&ctx(9)).is_none());
     }
 }

--- a/crates/node/src/sync/tracking.rs
+++ b/crates/node/src/sync/tracking.rs
@@ -134,6 +134,12 @@ impl SyncState {
         self.failure_count
     }
 
+    /// Get the most recent failure's error message, if the last attempt
+    /// failed (cleared on the next success).
+    pub(crate) fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
     /// Take last_sync value (for marking sync start while keeping old time)
     pub(crate) fn take_last_sync(&mut self) -> Option<Instant> {
         self.last_sync.take()

--- a/crates/server/primitives/src/jsonrpc.rs
+++ b/crates/server/primitives/src/jsonrpc.rs
@@ -210,11 +210,32 @@ impl SyncStatusRequest {
     }
 }
 
-/// Self-describing sync-status response. `sync_state` is a coarse,
-/// stable string (`"idle"`, `"syncing"`, `"backingOff"`) so JSON clients
-/// don't need to track the node's internal enum. The remaining fields carry
-/// the detail behind the state — a non-zero `failure_count` with
-/// `last_error` set is the "stuck" signal.
+/// Coarse, wire-facing sync phase. Serialized internally-tagged as
+/// `{ "state": "syncing" }`, with `backingOff` additionally carrying
+/// `retryInSecs`. A typed enum (rather than a bare string) keeps `retry_in_secs`
+/// structurally bound to the one state it applies to and lets callers match
+/// exhaustively. Not `#[non_exhaustive]` so the server handler can construct it.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(tag = "state", rename_all = "camelCase")]
+pub enum SyncState {
+    /// Context is settled — no sync in flight, nothing pending.
+    Idle,
+    /// Not yet initialized and nothing is actively syncing: typically waiting
+    /// for a co-member peer to appear to sync the initial state from.
+    WaitingForPeers,
+    /// A sync attempt is currently in flight.
+    Syncing,
+    /// The last attempt failed and the next retry is gated behind backoff.
+    BackingOff {
+        /// Estimated seconds until the next retry is eligible.
+        retry_in_secs: u64,
+    },
+}
+
+/// Sync-status response. `sync_state` carries the coarse phase; a non-zero
+/// `failure_count` with `last_error` set is the "stuck" signal. Note
+/// `is_initialized` and `sync_state` are orthogonal: an already-initialized
+/// context may still report `syncing` while it catches up on later deltas.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -223,16 +244,12 @@ pub struct SyncStatusResponse {
     /// `true` once the context has a non-zero root hash, i.e. initial state
     /// has been adopted and `execute` will no longer return `Uninitialized`.
     pub is_initialized: bool,
-    /// Coarse sync phase: `"idle"`, `"syncing"`, or `"backingOff"`.
-    pub sync_state: String,
-    /// Estimated seconds until the next retry, when `sync_state` is
-    /// `"backingOff"`. `None` for other states.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_in_secs: Option<u64>,
+    /// Coarse sync phase.
+    pub sync_state: SyncState,
     /// Consecutive failed sync attempts (0 when healthy).
     pub failure_count: u32,
     /// Most recent sync error, if the last attempt failed. Carries the reason
-    /// behind a `"backingOff"` state (e.g. "No peers to sync with").
+    /// behind a `backingOff` state (e.g. "No peers to sync with").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
 }
@@ -242,8 +259,7 @@ impl SyncStatusResponse {
     pub const fn new(
         context_id: ContextId,
         is_initialized: bool,
-        sync_state: String,
-        retry_in_secs: Option<u64>,
+        sync_state: SyncState,
         failure_count: u32,
         last_error: Option<String>,
     ) -> Self {
@@ -251,7 +267,6 @@ impl SyncStatusResponse {
             context_id,
             is_initialized,
             sync_state,
-            retry_in_secs,
             failure_count,
             last_error,
         }

--- a/crates/server/primitives/src/jsonrpc.rs
+++ b/crates/server/primitives/src/jsonrpc.rs
@@ -74,6 +74,7 @@ impl Request<RequestPayload> {
 #[serde(tag = "method", content = "params", rename_all = "snake_case")]
 pub enum RequestPayload {
     Execute(ExecutionRequest),
+    SyncStatus(SyncStatusRequest),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -192,7 +193,87 @@ pub enum ExecutionError {
     ExecuteError(ExecuteError),
 }
 
+/// Request the current state-sync status of a context. Lets a client that
+/// hit `Uninitialized` on `execute` tell whether sync is actively running,
+/// waiting for a peer, or wedged — instead of guessing from one opaque error.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SyncStatusRequest {
+    pub context_id: ContextId,
+}
+
+impl SyncStatusRequest {
+    #[must_use]
+    pub const fn new(context_id: ContextId) -> Self {
+        Self { context_id }
+    }
+}
+
+/// Self-describing sync-status response. `sync_state` is a coarse,
+/// stable string (`"idle"`, `"syncing"`, `"backingOff"`) so JSON clients
+/// don't need to track the node's internal enum. The remaining fields carry
+/// the detail behind the state — a non-zero `failure_count` with
+/// `last_error` set is the "stuck" signal.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SyncStatusResponse {
+    pub context_id: ContextId,
+    /// `true` once the context has a non-zero root hash, i.e. initial state
+    /// has been adopted and `execute` will no longer return `Uninitialized`.
+    pub is_initialized: bool,
+    /// Coarse sync phase: `"idle"`, `"syncing"`, or `"backingOff"`.
+    pub sync_state: String,
+    /// Estimated seconds until the next retry, when `sync_state` is
+    /// `"backingOff"`. `None` for other states.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_in_secs: Option<u64>,
+    /// Consecutive failed sync attempts (0 when healthy).
+    pub failure_count: u32,
+    /// Most recent sync error, if the last attempt failed. Carries the reason
+    /// behind a `"backingOff"` state (e.g. "No peers to sync with").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+impl SyncStatusResponse {
+    #[must_use]
+    pub const fn new(
+        context_id: ContextId,
+        is_initialized: bool,
+        sync_state: String,
+        retry_in_secs: Option<u64>,
+        failure_count: u32,
+        last_error: Option<String>,
+    ) -> Self {
+        Self {
+            context_id,
+            is_initialized,
+            sync_state,
+            retry_in_secs,
+            failure_count,
+            last_error,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Error)]
+#[serde(tag = "type", content = "data")]
+#[non_exhaustive]
+pub enum SyncStatusError {
+    #[error("context not found")]
+    ContextNotFound,
+}
+
 // -------------------------------------------- Validation Implementation --------------------------------------------
+
+impl Validate for SyncStatusRequest {
+    fn validate(&self) -> Vec<ValidationError> {
+        // `context_id` is a typed, fixed-size identifier — nothing to bound.
+        Vec::new()
+    }
+}
 
 impl Validate for ExecutionRequest {
     fn validate(&self) -> Vec<ValidationError> {

--- a/crates/server/src/jsonrpc.rs
+++ b/crates/server/src/jsonrpc.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::routing::{post, Router};
 use axum::{Extension, Json};
 use calimero_context_client::client::ContextClient;
+use calimero_node_primitives::client::NodeClient;
 use calimero_server_primitives::jsonrpc::{
     Request as PrimitiveRequest, RequestPayload, Response as PrimitiveResponse, ResponseBody,
     ResponseBodyError, ResponseBodyResult, ServerResponseError,
@@ -15,6 +16,7 @@ use uuid::Uuid;
 use crate::config::ServerConfig;
 
 mod execute;
+mod sync_status;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -32,11 +34,13 @@ impl JsonRpcConfig {
 
 pub(crate) struct ServiceState {
     ctx_client: ContextClient,
+    node_client: NodeClient,
 }
 
 pub(crate) fn service(
     config: &ServerConfig,
     ctx_client: ContextClient,
+    node_client: NodeClient,
 ) -> Option<(String, Router)> {
     // Check if JSON-RPC is configured and enabled
     let _jsonrpc_config = match &config.jsonrpc {
@@ -60,7 +64,10 @@ pub(crate) fn service(
         info!("JSON RPC server listening on {}/http{{{}}}", listen, path);
     }
 
-    let state = Arc::new(ServiceState { ctx_client });
+    let state = Arc::new(ServiceState {
+        ctx_client,
+        node_client,
+    });
     let handler = post(handle_request).layer(Extension(Arc::clone(&state)));
 
     let router = Router::new().route("/", handler);
@@ -142,6 +149,13 @@ async fn handle_request_inner(
                 }
 
                 result
+            }
+            RequestPayload::SyncStatus(status_request) => {
+                let span = tracing::Span::current();
+                span.record("context_id", field::display(&status_request.context_id));
+                span.record("method", "sync_status");
+
+                status_request.handle(state).await.to_res_body()
             }
         },
         Err(err) => {

--- a/crates/server/src/jsonrpc/sync_status.rs
+++ b/crates/server/src/jsonrpc/sync_status.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use calimero_node_primitives::SyncPhase;
+use calimero_server_primitives::jsonrpc::{SyncStatusError, SyncStatusRequest, SyncStatusResponse};
+use tracing::error;
+
+use super::{Request, RpcError, ServiceState};
+
+impl Request for SyncStatusRequest {
+    type Response = SyncStatusResponse;
+    type Error = SyncStatusError;
+
+    async fn handle(
+        self,
+        state: Arc<ServiceState>,
+    ) -> Result<Self::Response, RpcError<Self::Error>> {
+        let context_id = self.context_id;
+
+        // `is_initialized` is the authoritative "is the state here yet?" fact,
+        // read from the context's root hash. An all-zero root hash is the same
+        // condition that makes `execute` return `Uninitialized`. A missing
+        // context is a client error, not an internal one.
+        let Some(context) = state.ctx_client.get_context(&context_id)? else {
+            error!(%context_id, "sync_status requested for unknown context");
+            return Err(RpcError::MethodCallError(SyncStatusError::ContextNotFound));
+        };
+        let is_initialized = *context.root_hash != [0; 32];
+
+        // The sync run-loop's best-effort snapshot supplies the "why" when the
+        // context isn't initialized: syncing vs backing off vs nothing
+        // recorded. Absent snapshot (never dispatched, or already settled) maps
+        // to "idle".
+        let snapshot = state.node_client.sync_status(context_id).await?;
+
+        let (sync_state, retry_in_secs, failure_count, last_error) = match snapshot {
+            Some(snap) => {
+                let (state_str, retry) = match snap.phase {
+                    SyncPhase::Idle => ("idle", None),
+                    SyncPhase::Syncing => ("syncing", None),
+                    SyncPhase::BackingOff { retry_in_secs } => ("backingOff", Some(retry_in_secs)),
+                };
+                (
+                    state_str.to_owned(),
+                    retry,
+                    snap.failure_count,
+                    snap.last_error,
+                )
+            }
+            None => ("idle".to_owned(), None, 0, None),
+        };
+
+        Ok(SyncStatusResponse::new(
+            context_id,
+            is_initialized,
+            sync_state,
+            retry_in_secs,
+            failure_count,
+            last_error,
+        ))
+    }
+}

--- a/crates/server/src/jsonrpc/sync_status.rs
+++ b/crates/server/src/jsonrpc/sync_status.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use calimero_node_primitives::SyncPhase;
-use calimero_server_primitives::jsonrpc::{SyncStatusError, SyncStatusRequest, SyncStatusResponse};
-use tracing::error;
+use calimero_server_primitives::jsonrpc::{
+    SyncState, SyncStatusError, SyncStatusRequest, SyncStatusResponse,
+};
+use tracing::debug;
 
 use super::{Request, RpcError, ServiceState};
 
@@ -19,43 +21,101 @@ impl Request for SyncStatusRequest {
         // `is_initialized` is the authoritative "is the state here yet?" fact,
         // read from the context's root hash. An all-zero root hash is the same
         // condition that makes `execute` return `Uninitialized`. A missing
-        // context is a client error, not an internal one.
+        // context is an expected client error — log at debug so a caller can't
+        // flood error-level logs by probing arbitrary ids.
         let Some(context) = state.ctx_client.get_context(&context_id)? else {
-            error!(%context_id, "sync_status requested for unknown context");
+            debug!(%context_id, "sync_status requested for unknown context");
             return Err(RpcError::MethodCallError(SyncStatusError::ContextNotFound));
         };
         let is_initialized = *context.root_hash != [0; 32];
 
-        // The sync run-loop's best-effort snapshot supplies the "why" when the
-        // context isn't initialized: syncing vs backing off vs nothing
-        // recorded. Absent snapshot (never dispatched, or already settled) maps
-        // to "idle".
+        // The run-loop's advisory snapshot supplies the phase. The node's
+        // `SyncPhase` is blind to initialization, so resolve the ambiguous
+        // settled-but-no-state case here: an uninitialized context that the
+        // run-loop considers idle (including the benign no-peers / not-
+        // materialised outcome, which clears the in-flight marker without
+        // recording a failure, and the never-dispatched case) is waiting for a
+        // peer to sync from. `Syncing` / `BackingOff` are reported as-is
+        // regardless of initialization — an initialized context can still be
+        // catching up on later deltas.
         let snapshot = state.node_client.sync_status(context_id).await?;
 
-        let (sync_state, retry_in_secs, failure_count, last_error) = match snapshot {
-            Some(snap) => {
-                let (state_str, retry) = match snap.phase {
-                    SyncPhase::Idle => ("idle", None),
-                    SyncPhase::Syncing => ("syncing", None),
-                    SyncPhase::BackingOff { retry_in_secs } => ("backingOff", Some(retry_in_secs)),
-                };
-                (
-                    state_str.to_owned(),
-                    retry,
-                    snap.failure_count,
-                    snap.last_error,
-                )
-            }
-            None => ("idle".to_owned(), None, 0, None),
-        };
+        let sync_state = resolve_sync_state(snapshot.as_ref().map(|s| s.phase), is_initialized);
+        let (failure_count, last_error) = snapshot
+            .map(|s| (s.failure_count, s.last_error))
+            .unwrap_or((0, None));
 
         Ok(SyncStatusResponse::new(
             context_id,
             is_initialized,
             sync_state,
-            retry_in_secs,
             failure_count,
             last_error,
         ))
+    }
+}
+
+/// Resolve the wire-facing [`SyncState`] from the run-loop's advisory phase and
+/// the authoritative `is_initialized` flag.
+///
+/// `Syncing` and `BackingOff` are reported as-is — an initialized context can
+/// legitimately still be catching up on later deltas. The ambiguity is the
+/// settled-but-idle case: the node's `SyncPhase::Idle` (and the never-dispatched
+/// `None`) covers both a healthy initialized context *and* one that has no state
+/// yet and is simply waiting for a peer — including the benign no-peers /
+/// peer-not-materialised outcome, which clears the in-flight marker without
+/// recording a failure. `is_initialized` disambiguates the two.
+fn resolve_sync_state(phase: Option<SyncPhase>, is_initialized: bool) -> SyncState {
+    match phase {
+        Some(SyncPhase::Syncing) => SyncState::Syncing,
+        Some(SyncPhase::BackingOff { retry_in_secs }) => SyncState::BackingOff { retry_in_secs },
+        Some(SyncPhase::Idle) | None if is_initialized => SyncState::Idle,
+        Some(SyncPhase::Idle) | None => SyncState::WaitingForPeers,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_sync_state, SyncPhase, SyncState};
+
+    #[test]
+    fn uninitialized_and_idle_resolves_to_waiting_for_peers() {
+        // The bug this guards: a benign no-peers outcome leaves the node phase
+        // at Idle; without initialization context that would look "settled".
+        assert!(matches!(
+            resolve_sync_state(Some(SyncPhase::Idle), false),
+            SyncState::WaitingForPeers
+        ));
+    }
+
+    #[test]
+    fn uninitialized_and_never_dispatched_resolves_to_waiting_for_peers() {
+        assert!(matches!(
+            resolve_sync_state(None, false),
+            SyncState::WaitingForPeers
+        ));
+    }
+
+    #[test]
+    fn initialized_and_idle_resolves_to_idle() {
+        assert!(matches!(
+            resolve_sync_state(Some(SyncPhase::Idle), true),
+            SyncState::Idle
+        ));
+        assert!(matches!(resolve_sync_state(None, true), SyncState::Idle));
+    }
+
+    #[test]
+    fn syncing_and_backing_off_are_reported_regardless_of_initialization() {
+        for is_init in [false, true] {
+            assert!(matches!(
+                resolve_sync_state(Some(SyncPhase::Syncing), is_init),
+                SyncState::Syncing
+            ));
+            assert!(matches!(
+                resolve_sync_state(Some(SyncPhase::BackingOff { retry_in_secs: 8 }), is_init),
+                SyncState::BackingOff { retry_in_secs: 8 }
+            ));
+        }
     }
 }

--- a/crates/server/src/service_mounts.rs
+++ b/crates/server/src/service_mounts.rs
@@ -30,7 +30,8 @@ pub(crate) fn mount_runtime_services(
     let mut app = app;
     let mut service_count = 0usize;
 
-    if let Some((path, router)) = jsonrpc::service(config, ctx_client.clone()) {
+    if let Some((path, router)) = jsonrpc::service(config, ctx_client.clone(), node_client.clone())
+    {
         app = app.nest(&path, with_optional_auth(router, auth_service.clone()));
         service_count += 1;
     }


### PR DESCRIPTION
## What

Adds a `sync_status` JSON-RPC method so a client blocked on `Uninitialized` can tell **syncing** vs **waiting-for-peers** vs **stuck**, instead of guessing from one opaque error.

Closes the query-endpoint half of #2027 (Phase 1). WebSocket streaming + fine-grained page percent/ETA are deliberate follow-ups (see below).

## Why

A node that has joined a context but not yet adopted its initial state reports `root_hash == [0; 32]` and rejects execution with `ExecuteError::Uninitialized`:

```rust
// crates/context/src/handlers/execute/mod.rs
if !is_state_op && *context.meta.root_hash == [0; 32] {
    return ActorResponse::reply(Err(ExecuteError::Uninitialized));
}
```

That single error can't distinguish:

| Situation | Today | After |
|---|---|---|
| Snapshot streaming in | `Uninitialized` | `syncing` |
| Joined, no peer yet | `Uninitialized` | `backingOff` + `lastError: "No peers to sync with"` |
| Failed, retry pending | `Uninitialized` | `backingOff` + `retryInSecs` + `failureCount` |
| Initialized | works | `isInitialized: true, idle` |

The sync run-loop already tracks the answer (per-context `SyncState`: in-flight, `failure_count`, `last_error`, backoff) — but it lives on the run-loop's stack and the server layer can't reach it. This PR publishes a best-effort, lock-free snapshot of it and surfaces it over JSON-RPC.

## How

```
SessionTracker (run-loop)  --publishes-->  NodeState.sync_status  (Arc<DashMap>, lock-free)
                                                  │
JSON-RPC sync_status  →  NodeClient.sync_status() ┘  (round-trips via NodeManager actor)
                      →  merges is_initialized (root_hash) from ctx_client
```

- **node-primitives**: `SyncStatusSnapshot` / `SyncPhase` types.
- **NodeState**: a `sync_status` `DashMap` + run-loop publisher handle + out-of-band reader.
- **SessionTracker**: publish a derived snapshot after every `SyncState` transition (dispatch → `syncing`, success → `idle`, failure/wedge → `backingOff`). The two benign-failure early returns in `apply_result` are folded into an if/else chain so the snapshot also publishes on those paths.
- **NodeClient.sync_status** round-trips through `NodeManager` (the snapshot lives on node-crate-private `NodeState` the server can't name) via a new `NodeMessage::GetSyncStatus`, mirroring the existing `GetBlobBytes` oneshot pattern.
- **server**: `SyncStatusRequest`/`SyncStatusResponse` in server-primitives with a coarse, self-describing `sync_state` string; thread `node_client` into the JSON-RPC `ServiceState`; handler merges `is_initialized` from the context root hash.

### Example response

```json
{ "contextId": "Cx7…", "isInitialized": false, "syncState": "backingOff",
  "retryInSecs": 8, "failureCount": 1, "lastError": "No peers to sync with" }
```

## Scope / notes

- **Coarse phase only** (`idle`/`syncing`/`backingOff`). Snapshot-page percent, ETA, and the **WebSocket live subscription** from the issue's acceptance criteria are follow-ups that layer onto this snapshot **without changing the wire shape**.
- **Method-based, not the literal REST path** `GET /rpc/context/{id}/sync_status` from the issue — the server has no REST surface, everything is JSON-RPC. Implemented as a `sync_status` method on the existing `/jsonrpc` endpoint.
- The snapshot is **advisory** (published from the run-loop, read out-of-band, may be ~ms stale) — meant for UX, not control flow.

## Testing

- `cargo check --workspace --all-targets` — clean
- `cargo fmt --check` (workspace) — clean
- `cargo test -p calimero-node sync::session` — 44 passed (40 existing + 4 new: syncing / idle / backing-off / absent-context)
- Clippy on touched crates — no findings in changed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only observability path with advisory snapshots; no changes to sync control flow or execution authorization beyond clearer client-facing status.
> 
> **Overview**
> Adds a **`sync_status` JSON-RPC method** so clients blocked on `Uninitialized` can see whether a context is actively syncing, waiting for peers, or backing off after failures—instead of inferring from a single execute error.
> 
> The sync run-loop’s **`SessionTracker` now publishes** coarse `SyncPhase` snapshots (idle / syncing / backing off, plus `failure_count` and `last_error`) into a lock-free **`NodeState.sync_status` map** after every relevant transition, including benign no-peer / not-materialized outcomes (refactored so status is published on those paths too). **`NodeClient.sync_status`** reads via **`NodeMessage::GetSyncStatus`** through `NodeManager`.
> 
> The server handler merges **`is_initialized`** (non-zero root hash) with the advisory snapshot and maps to wire **`SyncState`**, notably turning uninitialized + idle/no snapshot into **`waitingForPeers`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e004f933df165d683fc5a8b9fe6b9de8f418fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->