### PR TITLE
feat(dag): bound delta-log growth with DAG compaction (#2026)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use mero_auth::config::AuthConfig;
 
-pub use calimero_node_primitives::NodeMode;
+pub use calimero_node_primitives::{DagCompactionConfig, NodeMode};
 
 pub const CONFIG_FILE: &str = "config.toml";
 
@@ -68,6 +68,12 @@ pub struct ConfigFile {
     /// TEE-related configuration (KMS, attestation, etc.).
     #[serde(default)]
     pub tee: Option<TeeConfig>,
+
+    /// DAG compaction (`[dag_compaction]`) — bounds on-disk delta-log growth
+    /// by pruning history older than a checkpoint. Disabled by default;
+    /// absent section falls back to [`DagCompactionConfig::default`].
+    #[serde(default)]
+    pub dag_compaction: DagCompactionConfig,
 }
 
 /// Configuration for TEE (Trusted Execution Environment) features.
@@ -494,6 +500,7 @@ impl ConfigFile {
             context,
             runtime: RuntimeConfig::default(),
             tee: None,
+            dag_compaction: DagCompactionConfig::default(),
         }
     }
 

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -388,6 +388,31 @@ impl ContextRegistry {
         Ok(())
     }
 
+    /// Atomically deletes a batch of DAG delta rows by key (issue #2026
+    /// compaction). Like [`persist_delta_records`](Self::persist_delta_records),
+    /// the whole batch lands in one [`Transaction`] so a crash mid-prune can
+    /// never leave the delta column half-deleted. Pruning is idempotent:
+    /// deleting an already-absent key is a no-op.
+    pub fn prune_delta_records(&self, delta_keys: &[key::ContextDagDelta]) -> eyre::Result<()> {
+        if delta_keys.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = Transaction::default();
+        for delta_key in delta_keys {
+            tx.delete(delta_key);
+        }
+
+        self.datastore.apply(&tx)?;
+
+        tracing::debug!(
+            delta_count = delta_keys.len(),
+            "Atomically pruned delta records"
+        );
+
+        Ok(())
+    }
+
     /// Updates the ApplicationId for a context.
     ///
     /// # Arguments
@@ -1135,6 +1160,12 @@ impl ContextClient {
         deltas: &[(key::ContextDagDelta, types::ContextDagDelta)],
     ) -> eyre::Result<()> {
         self.registry.persist_delta_records(deltas)
+    }
+
+    /// Atomically deletes a batch of DAG delta rows (issue #2026 compaction).
+    /// Delegates to [`ContextRegistry::prune_delta_records`].
+    pub fn prune_delta_records(&self, delta_keys: &[key::ContextDagDelta]) -> eyre::Result<()> {
+        self.registry.prune_delta_records(delta_keys)
     }
 
     /// Updates the ApplicationId for a context.

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -772,11 +772,11 @@ impl<T: Clone> DagStore<T> {
     /// matching rows from durable storage).
     ///
     /// "Recent" is defined by a breadth-first walk back from the current
-    /// heads: the retained set is the heads plus the first `retain_count`
-    /// deltas reachable from them. Heads are always retained regardless of
-    /// the budget — stranding a head would corrupt parenting of future
-    /// deltas. Everything applied and outside that window is dropped from
-    /// `deltas` and `applied`.
+    /// heads: the retained set is the heads plus the first `~retain_count`
+    /// deltas reachable from them (`retain_count` is a soft floor — see the
+    /// loop body). Heads are always retained regardless of the budget —
+    /// stranding a head would corrupt parenting of future deltas. Everything
+    /// applied and outside that window is dropped from `deltas` and `applied`.
     ///
     /// Retained deltas whose parents fall outside the window keep their
     /// original parent pointers; the pruned parents simply become absent.
@@ -790,10 +790,24 @@ impl<T: Clone> DagStore<T> {
     /// resolve once their missing parents arrive.
     pub fn prune_to_recent(&mut self, retain_count: usize) -> Vec<[u8; 32]> {
         // Seed the retained set with every head so a small `retain_count`
-        // can never evict a head.
-        let mut retained: HashSet<[u8; 32]> = self.heads.iter().copied().collect();
-        let mut queue: VecDeque<[u8; 32]> = self.heads.iter().copied().collect();
+        // can never evict a head. The genesis root is never a real delta
+        // (it lives only in `applied`/`heads`, never in `deltas`), so keep it
+        // out of the retained budget entirely.
+        let mut retained: HashSet<[u8; 32]> = self
+            .heads
+            .iter()
+            .copied()
+            .filter(|id| *id != self.root)
+            .collect();
+        let mut queue: VecDeque<[u8; 32]> = retained.iter().copied().collect();
 
+        // `retain_count` is a soft floor: the outer condition is the sole
+        // budget gate, so once a node is processed all of its parents are
+        // enqueued before the budget is re-checked. The final set can slightly
+        // exceed `retain_count` (by at most one node's fan-out), which only
+        // ever retains *more* recent history — the safe direction. A parent
+        // already in `retained` is never re-queued (`retained.insert` returns
+        // false), so diamond DAGs never re-walk a node.
         while retained.len() < retain_count {
             let Some(id) = queue.pop_front() else { break };
             let Some(delta) = self.deltas.get(&id) else {
@@ -804,9 +818,6 @@ impl<T: Clone> DagStore<T> {
                     continue;
                 }
                 queue.push_back(parent);
-                if retained.len() >= retain_count {
-                    break;
-                }
             }
         }
 

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -758,6 +758,74 @@ impl<T: Clone> DagStore<T> {
             head_count: self.heads.len(),
         }
     }
+
+    /// Number of deltas currently held in the in-memory DAG.
+    ///
+    /// This is the figure compaction (#2026) compares against its
+    /// `min_deltas_before_compact` threshold to decide eligibility.
+    pub fn delta_count(&self) -> usize {
+        self.deltas.len()
+    }
+
+    /// Prune applied history older than the most-recent `retain_count`
+    /// deltas, returning the ids removed (so the caller can delete the
+    /// matching rows from durable storage).
+    ///
+    /// "Recent" is defined by a breadth-first walk back from the current
+    /// heads: the retained set is the heads plus the first `retain_count`
+    /// deltas reachable from them. Heads are always retained regardless of
+    /// the budget — stranding a head would corrupt parenting of future
+    /// deltas. Everything applied and outside that window is dropped from
+    /// `deltas` and `applied`.
+    ///
+    /// Retained deltas whose parents fall outside the window keep their
+    /// original parent pointers; the pruned parents simply become absent.
+    /// [`get_deltas_since`](Self::get_deltas_since) traversal already stops
+    /// when `deltas.get(parent)` is `None`, and a peer fetching such a
+    /// parent gets "not found" — its cue to fall back to state-based sync
+    /// (HashComparison/Snapshot) rather than replay a gap it cannot close.
+    /// No re-parenting is performed, so delta content hashes are untouched.
+    ///
+    /// Pending deltas are never pruned: they are unapplied and may still
+    /// resolve once their missing parents arrive.
+    pub fn prune_to_recent(&mut self, retain_count: usize) -> Vec<[u8; 32]> {
+        // Seed the retained set with every head so a small `retain_count`
+        // can never evict a head.
+        let mut retained: HashSet<[u8; 32]> = self.heads.iter().copied().collect();
+        let mut queue: VecDeque<[u8; 32]> = self.heads.iter().copied().collect();
+
+        while retained.len() < retain_count {
+            let Some(id) = queue.pop_front() else { break };
+            let Some(delta) = self.deltas.get(&id) else {
+                continue;
+            };
+            for parent in delta.parents.clone() {
+                if parent == self.root || !retained.insert(parent) {
+                    continue;
+                }
+                queue.push_back(parent);
+                if retained.len() >= retain_count {
+                    break;
+                }
+            }
+        }
+
+        let pruned: Vec<[u8; 32]> = self
+            .deltas
+            .keys()
+            .copied()
+            .filter(|id| {
+                *id != self.root && !retained.contains(id) && !self.pending.contains_key(id)
+            })
+            .collect();
+
+        for id in &pruned {
+            let _ = self.deltas.remove(id);
+            let _ = self.applied.remove(id);
+        }
+
+        pruned
+    }
 }
 
 #[cfg(test)]

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -1225,3 +1225,74 @@ async fn test_extreme_late_parent_arrival() {
     assert_eq!(dag.pending_stats().count, 0);
     assert_eq!(dag.stats().applied_deltas, 102); // root + parent + 100
 }
+
+#[tokio::test]
+async fn test_prune_to_recent_linear_chain() {
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    // Linear chain of 10 deltas: 1 <- 2 <- ... <- 10 (10 is the head).
+    for i in 1..=10u8 {
+        let parent = if i == 1 { [0; 32] } else { [i - 1; 32] };
+        let delta = CausalDelta::new_test([i; 32], vec![parent], TestPayload { value: i as u32 });
+        dag.add_delta(delta, &applier).await.unwrap();
+    }
+    assert_eq!(dag.delta_count(), 10);
+
+    // Retain the 3 most-recent deltas (10, 9, 8). The other 7 are pruned.
+    let mut pruned = dag.prune_to_recent(3);
+    pruned.sort();
+    assert_eq!(
+        pruned,
+        vec![[1; 32], [2; 32], [3; 32], [4; 32], [5; 32], [6; 32], [7; 32]]
+    );
+    assert_eq!(dag.delta_count(), 3);
+
+    // Head is untouched; recent window is intact.
+    assert_eq!(dag.get_heads(), vec![[10; 32]]);
+    assert!(dag.has_delta(&[10; 32]));
+    assert!(dag.has_delta(&[8; 32]));
+    assert!(!dag.has_delta(&[7; 32]));
+
+    // Traversal from the head stops cleanly at the pruned frontier: only the
+    // retained window comes back, and requesting a pruned id is a miss.
+    let (deltas, _) = dag.get_deltas_since([0; 32], None, MAX_DELTA_QUERY_LIMIT);
+    assert_eq!(deltas.len(), 3);
+    assert!(dag.get_delta(&[7; 32]).is_none());
+}
+
+#[tokio::test]
+async fn test_prune_to_recent_never_strands_heads() {
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    // Two independent branches off genesis → two heads.
+    let a = CausalDelta::new_test([1; 32], vec![[0; 32]], TestPayload { value: 1 });
+    let b = CausalDelta::new_test([2; 32], vec![[0; 32]], TestPayload { value: 2 });
+    dag.add_delta(a, &applier).await.unwrap();
+    dag.add_delta(b, &applier).await.unwrap();
+
+    // retain_count below the head count must still keep every head.
+    let pruned = dag.prune_to_recent(1);
+    assert!(pruned.is_empty());
+    let mut heads = dag.get_heads();
+    heads.sort();
+    assert_eq!(heads, vec![[1; 32], [2; 32]]);
+}
+
+#[tokio::test]
+async fn test_prune_to_recent_below_threshold_is_noop() {
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    for i in 1..=3u8 {
+        let parent = if i == 1 { [0; 32] } else { [i - 1; 32] };
+        let delta = CausalDelta::new_test([i; 32], vec![parent], TestPayload { value: i as u32 });
+        dag.add_delta(delta, &applier).await.unwrap();
+    }
+
+    // Retaining more than we hold prunes nothing.
+    let pruned = dag.prune_to_recent(100);
+    assert!(pruned.is_empty());
+    assert_eq!(dag.delta_count(), 3);
+}

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -162,6 +162,7 @@ impl RunCommand {
             context: config.context,
             server: server_config,
             gc_interval_secs: None, // Use default (12 hours)
+            dag_compaction: config.dag_compaction,
             mode: node_mode,
             specialized_node: SpecializedNodeConfig {
                 invite_topic: network.specialized_node.invite_topic,

--- a/crates/node/primitives/src/dag_compaction.rs
+++ b/crates/node/primitives/src/dag_compaction.rs
@@ -3,9 +3,10 @@
 //! Every regular delta a context applies is persisted forever in the delta
 //! column, so the on-disk DAG log grows linearly with lifetime transaction
 //! count. Compaction bounds that growth: once a context accumulates enough
-//! delta rows, the oldest history is collapsed into a checkpoint and the
-//! superseded rows are pruned, retaining only a recent window for cheap
-//! incremental delta catch-up. Anything older converges via HashComparison,
+//! delta rows, the oldest history is pruned outright, retaining only a recent
+//! window for cheap incremental delta catch-up. (No checkpoint object is
+//! written — pruned deltas simply become absent.) Anything older converges via
+//! HashComparison,
 //! which reconciles current state without consulting the delta log — so the
 //! pruned history is never needed for correctness, only as an optimization.
 
@@ -73,12 +74,17 @@ impl Default for DagCompactionConfig {
 
 impl DagCompactionConfig {
     /// Returns `true` when the configuration is internally consistent enough
-    /// to run. `retain_recent_count` must be strictly below
-    /// `min_deltas_before_compact`, otherwise a sweep would either do no work
-    /// or re-trigger immediately (no hysteresis).
+    /// to run:
+    ///
+    /// * `retain_recent_count` must be strictly below
+    ///   `min_deltas_before_compact`, otherwise a sweep would either do no
+    ///   work or re-trigger immediately (no hysteresis); and
+    /// * `check_interval` must be non-zero — a zero interval would turn
+    ///   `run_interval` into a busy-loop spawning sweeps as fast as the
+    ///   mailbox allows.
     #[must_use]
     pub fn is_valid(&self) -> bool {
-        self.retain_recent_count < self.min_deltas_before_compact
+        self.retain_recent_count < self.min_deltas_before_compact && !self.check_interval.is_zero()
     }
 }
 
@@ -134,6 +140,15 @@ mod tests {
         cfg.retain_recent_count = cfg.min_deltas_before_compact;
         assert!(!cfg.is_valid());
         cfg.retain_recent_count = cfg.min_deltas_before_compact + 1;
+        assert!(!cfg.is_valid());
+    }
+
+    #[test]
+    fn zero_check_interval_is_invalid() {
+        let cfg = DagCompactionConfig {
+            check_interval: Duration::ZERO,
+            ..DagCompactionConfig::default()
+        };
         assert!(!cfg.is_valid());
     }
 

--- a/crates/node/primitives/src/dag_compaction.rs
+++ b/crates/node/primitives/src/dag_compaction.rs
@@ -1,0 +1,170 @@
+//! Configuration for DAG compaction (issue #2026).
+//!
+//! Every regular delta a context applies is persisted forever in the delta
+//! column, so the on-disk DAG log grows linearly with lifetime transaction
+//! count. Compaction bounds that growth: once a context accumulates enough
+//! delta rows, the oldest history is collapsed into a checkpoint and the
+//! superseded rows are pruned, retaining only a recent window for cheap
+//! incremental delta catch-up. Anything older converges via HashComparison,
+//! which reconciles current state without consulting the delta log — so the
+//! pruned history is never needed for correctness, only as an optimization.
+
+use core::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Default number of delta rows a context must hold before compaction is
+/// eligible. Aligned with the in-memory `MAX_TOPOLOGY_ENTRIES` cap (10k) in
+/// the delta store, so on-disk pruning and in-memory ancestry eviction kick
+/// in at the same threshold. The gap to [`DEFAULT_RETAIN_RECENT_COUNT`] (10:1)
+/// gives hysteresis: after compacting down to the retain window a context does
+/// not become eligible again until it has grown another ~9k deltas.
+pub const DEFAULT_MIN_DELTAS_BEFORE_COMPACT: usize = 10_000;
+
+/// Default number of most-recent deltas to keep after compaction. Kept at or
+/// below `MAX_DELTA_QUERY_LIMIT` (3000) so a behind peer can still catch up on
+/// the retained window in a single delta-sync round; beyond that, replaying
+/// the op log stops being cheaper than HashComparison anyway.
+pub const DEFAULT_RETAIN_RECENT_COUNT: usize = 1_000;
+
+/// Default interval between compaction sweeps. The per-context eligibility
+/// check (count delta rows) is cheap, and DAG growth between sweeps is bounded
+/// by op throughput, so an hour bounds worst-case inter-sweep bloat without
+/// busy-work. Mirrors the cadence story of the tombstone `GarbageCollector`.
+pub const DEFAULT_CHECK_INTERVAL_SECS: u64 = 3_600;
+
+/// Operator-tunable DAG compaction settings (`[dag_compaction]`).
+///
+/// Defaults are conservative and, crucially, compaction is **disabled by
+/// default** ([`enabled`](Self::enabled) is `false`) until the pruned-history
+/// sync fallback has soaked: a node must never prune deltas a peer still
+/// depends on without the requester falling back to a state-based protocol.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct DagCompactionConfig {
+    /// Whether periodic DAG compaction runs at all.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Minimum delta rows a context must hold before it is eligible for
+    /// compaction.
+    #[serde(default = "default_min_deltas_before_compact")]
+    pub min_deltas_before_compact: usize,
+
+    /// Number of most-recent deltas to retain after pruning.
+    #[serde(default = "default_retain_recent_count")]
+    pub retain_recent_count: usize,
+
+    /// Interval between compaction sweeps.
+    #[serde(default = "default_check_interval", with = "duration_secs")]
+    pub check_interval: Duration,
+}
+
+impl Default for DagCompactionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_deltas_before_compact: DEFAULT_MIN_DELTAS_BEFORE_COMPACT,
+            retain_recent_count: DEFAULT_RETAIN_RECENT_COUNT,
+            check_interval: default_check_interval(),
+        }
+    }
+}
+
+impl DagCompactionConfig {
+    /// Returns `true` when the configuration is internally consistent enough
+    /// to run. `retain_recent_count` must be strictly below
+    /// `min_deltas_before_compact`, otherwise a sweep would either do no work
+    /// or re-trigger immediately (no hysteresis).
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.retain_recent_count < self.min_deltas_before_compact
+    }
+}
+
+const fn default_min_deltas_before_compact() -> usize {
+    DEFAULT_MIN_DELTAS_BEFORE_COMPACT
+}
+
+const fn default_retain_recent_count() -> usize {
+    DEFAULT_RETAIN_RECENT_COUNT
+}
+
+const fn default_check_interval() -> Duration {
+    Duration::from_secs(DEFAULT_CHECK_INTERVAL_SECS)
+}
+
+/// Serialize/deserialize a [`Duration`] as whole seconds, matching how other
+/// interval-style config values are expressed in `config.toml`.
+mod duration_secs {
+    use core::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(value.as_secs())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled_with_sane_thresholds() {
+        let cfg = DagCompactionConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(
+            cfg.min_deltas_before_compact,
+            DEFAULT_MIN_DELTAS_BEFORE_COMPACT
+        );
+        assert_eq!(cfg.retain_recent_count, DEFAULT_RETAIN_RECENT_COUNT);
+        assert_eq!(cfg.check_interval.as_secs(), DEFAULT_CHECK_INTERVAL_SECS);
+        assert!(cfg.is_valid());
+    }
+
+    #[test]
+    fn retain_at_or_above_min_is_invalid() {
+        let mut cfg = DagCompactionConfig::default();
+        cfg.retain_recent_count = cfg.min_deltas_before_compact;
+        assert!(!cfg.is_valid());
+        cfg.retain_recent_count = cfg.min_deltas_before_compact + 1;
+        assert!(!cfg.is_valid());
+    }
+
+    #[test]
+    fn absent_fields_fall_back_to_defaults() {
+        // An empty object must deserialize to the disabled default — every
+        // field is `#[serde(default)]`, so omitted sections never break
+        // existing configs.
+        let cfg: DagCompactionConfig = serde_json::from_str("{}").expect("empty object");
+        assert!(!cfg.enabled);
+        assert_eq!(
+            cfg.min_deltas_before_compact,
+            DEFAULT_MIN_DELTAS_BEFORE_COMPACT
+        );
+        assert_eq!(cfg.check_interval.as_secs(), DEFAULT_CHECK_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn check_interval_round_trips_as_seconds() {
+        let cfg = DagCompactionConfig {
+            enabled: true,
+            min_deltas_before_compact: 5000,
+            retain_recent_count: 500,
+            check_interval: Duration::from_secs(900),
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        // The duration is encoded as whole seconds, not a struct.
+        assert!(json.contains("\"check_interval\":900"));
+        let back: DagCompactionConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.check_interval.as_secs(), 900);
+        assert!(back.enabled);
+        assert!(back.is_valid());
+    }
+}

--- a/crates/node/primitives/src/lib.rs
+++ b/crates/node/primitives/src/lib.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub mod bundle;
 pub mod client;
 pub use client::{BlobManager, SyncClient};
+pub mod dag_compaction;
+pub use dag_compaction::DagCompactionConfig;
 pub mod delta_buffer;
 pub mod join_bundle;
 pub use join_bundle::JoinBundle;

--- a/crates/node/src/dag_compactor.rs
+++ b/crates/node/src/dag_compactor.rs
@@ -1,0 +1,120 @@
+//! Periodic DAG compaction actor (issue #2026).
+//!
+//! Every regular delta a context applies is persisted forever in the delta
+//! column, so the on-disk DAG log grows linearly with lifetime transaction
+//! count. This actor periodically collapses old history: for each context
+//! whose in-memory DAG has grown past `min_deltas_before_compact`, it prunes
+//! everything older than the most-recent `retain_recent_count` deltas from
+//! both the in-memory DAG and the durable delta column.
+//!
+//! Pruned history is never needed for convergence — a peer that requests a
+//! pruned delta gets "not found" and falls back to HashComparison, which
+//! reconciles current state without the delta log. The retained window keeps
+//! the cheap incremental delta-catch-up fast-path working for small gaps.
+//!
+//! Modelled on [`crate::gc::GarbageCollector`]: an interval-scheduled actor
+//! that sweeps every live context. It only visits contexts with a live
+//! in-memory `DeltaStore` (those actively applying deltas, i.e. the ones whose
+//! logs are growing); cold contexts loaded later compact on a subsequent sweep.
+
+use std::sync::Arc;
+
+use actix::{Actor, AsyncContext, Context};
+use calimero_node_primitives::DagCompactionConfig;
+use calimero_primitives::context::ContextId;
+use dashmap::DashMap;
+use tracing::{debug, info};
+
+use crate::delta_store::DeltaStore;
+
+/// Periodic DAG-history compactor.
+#[derive(Clone)]
+pub struct DagCompactor {
+    /// Live per-context in-memory DAGs (shared with the node state). Each
+    /// `DeltaStore` is `Arc`-backed, so cloning out of the map shares the
+    /// same DAG the apply/sync paths mutate.
+    delta_stores: Arc<DashMap<ContextId, DeltaStore>>,
+    /// Operator-tuned thresholds and cadence.
+    config: DagCompactionConfig,
+}
+
+impl DagCompactor {
+    /// Create a new compactor over the node's live delta stores.
+    pub fn new(
+        delta_stores: Arc<DashMap<ContextId, DeltaStore>>,
+        config: DagCompactionConfig,
+    ) -> Self {
+        Self {
+            delta_stores,
+            config,
+        }
+    }
+
+    /// Compact every live context once. Returns the total deltas pruned.
+    async fn compact_all(
+        delta_stores: Arc<DashMap<ContextId, DeltaStore>>,
+        config: DagCompactionConfig,
+    ) -> usize {
+        // Snapshot (context_id, store) pairs up front: holding a DashMap
+        // reference guard across the `.await` below would risk deadlocking
+        // against the apply path, which also locks the map. `DeltaStore` is
+        // a cheap `Arc` clone.
+        let stores: Vec<(ContextId, DeltaStore)> = delta_stores
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().clone()))
+            .collect();
+
+        let context_count = stores.len();
+        let mut total_pruned = 0;
+
+        for (context_id, store) in stores {
+            let pruned = store
+                .compact(config.min_deltas_before_compact, config.retain_recent_count)
+                .await;
+            if pruned > 0 {
+                debug!(%context_id, pruned, "Compacted context DAG history");
+                crate::node_metrics::observe_compaction_pruned(pruned);
+                total_pruned += pruned;
+            }
+        }
+
+        if total_pruned > 0 {
+            info!(
+                contexts_scanned = context_count,
+                total_pruned, "DAG compaction sweep completed"
+            );
+        }
+
+        total_pruned
+    }
+}
+
+impl Actor for DagCompactor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        info!(
+            interval_secs = self.config.check_interval.as_secs(),
+            min_deltas_before_compact = self.config.min_deltas_before_compact,
+            retain_recent_count = self.config.retain_recent_count,
+            "DAG compaction actor started"
+        );
+
+        let interval = self.config.check_interval;
+        let _handle = ctx.run_interval(interval, |act, _ctx| {
+            // Compaction is async (it takes DAG locks); run it off the
+            // actor mailbox so a long sweep never blocks the actor. The
+            // shared `Arc`s make this safe — the spawned task mutates the
+            // same DAGs as the apply path, serialised by the per-DAG lock.
+            let delta_stores = act.delta_stores.clone();
+            let config = act.config;
+            actix::spawn(async move {
+                let _ = DagCompactor::compact_all(delta_stores, config).await;
+            });
+        });
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        info!("DAG compaction actor stopped");
+    }
+}

--- a/crates/node/src/dag_compactor.rs
+++ b/crates/node/src/dag_compactor.rs
@@ -17,6 +17,7 @@
 //! in-memory `DeltaStore` (those actively applying deltas, i.e. the ones whose
 //! logs are growing); cold contexts loaded later compact on a subsequent sweep.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use actix::{Actor, AsyncContext, Context};
@@ -36,6 +37,11 @@ pub struct DagCompactor {
     delta_stores: Arc<DashMap<ContextId, DeltaStore>>,
     /// Operator-tuned thresholds and cadence.
     config: DagCompactionConfig,
+    /// Guards against a sweep overlapping itself: set while a sweep task is
+    /// running, so a tick that fires before the previous sweep finishes
+    /// (many contexts / slow deletes vs. the interval) is skipped rather
+    /// than double-counting metrics and racing DB deletes.
+    sweep_in_progress: Arc<AtomicBool>,
 }
 
 impl DagCompactor {
@@ -47,7 +53,31 @@ impl DagCompactor {
         Self {
             delta_stores,
             config,
+            sweep_in_progress: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Spawn one sweep off the actor mailbox, unless a previous sweep is still
+    /// running. Compaction is async (it takes DAG locks), so it must not block
+    /// the actor; the shared `Arc`s make the detached task safe — it mutates
+    /// the same DAGs as the apply path, serialised by the per-DAG lock.
+    fn spawn_sweep(&self) {
+        if self
+            .sweep_in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            debug!("Skipping DAG compaction tick: previous sweep still running");
+            return;
+        }
+
+        let delta_stores = self.delta_stores.clone();
+        let config = self.config;
+        let in_progress = self.sweep_in_progress.clone();
+        actix::spawn(async move {
+            DagCompactor::compact_all(delta_stores, config).await;
+            in_progress.store(false, Ordering::Release);
+        });
     }
 
     /// Compact every live context once. Returns the total deltas pruned.
@@ -64,7 +94,8 @@ impl DagCompactor {
             .map(|entry| (*entry.key(), entry.value().clone()))
             .collect();
 
-        let context_count = stores.len();
+        let contexts_scanned = stores.len();
+        let mut contexts_compacted = 0;
         let mut total_pruned = 0;
 
         for (context_id, store) in stores {
@@ -74,14 +105,15 @@ impl DagCompactor {
             if pruned > 0 {
                 debug!(%context_id, pruned, "Compacted context DAG history");
                 crate::node_metrics::observe_compaction_pruned(pruned);
+                contexts_compacted += 1;
                 total_pruned += pruned;
             }
         }
 
         if total_pruned > 0 {
             info!(
-                contexts_scanned = context_count,
-                total_pruned, "DAG compaction sweep completed"
+                contexts_scanned,
+                contexts_compacted, total_pruned, "DAG compaction sweep completed"
             );
         }
 
@@ -100,18 +132,12 @@ impl Actor for DagCompactor {
             "DAG compaction actor started"
         );
 
+        // Sweep once on startup so a node that was already over threshold
+        // before (re)start doesn't stay bloated for a full interval.
+        self.spawn_sweep();
+
         let interval = self.config.check_interval;
-        let _handle = ctx.run_interval(interval, |act, _ctx| {
-            // Compaction is async (it takes DAG locks); run it off the
-            // actor mailbox so a long sweep never blocks the actor. The
-            // shared `Arc`s make this safe — the spawned task mutates the
-            // same DAGs as the apply path, serialised by the per-DAG lock.
-            let delta_stores = act.delta_stores.clone();
-            let config = act.config;
-            actix::spawn(async move {
-                let _ = DagCompactor::compact_all(delta_stores, config).await;
-            });
-        });
+        let _handle = ctx.run_interval(interval, |act, _ctx| act.spawn_sweep());
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -2824,6 +2824,13 @@ impl DeltaStore {
     ) -> usize {
         let mut dag = self.dag.write().await;
 
+        // `delta_count()` is the in-memory DAG size (applied + pending). It is
+        // NOT the number of DB rows: after a restart `load_persisted_deltas`
+        // is bounded by the in-memory caps (`MAX_TOPOLOGY_ENTRIES`), so a
+        // context with far more rows on disk can report a smaller count here
+        // and under-prune the DB. Bounding cold/large contexts' on-disk rows
+        // is the separate "cold-context compaction" follow-up; this sweep only
+        // bounds the live working set.
         let total = dag.delta_count();
         if total <= min_deltas_before_compact {
             return 0;
@@ -2832,7 +2839,10 @@ impl DeltaStore {
         // Don't compact mid-catch-up: pending deltas mean heads are still
         // advancing, so the retain window would be drawn against a moving
         // target. `prune_to_recent` already refuses to drop pending deltas,
-        // but skipping wholesale here also avoids needless churn.
+        // but skipping wholesale here also avoids needless churn. A delta
+        // stuck pending blocks its context's compaction until it resolves or
+        // the existing stale-pending eviction (PENDING_DELTA_MAX_AGE) clears
+        // it — so this never wedges a context permanently.
         let pending = dag.pending_stats().count;
         if pending > 0 {
             debug!(

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -2790,6 +2790,99 @@ impl DeltaStore {
 
         added_count
     }
+
+    /// Compact this context's DAG history, bounding on-disk delta growth
+    /// (issue #2026).
+    ///
+    /// When the in-memory DAG holds more than `min_deltas_before_compact`
+    /// deltas, history older than the most-recent `retain_recent_count` is
+    /// dropped from both the in-memory DAG and the durable delta column. The
+    /// retained window keeps cheap incremental delta catch-up working for
+    /// peers with small gaps; a peer that needs older history will request a
+    /// pruned delta, get "not found", and fall back to HashComparison — which
+    /// reconciles current state without the delta log, so the pruned history
+    /// is never required for convergence.
+    ///
+    /// The whole operation runs under the DAG write lock so it serialises
+    /// against `get_delta`/`has_delta` (the responder send path) and the apply
+    /// path: a peer either sees a delta or sees it gone, never a torn view.
+    /// Pruning is skipped while pending deltas exist — a mid-sync DAG whose
+    /// heads are about to advance is not a good moment to draw the retain
+    /// window.
+    ///
+    /// The in-memory prune happens first, then the DB delete. Order is not
+    /// correctness-critical: a crash between them leaves extra delta rows that
+    /// the next sweep re-prunes (and that `load_persisted_deltas` would simply
+    /// reload), never lost state — context state lives in the storage tree,
+    /// not the delta log.
+    ///
+    /// Returns the number of deltas pruned (0 when not eligible or skipped).
+    pub async fn compact(
+        &self,
+        min_deltas_before_compact: usize,
+        retain_recent_count: usize,
+    ) -> usize {
+        let mut dag = self.dag.write().await;
+
+        let total = dag.delta_count();
+        if total <= min_deltas_before_compact {
+            return 0;
+        }
+
+        // Don't compact mid-catch-up: pending deltas mean heads are still
+        // advancing, so the retain window would be drawn against a moving
+        // target. `prune_to_recent` already refuses to drop pending deltas,
+        // but skipping wholesale here also avoids needless churn.
+        let pending = dag.pending_stats().count;
+        if pending > 0 {
+            debug!(
+                context_id = %self.applier.context_id,
+                total,
+                pending,
+                "Skipping DAG compaction: pending deltas present (mid-sync)"
+            );
+            return 0;
+        }
+
+        let pruned_ids = dag.prune_to_recent(retain_recent_count);
+        if pruned_ids.is_empty() {
+            return 0;
+        }
+
+        // Mirror the prune to durable storage. Done while the write lock is
+        // still held so the in-memory and on-disk views can't diverge under a
+        // concurrent responder read.
+        let delta_keys: Vec<calimero_store::key::ContextDagDelta> = pruned_ids
+            .iter()
+            .map(|id| calimero_store::key::ContextDagDelta::new(self.applier.context_id, *id))
+            .collect();
+
+        match self.applier.context_client.prune_delta_records(&delta_keys) {
+            Ok(()) => {
+                let remaining = dag.delta_count();
+                tracing::info!(
+                    context_id = %self.applier.context_id,
+                    pruned = pruned_ids.len(),
+                    remaining,
+                    "Compacted DAG history"
+                );
+            }
+            Err(e) => {
+                // In-memory is already pruned; the DB still carries the rows.
+                // That's the safe direction — the next sweep re-deletes them,
+                // and a restart reloads them into the DAG (no lost state). Log
+                // and report the in-memory prune count regardless.
+                tracing::warn!(
+                    ?e,
+                    context_id = %self.applier.context_id,
+                    pruned = pruned_ids.len(),
+                    "DAG compaction pruned in-memory but failed to delete rows; next sweep retries"
+                );
+            }
+        }
+
+        pruned_ids.len()
+    }
 }
 
 #[cfg(test)]

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2290,6 +2290,13 @@ async fn request_missing_deltas(
     );
     let mut fetched_deltas: Vec<ParentFetch> = Vec::new();
     let mut fetch_count = 0;
+
+    // Set when the peer reports it no longer has a delta we still need —
+    // the expected outcome once that peer has compacted the delta away
+    // (#2026). Mirrors the same handling in `SyncManager::request_missing_deltas`:
+    // the ancestor chain is broken on the peer's side, so we abort the
+    // catch-up and let the next sync round reconcile via HashComparison.
+    let mut pruned_ancestor_encountered = false;
     // Accumulated (delta_id, events_data) pairs from any cascades that
     // happen while adding peer-fetched parents below. Passed back to the
     // caller so handlers can run.
@@ -2628,12 +2635,31 @@ async fn request_missing_deltas(
                     payload: MessagePayload::DeltaNotFound,
                     ..
                 }) => {
-                    warn!(%context_id, delta_id = ?missing_id, "Peer doesn't have requested delta");
+                    // The peer can't produce a delta we need — almost always
+                    // because it has compacted that history away (#2026).
+                    // Continuing to fetch its ancestors is futile; abort and
+                    // let the next sync round fall back to HashComparison.
+                    warn!(
+                        %context_id,
+                        delta_id = ?missing_id,
+                        "Peer doesn't have requested delta (likely pruned); \
+                         aborting parent fetch, will reconcile via state sync"
+                    );
+                    crate::node_metrics::observe_pruned_ancestor_fallback();
+                    pruned_ancestor_encountered = true;
+                    break;
                 }
                 other => {
                     warn!(%context_id, delta_id = ?missing_id, ?other, "Unexpected response to delta request");
                 }
             }
+        }
+
+        // A pruned ancestor breaks the chain from this peer; stop draining
+        // `to_fetch` entirely. Deltas already fetched stay as valid partial
+        // progress (applied to the DAG in Phase 2 below).
+        if pruned_ancestor_encountered {
+            break;
         }
     }
 

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2290,13 +2290,6 @@ async fn request_missing_deltas(
     );
     let mut fetched_deltas: Vec<ParentFetch> = Vec::new();
     let mut fetch_count = 0;
-
-    // Set when the peer reports it no longer has a delta we still need —
-    // the expected outcome once that peer has compacted the delta away
-    // (#2026). Mirrors the same handling in `SyncManager::request_missing_deltas`:
-    // the ancestor chain is broken on the peer's side, so we abort the
-    // catch-up and let the next sync round reconcile via HashComparison.
-    let mut pruned_ancestor_encountered = false;
     // Accumulated (delta_id, events_data) pairs from any cascades that
     // happen while adding peer-fetched parents below. Passed back to the
     // caller so handlers can run.
@@ -2635,31 +2628,18 @@ async fn request_missing_deltas(
                     payload: MessagePayload::DeltaNotFound,
                     ..
                 }) => {
-                    // The peer can't produce a delta we need — almost always
-                    // because it has compacted that history away (#2026).
-                    // Continuing to fetch its ancestors is futile; abort and
-                    // let the next sync round fall back to HashComparison.
-                    warn!(
-                        %context_id,
-                        delta_id = ?missing_id,
-                        "Peer doesn't have requested delta (likely pruned); \
-                         aborting parent fetch, will reconcile via state sync"
-                    );
-                    crate::node_metrics::observe_pruned_ancestor_fallback();
-                    pruned_ancestor_encountered = true;
-                    break;
+                    // `DeltaNotFound` is overloaded (compacted away #2026, a
+                    // not-yet-persisted post-broadcast race, or an unverifiable
+                    // row), so we just skip this id and keep fetching the rest.
+                    // A genuinely pruned ancestor leaves descendants pending and
+                    // the next sync round converges via HashComparison without
+                    // the delta log; no explicit abort/fallback is needed.
+                    warn!(%context_id, delta_id = ?missing_id, "Peer doesn't have requested delta");
                 }
                 other => {
                     warn!(%context_id, delta_id = ?missing_id, ?other, "Unexpected response to delta request");
                 }
             }
-        }
-
-        // A pruned ancestor breaks the chain from this peer; stop draining
-        // `to_fetch` entirely. Deltas already fetched stay as valid partial
-        // progress (applied to the DAG in Phase 2 below).
-        if pruned_ancestor_encountered {
-            break;
         }
     }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -15,6 +15,7 @@
 
 mod arbiter_pool;
 mod constants;
+pub mod dag_compactor;
 mod delta_store;
 pub mod gc;
 pub mod handlers;

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -106,7 +106,6 @@ pub(crate) struct NodeMetrics {
 
     // DAG compaction (#2026).
     pub(crate) dag_compaction_deltas_pruned_total: Counter,
-    pub(crate) dag_compaction_pruned_ancestor_fallbacks_total: Counter,
 
     // HC / LevelWise / EntityPush per-leaf authorization drops.
     pub(crate) hc_leaf_drops_total: Family<LeafDropLabels, Counter>,
@@ -240,24 +239,16 @@ impl NodeMetrics {
             dag_heads_count.clone(),
         );
 
-        // DAG compaction (#2026): how much history has been reclaimed, and
-        // how often peers hit a pruned frontier and fell back to state-based
-        // sync. A persistently rising fallback counter means
-        // `retain_recent_count` is too small for this node's reconnect gaps —
-        // peers are being pushed onto the more expensive HashComparison path.
+        // DAG compaction (#2026): how much history has been reclaimed. Counted
+        // on the compactor side, where the figure is unambiguous (a delta
+        // catch-up hitting a peer's `DeltaNotFound` can't be attributed to
+        // pruning vs. a persist race vs. an unverifiable row, so there is no
+        // honest receiver-side fallback counter).
         let dag_compaction_deltas_pruned_total = Counter::default();
         registry.register(
             "dag_compaction_deltas_pruned_total",
             "Total DAG delta rows pruned by compaction across all contexts",
             dag_compaction_deltas_pruned_total.clone(),
-        );
-
-        let dag_compaction_pruned_ancestor_fallbacks_total = Counter::default();
-        registry.register(
-            "dag_compaction_pruned_ancestor_fallbacks_total",
-            "Times a delta catch-up aborted because a peer had pruned a needed \
-             ancestor, deferring to state-based (HashComparison) sync",
-            dag_compaction_pruned_ancestor_fallbacks_total.clone(),
         );
 
         let hc_leaf_drops_total: Family<LeafDropLabels, Counter> = Family::default();
@@ -318,7 +309,6 @@ impl NodeMetrics {
             delta_missing_parents_total,
             dag_heads_count,
             dag_compaction_deltas_pruned_total,
-            dag_compaction_pruned_ancestor_fallbacks_total,
             hc_leaf_drops_total,
             governance_drain_outcomes_total,
             process_resident_memory_bytes,
@@ -579,14 +569,6 @@ pub(crate) fn observe_dag_heads_count(heads: usize) {
 pub(crate) fn observe_compaction_pruned(count: usize) {
     if let Some(m) = global() {
         m.dag_compaction_deltas_pruned_total.inc_by(count as u64);
-    }
-}
-
-/// Bump the counter for a delta catch-up that aborted on a pruned ancestor
-/// and deferred to state-based sync (#2026).
-pub(crate) fn observe_pruned_ancestor_fallback() {
-    if let Some(m) = global() {
-        m.dag_compaction_pruned_ancestor_fallbacks_total.inc();
     }
 }
 

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -104,6 +104,10 @@ pub(crate) struct NodeMetrics {
     pub(crate) delta_missing_parents_total: Counter,
     pub(crate) dag_heads_count: Histogram,
 
+    // DAG compaction (#2026).
+    pub(crate) dag_compaction_deltas_pruned_total: Counter,
+    pub(crate) dag_compaction_pruned_ancestor_fallbacks_total: Counter,
+
     // HC / LevelWise / EntityPush per-leaf authorization drops.
     pub(crate) hc_leaf_drops_total: Family<LeafDropLabels, Counter>,
 
@@ -236,6 +240,26 @@ impl NodeMetrics {
             dag_heads_count.clone(),
         );
 
+        // DAG compaction (#2026): how much history has been reclaimed, and
+        // how often peers hit a pruned frontier and fell back to state-based
+        // sync. A persistently rising fallback counter means
+        // `retain_recent_count` is too small for this node's reconnect gaps —
+        // peers are being pushed onto the more expensive HashComparison path.
+        let dag_compaction_deltas_pruned_total = Counter::default();
+        registry.register(
+            "dag_compaction_deltas_pruned_total",
+            "Total DAG delta rows pruned by compaction across all contexts",
+            dag_compaction_deltas_pruned_total.clone(),
+        );
+
+        let dag_compaction_pruned_ancestor_fallbacks_total = Counter::default();
+        registry.register(
+            "dag_compaction_pruned_ancestor_fallbacks_total",
+            "Times a delta catch-up aborted because a peer had pruned a needed \
+             ancestor, deferring to state-based (HashComparison) sync",
+            dag_compaction_pruned_ancestor_fallbacks_total.clone(),
+        );
+
         let hc_leaf_drops_total: Family<LeafDropLabels, Counter> = Family::default();
         registry.register(
             "hc_leaf_drops_total",
@@ -293,6 +317,8 @@ impl NodeMetrics {
             delta_cascade_size,
             delta_missing_parents_total,
             dag_heads_count,
+            dag_compaction_deltas_pruned_total,
+            dag_compaction_pruned_ancestor_fallbacks_total,
             hc_leaf_drops_total,
             governance_drain_outcomes_total,
             process_resident_memory_bytes,
@@ -546,6 +572,21 @@ pub(crate) fn observe_delta_cascade(size: usize) {
 pub(crate) fn observe_dag_heads_count(heads: usize) {
     if let Some(m) = global() {
         m.dag_heads_count.observe(heads as f64);
+    }
+}
+
+/// Record deltas reclaimed by a compaction sweep (#2026).
+pub(crate) fn observe_compaction_pruned(count: usize) {
+    if let Some(m) = global() {
+        m.dag_compaction_deltas_pruned_total.inc_by(count as u64);
+    }
+}
+
+/// Bump the counter for a delta catch-up that aborted on a pruned ancestor
+/// and deferred to state-based sync (#2026).
+pub(crate) fn observe_pruned_ancestor_fallback() {
+    if let Some(m) = global() {
+        m.dag_compaction_pruned_ancestor_fallbacks_total.inc();
     }
 }
 

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -32,6 +32,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::info;
 
 use crate::arbiter_pool::ArbiterPool;
+use crate::dag_compactor::DagCompactor;
 use crate::gc::GarbageCollector;
 use crate::network_event_channel::{self, NetworkEventChannelConfig};
 use crate::network_event_processor::NetworkEventBridge;
@@ -63,6 +64,8 @@ pub struct NodeConfig {
     pub context: ContextConfig,
     pub server: ServerConfig,
     pub gc_interval_secs: Option<u64>, // Optional GC interval in seconds (default: 12 hours)
+    /// DAG compaction settings (issue #2026). Disabled by default.
+    pub dag_compaction: calimero_node_primitives::DagCompactionConfig,
     pub mode: NodeMode,
     pub specialized_node: SpecializedNodeConfig,
     /// Resolved per-execution VM resource limits from the `[runtime.limits]`
@@ -388,6 +391,21 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     let gc = GarbageCollector::new(datastore.clone(), gc_interval);
 
     let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |_ctx| gc);
+
+    // Start DAG compaction actor (issue #2026). Disabled by default; only
+    // bounds on-disk delta growth when explicitly enabled in `[dag_compaction]`
+    // and the thresholds are internally consistent.
+    if config.dag_compaction.enabled && config.dag_compaction.is_valid() {
+        let compactor = DagCompactor::new(node_state.delta_stores_handle(), config.dag_compaction);
+        let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |_ctx| compactor);
+    } else if config.dag_compaction.enabled {
+        tracing::warn!(
+            min_deltas_before_compact = config.dag_compaction.min_deltas_before_compact,
+            retain_recent_count = config.dag_compaction.retain_recent_count,
+            "DAG compaction enabled but config is invalid (retain_recent_count must be \
+             < min_deltas_before_compact); compaction will NOT run"
+        );
+    }
 
     let mut sync = pin!(sync_manager.start());
     let mut server = tokio::spawn(server);

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -334,6 +334,14 @@ impl SyncManager {
         let mut to_fetch = missing_ids.clone();
         let mut fetch_count = 0;
 
+        // Set when the peer reports it no longer has a delta we still need —
+        // the expected outcome once that peer has compacted the delta away
+        // (#2026). Walking the gap further is futile: the ancestor chain is
+        // broken on the peer's side. We abort the delta catch-up so the next
+        // sync round reconciles via HashComparison, which converges current
+        // state without the delta log.
+        let mut pruned_ancestor_encountered = false;
+
         // Track visited IDs to prevent cycles/loops from malicious peers
         let mut visited_ids = std::collections::HashSet::new();
         // Initialize visited IDs with the starting set to ensure we don't re-queue them if they appear as parents.
@@ -463,7 +471,21 @@ impl SyncManager {
                         }
                     }
                     Ok(None) => {
-                        warn!(%context_id, delta_id = ?missing_id, "Peer doesn't have requested delta");
+                        // The peer can't produce a delta we need — almost
+                        // always because it has compacted that history away
+                        // (#2026). The chain to genesis is broken from this
+                        // peer, so continuing to fetch its ancestors is
+                        // pointless. Flag it, stop, and let the next sync
+                        // round fall back to HashComparison.
+                        warn!(
+                            %context_id,
+                            delta_id = ?missing_id,
+                            "Peer doesn't have requested delta (likely pruned); \
+                             aborting delta catch-up, will reconcile via state sync"
+                        );
+                        crate::node_metrics::observe_pruned_ancestor_fallback();
+                        pruned_ancestor_encountered = true;
+                        break;
                     }
                     Err(e) => {
                         error!(?e, %context_id, delta_id = ?missing_id, "Failed to request delta");
@@ -476,9 +498,17 @@ impl SyncManager {
                     }
                 }
             }
+
+            // A pruned ancestor breaks the chain from this peer; stop draining
+            // `to_fetch` entirely rather than just the current inner batch.
+            if pruned_ancestor_encountered {
+                break;
+            }
         }
 
         // Register any deltas left in the buffer below the chunk threshold.
+        // Deltas fetched before hitting the pruned frontier are still valid
+        // partial progress and worth persisting.
         flush_delta_batch(&delta_store, &context_id, std::mem::take(&mut delta_batch)).await;
 
         if fetch_count > 0 {

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -334,14 +334,6 @@ impl SyncManager {
         let mut to_fetch = missing_ids.clone();
         let mut fetch_count = 0;
 
-        // Set when the peer reports it no longer has a delta we still need —
-        // the expected outcome once that peer has compacted the delta away
-        // (#2026). Walking the gap further is futile: the ancestor chain is
-        // broken on the peer's side. We abort the delta catch-up so the next
-        // sync round reconciles via HashComparison, which converges current
-        // state without the delta log.
-        let mut pruned_ancestor_encountered = false;
-
         // Track visited IDs to prevent cycles/loops from malicious peers
         let mut visited_ids = std::collections::HashSet::new();
         // Initialize visited IDs with the starting set to ensure we don't re-queue them if they appear as parents.
@@ -471,21 +463,19 @@ impl SyncManager {
                         }
                     }
                     Ok(None) => {
-                        // The peer can't produce a delta we need — almost
-                        // always because it has compacted that history away
-                        // (#2026). The chain to genesis is broken from this
-                        // peer, so continuing to fetch its ancestors is
-                        // pointless. Flag it, stop, and let the next sync
-                        // round fall back to HashComparison.
-                        warn!(
-                            %context_id,
-                            delta_id = ?missing_id,
-                            "Peer doesn't have requested delta (likely pruned); \
-                             aborting delta catch-up, will reconcile via state sync"
-                        );
-                        crate::node_metrics::observe_pruned_ancestor_fallback();
-                        pruned_ancestor_encountered = true;
-                        break;
+                        // The peer didn't return this delta. `DeltaNotFound` is
+                        // overloaded: a delta compacted away (#2026), a delta
+                        // present in-memory but not yet persisted (a normal
+                        // post-broadcast race), or an unverifiable row (snapshot
+                        // checkpoint / pre-author-tracking). We can't tell which
+                        // from the wire, so we just skip this id and keep
+                        // fetching the rest of the batch and other branches.
+                        // No explicit fallback is needed: a genuinely pruned
+                        // ancestor leaves its descendants pending, and the next
+                        // sync round converges via HashComparison — already the
+                        // protocol selected for a diverged initialized node —
+                        // which reconciles state without the delta log.
+                        warn!(%context_id, delta_id = ?missing_id, "Peer doesn't have requested delta");
                     }
                     Err(e) => {
                         error!(?e, %context_id, delta_id = ?missing_id, "Failed to request delta");
@@ -498,17 +488,9 @@ impl SyncManager {
                     }
                 }
             }
-
-            // A pruned ancestor breaks the chain from this peer; stop draining
-            // `to_fetch` entirely rather than just the current inner batch.
-            if pruned_ancestor_encountered {
-                break;
-            }
         }
 
         // Register any deltas left in the buffer below the chunk threshold.
-        // Deltas fetched before hitting the pruned frontier are still valid
-        // partial progress and worth persisting.
         flush_delta_batch(&delta_store, &context_id, std::mem::take(&mut delta_batch)).await;
 
         if fetch_count > 0 {


### PR DESCRIPTION
## What

Implements DAG compaction to bound on-disk delta-log growth. Closes #2026.

Every regular delta was persisted forever in `Column::Delta`, so the DAG log grew linearly with lifetime transaction count — only the in-memory ancestry caps (`MAX_TOPOLOGY_ENTRIES` etc.) were bounded. This adds periodic pruning of history older than a configurable recent window, from both the in-memory DAG and the durable delta column.

## Why it's safe to prune

Deltas are an **optimization, not a convergence requirement**. `select_protocol` never returns `DeltaSync` — a diverged *initialized* node converges via `HashComparison`, which reconciles current state from the Merkle tree **without consulting the delta log**. Delta-catchup is only HC's fallback. So pruned history is never needed for correctness:

- A peer that requests a pruned delta gets **not-found** and aborts delta-catchup.
- Its next sync round selects `HashComparison` (already the default for diverged nodes) and converges from state.

The retained window keeps the cheap single-round delta-catchup fast-path for small reconnect gaps.

## Design decision

Considered (a) prune outright + not-found→HC fallback, (b) frontier checkpoint objects, (c) single head-checkpoint. Chose **(a)**: simplest, fewest moving parts, and leans on the protocol that already handles divergence. (b)/(c) still require the requester-side detection, so they only add an object to maintain.

## Changes

- **`DagCompactionConfig`** (`[dag_compaction]`, **disabled by default**) plumbed `ConfigFile → NodeConfig → merod`. Defaults anchor to existing constants rather than magic numbers:
  - `min_deltas_before_compact = 10000` (= `MAX_TOPOLOGY_ENTRIES`, so on-disk prune and in-memory eviction trip at one threshold)
  - `retain_recent_count = 1000` (≤ `MAX_DELTA_QUERY_LIMIT = 3000`, so a behind peer catches up in one delta round; 10:1 gap gives hysteresis)
  - `check_interval = 1h`
- **`DagStore::prune_to_recent`** + `delta_count` — retain set = BFS-from-heads up to `retain_recent_count`; heads always kept; pending never pruned; **no re-parenting** (traversal already stops at an absent parent).
- **`ContextClient::prune_delta_records`** — atomic `Transaction` batch delete, mirroring `persist_delta_records`.
- **`DeltaStore::compact`** — runs under the DAG write lock (serialises against the responder send path + apply); skips mid-sync (pending > 0).
- **`DagCompactor`** actor — interval-scheduled, mirrors `GarbageCollector`; sweeps live contexts; gated on `enabled && is_valid()`.
- **Requester fallback** — `request_missing_deltas` aborts on a pruned ancestor and defers to HC.
- **Metrics** — `dag_compaction_deltas_pruned_total`, `dag_compaction_pruned_ancestor_fallbacks_total` (a rising fallback counter means `retain_recent_count` is too small for this node's reconnect gaps).

## Tests

- `DagStore::prune_to_recent`: linear-chain prune, never-strands-heads, below-threshold no-op.
- `DagCompactionConfig`: disabled default, validity guard, absent-field fallback, seconds round-trip.
- `cargo fmt --check` clean; `merod` builds.

## Why draft / not yet enabled

Compaction is **off by default** and should stay off until the pruned-ancestor → HashComparison fallback has soaked in e2e/merobox. Never prune in production before that path is proven.

## Follow-ups (not in this PR)

- e2e/merobox soak of the fallback path, then flip `enabled` on.
- `DeltaStore::compact` integration test (needs a full `ContextStorageApplier`; only the pure dag-level prune is unit-tested here).
- Cold (non-loaded) context compaction — currently only live in-memory DAGs are swept.
- Coordinate with the parallel `rotation_log.rs` P6 compaction effort (shared threshold/config story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When enabled, pruning changes what peers can serve over delta-sync; correctness relies on HashComparison fallback and skipping compaction during pending catch-up. Default-off limits production exposure, but misconfiguration or premature enablement could widen sync gaps for lagging peers.
> 
> **Overview**
> Adds **optional DAG compaction** (#2026) to cap unbounded growth of persisted context delta rows. A new **`[dag_compaction]`** section (`DagCompactionConfig`, **off by default**) is wired through **`config.toml` → `merod` → `NodeConfig`**, with defaults aligned to existing topology/query limits (e.g. 10k min before compact, 1k retain, 1h interval).
> 
> **In-memory + on-disk pruning:** `DagStore` gains **`delta_count`** and **`prune_to_recent`** (BFS from heads, always keep heads, never prune pending). **`ContextRegistry` / `ContextClient`** add **`prune_delta_records`** for atomic batch deletes in the delta column. **`DeltaStore::compact`** runs under the DAG write lock, skips contexts with pending deltas, prunes memory then calls **`prune_delta_records`**.
> 
> **Runtime:** a **`DagCompactor`** actix actor periodically sweeps **live** in-memory `DeltaStore`s (startup + interval, overlap guard). Node startup only spawns it when **`enabled && is_valid()`**. Prometheus counter **`dag_compaction_deltas_pruned_total`** records reclaimed rows.
> 
> **Sync behavior:** comments/clarifications where peers return **`DeltaNotFound`** — treat as ambiguous (compaction, race, checkpoint) and continue; convergence is expected via **HashComparison**, not delta replay.
> 
> Unit tests cover **`prune_to_recent`** and config serde/validation. Cold contexts with large on-disk logs but small in-memory DAGs are explicitly called out as a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd11660cba534f50ffe2851d29491b55ca1d8838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->