### PR TITLE
feat(storage): SharedMember anchor — retroactive writer-set revocation for guarded collections

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1985,6 +1985,31 @@ pub(crate) fn sign_authorized_actions(
             }
         }
 
+        // SharedMember signs exactly like Shared: the placeholder presence is
+        // the signal, and the authorization decision (executor ∈ the anchor's
+        // writers) was already made in `save_raw` against the anchor's resolved
+        // set. A member carries no writer set, so there is nothing to log here
+        // beyond the anchor.
+        if let StorageType::SharedMember {
+            anchor,
+            signature_data: Some(sig_data),
+            ..
+        } = &mut metadata.storage_type
+        {
+            if sig_data.signature == [0; 64] {
+                sig_data.nonce = nonce;
+                let signature = identity_private_key.sign(&payload_for_signing)?;
+                sig_data.signature = signature.to_bytes();
+
+                debug!(
+                    action_id = ?action_id,
+                    anchor = %anchor,
+                    nonce = %nonce,
+                    "Signed shared-member action"
+                );
+            }
+        }
+
         if let StorageType::User {
             owner: _,
             signature_data: Some(_),
@@ -2087,6 +2112,10 @@ pub(crate) fn persist_signed_signatures(
                     ..
                 }
                 | StorageType::User {
+                    signature_data: Some(sig),
+                    ..
+                }
+                | StorageType::SharedMember {
                     signature_data: Some(sig),
                     ..
                 } if sig.signature != [0u8; 64] => true,

--- a/crates/node/primitives/src/sync/hash_comparison.rs
+++ b/crates/node/primitives/src/sync/hash_comparison.rs
@@ -453,7 +453,9 @@ impl LeafMetadata {
         use calimero_storage::entities::StorageType;
         let is_auth_type = matches!(
             authorization,
-            StorageType::Shared { .. } | StorageType::User { .. }
+            StorageType::Shared { .. }
+                | StorageType::User { .. }
+                | StorageType::SharedMember { .. }
         );
         if is_auth_type {
             self.authorization = Some(authorization);

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -673,6 +673,11 @@ impl ContextStorageApplier {
         delta: &CausalDelta<Vec<Action>>,
     ) -> Result<BTreeMap<Id, BTreeSet<PublicKey>>> {
         let mut shared_entities: BTreeSet<Id> = BTreeSet::new();
+        // (member entity id, its anchor id). A `SharedMember` carries no writer
+        // set of its own; it resolves the ANCHOR's writers and the result is
+        // keyed by the MEMBER id so `apply_action` finds it under the member's
+        // own `effective_writers` lookup.
+        let mut members: Vec<(Id, Id)> = Vec::new();
         for action in &delta.payload {
             let metadata = match action {
                 Action::Add { metadata, .. }
@@ -680,13 +685,19 @@ impl ContextStorageApplier {
                 | Action::DeleteRef { metadata, .. } => metadata,
                 Action::Compare { .. } => continue,
             };
-            if matches!(metadata.storage_type, StorageType::Shared { .. }) {
-                let _inserted = shared_entities.insert(action.id());
+            match metadata.storage_type {
+                StorageType::Shared { .. } => {
+                    let _inserted = shared_entities.insert(action.id());
+                }
+                StorageType::SharedMember { anchor, .. } => {
+                    members.push((action.id(), anchor));
+                }
+                StorageType::Public | StorageType::User { .. } | StorageType::Frozen => {}
             }
         }
 
         let mut out: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
-        if shared_entities.is_empty() {
+        if shared_entities.is_empty() && members.is_empty() {
             return Ok(out);
         }
 
@@ -720,6 +731,45 @@ impl ContextStorageApplier {
 
             if let Some(set) = resolved {
                 let _replaced = out.insert(entity_id, set);
+            }
+        }
+
+        // Members resolve from their anchor's rotation log at the same causal
+        // cut. Cache per anchor — one anchor commonly gates many members. When
+        // the anchor has no rotation log (never rotated), leave the member
+        // unset: `apply_action` then falls back to the anchor's settled local
+        // state (genesis writers), which is correct precisely because nothing
+        // has rotated. When the anchor is absent entirely, the fallback yields
+        // the empty set and verification fails closed (the member is retried
+        // once the anchor syncs).
+        let mut anchor_cache: BTreeMap<Id, Option<BTreeSet<PublicKey>>> = BTreeMap::new();
+        for (member_id, anchor) in members {
+            let resolved = match anchor_cache.get(&anchor) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let set = match load_rotation_log_direct(
+                        &self.context_client,
+                        self.context_id,
+                        anchor,
+                    ) {
+                        Ok(Some(log)) => {
+                            rotation_log_reader::writers_at(&log, &delta.parents, |a, b| {
+                                happens_before_in_topology(&topology_snapshot, a, b)
+                            })
+                        }
+                        Ok(None) => None,
+                        Err(e) => {
+                            return Err(eyre::eyre!(
+                                "rotation_log direct read for anchor {anchor:?} failed: {e}"
+                            ))
+                        }
+                    };
+                    let _cached = anchor_cache.insert(anchor, set.clone());
+                    set
+                }
+            };
+            if let Some(set) = resolved {
+                let _replaced = out.insert(member_id, set);
             }
         }
 

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -114,6 +114,13 @@ pub struct BatchAddResult {
 /// arrives (e.g. a forged anchor id).
 const MAX_ANCHOR_PENDING: usize = 256;
 
+/// Per-anchor cap on buffered orphan members. Bounds the blast radius of a
+/// single forged anchor id: without it, one bogus anchor with 256 distinct
+/// delta ids could exhaust the global buffer and starve buffering for every
+/// legitimate anchor. 32 comfortably covers a real cold-join burst for one
+/// domain while leaving global headroom for many anchors.
+const MAX_PENDING_PER_ANCHOR: usize = 32;
+
 /// In-memory buffer for **orphaned member deltas**: a delta carrying a
 /// `StorageType::SharedMember { anchor }` action that arrived before its
 /// `anchor` (the `Shared` wrapper entity / rotation log) had synced. Without
@@ -145,6 +152,15 @@ impl AnchorPendingBuffer {
             return Err(input);
         }
         if self.seen.len() >= MAX_ANCHOR_PENDING {
+            return Err(input);
+        }
+        // Per-anchor cap: a single (possibly forged) anchor id can't fill the
+        // global buffer and starve other anchors.
+        if self
+            .by_anchor
+            .get(&anchor)
+            .is_some_and(|q| q.len() >= MAX_PENDING_PER_ANCHOR)
+        {
             return Err(input);
         }
         let _inserted = self.seen.insert(input.delta.id);
@@ -3134,35 +3150,56 @@ mod anchor_pending_tests {
         assert_eq!(buf.len(), 1);
     }
 
+    // Distinct delta ids via the first two bytes (a single byte only gives 256
+    // values — exactly the global cap — leaving no room for an "extra").
+    fn id_for(n: usize) -> [u8; 32] {
+        let mut b = [0u8; 32];
+        b[0] = u8::try_from(n & 0xff).unwrap();
+        b[1] = u8::try_from((n >> 8) & 0xff).unwrap();
+        b
+    }
+
     #[test]
-    fn rejects_when_full_then_accepts_after_drain() {
-        // Distinct delta ids via the first two bytes (a single byte only gives
-        // 256 values — exactly the cap — leaving no room for the "extra").
-        let id_for = |n: usize| -> [u8; 32] {
-            let mut b = [0u8; 32];
-            b[0] = u8::try_from(n & 0xff).unwrap();
-            b[1] = u8::try_from((n >> 8) & 0xff).unwrap();
-            b
-        };
+    fn rejects_when_global_cap_reached_then_accepts_after_drain() {
+        // Spread across many anchors (each under the per-anchor cap) to reach
+        // the GLOBAL cap without tripping the per-anchor limit.
         let mut buf = AnchorPendingBuffer::default();
-        let a = anchor(0xA0);
         for n in 0..MAX_ANCHOR_PENDING {
             let mut inp = input(0);
             inp.delta.id = id_for(n);
+            let a = anchor(u8::try_from(n / MAX_PENDING_PER_ANCHOR).unwrap());
             assert!(buf.buffer(a, inp).is_ok());
         }
         assert_eq!(buf.len(), MAX_ANCHOR_PENDING);
-        // Full: a further distinct delta is handed back so the caller falls
-        // through to the normal fail-closed + re-fetch path.
+        // Global cap reached: a further distinct delta (fresh anchor) is handed
+        // back so the caller falls through to fail-closed + re-fetch.
         let mut extra = input(0);
         extra.delta.id = id_for(MAX_ANCHOR_PENDING);
-        assert!(buf.buffer(a, extra).is_err());
-        // Draining frees the whole anchor's capacity.
-        let _ = buf.take_for(&a);
-        assert_eq!(buf.len(), 0);
+        assert!(buf.buffer(anchor(0xFE), extra).is_err());
+        // Draining one anchor frees its slots; a new delta is accepted again.
+        let _ = buf.take_for(&anchor(0));
         let mut extra2 = input(0);
         extra2.delta.id = id_for(MAX_ANCHOR_PENDING);
-        assert!(buf.buffer(a, extra2).is_ok());
+        assert!(buf.buffer(anchor(0xFE), extra2).is_ok());
+    }
+
+    #[test]
+    fn per_anchor_cap_limits_one_anchor_without_starving_others() {
+        let mut buf = AnchorPendingBuffer::default();
+        let hot = anchor(0xA0);
+        for n in 0..MAX_PENDING_PER_ANCHOR {
+            let mut inp = input(0);
+            inp.delta.id = id_for(n);
+            assert!(buf.buffer(hot, inp).is_ok());
+        }
+        // One more under the SAME anchor is rejected (per-anchor cap)...
+        let mut over = input(0);
+        over.delta.id = id_for(MAX_PENDING_PER_ANCHOR);
+        assert!(buf.buffer(hot, over).is_err());
+        // ...but a different anchor is unaffected (no global starvation).
+        let mut other = input(0);
+        other.delta.id = id_for(MAX_PENDING_PER_ANCHOR + 1);
+        assert!(buf.buffer(anchor(0xB0), other).is_ok());
     }
 
     #[test]

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -9,7 +9,7 @@
 //! This ensures that all nodes converge to the same state regardless of the
 //! order in which they receive concurrent deltas.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -106,6 +106,67 @@ pub struct BatchAddResult {
     /// inputs' `applied: true` records and follow the same restart-replay
     /// safety net as a single `add_delta`'s primary.
     pub forwarded_events: Vec<([u8; 32], Vec<u8>)>,
+}
+
+/// Max orphaned member deltas held across all anchors before the buffer stops
+/// accepting new ones (and they fall back to the DAG / HashComparison re-fetch
+/// path). Bounds the memory a peer can pin by sending members whose anchor never
+/// arrives (e.g. a forged anchor id).
+const MAX_ANCHOR_PENDING: usize = 256;
+
+/// In-memory buffer for **orphaned member deltas**: a delta carrying a
+/// `StorageType::SharedMember { anchor }` action that arrived before its
+/// `anchor` (the `Shared` wrapper entity / rotation log) had synced. Without
+/// the anchor the member's writers can't be resolved, so applying it now would
+/// fail closed. Rather than drop it and wait for a HashComparison re-fetch, we
+/// hold it here keyed by the missing anchor id and re-inject it the moment that
+/// anchor applies.
+///
+/// This is a pure **liveness** optimization layered on the already-correct
+/// fail-closed path: anything not buffered (or evicted on overflow, or lost on
+/// restart since this is in-memory) still converges via the re-fetch fallback.
+///
+/// Self-contained and lock-free so it can be unit-tested directly; the
+/// `DeltaStore` wraps it in an `RwLock`.
+#[derive(Debug, Default)]
+struct AnchorPendingBuffer {
+    /// anchor id → FIFO queue of deltas waiting on it.
+    by_anchor: HashMap<Id, VecDeque<BatchDeltaInput>>,
+    /// delta ids currently buffered, for O(1) dedup across anchors.
+    seen: HashSet<[u8; 32]>,
+}
+
+impl AnchorPendingBuffer {
+    /// Buffer `input` under `anchor`. Returns `Ok(())` if buffered; returns
+    /// `Err(input)` (handing ownership back) if it was already buffered or the
+    /// global cap is reached, so the caller can fall back to the normal path.
+    fn buffer(&mut self, anchor: Id, input: BatchDeltaInput) -> Result<(), BatchDeltaInput> {
+        if self.seen.contains(&input.delta.id) {
+            return Err(input);
+        }
+        if self.seen.len() >= MAX_ANCHOR_PENDING {
+            return Err(input);
+        }
+        let _inserted = self.seen.insert(input.delta.id);
+        self.by_anchor.entry(anchor).or_default().push_back(input);
+        Ok(())
+    }
+
+    /// Remove and return every delta waiting on `anchor` (FIFO order).
+    fn take_for(&mut self, anchor: &Id) -> Vec<BatchDeltaInput> {
+        let Some(queue) = self.by_anchor.remove(anchor) else {
+            return Vec::new();
+        };
+        for input in &queue {
+            let _removed = self.seen.remove(&input.delta.id);
+        }
+        queue.into_iter().collect()
+    }
+
+    /// Total buffered deltas across all anchors.
+    fn len(&self) -> usize {
+        self.seen.len()
+    }
 }
 
 /// Result of `load_persisted_deltas`.
@@ -867,6 +928,31 @@ fn load_rotation_log_direct(
     Ok(Some(log))
 }
 
+/// Whether the anchor entity `anchor` has synced to this node, by a direct
+/// datastore read (no WASM env). True if either its rotation log
+/// (`StorageKey::RotationLog`) or its index entry (`StorageKey::Index`, written
+/// the moment its `Shared` action applies) exists. Mirrors the two sources
+/// `Interface::resolve_anchor_writers` consults — so "present" here means the
+/// member's writers WILL resolve at apply time. A presence check only (no
+/// decode): we just need to know the anchor arrived.
+fn anchor_present_direct(
+    context_client: &ContextClient,
+    context_id: ContextId,
+    anchor: Id,
+) -> bool {
+    let handle = context_client.datastore_handle();
+    for key_bytes in [
+        StorageKey::RotationLog(anchor).to_bytes(),
+        StorageKey::Index(anchor).to_bytes(),
+    ] {
+        let state_key = calimero_store::key::ContextState::new(context_id, key_bytes);
+        if matches!(handle.get(&state_key), Ok(Some(_))) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Reverse-BFS reachability over a `delta_id → parents` mirror of the
 /// DAG: returns true iff `a` is in the transitive ancestry of `b`. Pure
 /// over the snapshot — `happens_before(x, x) == false` (strict ancestry).
@@ -910,6 +996,11 @@ pub struct DeltaStore {
     /// Maps delta_id -> expected_root_hash for deterministic selection
     /// when multiple DAG heads exist (concurrent branches)
     head_root_hashes: Arc<RwLock<HashMap<[u8; 32], [u8; 32]>>>,
+
+    /// Orphaned member deltas (a `SharedMember` whose `anchor` hasn't synced
+    /// yet), keyed by the missing anchor id. Re-injected when that anchor
+    /// applies. Liveness only — see [`AnchorPendingBuffer`].
+    anchor_pending: Arc<RwLock<AnchorPendingBuffer>>,
 }
 
 /// Outcome of [`DeltaStore::persist_cascaded_deltas_and_update_heads`].
@@ -958,6 +1049,7 @@ impl DeltaStore {
             dag: Arc::new(RwLock::new(CoreDagStore::new(root))),
             applier,
             head_root_hashes: Arc::new(RwLock::new(HashMap::new())),
+            anchor_pending: Arc::new(RwLock::new(AnchorPendingBuffer::default())),
         }
     }
 
@@ -1661,6 +1753,47 @@ impl DeltaStore {
     }
 
     /// Internal add_delta implementation
+    /// If this delta writes a `SharedMember` whose anchor has not synced to
+    /// this node, return that anchor id (the delta is an "orphan" — its
+    /// member's writers can't be resolved yet). Returns `None` when every
+    /// member's anchor is present, or is being created by a `Shared` action in
+    /// THIS same delta (then anchor + members apply together, so it isn't an
+    /// orphan). First missing anchor only: a delta orphaned on several anchors
+    /// re-checks the rest after the first one drains.
+    fn first_missing_anchor(&self, delta: &CausalDelta<Vec<Action>>) -> Option<Id> {
+        // Anchors created/updated in THIS delta.
+        let mut shared_here: HashSet<Id> = HashSet::new();
+        for action in &delta.payload {
+            if let Action::Add { metadata, .. } | Action::Update { metadata, .. } = action {
+                if matches!(metadata.storage_type, StorageType::Shared { .. }) {
+                    let _inserted = shared_here.insert(action.id());
+                }
+            }
+        }
+        for action in &delta.payload {
+            let anchor = match action {
+                Action::Add { metadata, .. }
+                | Action::Update { metadata, .. }
+                | Action::DeleteRef { metadata, .. } => match metadata.storage_type {
+                    StorageType::SharedMember { anchor, .. } => anchor,
+                    _ => continue,
+                },
+                Action::Compare { .. } => continue,
+            };
+            if shared_here.contains(&anchor) {
+                continue;
+            }
+            if !anchor_present_direct(
+                &self.applier.context_client,
+                self.applier.context_id,
+                anchor,
+            ) {
+                return Some(anchor);
+            }
+        }
+        None
+    }
+
     async fn add_delta_internal(
         &self,
         delta: CausalDelta<Vec<Action>>,
@@ -1669,6 +1802,55 @@ impl DeltaStore {
         governance_position_blob: Option<Vec<u8>>,
         delta_signature: Option<[u8; 64]>,
     ) -> Result<AddDeltaResult> {
+        // Orphan-member buffering (liveness): if this delta writes a
+        // `SharedMember` whose anchor hasn't synced, the member's writers can't
+        // be resolved and applying now would fail closed (then drop, awaiting a
+        // HashComparison re-fetch). Instead hold it keyed by the missing anchor
+        // and re-inject the moment that anchor applies (drain at the end of this
+        // fn). Done BEFORE any persist/DAG work so a buffered delta leaves no
+        // half-state. Best-effort: if it's already buffered or the buffer is
+        // full, `buffer` hands ownership back and we fall through to the normal
+        // (fail-closed + re-fetch) path, which still converges.
+        let (delta, events, author_id, governance_position_blob, delta_signature) =
+            match self.first_missing_anchor(&delta) {
+                Some(anchor) => {
+                    let input = BatchDeltaInput {
+                        delta,
+                        events,
+                        author_id,
+                        governance_position_blob,
+                        delta_signature,
+                    };
+                    match self.anchor_pending.write().await.buffer(anchor, input) {
+                        Ok(()) => {
+                            debug!(
+                                context_id = %self.applier.context_id,
+                                %anchor,
+                                "Buffered orphan member delta awaiting its anchor"
+                            );
+                            return Ok(AddDeltaResult {
+                                applied: false,
+                                cascaded_events: Vec::new(),
+                            });
+                        }
+                        Err(returned) => (
+                            returned.delta,
+                            returned.events,
+                            returned.author_id,
+                            returned.governance_position_blob,
+                            returned.delta_signature,
+                        ),
+                    }
+                }
+                None => (
+                    delta,
+                    events,
+                    author_id,
+                    governance_position_blob,
+                    delta_signature,
+                ),
+            };
+
         let delta_id = delta.id;
         let expected_root_hash = delta.expected_root_hash;
         let parents = delta.parents.clone();
@@ -1917,6 +2099,61 @@ impl DeltaStore {
             crate::node_metrics::observe_delta_cascade(cascade_size);
             for _ in 0..cascade_size {
                 crate::node_metrics::record_delta_outcome("cascaded");
+            }
+        }
+
+        // Drain orphan members whose anchor just applied (liveness). If this
+        // delta applied any `Shared` anchor, its writers/rotation-log are now on
+        // disk (the WASM apply committed before `dag.add_delta` returned), so
+        // members that were buffered awaiting it will now verify — re-inject
+        // them. Recursive (a re-injected member could itself unblock a nested
+        // anchor); bounded by the buffer size + per-delta dedup. Best-effort:
+        // a re-injected delta that still can't apply re-buffers or falls back
+        // to the HashComparison re-fetch path. The DAG lock was already
+        // released above, so the recursive call re-acquires it cleanly.
+        if result {
+            let anchors_applied: Vec<Id> = actions_for_db
+                .iter()
+                .filter_map(|a| match a {
+                    Action::Add { metadata, .. } | Action::Update { metadata, .. }
+                        if matches!(metadata.storage_type, StorageType::Shared { .. }) =>
+                    {
+                        Some(a.id())
+                    }
+                    _ => None,
+                })
+                .collect();
+            if !anchors_applied.is_empty() {
+                let to_reinject: Vec<BatchDeltaInput> = {
+                    let mut buf = self.anchor_pending.write().await;
+                    let mut out = Vec::new();
+                    for anchor in anchors_applied {
+                        out.append(&mut buf.take_for(&anchor));
+                    }
+                    out
+                };
+                for input in to_reinject {
+                    debug!(
+                        context_id = %self.applier.context_id,
+                        delta_id = ?input.delta.id,
+                        "Re-injecting buffered orphan member delta (anchor applied)"
+                    );
+                    if let Err(e) = Box::pin(self.add_delta_internal(
+                        input.delta,
+                        input.events,
+                        input.author_id,
+                        input.governance_position_blob,
+                        input.delta_signature,
+                    ))
+                    .await
+                    {
+                        debug!(
+                            context_id = %self.applier.context_id,
+                            ?e,
+                            "Re-injected orphan member delta failed; relying on re-fetch"
+                        );
+                    }
+                }
             }
         }
 
@@ -2839,6 +3076,105 @@ impl DeltaStore {
         );
 
         added_count
+    }
+}
+
+#[cfg(test)]
+mod anchor_pending_tests {
+    //! Unit tests for the orphan-member buffer in isolation (no DAG / WASM):
+    //! dedup, FIFO drain, the global cap, and re-buffer-after-drain.
+
+    use super::*;
+
+    fn anchor(b: u8) -> Id {
+        Id::new([b; 32])
+    }
+
+    fn input(id_byte: u8) -> BatchDeltaInput {
+        BatchDeltaInput {
+            delta: CausalDelta {
+                id: [id_byte; 32],
+                parents: vec![],
+                payload: vec![],
+                hlc: calimero_storage::logical_clock::HybridTimestamp::default(),
+                expected_root_hash: [0u8; 32],
+                kind: calimero_dag::DeltaKind::Regular,
+            },
+            events: None,
+            author_id: None,
+            governance_position_blob: None,
+            delta_signature: None,
+        }
+    }
+
+    #[test]
+    fn buffer_and_drain_fifo() {
+        let mut buf = AnchorPendingBuffer::default();
+        let a = anchor(0xA0);
+        assert!(buf.buffer(a, input(1)).is_ok());
+        assert!(buf.buffer(a, input(2)).is_ok());
+        assert_eq!(buf.len(), 2);
+
+        let drained = buf.take_for(&a);
+        let ids: Vec<u8> = drained.iter().map(|d| d.delta.id[0]).collect();
+        assert_eq!(ids, vec![1, 2], "drain must preserve FIFO order");
+        assert_eq!(buf.len(), 0, "drain empties the buffer");
+        assert!(buf.take_for(&a).is_empty(), "second drain is empty");
+    }
+
+    #[test]
+    fn dedup_same_delta_id() {
+        let mut buf = AnchorPendingBuffer::default();
+        let a = anchor(0xA0);
+        assert!(buf.buffer(a, input(1)).is_ok());
+        // Same delta id under the same anchor — rejected (handed back).
+        assert!(buf.buffer(a, input(1)).is_err());
+        // Same delta id under a DIFFERENT anchor — still rejected (global dedup).
+        assert!(buf.buffer(anchor(0xB0), input(1)).is_err());
+        assert_eq!(buf.len(), 1);
+    }
+
+    #[test]
+    fn rejects_when_full_then_accepts_after_drain() {
+        // Distinct delta ids via the first two bytes (a single byte only gives
+        // 256 values — exactly the cap — leaving no room for the "extra").
+        let id_for = |n: usize| -> [u8; 32] {
+            let mut b = [0u8; 32];
+            b[0] = u8::try_from(n & 0xff).unwrap();
+            b[1] = u8::try_from((n >> 8) & 0xff).unwrap();
+            b
+        };
+        let mut buf = AnchorPendingBuffer::default();
+        let a = anchor(0xA0);
+        for n in 0..MAX_ANCHOR_PENDING {
+            let mut inp = input(0);
+            inp.delta.id = id_for(n);
+            assert!(buf.buffer(a, inp).is_ok());
+        }
+        assert_eq!(buf.len(), MAX_ANCHOR_PENDING);
+        // Full: a further distinct delta is handed back so the caller falls
+        // through to the normal fail-closed + re-fetch path.
+        let mut extra = input(0);
+        extra.delta.id = id_for(MAX_ANCHOR_PENDING);
+        assert!(buf.buffer(a, extra).is_err());
+        // Draining frees the whole anchor's capacity.
+        let _ = buf.take_for(&a);
+        assert_eq!(buf.len(), 0);
+        let mut extra2 = input(0);
+        extra2.delta.id = id_for(MAX_ANCHOR_PENDING);
+        assert!(buf.buffer(a, extra2).is_ok());
+    }
+
+    #[test]
+    fn drain_removes_from_dedup_set() {
+        let mut buf = AnchorPendingBuffer::default();
+        let a = anchor(0xA0);
+        assert!(buf.buffer(a, input(1)).is_ok());
+        let _ = buf.take_for(&a);
+        // After draining, the same delta id can be buffered again (e.g. a
+        // re-injected delta that orphaned on a different anchor).
+        assert!(buf.buffer(anchor(0xB0), input(1)).is_ok());
+        assert_eq!(buf.len(), 1);
     }
 }
 

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -78,9 +78,9 @@ pub fn wire_authorization_for(
 ) -> Option<calimero_storage::entities::StorageType> {
     match &metadata.storage_type {
         StorageType::Public | StorageType::Frozen => None,
-        StorageType::Shared { .. } | StorageType::User { .. } => {
-            Some(metadata.storage_type.clone())
-        }
+        StorageType::Shared { .. }
+        | StorageType::User { .. }
+        | StorageType::SharedMember { .. } => Some(metadata.storage_type.clone()),
     }
 }
 
@@ -101,7 +101,8 @@ fn extract_author_from_leaf_authorization(
 ) -> Option<PublicKey> {
     match authorization? {
         StorageType::User { owner, .. } => Some(*owner),
-        StorageType::Shared { signature_data, .. } => {
+        StorageType::Shared { signature_data, .. }
+        | StorageType::SharedMember { signature_data, .. } => {
             signature_data.as_ref().and_then(|sd| sd.signer)
         }
         StorageType::Public | StorageType::Frozen => None,

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -1,6 +1,6 @@
 //! Snapshot sync protocol for full state bootstrap.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use borsh::BorshDeserialize;
 use calimero_crypto::Nonce;
@@ -468,6 +468,21 @@ impl SyncManager {
         let mut total_applied = 0;
         let mut resume_cursor: Option<Vec<u8>> = None;
 
+        // `SharedMember` entities are verified in a SECOND pass, after every
+        // page has been applied. A member carries no inline writer set — its
+        // writers live at its anchor (a `Shared` wrapper) — and the snapshot
+        // apply path runs OUTSIDE the WASM `RUNTIME_ENV`, so the storage-layer
+        // `resolve_anchor_writers` (which reads via `MainStorage`) can't see the
+        // anchor here even once persisted; the anchor may also arrive in a later
+        // page. So we collect each verified anchor's writer set as it applies
+        // (`anchor_writers`), defer members (`deferred_members`), and verify the
+        // members against that authenticated map once the stream completes. A
+        // member still only persists after its writers are authenticated (the
+        // anchor's own record is signature-verified in pass 1).
+        let mut anchor_writers: HashMap<Id, BTreeSet<calimero_primitives::identity::PublicKey>> =
+            HashMap::new();
+        let mut deferred_members: Vec<(Id, Vec<u8>, Vec<u8>)> = Vec::new();
+
         loop {
             let msg = StreamMessage::Init {
                 context_id,
@@ -565,6 +580,24 @@ impl SyncManager {
                                             }
                                         };
                                     let id_obj = Id::new(*id);
+
+                                    // SharedMember: defer to pass 2. Its writers
+                                    // resolve from its anchor, which may not be
+                                    // applied yet (later page) and isn't readable
+                                    // via MainStorage here anyway. Hold the raw
+                                    // blobs; pass 2 verifies + persists.
+                                    if matches!(
+                                        index_entity.metadata.storage_type,
+                                        calimero_storage::entities::StorageType::SharedMember { .. }
+                                    ) {
+                                        deferred_members.push((
+                                            id_obj,
+                                            entry.clone(),
+                                            index.clone(),
+                                        ));
+                                        continue;
+                                    }
+
                                     if let Err(e) =
                                         Interface::<MainStorage>::verify_snapshot_entity_signature(
                                             id_obj,
@@ -611,6 +644,18 @@ impl SyncManager {
                                     let _ = received_keys
                                         .insert(StorageKey::RotationLog(id_obj).to_bytes());
                                     applied += 1;
+
+                                    // Record this verified anchor's writer set so
+                                    // pass 2 can authenticate members against it
+                                    // (the snapshot path can't use
+                                    // `resolve_anchor_writers` — no RUNTIME_ENV).
+                                    if let calimero_storage::entities::StorageType::Shared {
+                                        writers,
+                                        ..
+                                    } = &index_entity.metadata.storage_type
+                                    {
+                                        let _ = anchor_writers.insert(id_obj, writers.clone());
+                                    }
                                 }
                                 SnapshotRecord::Auxiliary { kind, id, .. } => {
                                     // `Auxiliary` is the channel for
@@ -698,6 +743,93 @@ impl SyncManager {
                             // Check if there are more pages to fetch
                             match cursor {
                                 None => {
+                                    // Pass 2: every anchor is now applied, so
+                                    // verify + persist the deferred SharedMember
+                                    // entities against their anchor's collected
+                                    // (and signature-verified) writer set. A
+                                    // member whose anchor never appeared, or
+                                    // whose signature doesn't verify, is dropped
+                                    // — same fail-closed semantics as pass 1.
+                                    if !deferred_members.is_empty() {
+                                        let mut handle = self.context_client.datastore_handle();
+                                        for (id_obj, entry, index) in deferred_members.drain(..) {
+                                            let metadata = match borsh::from_slice::<
+                                                calimero_storage::index::EntityIndex,
+                                            >(
+                                                &index
+                                            ) {
+                                                Ok(idx) => idx.metadata,
+                                                Err(e) => {
+                                                    warn!(
+                                                        %context_id,
+                                                        id = ?id_obj.as_bytes(),
+                                                        error = ?e,
+                                                        "snapshot deferred SharedMember: index \
+                                                         blob failed to deserialize — dropping"
+                                                    );
+                                                    continue;
+                                                }
+                                            };
+                                            let anchor = match &metadata.storage_type {
+                                                calimero_storage::entities::StorageType::SharedMember {
+                                                    anchor,
+                                                    ..
+                                                } => *anchor,
+                                                // A deferred record is always a
+                                                // member; defensive only.
+                                                _ => continue,
+                                            };
+                                            let Some(writers) = anchor_writers.get(&anchor) else {
+                                                warn!(
+                                                    %context_id,
+                                                    id = ?id_obj.as_bytes(),
+                                                    anchor = ?anchor.as_bytes(),
+                                                    "snapshot deferred SharedMember: anchor not \
+                                                     present in snapshot — dropping (member's \
+                                                     writers unresolvable)"
+                                                );
+                                                continue;
+                                            };
+                                            if let Err(e) =
+                                                Interface::<MainStorage>::verify_snapshot_member_signature(
+                                                    id_obj, &entry, &metadata, writers,
+                                                )
+                                            {
+                                                warn!(
+                                                    %context_id,
+                                                    id = ?id_obj.as_bytes(),
+                                                    error = ?e,
+                                                    "snapshot deferred SharedMember: signature \
+                                                     verification failed — dropping"
+                                                );
+                                                continue;
+                                            }
+                                            let entry_state_key =
+                                                StorageKey::Entry(id_obj).to_bytes();
+                                            let index_state_key =
+                                                StorageKey::Index(id_obj).to_bytes();
+                                            let entry_key =
+                                                ContextStateKey::new(context_id, entry_state_key);
+                                            let index_key =
+                                                ContextStateKey::new(context_id, index_state_key);
+                                            let entry_slice: Slice<'_> = entry.into();
+                                            let index_slice: Slice<'_> = index.into();
+                                            handle.put(
+                                                &entry_key,
+                                                &ContextStateValue::from(entry_slice),
+                                            )?;
+                                            handle.put(
+                                                &index_key,
+                                                &ContextStateValue::from(index_slice),
+                                            )?;
+                                            let _ = received_keys.insert(entry_state_key);
+                                            let _ = received_keys.insert(index_state_key);
+                                            let _ = received_keys
+                                                .insert(StorageKey::RotationLog(id_obj).to_bytes());
+                                            total_applied += 1;
+                                        }
+                                    }
+
                                     // All pages received - cleanup stale keys
                                     self.cleanup_stale_keys(
                                         context_id,

--- a/crates/storage/src/action.rs
+++ b/crates/storage/src/action.rs
@@ -302,6 +302,30 @@ fn hash_authorization_for_payload(hasher: &mut Sha256, metadata: &Metadata) {
                 hasher.update([0u8]);
             }
         }
+        StorageType::SharedMember {
+            anchor,
+            signature_data,
+        } => {
+            hasher.update([4u8]); // type tag (distinct from Shared's [3u8])
+                                  // The member commits to its anchor id, not a
+                                  // writer set — the writers live at the anchor
+                                  // and never ride the member's bytes, so the
+                                  // member's hash is stable across rotations.
+            hasher.update(anchor.as_bytes());
+            // sig-data presence tag — mirrors the Shared arm.
+            if let Some(sig_data) = signature_data.as_ref() {
+                hasher.update([1u8]);
+                hasher.update(sig_data.nonce.to_le_bytes());
+                if let Some(signer_hint) = sig_data.signer {
+                    hasher.update([1u8]); // hint-present tag
+                    hasher.update(signer_hint.as_ref() as &[u8; 32]);
+                } else {
+                    hasher.update([0u8]); // hint-absent tag
+                }
+            } else {
+                hasher.update([0u8]);
+            }
+        }
     }
 }
 

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -74,14 +74,18 @@ const VALUE_KEY: &[u8] = b"__calimero_shared_value__";
 
 /// Group-writable storage with an authenticated, mutable writer set.
 ///
-/// A handle over a [`Collection`] holding the value as one `Shared`-stamped
-/// child entry. Borsh = the inner collection's `Element` (a reference) plus the
-/// monotonic `frozen` flag; the value body never rides root state.
+/// A handle over a [`Collection`]: the wrapper entity is the `Shared` **anchor**
+/// that owns the writer set + rotation log, and the value is held as one
+/// `SharedMember`-stamped child entry pointing back at that anchor. Borsh = the
+/// inner collection's `Element` (a reference) plus the monotonic `frozen` flag;
+/// the value body never rides root state.
 ///
 /// When `T` is a **collection** (`UnorderedMap`, `UnorderedSet`, …), in-place
 /// edits MUST go through [`get_mut`](SharedStorage::get_mut): it re-establishes
-/// the `Shared{writers}` domain on the collection element so every entry
-/// inserted through it is guarded at merge.
+/// the `SharedMember{anchor}` domain on the collection element so every entry
+/// inserted through it is guarded at merge. Members carry no writer set — they
+/// resolve the anchor's writers — so rotating the anchor retroactively revokes
+/// the whole subtree without re-stamping any entry.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct SharedStorage<
     T: BorshSerialize + BorshDeserialize + Mergeable,
@@ -171,16 +175,22 @@ where
     #[expect(clippy::expect_used, reason = "fatal error if it happens")]
     fn from_inner(
         mut inner: Collection<T, MainStorage>,
-        writers: BTreeSet<PublicKey>,
+        _writers: BTreeSet<PublicKey>,
         frozen: bool,
     ) -> Self {
-        let value_id = compute_id(inner.id(), VALUE_KEY);
+        // The wrapper entity is the `Shared` anchor (stamped by `new_shared`
+        // with `writers`); the value entry — and, when `T` is a collection,
+        // everything beneath it — is a `SharedMember` pointing back at the
+        // wrapper. The member carries no writer set; it resolves the anchor's
+        // writers at verify time.
+        let anchor = inner.id();
+        let value_id = compute_id(anchor, VALUE_KEY);
         let value = inner
             .insert_with_storage_type(
                 Some(value_id),
                 T::default(),
-                StorageType::Shared {
-                    writers,
+                StorageType::SharedMember {
+                    anchor,
                     signature_data: None,
                 },
             )
@@ -248,15 +258,17 @@ where
         let _saved = <Interface<MainStorage>>::save(&mut self.inner)
             .expect("failed to persist relocated SharedStorage wrapper");
 
-        // Re-write the value entry under the new wrapper id (always).
-        let new_value_id = compute_id(self.inner.id(), VALUE_KEY);
+        // Re-write the value entry under the new wrapper id (always), stamped as
+        // a member anchored to the new wrapper id.
+        let new_anchor = self.inner.id();
+        let new_value_id = compute_id(new_anchor, VALUE_KEY);
         let value = self
             .inner
             .insert_with_storage_type(
                 Some(new_value_id),
                 carried_value,
-                StorageType::Shared {
-                    writers,
+                StorageType::SharedMember {
+                    anchor: new_anchor,
                     signature_data: None,
                 },
             )
@@ -312,23 +324,29 @@ where
     /// Mutable access to a collection value (`UnorderedMap`, `UnorderedSet`, …)
     /// for in-place editing.
     ///
-    /// Re-establishes the writer domain on the collection's element before
+    /// Re-establishes the member domain on the collection's element before
     /// handing out the reference, so every entry inserted through it inherits
-    /// `Shared{writers}` and is guarded at merge — including after a reload.
+    /// `SharedMember{anchor=wrapper}` and is guarded at merge — including after a
+    /// reload. The entries carry no writer set; they resolve the anchor's
+    /// writers at verify time, so a rotation revokes the whole subtree at once.
     /// Only collections (which implement [`Data`]) get this; a scalar value is
     /// edited via [`insert`](SharedStorage::insert) instead.
     ///
     /// # Errors
     /// Currently infallible; the `Result` is preserved for forward compatibility.
     pub fn get_mut(&mut self) -> Result<&mut T, StoreError> {
-        let writers = self.current_writers();
+        let anchor = self.inner.id();
         let value = self.load_value();
+        // Stamp the value-collection element as a member anchored to the
+        // wrapper. `Collection::insert` clones this element's `storage_type`
+        // onto every entry, so all entries (at any depth) inherit the SAME
+        // anchor — a flat domain whose writers live once, at the wrapper.
         let already_current = matches!(
             &value.element().metadata.storage_type,
-            StorageType::Shared { writers: w, .. } if w == &writers
+            StorageType::SharedMember { anchor: a, .. } if *a == anchor
         );
         if !already_current {
-            value.element_mut().set_shared_domain(writers);
+            value.element_mut().set_shared_member_domain(anchor);
         }
         Ok(value)
     }
@@ -455,21 +473,19 @@ where
         let old = self.inner.get(self.value_id())?.unwrap_or_default();
 
         let value_id = self.value_id();
-        let shared = StorageType::Shared {
-            writers,
+        // The value entry is a member anchored to the wrapper; it carries no
+        // writer set, so there is nothing to keep consistent with a rotation —
+        // the anchor's rotation log is the single source. (This is why the
+        // old value-entry `set_storage_type` writer-patch is gone: a member's
+        // `update_signature_in_place` matches on the anchor, which never
+        // changes on rotation.)
+        let member = StorageType::SharedMember {
+            anchor: self.inner.id(),
             signature_data: None,
         };
         let new = self
             .inner
-            .insert_with_storage_type(Some(value_id), value, shared.clone())?;
-        // Track the current writer set on the value entry's own index. After a
-        // rotation this node received, the value entry's index still carries the
-        // pre-rotation set (apply does not patch a child's own `storage_type`);
-        // without this, the runtime's post-execution `update_signature_in_place`
-        // would see a writer-set mismatch (the just-signed write claims the new
-        // set) and abort the whole transaction. Hash-neutral; no-ops when
-        // unchanged.
-        let _ignored = <Index<S>>::set_storage_type(value_id, shared);
+            .insert_with_storage_type(Some(value_id), value, member)?;
         *self.value.borrow_mut() = Some(new);
         Ok(Some(old))
     }
@@ -521,52 +537,21 @@ where
             .set_shared_domain(new_writers.clone());
         let _saved = <Interface<S>>::save(&mut self.inner)?;
 
-        // Re-stamp the single value entry too. The value lives in its own
-        // entity, verified at merge against *its* writer set; without
-        // re-stamping, a writer added by this rotation could never write the
-        // value (the entry would stay guarded by the pre-rotation set).
-        // Re-stamping emits a signed `Update` (data unchanged → hash unchanged,
-        // no divergence) so the receiver appends the new set to the value
-        // entry's own rotation log, and the new writer's later writes verify.
-        // This is the single-child analogue of the per-collection
-        // anchor-inheritance that retroactive collection revocation will
-        // generalise.
-        //
-        // The value entry is created eagerly at construction, so it is present
-        // on the originating node. If it is somehow absent (corruption, or a
-        // writer rotating before the value entry has synced), do NOT fabricate a
-        // default: re-stamping a default value would ship a signed `Update` that
-        // overwrites the real value once it arrives. Skip the value re-stamp and
-        // warn — the value entry's rotation log picks up the new set when its own
-        // `Add` is (re)applied.
-        let value_id = self.value_id();
-        match self.inner.get(value_id)? {
-            Some(value) => {
-                let _restamped = self.inner.insert_with_storage_type(
-                    Some(value_id),
-                    value,
-                    new_shared.clone(),
-                )?;
-                // Originating-node fallback: persist the new set on the value
-                // entry's index too (the rotation log is only appended on
-                // receivers, so this node's own log stays empty).
-                let _ignored = <Index<S>>::set_storage_type(value_id, new_shared.clone());
-            }
-            None => {
-                tracing::warn!(
-                    target: "storage::shared",
-                    value_id = %value_id,
-                    "SharedStorage value entry missing during rotation — skipping \
-                     value re-stamp (possible storage corruption or pre-sync race)"
-                );
-            }
-        }
-        // Originating-node fallback: persist the new set on the wrapper's index.
+        // Members are NOT re-stamped. The value entry and every collection
+        // child are `SharedMember`s pointing at this wrapper; their writer set
+        // is resolved from the wrapper's rotation log at verify time, so the
+        // single append above retroactively revokes (and grants) access for the
+        // entire subtree at once. No per-entity `Update` storm — every member's
+        // bytes are unchanged — so the rotation cannot diverge the root hash.
+        // This is exactly why the variant was split: rotation is O(1) and
+        // split-brain-safe by construction.
+
+        // Originating-node fallback: persist the new set on the wrapper's index
+        // (the rotation log is only appended on receivers, so this node's own
+        // log stays empty and `current_writers` reads the index).
         let _ignored = <Index<S>>::set_storage_type(wrapper_id, new_shared);
 
-        // Invalidate the lazy cache so the next access reloads the value with
-        // the new writer stamp rather than serving a copy whose in-memory
-        // element still carries the pre-rotation set.
+        // Invalidate the lazy cache so the next access reloads the value fresh.
         *self.value.borrow_mut() = None;
         Ok(())
     }
@@ -698,12 +683,14 @@ mod tests {
 
     #[test]
     #[serial]
-    fn value_entry_index_tracks_writers_through_rotation() {
-        // Regression for the post-rotation write abort: the value entry's index
-        // `storage_type` must follow the writer set so the runtime's
-        // post-execution `update_signature_in_place` does not see a writer-set
-        // mismatch (which aborts the transaction). `insert` and `rotate_writers`
-        // both keep it current.
+    fn value_entry_is_member_anchored_and_untouched_by_rotation() {
+        // The value entry is a `SharedMember` pointing at the wrapper (anchor).
+        // It carries NO writer set and is NOT re-stamped on rotation — the
+        // wrapper's rotation log is the single source. This is the invariant
+        // that makes rotation O(1) and split-brain-safe: a member's bytes never
+        // change, so a rotation can't diverge the root hash. (The newly-added
+        // writer can still write afterward because authorization resolves from
+        // the anchor, not from a stale inline copy.)
         use crate::collections::compute_id;
         use crate::entities::{Data, StorageType};
         use crate::index::Index;
@@ -715,26 +702,43 @@ mod tests {
         let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), false));
         s.insert(TestVal(1)).unwrap();
 
-        let value_id = compute_id(s.element().id(), super::VALUE_KEY);
-        let writers_of = |id| match <Index<MainStorage>>::get_metadata(id)
-            .unwrap()
-            .unwrap()
-            .storage_type
-        {
-            StorageType::Shared { writers, .. } => writers,
-            other => panic!("expected Shared, got {other:?}"),
+        let wrapper_id = s.element().id();
+        let value_id = compute_id(wrapper_id, super::VALUE_KEY);
+        let storage_type_of = |id| {
+            <Index<MainStorage>>::get_metadata(id)
+                .unwrap()
+                .unwrap()
+                .storage_type
         };
-        assert_eq!(writers_of(value_id), writers(&[ALICE]));
+        let assert_member_of = |st: StorageType| match st {
+            StorageType::SharedMember { anchor, .. } => assert_eq!(anchor, wrapper_id),
+            other => panic!("value entry must be SharedMember, got {other:?}"),
+        };
+        let anchor_writers = |st: StorageType| match st {
+            StorageType::Shared { writers, .. } => writers,
+            other => panic!("wrapper must be a Shared anchor, got {other:?}"),
+        };
 
-        // Rotation must carry the value entry's index to the new set.
+        // Value entry anchors to the wrapper; the wrapper (anchor) holds writers.
+        assert_member_of(storage_type_of(value_id));
+        assert_eq!(
+            anchor_writers(storage_type_of(wrapper_id)),
+            writers(&[ALICE])
+        );
+
+        // Rotation updates the anchor only; the value entry is byte-untouched.
         s.rotate_writers(writers(&[ALICE, BOB])).unwrap();
-        assert_eq!(writers_of(value_id), writers(&[ALICE, BOB]));
+        assert_member_of(storage_type_of(value_id));
+        assert_eq!(
+            anchor_writers(storage_type_of(wrapper_id)),
+            writers(&[ALICE, BOB])
+        );
 
-        // A write by the newly-added writer keeps it current (would mismatch if
-        // the index had stayed at the pre-rotation set).
+        // The newly-added writer can write — authorization resolves from the
+        // anchor's (rotated) writer set, and the entry stays an anchored member.
         env::set_executor_id(BOB);
         s.insert(TestVal(2)).unwrap();
-        assert_eq!(writers_of(value_id), writers(&[ALICE, BOB]));
+        assert_member_of(storage_type_of(value_id));
     }
 
     #[test]
@@ -761,8 +765,11 @@ mod tests {
             .insert("k".to_owned(), LwwRegister::new("v".to_owned()))
             .expect("insert");
 
-        // The entry must carry the Shared writer domain — the whole subtree is
-        // guarded at merge, not just the SharedStorage wrapper entity.
+        // The entry must be anchored to the wrapper — the whole subtree is
+        // guarded at merge, not just the SharedStorage wrapper entity. It
+        // carries no inline writer set: the anchor pointer is the domain, and
+        // writers resolve from the anchor's rotation log.
+        let wrapper_id = guarded.element().id();
         let map_id = <Map as Data>::id(guarded.get().expect("get"));
         let child = compute_id(map_id, "k".as_bytes());
         let entry = <Interface<MainStorage>>::find_by_id::<
@@ -771,8 +778,11 @@ mod tests {
         .expect("load child")
         .expect("child exists");
         match entry.storage.metadata.storage_type {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, ws),
-            other => panic!("SharedStorage<Map> entry must inherit Shared, got {other:?}"),
+            StorageType::SharedMember { anchor, .. } => assert_eq!(anchor, wrapper_id),
+            other => panic!(
+                "SharedStorage<Map> entry must be a SharedMember anchored to the wrapper, \
+                 got {other:?}"
+            ),
         }
     }
 

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -568,5 +568,22 @@ fn hash_metadata_storage_type_for_id(hasher: &mut Sha256, metadata: &Metadata) {
             };
             hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
         }
+        StorageType::SharedMember {
+            anchor,
+            signature_data,
+        } => {
+            // Hash the SharedMember variant *without* the signature. Only the
+            // anchor id is committed — the writer set lives at the anchor, so a
+            // rotation leaves every member's hash unchanged.
+            let partial_type = StorageType::SharedMember {
+                anchor: *anchor,
+                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
+                    nonce: sig_data.nonce,
+                    signature: [0; 64], // Use placeholder for hash
+                    signer: sig_data.signer,
+                }),
+            };
+            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
+        }
     }
 }

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -362,10 +362,22 @@ impl Element {
         self.update(); // Mark as dirty
     }
 
-    /// Helper to set the storage domain to `Shared`.
+    /// Helper to set the storage domain to `Shared` (an anchor entity).
     pub fn set_shared_domain(&mut self, writers: BTreeSet<PublicKey>) {
         self.metadata.storage_type = StorageType::Shared {
             writers,
+            signature_data: None, // Will be signed later
+        };
+        self.update(); // Mark as dirty
+    }
+
+    /// Helper to set the storage domain to `SharedMember`, pointing at the
+    /// `anchor` entity whose rotation log defines the writer set. Used for every
+    /// entry under a guarded `SharedStorage` collection; the member carries no
+    /// writer set of its own.
+    pub fn set_shared_member_domain(&mut self, anchor: Id) {
+        self.metadata.storage_type = StorageType::SharedMember {
+            anchor,
             signature_data: None, // Will be signed later
         };
         self.update(); // Mark as dirty
@@ -430,15 +442,36 @@ pub enum StorageType {
     },
     /// Data that can be set only once, can'be modified or deleted.
     Frozen,
-    /// Group-writable storage. Any signer in `writers` can modify; the writer set
-    /// itself is rotatable (signed by a current writer). The wrapper-level
-    /// `writers_frozen` flag (held on `SharedStorage<T>`, not in this stamp)
-    /// disables rotation at the API layer.
+    /// Group-writable storage **anchor**. Any signer in `writers` can modify;
+    /// the writer set itself is rotatable (signed by a current writer). The
+    /// wrapper-level `writers_frozen` flag (held on `SharedStorage<T>`, not in
+    /// this stamp) disables rotation at the API layer.
+    ///
+    /// This stamp owns the writer set for a whole domain: the wrapper entity
+    /// carries `Shared`, and every entry beneath it carries [`SharedMember`]
+    /// pointing back at this entity's id. Rotation appends one entry to *this*
+    /// entity's rotation log; members are never re-stamped, so rotation is
+    /// O(1) and retroactively revokes access for the entire subtree without
+    /// changing any member's bytes (no per-entity churn → no split-brain).
     Shared {
         /// The set of public keys authorized to write or rotate.
         writers: BTreeSet<PublicKey>,
         /// A signature and nonce. The signature must be from a key in `writers`
         /// (the *currently stored* set, not the action's claimed set).
+        signature_data: Option<SignatureData>,
+    },
+    /// A **member** of a [`Shared`](StorageType::Shared) domain — every entry
+    /// under a guarded `SharedStorage`. It carries **no writer set of its own**:
+    /// the authoritative writers are resolved from `anchor`'s rotation log at
+    /// the action's causal cut (`writers_at`). Because members hold only a
+    /// pointer, rotating the anchor revokes access to all members at once, and a
+    /// member's bytes never change on rotation.
+    SharedMember {
+        /// The id of the [`Shared`](StorageType::Shared) anchor entity whose
+        /// rotation log defines this member's writer set over causal time.
+        anchor: Id,
+        /// A signature and nonce. The signature must be from a key in the
+        /// writer set resolved from `anchor` at the action's causal cut.
         signature_data: Option<SignatureData>,
     },
 }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -206,6 +206,39 @@ const fn nonce_check_disabled_for_testing() -> bool {
 pub struct Interface<S: StorageAdaptor = MainStorage>(PhantomData<S>);
 
 impl<S: StorageAdaptor> Interface<S> {
+    /// Resolve a [`SharedMember`](StorageType::SharedMember)'s writer set from
+    /// its `anchor`'s **locally verified** state, mirroring
+    /// `SharedStorage::current_writers`:
+    ///
+    /// 1. the anchor's rotation log (latest entry, then its compacted
+    ///    snapshot) — only ever written by a signature-verified rotation apply
+    ///    or the originating node's own committed rotation; and
+    /// 2. the anchor's index metadata (`Shared { writers }`).
+    ///
+    /// Returns the empty set when the anchor has neither — i.e. the anchor has
+    /// not synced to this node yet. The caller treats the empty set as "cannot
+    /// verify this member yet" (fail closed / buffer), never as "no writers".
+    /// This is the local-execution / settled-state resolver; the
+    /// causal-cut-accurate resolution at merge is the node layer's
+    /// `writers_at(anchor_log, delta.parents)`, passed in via
+    /// `effective_writers`.
+    fn resolve_anchor_writers(anchor: Id) -> BTreeSet<PublicKey> {
+        if let Ok(Some(log)) = crate::rotation_log::load::<S>(anchor) {
+            if let Some(entry) = log.entries.last() {
+                return entry.new_writers.clone();
+            }
+            if let Some(snapshot) = log.snapshot {
+                return snapshot.writers;
+            }
+        }
+        if let Ok(Some(metadata)) = <Index<S>>::get_metadata(anchor) {
+            if let StorageType::Shared { writers, .. } = metadata.storage_type {
+                return writers;
+            }
+        }
+        BTreeSet::new()
+    }
+
     /// Verify the writer's signature on a snapshot-supplied entity
     /// against the access-control rules in its metadata.
     ///
@@ -252,7 +285,9 @@ impl<S: StorageAdaptor> Interface<S> {
         // Public / Frozen don't require signature verification.
         match &metadata.storage_type {
             StorageType::Public | StorageType::Frozen => return Ok(()),
-            StorageType::User { .. } | StorageType::Shared { .. } => {}
+            StorageType::User { .. }
+            | StorageType::Shared { .. }
+            | StorageType::SharedMember { .. } => {}
         }
 
         // Reconstruct the authorization payload the writer signed.
@@ -325,6 +360,36 @@ impl<S: StorageAdaptor> Interface<S> {
                 signature_data: None,
                 ..
             } => Err(StorageError::InvalidSignature),
+            StorageType::SharedMember {
+                anchor,
+                signature_data: Some(sig_data),
+            } => {
+                if sig_data.signature == [0u8; 64] {
+                    return Err(StorageError::InvalidSignature);
+                }
+                // A member carries no writer set: resolve it from the anchor's
+                // locally-verified state. An unsynced anchor yields the empty
+                // set, which fails verification (the scan finds no writer) —
+                // fail closed rather than accept an unverifiable member.
+                let writers = Self::resolve_anchor_writers(*anchor);
+                let verified = match sig_data.signer {
+                    Some(hint) if writers.contains(&hint) => {
+                        crate::env::ed25519_verify(&sig_data.signature, hint.digest(), &payload)
+                    }
+                    _ => writers.iter().any(|w| {
+                        crate::env::ed25519_verify(&sig_data.signature, w.digest(), &payload)
+                    }),
+                };
+                if verified {
+                    Ok(())
+                } else {
+                    Err(StorageError::InvalidSignature)
+                }
+            }
+            StorageType::SharedMember {
+                signature_data: None,
+                ..
+            } => Err(StorageError::InvalidSignature),
             // Unreachable: handled at the top of the function.
             StorageType::Public | StorageType::Frozen => Ok(()),
         }
@@ -390,12 +455,20 @@ impl<S: StorageAdaptor> Interface<S> {
             | StorageType::User {
                 signature_data: Some(sd),
                 ..
+            }
+            | StorageType::SharedMember {
+                signature_data: Some(sd),
+                ..
             } => sd,
             StorageType::Shared {
                 signature_data: None,
                 ..
             }
             | StorageType::User {
+                signature_data: None,
+                ..
+            }
+            | StorageType::SharedMember {
                 signature_data: None,
                 ..
             } => {
@@ -460,6 +533,24 @@ impl<S: StorageAdaptor> Interface<S> {
                 if stored_owner != new_owner {
                     return Err(StorageError::InvalidData(
                         "update_signature_in_place: owner mismatch".to_owned(),
+                    ));
+                }
+            }
+            (
+                StorageType::SharedMember {
+                    anchor: stored_anchor,
+                    ..
+                },
+                StorageType::SharedMember {
+                    anchor: new_anchor, ..
+                },
+            ) => {
+                // A member's access control is its anchor pointer; patching the
+                // signature must not re-anchor it (that would silently move it
+                // to a different writer domain).
+                if stored_anchor != new_anchor {
+                    return Err(StorageError::InvalidData(
+                        "update_signature_in_place: anchor mismatch".to_owned(),
                     ));
                 }
             }
@@ -1013,6 +1104,87 @@ impl<S: StorageAdaptor> Interface<S> {
                             stored_writers.clone(),
                         )?;
                     }
+                    StorageType::SharedMember {
+                        anchor,
+                        signature_data,
+                    } => {
+                        debug!(
+                            %id,
+                            created_at = metadata.created_at,
+                            updated_at = metadata.updated_at(),
+                            %anchor,
+                            data_len = data.len(),
+                            "Interface::apply_action received upsert shared-member action"
+                        );
+                        let sig_data = signature_data.as_ref().ok_or(StorageError::InvalidData(
+                            "Remote SharedMember action must be signed".to_owned(),
+                        ))?;
+
+                        // A member carries NO writer set. The authoritative set
+                        // is the anchor's, resolved by the node at the delta's
+                        // causal cut (`writers_at(anchor_log, delta.parents)`)
+                        // and passed in `effective_writers`. With no causal
+                        // context (snapshot leaf push / local apply) fall back
+                        // to the anchor's settled local state. There is NO
+                        // inline-writers fallback — that is the whole point of
+                        // the member design.
+                        //
+                        // An empty set here means the anchor has not synced to
+                        // this node yet: verification fails closed and the node
+                        // buffers the member delta until the anchor arrives,
+                        // rather than trusting an unverifiable member. (Buffering
+                        // lives in the node sync layer; storage just rejects.)
+                        let authoritative_writers = match ctx.effective_writers.as_ref() {
+                            Some(effective) => effective.clone(),
+                            None => Self::resolve_anchor_writers(*anchor),
+                        };
+
+                        // Replay protection — identical baseline to the Shared
+                        // arm (stored monotonic nonce; type-agnostic).
+                        let stored_metadata = <Index<S>>::get_metadata(*id)?;
+                        let new_nonce = sig_data.nonce;
+                        let last_nonce =
+                            stored_metadata.as_ref().map(|m| *m.updated_at).unwrap_or(0);
+                        let skip_nonce =
+                            nonce_check_disabled_for_testing() || crate::env::in_merge_mode();
+
+                        // Verify signature first (same hint-fast-path / scan as
+                        // Shared), against the anchor-resolved set.
+                        let payload = action.payload_for_signing();
+                        let verified = match sig_data.signer {
+                            Some(hint) if authoritative_writers.contains(&hint) => {
+                                crate::env::ed25519_verify(
+                                    &sig_data.signature,
+                                    hint.digest(),
+                                    &payload,
+                                )
+                            }
+                            _ => authoritative_writers.iter().any(|w| {
+                                crate::env::ed25519_verify(
+                                    &sig_data.signature,
+                                    w.digest(),
+                                    &payload,
+                                )
+                            }),
+                        };
+                        if !verified {
+                            return Err(StorageError::InvalidSignature);
+                        }
+
+                        if !skip_nonce && new_nonce < last_nonce {
+                            tracing::warn!(
+                                %id,
+                                new_nonce,
+                                last_nonce,
+                                "SharedMember upsert: stale nonce, signature verified \
+                                 — skipping save_internal (authentic but no-op)"
+                            );
+                            return Ok(());
+                        }
+
+                        // NB: no rotation-log hook. A member owns no rotation
+                        // log; rotations live only at its anchor.
+                    }
                     StorageType::Public => {
                         // No signature verification for Public.
                         //
@@ -1222,6 +1394,81 @@ impl<S: StorageAdaptor> Interface<S> {
                             }
                             _ => {
                                 // Action metadata is not Shared, but existing is.
+                                return Err(StorageError::InvalidSignature);
+                            }
+                        }
+                    }
+                    StorageType::SharedMember {
+                        anchor: existing_anchor,
+                        ..
+                    } => {
+                        // Verify the action's metadata, which contains the signature
+                        match &metadata.storage_type {
+                            StorageType::SharedMember {
+                                anchor: action_anchor,
+                                signature_data,
+                                ..
+                            } => {
+                                // The action's claimed anchor must match stored —
+                                // delete is not a re-anchor channel.
+                                if *action_anchor != existing_anchor {
+                                    return Err(StorageError::InvalidSignature);
+                                }
+
+                                let sig_data =
+                                    signature_data.as_ref().ok_or(StorageError::InvalidData(
+                                        "Remote SharedMember delete must be signed".to_owned(),
+                                    ))?;
+
+                                // Writers come from the anchor's settled local
+                                // state (no inline set). An unsynced anchor →
+                                // empty set → signer scan fails → InvalidSignature
+                                // (fail closed), same as the upsert arm.
+                                let existing_writers =
+                                    Self::resolve_anchor_writers(existing_anchor);
+
+                                let payload = action.payload_for_signing();
+                                let signer = match sig_data.signer {
+                                    Some(hint) if existing_writers.contains(&hint) => {
+                                        if crate::env::ed25519_verify(
+                                            &sig_data.signature,
+                                            hint.digest(),
+                                            &payload,
+                                        ) {
+                                            Some(hint)
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    _ => existing_writers.iter().copied().find(|w| {
+                                        crate::env::ed25519_verify(
+                                            &sig_data.signature,
+                                            w.digest(),
+                                            &payload,
+                                        )
+                                    }),
+                                };
+                                if signer.is_none() {
+                                    return Err(StorageError::InvalidSignature);
+                                }
+
+                                // Replay protection (strict `<=` Err, as Shared).
+                                let new_nonce = sig_data.nonce;
+                                let last_nonce = *existing_metadata.updated_at;
+                                if new_nonce <= last_nonce {
+                                    let placeholder = existing_writers
+                                        .iter()
+                                        .copied()
+                                        .next()
+                                        .unwrap_or_else(|| [0u8; 32].into());
+                                    return Err(StorageError::NonceReplay(Box::new((
+                                        placeholder,
+                                        new_nonce,
+                                    ))));
+                                }
+                            }
+                            _ => {
+                                // Action metadata is not SharedMember, but existing is.
                                 return Err(StorageError::InvalidSignature);
                             }
                         }
@@ -1969,6 +2216,33 @@ impl<S: StorageAdaptor> Interface<S> {
             };
         }
 
+        // Same for a member delete: authorize against the ANCHOR's writers
+        // (the member carries none), re-stamp the anchor pointer with a fresh
+        // signature placeholder for the signer to fill in.
+        let member_to_stamp =
+            if let StorageType::SharedMember { anchor, .. } = &metadata.storage_type {
+                let executor: calimero_primitives::identity::PublicKey =
+                    crate::env::executor_id().into();
+                let writers = Self::resolve_anchor_writers(*anchor);
+                if writers.contains(&executor) {
+                    Some((*anchor, executor))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+        if let Some((anchor, signer)) = member_to_stamp {
+            metadata.storage_type = StorageType::SharedMember {
+                anchor,
+                signature_data: Some(SignatureData {
+                    signature: [0; 64], // Placeholder, added by signer
+                    nonce: deleted_at,
+                    signer: Some(signer), // O(1) verifier lookup
+                }),
+            };
+        }
+
         <Index<S>>::remove_child_from(parent_id, child_id)?;
 
         // Use DeleteRef for efficient tombstone-based deletion.
@@ -2703,6 +2977,33 @@ impl<S: StorageAdaptor> Interface<S> {
             };
         }
 
+        // Member upsert: a member carries no writer set, so there is no
+        // claimed-set union — authority is purely the ANCHOR's resolved writers
+        // (settled local state). Stamp the anchor pointer + signer placeholder.
+        let member_to_stamp =
+            if let StorageType::SharedMember { anchor, .. } = &metadata.storage_type {
+                let executor: calimero_primitives::identity::PublicKey =
+                    crate::env::executor_id().into();
+                if Self::resolve_anchor_writers(*anchor).contains(&executor) {
+                    Some((*anchor, executor))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+        if let Some((anchor, signer)) = member_to_stamp {
+            let nonce = *metadata.updated_at;
+            metadata.storage_type = StorageType::SharedMember {
+                anchor,
+                signature_data: Some(SignatureData {
+                    signature: [0; 64], // Placeholder, added by signer
+                    nonce,
+                    signer: Some(signer), // O(1) verifier lookup
+                }),
+            };
+        }
+
         let Some((is_new, full_hash)) = Self::save_internal(id, &data, metadata.clone())? else {
             return Ok(None);
         };
@@ -2822,6 +3123,27 @@ impl<S: StorageAdaptor> Interface<S> {
                     (StorageType::Shared { .. }, StorageType::Shared { .. }) => {
                         // Writer-set changes (rotation) are gated by signature
                         // verification in apply_action against the stored writer set.
+                        Ok(())
+                    }
+                    (
+                        StorageType::SharedMember {
+                            anchor: existing_anchor,
+                            ..
+                        },
+                        StorageType::SharedMember {
+                            anchor: new_anchor, ..
+                        },
+                    ) => {
+                        // A member's anchor is immutable (like User's owner):
+                        // re-anchoring would silently move it to a different
+                        // writer domain. The write itself is gated by signature
+                        // verification against the anchor's writers in
+                        // apply_action.
+                        if *new_anchor != *existing_anchor {
+                            return Err(StorageError::ActionNotAllowed(
+                                "Cannot change SharedMember anchor".to_owned(),
+                            ));
+                        }
                         Ok(())
                     }
                     (existing, new) => {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -222,6 +222,20 @@ impl<S: StorageAdaptor> Interface<S> {
     /// causal-cut-accurate resolution at merge is the node layer's
     /// `writers_at(anchor_log, delta.parents)`, passed in via
     /// `effective_writers`.
+    ///
+    /// **Best-effort under concurrent rotations** — same caveat the `Shared`
+    /// path carries (see `SharedStorage::current_writers` and the `Shared` arm
+    /// of `apply_action`, which falls back to the entity's *stored* writers the
+    /// same way). The rotation log's *latest* entry is this node's insertion
+    /// order, which can differ from causal order if two rotations arrive
+    /// interleaved; resolving against it (rather than the set causally valid at
+    /// the op's cut) can therefore accept/reject differently across nodes. The
+    /// causal `writers_at` set passed as `effective_writers` is the security
+    /// boundary on the merge path; this fallback only fires when no causal
+    /// context exists (local exec / snapshot) or `writers_at` can't resolve (an
+    /// op causally before any logged rotation). Full causal resolution here is
+    /// deferred to the concurrent-rotation work (P4 / the DAG-causal rotation
+    /// epic), which fixes `Shared` and `SharedMember` uniformly.
     fn resolve_anchor_writers(anchor: Id) -> BTreeSet<PublicKey> {
         if let Ok(Some(log)) = crate::rotation_log::load::<S>(anchor) {
             if let Some(entry) = log.entries.last() {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -395,6 +395,67 @@ impl<S: StorageAdaptor> Interface<S> {
         }
     }
 
+    /// Verify a snapshot-supplied [`SharedMember`](StorageType::SharedMember)
+    /// leaf against an **explicitly provided** writer set.
+    ///
+    /// [`verify_snapshot_entity_signature`](Self::verify_snapshot_entity_signature)
+    /// resolves a member's writers via `resolve_anchor_writers`, which reads
+    /// through `MainStorage` — only valid inside the WASM `RUNTIME_ENV`. The
+    /// snapshot apply path runs **outside** that env, and a member's anchor may
+    /// arrive in a later page anyway, so the node instead resolves the writers
+    /// from the anchor's own snapshot record (itself signature-verified) and
+    /// passes them here. Otherwise identical to the member arm above:
+    /// placeholder reject, signer-hint fast path, else a scan over `writers`.
+    ///
+    /// `metadata.storage_type` must be `SharedMember`; any other variant is a
+    /// caller error and is rejected as `InvalidData`.
+    ///
+    /// # Errors
+    /// `InvalidSignature` if `signature_data` is `None`, carries the `[0; 64]`
+    /// placeholder, or fails ed25519 verification against `writers`;
+    /// `InvalidData` if `metadata.storage_type` is not `SharedMember`.
+    pub fn verify_snapshot_member_signature(
+        id: crate::address::Id,
+        data: &[u8],
+        metadata: &crate::entities::Metadata,
+        writers: &BTreeSet<PublicKey>,
+    ) -> Result<(), StorageError> {
+        use crate::action::Action;
+        use crate::entities::StorageType;
+
+        let StorageType::SharedMember { signature_data, .. } = &metadata.storage_type else {
+            return Err(StorageError::InvalidData(
+                "verify_snapshot_member_signature: storage_type is not SharedMember".to_owned(),
+            ));
+        };
+        let Some(sig_data) = signature_data.as_ref() else {
+            return Err(StorageError::InvalidSignature);
+        };
+        if sig_data.signature == [0u8; 64] {
+            return Err(StorageError::InvalidSignature);
+        }
+        let action = Action::Add {
+            id,
+            data: data.to_vec(),
+            ancestors: vec![],
+            metadata: metadata.clone(),
+        };
+        let payload = action.payload_for_signing();
+        let verified = match sig_data.signer {
+            Some(hint) if writers.contains(&hint) => {
+                crate::env::ed25519_verify(&sig_data.signature, hint.digest(), &payload)
+            }
+            _ => writers
+                .iter()
+                .any(|w| crate::env::ed25519_verify(&sig_data.signature, w.digest(), &payload)),
+        };
+        if verified {
+            Ok(())
+        } else {
+            Err(StorageError::InvalidSignature)
+        }
+    }
+
     /// Persist the signed `signature_data` produced by the runtime's
     /// `sign_authorized_actions` step back to the local index entry.
     ///
@@ -1420,12 +1481,19 @@ impl<S: StorageAdaptor> Interface<S> {
                                         "Remote SharedMember delete must be signed".to_owned(),
                                     ))?;
 
-                                // Writers come from the anchor's settled local
-                                // state (no inline set). An unsynced anchor →
-                                // empty set → signer scan fails → InvalidSignature
-                                // (fail closed), same as the upsert arm.
+                                // Writers: prefer the node-resolved causal set
+                                // (`writers_at(anchor_log, delta.parents)`, keyed
+                                // by this member id) exactly like the upsert arm,
+                                // so a delete is authorized against the same set
+                                // a concurrent rotation would resolve. Only fall
+                                // back to the anchor's settled local state when
+                                // no causal set was supplied (snapshot/local
+                                // apply). An unsynced anchor → empty set → signer
+                                // scan fails → InvalidSignature (fail closed).
                                 let existing_writers =
-                                    Self::resolve_anchor_writers(existing_anchor);
+                                    ctx.effective_writers.clone().unwrap_or_else(|| {
+                                        Self::resolve_anchor_writers(existing_anchor)
+                                    });
 
                                 let payload = action.payload_for_signing();
                                 let signer = match sig_data.signer {

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -363,6 +363,107 @@ pub fn build_signed_shared_action(
     action
 }
 
+/// Build a signed `SharedMember` action (Add when `add`, else Update). The
+/// member carries no writer set — only its `anchor` pointer — so verification
+/// resolves writers from the anchor (via `effective_writers` or the anchor's
+/// settled local state). Signed by `signer_sk`.
+pub fn build_signed_member_action(
+    add: bool,
+    id: Id,
+    anchor: Id,
+    data: Vec<u8>,
+    hlc_ns: u64,
+    signer_sk: &SigningKey,
+    ancestors: Vec<ChildInfo>,
+) -> Action {
+    let metadata = Metadata {
+        created_at: hlc_ns,
+        updated_at: hlc_ns.into(),
+        storage_type: StorageType::SharedMember {
+            anchor,
+            signature_data: Some(SignatureData {
+                signature: [0; 64],
+                nonce: hlc_ns,
+                signer: Some(pubkey_of(signer_sk)),
+            }),
+        },
+        crdt_type: None,
+        field_name: None,
+    };
+    let mut action = if add {
+        Action::Add {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors,
+            metadata,
+        }
+    };
+    let payload = action.payload_for_signing();
+    let signature = signer_sk.sign(&payload).to_bytes();
+    let metadata_mut = match &mut action {
+        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
+        _ => unreachable!(),
+    };
+    if let StorageType::SharedMember {
+        signature_data: Some(sd),
+        ..
+    } = &mut metadata_mut.storage_type
+    {
+        sd.signature = signature;
+    }
+    action
+}
+
+/// Build a signed `SharedMember` `DeleteRef`, signed by `signer_sk`. The
+/// member's writers are resolved from `anchor` at apply time (no inline set).
+pub fn build_signed_member_delete(
+    id: Id,
+    anchor: Id,
+    signer_sk: &SigningKey,
+    deleted_at: u64,
+) -> Action {
+    let metadata = Metadata {
+        created_at: env::time_now(),
+        updated_at: deleted_at.into(),
+        storage_type: StorageType::SharedMember {
+            anchor,
+            signature_data: Some(SignatureData {
+                signature: [0; 64],
+                nonce: deleted_at,
+                signer: Some(pubkey_of(signer_sk)),
+            }),
+        },
+        crdt_type: None,
+        field_name: None,
+    };
+    let mut action = Action::DeleteRef {
+        id,
+        deleted_at,
+        metadata,
+    };
+    let signature = sign_action(&action, signer_sk);
+    if let Action::DeleteRef {
+        ref mut metadata, ..
+    } = action
+    {
+        if let StorageType::SharedMember {
+            signature_data: Some(sd),
+            ..
+        } = &mut metadata.storage_type
+        {
+            sd.signature = signature;
+        }
+    }
+    action
+}
+
 /// Helper to create a User storage Update action with proper signature.
 pub fn create_signed_user_update_action(
     signing_key: &SigningKey,

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1377,7 +1377,10 @@ mod shared_storage_rotation_authentication {
     use crate::index::Index;
     use crate::interface::{ApplyContext, MainInterface, StorageError};
     use crate::store::MainStorage;
-    use crate::tests::common::{build_signed_shared_action, pubkey_of, setup_root_for_main};
+    use crate::tests::common::{
+        build_signed_member_action, build_signed_member_delete, build_signed_shared_action,
+        pubkey_of, setup_root_for_main,
+    };
 
     fn make_signing_key(seed: u8) -> SigningKey {
         SigningKey::from_bytes(&[seed; 32])
@@ -1566,6 +1569,240 @@ mod shared_storage_rotation_authentication {
             log.entries.last().expect("a rotation entry").new_writers,
             new_writers,
             "accepted rotation must record the new writer set in the rotation log"
+        );
+    }
+
+    /// The headline property of the anchor design: rotating the anchor's writer
+    /// set retroactively revokes write access to its members — *without*
+    /// changing any member's bytes. A member written by Bob while he was a
+    /// writer becomes un-writable by Bob the instant the anchor rotates him out,
+    /// even though the member entity itself is byte-identical throughout.
+    ///
+    /// We model the rotation by the writer set the node's `writers_at` would
+    /// resolve from the anchor's rotation log at the delta's causal cut, passed
+    /// as `effective_writers`. The member carries only its anchor pointer, so
+    /// the SAME stored member is verified against {alice, bob} before the
+    /// rotation and {alice} after — no per-member re-stamp involved.
+    #[test]
+    fn rotating_anchor_retroactively_revokes_member_writes() {
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let bob_sk = make_signing_key(0xB0);
+        let bob = pubkey_of(&bob_sk);
+
+        let anchor = Id::new([0xA0; 32]);
+        let member = Id::new([0x3E; 32]);
+        let pre: BTreeSet<_> = [alice, bob].into_iter().collect();
+        let post: BTreeSet<_> = [alice].into_iter().collect();
+
+        // Bootstrap the anchor (a `Shared` entity) with writers {alice, bob}.
+        let n0 = env::time_now();
+        let bootstrap = build_signed_shared_action(
+            true,
+            anchor,
+            b"anchor".to_vec(),
+            pre.clone(),
+            n0,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+
+        let pre_ctx = || ApplyContext {
+            effective_writers: Some(pre.clone()),
+            delta_id: None,
+            delta_hlc: None,
+        };
+        let post_ctx = || ApplyContext {
+            effective_writers: Some(post.clone()),
+            delta_id: None,
+            delta_hlc: None,
+        };
+
+        // BEFORE rotation: Bob (a writer) writes the member — accepted.
+        let bob_add = build_signed_member_action(
+            true,
+            member,
+            anchor,
+            b"by-bob".to_vec(),
+            n0 + 1_000_000,
+            &bob_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(bob_add, &pre_ctx())
+            .expect("a writer's member write must be accepted before rotation");
+
+        // The stored member is anchored — no inline writer set.
+        let stored = <Index<MainStorage>>::get_metadata(member).unwrap().unwrap();
+        assert!(
+            matches!(stored.storage_type, StorageType::SharedMember { anchor: a, .. } if a == anchor),
+            "member must be anchored to the wrapper, got {:?}",
+            stored.storage_type
+        );
+
+        // AFTER rotation (anchor writers now {alice}): Bob writes the SAME member
+        // again — must be rejected. The member entity never changed; only the
+        // anchor-resolved writer set did. This is retroactive revocation.
+        let bob_revoked = build_signed_member_action(
+            false,
+            member,
+            anchor,
+            b"by-bob-after-revoke".to_vec(),
+            n0 + 2_000_000,
+            &bob_sk,
+            vec![],
+        );
+        let result = MainInterface::apply_action(bob_revoked, &post_ctx());
+        assert!(
+            matches!(result, Err(StorageError::InvalidSignature)),
+            "a rotated-out writer's member write must be rejected, got {result:?}"
+        );
+
+        // Alice (still a writer) can write the member under the same post-rotation
+        // set — proving the rejection is authorization, not a broken member path.
+        let alice_write = build_signed_member_action(
+            false,
+            member,
+            anchor,
+            b"by-alice".to_vec(),
+            n0 + 3_000_000,
+            &alice_sk,
+            vec![],
+        );
+        MainInterface::apply_action(alice_write, &post_ctx())
+            .expect("a current writer's member write must still be accepted");
+    }
+
+    /// The delete path mirrors the upsert path: deleting a member is authorized
+    /// against the anchor's writers (resolved from the anchor's settled local
+    /// state), not an inline set. A non-writer's member delete is rejected; a
+    /// writer's is accepted.
+    #[test]
+    fn member_delete_authorized_against_anchor_writers() {
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let mallory_sk = make_signing_key(0x4D); // a context member, NOT a writer
+        let _mallory = pubkey_of(&mallory_sk);
+
+        let anchor = Id::new([0xA0; 32]);
+        let member = Id::new([0x3E; 32]);
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+
+        let n0 = env::time_now();
+        // Anchor (Shared {alice}) + a member written by alice.
+        let bootstrap = build_signed_shared_action(
+            true,
+            anchor,
+            b"anchor".to_vec(),
+            writers.clone(),
+            n0,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+        let member_add = build_signed_member_action(
+            true,
+            member,
+            anchor,
+            b"v".to_vec(),
+            n0 + 1_000_000,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(member_add, &ApplyContext::empty())
+            .expect("writer's member add must be accepted");
+
+        // Mallory (non-writer) tries to delete the member → rejected.
+        let forged_delete = build_signed_member_delete(member, anchor, &mallory_sk, n0 + 2_000_000);
+        let result = MainInterface::apply_action(forged_delete, &ApplyContext::empty());
+        assert!(
+            matches!(result, Err(StorageError::InvalidSignature)),
+            "a non-writer's member delete must be rejected, got {result:?}"
+        );
+
+        // Alice (a writer) deletes the member → accepted.
+        let ok_delete = build_signed_member_delete(member, anchor, &alice_sk, n0 + 3_000_000);
+        MainInterface::apply_action(ok_delete, &ApplyContext::empty())
+            .expect("a writer's member delete must be accepted");
+    }
+
+    /// Snapshot verification of a member resolves the anchor's writers (the
+    /// snapshot path bypasses the delta pipeline, so it must independently reach
+    /// the anchor). A writer-signed member verifies; a non-writer-signed one is
+    /// rejected.
+    #[test]
+    fn snapshot_verify_member_resolves_anchor_writers() {
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let mallory_sk = make_signing_key(0x4D);
+
+        let anchor = Id::new([0xA0; 32]);
+        let member = Id::new([0x3E; 32]);
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+
+        let n0 = env::time_now();
+        // Bootstrap the anchor so `resolve_anchor_writers` finds {alice} locally.
+        let bootstrap = build_signed_shared_action(
+            true,
+            anchor,
+            b"anchor".to_vec(),
+            writers,
+            n0,
+            &alice_sk,
+            vec![root],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+
+        // A member action signed by a writer (alice) — extract its metadata and
+        // verify as a snapshot leaf.
+        let data = b"snapshot-leaf".to_vec();
+        let by_writer = build_signed_member_action(
+            true,
+            member,
+            anchor,
+            data.clone(),
+            n0 + 1_000_000,
+            &alice_sk,
+            vec![],
+        );
+        let writer_meta = match &by_writer {
+            crate::action::Action::Add { metadata, .. } => metadata.clone(),
+            _ => unreachable!(),
+        };
+        assert!(
+            MainInterface::verify_snapshot_entity_signature(member, &data, &writer_meta).is_ok(),
+            "a writer-signed member snapshot leaf must verify against the anchor's writers"
+        );
+
+        // The same leaf signed by a non-writer (mallory) must be rejected.
+        let by_nonwriter = build_signed_member_action(
+            true,
+            member,
+            anchor,
+            data.clone(),
+            n0 + 1_000_000,
+            &mallory_sk,
+            vec![],
+        );
+        let nonwriter_meta = match &by_nonwriter {
+            crate::action::Action::Add { metadata, .. } => metadata.clone(),
+            _ => unreachable!(),
+        };
+        assert!(
+            matches!(
+                MainInterface::verify_snapshot_entity_signature(member, &data, &nonwriter_meta),
+                Err(StorageError::InvalidSignature)
+            ),
+            "a non-writer-signed member snapshot leaf must be rejected"
         );
     }
 }


### PR DESCRIPTION
Closes #2590. Follow-up to #2588 (static-writer collection guarding).

## Problem
Each entry under a `SharedStorage<Collection>` stored its **own inline copy** of the writer set, so `rotate_writers` was forward-only: it re-stamped the wrapper but left existing entries trusting the old set. The earlier attempt to eagerly re-stamp every entry on rotation **diverged the root hash across peers (permanent split-brain)** and was disabled. So a rotated-out writer kept write access to every pre-rotation entry.

## Approach — anchor inheritance, no inline copy
Split the storage domain into two variants:

| Variant | Role |
|---|---|
| `StorageType::Shared { writers, .. }` | the **anchor** (the `SharedStorage` wrapper entity); owns the writer set + rotation log |
| `StorageType::SharedMember { anchor, .. }` | every entry beneath it; **no writer set**, just a pointer to the anchor |

A member resolves its writers from the **anchor's** rotation log at the action's causal cut (`writers_at`), with **no inline fallback**. Rotation appends one entry to the anchor's log; members are **never re-stamped**.

Because a member's bytes never change on rotation:
- rotation is **O(1)** and **retroactively revokes the whole subtree at once**, and
- the root-hash divergence that killed the earlier eager re-stamp **cannot happen by construction**.

`Collection::insert` already clones the element's `storage_type` onto children, so every entry at any depth inherits the same anchor (a flat domain) for free.

## Coverage
All three verification entry points resolve writers from the anchor and fail closed when it isn't present:
- **apply upsert** — `apply_action` (`SharedMember` arm)
- **delete** — `apply_action` `DeleteRef` (`SharedMember` arm)
- **snapshot-verify** — `verify_snapshot_entity_signature`

Node layer (`delta_store`) resolves a member's `effective_writers` from the anchor's log, keyed by the member id; signing (`execute`), `update_signature_in_place`, `verify_action_update`, and HashComparison authorization all handle members.

### Tests (storage lib, 550 pass)
- `rotating_anchor_retroactively_revokes_member_writes` — the headline: a **byte-identical** member is writable by Bob pre-rotation and **rejected** post-rotation, with no per-entry re-stamp.
- `member_delete_authorized_against_anchor_writers`
- `snapshot_verify_member_resolves_anchor_writers`

## Notes / follow-ups
- **No back-compat** — clean wire-format break (new variant in the signing/hashing payload); needs a coordinated state reset.
- When a member delta arrives **before its anchor has synced**, verification fails closed and the member retries via HashComparison (a liveness path). Explicit **orphan-buffering** is a deliberate follow-up.
- Concurrent `insert∥rotate` / `rotate∥rotate` convergence and the `SharedStorage<UnorderedMap>` merobox e2e exercise the node DAG-topology / CI harness; the underlying `writers_at` convergence is already proven for the `Shared` path this reuses unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization model and signing/hashing wire format for group-writable storage; incorrect anchor resolution or snapshot deferral could admit or drop protected data.
> 
> **Overview**
> Introduces **`StorageType::SharedMember`**: entries under `SharedStorage` no longer embed a writer set; they point at a **`Shared` anchor** whose rotation log is the single source of truth. **`SharedStorage`** now stamps the wrapper as `Shared` and the value (and collection children via `get_mut`) as `SharedMember`, and **`rotate_writers` drops per-entry re-stamps** so rotation is O(1) and retroactively revokes the subtree without changing member bytes (avoiding the prior split-brain from eager re-stamp).
> 
> **Storage / context** extends signing payloads, delta hashing, `apply_action` (upsert/delete), `save_raw`, `update_signature_in_place`, and snapshot verification (`resolve_anchor_writers`, `verify_snapshot_member_signature`). **Node** resolves `effective_writers` for members from the anchor’s rotation log, wires `SharedMember` through sync helpers and HashComparison, **buffers orphan member deltas** until the anchor syncs (capped in-memory buffer + re-inject on anchor apply), and runs a **two-pass snapshot apply** (defer members, verify against collected anchor writer sets).
> 
> **Breaking wire/state change** (new storage variant in hashes/signing); coordinated reset expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecdf348f1e2537d489bf561a650459bb957eaabd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->