### PR TITLE
feat(node): complete DAG-causal rotation — self-log own rotations so writers_at is total

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -997,6 +997,82 @@ pub(crate) fn seed_rotation_log_genesis_direct(
     save_rotation_log_direct(context_client, context_id, entity_id, &log)
 }
 
+/// Self-log the `Shared` rotations carried by a locally-originated delta's
+/// `actions` into their entities' rotation logs, via direct datastore writes.
+///
+/// The receive path records rotations in `Interface::maybe_append_rotation_log`
+/// (inside the WASM sync-apply); a locally-created delta never goes through that
+/// path, so without this a node is missing its OWN rotations and `writers_at`
+/// stays asymmetric across nodes under concurrent rotation. Mirrors the
+/// receive-path logic: append only on a real rotation — bootstrap (no prior
+/// writers) or a changed writer set — never on a plain value-write. Idempotent
+/// (dedup on `delta_id`), so it is safe to run on both the live notify
+/// (`add_local_applied_delta`) and crash/restart recovery
+/// (`load_persisted_deltas`); the latter backstops the case where the live
+/// notify was skipped (DeltaStore not yet up) and the delta is later restored
+/// as already-applied.
+///
+/// Best-effort: a per-entity read/write failure is logged and skipped, leaving
+/// that entry for the next restart's restore to re-attempt — it never aborts
+/// the (already-committed) delta.
+fn self_log_rotations_direct(
+    context_client: &ContextClient,
+    context_id: ContextId,
+    delta_id: [u8; 32],
+    delta_hlc: calimero_storage::logical_clock::HybridTimestamp,
+    actions: &[Action],
+) {
+    for action in actions {
+        let (entity_id, metadata) = match action {
+            Action::Add { id, metadata, .. } | Action::Update { id, metadata, .. } => {
+                (*id, metadata)
+            }
+            Action::DeleteRef { .. } | Action::Compare { .. } => continue,
+        };
+        // Only `Shared` anchors own a rotation log; members/others don't.
+        let StorageType::Shared {
+            writers,
+            signature_data,
+        } = &metadata.storage_type
+        else {
+            continue;
+        };
+        let mut log = match load_rotation_log_direct(context_client, context_id, entity_id) {
+            Ok(existing) => existing.unwrap_or_else(RotationLog::empty),
+            Err(e) => {
+                warn!(?e, %context_id, %entity_id,
+                    "self-log: failed to read rotation log — skipping (restore will retry)");
+                continue;
+            }
+        };
+        // Append only on an actual rotation — bootstrap (no prior writers) OR
+        // the writer set changed. Mirrors `maybe_append_rotation_log`.
+        let prior = log
+            .entries
+            .last()
+            .map(|e| &e.new_writers)
+            .or_else(|| log.snapshot.as_ref().map(|s| &s.writers));
+        if !prior.map_or(true, |p| p != writers) {
+            continue;
+        }
+        // Idempotent on delta_id (one rotation per entity per delta).
+        if log.entries.iter().any(|e| e.delta_id == delta_id) {
+            continue;
+        }
+        log.entries.push(RotationLogEntry {
+            delta_id,
+            delta_hlc,
+            signer: signature_data.as_ref().and_then(|s| s.signer),
+            new_writers: writers.clone(),
+            writers_nonce: signature_data.as_ref().map(|s| s.nonce).unwrap_or(0),
+        });
+        if let Err(e) = save_rotation_log_direct(context_client, context_id, entity_id, &log) {
+            warn!(?e, %context_id, %entity_id,
+                "self-log: failed to write rotation log — leaving for restore retry");
+        }
+    }
+}
+
 /// Whether the anchor entity `anchor` has synced to this node, by a direct
 /// datastore read (no WASM env). True if either its rotation log
 /// (`StorageKey::RotationLog`) or its index entry (`StorageKey::Index`, written
@@ -1221,6 +1297,25 @@ impl DeltaStore {
                     continue;
                 }
             };
+
+            // P4 backstop: re-self-log this delta's `Shared` rotations on
+            // restore. If the live notify (`add_local_applied_delta`) was
+            // skipped — e.g. the DeltaStore wasn't up when the delta was created
+            // and persisted — the originator's own rotation would otherwise be
+            // missing from its log forever (this delta is restored as
+            // already-applied, so `add_local_applied_delta` won't re-run for
+            // it). Idempotent (dedup on delta_id): a no-op for deltas already
+            // logged at creation or by the receive path. Only applied deltas
+            // represent rotations that actually took effect.
+            if stored_delta.applied {
+                self_log_rotations_direct(
+                    &self.applier.context_client,
+                    self.applier.context_id,
+                    stored_delta.delta_id,
+                    stored_delta.hlc,
+                    &actions,
+                );
+            }
 
             // Reconstruct the delta
             // Infer checkpoint status: checkpoints have genesis as parent and empty payload
@@ -1717,78 +1812,19 @@ impl DeltaStore {
             }
         }
 
-        // P4: self-log this delta's own `Shared` rotations.
-        //
-        // The receive path records rotations in `maybe_append_rotation_log`
-        // (inside the WASM sync-apply, via `MainStorage`/`RUNTIME_ENV`). A
-        // locally-created delta never goes through that path, so without this a
-        // node would be missing its OWN rotations from its log — leaving
-        // concurrent rotations asymmetric across nodes and `writers_at`
-        // divergent (each node would resolve only the rotations it received).
-        // Mirror the receive-path logic here, with a DIRECT datastore write
-        // (this runs after execute returned, outside `RUNTIME_ENV`). Done
-        // before DAG registration but after the `is_applied` dedup above, so a
-        // delta is self-logged exactly once. `delta_id`/`delta_hlc` are final.
-        for action in &delta.payload {
-            let (entity_id, metadata) = match action {
-                Action::Add { id, metadata, .. } | Action::Update { id, metadata, .. } => {
-                    (*id, metadata)
-                }
-                Action::DeleteRef { .. } | Action::Compare { .. } => continue,
-            };
-            // Only `Shared` anchors own a rotation log; members/others don't.
-            let StorageType::Shared {
-                writers,
-                signature_data,
-            } = &metadata.storage_type
-            else {
-                continue;
-            };
-            let mut log = match load_rotation_log_direct(
-                &self.applier.context_client,
-                self.applier.context_id,
-                entity_id,
-            ) {
-                Ok(existing) => existing.unwrap_or_else(RotationLog::empty),
-                Err(e) => {
-                    warn!(?e, context_id = %self.applier.context_id, %entity_id,
-                        "self-log: failed to read rotation log for local delta — skipping");
-                    continue;
-                }
-            };
-            // Append only on an actual rotation — bootstrap (no prior writers)
-            // OR the writer set changed. Plain value-writes leave it untouched.
-            // Mirrors `maybe_append_rotation_log`'s `is_rotation`.
-            let prior = log
-                .entries
-                .last()
-                .map(|e| &e.new_writers)
-                .or_else(|| log.snapshot.as_ref().map(|s| &s.writers));
-            let is_rotation = prior.map_or(true, |p| p != writers);
-            if !is_rotation {
-                continue;
-            }
-            // Idempotent on delta_id (one rotation per entity per delta).
-            if log.entries.iter().any(|e| e.delta_id == delta_id) {
-                continue;
-            }
-            log.entries.push(RotationLogEntry {
-                delta_id,
-                delta_hlc: delta.hlc,
-                signer: signature_data.as_ref().and_then(|s| s.signer),
-                new_writers: writers.clone(),
-                writers_nonce: signature_data.as_ref().map(|s| s.nonce).unwrap_or(0),
-            });
-            if let Err(e) = save_rotation_log_direct(
-                &self.applier.context_client,
-                self.applier.context_id,
-                entity_id,
-                &log,
-            ) {
-                warn!(?e, context_id = %self.applier.context_id, %entity_id,
-                    "self-log: failed to write rotation log for local delta");
-            }
-        }
+        // P4: self-log this delta's own `Shared` rotations (the receive path
+        // logs received rotations; locally-created deltas need this so the node
+        // records its OWN, keeping `writers_at` symmetric across nodes). Runs
+        // after the `is_applied` dedup, so a live local delta is logged once;
+        // `load_persisted_deltas` re-runs the same idempotent helper on restore,
+        // backstopping the case where this live notify was skipped.
+        self_log_rotations_direct(
+            &self.applier.context_client,
+            self.applier.context_id,
+            delta_id,
+            delta.hlc,
+            &delta.payload,
+        );
 
         // Mirror the hash-tracking writes load_persisted_deltas does.
         {

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -25,7 +25,7 @@ use calimero_storage::action::Action;
 use calimero_storage::address::Id;
 use calimero_storage::delta::StorageDelta;
 use calimero_storage::entities::StorageType;
-use calimero_storage::rotation_log::RotationLog;
+use calimero_storage::rotation_log::{RotationLog, RotationLogEntry, RotationSnapshot};
 use calimero_storage::store::Key as StorageKey;
 use eyre::Result;
 use indexmap::IndexMap;
@@ -920,7 +920,7 @@ fn cap_topology(topology: &mut IndexMap<[u8; 32], Vec<[u8; 32]>>) {
 /// Returns `Ok(None)` for entities with no rotation log yet (every
 /// pre-rotation Shared entity), which is fine — the receiver verifier
 /// then falls back to v2 stored-writers, matching pre-#2266 behavior.
-fn load_rotation_log_direct(
+pub(crate) fn load_rotation_log_direct(
     context_client: &ContextClient,
     context_id: ContextId,
     entity_id: Id,
@@ -942,6 +942,59 @@ fn load_rotation_log_direct(
     let log = borsh::from_slice::<RotationLog>(&bytes)
         .map_err(|e| eyre::eyre!("rotation_log decode failed: {e}"))?;
     Ok(Some(log))
+}
+
+/// Write `log` for `entity_id` via a DIRECT datastore write (no WASM
+/// `RUNTIME_ENV`). The byte format is identical to
+/// [`rotation_log::save`](calimero_storage::rotation_log) (borsh `RotationLog`
+/// under `StorageKey::RotationLog`), so a log written here and one written by
+/// the receive-path `MainStorage` hook are interchangeable. Used to self-log a
+/// locally-created delta's own rotations, which happens after execute returns —
+/// outside the env where `MainStorage` is valid.
+fn save_rotation_log_direct(
+    context_client: &ContextClient,
+    context_id: ContextId,
+    entity_id: Id,
+    log: &RotationLog,
+) -> Result<()> {
+    let bytes = borsh::to_vec(log).map_err(|e| eyre::eyre!("rotation_log encode failed: {e}"))?;
+    let storage_key = StorageKey::RotationLog(entity_id).to_bytes();
+    let state_key = calimero_store::key::ContextState::new(context_id, storage_key);
+    let mut handle = context_client.datastore_handle();
+    handle
+        .put(
+            &state_key,
+            &calimero_store::types::ContextState::from(calimero_store::slice::Slice::from(bytes)),
+        )
+        .map_err(|e| eyre::eyre!("rotation_log datastore write failed: {e:?}"))?;
+    Ok(())
+}
+
+/// Seed `entity_id`'s rotation log with `writers` as its genesis/floor snapshot
+/// via a direct datastore write, **if no log exists yet** (idempotent — never
+/// clobbers real history). Datastore-direct counterpart of
+/// [`rotation_log::seed_genesis`](calimero_storage::rotation_log::seed_genesis)
+/// for the cold-join snapshot path (no `RUNTIME_ENV`): a joiner that receives
+/// settled state needs the boundary writer set as its causal floor, so
+/// `writers_at` is total for any post-join cut (it never applies deltas
+/// predating its snapshot boundary).
+pub(crate) fn seed_rotation_log_genesis_direct(
+    context_client: &ContextClient,
+    context_id: ContextId,
+    entity_id: Id,
+    writers: BTreeSet<PublicKey>,
+) -> Result<()> {
+    if load_rotation_log_direct(context_client, context_id, entity_id)?.is_some() {
+        return Ok(());
+    }
+    let log = RotationLog {
+        snapshot: Some(RotationSnapshot {
+            writers,
+            cutoff_index: 0,
+        }),
+        entries: Vec::new(),
+    };
+    save_rotation_log_direct(context_client, context_id, entity_id, &log)
 }
 
 /// Whether the anchor entity `anchor` has synced to this node, by a direct
@@ -1661,6 +1714,79 @@ impl DeltaStore {
             let dag = self.dag.read().await;
             if dag.is_applied(&delta_id) {
                 return Ok(Vec::new());
+            }
+        }
+
+        // P4: self-log this delta's own `Shared` rotations.
+        //
+        // The receive path records rotations in `maybe_append_rotation_log`
+        // (inside the WASM sync-apply, via `MainStorage`/`RUNTIME_ENV`). A
+        // locally-created delta never goes through that path, so without this a
+        // node would be missing its OWN rotations from its log — leaving
+        // concurrent rotations asymmetric across nodes and `writers_at`
+        // divergent (each node would resolve only the rotations it received).
+        // Mirror the receive-path logic here, with a DIRECT datastore write
+        // (this runs after execute returned, outside `RUNTIME_ENV`). Done
+        // before DAG registration but after the `is_applied` dedup above, so a
+        // delta is self-logged exactly once. `delta_id`/`delta_hlc` are final.
+        for action in &delta.payload {
+            let (entity_id, metadata) = match action {
+                Action::Add { id, metadata, .. } | Action::Update { id, metadata, .. } => {
+                    (*id, metadata)
+                }
+                Action::DeleteRef { .. } | Action::Compare { .. } => continue,
+            };
+            // Only `Shared` anchors own a rotation log; members/others don't.
+            let StorageType::Shared {
+                writers,
+                signature_data,
+            } = &metadata.storage_type
+            else {
+                continue;
+            };
+            let mut log = match load_rotation_log_direct(
+                &self.applier.context_client,
+                self.applier.context_id,
+                entity_id,
+            ) {
+                Ok(existing) => existing.unwrap_or_else(RotationLog::empty),
+                Err(e) => {
+                    warn!(?e, context_id = %self.applier.context_id, %entity_id,
+                        "self-log: failed to read rotation log for local delta — skipping");
+                    continue;
+                }
+            };
+            // Append only on an actual rotation — bootstrap (no prior writers)
+            // OR the writer set changed. Plain value-writes leave it untouched.
+            // Mirrors `maybe_append_rotation_log`'s `is_rotation`.
+            let prior = log
+                .entries
+                .last()
+                .map(|e| &e.new_writers)
+                .or_else(|| log.snapshot.as_ref().map(|s| &s.writers));
+            let is_rotation = prior.map_or(true, |p| p != writers);
+            if !is_rotation {
+                continue;
+            }
+            // Idempotent on delta_id (one rotation per entity per delta).
+            if log.entries.iter().any(|e| e.delta_id == delta_id) {
+                continue;
+            }
+            log.entries.push(RotationLogEntry {
+                delta_id,
+                delta_hlc: delta.hlc,
+                signer: signature_data.as_ref().and_then(|s| s.signer),
+                new_writers: writers.clone(),
+                writers_nonce: signature_data.as_ref().map(|s| s.nonce).unwrap_or(0),
+            });
+            if let Err(e) = save_rotation_log_direct(
+                &self.applier.context_client,
+                self.applier.context_id,
+                entity_id,
+                &log,
+            ) {
+                warn!(?e, context_id = %self.applier.context_id, %entity_id,
+                    "self-log: failed to write rotation log for local delta");
             }
         }
 

--- a/crates/node/src/delta_store_head_hashes_test.rs
+++ b/crates/node/src/delta_store_head_hashes_test.rs
@@ -115,3 +115,113 @@ async fn add_local_applied_delta_prunes_non_head_ancestors() {
         "parent entry must be pruned once it is no longer a head"
     );
 }
+
+/// P4: a locally-created delta must self-log its own `Shared` rotations into
+/// the entity's rotation log (the receive path does this via
+/// `maybe_append_rotation_log`; the originator has no such path). Genesis Add
+/// and writer-set changes append entries; a plain value-write does not.
+#[tokio::test]
+async fn add_local_applied_delta_self_logs_own_rotations() {
+    use std::collections::BTreeSet;
+
+    use calimero_storage::address::Id;
+    use calimero_storage::tests::common::{build_signed_shared_action, pubkey_of};
+    use ed25519_dalek::SigningKey;
+
+    use crate::delta_store::load_rotation_log_direct;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+    let blob_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+    let network_client = NetworkClient::new(LazyRecipient::new());
+    let (event_sender, _) = broadcast::channel(16);
+    let (ctx_sync_tx, _r0) = mpsc::channel(1);
+    let (ns_sync_tx, _r1) = mpsc::channel(1);
+    let (ns_join_tx, _r2) = mpsc::channel(1);
+    let (open_subgroup_join_tx, _r3) = mpsc::channel(1);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client,
+        LazyRecipient::new(),
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+    let context_id = ContextId::from([0xAA; 32]);
+    let our_identity = PublicKey::from([0xBB; 32]);
+    // Keep a clone to read the rotation log back; `DeltaStore::new` takes one.
+    let context_client = ContextClient::new(store, node_client, LazyRecipient::new());
+    let reader = context_client.clone();
+    let delta_store = DeltaStore::new([0u8; 32], context_client, context_id, our_identity);
+
+    let anchor = Id::new([0x33; 32]);
+    let alice_sk = SigningKey::from_bytes(&[0xA1; 32]);
+    let bob_sk = SigningKey::from_bytes(&[0xB2; 32]);
+    let alice = pubkey_of(&alice_sk);
+    let bob = pubkey_of(&bob_sk);
+    let writers = |set: &[PublicKey]| -> BTreeSet<PublicKey> { set.iter().copied().collect() };
+
+    // Build a signed Shared Add/Update for `anchor` carrying `w` as its writer
+    // set (signed by alice; the self-log only reads writers/signer, not verify).
+    let shared_action = |add: bool, w: BTreeSet<PublicKey>, nonce: u64| -> Action {
+        build_signed_shared_action(add, anchor, vec![1], w, nonce, &alice_sk, vec![])
+    };
+
+    let log_entries = || {
+        load_rotation_log_direct(&reader, context_id, anchor)
+            .expect("read log")
+            .map(|l| {
+                l.entries
+                    .iter()
+                    .map(|e| e.new_writers.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    };
+
+    // 1. Genesis Add {alice} → bootstrap entry recorded.
+    let mut d = make_delta([0x01; 32], vec![[0u8; 32]], [0xD1; 32]);
+    d.payload = vec![shared_action(true, writers(&[alice]), 1)];
+    let _ = delta_store
+        .add_local_applied_delta(d)
+        .await
+        .expect("add genesis");
+    assert_eq!(
+        log_entries(),
+        vec![writers(&[alice])],
+        "genesis Add must self-log a bootstrap entry"
+    );
+
+    // 2. Rotation Update {alice,bob} → second entry recorded.
+    let mut d = make_delta([0x02; 32], vec![[0x01; 32]], [0xD2; 32]);
+    d.payload = vec![shared_action(false, writers(&[alice, bob]), 2)];
+    let _ = delta_store
+        .add_local_applied_delta(d)
+        .await
+        .expect("add rotation");
+    assert_eq!(
+        log_entries(),
+        vec![writers(&[alice]), writers(&[alice, bob])],
+        "writer-set change must self-log a rotation entry"
+    );
+
+    // 3. Value-write Update with UNCHANGED writers {alice,bob} → no new entry.
+    let mut d = make_delta([0x03; 32], vec![[0x02; 32]], [0xD3; 32]);
+    d.payload = vec![shared_action(false, writers(&[alice, bob]), 3)];
+    let _ = delta_store
+        .add_local_applied_delta(d)
+        .await
+        .expect("add value-write");
+    assert_eq!(
+        log_entries(),
+        vec![writers(&[alice]), writers(&[alice, bob])],
+        "a value-write that doesn't change writers must NOT append a rotation entry"
+    );
+}

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -655,6 +655,26 @@ impl SyncManager {
                                     } = &index_entity.metadata.storage_type
                                     {
                                         let _ = anchor_writers.insert(id_obj, writers.clone());
+                                        // P4: seed this anchor's rotation-log floor
+                                        // with the settled writers at the snapshot
+                                        // boundary, so post-join `writers_at` is
+                                        // total (the joiner never applies deltas
+                                        // predating its boundary). Idempotent.
+                                        if let Err(e) =
+                                            crate::delta_store::seed_rotation_log_genesis_direct(
+                                                &self.context_client,
+                                                context_id,
+                                                id_obj,
+                                                writers.clone(),
+                                            )
+                                        {
+                                            warn!(
+                                                %context_id,
+                                                id = ?id_obj.as_bytes(),
+                                                error = ?e,
+                                                "snapshot: failed to seed anchor rotation-log floor"
+                                            );
+                                        }
                                     }
                                 }
                                 SnapshotRecord::Auxiliary { kind, id, .. } => {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -223,19 +223,24 @@ impl<S: StorageAdaptor> Interface<S> {
     /// `writers_at(anchor_log, delta.parents)`, passed in via
     /// `effective_writers`.
     ///
-    /// **Best-effort under concurrent rotations** — same caveat the `Shared`
-    /// path carries (see `SharedStorage::current_writers` and the `Shared` arm
-    /// of `apply_action`, which falls back to the entity's *stored* writers the
-    /// same way). The rotation log's *latest* entry is this node's insertion
-    /// order, which can differ from causal order if two rotations arrive
-    /// interleaved; resolving against it (rather than the set causally valid at
-    /// the op's cut) can therefore accept/reject differently across nodes. The
-    /// causal `writers_at` set passed as `effective_writers` is the security
-    /// boundary on the merge path; this fallback only fires when no causal
-    /// context exists (local exec / snapshot) or `writers_at` can't resolve (an
-    /// op causally before any logged rotation). Full causal resolution here is
-    /// deferred to the concurrent-rotation work (P4 / the DAG-causal rotation
-    /// epic), which fixes `Shared` and `SharedMember` uniformly.
+    /// The rotation log's *latest* entry is this node's insertion order, which
+    /// can differ from causal order under concurrent rotations — so this
+    /// fallback is **not** causally exact. It is therefore reserved for the
+    /// **local-execution / settled-state** gate, where "current writers" is the
+    /// right answer (a local writer acts under the current set). The
+    /// **merge-path** security boundary is the causal `writers_at(anchor_log,
+    /// delta.parents)` set passed as `effective_writers`.
+    ///
+    /// As of the DAG-causal rotation completion (P4), every node records the
+    /// genesis writer set **and its own rotations** in the log (the originator
+    /// via `add_local_applied_delta`'s self-log, receivers via
+    /// `maybe_append_rotation_log`, cold-joiners via a seeded floor). With a
+    /// complete log on every node, `writers_at` is **total** — it never returns
+    /// `None` for a causal cut, so the node always supplies `effective_writers`
+    /// and this non-causal fallback is no longer reached on the merge path for
+    /// anchors created post-P4. It remains for local execution (correct there)
+    /// and for legacy anchors whose log predates P4 (a vanishing set after a
+    /// state reset).
     fn resolve_anchor_writers(anchor: Id) -> BTreeSet<PublicKey> {
         if let Ok(Some(log)) = crate::rotation_log::load::<S>(anchor) {
             if let Some(entry) = log.entries.last() {


### PR DESCRIPTION
Completes the concurrent-rotation correctness that #2655 explicitly deferred — the "P4" piece of the #2233 DAG-causal rotation epic — uniformly for `Shared` and `SharedMember`.

## Problem
A node only logged rotations it **received** (`maybe_append_rotation_log`, on the apply path); it never logged **its own** (local execute doesn't go through that path). So under concurrent rotations each node held an *asymmetric* log — only the other node's rotation — and `writers_at` resolved a different writer set per node → divergent verification / split-brain:

```
{Alice,Bob}.  node-1 rotates →{Alice,Carol} (R1).  node-2 rotates →{Alice,Bob,Dave} (R2).  (concurrent)
node-1 log = [genesis, R2]   (logged only what it received — missing its own R1)
node-2 log = [genesis, R1]   (missing its own R2)
writers_at(after both):  node-1 → {Alice,Bob,Dave}   node-2 → {Alice,Carol}   ✗ diverge
```
And pre-rotation cuts compounded it: with no genesis recorded, `writers_at` returned `None` → callers fell back to a non-causal "latest writers" guess.

## Fix — every node holds the complete `[genesis, …all rotations]` log
- **Self-log own rotations** (`DeltaStore::add_local_applied_delta`): once a local delta is finalized (id/hlc assigned), append a rotation-log entry for each `Shared` Add (genesis bootstrap) / writer-changing Update — mirroring the receive-path hook. Value-writes that don't change writers are skipped. Uses a **direct datastore write** (`save_rotation_log_direct`) because this runs *outside* the WASM `RUNTIME_ENV` where `MainStorage` is valid.
- **Cold-join floor** (`snapshot.rs`): a snapshot-syncing joiner seeds each anchor's rotation log with the settled writers at its boundary (`seed_rotation_log_genesis_direct`) — its causal floor; it never applies deltas predating the boundary.

With a complete log on every node, `writers_at` is **total** (genesis covers any pre-rotation cut; the existing ADR-0001 merge resolves concurrent rotations order-independently), so the merge path always supplies the causal `effective_writers` and **never reaches the non-causal `resolve_anchor_writers` fallback** — now reserved for local execution (where "current writers" is correct) and legacy pre-P4 anchors. No state-hash change (the rotation log is auxiliary, node-local).

```
After the fix, both nodes log own+received → both = [genesis, R1, R2]
writers_at merges deterministically (order-independent) → identical on every node ✓
```

## Tests
- `add_local_applied_delta_self_logs_own_rotations` (node) — genesis + rotation logged, value-write skipped.
- Convergence follows by composition of existing unit tests: each node logs own+received (this test + the receive path), and `writers_at` is order-independent for concurrent rotations (`writers_at_concurrent_siblings_resolved_by_hlc`) + total via the genesis/snapshot floor (`writers_at_falls_back_to_snapshot_when_entries_unreachable`).
- storage 550 + node 267 lib tests green; fmt clean.

## Remaining / follow-up
A dedicated **cross-node concurrent-rotation merobox e2e** is the integration-level coverage (CI-only; not locally runnable). The existing shared-storage + sync-resilience e2e suites also exercise the rotation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Shared writer-set history and merge-time `effective_writers` resolution (consensus-adjacent), but writes are idempotent, best-effort on failure, and auxiliary to state hashes; snapshot genesis seeding only runs when no log exists.
> 
> **Overview**
> Completes **DAG-causal rotation (P4)** so every node keeps a **symmetric** per-anchor rotation log: received rotations were already recorded on apply; **locally created** deltas were not, which made `writers_at` disagree under concurrent writer-set changes.
> 
> The node layer adds **direct datastore** read/write helpers for rotation logs (outside WASM `RUNTIME_ENV`), **`self_log_rotations_direct`** (mirrors receive-path rules: genesis / writer-set change only, dedup by `delta_id`), and wires it into **`add_local_applied_delta`** and **`load_persisted_deltas`** (restart backstop). **Snapshot sync** seeds a genesis floor via **`seed_rotation_log_genesis_direct`** when an anchor has no log yet. Storage docs are updated to say merge-path verification should use causal **`writers_at`** / `effective_writers`, with non-causal **`resolve_anchor_writers`** left for local execution and legacy logs.
> 
> A new test asserts local deltas self-log genesis and rotations but skip plain value-writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fff19ce218e2d950a1ccbf71c1005461bfeece1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->