### PR TITLE
ci: don't cancel in-progress workflow runs on master

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -49,7 +49,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -31,7 +31,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sync-regression.yml
+++ b/.github/workflows/sync-regression.yml
@@ -40,7 +40,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

Jobs on `master` get cancelled when newer commits land — e.g. [run 26887672278](https://github.com/calimero-network/core/actions/runs/26887672278/job/79304418749) ("E2E - Rust Apps") ended `cancelled`.

Three workflows that trigger on `push: [master]` share this concurrency block:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On master, `github.ref` is **always** `refs/heads/master`, so every push lands in the *same* concurrency group. With `cancel-in-progress: true`, a new commit cancels the run still in flight for the previous commit — leaving master commits without a completed run.

## Fix

Make `cancel-in-progress` conditional: keep auto-cancel for PRs/branches (where killing stale runs saves runners), disable it on master so every commit runs to completion.

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

| Event | resolves to | effect |
|---|---|---|
| Push to master | `false` | every commit runs to completion |
| PR / other branch | `true` | new commit cancels the stale run |

Applied to `e2e-rust-apps.yml`, `sync-regression.yml`, and `app-migration-e2e.yml` — the three `push:[master]` workflows that had unconditional `cancel-in-progress: true`. Other workflows were intentionally left alone (release/tag-keyed, PR-only, deploy-latest-wins, or already `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow concurrency tuning only; no application, auth, or deployment logic changes.
> 
> **Overview**
> **Stops master E2E workflows from being cancelled** when another commit lands on `master`. All three `push: [master]` workflows shared one concurrency group per ref, so `cancel-in-progress: true` aborted in-flight runs and left commits without a finished check.
> 
> `cancel-in-progress` is now **`${{ github.ref != 'refs/heads/master' }}`** in `e2e-rust-apps.yml`, `sync-regression.yml`, and `app-migration-e2e.yml`. **Master** runs complete; **PRs and other branches** still cancel superseded runs to save runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae09e21a73d8cf765c5490dab907040f2e363070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->