### PR TITLE
refactor(tests): dedupe DAG-causal Shared verifier test helpers

### DIFF
--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -65,6 +65,9 @@ mod tracking;
 mod p3_dag_causal_tests;
 #[cfg(test)]
 mod p5_partition_scenarios_tests;
+// Shared scaffolding for the P3/P5 tests above (the `Dag` topology mirror).
+#[cfg(test)]
+mod test_helpers;
 
 pub use config::SyncConfig;
 // Re-export for integration tests so they can mirror the production

--- a/crates/node/src/sync/p3_dag_causal_tests.rs
+++ b/crates/node/src/sync/p3_dag_causal_tests.rs
@@ -15,64 +15,28 @@
 //! regression stays in `calimero_storage::tests::write_hook` (it asserts
 //! a storage-internal invariant; no DAG needed).
 
-use core::num::NonZeroU128;
-use std::collections::{BTreeSet, HashMap, HashSet};
-
-use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
-use calimero_storage::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use calimero_storage::entities::{ChildInfo, Metadata};
 use calimero_storage::index::Index;
 use calimero_storage::interface::{ApplyContext, Interface, StorageError};
 use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 use calimero_storage::rotation_log::{self, RotationLogEntry};
 use calimero_storage::store::{MockedStorage, StorageAdaptor};
-use ed25519_dalek::{Signer, SigningKey};
+use calimero_storage::tests::common::{build_signed_shared_action, pubkey_of};
+use core::num::NonZeroU128;
+use ed25519_dalek::SigningKey;
 
 use crate::sync::rotation_log_reader;
+use crate::sync::test_helpers::Dag;
 
 // =============================================================================
 // Harness
 // =============================================================================
 
-/// Minimal DAG mirror used by tests to provide a `happens_before` predicate
-/// over delta ids — same shape as P5's `Dag`, scoped here so each test
-/// builds the DAG it needs.
-struct Dag {
-    parents: HashMap<[u8; 32], Vec<[u8; 32]>>,
-}
-
-impl Dag {
-    fn new() -> Self {
-        Self {
-            parents: HashMap::new(),
-        }
-    }
-
-    fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {
-        self.parents.insert(delta_id, parents);
-    }
-
-    fn happens_before(&self, ancestor: &[u8; 32], descendant: &[u8; 32]) -> bool {
-        if ancestor == descendant {
-            return false;
-        }
-        let mut frontier: Vec<[u8; 32]> = self.parents.get(descendant).cloned().unwrap_or_default();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        while let Some(node) = frontier.pop() {
-            if !seen.insert(node) {
-                continue;
-            }
-            if node == *ancestor {
-                return true;
-            }
-            if let Some(ps) = self.parents.get(&node) {
-                frontier.extend(ps.iter().copied());
-            }
-        }
-        false
-    }
-}
+// The `Dag` topology mirror is shared with P5 via `crate::sync::test_helpers`.
+// Signing/action builders (`build_signed_shared_action`, `pubkey_of`) come from
+// `calimero_storage::tests::common`.
 
 // Each test uses a unique mocked-storage scope so they don't bleed into each
 // other (the mock store is a thread-local BTreeMap keyed on (scope, key)).
@@ -80,10 +44,6 @@ type S<const SCOPE: usize> = MockedStorage<SCOPE>;
 
 fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
-}
-
-fn pubkey_of(sk: &SigningKey) -> PublicKey {
-    PublicKey::from(*sk.verifying_key().as_bytes())
 }
 
 fn hlc(ns: u64) -> HybridTimestamp {
@@ -117,57 +77,6 @@ fn setup_root<S: StorageAdaptor>() -> ChildInfo {
 
 fn entity_id(seed: u8) -> Id {
     Id::new([seed; 32])
-}
-
-/// Build a signed `Shared` action — see notes on the storage-side helper
-/// (`tests::common::build_signed_shared_action`) for invariants.
-fn build_signed_shared_action(
-    add: bool,
-    id: Id,
-    data: Vec<u8>,
-    writers: BTreeSet<PublicKey>,
-    hlc_ns: u64,
-    signer_sk: &SigningKey,
-    ancestors: Vec<ChildInfo>,
-) -> Action {
-    let mut metadata = Metadata::new(hlc_ns, hlc_ns);
-    metadata.storage_type = StorageType::Shared {
-        writers,
-        signature_data: Some(SignatureData {
-            signature: [0; 64],
-            nonce: hlc_ns,
-            signer: Some(pubkey_of(signer_sk)),
-        }),
-    };
-    let mut action = if add {
-        Action::Add {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    } else {
-        Action::Update {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    };
-    let payload = action.payload_for_signing();
-    let signature = signer_sk.sign(&payload).to_bytes();
-    let metadata_mut = match &mut action {
-        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
-        _ => unreachable!(),
-    };
-    if let StorageType::Shared {
-        signature_data: Some(sd),
-        ..
-    } = &mut metadata_mut.storage_type
-    {
-        sd.signature = signature;
-    }
-    action
 }
 
 /// Build an `ApplyContext` for `apply_action` by resolving `effective_writers`

--- a/crates/node/src/sync/p5_partition_scenarios_tests.rs
+++ b/crates/node/src/sync/p5_partition_scenarios_tests.rs
@@ -9,12 +9,12 @@
 //! and apply with the resolved set in `ApplyContext`. See ADR 0001.
 
 use core::num::NonZeroU128;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::BTreeSet;
 
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
-use calimero_storage::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use calimero_storage::entities::{ChildInfo, Metadata};
 use calimero_storage::index::Index;
 use calimero_storage::interface::{
     disable_nonce_check_for_testing, ApplyContext, Interface, StorageError,
@@ -22,52 +22,19 @@ use calimero_storage::interface::{
 use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 use calimero_storage::rotation_log;
 use calimero_storage::store::{MockedStorage, StorageAdaptor};
-use ed25519_dalek::{Signer, SigningKey};
+use calimero_storage::tests::common::{build_signed_shared_action, pubkey_of};
+use ed25519_dalek::SigningKey;
 
 use crate::sync::rotation_log_reader;
+use crate::sync::test_helpers::Dag;
 
 // =============================================================================
 // Harness
 // =============================================================================
 
-/// Tracks a DAG of deltas by parent links. Tests build this incrementally as
-/// they author deltas; the `happens_before` predicate is then derived via
-/// reverse BFS from the second argument.
-struct Dag {
-    parents: HashMap<[u8; 32], Vec<[u8; 32]>>,
-}
-
-impl Dag {
-    fn new() -> Self {
-        Self {
-            parents: HashMap::new(),
-        }
-    }
-
-    fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {
-        self.parents.insert(delta_id, parents);
-    }
-
-    fn happens_before(&self, ancestor: &[u8; 32], descendant: &[u8; 32]) -> bool {
-        if ancestor == descendant {
-            return false;
-        }
-        let mut frontier: Vec<[u8; 32]> = self.parents.get(descendant).cloned().unwrap_or_default();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        while let Some(node) = frontier.pop() {
-            if !seen.insert(node) {
-                continue;
-            }
-            if node == *ancestor {
-                return true;
-            }
-            if let Some(ps) = self.parents.get(&node) {
-                frontier.extend(ps.iter().copied());
-            }
-        }
-        false
-    }
-}
+// The `Dag` topology mirror is shared with P3 via `crate::sync::test_helpers`.
+// Signing/action builders (`build_signed_shared_action`, `pubkey_of`) come from
+// `calimero_storage::tests::common`.
 
 /// One delta authored on some node; gets delivered to one or more nodes.
 struct Delta {
@@ -104,62 +71,6 @@ fn deliver<S: StorageAdaptor>(delta: &Delta, dag: &Dag) -> Result<(), StorageErr
 
 fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
-}
-
-fn pubkey_of(sk: &SigningKey) -> PublicKey {
-    PublicKey::from(*sk.verifying_key().as_bytes())
-}
-
-/// Build a signed `Shared` storage action (Add or Update). Inlined from
-/// `calimero_storage::tests::common::build_signed_shared_action` because
-/// that module is `#[cfg(test)]` inside storage and not visible across crates.
-fn build_signed_shared_action(
-    add: bool,
-    id: Id,
-    data: Vec<u8>,
-    writers: BTreeSet<PublicKey>,
-    hlc_ns: u64,
-    signer_sk: &SigningKey,
-    ancestors: Vec<ChildInfo>,
-) -> Action {
-    let mut metadata = Metadata::new(hlc_ns, hlc_ns);
-    metadata.storage_type = StorageType::Shared {
-        writers,
-        signature_data: Some(SignatureData {
-            signature: [0; 64],
-            nonce: hlc_ns,
-            signer: Some(pubkey_of(signer_sk)),
-        }),
-    };
-    let mut action = if add {
-        Action::Add {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    } else {
-        Action::Update {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    };
-    let payload = action.payload_for_signing();
-    let signature = signer_sk.sign(&payload).to_bytes();
-    let metadata_mut = match &mut action {
-        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
-        _ => unreachable!(),
-    };
-    if let StorageType::Shared {
-        signature_data: Some(sd),
-        ..
-    } = &mut metadata_mut.storage_type
-    {
-        sd.signature = signature;
-    }
-    action
 }
 
 fn setup_root<S: StorageAdaptor>() -> ChildInfo {

--- a/crates/node/src/sync/test_helpers.rs
+++ b/crates/node/src/sync/test_helpers.rs
@@ -1,0 +1,49 @@
+//! Shared test scaffolding for the node-side DAG-causal Shared verifier
+//! tests (the P3 verifier-swap and P5 partition-scenario suites).
+//!
+//! The signing/action builders these tests need live in
+//! `calimero_storage::tests::common`, shared cross-crate via the storage
+//! `testing` feature. What stays here is the node-side-specific piece: the
+//! [`Dag`] mirror whose `happens_before` reverse-BFS over delta parent links
+//! feeds `rotation_log_reader::writers_at`.
+
+use std::collections::{HashMap, HashSet};
+
+/// Tracks a DAG of deltas by parent links. Tests build this incrementally as
+/// they author deltas; the [`Dag::happens_before`] predicate is then derived
+/// via reverse BFS from the descendant.
+pub(crate) struct Dag {
+    parents: HashMap<[u8; 32], Vec<[u8; 32]>>,
+}
+
+impl Dag {
+    pub(crate) fn new() -> Self {
+        Self {
+            parents: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {
+        self.parents.insert(delta_id, parents);
+    }
+
+    pub(crate) fn happens_before(&self, ancestor: &[u8; 32], descendant: &[u8; 32]) -> bool {
+        if ancestor == descendant {
+            return false;
+        }
+        let mut frontier: Vec<[u8; 32]> = self.parents.get(descendant).cloned().unwrap_or_default();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        while let Some(node) = frontier.pop() {
+            if !seen.insert(node) {
+                continue;
+            }
+            if node == *ancestor {
+                return true;
+            }
+            if let Some(ps) = self.parents.get(&node) {
+                frontier.extend(ps.iter().copied());
+            }
+        }
+        false
+    }
+}

--- a/crates/node/src/sync/test_helpers.rs
+++ b/crates/node/src/sync/test_helpers.rs
@@ -12,15 +12,14 @@ use std::collections::{HashMap, HashSet};
 /// Tracks a DAG of deltas by parent links. Tests build this incrementally as
 /// they author deltas; the [`Dag::happens_before`] predicate is then derived
 /// via reverse BFS from the descendant.
+#[derive(Default)]
 pub(crate) struct Dag {
     parents: HashMap<[u8; 32], Vec<[u8; 32]>>,
 }
 
 impl Dag {
     pub(crate) fn new() -> Self {
-        Self {
-            parents: HashMap::new(),
-        }
+        Self::default()
     }
 
     pub(crate) fn record(&mut self, delta_id: [u8; 32], parents: Vec<[u8; 32]>) {

--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -60,7 +60,7 @@ use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
 use calimero_storage::delta::StorageDelta;
-use calimero_storage::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+use calimero_storage::entities::{ChildInfo, Metadata, StorageType};
 use calimero_storage::index::Index;
 use calimero_storage::interface::{
     disable_nonce_check_for_testing, ApplyContext, Interface, StorageError,
@@ -68,8 +68,9 @@ use calimero_storage::interface::{
 use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 use calimero_storage::rotation_log;
 use calimero_storage::store::MainStorage;
+use calimero_storage::tests::common::{build_signed_shared_action, pubkey_of};
 use core::num::NonZeroU128;
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::SigningKey;
 use tokio::sync::RwLock;
 
 // =============================================================================
@@ -78,10 +79,6 @@ use tokio::sync::RwLock;
 
 fn make_signing_key(seed: u8) -> SigningKey {
     SigningKey::from_bytes(&[seed; 32])
-}
-
-fn pubkey_of(sk: &SigningKey) -> PublicKey {
-    PublicKey::from(*sk.verifying_key().as_bytes())
 }
 
 fn one_sec(n: u64) -> u64 {
@@ -107,56 +104,9 @@ fn setup_root() -> ChildInfo {
     ChildInfo::new(root_id, full_hash, root_meta)
 }
 
-/// Build a signed `Shared` action (Add or Update). The signature is over
-/// `payload_for_signing()`, just like production.
-fn build_signed_shared_action(
-    add: bool,
-    id: Id,
-    data: Vec<u8>,
-    writers: BTreeSet<PublicKey>,
-    hlc_ns: u64,
-    signer_sk: &SigningKey,
-    ancestors: Vec<ChildInfo>,
-) -> Action {
-    let mut metadata = Metadata::new(hlc_ns, hlc_ns);
-    metadata.storage_type = StorageType::Shared {
-        writers,
-        signature_data: Some(SignatureData {
-            signature: [0; 64],
-            nonce: hlc_ns,
-            signer: Some(pubkey_of(signer_sk)),
-        }),
-    };
-    let mut action = if add {
-        Action::Add {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    } else {
-        Action::Update {
-            id,
-            data,
-            ancestors,
-            metadata,
-        }
-    };
-    let payload = action.payload_for_signing();
-    let signature = signer_sk.sign(&payload).to_bytes();
-    let metadata_mut = match &mut action {
-        Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
-        _ => unreachable!(),
-    };
-    if let StorageType::Shared {
-        signature_data: Some(sd),
-        ..
-    } = &mut metadata_mut.storage_type
-    {
-        sd.signature = signature;
-    }
-    action
-}
+// `build_signed_shared_action` / `pubkey_of` come from
+// `calimero_storage::tests::common`, shared cross-crate via the `testing`
+// feature.
 
 // =============================================================================
 // SharedRotationApplier — production-flow mirror minus the WASM hop

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -43,6 +43,9 @@ default = []
 # integration tests can exercise the dispatch shape without a real
 # WASM runtime. Required by the registry integration tests; dependent
 # crates that want to mock registered merge functions enable this too.
+# Also exposes `tests::common` (action signing / builder helpers) across
+# crate boundaries so dependent crates' DAG-causal tests can share one
+# canonical copy instead of mirroring it.
 testing = []
 
 # Registry tests live in `tests/` as separate integration binaries

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -110,32 +110,68 @@ pub use error::StorageError;
 pub use interface::Interface;
 
 /// Shared test functionality.
-#[cfg(test)]
+///
+/// The module gate is `any(test, feature = "testing")` rather than plain
+/// `#[cfg(test)]` so the cross-crate helpers in [`common`] (action signing /
+/// builder utilities) are visible to dependent crates' tests through the
+/// `testing` feature. Every other submodule stays `#[cfg(test)]`: they are
+/// storage-internal unit tests with no cross-crate consumers, and exposing
+/// them under the feature would pull dev-only dependencies into ordinary
+/// `--features testing` builds.
+#[cfg(any(test, feature = "testing"))]
 pub mod tests {
+    /// Common test utilities and data structures.
+    ///
+    /// This is the one submodule exposed cross-crate via the `testing`
+    /// feature, so it compiles outside `cfg(test)` — where the crate-level
+    /// `cfg_attr(test, allow(...))` test-lint exemptions don't apply. The
+    /// `cfg_attr` below re-grants the unwrap/expect/panic exemptions for this
+    /// test-support code so a `--features testing` build lints clean.
+    #[cfg_attr(
+        all(not(test), feature = "testing"),
+        allow(
+            clippy::expect_used,
+            clippy::panic,
+            clippy::unwrap_in_result,
+            clippy::unwrap_used,
+            reason = "test-support helpers; mirror the crate's cfg(test) exemptions"
+        )
+    )]
+    pub mod common;
+
     /// AuthoredMap/AuthoredVector merge-time auth tests.
+    #[cfg(test)]
     pub mod authored_primitives;
     /// CRDT collections (UnorderedMap, Vector, Counter) tests.
+    #[cfg(test)]
     pub mod collections;
-    /// Common test utilities and data structures.
-    pub mod common;
     /// Concurrency race reproduction (core#2571).
+    #[cfg(test)]
     pub mod concurrency;
     /// Comprehensive CRDT behavior tests.
+    #[cfg(test)]
     pub mod crdt;
     /// Delta creation and commit tests.
+    #[cfg(test)]
     pub mod delta;
     /// LWW (Last-Write-Wins) Register CRDT tests.
+    #[cfg(test)]
     pub mod lww_register;
     /// CRDT type-based merge dispatch tests (TDD for PR #1889).
+    #[cfg(test)]
     pub mod merge_dispatch;
     /// Merge integration tests (using serialization instead of Clone).
+    #[cfg(test)]
     pub mod merge_integration;
     /// Merkle hash propagation tests.
+    #[cfg(test)]
     pub mod merkle;
     /// RGA (Replicated Growable Array) CRDT tests.
+    #[cfg(test)]
     pub mod rga;
     /// Storage-internal regression: the rotation-write hook depends on the
     /// stored-writers field staying frozen at bootstrap (see #2266 step 5).
+    #[cfg(test)]
     pub mod write_hook_stale_writers;
     // TODO: Re-enable once Clone is implemented for collections
     // /// Nested CRDT merge behavior tests.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -118,25 +118,17 @@ pub use interface::Interface;
 /// storage-internal unit tests with no cross-crate consumers, and exposing
 /// them under the feature would pull dev-only dependencies into ordinary
 /// `--features testing` builds.
+///
+/// `#[doc(hidden)]`: this is test/dev scaffolding, not public API. Consumers
+/// must enable `testing` only in `[dev-dependencies]` (as `calimero-node`
+/// does); it is not meant for production dependency graphs.
 #[cfg(any(test, feature = "testing"))]
+#[doc(hidden)]
 pub mod tests {
     /// Common test utilities and data structures.
     ///
     /// This is the one submodule exposed cross-crate via the `testing`
-    /// feature, so it compiles outside `cfg(test)` — where the crate-level
-    /// `cfg_attr(test, allow(...))` test-lint exemptions don't apply. The
-    /// `cfg_attr` below re-grants the unwrap/expect/panic exemptions for this
-    /// test-support code so a `--features testing` build lints clean.
-    #[cfg_attr(
-        all(not(test), feature = "testing"),
-        allow(
-            clippy::expect_used,
-            clippy::panic,
-            clippy::unwrap_in_result,
-            clippy::unwrap_used,
-            reason = "test-support helpers; mirror the crate's cfg(test) exemptions"
-        )
-    )]
+    /// feature.
     pub mod common;
 
     /// AuthoredMap/AuthoredVector merge-time auth tests.

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 use ed25519_dalek::{Signer, SigningKey};
-use velcro::btree_map;
 
 use crate::action::Action;
 use crate::address::Id;
@@ -81,9 +80,12 @@ impl Mergeable for Page {
 
 impl Data for Page {
     fn collections(&self) -> BTreeMap<String, Vec<ChildInfo>> {
-        btree_map! {
-            "Paragraphs".to_owned(): MainInterface::child_info_for(self.id()).unwrap_or_default(),
-        }
+        let mut collections = BTreeMap::new();
+        collections.insert(
+            "Paragraphs".to_owned(),
+            MainInterface::child_info_for(self.id()).unwrap_or_default(),
+        );
+        collections
     }
 
     fn element(&self) -> &Element {

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -289,6 +289,15 @@ pub fn pubkey_of(sk: &SigningKey) -> PublicKey {
 /// referencing it. Mirrors `setup_root::<MockedStorage<N>>` from
 /// `write_hook_stale_writers.rs` for tests that use the `MainInterface`
 /// alias.
+///
+// `unwrap` is fine in this test helper; crate-wide it's denied, and the
+// `cfg(test)` exemption doesn't reach the `feature = "testing"` build that
+// exposes this module cross-crate — so grant it locally on the one function
+// that needs it rather than the whole module.
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper; setup failure should abort the test"
+)]
 pub fn setup_root_for_main() -> ChildInfo {
     use crate::index::Index;
     use crate::store::MainStorage;


### PR DESCRIPTION
## Summary

The P3/P5 unit tests and the e2e probe each carried near-identical copies of `build_signed_shared_action`, `pubkey_of`, and the `Dag` topology mirror (flagged in #2272's review). The canonical signing/builder helpers already lived in `calimero_storage::tests::common`, but that module was `#[cfg(test)]`-only and so invisible across crate boundaries.

This implements **Option A** from the issue: expose `tests::common` cross-crate behind the storage crate's existing `testing` feature.

## Changes

- **`crates/storage/src/lib.rs`** — gate the `tests` module on `any(test, feature = "testing")` while keeping every *other* test submodule `#[cfg(test)]`, so only `common` leaks under the feature (the dev-dependency-heavy unit-test tree stays test-only). Added a surgical `cfg_attr` re-granting the `unwrap`/`expect`/`panic` lint exemptions on `common` for the non-test feature build (mirrors the crate's existing `cfg_attr(test, allow(...))`).
- **`crates/storage/src/tests/common.rs`** — dropped the lone `velcro::btree_map!` (a dev-dependency) so `common` compiles outside `cfg(test)`.
- **`crates/storage/Cargo.toml`** — documented the widened `testing` feature.
- **node test files** — deleted `build_signed_shared_action` + `pubkey_of` from all three (now imported from `calimero_storage::tests::common`), and moved the duplicated `Dag` topology mirror into a new `crates/node/src/sync/test_helpers.rs` shared by P3 and P5. Trimmed now-unused imports.

Net **−259 / +73** across the three test files, plus one ~50-line shared helper. Behaviour unchanged.

Node already enabled `calimero-storage = { features = ["testing"] }` as a dev-dependency, so no consumer Cargo wiring was needed.

## Acceptance criteria

- [x] `build_signed_shared_action` and `pubkey_of` deleted from all three test files
- [x] `Dag` test struct deduped (under `crates/node/src/sync/test_helpers.rs`)
- [x] All migrated P3/P5 tests + e2e probe still pass

## Verification

- `cargo fmt --check`: clean
- storage lib tests: **547 passed, 0 failed**
- P3: **10/10**, P5: **4/4**, e2e (`dag_causal_shared_e2e`): **3/3**
- `cargo check -p calimero-node --tests`: clean (no warnings from any changed file)
- `common.rs` is clippy-clean under `--features testing`

Closes #2274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor and dev-feature module exposure; production paths and sync logic are unchanged.
> 
> **Overview**
> Deduplicates DAG-causal Shared verifier test scaffolding by exposing **`calimero_storage::tests::common`** cross-crate behind the existing **`testing`** feature, and consolidating the duplicated **`Dag`** topology helper in the node sync test tree.
> 
> **Storage:** The `tests` module is gated on `any(test, feature = "testing")` with only **`common`** visible under the feature; other test submodules stay `#[cfg(test)]`. **`common`** drops the `velcro` dev-dependency usage and adds a local `allow` for `unwrap` in `setup_root_for_main` when built with `testing` only.
> 
> **Node / e2e:** P3, P5, and **`dag_causal_shared_e2e`** import **`build_signed_shared_action`** and **`pubkey_of`** from storage instead of inlined copies; P3/P5 share **`sync/test_helpers::Dag`**. No intended behavior change to the scenarios under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69171aae788ff41eeaeaca25c525ab9db85b307. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->