### PR TITLE
feat(api): stream sync status over WebSocket + snapshot progress (#2027)

### DIFF
--- a/crates/node/primitives/src/lib.rs
+++ b/crates/node/primitives/src/lib.rs
@@ -10,7 +10,7 @@ pub use join_bundle::JoinBundle;
 pub mod messages;
 pub mod sync;
 pub mod sync_status;
-pub use sync_status::{SyncPhase, SyncStatusSnapshot};
+pub use sync_status::{SyncState, SyncStatusSnapshot};
 pub mod topic_manager;
 pub use topic_manager::TopicManager;
 

--- a/crates/node/primitives/src/sync_status.rs
+++ b/crates/node/primitives/src/sync_status.rs
@@ -8,51 +8,25 @@
 //! per-context bookkeeping so the distinction is observable.
 //!
 //! The data is advisory: it is published from the sync run-loop on a
-//! lock-free map and read out-of-band, so a reader may observe a value that is
-//! a few hundred milliseconds stale. It is meant for UX ("syncing, please
-//! wait" vs "stuck"), not for control flow.
+//! lock-free map and read out-of-band (or pushed as a WebSocket event), so a
+//! reader may observe a value that is a few hundred milliseconds stale. It is
+//! meant for UX ("syncing, please wait" vs "stuck"), not for control flow.
 //!
-//! These types are passed in-process only (run-loop publisher → `NodeManager`
-//! → `NodeClient`); the wire-facing shape lives in `calimero-server-primitives`
-//! (`jsonrpc::SyncState`), which the server handler maps onto. So there are
-//! deliberately no `serde` derives here.
+//! The phase vocabulary ([`SyncState`]) is the shared wire type from
+//! `calimero-primitives`, so the run-loop, the JSON-RPC response, and the
+//! WebSocket event all speak the same language.
+
+pub use calimero_primitives::sync_status::SyncState;
 
 /// A snapshot of where a context is in the sync lifecycle.
 #[derive(Clone, Debug)]
 pub struct SyncStatusSnapshot {
-    /// Coarse phase the sync manager last recorded for this context.
-    pub phase: SyncPhase,
+    /// Coarse phase the sync run-loop last recorded for this context.
+    pub state: SyncState,
     /// Consecutive failed sync attempts. Resets to 0 on the next success.
-    /// A non-zero value with `phase == BackingOff` is the "stuck" signal.
+    /// A non-zero value with `state == BackingOff` is the "stuck" signal.
     pub failure_count: u32,
     /// The error from the most recent failed attempt, if any. Carries the
-    /// reason behind a `BackingOff` phase (e.g. "No peers to sync with"),
-    /// which is what lets a client distinguish "waiting for a peer" from a
-    /// genuine protocol failure.
+    /// reason behind a `BackingOff` state (e.g. "No peers to sync with").
     pub last_error: Option<String>,
-}
-
-/// Coarse sync phase. Deliberately small: finer-grained snapshot progress
-/// (page percent, bytes) can be layered on later without changing the
-/// distinction this enum exists to make — running vs settled vs wedged.
-///
-/// Note this phase is derived purely from the run-loop's `SyncState` and is
-/// blind to whether the context is initialized. In particular the benign
-/// "no peers / peer not materialised" outcome clears the in-flight marker
-/// without recording a failure, so it lands here as [`SyncPhase::Idle`]; it is
-/// the *reader* (which also knows `is_initialized`) that resolves an
-/// uninitialized-yet-idle context to "waiting for peers".
-#[derive(Clone, Copy, Debug)]
-pub enum SyncPhase {
-    /// No attempt is in flight and none is gated behind backoff.
-    Idle,
-    /// A sync attempt is currently in flight (snapshot or delta exchange).
-    Syncing,
-    /// The last attempt finished without success and the next retry is gated
-    /// behind exponential backoff. `retry_in_secs` is the manager's best
-    /// estimate of the remaining wait; it is `0` once a retry is due.
-    BackingOff {
-        /// Estimated seconds until the next retry is eligible.
-        retry_in_secs: u64,
-    },
 }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -475,6 +475,7 @@ impl SyncManager {
             self.sync_config.session_deadline,
             self.sync_config.interval,
             self.node_state.sync_status_handle(),
+            Some(self.node_client.clone()),
         );
 
         let driver = super::driver::SyncDriver::new(

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -223,10 +223,11 @@ impl SessionTracker {
         failure_count: u32,
         last_error: Option<String>,
     ) {
-        let changed = self
-            .status_sink
-            .get(ctx)
-            .is_none_or(|prev| prev.state != phase || prev.failure_count != failure_count);
+        let changed = self.status_sink.get(ctx).is_none_or(|prev| {
+            prev.state != phase
+                || prev.failure_count != failure_count
+                || prev.last_error.as_deref() != last_error.as_deref()
+        });
         let _prev = self.status_sink.insert(
             *ctx,
             SyncStatusSnapshot {

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -21,8 +21,16 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use calimero_node_primitives::{SyncPhase, SyncStatusSnapshot};
+use calimero_node_primitives::client::NodeClient;
+use calimero_node_primitives::SyncStatusSnapshot;
 use calimero_primitives::context::ContextId;
+use calimero_primitives::events::{
+    ContextEvent, ContextEventPayload, NodeEvent, SyncStatusPayload,
+};
+// The wire-facing phase enum. Aliased to `SyncPhase` to avoid colliding with
+// the run-loop's internal `tracking::SyncState` (imported below), which is a
+// different type tracking last-sync/failure bookkeeping.
+use calimero_primitives::sync_status::SyncState as SyncPhase;
 use dashmap::DashMap;
 use tokio::time::Instant;
 use tracing::{debug, info, warn};
@@ -89,6 +97,11 @@ pub(super) struct SessionTracker {
     /// tracker is the sole writer; readers only ever see committed
     /// snapshots. Shares the `Arc` held by `NodeState::sync_status`.
     status_sink: Arc<DashMap<ContextId, SyncStatusSnapshot>>,
+    /// Used to push a `SyncStatus` WebSocket event whenever a context's
+    /// phase changes, so subscribers get live updates instead of polling.
+    /// `None` in unit tests (no node wired up); event emission is then a
+    /// no-op while the `status_sink` mirror still updates.
+    event_emitter: Option<NodeClient>,
 }
 
 /// Outcome of [`SessionTracker::dispatch_decision`].
@@ -150,6 +163,7 @@ impl SessionTracker {
         session_deadline: Duration,
         dispatch_backoff: Duration,
         status_sink: Arc<DashMap<ContextId, SyncStatusSnapshot>>,
+        event_emitter: Option<NodeClient>,
     ) -> Self {
         const SESSION_WEDGE_GRACE_MULTIPLIER: u32 = 2;
         Self {
@@ -163,14 +177,17 @@ impl SessionTracker {
             session_wedge_grace: session_deadline * SESSION_WEDGE_GRACE_MULTIPLIER,
             dispatch_backoff,
             status_sink,
+            event_emitter,
         }
     }
 
     /// Recompute and publish the observable sync-status snapshot for `ctx`
-    /// from its current `SyncState`. Called after every transition so the
-    /// out-of-band reader sees a fresh phase. Cheap: one map lookup plus a
-    /// `DashMap` insert. A context with no tracked state is left absent
-    /// (the reader treats absence as "no sync activity recorded").
+    /// from its current `SyncState`, deriving the wire phase the same way the
+    /// dispatch loop reasons about the context. The benign no-peers /
+    /// not-materialised outcome is *not* derivable from `SyncState` (it clears
+    /// the in-flight marker without recording a failure, so it looks idle), so
+    /// the call sites that know about it pass [`SyncPhase::WaitingForPeers`]
+    /// explicitly via [`Self::publish_state`].
     fn publish_status(&self, ctx: &ContextId) {
         let Some(state) = self.state.get(ctx) else {
             return;
@@ -187,14 +204,52 @@ impl SessionTracker {
             }
             Some(_) => SyncPhase::Idle,
         };
+        let failure_count = state.failure_count();
+        let last_error = state.last_error().map(ToOwned::to_owned);
+        // Drop the borrow of `self.state` before touching the sink/emitter.
+        drop(state);
+        self.publish_state(ctx, phase, failure_count, last_error);
+    }
+
+    /// Write the snapshot for `ctx` and, when the phase actually changed,
+    /// push a `SyncStatus` WebSocket event. Change detection keeps the event
+    /// stream quiet between real transitions; the lock-free mirror is always
+    /// refreshed so a polling reader sees the latest. Cheap: a `DashMap`
+    /// lookup + insert, plus a broadcast send only on change.
+    fn publish_state(
+        &self,
+        ctx: &ContextId,
+        phase: SyncPhase,
+        failure_count: u32,
+        last_error: Option<String>,
+    ) {
+        let changed = self
+            .status_sink
+            .get(ctx)
+            .is_none_or(|prev| prev.state != phase || prev.failure_count != failure_count);
         let _prev = self.status_sink.insert(
             *ctx,
             SyncStatusSnapshot {
-                phase,
-                failure_count: state.failure_count(),
-                last_error: state.last_error().map(ToOwned::to_owned),
+                state: phase,
+                failure_count,
+                last_error: last_error.clone(),
             },
         );
+        if changed {
+            if let Some(node_client) = &self.event_emitter {
+                let event = NodeEvent::Context(ContextEvent {
+                    context_id: *ctx,
+                    payload: ContextEventPayload::SyncStatus(SyncStatusPayload {
+                        sync_state: phase,
+                        failure_count,
+                        last_error,
+                    }),
+                });
+                if let Err(err) = node_client.send_event(event) {
+                    debug!(context_id = %ctx, %err, "failed to emit sync-status event");
+                }
+            }
+        }
     }
 
     /// `session_wedge_grace` exposed for the caller's wedge warn-log
@@ -345,6 +400,13 @@ impl SessionTracker {
             result,
         } = result;
 
+        // Set by the benign no-peers / not-materialised arms. That outcome
+        // clears the in-flight marker without recording a failure, so the
+        // generic `publish_status` derivation would read it as plain idle —
+        // indistinguishable from a settled context. Flag it so the trailing
+        // publish reports `WaitingForPeers` instead.
+        let mut waiting_for_peers = false;
+
         match self.state.get_mut(&context_id) {
             None => {
                 // Log the result discriminant + Display-only error
@@ -412,6 +474,7 @@ impl SessionTracker {
                         // the next tick pick a different peer is the
                         // graceful recovery.
                         s.on_not_materialized();
+                        waiting_for_peers = true;
                     } else if err.downcast_ref::<NoPeersAvailable>().is_some() {
                         // Transient: no co-member is connected for this
                         // context right now (empty mesh + no namespace
@@ -430,6 +493,7 @@ impl SessionTracker {
                              waiting for a co-member, not a failure"
                         );
                         s.on_not_materialized();
+                        waiting_for_peers = true;
                     } else {
                         s.on_failure(err.to_string());
                         warn!(
@@ -455,8 +519,20 @@ impl SessionTracker {
             },
         }
         // The mutable `s` borrow above is released; publish the settled phase
-        // so the out-of-band reader observes success/idle/backoff immediately.
-        self.publish_status(&context_id);
+        // so readers (and subscribers) observe the outcome immediately.
+        if waiting_for_peers {
+            let (failure_count, last_error) = self.state.get(&context_id).map_or((0, None), |s| {
+                (s.failure_count(), s.last_error().map(ToOwned::to_owned))
+            });
+            self.publish_state(
+                &context_id,
+                SyncPhase::WaitingForPeers,
+                failure_count,
+                last_error,
+            );
+        } else {
+            self.publish_status(&context_id);
+        }
     }
 
     /// Wedge-watchdog tick. Returns contexts whose initiator was
@@ -588,11 +664,12 @@ mod tests {
 
     fn tracker() -> SessionTracker {
         // Use small but realistic durations so the `force` override
-        // tests have a meaningful "minimum".
+        // tests have a meaningful "minimum". No event emitter in unit tests.
         SessionTracker::new(
             Duration::from_secs(30),
             Duration::from_secs(5),
             Arc::new(DashMap::new()),
+            None,
         )
     }
 
@@ -1379,10 +1456,12 @@ mod tests {
 
     fn tracker_with_sink() -> (SessionTracker, Arc<DashMap<ContextId, SyncStatusSnapshot>>) {
         let sink = Arc::new(DashMap::new());
+        // No event emitter — exercises the sink mirror without a live node.
         let t = SessionTracker::new(
             Duration::from_secs(30),
             Duration::from_secs(5),
             Arc::clone(&sink),
+            None,
         );
         (t, sink)
     }
@@ -1393,7 +1472,7 @@ mod tests {
         // A dispatched first sync leaves the in-progress marker set.
         t.record_dispatch_succeeded(ctx(1), true);
         let snap = sink.get(&ctx(1)).expect("status published on dispatch");
-        assert!(matches!(snap.phase, SyncPhase::Syncing));
+        assert!(matches!(snap.state, SyncPhase::Syncing));
         assert_eq!(snap.failure_count, 0);
         assert!(snap.last_error.is_none());
     }
@@ -1409,7 +1488,7 @@ mod tests {
         let _ = t.state.insert(ctx(1), s);
         t.publish_status(&ctx(1));
         let snap = sink.get(&ctx(1)).expect("status published");
-        assert!(matches!(snap.phase, SyncPhase::Idle));
+        assert!(matches!(snap.state, SyncPhase::Idle));
         assert_eq!(snap.failure_count, 0);
         assert!(snap.last_error.is_none());
     }
@@ -1418,18 +1497,39 @@ mod tests {
     fn publish_status_reports_backing_off_after_failure() {
         let (mut t, sink) = tracker_with_sink();
         let mut s = SyncState::new();
-        s.on_failure("No peers to sync with".to_owned());
+        s.on_failure("a real protocol error".to_owned());
         let _ = t.state.insert(ctx(1), s);
         t.publish_status(&ctx(1));
         let snap = sink.get(&ctx(1)).expect("status published");
-        match snap.phase {
+        match snap.state {
             // backoff_delay(2^1=2s) is below the 5s dispatch floor, so the
             // reported wait is the floor minus the (near-zero) elapsed time.
             SyncPhase::BackingOff { retry_in_secs } => assert!(retry_in_secs <= 5),
             other => panic!("expected BackingOff, got {other:?}"),
         }
         assert_eq!(snap.failure_count, 1);
-        assert_eq!(snap.last_error.as_deref(), Some("No peers to sync with"));
+        assert_eq!(snap.last_error.as_deref(), Some("a real protocol error"));
+    }
+
+    #[test]
+    fn apply_result_no_peers_reports_waiting_for_peers() {
+        let (mut t, sink) = tracker_with_sink();
+        // Put the context in-flight first (dispatched), so apply_result finds
+        // a tracked SyncState to settle.
+        t.record_dispatch_succeeded(ctx(1), true);
+        // A NoPeersAvailable outcome is benign: it must surface as
+        // WaitingForPeers, not idle — the regression this guards.
+        t.apply_result(no_peers_available_result(ctx(1)));
+        let snap = sink.get(&ctx(1)).expect("status published");
+        assert!(
+            matches!(snap.state, SyncPhase::WaitingForPeers),
+            "no-peers outcome must report WaitingForPeers, got {:?}",
+            snap.state
+        );
+        assert_eq!(
+            snap.failure_count, 0,
+            "no-peers must not count as a failure"
+        );
     }
 
     #[test]

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -11,7 +11,11 @@ use calimero_node_primitives::sync::snapshot::{
 use calimero_node_primitives::sync::{
     MessagePayload, SnapshotCursor, SnapshotError, StreamMessage,
 };
+use calimero_node_primitives::{SyncState, SyncStatusSnapshot};
 use calimero_primitives::context::ContextId;
+use calimero_primitives::events::{
+    ContextEvent, ContextEventPayload, NodeEvent, SyncStatusPayload,
+};
 use calimero_primitives::hash::Hash;
 use calimero_storage::address::Id;
 use calimero_storage::env::time_now;
@@ -691,6 +695,11 @@ impl SyncManager {
                             "Applied snapshot page"
                         );
 
+                        // Surface snapshot progress (per page-burst, a natural
+                        // throttle) so a subscriber watching this uninitialized
+                        // context sees forward motion rather than a silent wait.
+                        self.emit_snapshot_progress(context_id, total_applied as u64);
+
                         // Check if this is the last page in this burst
                         let is_last_in_burst = sent_count == page_count;
 
@@ -762,6 +771,33 @@ impl SyncManager {
         handle.put(&key, &value)?;
         debug!(%context_id, "Set sync-in-progress marker");
         Ok(())
+    }
+
+    /// Record snapshot progress on the advisory `sync_status` mirror and push a
+    /// `SyncStatus` event to subscribers. Best-effort: a broadcast with no
+    /// receivers is fine, and `records_received` is a monotonic liveness signal
+    /// (not a percentage — the receiver isn't told a grand total up front).
+    fn emit_snapshot_progress(&self, context_id: ContextId, records_received: u64) {
+        let state = SyncState::ReceivingSnapshot { records_received };
+        let _prev = self.node_state.sync_status_handle().insert(
+            context_id,
+            SyncStatusSnapshot {
+                state,
+                failure_count: 0,
+                last_error: None,
+            },
+        );
+        let event = NodeEvent::Context(ContextEvent {
+            context_id,
+            payload: ContextEventPayload::SyncStatus(SyncStatusPayload {
+                sync_state: state,
+                failure_count: 0,
+                last_error: None,
+            }),
+        });
+        if let Err(err) = self.node_client.send_event(event) {
+            debug!(%context_id, %err, "failed to emit snapshot-progress event");
+        }
     }
 
     /// Clear the sync-in-progress marker after successful sync completion.

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -779,20 +779,31 @@ impl SyncManager {
     /// (not a percentage — the receiver isn't told a grand total up front).
     fn emit_snapshot_progress(&self, context_id: ContextId, records_received: u64) {
         let state = SyncState::ReceivingSnapshot { records_received };
-        let _prev = self.node_state.sync_status_handle().insert(
+        let handle = self.node_state.sync_status_handle();
+        // Preserve any failure history the run-loop has already published for
+        // this context; this path only advances the snapshot phase. Writing
+        // 0/None here would flip `failure_count`/`last_error` to "healthy"
+        // mid-snapshot until the next run-loop publish. (Copy into owned values
+        // and drop the read guard before `insert` — a same-key get+insert on a
+        // `DashMap` shard would otherwise deadlock.)
+        let (failure_count, last_error) = match handle.get(&context_id) {
+            Some(prev) => (prev.failure_count, prev.last_error.clone()),
+            None => (0, None),
+        };
+        let _prev = handle.insert(
             context_id,
             SyncStatusSnapshot {
                 state,
-                failure_count: 0,
-                last_error: None,
+                failure_count,
+                last_error: last_error.clone(),
             },
         );
         let event = NodeEvent::Context(ContextEvent {
             context_id,
             payload: ContextEventPayload::SyncStatus(SyncStatusPayload {
                 sync_state: state,
-                failure_count: 0,
-                last_error: None,
+                failure_count,
+                last_error,
             }),
         });
         if let Err(err) = self.node_client.send_event(event) {

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::context::ContextId;
 use crate::hash::Hash;
+use crate::sync_status::SyncState;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
@@ -22,6 +23,24 @@ pub struct ContextEvent {
 #[allow(variant_size_differences, reason = "fine for now")]
 pub enum ContextEventPayload {
     StateMutation(StateMutationPayload),
+    /// Live sync-status update, pushed to subscribers as the sync run-loop
+    /// changes phase (and as snapshot pages arrive). Lets a client waiting on
+    /// initial state watch progress instead of polling `sync_status`.
+    SyncStatus(SyncStatusPayload),
+}
+
+/// Payload of a [`ContextEventPayload::SyncStatus`] event. Mirrors the fields
+/// of the `sync_status` JSON-RPC response that the run-loop knows; `is_initialized`
+/// is deliberately omitted (it's a context-layer fact, not a sync-phase one —
+/// a client reads it from the RPC or infers initialization from the first
+/// [`ContextEventPayload::StateMutation`]).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncStatusPayload {
+    pub sync_state: SyncState,
+    pub failure_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -9,5 +9,6 @@ pub mod hash;
 pub mod identity;
 pub mod metadata;
 pub mod reflect;
+pub mod sync_status;
 pub mod utils;
 pub mod version;

--- a/crates/primitives/src/sync_status.rs
+++ b/crates/primitives/src/sync_status.rs
@@ -1,0 +1,38 @@
+//! Wire-facing sync-status types shared by the `sync_status` JSON-RPC response
+//! and the `SyncStatus` WebSocket event, so both speak one vocabulary.
+//!
+//! See `calimero-node`'s sync run-loop for where these are produced, and the
+//! issue this serves: a node blocked on `Uninitialized` needs to tell
+//! "syncing" from "waiting for a peer" from "stuck".
+
+use serde::{Deserialize, Serialize};
+
+/// Coarse sync phase. Serialized internally-tagged as `{ "state": "syncing" }`,
+/// with data-carrying variants adding their fields alongside the tag (e.g.
+/// `{ "state": "backingOff", "retryInSecs": 8 }`). A typed enum keeps each
+/// variant's data bound to it and lets clients match exhaustively.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "camelCase")]
+pub enum SyncState {
+    /// Settled — no sync in flight, nothing pending.
+    Idle,
+    /// Not yet initialized and nothing is actively syncing: typically waiting
+    /// for a co-member peer to appear to sync the initial state from.
+    WaitingForPeers,
+    /// A sync attempt is in flight (handshake / delta exchange).
+    Syncing,
+    /// Receiving an initial-state snapshot. `records_received` is a monotonic
+    /// count of applied entries — a liveness/progress signal. It is not a
+    /// percentage: the snapshot stream is cursor-paged and the receiver is not
+    /// told a grand total up front, so a true percent/ETA would require the
+    /// sender to advertise one (a follow-up wire change).
+    ReceivingSnapshot {
+        /// Entries applied from the snapshot so far.
+        records_received: u64,
+    },
+    /// The last attempt failed and the next retry is gated behind backoff.
+    BackingOff {
+        /// Estimated seconds until the next retry is eligible.
+        retry_in_secs: u64,
+    },
+}

--- a/crates/server/primitives/src/jsonrpc.rs
+++ b/crates/server/primitives/src/jsonrpc.rs
@@ -210,27 +210,9 @@ impl SyncStatusRequest {
     }
 }
 
-/// Coarse, wire-facing sync phase. Serialized internally-tagged as
-/// `{ "state": "syncing" }`, with `backingOff` additionally carrying
-/// `retryInSecs`. A typed enum (rather than a bare string) keeps `retry_in_secs`
-/// structurally bound to the one state it applies to and lets callers match
-/// exhaustively. Not `#[non_exhaustive]` so the server handler can construct it.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(tag = "state", rename_all = "camelCase")]
-pub enum SyncState {
-    /// Context is settled — no sync in flight, nothing pending.
-    Idle,
-    /// Not yet initialized and nothing is actively syncing: typically waiting
-    /// for a co-member peer to appear to sync the initial state from.
-    WaitingForPeers,
-    /// A sync attempt is currently in flight.
-    Syncing,
-    /// The last attempt failed and the next retry is gated behind backoff.
-    BackingOff {
-        /// Estimated seconds until the next retry is eligible.
-        retry_in_secs: u64,
-    },
-}
+/// The coarse phase carried in the response — the shared wire type, so the
+/// JSON-RPC response and the WebSocket `SyncStatus` event speak the same enum.
+pub use calimero_primitives::sync_status::SyncState;
 
 /// Sync-status response. `sync_state` carries the coarse phase; a non-zero
 /// `failure_count` with `last_error` set is the "stuck" signal. Note

--- a/crates/server/src/jsonrpc/sync_status.rs
+++ b/crates/server/src/jsonrpc/sync_status.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use calimero_node_primitives::SyncPhase;
 use calimero_server_primitives::jsonrpc::{
     SyncState, SyncStatusError, SyncStatusRequest, SyncStatusResponse,
 };
@@ -29,21 +28,20 @@ impl Request for SyncStatusRequest {
         };
         let is_initialized = *context.root_hash != [0; 32];
 
-        // The run-loop's advisory snapshot supplies the phase. The node's
-        // `SyncPhase` is blind to initialization, so resolve the ambiguous
-        // settled-but-no-state case here: an uninitialized context that the
-        // run-loop considers idle (including the benign no-peers / not-
-        // materialised outcome, which clears the in-flight marker without
-        // recording a failure, and the never-dispatched case) is waiting for a
-        // peer to sync from. `Syncing` / `BackingOff` are reported as-is
-        // regardless of initialization — an initialized context can still be
-        // catching up on later deltas.
+        // The run-loop publishes the phase directly (including WaitingForPeers
+        // for the benign no-peers outcome), so this passes it through. The one
+        // adjustment: a context with no recorded snapshot defaults to "waiting"
+        // when uninitialized, "idle" once it has state.
         let snapshot = state.node_client.sync_status(context_id).await?;
-
-        let sync_state = resolve_sync_state(snapshot.as_ref().map(|s| s.phase), is_initialized);
-        let (failure_count, last_error) = snapshot
-            .map(|s| (s.failure_count, s.last_error))
-            .unwrap_or((0, None));
+        let (sync_state, failure_count, last_error) = match snapshot {
+            Some(snap) => (
+                normalize(snap.state, is_initialized),
+                snap.failure_count,
+                snap.last_error,
+            ),
+            None if is_initialized => (SyncState::Idle, 0, None),
+            None => (SyncState::WaitingForPeers, 0, None),
+        };
 
         Ok(SyncStatusResponse::new(
             context_id,
@@ -55,65 +53,57 @@ impl Request for SyncStatusRequest {
     }
 }
 
-/// Resolve the wire-facing [`SyncState`] from the run-loop's advisory phase and
-/// the authoritative `is_initialized` flag.
-///
-/// `Syncing` and `BackingOff` are reported as-is — an initialized context can
-/// legitimately still be catching up on later deltas. The ambiguity is the
-/// settled-but-idle case: the node's `SyncPhase::Idle` (and the never-dispatched
-/// `None`) covers both a healthy initialized context *and* one that has no state
-/// yet and is simply waiting for a peer — including the benign no-peers /
-/// peer-not-materialised outcome, which clears the in-flight marker without
-/// recording a failure. `is_initialized` disambiguates the two.
-fn resolve_sync_state(phase: Option<SyncPhase>, is_initialized: bool) -> SyncState {
-    match phase {
-        Some(SyncPhase::Syncing) => SyncState::Syncing,
-        Some(SyncPhase::BackingOff { retry_in_secs }) => SyncState::BackingOff { retry_in_secs },
-        Some(SyncPhase::Idle) | None if is_initialized => SyncState::Idle,
-        Some(SyncPhase::Idle) | None => SyncState::WaitingForPeers,
+/// Safety net for stale snapshots: an initialized context already has its
+/// state, so it can't still be "waiting for peers" to deliver it. Every other
+/// phase (including `Syncing`/`ReceivingSnapshot` while catching up on later
+/// deltas) is reported verbatim.
+fn normalize(state: SyncState, is_initialized: bool) -> SyncState {
+    match state {
+        SyncState::WaitingForPeers if is_initialized => SyncState::Idle,
+        other => other,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_sync_state, SyncPhase, SyncState};
+    use super::{normalize, SyncState};
 
     #[test]
-    fn uninitialized_and_idle_resolves_to_waiting_for_peers() {
-        // The bug this guards: a benign no-peers outcome leaves the node phase
-        // at Idle; without initialization context that would look "settled".
+    fn waiting_for_peers_on_initialized_context_becomes_idle() {
         assert!(matches!(
-            resolve_sync_state(Some(SyncPhase::Idle), false),
-            SyncState::WaitingForPeers
-        ));
-    }
-
-    #[test]
-    fn uninitialized_and_never_dispatched_resolves_to_waiting_for_peers() {
-        assert!(matches!(
-            resolve_sync_state(None, false),
-            SyncState::WaitingForPeers
-        ));
-    }
-
-    #[test]
-    fn initialized_and_idle_resolves_to_idle() {
-        assert!(matches!(
-            resolve_sync_state(Some(SyncPhase::Idle), true),
+            normalize(SyncState::WaitingForPeers, true),
             SyncState::Idle
         ));
-        assert!(matches!(resolve_sync_state(None, true), SyncState::Idle));
     }
 
     #[test]
-    fn syncing_and_backing_off_are_reported_regardless_of_initialization() {
+    fn waiting_for_peers_on_uninitialized_context_is_preserved() {
+        assert!(matches!(
+            normalize(SyncState::WaitingForPeers, false),
+            SyncState::WaitingForPeers
+        ));
+    }
+
+    #[test]
+    fn active_phases_are_reported_verbatim_regardless_of_initialization() {
         for is_init in [false, true] {
             assert!(matches!(
-                resolve_sync_state(Some(SyncPhase::Syncing), is_init),
+                normalize(SyncState::Syncing, is_init),
                 SyncState::Syncing
             ));
             assert!(matches!(
-                resolve_sync_state(Some(SyncPhase::BackingOff { retry_in_secs: 8 }), is_init),
+                normalize(
+                    SyncState::ReceivingSnapshot {
+                        records_received: 7
+                    },
+                    is_init
+                ),
+                SyncState::ReceivingSnapshot {
+                    records_received: 7
+                }
+            ));
+            assert!(matches!(
+                normalize(SyncState::BackingOff { retry_in_secs: 8 }, is_init),
                 SyncState::BackingOff { retry_in_secs: 8 }
             ));
         }


### PR DESCRIPTION
**Stacked on #2652** (base branch is `feat/2027-sync-status`). Review/merge that first; this diff shows only the Phase 2 delta.

## What

Phase 2 of #2027: makes `sync_status` **push-based** over WebSocket and adds **snapshot-receive progress** — completing the remaining acceptance criteria.

## Changes

- **Unified wire vocabulary.** Moved the `SyncState` phase enum down into `calimero-primitives` so the JSON-RPC response *and* the new WebSocket event share one type (server-primitives re-exports it; the node side uses it directly, dropping the separate `SyncPhase`). No more parallel representations.

- **WebSocket streaming.** New `ContextEventPayload::SyncStatus` event, emitted from the run-loop whenever a context's phase changes. Reuses the existing per-context subscription fan-out — a client already subscribed to a context now receives live phase transitions instead of polling. Emission is change-detected, so the stream stays quiet between real transitions.

  Event shape (under the existing `{type, data}` envelope):
  ```json
  { "type": "SyncStatus", "data": { "syncState": { "state": "syncing" }, "failureCount": 0 } }
  ```

- **`WaitingForPeers` reported at the source.** The benign no-peers / not-materialised outcome clears the in-flight marker without recording a failure, so the run-loop used to derive it as plain `idle`. It now publishes `WaitingForPeers` explicitly, so the RPC *and* the event stream are accurate and consistent. The handler's `is_initialized` normalization (added in #2652) becomes just a safety net for stale snapshots.

- **Snapshot progress.** Emits `ReceivingSnapshot { recordsReceived }` per page-burst from the receive loop, to both the status mirror and the event stream.

## Scope note — why `recordsReceived`, not a percentage

`recordsReceived` is a **monotonic liveness signal, not a percent**. The snapshot stream is cursor-paged and the `SnapshotPage` wire message carries only per-burst `page_count`/`sent_count` — the receiver is never told a grand total. A true percent/ETA would require the **sender to advertise `total_entries`** in the page message (which it already computes and logs), a backward-incompatible wire change I've deliberately left as a follow-up rather than fabricate a number. Tracked as the remaining open item on the issue.

`is_initialized` is intentionally **not** on the event (it's a context-layer fact, not a sync-phase one); clients read it from the RPC or infer it from the first `StateMutation` event.

## Acceptance criteria (issue #2027), after #2652 + this

- [x] sync progress tracked in `NodeState`
- [x] `sync_status` endpoint returns progress
- [x] **WebSocket subscription for live updates** ← this PR
- [x] **progress updates during snapshot sync** (`recordsReceived`) ← this PR
- [ ] ETA / percent — needs sender-advertised total (documented follow-up)

## Testing

- `cargo check --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- `cargo test -p calimero-node sync::session` — 45 passed (incl. new no-peers → `WaitingForPeers` regression test)
- `cargo test -p calimero-server jsonrpc::sync_status` — 3 passed (normalize unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory status and event emission only; no changes to sync execution, auth, or persistence beyond mirroring existing tracker state.
> 
> **Overview**
> **Unifies sync phase types** by moving `SyncState` into `calimero-primitives` and replacing the node-only `SyncPhase` / server duplicate enum so JSON-RPC, the advisory snapshot, and WebSocket events share one vocabulary (`SyncStatusSnapshot.state`).
> 
> **Adds live `SyncStatus` WebSocket events** on phase changes from `SessionTracker` (optional `NodeClient`, change-detected) and **snapshot page progress** as `ReceivingSnapshot { records_received }` from the snapshot receive loop, both updating the existing lock-free status mirror.
> 
> **Publishes `WaitingForPeers` at the source** when benign `NoPeersAvailable` / peer-not-materialized outcomes occur, instead of deriving idle; JSON-RPC `sync_status` mostly passes through with a small `normalize` for initialized contexts.
> 
> **Risk:** Low–medium — observability and API surface only; sync control logic unchanged aside from clearer status reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408cbd95a610fcded13a500e188a02f93594c43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->