### PR TITLE
ci: use merobox native container logs, drop docker-logs watcher (#2179)

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -24,3 +24,15 @@ runs:
         timeout 180 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
           -o Acquire::https::Timeout=20 install -y merobox
         merobox --version
+        # The e2e workflows rely on merobox persisting per-container logs
+        # natively to data/container-logs/ (calimero-network/merobox#207),
+        # which let us drop the old background docker-logs watcher. That
+        # landed in merobox 0.6.34. The APT repo serves "latest", so pin a
+        # floor here: fail loudly if an older build is installed rather than
+        # silently collecting empty log artifacts.
+        MIN_MEROBOX="0.6.34"
+        HAVE_MEROBOX="$(merobox --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        if [ "$(printf '%s\n%s\n' "$MIN_MEROBOX" "$HAVE_MEROBOX" | sort -V | head -1)" != "$MIN_MEROBOX" ]; then
+          echo "::error::merobox ${HAVE_MEROBOX} is older than the required ${MIN_MEROBOX} (native container-log persistence, merobox#207)"
+          exit 1
+        fi

--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -234,24 +234,10 @@ jobs:
         run: |
           mkdir -p docker-logs
           LOGDIR="$GITHUB_WORKSPACE/docker-logs"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-              for c in $(docker ps --filter "label=calimero.node=true" \
-                                   --format "{{.Names}}" 2>/dev/null \
-                         | grep -v -- '-init$' || true); do
-                mark="$WATCHER_STATE_DIR/${c}"
-                if [ ! -f "$mark" ]; then
-                  touch "$mark"
-                  echo "[log-watcher] following $c"
-                  docker logs -f --timestamps "$c" \
-                    > "$LOGDIR/${c}.log" 2>&1 &
-                fi
-              done
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
+          # merobox 0.6.34+ persists per-container logs natively to
+          # data/container-logs/<name>.log on every `bootstrap run`,
+          # regardless of `stop_all_nodes` (calimero-network/merobox#207).
+          # This replaces the old background `docker logs -f` watcher.
 
           set +e
           set -o pipefail
@@ -262,11 +248,11 @@ jobs:
           wf_exit=${PIPESTATUS[0]}
           set +o pipefail
 
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          # Collect merobox's native per-container logs into the artifact dir.
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/$(basename "$f")"
+          done
 
           exit "$wf_exit"
 

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -390,45 +390,22 @@ jobs:
           mkdir -p docker-logs
           cd apps/${{ matrix.app }}
 
-          # Start a background watcher that streams `docker logs -f` from
-          # each node container to an artifact file as soon as it appears.
-          # A post-run `docker logs` loop does not work reliably on current
-          # merobox because the runtime containers are torn down as part of
-          # `merobox bootstrap run`'s exit path (regardless of
-          # `stop_all_nodes: false`), leaving only the init-container names
-          # behind by the time the shell regains control. The watcher
-          # captures logs *while* containers are live, so post-run cleanup
-          # can't remove what we've already written to disk.
-          #
-          # Workaround tracked in calimero-network/merobox#207; once merobox
-          # persists logs natively we'll remove this block (calimero/core#2179).
+          # merobox 0.6.34+ persists per-container logs to
+          # `data/container-logs/<name>.log` natively on every `bootstrap
+          # run`, regardless of `stop_all_nodes` (calimero-network/merobox#207).
+          # This replaces the old background `docker logs -f` watcher, which
+          # existed only because earlier merobox tore the runtime containers
+          # down on exit before a post-run `docker logs` could read them.
           LOGDIR="$GITHUB_WORKSPACE/docker-logs"
           # Point merobox's `restart_container` pre-restart snapshot
           # (merobox 0.6.22+) at the same absolute LOGDIR. Without this
           # env override, merobox writes the snapshot to a CWD-relative
           # `docker-logs/` which resolves to `$GITHUB_WORKSPACE/apps/
-          # <app>/docker-logs/` (because the next line `cd`s into the
+          # <app>/docker-logs/` (because the line above `cd`s into the
           # app dir) — separate from the artifact-uploaded LOGDIR. The
           # snapshot would then be invisible to the artifact uploader
           # and post-restart debugging would stay blocked.
           export MEROBOX_PRE_RESTART_LOG_DIR="$LOGDIR"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-              while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-                  # Follow containers labeled by merobox, excluding the
-                  # short-lived init containers (`*-init`).
-                  for c in $(docker ps --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null | grep -v -- '-init$' || true); do
-                      mark="$WATCHER_STATE_DIR/${c}"
-                      if [ ! -f "$mark" ]; then
-                          touch "$mark"
-                          echo "[log-watcher] following $c"
-                          docker logs -f "$c" > "$LOGDIR/${{ matrix.workflow }}-${c}.log" 2>&1 &
-                      fi
-                  done
-                  sleep 1
-              done
-          ) &
-          WATCHER_PID=$!
 
           if merobox bootstrap run \
               "${{ matrix.file }}" \
@@ -439,13 +416,16 @@ jobs:
               success=false
           fi
 
-          # Signal the watcher to stop and give `docker logs -f` followers
-          # a moment to flush their final output.
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          # Collect merobox's native per-container logs into the artifact
+          # dir before `nuke` clears node state. `nuke` only removes
+          # `calimero-node-*` data dirs, not `data/container-logs/`, but
+          # copying first keeps this robust to that behaviour changing.
+          # Prefix with the workflow name to keep filenames self-describing
+          # when several artifacts are downloaded together.
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/${{ matrix.workflow }}-$(basename "$f")"
+          done
 
           merobox stop --all || true
           merobox nuke --force || true
@@ -465,9 +445,10 @@ jobs:
         with:
           name: logs-${{ matrix.workflow }}-${{ github.sha }}
           # `docker-logs/` (with a trailing slash) uploads the
-          # ENTIRE directory: the watcher-captured `docker logs -f`
-          # streams (`${matrix.workflow}-${container}.log`) AND
-          # merobox 0.6.22+'s pre-restart snapshots
+          # ENTIRE directory: merobox's native per-container logs,
+          # copied in as `${matrix.workflow}-${container}.log`
+          # (calimero-network/merobox#207), AND merobox 0.6.22+'s
+          # pre-restart snapshots
           # (`${container}.pre-restart-${utc-ts}.log` — see
           # merobox#258). Each matrix entry runs on its own runner
           # with its own `docker-logs/` dir, so this doesn't

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -294,33 +294,15 @@ jobs:
             VMAGENT_PID=$(grep "^vmagent_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
           fi
 
-          # Stream docker logs live to disk so we keep them even when
-          # `merobox bootstrap run` tears containers down on exit — a
-          # post-run `docker logs` loop loses everything because the
-          # containers are already gone. Mirrors the pattern we settled
-          # on in e2e-rust-apps.yml (see merobox#207, #2179).
+          # merobox 0.6.34+ persists per-container logs natively to
+          # data/container-logs/<name>.log on every `bootstrap run`,
+          # regardless of `stop_all_nodes` (calimero-network/merobox#207).
+          # This replaces the old background `docker logs -f` watcher.
+          # The fuzzy test cases run sequentially from the repo root and
+          # share one data/container-logs/, so clear it before each run to
+          # keep this case's logs isolated.
           LOGDIR="$GITHUB_WORKSPACE/fuzzy-test-logs/kv-store/docker-logs"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-              # Label filter matches merobox-started containers; exclude
-              # short-lived `*-init` containers (setup-only, torn down
-              # quickly and not useful for diagnosing steady-state).
-              for c in $(docker ps --filter "label=calimero.node=true" \
-                                   --format "{{.Names}}" 2>/dev/null \
-                         | grep -v -- '-init$' || true); do
-                mark="$WATCHER_STATE_DIR/${c}"
-                if [ ! -f "$mark" ]; then
-                  touch "$mark"
-                  echo "[log-watcher] following $c"
-                  docker logs -f --timestamps "$c" \
-                    > "$LOGDIR/${c}.log" 2>&1 &
-                fi
-              done
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
+          rm -rf data/container-logs
 
           set +e
           set -o pipefail
@@ -333,13 +315,12 @@ jobs:
           exit_code=$?
           set +o pipefail
 
-          # Signal the watcher to stop and let the `docker logs -f`
-          # followers flush their final output before we move on.
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          # Collect merobox's native per-container logs into this test
+          # case's artifact dir.
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/$(basename "$f")"
+          done
 
           echo "end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
@@ -535,27 +516,10 @@ jobs:
             VMAGENT_PID=$(grep "^vmagent_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
           fi
 
-          # Live docker-logs watcher — see the kv-store job for the
-          # rationale (merobox tears containers down on exit).
+          # Native merobox per-container logs — see the kv-store case for
+          # the rationale (calimero-network/merobox#207).
           LOGDIR="$GITHUB_WORKSPACE/fuzzy-test-logs/kv-store-with-handlers/docker-logs"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-              for c in $(docker ps --filter "label=calimero.node=true" \
-                                   --format "{{.Names}}" 2>/dev/null \
-                         | grep -v -- '-init$' || true); do
-                mark="$WATCHER_STATE_DIR/${c}"
-                if [ ! -f "$mark" ]; then
-                  touch "$mark"
-                  echo "[log-watcher] following $c"
-                  docker logs -f --timestamps "$c" \
-                    > "$LOGDIR/${c}.log" 2>&1 &
-                fi
-              done
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
+          rm -rf data/container-logs
 
           set +e
           set -o pipefail
@@ -568,11 +532,10 @@ jobs:
           exit_code=$?
           set +o pipefail
 
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/$(basename "$f")"
+          done
 
           echo "end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
@@ -765,25 +728,10 @@ jobs:
             VMAGENT_PID=$(grep "^vmagent_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
           fi
 
+          # Native merobox per-container logs — see the kv-store case for
+          # the rationale (calimero-network/merobox#207).
           LOGDIR="$GITHUB_WORKSPACE/fuzzy-test-logs/scaffolding-e2e/docker-logs"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-              for c in $(docker ps --filter "label=calimero.node=true" \
-                                   --format "{{.Names}}" 2>/dev/null \
-                         | grep -v -- '-init$' || true); do
-                mark="$WATCHER_STATE_DIR/${c}"
-                if [ ! -f "$mark" ]; then
-                  touch "$mark"
-                  echo "[log-watcher] following $c"
-                  docker logs -f --timestamps "$c" \
-                    > "$LOGDIR/${c}.log" 2>&1 &
-                fi
-              done
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
+          rm -rf data/container-logs
 
           set +e
           set -o pipefail
@@ -796,11 +744,10 @@ jobs:
           exit_code=$?
           set +o pipefail
 
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/$(basename "$f")"
+          done
 
           echo "end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
@@ -991,25 +938,10 @@ jobs:
             VMAGENT_PID=$(grep "^vmagent_pid=" $GITHUB_OUTPUT | tail -1 | cut -d= -f2 || echo "")
           fi
 
+          # Native merobox per-container logs — see the kv-store case for
+          # the rationale (calimero-network/merobox#207).
           LOGDIR="$GITHUB_WORKSPACE/fuzzy-test-logs/group-governance/docker-logs"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-              for c in $(docker ps --filter "label=calimero.node=true" \
-                                   --format "{{.Names}}" 2>/dev/null \
-                         | grep -v -- '-init$' || true); do
-                mark="$WATCHER_STATE_DIR/${c}"
-                if [ ! -f "$mark" ]; then
-                  touch "$mark"
-                  echo "[log-watcher] following $c"
-                  docker logs -f --timestamps "$c" \
-                    > "$LOGDIR/${c}.log" 2>&1 &
-                fi
-              done
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
+          rm -rf data/container-logs
 
           set +e
           set -o pipefail
@@ -1022,11 +954,10 @@ jobs:
           exit_code=$?
           set +o pipefail
 
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/$(basename "$f")"
+          done
 
           echo "end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync-regression.yml
+++ b/.github/workflows/sync-regression.yml
@@ -94,31 +94,11 @@ jobs:
         run: |
           mkdir -p docker-logs
 
-          # Stream docker logs to per-container files while the run is
-          # live. The init containers exit quickly and `merobox bootstrap
-          # run` tears the runtime containers down on its way out, so a
-          # post-run `docker logs` pass catches nothing — capture during
-          # the run instead. Same shape as e2e-rust-apps.yml and
-          # fuzzy-load-test.yml's watcher (calimero-network/merobox#207).
+          # merobox 0.6.34+ persists per-container logs natively to
+          # data/container-logs/<name>.log on every `bootstrap run`,
+          # regardless of `stop_all_nodes` (calimero-network/merobox#207).
+          # This replaces the old background `docker logs -f` watcher.
           LOGDIR="$GITHUB_WORKSPACE/docker-logs"
-          WATCHER_STATE_DIR="$(mktemp -d)"
-          (
-            while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
-              for c in $(docker ps --filter "label=calimero.node=true" \
-                                   --format "{{.Names}}" 2>/dev/null \
-                         | grep -v -- '-init$' || true); do
-                mark="$WATCHER_STATE_DIR/${c}"
-                if [ ! -f "$mark" ]; then
-                  touch "$mark"
-                  echo "[log-watcher] following $c"
-                  docker logs -f --timestamps "$c" \
-                    > "$LOGDIR/${c}.log" 2>&1 &
-                fi
-              done
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
 
           set +e
           set -o pipefail
@@ -130,11 +110,11 @@ jobs:
           exit_code=$?
           set +o pipefail
 
-          touch "$WATCHER_STATE_DIR/stop"
-          sleep 2
-          kill "$WATCHER_PID" 2>/dev/null || true
-          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
-          wait 2>/dev/null || true
+          # Collect merobox's native per-container logs into the artifact dir.
+          for f in data/container-logs/*.log; do
+              [ -e "$f" ] || continue
+              cp -f "$f" "$LOGDIR/$(basename "$f")"
+          done
 
           exit "$exit_code"
 


### PR DESCRIPTION
## Summary

Closes #2179. Now that merobox **0.6.34** persists per-container logs to `data/container-logs/<name>.log` on every `bootstrap run` regardless of `stop_all_nodes` (calimero-network/merobox#207, shipped in calimero-network/merobox#275), we can drop the temporary background `docker logs -f` watcher that PR #2177 introduced.

The watcher existed because earlier merobox tore the runtime containers down on its exit path before a post-run `docker logs` pass could read them — so we had to stream logs while containers were live. merobox now dumps them itself (in both the leave-running success branch and the failure-exit path), so a simple copy after the run suffices.

## Changes

Removed the watcher and switched to merobox's native logs in all four e2e workflows that carried the workaround:

- **`e2e-rust-apps.yml`** — the workflow the issue names.
- **`app-migration-e2e.yml`**
- **`sync-regression.yml`**
- **`fuzzy-load-test.yml`** — 4 test cases (kv-store, kv-store-with-handlers, scaffolding-e2e, group-governance). These run sequentially from the repo root and share one `data/container-logs/`, so each clears it before its run and copies out after.

Each workflow copies `data/container-logs/*.log` into its existing artifact dir (before `nuke`, which only removes `calimero-node-*` data dirs anyway). The merobox `restart_container` pre-restart snapshot wiring (`MEROBOX_PRE_RESTART_LOG_DIR`) is preserved.

**`setup-merobox/action.yml`**: the APT repo serves "latest" (no version pin existed), so I added a **0.6.34 version floor** — if an older merobox is installed, the action fails loudly rather than silently collecting empty log artifacts.

Net **~110 fewer lines** of CI shell.

## Validation

- All five files pass `yaml.safe_load`.
- Version-floor comparison logic unit-checked locally (0.6.33/0.6.9 → fail; 0.6.34/0.6.35/0.7.0 → ok).
- merobox 0.6.34 is live on both PyPI and the APT repo (`0.6.34-1`), so CI installs it and the floor guard passes.
- The real validation is this PR's own CI run: the log artifacts (`logs-*`, `*-docker-logs`, `fuzzy-test-logs/*`) should be present and non-empty — issue #2179's step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions shell for test log collection; no application runtime, auth, or data-path code is modified.
> 
> **Overview**
> E2E and load-test CI no longer run background **`docker logs -f`** watchers during **`merobox bootstrap run`**. After each run, workflows copy **`data/container-logs/*.log`** (merobox **0.6.34+**) into the existing artifact directories instead.
> 
> **`setup-merobox`** now enforces a **0.6.34** minimum version so an older APT “latest” install fails the job instead of producing empty log artifacts.
> 
> Touched workflows: **`e2e-rust-apps`**, **`app-migration-e2e`**, **`sync-regression`**, and **`fuzzy-load-test`** (four cases clear **`data/container-logs`** before each run so sequential cases do not mix logs). **`MEROBOX_PRE_RESTART_LOG_DIR`** and workflow-prefixed log names in rust e2e are unchanged in intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d9d978153d31950e0d7f965835b4e5e9388add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->