### PR TITLE
fix(node): serialize sync-session storage applies under the per-context lock

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -49,12 +49,12 @@ use crate::group::{
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
-    ApplySignedGroupOpRequest, ApplySignedNamespaceOpRequest, ContextMessage, CreateContextRequest,
-    CreateContextResponse, DeleteContextRequest, DeleteContextResponse, ExecuteError,
-    ExecuteRequest, ExecuteResponse, MigrationParams, NamespaceApplyOutcome,
-    UpdateApplicationRequest,
+    AcquireContextLockRequest, ApplySignedGroupOpRequest, ApplySignedNamespaceOpRequest,
+    ContextMessage, CreateContextRequest, CreateContextResponse, DeleteContextRequest,
+    DeleteContextResponse, ExecuteError, ExecuteRequest, ExecuteResponse, MigrationParams,
+    NamespaceApplyOutcome, UpdateApplicationRequest,
 };
-use crate::ContextAtomic;
+use crate::{ContextAtomic, ContextAtomicKey};
 
 mod context_api;
 pub mod crypto;
@@ -1240,6 +1240,36 @@ impl ContextClient {
                     payload,
                     aliases,
                     atomic,
+                },
+                outcome: sender,
+            })
+            .await
+            .expect("Mailbox not to be dropped");
+
+        receiver.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Acquire the per-context execution lock and return its owned guard.
+    ///
+    /// This is the same `Arc<Mutex<ContextId>>` the executor holds for a WASM
+    /// run. Host-side storage mutations that bypass the executor — the sync
+    /// session's `EntityPush` / `EntityDeletePush` apply paths — must hold this
+    /// guard for the duration of their apply so they cannot interleave with a
+    /// concurrent `__calimero_sync_next` delta merge (which would record a torn
+    /// root hash that delta-sync can't repair). Drop the guard before invoking
+    /// anything that re-enters the executor (e.g. `merge_root_state`), or it
+    /// will deadlock against itself.
+    ///
+    /// Returns `None` for an unknown context; the caller then applies
+    /// best-effort without serialization (the apply no-ops on a missing
+    /// context anyway).
+    pub async fn acquire_lock(&self, context_id: &ContextId) -> Option<ContextAtomicKey> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.context_manager
+            .send(ContextMessage::AcquireContextLock {
+                request: AcquireContextLockRequest {
+                    context: *context_id,
                 },
                 outcome: sender,
             })

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -100,6 +100,28 @@ impl Message for ExecuteRequest {
     type Result = Result<ExecuteResponse, ExecuteError>;
 }
 
+/// Acquire the per-context execution lock without running a method.
+///
+/// Returns the same `Arc<Mutex<ContextId>>` guard that [`ExecuteRequest`]
+/// holds for the duration of a WASM run. Host-side storage mutations that
+/// happen outside the executor (notably the sync session's `EntityPush` /
+/// `EntityDeletePush` apply paths) must hold this guard so they are mutually
+/// exclusive with concurrent `__calimero_sync_next` delta merges. Without it
+/// the two interleave their ancestor-hash recomputes and record a torn root
+/// hash that delta-sync can't repair (split-brain).
+///
+/// `None` is returned only when the context is unknown — the caller then
+/// applies best-effort without a guard, matching the pre-lock behaviour (the
+/// apply itself no-ops on a missing context).
+#[derive(Copy, Clone, Debug)]
+pub struct AcquireContextLockRequest {
+    pub context: ContextId,
+}
+
+impl Message for AcquireContextLockRequest {
+    type Result = Option<ContextAtomicKey>;
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, ThisError)]
 #[serde(tag = "type", content = "data")]
 #[non_exhaustive]
@@ -282,6 +304,10 @@ pub enum ContextMessage {
     Execute {
         request: ExecuteRequest,
         outcome: oneshot::Sender<<ExecuteRequest as Message>::Result>,
+    },
+    AcquireContextLock {
+        request: AcquireContextLockRequest,
+        outcome: oneshot::Sender<<AcquireContextLockRequest as Message>::Result>,
     },
     CreateContext {
         request: CreateContextRequest,

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -4,6 +4,7 @@ use calimero_utils_actix::adapters::ActorExt;
 
 use crate::ContextManager;
 
+pub mod acquire_context_lock;
 pub mod add_group_members;
 pub mod admit_tee_node;
 pub mod apply_signed_group_op;
@@ -70,6 +71,9 @@ impl Handler<ContextMessage> for ContextManager {
     fn handle(&mut self, msg: ContextMessage, ctx: &mut Self::Context) -> Self::Result {
         match msg {
             ContextMessage::Execute { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::AcquireContextLock { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::UpdateApplication { request, outcome } => {

--- a/crates/context/src/handlers/acquire_context_lock.rs
+++ b/crates/context/src/handlers/acquire_context_lock.rs
@@ -1,0 +1,57 @@
+use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_context_client::messages::AcquireContextLockRequest;
+use calimero_context_client::ContextAtomicKey;
+use either::Either;
+use tracing::error;
+
+use crate::ContextManager;
+
+/// Hand out the per-context execution lock guard to an off-actor caller.
+///
+/// This is the seam that lets the sync session serialize its host-side
+/// storage mutations against the executor. The executor (`ExecuteRequest`)
+/// takes `ContextMeta::lock()` for the whole of a WASM run; the sync
+/// session's `EntityPush` / `EntityDeletePush` apply paths run in a
+/// separate actor and historically wrote storage directly, holding only
+/// the byte-level `index_mutation_guard`. That guard makes each individual
+/// mutator atomic but does NOT make a whole multi-leaf apply atomic against
+/// a concurrent delta merge — the two interleave their ancestor-hash
+/// recomputes and record a torn root hash that delta-sync can't repair.
+/// Handing the *same* `Arc<Mutex<ContextId>>` guard to the sync session
+/// closes that gap.
+///
+/// Awaiting the lock here yields cooperatively (it's a `tokio::sync::Mutex`),
+/// so an in-flight `ExecuteRequest` future on this actor keeps making
+/// progress and drops its guard normally; this future then acquires it.
+impl Handler<AcquireContextLockRequest> for ContextManager {
+    type Result = ActorResponse<Self, <AcquireContextLockRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        AcquireContextLockRequest { context }: AcquireContextLockRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        // `lock()` clones the context's `Arc<Mutex<_>>` into an owned guard
+        // (or a `'static` acquire future), so the returned `Either` does not
+        // borrow `self` and the async block below can `into_actor(self)`.
+        let lock = match self.get_or_fetch_context(&context) {
+            Ok(Some(context_meta)) => context_meta.lock(),
+            Ok(None) => return ActorResponse::reply(None),
+            Err(err) => {
+                error!(%context, %err, "acquire_context_lock: failed to fetch context");
+                return ActorResponse::reply(None);
+            }
+        };
+
+        ActorResponse::r#async(
+            async move {
+                let guard = match lock {
+                    Either::Left(guard) => guard,
+                    Either::Right(task) => task.await,
+                };
+                Some(ContextAtomicKey(guard))
+            }
+            .into_actor(self),
+        )
+    }
+}

--- a/crates/node/src/sync/hash_comparison.rs
+++ b/crates/node/src/sync/hash_comparison.rs
@@ -19,7 +19,7 @@
 //! └────────────────────────────────────────────┘
 //! ```
 
-use crate::sync::helpers::handle_entity_push;
+use crate::sync::helpers::{handle_entity_delete_push_locked, handle_entity_push_locked};
 use calimero_crypto::Nonce;
 use calimero_node_primitives::sync::{
     create_runtime_env, InitPayload, LeafMetadata, MessagePayload, StreamMessage, SyncTransport,
@@ -180,8 +180,17 @@ impl SyncManager {
                     let entity_count = entities.len();
                     trace!(%context_id, entity_count, "Handling EntityPush from initiator");
 
-                    let outcome =
-                        handle_entity_push(&datastore, &runtime_env, context_id, &entities);
+                    // Apply under the per-context execution lock so this
+                    // host-side merge can't interleave with a concurrent
+                    // delta merge in the executor (torn-root split-brain).
+                    let outcome = handle_entity_push_locked(
+                        Some(&self.context_client),
+                        &datastore,
+                        &runtime_env,
+                        context_id,
+                        &entities,
+                    )
+                    .await;
                     let applied = outcome.applied;
 
                     // Dispatch any deferred root-entity merges through
@@ -224,33 +233,16 @@ impl SyncManager {
                     let total = deletions.len();
                     trace!(%context_id, total, "Handling EntityDeletePush from initiator");
 
-                    // Apply each tombstone through the authenticated DeleteRef
-                    // path (delete-wins by HLC; signature/nonce verified for
-                    // User/Shared). A deletion that loses the LWW race or fails
-                    // authorization is a safe no-op.
-                    let mut applied: u32 = 0;
-                    for deletion in &deletions {
-                        let action = calimero_storage::action::Action::DeleteRef {
-                            id: Id::new(deletion.id),
-                            deleted_at: deletion.deleted_at,
-                            metadata: deletion.metadata.clone(),
-                        };
-                        let result = with_runtime_env(runtime_env.clone(), || {
-                            Interface::<MainStorage>::apply_action(
-                                action,
-                                &calimero_storage::interface::ApplyContext::empty(),
-                            )
-                        });
-                        match result {
-                            Ok(_) => applied += 1,
-                            Err(e) => debug!(
-                                %context_id,
-                                id = %hex::encode(deletion.id),
-                                error = %e,
-                                "EntityDeletePush: skipped a tombstone (lost LWW or unauthorized)"
-                            ),
-                        }
-                    }
+                    // Apply the tombstones (delete-wins by HLC; signature/nonce
+                    // verified for User/Shared) under the per-context execution
+                    // lock, same split-brain guard as the EntityPush path.
+                    let applied = handle_entity_delete_push_locked(
+                        Some(&self.context_client),
+                        context_id,
+                        &runtime_env,
+                        &deletions,
+                    )
+                    .await;
 
                     let msg = StreamMessage::Message {
                         sequence_id: sqx.next(),

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -24,7 +24,7 @@
 //!     &store,
 //!     context_id,
 //!     identity,
-//!     HashComparisonConfig { remote_root_hash },
+//!     HashComparisonConfig { remote_root_hash, context_client: Some(client) },
 //! ).await?;
 //!
 //! // Responder side (manager extracts first request data)
@@ -39,10 +39,12 @@
 //! ```
 
 use crate::sync::helpers::{
-    apply_leaf_with_crdt_merge, generate_nonce, get_local_root_hash_for_context,
-    handle_entity_push, is_leaf_currently_authorized, MAX_ENTITIES_PER_PUSH,
+    apply_leaf_with_crdt_merge, apply_under_context_lock, generate_nonce,
+    get_local_root_hash_for_context, handle_entity_push, is_leaf_currently_authorized,
+    MAX_ENTITIES_PER_PUSH,
 };
 use async_trait::async_trait;
+use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::sync::{
     compare_tree_nodes, create_runtime_env, EntityDeletion, InitPayload, LeafMetadata,
     MessagePayload, StreamMessage, SyncProtocolExecutor, SyncTransport, TreeCompareResult,
@@ -96,6 +98,11 @@ pub const MAX_HASH_COMPARISON_REQUESTS: u64 = 10_000;
 pub struct HashComparisonConfig {
     /// Remote peer's root hash (from handshake).
     pub remote_root_hash: [u8; 32],
+    /// Client used to acquire the per-context execution lock so the initiator's
+    /// host-side leaf/tombstone applies are mutually exclusive with a concurrent
+    /// delta merge in the executor. `None` in the single-threaded sync-sim
+    /// harness, where no executor runs alongside the protocol.
+    pub context_client: Option<ContextClient>,
 }
 
 /// Data from the first `TreeNodeRequest` for responder dispatch.
@@ -170,6 +177,7 @@ impl SyncProtocolExecutor for HashComparisonProtocol {
             context_id,
             identity,
             config.remote_root_hash,
+            config.context_client.as_ref(),
         )
         .await
     }
@@ -203,6 +211,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     context_id: ContextId,
     identity: PublicKey,
     remote_root_hash: [u8; 32],
+    context_client: Option<&ContextClient>,
 ) -> Result<HashComparisonStats> {
     info!(%context_id, "Starting HashComparison sync (initiator)");
 
@@ -379,9 +388,13 @@ async fn run_initiator_impl<T: SyncTransport>(
                         continue;
                     }
 
-                    with_runtime_env(runtime_env.clone(), || {
+                    // Under the per-context execution lock: this leaf merge is a
+                    // read-modify-write up to the root and must not interleave
+                    // with a concurrent delta merge (torn-root split-brain).
+                    apply_under_context_lock(context_client, context_id, &runtime_env, || {
                         apply_leaf_with_crdt_merge(context_id, leaf_data)
-                    })?;
+                    })
+                    .await?;
                     stats.entities_merged += 1;
 
                     // #2407 bidirectional leaf reconciliation: a parent's
@@ -446,9 +459,11 @@ async fn run_initiator_impl<T: SyncTransport>(
                 // pushing the live entity. (Our own deletions flow the other way
                 // via the remote_only → EntityDeletePush path below.)
                 if !remote_node.deleted_children.is_empty() {
-                    let applied = with_runtime_env(runtime_env.clone(), || {
-                        apply_remote_tombstones(&remote_node.deleted_children)
-                    });
+                    let applied =
+                        apply_under_context_lock(context_client, context_id, &runtime_env, || {
+                            apply_remote_tombstones(&remote_node.deleted_children)
+                        })
+                        .await;
                     if applied > 0 {
                         debug!(
                             %context_id,
@@ -1348,6 +1363,7 @@ mod tests {
     fn test_config_creation() {
         let config = HashComparisonConfig {
             remote_root_hash: [1u8; 32],
+            context_client: None,
         };
         assert_eq!(config.remote_root_hash, [1u8; 32]);
     }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -1,7 +1,8 @@
 //! Common helper functions for sync protocols.
 //!
 //! **DRY Principle**: Extract repeated logic from protocol implementations.
-use calimero_node_primitives::sync::TreeLeafData;
+use calimero_context_client::client::ContextClient;
+use calimero_node_primitives::sync::{EntityDeletion, TreeLeafData};
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
@@ -621,6 +622,111 @@ pub fn handle_entity_push(
             deferred_root_merges,
         }
     })
+}
+
+/// Run a host-side storage mutation while holding the per-context execution
+/// lock, so it cannot interleave with a concurrent `__calimero_sync_next`
+/// delta merge running in the executor.
+///
+/// The sync session and the executor live in different actors. The executor
+/// holds the context's `Arc<Mutex<_>>` for the whole of a WASM run, but the
+/// sync apply paths historically wrote storage directly, guarded only by the
+/// byte-level `index_mutation_guard`. That guard makes each individual mutator
+/// atomic but does NOT make a whole logical apply (a multi-write read-modify-
+/// write that recomputes ancestor hashes up to the root) atomic against another
+/// logical apply. Two such operations then interleave their recomputes and
+/// record a torn root hash that delta-sync can't repair — a permanent
+/// split-brain. Taking the same lock here serializes them.
+///
+/// `context_client` is `None` only on paths with no executor running
+/// concurrently (the single-threaded sync-sim harness); there the apply runs
+/// unguarded, exactly as before.
+pub async fn apply_under_context_lock<R>(
+    context_client: Option<&ContextClient>,
+    context_id: ContextId,
+    runtime_env: &calimero_storage::env::RuntimeEnv,
+    f: impl FnOnce() -> R,
+) -> R {
+    // Held across the synchronous `with_runtime_env` body below; dropped on
+    // return. The guard owns a clone of the context's lock `Arc`, so the
+    // context-cache eviction invariant (evict only when strong_count == 1)
+    // continues to treat this context as busy while we apply.
+    let _guard = match context_client {
+        Some(client) => client.acquire_lock(&context_id).await,
+        None => None,
+    };
+    calimero_storage::env::with_runtime_env(runtime_env.clone(), f)
+}
+
+/// [`handle_entity_push`] under the per-context execution lock.
+///
+/// Use this from every production responder/initiator path. The lock is
+/// released before the caller dispatches `deferred_root_merges` (those re-enter
+/// the executor via `ContextClient::merge_root_state`, which would deadlock
+/// against a held guard).
+pub async fn handle_entity_push_locked(
+    context_client: Option<&ContextClient>,
+    store: &Store,
+    runtime_env: &calimero_storage::env::RuntimeEnv,
+    context_id: ContextId,
+    entities: &[TreeLeafData],
+) -> EntityPushOutcome {
+    let _guard = match context_client {
+        Some(client) => client.acquire_lock(&context_id).await,
+        None => None,
+    };
+    handle_entity_push(store, runtime_env, context_id, entities)
+}
+
+/// Apply a batch of tombstones (delete-wins by HLC) through the authenticated
+/// `DeleteRef` path. Synchronous; the caller must already be holding the
+/// per-context execution lock (see [`handle_entity_delete_push_locked`]).
+///
+/// A deletion that loses the LWW race or fails authorization is a safe no-op
+/// and is not counted. Returns the number applied.
+fn apply_entity_deletions(
+    context_id: ContextId,
+    runtime_env: &calimero_storage::env::RuntimeEnv,
+    deletions: &[EntityDeletion],
+) -> u32 {
+    calimero_storage::env::with_runtime_env(runtime_env.clone(), || {
+        let mut applied: u32 = 0;
+        for deletion in deletions {
+            let action = Action::DeleteRef {
+                id: Id::new(deletion.id),
+                deleted_at: deletion.deleted_at,
+                metadata: deletion.metadata.clone(),
+            };
+            match Interface::<MainStorage>::apply_action(action, &ApplyContext::empty()) {
+                Ok(_) => applied += 1,
+                Err(e) => tracing::debug!(
+                    %context_id,
+                    id = %hex::encode(deletion.id),
+                    error = %e,
+                    "EntityDeletePush: skipped a tombstone (lost LWW or unauthorized)"
+                ),
+            }
+        }
+        applied
+    })
+}
+
+/// Apply a batch of tombstones under the per-context execution lock.
+///
+/// Same split-brain guard as [`handle_entity_push_locked`]: a tombstone apply
+/// is a read-modify-write up to the root and must not interleave with a
+/// concurrent delta merge.
+pub async fn handle_entity_delete_push_locked(
+    context_client: Option<&ContextClient>,
+    context_id: ContextId,
+    runtime_env: &calimero_storage::env::RuntimeEnv,
+    deletions: &[EntityDeletion],
+) -> u32 {
+    let _guard = match context_client {
+        Some(client) => client.acquire_lock(&context_id).await,
+        None => None,
+    };
+    apply_entity_deletions(context_id, runtime_env, deletions)
 }
 
 /// Extract a [`SignedNamespaceOp`](calimero_context_client::local_governance::SignedNamespaceOp)

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -41,11 +41,11 @@
 //!     &store,
 //!     context_id,
 //!     identity,
-//!     LevelWiseConfig { remote_root_hash, max_depth: 2 },
+//!     LevelWiseConfig { remote_root_hash, max_depth: 2, context_client: Some(client) },
 //! ).await?;
 //!
 //! // Responder side (manager extracts first request data)
-//! let first_request = LevelWiseFirstRequest { level: 0, parent_ids: None };
+//! let first_request = LevelWiseFirstRequest { level: 0, parent_ids: None, context_client: Some(client) };
 //! LevelWiseProtocol::run_responder(
 //!     &mut transport,
 //!     &store,
@@ -58,6 +58,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
+use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::sync::{
     compare_level_nodes, create_runtime_env, EntityDeletion, InitPayload, LevelNode,
     MessagePayload, StreamMessage, SyncProtocolExecutor, SyncTransport, TreeLeafData,
@@ -75,7 +76,8 @@ use eyre::{bail, Result};
 use tracing::{debug, info, trace, warn};
 
 use crate::sync::helpers::{
-    apply_leaf_with_crdt_merge, generate_nonce, get_local_root_hash_for_context,
+    apply_leaf_with_crdt_merge, apply_under_context_lock, generate_nonce,
+    get_local_root_hash_for_context, handle_entity_delete_push_locked,
     is_leaf_currently_authorized, MAX_ENTITIES_PER_PUSH,
 };
 
@@ -90,6 +92,10 @@ pub struct LevelWiseConfig {
     pub remote_root_hash: [u8; 32],
     /// Maximum depth to traverse (from protocol negotiation).
     pub max_depth: u32,
+    /// Client used to acquire the per-context execution lock around the
+    /// initiator's host-side leaf/tombstone applies (split-brain guard). `None`
+    /// in the single-threaded sync-sim harness.
+    pub context_client: Option<ContextClient>,
 }
 
 /// Data from the first `LevelWiseRequest` for responder dispatch.
@@ -103,6 +109,10 @@ pub struct LevelWiseFirstRequest {
     pub level: u32,
     /// Parent node IDs to query children for (None = query from root).
     pub parent_ids: Option<Vec<[u8; 32]>>,
+    /// Client used to acquire the per-context execution lock around the
+    /// responder's host-side tombstone applies (split-brain guard). `None` in
+    /// the single-threaded sync-sim harness.
+    pub context_client: Option<ContextClient>,
 }
 
 // =============================================================================
@@ -174,6 +184,7 @@ impl SyncProtocolExecutor for LevelWiseProtocol {
             identity,
             config.remote_root_hash,
             config.max_depth,
+            config.context_client.as_ref(),
         )
         .await
     }
@@ -192,6 +203,7 @@ impl SyncProtocolExecutor for LevelWiseProtocol {
             identity,
             first_request.level,
             first_request.parent_ids,
+            first_request.context_client,
         )
         .await
     }
@@ -208,6 +220,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     identity: PublicKey,
     remote_root_hash: [u8; 32],
     max_depth: u32,
+    context_client: Option<&ContextClient>,
 ) -> Result<LevelWiseStats> {
     info!(
         %context_id,
@@ -331,9 +344,11 @@ async fn run_initiator_impl<T: SyncTransport>(
         // (authenticated DeleteRef, delete-wins) is what converges a clear when
         // the holder initiates. Safe no-op when we already deleted or lose LWW.
         if !remote_deleted.is_empty() {
-            let applied = with_runtime_env(runtime_env.clone(), || {
-                crate::sync::hash_comparison_protocol::apply_remote_tombstones(&remote_deleted)
-            });
+            let applied =
+                apply_under_context_lock(context_client, context_id, &runtime_env, || {
+                    crate::sync::hash_comparison_protocol::apply_remote_tombstones(&remote_deleted)
+                })
+                .await;
             stats.entities_merged += applied;
             debug!(
                 %context_id,
@@ -459,9 +474,10 @@ async fn run_initiator_impl<T: SyncTransport>(
                         continue;
                     }
 
-                    with_runtime_env(runtime_env.clone(), || {
+                    apply_under_context_lock(context_client, context_id, &runtime_env, || {
                         apply_leaf_with_crdt_merge(context_id, leaf_data)
-                    })?;
+                    })
+                    .await?;
                     stats.entities_merged += 1;
                 }
             } else {
@@ -598,6 +614,7 @@ async fn run_responder_impl<T: SyncTransport>(
     identity: PublicKey,
     first_level: u32,
     first_parent_ids: Option<Vec<[u8; 32]>>,
+    context_client: Option<ContextClient>,
 ) -> Result<()> {
     info!(%context_id, "Starting LevelWise sync (responder)");
 
@@ -652,7 +669,15 @@ async fn run_responder_impl<T: SyncTransport>(
     sequence_id += 1;
 
     // Handle subsequent requests in a loop
-    run_responder_loop(transport, context_id, &runtime_env, sequence_id, 1).await
+    run_responder_loop(
+        transport,
+        context_id,
+        &runtime_env,
+        sequence_id,
+        1,
+        context_client.as_ref(),
+    )
+    .await
 }
 
 /// Handle a single LevelWise request and return the response data.
@@ -708,6 +733,7 @@ async fn run_responder_loop<T: SyncTransport>(
     runtime_env: &calimero_storage::env::RuntimeEnv,
     mut sequence_id: u64,
     initial_requests_handled: u64,
+    context_client: Option<&ContextClient>,
 ) -> Result<()> {
     let mut requests_handled = initial_requests_handled;
 
@@ -775,29 +801,15 @@ async fn run_responder_loop<T: SyncTransport>(
                 let total = deletions.len();
                 trace!(%context_id, total, "Handling EntityDeletePush from initiator");
 
-                let mut applied: u32 = 0;
-                for deletion in &deletions {
-                    let action = calimero_storage::action::Action::DeleteRef {
-                        id: Id::new(deletion.id),
-                        deleted_at: deletion.deleted_at,
-                        metadata: deletion.metadata.clone(),
-                    };
-                    let result = with_runtime_env(runtime_env.clone(), || {
-                        Interface::<MainStorage>::apply_action(
-                            action,
-                            &calimero_storage::interface::ApplyContext::empty(),
-                        )
-                    });
-                    match result {
-                        Ok(_) => applied += 1,
-                        Err(e) => debug!(
-                            %context_id,
-                            id = %hex::encode(deletion.id),
-                            error = %e,
-                            "EntityDeletePush: skipped a tombstone (lost LWW or unauthorized)"
-                        ),
-                    }
-                }
+                // Apply under the per-context execution lock so the tombstone
+                // writes can't interleave with a concurrent delta merge.
+                let applied = handle_entity_delete_push_locked(
+                    context_client,
+                    context_id,
+                    runtime_env,
+                    &deletions,
+                )
+                .await;
 
                 let response = StreamMessage::Message {
                     sequence_id,
@@ -1064,6 +1076,7 @@ mod tests {
         let config = LevelWiseConfig {
             remote_root_hash: [1u8; 32],
             max_depth: 2,
+            context_client: None,
         };
         assert_eq!(config.remote_root_hash, [1u8; 32]);
         assert_eq!(config.max_depth, 2);

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3134,6 +3134,7 @@ impl SyncManager {
                 let first_request = super::level_sync::LevelWiseFirstRequest {
                     level: first_level,
                     parent_ids: first_parent_ids,
+                    context_client: Some(self.context_client.clone()),
                 };
 
                 // Run the LevelWise responder via the trait method

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -213,6 +213,7 @@ impl ProtocolSelector {
                 let store = self.context_client.datastore_handle().into_inner();
                 let config = HashComparisonConfig {
                     remote_root_hash: root_hash,
+                    context_client: Some(self.context_client.clone()),
                 };
 
                 match HashComparisonProtocol::run_initiator(
@@ -351,6 +352,7 @@ impl ProtocolSelector {
                 let config = LevelWiseConfig {
                     remote_root_hash: **peer_root_hash,
                     max_depth,
+                    context_client: Some(self.context_client.clone()),
                 };
 
                 match LevelWiseProtocol::run_initiator(

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -128,6 +128,7 @@ pub async fn execute_hash_comparison_sync(
     // Config for initiator
     let config = HashComparisonConfig {
         remote_root_hash: resp_root,
+        context_client: None,
     };
 
     // Run both sides concurrently using the PRODUCTION protocol
@@ -203,6 +204,7 @@ pub async fn execute_level_wise_sync(initiator: &mut SimNode, responder: &SimNod
     let config = LevelWiseConfig {
         remote_root_hash: resp_root,
         max_depth: 8,
+        context_client: None,
     };
 
     let initiator_fut = async {
@@ -229,7 +231,11 @@ pub async fn execute_level_wise_sync(initiator: &mut SimNode, responder: &SimNod
                         level, parent_ids, ..
                     },
                 ..
-            } => LevelWiseFirstRequest { level, parent_ids },
+            } => LevelWiseFirstRequest {
+                level,
+                parent_ids,
+                context_client: None,
+            },
             _ => bail!("Expected LevelWiseRequest Init message"),
         };
 
@@ -1698,6 +1704,7 @@ mod tests {
                 identity,
                 HashComparisonConfig {
                     remote_root_hash: stale_root,
+                    context_client: None,
                 },
             )
             .await


### PR DESCRIPTION
## Problem

`scaffolding-e2e` is intermittently red with a split-brain: after the *Set document title* step, node-1/node-2 converge (`9ibd…`) but node-3 sticks at `9dKa…` and 101 sync attempts over 60s can't repair it ([run 26869190425](https://github.com/calimero-network/core/actions/runs/26869190425/job/79240728495)).

### Root cause

The same op from the same ancestor root produces two different roots depending on apply path:
- node-2 applied the byte-identical title delta via `__calimero_sync_next` with **no concurrent sync activity** → correct `9ibd…`.
- node-3 applied the same delta **while simultaneously serving a HashComparison responder** (`Applied pushed entities via CRDT merge` landed *mid* the delta merge's execution window) → torn `9dKa…`.

The executor holds the per-context `Arc<Mutex<ContextId>>` for the whole of a WASM run (user calls **and** `__calimero_sync_next` delta merges). The sync session runs in a separate actor and applied storage **directly** (`Interface::apply_action` / `apply_leaf_with_crdt_merge`), guarded only by the byte-level index-mutation lock. That lock makes each individual mutator atomic but does **not** make a whole logical apply — a multi-write read-modify-write that recomputes ancestor hashes up to the root — atomic against another logical apply. The two interleave, the merge records a root computed over a child set the sync apply mutated mid-flight, and the result is unrepairable by delta-sync/HashComparison.

This is the same race family as the index-guard (`#2573`) and value/own_hash (`#2575`) fixes, on the sync-apply paths those didn't cover.

## Fix

Hand the same per-context lock to off-actor callers and hold it around every production sync apply:

- New `AcquireContextLock` actor message → `ContextClient::acquire_lock(&ContextId) -> Option<ContextAtomicKey>` (handler mirrors the executor's `guard_task`).
- New helpers in `sync/helpers.rs`: `apply_under_context_lock`, `handle_entity_push_locked`, `handle_entity_delete_push_locked`.
- Locked paths: HashComparison responder (EntityPush + EntityDeletePush), HashComparison initiator (leaf merge + remote tombstones), LevelWise responder (EntityDeletePush) and initiator (leaf merge + tombstones).

The client is threaded through each protocol's `Config`/`ResponderInit` as `Option<ContextClient>`; the single-threaded sync-sim harness passes `None` and applies unguarded as before. The trait-only HashComparison responder in `hash_comparison_protocol.rs` is sim-only and left unguarded.

### Safety

- **Deadlock**: the lock is released *before* deferred root-state merges are dispatched (those re-enter the executor via `merge_root_state`).
- **Lock ordering** is acyclic: delta-apply takes DAG-lock → context-lock; the sync paths take only the context-lock (never the DAG lock while applying).
- **Context-cache eviction invariant** (evict iff `Arc::strong_count == 1`) is preserved — a held guard keeps the count ≥ 2.

## Testing

- `calimero-node` + `merod` compile clean; `cargo fmt --check` clean.
- `sync_sim`: 312 passed, 0 failed.
- node lib `sync::`: 174 passed, 0 failed.

No deterministic unit regression test is added — the race needs real two-node timing, which is exactly what `scaffolding-e2e` exercises; relying on CI soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency around context storage and Merkle root updates on hot sync/execute paths; incorrect lock scope or ordering could cause deadlocks or prolonged blocking, though the design explicitly drops the lock before executor re-entry.
> 
> **Overview**
> **Fixes intermittent split-brain** where a node applies the same delta as peers but keeps a different Merkle root because **HashComparison / LevelWise host-side applies** (`EntityPush`, leaf merge, tombstones) ran **without** the per-context lock that WASM execution (including `__calimero_sync_next`) already holds—only the byte-level index guard, so multi-step ancestor recomputes could interleave and record a **torn root** that later sync cannot repair.
> 
> Adds **`AcquireContextLock`** on `ContextManager` and **`ContextClient::acquire_lock`**, plus sync helpers **`apply_under_context_lock`**, **`handle_entity_push_locked`**, and **`handle_entity_delete_push_locked`**. Production sync paths thread **`Option<ContextClient>`** through protocol config; the lock is **released before** deferred `merge_root_state` to avoid deadlock. **sync-sim** keeps **`context_client: None`** (unchanged behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5c3dc140815ed2b2171e773b73bfe3b8b4b5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->