### PR TITLE
feat(sync): snapshot progress percent + ETA (#2027)

### DIFF
--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -352,6 +352,13 @@ pub enum MessagePayload<'a> {
         page_count: u64,
         /// Pages sent so far.
         sent_count: u64,
+        /// Grand total of entity records across the whole snapshot (stable
+        /// across bursts — the count from the sender's full boundary scan),
+        /// so the receiver can compute a real percent/ETA against its
+        /// cumulative applied count. `0` means "unknown" — an empty snapshot,
+        /// or a peer too old to advertise it; the receiver then reports raw
+        /// progress only.
+        total_records: u64,
     },
 
     /// Snapshot sync error.

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -352,12 +352,13 @@ pub enum MessagePayload<'a> {
         page_count: u64,
         /// Pages sent so far.
         sent_count: u64,
-        /// Grand total of entity records across the whole snapshot (stable
-        /// across bursts — the count from the sender's full boundary scan),
-        /// so the receiver can compute a real percent/ETA against its
-        /// cumulative applied count. `0` means "unknown" — an empty snapshot,
-        /// or a peer too old to advertise it; the receiver then reports raw
-        /// progress only.
+        /// Grand total of shippable `Entity` records across the whole snapshot
+        /// — every entity with both an `Index` and an `Entry`, counted from the
+        /// sender's full boundary scan and stable across bursts. Excludes
+        /// orphans that are never shipped, so it's the exact denominator the
+        /// receiver's cumulative applied count reaches (percent → 100, ETA →
+        /// 0). `0` means "unknown" — an empty snapshot, or a peer too old to
+        /// advertise it; the receiver then reports raw progress only.
         total_records: u64,
     },
 

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -149,7 +149,7 @@ impl SyncManager {
         stream: &mut Stream,
     ) -> Result<()> {
         let handle = self.context_client.datastore_handle();
-        let (pages, next_cursor, total_entries, grand_total_entities) = generate_snapshot_pages(
+        let (pages, next_cursor, total_entries) = generate_snapshot_pages(
             &handle,
             context_id,
             start_cursor.as_ref(),
@@ -225,7 +225,7 @@ impl SyncManager {
                     cursor,
                     page_count,
                     sent_count: (i + 1) as u64,
-                    total_records: grand_total_entities,
+                    total_records: total_entries,
                 },
                 next_nonce: super::helpers::generate_nonce(),
             };
@@ -1011,8 +1011,12 @@ struct SnapshotBoundary {
     dag_heads: Vec<[u8; 32]>,
 }
 
-/// Generate snapshot pages. Returns
-/// `(pages, next_cursor, total_entries_this_burst, grand_total_entities)`.
+/// Generate snapshot pages. Returns `(pages, next_cursor, total_entries)`,
+/// where `total_entries` is the grand total of shippable `Entity` records at
+/// this boundary — every entity with both an `Index` and an `Entry`, counted
+/// across the whole snapshot regardless of the cursor window, and excluding
+/// orphans that are never shipped. It is therefore the exact denominator the
+/// receiver's cumulative applied count converges to.
 ///
 /// Uses a snapshot iterator to ensure consistent reads even if writes occur
 /// during iteration. The snapshot provides a frozen point-in-time view.
@@ -1059,7 +1063,7 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
     start_cursor: Option<&SnapshotCursor>,
     page_limit: u16,
     byte_limit: u32,
-) -> Result<(Vec<Vec<u8>>, Option<SnapshotCursor>, u64, u64)> {
+) -> Result<(Vec<Vec<u8>>, Option<SnapshotCursor>, u64)> {
     // Pass 1 — single snapshot scan, memory bounded to keys + ids.
     //
     // Retain only the 32-byte hashed state keys (`present_keys`,
@@ -1177,10 +1181,6 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
     // Decrementing on skip would instead make the figure depend on
     // which page window this call serves, breaking the
     // stable-across-pages property operators rely on.
-    // Grand total of entities at this boundary (the full id-sorted set, before
-    // the cursor window is applied below). Stable across bursts, so the
-    // receiver can divide its cumulative applied count by it for a percent.
-    let grand_total_entities = entity_ids.len() as u64;
     let mut total_entries: u64 = 0;
     for id in &entity_ids {
         let id_bytes = *id.as_bytes();
@@ -1409,7 +1409,6 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
                     pages,
                     last_id.map(|k| SnapshotCursor { last_key: k }),
                     total_entries,
-                    grand_total_entities,
                 ));
             }
         }
@@ -1422,7 +1421,7 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
         pages.push(current_page);
     }
 
-    Ok((pages, None, total_entries, grand_total_entities))
+    Ok((pages, None, total_entries))
 }
 
 /// Derive `(percent, eta_secs)` for a snapshot in progress.
@@ -1445,7 +1444,15 @@ fn snapshot_progress_estimate(
     let eta = if records_received > 0 && secs > 0.0 {
         let rate = records_received as f64 / secs; // records/sec
         let remaining = total_records.saturating_sub(records_received) as f64;
-        Some((remaining / rate).ceil() as u64)
+        let est = (remaining / rate).ceil();
+        // `as u64` already saturates in current Rust (NaN → 0, +∞ → u64::MAX),
+        // but guard explicitly so a degenerate rate can't surface a misleading
+        // near-zero ETA, and an absurdly large estimate clamps cleanly.
+        if est.is_finite() {
+            Some(est.min(u64::MAX as f64) as u64)
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -1672,7 +1679,7 @@ mod tests {
         // clear message instead of masquerading as a dropped entity.
         let mut completed = false;
         for _ in 0..10_000 {
-            let (pages, next, total, _grand_total) =
+            let (pages, next, total) =
                 generate_snapshot_pages(&handle, ctx, cursor.as_ref(), page_limit, byte_limit)
                     .unwrap();
             totals.push(total);
@@ -1705,7 +1712,7 @@ mod tests {
         let store = Store::new(Arc::new(InMemoryDB::owned()));
         let handle = store.handle();
         let ctx = ContextId::from([1u8; 32]);
-        let (pages, cursor, total, _grand_total) = generate_snapshot_pages(
+        let (pages, cursor, total) = generate_snapshot_pages(
             &handle,
             ctx,
             None,
@@ -1732,7 +1739,7 @@ mod tests {
             .collect();
 
         // One generous page — everything fits, cursor signals done.
-        let (pages, cursor, total, _grand_total) =
+        let (pages, cursor, total) =
             generate_snapshot_pages(&store.handle(), ctx, None, DEFAULT_PAGE_LIMIT, 1 << 20)
                 .unwrap();
         assert!(cursor.is_none(), "single page should not request a resume");

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -1,6 +1,7 @@
 //! Snapshot sync protocol for full state bootstrap.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::time::Instant;
 
 use borsh::BorshDeserialize;
 use calimero_crypto::Nonce;
@@ -148,7 +149,7 @@ impl SyncManager {
         stream: &mut Stream,
     ) -> Result<()> {
         let handle = self.context_client.datastore_handle();
-        let (pages, next_cursor, total_entries) = generate_snapshot_pages(
+        let (pages, next_cursor, total_entries, grand_total_entities) = generate_snapshot_pages(
             &handle,
             context_id,
             start_cursor.as_ref(),
@@ -185,6 +186,7 @@ impl SyncManager {
                     cursor: None,
                     page_count: 0,
                     sent_count: 0,
+                    total_records: 0,
                 },
                 next_nonce: super::helpers::generate_nonce(),
             };
@@ -223,6 +225,7 @@ impl SyncManager {
                     cursor,
                     page_count,
                     sent_count: (i + 1) as u64,
+                    total_records: grand_total_entities,
                 },
                 next_nonce: super::helpers::generate_nonce(),
             };
@@ -446,6 +449,9 @@ impl SyncManager {
         // Set sync-in-progress marker for crash recovery detection
         self.set_sync_in_progress_marker(context_id, &boundary.boundary_root_hash)?;
 
+        // Wall-clock start, for the snapshot-progress ETA estimate.
+        let started_at = Instant::now();
+
         // Collect existing keys BEFORE receiving any pages
         // We'll use this to determine which keys to delete after sync completes
         let existing_keys: HashSet<[u8; 32]> = {
@@ -518,6 +524,7 @@ impl SyncManager {
                         cursor,
                         page_count,
                         sent_count,
+                        total_records,
                     } => {
                         // Handle empty snapshot (no entries)
                         if payload.is_empty() && uncompressed_len == 0 {
@@ -743,7 +750,12 @@ impl SyncManager {
                         // Surface snapshot progress (per page-burst, a natural
                         // throttle) so a subscriber watching this uninitialized
                         // context sees forward motion rather than a silent wait.
-                        self.emit_snapshot_progress(context_id, total_applied as u64);
+                        self.emit_snapshot_progress(
+                            context_id,
+                            total_applied as u64,
+                            total_records,
+                            started_at.elapsed(),
+                        );
 
                         // Check if this is the last page in this burst
                         let is_last_in_burst = sent_count == page_count;
@@ -907,10 +919,23 @@ impl SyncManager {
 
     /// Record snapshot progress on the advisory `sync_status` mirror and push a
     /// `SyncStatus` event to subscribers. Best-effort: a broadcast with no
-    /// receivers is fine, and `records_received` is a monotonic liveness signal
-    /// (not a percentage — the receiver isn't told a grand total up front).
-    fn emit_snapshot_progress(&self, context_id: ContextId, records_received: u64) {
-        let state = SyncState::ReceivingSnapshot { records_received };
+    /// receivers is fine. `percent`/`eta_secs` are derived only when the sender
+    /// advertised a non-zero grand total (`total_records`); otherwise the
+    /// update carries the raw `records_received` liveness signal alone.
+    fn emit_snapshot_progress(
+        &self,
+        context_id: ContextId,
+        records_received: u64,
+        total_records: u64,
+        elapsed: std::time::Duration,
+    ) {
+        let (percent, eta_secs) =
+            snapshot_progress_estimate(records_received, total_records, elapsed);
+        let state = SyncState::ReceivingSnapshot {
+            records_received,
+            percent,
+            eta_secs,
+        };
         let handle = self.node_state.sync_status_handle();
         // Preserve any failure history the run-loop has already published for
         // this context; this path only advances the snapshot phase. Writing
@@ -986,7 +1011,8 @@ struct SnapshotBoundary {
     dag_heads: Vec<[u8; 32]>,
 }
 
-/// Generate snapshot pages. Returns (pages, next_cursor, total_entries).
+/// Generate snapshot pages. Returns
+/// `(pages, next_cursor, total_entries_this_burst, grand_total_entities)`.
 ///
 /// Uses a snapshot iterator to ensure consistent reads even if writes occur
 /// during iteration. The snapshot provides a frozen point-in-time view.
@@ -1033,7 +1059,7 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
     start_cursor: Option<&SnapshotCursor>,
     page_limit: u16,
     byte_limit: u32,
-) -> Result<(Vec<Vec<u8>>, Option<SnapshotCursor>, u64)> {
+) -> Result<(Vec<Vec<u8>>, Option<SnapshotCursor>, u64, u64)> {
     // Pass 1 — single snapshot scan, memory bounded to keys + ids.
     //
     // Retain only the 32-byte hashed state keys (`present_keys`,
@@ -1151,6 +1177,10 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
     // Decrementing on skip would instead make the figure depend on
     // which page window this call serves, breaking the
     // stable-across-pages property operators rely on.
+    // Grand total of entities at this boundary (the full id-sorted set, before
+    // the cursor window is applied below). Stable across bursts, so the
+    // receiver can divide its cumulative applied count by it for a percent.
+    let grand_total_entities = entity_ids.len() as u64;
     let mut total_entries: u64 = 0;
     for id in &entity_ids {
         let id_bytes = *id.as_bytes();
@@ -1379,6 +1409,7 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
                     pages,
                     last_id.map(|k| SnapshotCursor { last_key: k }),
                     total_entries,
+                    grand_total_entities,
                 ));
             }
         }
@@ -1391,7 +1422,34 @@ fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
         pages.push(current_page);
     }
 
-    Ok((pages, None, total_entries))
+    Ok((pages, None, total_entries, grand_total_entities))
+}
+
+/// Derive `(percent, eta_secs)` for a snapshot in progress.
+///
+/// `percent` is `records_received / total_records` clamped to `0..=100`, or
+/// `None` when `total_records` is `0` (sender didn't advertise a total — an
+/// empty snapshot or a peer too old). `eta_secs` extrapolates the remaining
+/// records from the average rate so far; it is `None` until there is at least
+/// one record and a non-zero elapsed window, and `Some(0)` at completion.
+fn snapshot_progress_estimate(
+    records_received: u64,
+    total_records: u64,
+    elapsed: std::time::Duration,
+) -> (Option<u8>, Option<u64>) {
+    if total_records == 0 {
+        return (None, None);
+    }
+    let percent = (records_received.saturating_mul(100) / total_records).min(100) as u8;
+    let secs = elapsed.as_secs_f64();
+    let eta = if records_received > 0 && secs > 0.0 {
+        let rate = records_received as f64 / secs; // records/sec
+        let remaining = total_records.saturating_sub(records_received) as f64;
+        Some((remaining / rate).ceil() as u64)
+    } else {
+        None
+    };
+    (Some(percent), eta)
 }
 
 /// Decompress a received snapshot page, guarding against a decompression bomb.
@@ -1518,6 +1576,7 @@ fn collect_context_state_keys<L: calimero_store::layer::ReadLayer>(
 mod tests {
     use std::collections::BTreeSet;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use calimero_primitives::context::ContextId;
     use calimero_storage::index::EntityIndex;
@@ -1525,6 +1584,42 @@ mod tests {
     use calimero_store::Store;
 
     use super::*;
+
+    #[test]
+    fn snapshot_progress_unknown_total_yields_no_estimate() {
+        // total_records == 0 (empty snapshot or pre-feature peer) → no derived
+        // percent/ETA; the caller still reports raw records_received.
+        let (percent, eta) = snapshot_progress_estimate(5, 0, Duration::from_secs(1));
+        assert_eq!(percent, None);
+        assert_eq!(eta, None);
+    }
+
+    #[test]
+    fn snapshot_progress_percent_is_clamped_and_eta_extrapolates() {
+        // 50 of 200 records in 5s → 25%, rate 10/s, 150 remaining → 15s ETA.
+        let (percent, eta) = snapshot_progress_estimate(50, 200, Duration::from_secs(5));
+        assert_eq!(percent, Some(25));
+        assert_eq!(eta, Some(15));
+
+        // Over-count (receiver applied more than advertised) clamps to 100.
+        let (percent, _) = snapshot_progress_estimate(250, 200, Duration::from_secs(1));
+        assert_eq!(percent, Some(100));
+    }
+
+    #[test]
+    fn snapshot_progress_eta_none_before_any_record_or_time() {
+        // No elapsed window yet → percent known, ETA not.
+        let (percent, eta) = snapshot_progress_estimate(0, 100, Duration::ZERO);
+        assert_eq!(percent, Some(0));
+        assert_eq!(eta, None);
+    }
+
+    #[test]
+    fn snapshot_progress_complete_reports_zero_eta() {
+        let (percent, eta) = snapshot_progress_estimate(100, 100, Duration::from_secs(2));
+        assert_eq!(percent, Some(100));
+        assert_eq!(eta, Some(0));
+    }
 
     /// Persist a well-formed entity (Index + Entry pair) for `ctx`
     /// into `store`, mirroring how production state is laid out: the
@@ -1577,7 +1672,7 @@ mod tests {
         // clear message instead of masquerading as a dropped entity.
         let mut completed = false;
         for _ in 0..10_000 {
-            let (pages, next, total) =
+            let (pages, next, total, _grand_total) =
                 generate_snapshot_pages(&handle, ctx, cursor.as_ref(), page_limit, byte_limit)
                     .unwrap();
             totals.push(total);
@@ -1610,7 +1705,7 @@ mod tests {
         let store = Store::new(Arc::new(InMemoryDB::owned()));
         let handle = store.handle();
         let ctx = ContextId::from([1u8; 32]);
-        let (pages, cursor, total) = generate_snapshot_pages(
+        let (pages, cursor, total, _grand_total) = generate_snapshot_pages(
             &handle,
             ctx,
             None,
@@ -1637,7 +1732,7 @@ mod tests {
             .collect();
 
         // One generous page — everything fits, cursor signals done.
-        let (pages, cursor, total) =
+        let (pages, cursor, total, _grand_total) =
             generate_snapshot_pages(&store.handle(), ctx, None, DEFAULT_PAGE_LIMIT, 1 << 20)
                 .unwrap();
         assert!(cursor.is_none(), "single page should not request a resume");

--- a/crates/primitives/src/sync_status.rs
+++ b/crates/primitives/src/sync_status.rs
@@ -22,13 +22,19 @@ pub enum SyncState {
     /// A sync attempt is in flight (handshake / delta exchange).
     Syncing,
     /// Receiving an initial-state snapshot. `records_received` is a monotonic
-    /// count of applied entries — a liveness/progress signal. It is not a
-    /// percentage: the snapshot stream is cursor-paged and the receiver is not
-    /// told a grand total up front, so a true percent/ETA would require the
-    /// sender to advertise one (a follow-up wire change).
+    /// count of applied entries. `percent` and `eta_secs` are populated once
+    /// the sender advertises the snapshot's total entity count; they are
+    /// `None` against a peer too old to advertise it (the count then degrades
+    /// to the raw `records_received` liveness signal).
     ReceivingSnapshot {
         /// Entries applied from the snapshot so far.
         records_received: u64,
+        /// Completion percentage in `0..=100`, or `None` if the total is
+        /// unknown. Derived as `records_received / total` and clamped.
+        percent: Option<u8>,
+        /// Estimated seconds remaining, from the observed transfer rate.
+        /// `None` until measurable (or when the total is unknown).
+        eta_secs: Option<u64>,
     },
     /// The last attempt failed and the next retry is gated behind backoff.
     BackingOff {

--- a/crates/server/src/jsonrpc/sync_status.rs
+++ b/crates/server/src/jsonrpc/sync_status.rs
@@ -91,15 +91,16 @@ mod tests {
                 normalize(SyncState::Syncing, is_init),
                 SyncState::Syncing
             ));
+            let snapshot = SyncState::ReceivingSnapshot {
+                records_received: 7,
+                percent: Some(50),
+                eta_secs: Some(3),
+            };
             assert!(matches!(
-                normalize(
-                    SyncState::ReceivingSnapshot {
-                        records_received: 7
-                    },
-                    is_init
-                ),
+                normalize(snapshot, is_init),
                 SyncState::ReceivingSnapshot {
-                    records_received: 7
+                    records_received: 7,
+                    ..
                 }
             ));
             assert!(matches!(


### PR DESCRIPTION
**Stacked on #2659** (base branch `feat/2027-sync-status-streaming`). Merge #2652 → #2659 → this. The diff shows only the Phase 3 delta. Closes the last open acceptance criterion on #2027.

## What

Turns the snapshot `recordsReceived` liveness signal (added in #2659) into a real **percentage + ETA**.

```json
{ "type": "SyncStatus", "data": {
  "syncState": { "state": "receivingSnapshot", "recordsReceived": 50, "percent": 25, "etaSecs": 15 },
  "failureCount": 0 } }
```

## Why it wasn't done before

The receiver was never told how big the snapshot is. The `SnapshotPage` wire message carried only per-burst `page_count`/`sent_count`, and the stream is cursor-paged, so there was no honest denominator — which is why #2659 deliberately shipped a raw count instead of a fabricated percent. The sender already computes the grand total during its boundary scan (the id-sorted `entity_ids` set); it just wasn't on the wire.

## How

- **Advertise the total.** Add `total_records: u64` to the `SnapshotPage` wire message — the grand total of entity records across the whole snapshot, stable across bursts. `0` = unknown (empty snapshot, or a peer too old to advertise). `generate_snapshot_pages` now returns the count; the sender populates it.

- **Derive on the receiver.** `percent` = `recordsReceived / total` clamped to `0..=100`; `eta_secs` extrapolates the remaining records from the average rate so far. Both are `Option` on `SyncState::ReceivingSnapshot` and fall back to `None` against a non-advertising peer — degrading gracefully to the raw `recordsReceived` from #2659. Extracted as a pure `snapshot_progress_estimate` with unit tests.

## ⚠️ Wire compatibility

Appending `total_records` to `SnapshotPage` is a **borsh-positional change**, so snapshot sync between a patched and an unpatched node is incompatible. This needs a **coordinated rollout** (or a protocol-version gate) before release — calling it out explicitly so it's a conscious merge decision, not a surprise. Everything else in the stack is additive/back-compatible; this is the one PR with a wire break.

## Denominator choice

The total is the **entity count** (`entity_ids.len()` from the sender's full scan), which matches the receiver's entity-based applied counter. `present_keys.len()` was rejected — it counts Entry+Index keys per entity and would peg progress below 100%.

## Testing

- `cargo check --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- `cargo test -p calimero-node sync::snapshot::tests::snapshot_progress` — 4 passed (unknown-total, clamp + ETA extrapolation, pre-record/pre-time None, completion → 0)
- `cargo test -p calimero-server jsonrpc::sync_status` — 3 passed

## Acceptance criteria (#2027) — all met after #2652 + #2659 + this

- [x] sync progress tracked in `NodeState`
- [x] `sync_status` endpoint returns progress
- [x] WebSocket subscription for live updates
- [x] progress updates during snapshot sync
- [x] **ETA calculation based on transfer rate** ← this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> SnapshotPage gains a borsh field that breaks wire compatibility between patched and unpatched nodes during snapshot sync; rollout must be coordinated despite the change being observability-only on the receiver.
> 
> **Overview**
> Adds **`total_records`** to the **`SnapshotPage`** borsh wire message so the snapshot sender advertises the full shippable entity count (stable across cursor-paged bursts); **`0`** means unknown for empty snapshots or older peers.
> 
> On the receiver, each applied page burst now computes **`percent`** and **`eta_secs`** from cumulative applied entities, that total, and elapsed time via **`snapshot_progress_estimate`**, and publishes them on **`SyncState::ReceivingSnapshot`** (JSON-RPC / WebSocket) while still emitting raw **`records_received`** when no total is advertised.
> 
> **Wire note:** appending **`total_records`** is a **borsh-positional break** for **`SnapshotPage`** — mixed-version snapshot sync needs a coordinated rollout or protocol gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8677cbe9a0aa1b93040783ce9af23ea370198c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->