### PR TITLE
feat(dag): enable DAG compaction by default (#2026)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -70,8 +70,9 @@ pub struct ConfigFile {
     pub tee: Option<TeeConfig>,
 
     /// DAG compaction (`[dag_compaction]`) — bounds on-disk delta-log growth
-    /// by pruning history older than a checkpoint. Disabled by default;
-    /// absent section falls back to [`DagCompactionConfig::default`].
+    /// by pruning history older than a recent retain window. Enabled by
+    /// default; an absent section falls back to [`DagCompactionConfig::default`]
+    /// (set `enabled = false` to opt out).
     #[serde(default)]
     pub dag_compaction: DagCompactionConfig,
 }

--- a/crates/node/primitives/src/dag_compaction.rs
+++ b/crates/node/primitives/src/dag_compaction.rs
@@ -43,6 +43,11 @@ pub const DEFAULT_CHECK_INTERVAL_SECS: u64 = 3_600;
 /// selected for a diverged initialized node — which converges current state
 /// without consulting the delta log. Operators can still set `enabled = false`
 /// to opt out.
+///
+/// **Upgrade note:** a node upgrading from a build where compaction was
+/// disabled-by-default, and whose config has no `[dag_compaction]` section,
+/// will begin compacting automatically on the next restart. Set
+/// `enabled = false` to preserve the old behavior.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DagCompactionConfig {

--- a/crates/node/primitives/src/dag_compaction.rs
+++ b/crates/node/primitives/src/dag_compaction.rs
@@ -36,15 +36,18 @@ pub const DEFAULT_CHECK_INTERVAL_SECS: u64 = 3_600;
 
 /// Operator-tunable DAG compaction settings (`[dag_compaction]`).
 ///
-/// Defaults are conservative and, crucially, compaction is **disabled by
-/// default** ([`enabled`](Self::enabled) is `false`) until the pruned-history
-/// sync fallback has soaked: a node must never prune deltas a peer still
-/// depends on without the requester falling back to a state-based protocol.
+/// Compaction is **enabled by default** with conservative thresholds. It is
+/// safe to prune because deltas are an optimization, not a convergence
+/// requirement: a peer that requests a pruned delta gets "not found" and the
+/// next sync round reconciles via HashComparison — already the protocol
+/// selected for a diverged initialized node — which converges current state
+/// without consulting the delta log. Operators can still set `enabled = false`
+/// to opt out.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DagCompactionConfig {
     /// Whether periodic DAG compaction runs at all.
-    #[serde(default)]
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
 
     /// Minimum delta rows a context must hold before it is eligible for
@@ -64,7 +67,7 @@ pub struct DagCompactionConfig {
 impl Default for DagCompactionConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: default_enabled(),
             min_deltas_before_compact: DEFAULT_MIN_DELTAS_BEFORE_COMPACT,
             retain_recent_count: DEFAULT_RETAIN_RECENT_COUNT,
             check_interval: default_check_interval(),
@@ -86,6 +89,10 @@ impl DagCompactionConfig {
     pub fn is_valid(&self) -> bool {
         self.retain_recent_count < self.min_deltas_before_compact && !self.check_interval.is_zero()
     }
+}
+
+const fn default_enabled() -> bool {
+    true
 }
 
 const fn default_min_deltas_before_compact() -> usize {
@@ -122,9 +129,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_is_disabled_with_sane_thresholds() {
+    fn default_is_enabled_with_sane_thresholds() {
         let cfg = DagCompactionConfig::default();
-        assert!(!cfg.enabled);
+        assert!(cfg.enabled);
         assert_eq!(
             cfg.min_deltas_before_compact,
             DEFAULT_MIN_DELTAS_BEFORE_COMPACT
@@ -154,16 +161,23 @@ mod tests {
 
     #[test]
     fn absent_fields_fall_back_to_defaults() {
-        // An empty object must deserialize to the disabled default — every
-        // field is `#[serde(default)]`, so omitted sections never break
-        // existing configs.
+        // An empty object must deserialize to the enabled default — every
+        // field has an explicit `#[serde(default = ...)]`, so an omitted
+        // section behaves identically to a fully-defaulted struct.
         let cfg: DagCompactionConfig = serde_json::from_str("{}").expect("empty object");
-        assert!(!cfg.enabled);
+        assert!(cfg.enabled);
         assert_eq!(
             cfg.min_deltas_before_compact,
             DEFAULT_MIN_DELTAS_BEFORE_COMPACT
         );
         assert_eq!(cfg.check_interval.as_secs(), DEFAULT_CHECK_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn explicit_disable_is_respected() {
+        let cfg: DagCompactionConfig =
+            serde_json::from_str(r#"{"enabled": false}"#).expect("explicit disable");
+        assert!(!cfg.enabled);
     }
 
     #[test]

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -64,7 +64,7 @@ pub struct NodeConfig {
     pub context: ContextConfig,
     pub server: ServerConfig,
     pub gc_interval_secs: Option<u64>, // Optional GC interval in seconds (default: 12 hours)
-    /// DAG compaction settings (issue #2026). Disabled by default.
+    /// DAG compaction settings (issue #2026). Enabled by default.
     pub dag_compaction: calimero_node_primitives::DagCompactionConfig,
     pub mode: NodeMode,
     pub specialized_node: SpecializedNodeConfig,
@@ -392,9 +392,9 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
 
     let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |_ctx| gc);
 
-    // Start DAG compaction actor (issue #2026). Disabled by default; only
-    // bounds on-disk delta growth when explicitly enabled in `[dag_compaction]`
-    // and the thresholds are internally consistent.
+    // Start DAG compaction actor (issue #2026). Enabled by default; bounds
+    // on-disk delta growth unless `[dag_compaction] enabled = false` or the
+    // thresholds are internally inconsistent.
     if config.dag_compaction.enabled && config.dag_compaction.is_valid() {
         let compactor = DagCompactor::new(node_state.delta_stores_handle(), config.dag_compaction);
         let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |_ctx| compactor);

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -393,18 +393,23 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |_ctx| gc);
 
     // Start DAG compaction actor (issue #2026). Enabled by default; bounds
-    // on-disk delta growth unless `[dag_compaction] enabled = false` or the
-    // thresholds are internally inconsistent.
-    if config.dag_compaction.enabled && config.dag_compaction.is_valid() {
+    // on-disk delta growth unless `[dag_compaction] enabled = false`.
+    if config.dag_compaction.enabled {
+        // Fail fast on a misconfigured-but-enabled config rather than silently
+        // skipping compaction. With compaction default-on, a silent skip (e.g.
+        // an operator setting `retain_recent_count >= min_deltas_before_compact`
+        // or a zero `check_interval`) would let delta-log growth go unbounded
+        // unnoticed — the opposite of this feature's intent. The default config
+        // is always valid, so this only trips a deliberate misconfiguration.
+        eyre::ensure!(
+            config.dag_compaction.is_valid(),
+            "invalid [dag_compaction] config: retain_recent_count ({}) must be \
+             < min_deltas_before_compact ({}) and check_interval must be non-zero",
+            config.dag_compaction.retain_recent_count,
+            config.dag_compaction.min_deltas_before_compact,
+        );
         let compactor = DagCompactor::new(node_state.delta_stores_handle(), config.dag_compaction);
         let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |_ctx| compactor);
-    } else if config.dag_compaction.enabled {
-        tracing::warn!(
-            min_deltas_before_compact = config.dag_compaction.min_deltas_before_compact,
-            retain_recent_count = config.dag_compaction.retain_recent_count,
-            "DAG compaction enabled but config is invalid (retain_recent_count must be \
-             < min_deltas_before_compact); compaction will NOT run"
-        );
     }
 
     let mut sync = pin!(sync_manager.start());


### PR DESCRIPTION
## What

Enables DAG compaction (#2026) by default. Follow-up to #2664, which shipped the machinery disabled.

Flips `DagCompactionConfig::enabled` to `true` in both the `Default` impl and the serde field default, so a node with no `[dag_compaction]` section compacts with conservative defaults. Operators opt out with:

```toml
[dag_compaction]
enabled = false
```

## Why it's safe to default-on

Deltas are an optimization, not a convergence requirement. A peer that requests a pruned delta gets `DeltaNotFound`, and the next sync round reconciles via **HashComparison** — already the protocol selected for a diverged initialized node — which converges current state without consulting the delta log. Nothing prunes within the recent retain window, so cheap incremental delta catch-up still covers normal reconnect gaps.

Thresholds are unchanged and conservative:
- `min_deltas_before_compact = 10000` (= `MAX_TOPOLOGY_ENTRIES`)
- `retain_recent_count = 1000` (≤ `MAX_DELTA_QUERY_LIMIT`)
- `check_interval = 1h`, with the overlap guard + startup sweep from #2664.

## Tests

- `default_is_enabled_with_sane_thresholds`, `absent_fields_fall_back_to_defaults` (now expect enabled), and a new `explicit_disable_is_respected`.
- `cargo fmt --check` clean; node + config build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on changes on-disk delta retention for upgraded nodes without config changes; invalid enabled settings now abort startup instead of only logging a warning.
> 
> **Overview**
> Turns on **DAG compaction by default** so nodes without a `[dag_compaction]` section (or with an empty/default block) run periodic pruning with the existing conservative thresholds. Operators opt out with `enabled = false`.
> 
> Docs now explain the default-on rationale (pruned deltas fall back to **HashComparison** sync) and call out that **upgrades** from older builds will start compacting on restart unless they disable it explicitly.
> 
> **Node startup** no longer silently skips compaction when `enabled` is true but thresholds are invalid—it **errors at boot** via `eyre::ensure!` so misconfigured `retain_recent_count` / `check_interval` cannot leave delta growth unbounded without notice.
> 
> Tests expect enabled defaults and cover explicit disable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d61f917687ec2834ea924d18488d7d867937b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->