### PR TITLE
refactor(context): consolidate hot caches into BoundedCache + bound namespace DAG history

### DIFF
--- a/crates/context/src/cache.rs
+++ b/crates/context/src/cache.rs
@@ -1,0 +1,306 @@
+//! A single size-capped in-memory cache abstraction shared by every hot cache
+//! `ContextManager` keeps (`contexts`, `applications`, `modules`,
+//! `namespace_dags`).
+//!
+//! Before this module each cache hand-rolled its own cap + eviction: two
+//! free functions (`evict_idle_context_if_full`, `evict_application_if_full`),
+//! an inline `pop_first` in the execute handler, and — for `namespace_dags` —
+//! nothing at all (it grew unbounded; see the `namespace_dags` issue this
+//! consolidation closes). The three live implementations only ever differed on
+//! one axis: whether an entry may be evicted while a caller holds a live handle
+//! to it. That axis is captured by [`Evictable`]; everything else (the cap, the
+//! fetch-before-evict insert discipline, the "all entries live → defer and
+//! stay over-cap" behaviour) lives here once.
+//!
+//! The datastore is always authoritative, so an evicted entry costs at most a
+//! re-fetch on next access — the cap is a safety valve against unbounded growth
+//! on long-running nodes, not a correctness boundary.
+
+use std::collections::{btree_map, BTreeMap};
+use std::fmt::Debug;
+
+/// Whether a cached value may be dropped right now.
+///
+/// The default (`true`) suits a *plain* cache whose values are pure clones of
+/// datastore state — evicting one is always safe. A cache whose entries hand
+/// out a live handle (e.g. an `Arc<Mutex<_>>` guard held across an async
+/// operation) overrides this so the entry is only evictable once no caller
+/// holds that handle; see the `ContextMeta` / namespace-DAG impls in `lib.rs`
+/// for why evicting a live entry would let two operations serialize on
+/// different mutexes and corrupt state.
+pub(crate) trait Evictable {
+    /// `true` when nothing outside the cache references this entry and it is
+    /// safe to evict. Always `true` for plain caches.
+    fn is_idle(&self) -> bool {
+        true
+    }
+}
+
+/// A `BTreeMap`-backed cache bounded to `cap` entries.
+///
+/// Eviction runs only just before inserting a *new* key (re-touching an
+/// existing key never evicts) and removes the lowest-keyed [`Evictable::is_idle`]
+/// entry. Victim selection is by key order, not true LRU — deliberately:
+/// `ContextId`/`ApplicationId` keys are hashes, so "lowest key" is effectively
+/// arbitrary, and a wrong guess only costs a re-fetch. Upgrading to LRU is a
+/// possible follow-up if profiling ever shows churn on a hot entry.
+#[derive(Debug)]
+pub(crate) struct BoundedCache<K, V> {
+    map: BTreeMap<K, V>,
+    cap: usize,
+    /// Stable label for tracing (`contexts`, `applications`, …).
+    name: &'static str,
+}
+
+impl<K: Ord + Clone + Debug, V: Evictable> BoundedCache<K, V> {
+    /// A new empty cache holding at most `cap` entries, tagged `name` in logs.
+    pub(crate) fn new(cap: usize, name: &'static str) -> Self {
+        Self {
+            map: BTreeMap::new(),
+            cap,
+            name,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub(crate) fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub(crate) fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key)
+    }
+
+    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.map.get_mut(key)
+    }
+
+    pub(crate) fn remove(&mut self, key: &K) -> Option<V> {
+        self.map.remove(key)
+    }
+
+    /// Drop every entry for which `keep` returns `false`. Used for bulk
+    /// invalidation (e.g. dropping all compiled modules of an updated
+    /// application), which is independent of the size cap.
+    pub(crate) fn retain(&mut self, keep: impl FnMut(&K, &mut V) -> bool) {
+        self.map.retain(keep);
+    }
+
+    /// Raw entry access, for the one caller (`create_context`) that needs a
+    /// `VacantEntry` to satisfy a borrow-checker workaround. Callers inserting
+    /// a new key through this path must call [`Self::evict_if_full`] first;
+    /// every other insert site should use [`Self::insert_new`] /
+    /// [`Self::get_or_insert_with`], which cap automatically.
+    pub(crate) fn entry(&mut self, key: K) -> btree_map::Entry<'_, K, V> {
+        self.map.entry(key)
+    }
+
+    /// Evict one idle entry if the cache is at capacity; a no-op below it.
+    ///
+    /// If every entry is live nothing is evicted and the cache is allowed to
+    /// sit over `cap` until in-flight work finishes — a legitimate designed
+    /// state for lock-gated caches (it self-corrects as each later insert frees
+    /// one slot). Plain caches always find a victim, so they never reach this.
+    pub(crate) fn evict_if_full(&mut self) {
+        if self.map.len() < self.cap {
+            return;
+        }
+
+        let victim = self
+            .map
+            .iter()
+            .find(|(_, value)| value.is_idle())
+            .map(|(key, _)| key.clone());
+
+        let Some(key) = victim else {
+            // Over-cap with every entry live. Surface a *significant* overage
+            // (sustained high concurrency) at warn; a small one is routine.
+            let len = self.map.len();
+            if len > self.cap + self.cap / 10 {
+                tracing::warn!(
+                    cache = self.name,
+                    cap = self.cap,
+                    len,
+                    "cache significantly over capacity and all entries live; \
+                     deferring eviction (sustained high concurrency?)"
+                );
+            } else {
+                tracing::debug!(
+                    cache = self.name,
+                    cap = self.cap,
+                    len,
+                    "cache at capacity but all entries live; deferring eviction"
+                );
+            }
+            return;
+        };
+
+        let _ = self.map.remove(&key);
+        tracing::debug!(
+            cache = self.name,
+            ?key,
+            "evicted idle cache entry (at capacity)"
+        );
+    }
+
+    /// Insert `value` at `key`, capping the cache. Replacing an existing key
+    /// never evicts (it isn't a new entry); inserting a new key evicts one idle
+    /// entry first when at capacity. Returns the previous value, if any.
+    ///
+    /// Use this when the key may already be present (e.g. overwriting a
+    /// recompiled module); prefer [`Self::insert_new`] when novelty is
+    /// guaranteed and a returned `&mut V` is convenient.
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if !self.map.contains_key(&key) {
+            self.evict_if_full();
+        }
+        self.map.insert(key, value)
+    }
+
+    /// Insert a brand-new key, evicting one idle entry first if at capacity.
+    ///
+    /// The caller must have already confirmed `key` is absent (so a re-touch
+    /// never evicts, and the key about to be inserted is never itself the
+    /// victim). Returns a mutable reference to the inserted value.
+    pub(crate) fn insert_new(&mut self, key: K, value: V) -> &mut V {
+        debug_assert!(
+            !self.map.contains_key(&key),
+            "insert_new called with a key already present; caller must guard on absence"
+        );
+        self.evict_if_full();
+        self.map.entry(key).or_insert(value)
+    }
+
+    /// Return the value for `key`, computing and inserting it (capped) on a
+    /// miss. `make` runs only on a miss, after any eviction.
+    pub(crate) fn get_or_insert_with(&mut self, key: K, make: impl FnOnce() -> V) -> &mut V {
+        if !self.map.contains_key(&key) {
+            self.evict_if_full();
+            let _ = self.map.insert(key.clone(), make());
+        }
+        self.map
+            .get_mut(&key)
+            .expect("entry just inserted or already present")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    /// A value carrying an `Arc` so a test can hold a clone to keep it "live"
+    /// (`strong_count > 1`), exercising the lock-gated eviction path.
+    #[derive(Clone)]
+    struct Lockable(Arc<()>);
+
+    impl Lockable {
+        fn idle() -> Self {
+            Self(Arc::new(()))
+        }
+    }
+
+    impl Evictable for Lockable {
+        fn is_idle(&self) -> bool {
+            Arc::strong_count(&self.0) == 1
+        }
+    }
+
+    /// A plain value that is always evictable (the default impl).
+    #[derive(Clone)]
+    struct Plain(u32);
+    impl Evictable for Plain {}
+
+    #[test]
+    fn no_eviction_below_cap() {
+        let mut cache: BoundedCache<u32, Plain> = BoundedCache::new(4, "plain");
+        for i in 0..3 {
+            let _ = cache.insert_new(i, Plain(i));
+        }
+        assert_eq!(cache.len(), 3);
+    }
+
+    #[test]
+    fn plain_cache_evicts_lowest_key_at_cap() {
+        let mut cache: BoundedCache<u32, Plain> = BoundedCache::new(4, "plain");
+        for i in 0..4 {
+            let _ = cache.insert_new(i, Plain(i));
+        }
+        // At cap; inserting a 5th evicts the lowest key (0).
+        let _ = cache.insert_new(99, Plain(99));
+        assert_eq!(cache.len(), 4);
+        assert!(!cache.contains_key(&0));
+        assert!(cache.contains_key(&99));
+    }
+
+    #[test]
+    fn lock_gated_cache_never_evicts_a_live_entry() {
+        let mut cache: BoundedCache<u32, Lockable> = BoundedCache::new(4, "locked");
+
+        // Key 0 is idle; keys 1..4 are live (held by `guards`).
+        let _ = cache.insert_new(0, Lockable::idle());
+        let mut guards = Vec::new();
+        for i in 1..4 {
+            let v = Lockable::idle();
+            guards.push(v.clone()); // bump strong_count → live
+            let _ = cache.insert_new(i, v);
+        }
+
+        // At cap; the next insert must evict the single idle entry (0), never
+        // a live one.
+        let _ = cache.insert_new(50, Lockable::idle());
+        assert_eq!(cache.len(), 4);
+        assert!(
+            !cache.contains_key(&0),
+            "idle entry should have been evicted"
+        );
+        for i in 1..4 {
+            assert!(cache.contains_key(&i), "live entry {i} was wrongly evicted");
+        }
+        drop(guards);
+    }
+
+    #[test]
+    fn lock_gated_cache_defers_when_all_entries_live() {
+        let mut cache: BoundedCache<u32, Lockable> = BoundedCache::new(4, "locked");
+        let mut guards = Vec::new();
+        for i in 0..4 {
+            let v = Lockable::idle();
+            guards.push(v.clone());
+            let _ = cache.insert_new(i, v);
+        }
+        // Cap reached, nothing evictable: evict_if_full is a no-op rather than
+        // dropping a live entry.
+        cache.evict_if_full();
+        assert_eq!(cache.len(), 4);
+        drop(guards);
+    }
+
+    #[test]
+    fn get_or_insert_with_runs_make_only_on_miss() {
+        let mut cache: BoundedCache<u32, Plain> = BoundedCache::new(4, "plain");
+        let _ = cache.get_or_insert_with(7, || Plain(7));
+        // Hit: closure must not run (would panic if it did).
+        let v = cache.get_or_insert_with(7, || panic!("make ran on a hit"));
+        assert_eq!(v.0, 7);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn retouching_existing_key_never_evicts() {
+        let mut cache: BoundedCache<u32, Plain> = BoundedCache::new(4, "plain");
+        for i in 0..4 {
+            let _ = cache.insert_new(i, Plain(i));
+        }
+        // Re-touch an existing key at cap: no eviction, no growth.
+        let _ = cache.get_or_insert_with(0, || panic!("make ran on a hit"));
+        assert_eq!(cache.len(), 4);
+        for i in 0..4 {
+            assert!(cache.contains_key(&i));
+        }
+    }
+}

--- a/crates/context/src/cache.rs
+++ b/crates/context/src/cache.rs
@@ -90,11 +90,16 @@ impl<K: Ord + Clone + Debug, V: Evictable> BoundedCache<K, V> {
     }
 
     /// Raw entry access, for the one caller (`create_context`) that needs a
-    /// `VacantEntry` to satisfy a borrow-checker workaround. Callers inserting
-    /// a new key through this path must call [`Self::evict_if_full`] first;
-    /// every other insert site should use [`Self::insert_new`] /
-    /// [`Self::get_or_insert_with`], which cap automatically.
+    /// `VacantEntry` to satisfy a borrow-checker workaround.
+    ///
+    /// Caps automatically: a *new* key evicts one idle entry first (so this
+    /// path can't grow the cache past cap), while re-accessing an existing key
+    /// never evicts — matching [`Self::insert_new`] / [`Self::get_or_insert_with`].
+    /// The cap is therefore enforced here, not by a caller convention.
     pub(crate) fn entry(&mut self, key: K) -> btree_map::Entry<'_, K, V> {
+        if !self.map.contains_key(&key) {
+            self.evict_if_full();
+        }
         self.map.entry(key)
     }
 
@@ -177,13 +182,15 @@ impl<K: Ord + Clone + Debug, V: Evictable> BoundedCache<K, V> {
     /// Return the value for `key`, computing and inserting it (capped) on a
     /// miss. `make` runs only on a miss, after any eviction.
     pub(crate) fn get_or_insert_with(&mut self, key: K, make: impl FnOnce() -> V) -> &mut V {
-        if !self.map.contains_key(&key) {
-            self.evict_if_full();
-            let _ = self.map.insert(key.clone(), make());
+        // Hit: return the existing value. Miss: evict-if-full, then insert via
+        // the entry API so the value is materialised in a single lookup with
+        // the key moved (not cloned). `evict_if_full` runs before `entry()`, so
+        // the entry it returns is always vacant for `key`.
+        if self.map.contains_key(&key) {
+            return self.map.get_mut(&key).expect("checked present");
         }
-        self.map
-            .get_mut(&key)
-            .expect("entry just inserted or already present")
+        self.evict_if_full();
+        self.map.entry(key).or_insert_with(make)
     }
 }
 
@@ -302,5 +309,26 @@ mod tests {
         for i in 0..4 {
             assert!(cache.contains_key(&i));
         }
+    }
+
+    #[test]
+    fn entry_caps_on_new_key_but_not_on_existing() {
+        let mut cache: BoundedCache<u32, Plain> = BoundedCache::new(4, "plain");
+        for i in 0..4 {
+            let _ = cache.insert_new(i, Plain(i));
+        }
+        // entry() for a NEW key at cap must evict first (key 0, the lowest),
+        // holding at cap — the cap is enforced by entry() itself.
+        if let btree_map::Entry::Vacant(e) = cache.entry(99) {
+            let _ = e.insert(Plain(99));
+        }
+        assert_eq!(cache.len(), 4);
+        assert!(cache.contains_key(&99));
+        assert!(!cache.contains_key(&0), "lowest idle key should be evicted");
+
+        // entry() for an EXISTING key must NOT evict (re-access, not growth).
+        let _ = cache.entry(99);
+        assert_eq!(cache.len(), 4);
+        assert!(cache.contains_key(&99));
     }
 }

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -35,18 +35,28 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                 // Done under the held DAG lock (the apply path is the only
                 // writer), and only after `Applied` advanced the frontier.
                 //
+                // Gate on the *applied* count, not the total `delta_count()`
+                // (which also counts pending deltas). `prune_to_recent` only
+                // prunes applied, non-head history, so triggering off a large
+                // *pending* backlog (e.g. a partition with missing parents)
+                // would re-walk the whole DAG on every apply while pruning
+                // nothing. Applied history advancing past the threshold is the
+                // only thing this prune can actually act on; once it fires it
+                // drops applied back to the retain window, so the next prune is
+                // ~RETAIN..THRESHOLD applies away (a built-in hysteresis band).
+                //
                 // Lossless for peers: applied ops are durably persisted and the
                 // backfill responder serves from RocksDB, not this DAG — so the
                 // pruned ids are discarded, NOT deleted from disk.
                 if matches!(outcome, Ok(AddDeltaOutcome::Applied))
-                    && dag.delta_count() > NAMESPACE_DAG_PRUNE_THRESHOLD
+                    && dag.stats().applied_deltas > NAMESPACE_DAG_PRUNE_THRESHOLD
                 {
                     let pruned = dag.prune_to_recent(NAMESPACE_DAG_PRUNE_RETAIN);
                     if !pruned.is_empty() {
                         tracing::debug!(
                             namespace = ?namespace_id,
                             pruned = pruned.len(),
-                            retained = dag.delta_count(),
+                            retained = dag.stats().applied_deltas,
                             "pruned applied governance-DAG history (durable op-log retained)"
                         );
                     }

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -3,7 +3,7 @@ use calimero_context_client::messages::{ApplySignedNamespaceOpRequest, Namespace
 use calimero_dag::AddDeltaOutcome;
 
 use crate::governance_dag::{signed_namespace_op_to_delta, NamespaceGovernanceApplier};
-use crate::ContextManager;
+use crate::{ContextManager, NAMESPACE_DAG_PRUNE_RETAIN, NAMESPACE_DAG_PRUNE_THRESHOLD};
 
 impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
     type Result = ActorResponse<Self, <ApplySignedNamespaceOpRequest as Message>::Result>;
@@ -28,6 +28,30 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
             async move {
                 let mut dag = dag.lock().await;
                 let outcome = dag.add_delta_with_outcome(delta, &applier).await;
+
+                // Bound this namespace's in-memory governance-DAG history. A hot
+                // namespace that never gets evicted from `namespace_dags` would
+                // otherwise retain every applied op for the process lifetime.
+                // Done under the held DAG lock (the apply path is the only
+                // writer), and only after `Applied` advanced the frontier.
+                //
+                // Lossless for peers: applied ops are durably persisted and the
+                // backfill responder serves from RocksDB, not this DAG — so the
+                // pruned ids are discarded, NOT deleted from disk.
+                if matches!(outcome, Ok(AddDeltaOutcome::Applied))
+                    && dag.delta_count() > NAMESPACE_DAG_PRUNE_THRESHOLD
+                {
+                    let pruned = dag.prune_to_recent(NAMESPACE_DAG_PRUNE_RETAIN);
+                    if !pruned.is_empty() {
+                        tracing::debug!(
+                            namespace = ?namespace_id,
+                            pruned = pruned.len(),
+                            retained = dag.delta_count(),
+                            "pruned applied governance-DAG history (durable op-log retained)"
+                        );
+                    }
+                }
+
                 // Read-and-clear the applier's divergence outbox after
                 // the DAG call returns. The outbox is populated by the
                 // applier's `apply` impl when `MemberRemoved` /

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -231,12 +231,10 @@ impl Prepared<'_> {
             }
         };
 
-        // Make room for the freshly created context. Placed after the
-        // membership/capability validation above (so failed auth never drains
-        // the cache) and immediately before the derivation loop that inserts
-        // via the raw `entry()` escape hatch (the VacantEntry transmute below).
-        contexts.evict_if_full();
-
+        // The derivation loop below inserts via the raw `entry()` escape hatch
+        // (the VacantEntry transmute); `entry()` caps the cache itself, evicting
+        // one idle entry before admitting a new key, so no separate
+        // `evict_if_full()` is needed here.
         let mut context = None;
         for _ in 0..5 {
             let context_secret = if let Some(seed) = seed {

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, warn};
 use super::execute::execute;
 use super::execute::storage::{ContextPrivateStorage, ContextStorage};
 use crate::handlers::execute::{persist_signed_signatures, sign_authorized_actions};
-use crate::{evict_application_if_full, evict_idle_context_if_full, ContextManager, ContextMeta};
+use crate::{BoundedCache, ContextManager, ContextMeta};
 use calimero_governance_store::governance_broadcast::ObserveDelivery;
 
 impl Handler<CreateContextRequest> for ContextManager {
@@ -160,8 +160,8 @@ impl Prepared<'_> {
     fn new(
         node_client: &NodeClient,
         context_client: &ContextClient,
-        contexts: &mut BTreeMap<ContextId, ContextMeta>,
-        applications: &mut BTreeMap<ApplicationId, Application>,
+        contexts: &mut BoundedCache<ContextId, ContextMeta>,
+        applications: &mut BoundedCache<ApplicationId, Application>,
         seed: Option<[u8; 32]>,
         application_id: &ApplicationId,
         identity_secret: Option<PrivateKey>,
@@ -225,18 +225,17 @@ impl Prepared<'_> {
                 let fetched = node_client
                     .get_application(&effective_app_id)?
                     .ok_or_eyre("application not found")?;
-                evict_application_if_full(applications);
-                applications
-                    .entry(effective_app_id)
-                    .or_insert(fetched)
-                    .clone()
+                // Confirmed absent in the match arm above, so `insert_new`
+                // (which caps the cache) is safe.
+                applications.insert_new(effective_app_id, fetched).clone()
             }
         };
 
         // Make room for the freshly created context. Placed after the
         // membership/capability validation above (so failed auth never drains
-        // the cache) and immediately before the derivation loop that inserts.
-        evict_idle_context_if_full(contexts);
+        // the cache) and immediately before the derivation loop that inserts
+        // via the raw `entry()` escape hatch (the VacantEntry transmute below).
+        contexts.evict_if_full();
 
         let mut context = None;
         for _ in 0..5 {

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -47,24 +47,12 @@ use crate::error::ContextError;
 use crate::handlers::update_application::{
     create_storage_callbacks, update_application_id, update_application_with_migration,
 };
-use crate::{evict_application_if_full, ContextManager};
+use crate::ContextManager;
 use calimero_governance_store::metrics::ExecutionLabels;
 
 pub mod storage;
 
 use storage::{ContextPrivateStorage, ContextStorage};
-
-/// Upper bound on entries in `ContextManager::modules` to prevent
-/// unbounded growth on nodes that cycle through many distinct
-/// applications (multi-tenant / churn-heavy workloads). Each entry
-/// holds native machine code that's 2–10× the WASM source size, so
-/// a cap here matters even if the peer `applications` map is larger.
-///
-/// TODO: this is a simple size cap with first-entry eviction — not
-/// true LRU. When the hot-path behaviour is understood better,
-/// upgrade to LRU or TTL-based eviction (tracked alongside the
-/// existing TODOs on `contexts` / `applications` in `lib.rs`).
-const MAX_CACHED_MODULES: usize = 32;
 
 impl Handler<ExecuteRequest> for ContextManager {
     type Result = ActorResponse<Self, <ExecuteRequest as Message>::Result>;
@@ -948,16 +936,15 @@ impl ContextManager {
                 return Ok(CachedOrBlob::Cached(cached.clone()));
             }
 
-            // Fetch on a cache miss *before* evicting (so a not-installed app
-            // never wastes an eviction), then cap the cache before inserting.
-            // This `get_module` path is the dominant `applications` insert site
-            // on a long-running node, so it must honour the cap too.
+            // Fetch on a cache miss *before* inserting (so a not-installed app
+            // never wastes an eviction); `insert_new` caps the cache. This
+            // `get_module` path is the dominant `applications` insert site on a
+            // long-running node, so it must honour the cap too.
             if !act.applications.contains_key(&application_id) {
                 let Some(app) = act.node_client.get_application(&application_id)? else {
                     bail!(ExecuteError::ApplicationNotInstalled { application_id });
                 };
-                evict_application_if_full(&mut act.applications);
-                let _ = act.applications.insert(application_id, app);
+                let _ = act.applications.insert_new(application_id, app);
             }
             let app = act
                 .applications
@@ -1151,18 +1138,10 @@ impl ContextManager {
                                 }
                             }
 
-                            // Bounded insert: drop the oldest entry
-                            // before adding a new one when at capacity.
-                            // BTreeMap iteration order isn't LRU; this
-                            // is a simple size cap to prevent unbounded
-                            // growth on multi-tenant nodes. Upgrading
-                            // to proper LRU is a follow-up (see the
-                            // `modules` field doc in `lib.rs`).
-                            if !act.modules.contains_key(&(application_id, svc_name.clone()))
-                                && act.modules.len() >= MAX_CACHED_MODULES
-                            {
-                                let _ = act.modules.pop_first();
-                            }
+                            // `BoundedCache::insert` caps the map: replacing an
+                            // already-cached (recompiled) key overwrites in
+                            // place, while a new key evicts a by-key-order
+                            // victim first when at capacity.
                             let _ = act
                                 .modules
                                 .insert((application_id, svc_name), module.clone());

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -29,7 +29,7 @@ use eyre::bail;
 use tracing::{debug, error, info};
 
 use crate::handlers::execute::storage::ContextStorage;
-use crate::{evict_application_if_full, ContextManager};
+use crate::ContextManager;
 
 impl Handler<UpdateApplicationRequest> for ContextManager {
     type Result = ActorResponse<Self, <UpdateApplicationRequest as Message>::Result>;
@@ -165,15 +165,12 @@ impl Handler<UpdateApplicationRequest> for ContextManager {
         );
 
         ActorResponse::r#async(task.into_actor(self).map_ok(move |application, act, _ctx| {
-            // Honour MAX_CACHED_APPLICATIONS on this insert site too — only
-            // evict when we're actually adding a new entry.
-            if !act.applications.contains_key(&application_id) {
-                evict_application_if_full(&mut act.applications);
-            }
+            // Insert-if-absent, honouring MAX_CACHED_APPLICATIONS (evicts only
+            // when actually adding a new entry); an already-cached entry is
+            // left untouched.
             let _ignored = act
                 .applications
-                .entry(application_id)
-                .or_insert(application);
+                .get_or_insert_with(application_id, || application);
 
             if let Some(context) = act.contexts.get_mut(&context_id) {
                 // service_name is preserved: we only update application_id (not service_name).

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -4,7 +4,7 @@
 use calimero_governance_store::{
     MembershipRepository, MetaRepository, NamespaceRepository, SigningKeysRepository,
 };
-use std::collections::{btree_map, BTreeMap, HashMap, HashSet};
+use std::collections::HashSet;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -27,12 +27,15 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use calimero_governance_store::metrics::Metrics;
 
 pub mod auto_follow;
+mod cache;
 pub mod config;
 pub mod error;
 pub mod governance_dag;
 pub mod handlers;
 pub mod hlc_fence;
 mod lifecycle;
+
+pub(crate) use cache::{BoundedCache, Evictable};
 
 // Backward-compat re-export shims for the modules moved to
 // `calimero-governance-store` in #2307. External callers
@@ -131,15 +134,55 @@ impl Default for ContextManagerConfig {
 /// Upper bound on the number of contexts kept in the in-memory hot cache
 /// (`ContextManager::contexts`). A safety valve against unbounded growth on
 /// long-running nodes that access many distinct contexts — NOT a hard limit:
-/// the cache may briefly exceed it when every entry is live (see
-/// [`evict_idle_context_if_full`]). The datastore remains authoritative, so an
-/// evicted context is simply re-fetched on next access.
+/// the cache may briefly exceed it when every entry is live (lock-gated
+/// eviction; see [`ContextMeta`]'s [`Evictable`] impl). The datastore remains
+/// authoritative, so an evicted context is simply re-fetched on next access.
 const MAX_CACHED_CONTEXTS: usize = 1024;
 
 /// Upper bound on cached application metadata (`ContextManager::applications`).
 /// Mirrors the compiled-`modules` cap (`MAX_CACHED_MODULES`); application
 /// metadata is a pure cache over the datastore, so eviction is harmless.
 const MAX_CACHED_APPLICATIONS: usize = 256;
+
+/// Upper bound on cached compiled WASM modules (`ContextManager::modules`),
+/// keyed by `(application_id, service_name)`. Compiled native code is 2–10× the
+/// WASM source size, so a tighter cap than `applications` is warranted on
+/// multi-tenant nodes that rotate through many applications. A pure cache over
+/// the datastore, so eviction is harmless (a recompile on next use).
+const MAX_CACHED_MODULES: usize = 32;
+
+/// Upper bound on resident per-namespace governance DAGs
+/// (`ContextManager::namespace_dags`). A node that admits or observes ops for
+/// many namespaces would otherwise retain one in-memory DAG per namespace for
+/// the whole process lifetime. Lock-gated like `contexts` (an in-flight op
+/// holds the DAG's `Arc<Mutex>`), so the map may sit briefly over-cap when
+/// every entry is live. Evicted DAGs are rebuilt from the datastore on next
+/// touch.
+const MAX_CACHED_NAMESPACE_DAGS: usize = 1024;
+
+/// Per-namespace in-memory governance-DAG history is bounded independently of
+/// the [`MAX_CACHED_NAMESPACE_DAGS`] count: a single hot namespace that never
+/// gets evicted would otherwise retain *every* applied op in its
+/// `DagStore.deltas` for the process lifetime. Once a resident DAG exceeds
+/// `NAMESPACE_DAG_PRUNE_THRESHOLD` applied deltas, it is pruned back to the most
+/// recent `NAMESPACE_DAG_PRUNE_RETAIN`.
+///
+/// This is safe — and lossless for peers — because applied governance ops are
+/// durably persisted as `NamespaceGovOp` rows and the backfill responder serves
+/// peers *from RocksDB*, not from this in-memory DAG; the pruned ids are
+/// discarded rather than deleted from disk. The in-memory DAG is already
+/// transient (rebuilt from gossip/backfill after a restart), so pruning only
+/// accelerates what a restart does anyway.
+///
+/// The threshold is set high so normal namespaces never prune, and the retain
+/// window is many backfill batches deep (`MAX_BACKFILL_OPS` is 500), so a
+/// re-delivered recent op still parents onto a retained delta rather than
+/// re-pending on a pruned ancestor.
+const NAMESPACE_DAG_PRUNE_THRESHOLD: usize = 8192;
+
+/// Recent applied deltas retained when a namespace DAG is pruned (see
+/// [`NAMESPACE_DAG_PRUNE_THRESHOLD`]). Heads are always retained on top of this.
+const NAMESPACE_DAG_PRUNE_RETAIN: usize = 4096;
 
 /// How often the periodic task logs context-cache effectiveness.
 const CACHE_STATS_LOG_INTERVAL: Duration = Duration::from_secs(300);
@@ -192,12 +235,7 @@ struct ContextMeta {
     lock: Arc<Mutex<ContextId>>,
 }
 
-/// Evict one *idle* context to keep `contexts` under [`MAX_CACHED_CONTEXTS`].
-///
-/// Call this immediately before inserting a *new* (not-yet-cached) context. It
-/// is a no-op while the cache is below the cap.
-///
-/// # Why eviction must be gated on the lock being idle
+/// A context is evictable only while no operation is in flight against it.
 ///
 /// Each [`ContextMeta`] carries a per-context `lock: Arc<Mutex<ContextId>>`
 /// that serializes all operations on that context. The guard is handed out as
@@ -205,97 +243,35 @@ struct ContextMeta {
 /// actor across the entire WASM execution — it can even be passed back in as
 /// `ContextAtomic::Held(..)`. An outstanding guard therefore holds a clone of
 /// the `Arc`, so a context with an in-flight operation always has
-/// `Arc::strong_count(&lock) >= 2`. An idle, evictable entry is exactly
+/// `Arc::strong_count(&lock) >= 2`; an idle, evictable entry is exactly
 /// `strong_count == 1` (only the cache holds it).
 ///
 /// If we evicted a *live* entry, the next `get_or_fetch_context` would mint a
-/// brand-new `Arc<Mutex>` for that context. Two concurrent operations would
+/// brand-new `Arc<Mutex>` for that context, and two concurrent operations would
 /// then serialize on *different* mutexes — breaking the invariant and
-/// corrupting state. Hence we only ever evict `strong_count == 1` entries.
-///
-/// If every entry is live, no eviction happens and the cache is allowed to
-/// exceed the cap temporarily; it self-corrects as in-flight operations
-/// finish. The over-cap count is bounded by the number of contexts executing
-/// concurrently, which node concurrency already limits.
-///
-/// The victim is the first *idle* entry in `ContextId` (key) order, not the
-/// least-recently-used one — deliberately, matching the compiled-`modules`
-/// cap. A wrong guess only costs a re-fetch from the authoritative datastore,
-/// so true LRU isn't worth the access-tracking overhead; it remains a possible
-/// follow-up if profiling ever shows churn on a hot context.
-fn evict_idle_context_if_full(contexts: &mut BTreeMap<ContextId, ContextMeta>) {
-    if contexts.len() < MAX_CACHED_CONTEXTS {
-        return;
-    }
-
-    let victim = contexts
-        .iter()
-        .find(|(_, meta)| Arc::strong_count(&meta.lock) == 1)
-        .map(|(id, _)| *id);
-
-    match victim {
-        Some(id) => {
-            let _ = contexts.remove(&id);
-            tracing::debug!(context = %id, "evicted idle context from cache (at capacity)");
-        }
-        None => {
-            // Over-cap with every entry live is a *legitimate* designed state
-            // here (unlike the applications cap, which has no live-gating and
-            // can always drain to cap — hence its debug_assert). So we don't
-            // assert; instead we make a *significant* overage observable in
-            // production, since it signals sustained high concurrency on this
-            // node. The map drains back toward the cap as live ops finish and
-            // subsequent inserts each evict one freed entry.
-            let len = contexts.len();
-            if len > MAX_CACHED_CONTEXTS + MAX_CACHED_CONTEXTS / 10 {
-                tracing::warn!(
-                    cap = MAX_CACHED_CONTEXTS,
-                    len,
-                    "context cache significantly over capacity and all entries \
-                     live; deferring eviction (sustained high concurrency?)"
-                );
-            } else {
-                tracing::debug!(
-                    cap = MAX_CACHED_CONTEXTS,
-                    len,
-                    "context cache at capacity but all entries live; deferring eviction"
-                );
-            }
-        }
+/// corrupting state. Hence the lock-gated `is_idle`.
+impl Evictable for ContextMeta {
+    fn is_idle(&self) -> bool {
+        Arc::strong_count(&self.lock) == 1
     }
 }
 
-/// Evict one application to keep `applications` under
-/// [`MAX_CACHED_APPLICATIONS`]. Call before inserting a new application.
-///
-/// Application metadata carries no per-entry lock, so this is a plain
-/// first-entry-by-key-order eviction — identical to the compiled-`modules`
-/// cap. Like that cap it is NOT usage-aware: `ApplicationId`s are hashes, so
-/// the lowest key is effectively random rather than "least useful", and an
-/// evicted entry is simply re-fetched from the node on next use. A no-op while
-/// below the cap.
-///
-/// Callers guard on `!contains_key(id)` before calling, and `pop_first` only
-/// removes a key already present, so the entry about to be inserted is never
-/// itself the victim.
-fn evict_application_if_full(applications: &mut BTreeMap<ApplicationId, Application>) {
-    if applications.len() < MAX_CACHED_APPLICATIONS {
-        return;
-    }
+/// Application metadata is a pure clone of datastore state with no live handle,
+/// so it is always safe to evict (the default).
+impl Evictable for Application {}
 
-    if let Some((id, _)) = applications.pop_first() {
-        tracing::debug!(application = %id, "evicted application from cache (at capacity)");
-    }
+/// A compiled module is an `Arc`-backed clone with no exclusive handle held by
+/// the cache, so it is always safe to evict (the default).
+impl Evictable for calimero_runtime::Module {}
 
-    // Each insert site evicts exactly once before adding one entry, so the map
-    // should never sit more than one over the cap here. A larger overage means
-    // an insert site bypassed this helper — catch it in dev.
-    debug_assert!(
-        applications.len() <= MAX_CACHED_APPLICATIONS,
-        "applications cache over cap after eviction ({} > {MAX_CACHED_APPLICATIONS}); \
-         an insert site likely bypassed evict_application_if_full",
-        applications.len(),
-    );
+/// A per-namespace governance DAG is lock-gated exactly like [`ContextMeta`]:
+/// an in-flight op holds the `Arc<Mutex<DagStore>>`, so the DAG is evictable
+/// only at `strong_count == 1`. Evicting a live DAG would split it across two
+/// `Arc<Mutex>` instances and let concurrent ops serialize on different locks.
+impl Evictable for Arc<Mutex<DagStore<SignedNamespaceOp>>> {
+    fn is_idle(&self) -> bool {
+        Arc::strong_count(self) == 1
+    }
 }
 
 /// The central actor responsible for managing the lifecycle of all contexts.
@@ -318,24 +294,24 @@ pub struct ContextManager {
     ///
     /// Size-capped to `MAX_CACHED_CONTEXTS` so long-running nodes that touch
     /// many distinct contexts don't grow this map without bound. Eviction is
-    /// gated on the per-context lock being idle — see
-    /// [`evict_idle_context_if_full`] for why that gate is load-bearing for
-    /// correctness, not just hygiene.
+    /// gated on the per-context lock being idle — see [`ContextMeta`]'s
+    /// [`Evictable`] impl for why that gate is load-bearing for correctness,
+    /// not just hygiene.
     // todo! potentially make this a dashmap::DashMap
-    contexts: BTreeMap<ContextId, ContextMeta>,
+    contexts: BoundedCache<ContextId, ContextMeta>,
     /// An in-memory cache of application metadata (`ApplicationId` -> `Application`).
     /// Caching this prevents repeated fetching and parsing of application details.
     ///
-    /// Size-capped to `MAX_CACHED_APPLICATIONS` via [`evict_application_if_full`]
-    /// (a plain by-key-order eviction, mirroring the compiled-`modules` cap)
-    /// since application metadata is a pure cache over the datastore.
+    /// Size-capped to `MAX_CACHED_APPLICATIONS` via [`BoundedCache`] (a plain
+    /// by-key-order eviction, since application metadata is a pure cache over
+    /// the datastore).
     ///
     /// # Note
     /// Even when 2 applications point to the same bytecode,
     /// the application's metadata may include information
     /// that might be relevant in the compilation process,
     /// so we cannot blindly reuse compiled blobs across apps.
-    applications: BTreeMap<ApplicationId, Application>,
+    applications: BoundedCache<ApplicationId, Application>,
 
     /// In-memory cache of compiled WASM modules, keyed by
     /// `(application_id, service_name)`. Populated on the first
@@ -348,14 +324,13 @@ pub struct ContextManager {
     /// `Engine::from_precompiled` (observed in #2238 follow-up
     /// profiling).
     ///
-    /// Size-capped to `MAX_CACHED_MODULES` (see
-    /// `handlers/execute/mod.rs`). Compiled modules are 2–10× larger
-    /// than the source WASM, so we cap to prevent unbounded growth on
-    /// multi-tenant nodes that rotate through many applications.
-    /// Eviction is currently first-entry-by-key-order rather than
-    /// true LRU — good enough as a safety valve; upgrade tracked
-    /// alongside the `contexts` LRU TODO above.
-    modules: BTreeMap<(ApplicationId, Option<String>), calimero_runtime::Module>,
+    /// Size-capped to `MAX_CACHED_MODULES` via [`BoundedCache`]. Compiled
+    /// modules are 2–10× larger than the source WASM, so we cap to prevent
+    /// unbounded growth on multi-tenant nodes that rotate through many
+    /// applications. Eviction is by-key-order rather than true LRU — good
+    /// enough as a safety valve; upgrade tracked alongside the `contexts` LRU
+    /// TODO above.
+    modules: BoundedCache<(ApplicationId, Option<String>), calimero_runtime::Module>,
 
     /// Cumulative hit/miss counters for the `contexts` hot cache, driving the
     /// periodic effectiveness log (see [`ContextCacheStats`] and
@@ -374,7 +349,12 @@ pub struct ContextManager {
 
     /// Per-namespace governance DAG. Single DAG per namespace containing both
     /// root ops and encrypted group-scoped ops.
-    namespace_dags: HashMap<[u8; 32], Arc<tokio::sync::Mutex<DagStore<SignedNamespaceOp>>>>,
+    ///
+    /// Size-capped to `MAX_CACHED_NAMESPACE_DAGS` via [`BoundedCache`], with
+    /// lock-gated eviction (an in-flight op holds the DAG's `Arc<Mutex>`); see
+    /// the `Arc<Mutex<DagStore>>` [`Evictable`] impl. The datastore stays
+    /// authoritative, so an evicted DAG is rebuilt on next touch.
+    namespace_dags: BoundedCache<[u8; 32], Arc<Mutex<DagStore<SignedNamespaceOp>>>>,
 
     /// Routes incoming `SignedAck` messages from the wire receiver to the
     /// in-flight `publish_and_await_ack` caller waiting on a specific
@@ -415,14 +395,14 @@ impl ContextManager {
             node_client,
             context_client,
 
-            contexts: BTreeMap::new(),
-            applications: BTreeMap::new(),
-            modules: BTreeMap::new(),
+            contexts: BoundedCache::new(MAX_CACHED_CONTEXTS, "contexts"),
+            applications: BoundedCache::new(MAX_CACHED_APPLICATIONS, "applications"),
+            modules: BoundedCache::new(MAX_CACHED_MODULES, "modules"),
             cache_stats: ContextCacheStats::default(),
 
             metrics: prometheus_registry.map(Metrics::new),
             active_propagators: HashSet::new(),
-            namespace_dags: HashMap::new(),
+            namespace_dags: BoundedCache::new(MAX_CACHED_NAMESPACE_DAGS, "namespace_dags"),
             ack_router,
             config: ContextManagerConfig::default(),
             vm_limits: calimero_runtime::logic::VMLimits::default(),
@@ -588,10 +568,11 @@ impl ContextManager {
     fn get_or_create_namespace_dag(
         &mut self,
         namespace_id: &[u8; 32],
-    ) -> Arc<tokio::sync::Mutex<DagStore<SignedNamespaceOp>>> {
+    ) -> Arc<Mutex<DagStore<SignedNamespaceOp>>> {
         self.namespace_dags
-            .entry(*namespace_id)
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(DagStore::new([0u8; 32]))))
+            .get_or_insert_with(*namespace_id, || {
+                Arc::new(Mutex::new(DagStore::new([0u8; 32])))
+            })
             .clone()
     }
 }
@@ -751,10 +732,8 @@ impl ContextManager {
             };
             self.record_cache_access(false);
 
-            evict_idle_context_if_full(&mut self.contexts);
-
             let lock = Arc::new(Mutex::new(*context_id));
-            let _ = self.contexts.insert(
+            let _ = self.contexts.insert_new(
                 *context_id,
                 ContextMeta {
                     meta: context,
@@ -763,7 +742,7 @@ impl ContextManager {
             );
         }
 
-        let btree_map::Entry::Occupied(mut occupied) = self.contexts.entry(*context_id) else {
+        let Some(cached) = self.contexts.get_mut(context_id) else {
             // Unreachable: the entry was either already cached or just inserted
             // above, and this actor processes messages serially.
             debug_assert!(false, "context entry vanished between insert and lookup");
@@ -782,8 +761,6 @@ impl ContextManager {
             let key = calimero_store::key::ContextMeta::new(*context_id);
 
             if let Some(meta) = handle.get(&key)? {
-                let cached = occupied.get_mut();
-
                 // Update dag_heads if they changed in DB
                 if cached.meta.dag_heads != meta.dag_heads {
                     tracing::debug!(
@@ -821,7 +798,7 @@ impl ContextManager {
             }
         }
 
-        Ok(Some(occupied.into_mut()))
+        Ok(Some(cached))
     }
 }
 
@@ -860,46 +837,59 @@ mod cache_eviction_tests {
         (meta, guard)
     }
 
+    // These tests drive the real `ContextMeta` / `Application` types through
+    // `BoundedCache` so they pin the *wiring* — the cap constants and the
+    // `Evictable` impls (lock-gated for contexts, always-idle for apps). The
+    // generic cap/eviction mechanics themselves are covered in `cache::tests`.
+
     #[test]
     fn no_eviction_below_cap() {
-        let mut contexts = BTreeMap::new();
+        let mut contexts = BoundedCache::new(MAX_CACHED_CONTEXTS, "contexts");
         for i in 0..(MAX_CACHED_CONTEXTS - 1) {
-            let _ = contexts.insert(cid(i), idle_meta(cid(i)));
+            let _ = contexts.insert_new(cid(i), idle_meta(cid(i)));
         }
-        evict_idle_context_if_full(&mut contexts);
         assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS - 1);
     }
 
     #[test]
     fn evicts_one_idle_entry_at_cap() {
-        let mut contexts = BTreeMap::new();
+        let mut contexts = BoundedCache::new(MAX_CACHED_CONTEXTS, "contexts");
         for i in 0..MAX_CACHED_CONTEXTS {
-            let _ = contexts.insert(cid(i), idle_meta(cid(i)));
+            let _ = contexts.insert_new(cid(i), idle_meta(cid(i)));
         }
-        evict_idle_context_if_full(&mut contexts);
-        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS - 1);
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS);
+
+        // A new key at cap evicts exactly one idle entry, holding at cap.
+        let new_id = cid(MAX_CACHED_CONTEXTS);
+        let _ = contexts.insert_new(new_id, idle_meta(new_id));
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS);
     }
 
     #[test]
     fn never_evicts_a_live_entry() {
-        let mut contexts = BTreeMap::new();
+        let mut contexts = BoundedCache::new(MAX_CACHED_CONTEXTS, "contexts");
         let mut guards = Vec::new();
 
         // Every entry live except a single idle one (the lowest key, so it's
         // also the first candidate eviction would consider by key order).
         let idle_id = cid(0);
-        let _ = contexts.insert(idle_id, idle_meta(idle_id));
+        let _ = contexts.insert_new(idle_id, idle_meta(idle_id));
         for i in 1..MAX_CACHED_CONTEXTS {
             let (meta, guard) = live_meta(cid(i));
-            let _ = contexts.insert(cid(i), meta);
+            let _ = contexts.insert_new(cid(i), meta);
             guards.push(guard);
         }
 
-        evict_idle_context_if_full(&mut contexts);
+        // At cap; the next new insert must evict the single idle entry, never
+        // a live one.
+        let new_id = cid(MAX_CACHED_CONTEXTS);
+        let _ = contexts.insert_new(new_id, idle_meta(new_id));
 
-        // The idle entry is gone; every live entry survives.
-        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS - 1);
-        assert!(!contexts.contains_key(&idle_id));
+        assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS);
+        assert!(
+            !contexts.contains_key(&idle_id),
+            "idle entry should be gone"
+        );
         for i in 1..MAX_CACHED_CONTEXTS {
             assert!(contexts.contains_key(&cid(i)), "live entry {i} was evicted");
         }
@@ -908,17 +898,17 @@ mod cache_eviction_tests {
 
     #[test]
     fn no_eviction_when_all_entries_live() {
-        let mut contexts = BTreeMap::new();
+        let mut contexts = BoundedCache::new(MAX_CACHED_CONTEXTS, "contexts");
         let mut guards = Vec::new();
         for i in 0..MAX_CACHED_CONTEXTS {
             let (meta, guard) = live_meta(cid(i));
-            let _ = contexts.insert(cid(i), meta);
+            let _ = contexts.insert_new(cid(i), meta);
             guards.push(guard);
         }
 
-        // Cache is at cap but nothing is evictable → it stays over/at cap
-        // rather than corrupting a live context's lock identity.
-        evict_idle_context_if_full(&mut contexts);
+        // Cache is at cap but nothing is evictable → it stays at cap rather
+        // than corrupting a live context's lock identity.
+        contexts.evict_if_full();
         assert_eq!(contexts.len(), MAX_CACHED_CONTEXTS);
         drop(guards);
     }
@@ -926,7 +916,11 @@ mod cache_eviction_tests {
     fn app(i: usize) -> Application {
         use calimero_primitives::application::{ApplicationBlob, ApplicationSource};
         use calimero_primitives::blobs::BlobId;
-        let id = ApplicationId::from([i as u8; 32]);
+        // Two key bytes so indices beyond 255 stay distinct (the cap is 256).
+        let mut bytes = [0u8; 32];
+        bytes[0] = (i & 0xff) as u8;
+        bytes[1] = ((i >> 8) & 0xff) as u8;
+        let id = ApplicationId::from(bytes);
         Application::new(
             id,
             ApplicationBlob {
@@ -941,20 +935,18 @@ mod cache_eviction_tests {
 
     #[test]
     fn application_cap_evicts_at_cap_only() {
-        let mut apps = BTreeMap::new();
-        for i in 0..(MAX_CACHED_APPLICATIONS - 1) {
+        let mut apps = BoundedCache::new(MAX_CACHED_APPLICATIONS, "applications");
+        for i in 0..MAX_CACHED_APPLICATIONS {
             let a = app(i);
-            let _ = apps.insert(a.id, a);
+            let _ = apps.insert_new(a.id, a);
         }
-        // Below cap → no-op.
-        evict_application_if_full(&mut apps);
-        assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS - 1);
+        assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS);
 
-        // Fill to cap, then eviction drops exactly one.
-        let a = app(MAX_CACHED_APPLICATIONS - 1);
-        let _ = apps.insert(a.id, a);
-        evict_application_if_full(&mut apps);
-        assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS - 1);
+        // Application metadata is always idle, so a new key evicts exactly one
+        // (the lowest), holding at cap.
+        let a = app(MAX_CACHED_APPLICATIONS);
+        let _ = apps.insert_new(a.id, a);
+        assert_eq!(apps.len(), MAX_CACHED_APPLICATIONS);
     }
 
     #[test]

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -244,7 +244,6 @@ pub struct DagStore<T> {
     heads: HashSet<[u8; 32]>,
 
     /// Root delta (genesis)
-    #[allow(dead_code)]
     root: [u8; 32],
 
     /// Maximum number of items returned by query methods to prevent resource exhaustion.

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -1296,3 +1296,30 @@ async fn test_prune_to_recent_below_threshold_is_noop() {
     assert!(pruned.is_empty());
     assert_eq!(dag.delta_count(), 3);
 }
+
+#[tokio::test]
+async fn test_prune_to_recent_never_prunes_pending() {
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    // Applied chain 1 <- 2 <- 3 <- 4 <- 5 (head 5), plus an orphan [9] whose
+    // parent [8] never arrives so it stays pending.
+    for i in 1..=5u8 {
+        let parent = if i == 1 { [0; 32] } else { [i - 1; 32] };
+        let delta = CausalDelta::new_test([i; 32], vec![parent], TestPayload { value: i as u32 });
+        dag.add_delta(delta, &applier).await.unwrap();
+    }
+    let orphan = CausalDelta::new_test([9; 32], vec![[8; 32]], TestPayload { value: 9 });
+    dag.add_delta(orphan, &applier).await.unwrap();
+    assert_eq!(dag.pending_stats().count, 1);
+
+    // Retain only the 2 most-recent applied deltas; deep applied history is
+    // pruned but the pending orphan must be left alone.
+    let mut pruned = dag.prune_to_recent(2);
+    pruned.sort();
+    assert_eq!(pruned, vec![[1; 32], [2; 32], [3; 32]]);
+
+    // The pending delta survives so it can still resolve when [8;32] arrives.
+    assert_eq!(dag.pending_stats().count, 1);
+    assert!(dag.has_delta(&[9; 32]));
+}


### PR DESCRIPTION
## Summary

Closes #2638.

`ContextManager` kept **four** in-memory hot caches with **three** different hand-rolled size-cap/eviction implementations across two files, plus a fourth map (`namespace_dags`) that was **never bounded at all** — it grew for the whole process lifetime, a slow OOM on nodes that touch many namespaces (#2638).

This consolidates all four onto one abstraction and then bounds the one remaining unbounded dimension (per-namespace DAG history).

### Part 1 — cache consolidation
- New `BoundedCache<K, V>` (`crates/context/src/cache.rs`) + an `Evictable` trait. The only axis the caches differed on was whether an entry may be dropped while a caller holds a live handle; `Evictable::is_idle` captures exactly that — default `true` for plain caches (`applications`, `modules`), `Arc::strong_count == 1` for lock-gated ones (`contexts`, `namespace_dags`). All cap / eviction / over-cap-deferral logic now lives in **one** place, tested once.
- Migrated `contexts`, `applications`, `modules`, and `namespace_dags` onto it. The last one is now size-capped (`MAX_CACHED_NAMESPACE_DAGS = 1024`) with the same `strong_count`-gated eviction as `contexts`, closing the #2638 leak. `MAX_CACHED_MODULES` moved out of the execute handler into `lib.rs` next to the other caps.
- The three bespoke helpers (`evict_idle_context_if_full`, `evict_application_if_full`, the inline `pop_first`) are gone.

### Part 2 — bound per-namespace governance DAG history
Even a single long-lived namespace grew its in-memory `DagStore<SignedNamespaceOp>.deltas` without bound. After an applied op advances the frontier, prune applied history back to a recent window via `DagStore::prune_to_recent` (the primitive added in #2664).

**Why this is safe and lossless for peers:** applied governance ops are durably persisted as `NamespaceGovOp` rows, and the backfill responder serves peers **from RocksDB, not this in-memory DAG**. The in-memory DAG is already transient (rebuilt from gossip/backfill after a restart). So pruned ids are **discarded, not deleted from disk** — pruning only bounds the in-memory footprint and merely accelerates what a restart already does. Only pathologically long histories prune (threshold 8192 → retain 4096); the retain window is many backfill batches deep (`MAX_BACKFILL_OPS` is 500), so a re-delivered recent op still parents onto a retained delta instead of re-pending on a pruned ancestor.

Built on top of #2664 (DAG compaction), which merged the `prune_to_recent` / `delta_count` primitive this reuses.

## Testing
- `cargo test -p calimero-context --lib` — 78 pass (incl. 13 `BoundedCache`/cache-wiring tests)
- `cargo test -p calimero-dag --lib` — 55 pass (incl. a new `test_prune_to_recent_never_prunes_pending`)
- `cargo check --workspace` green; `cargo fmt --check` and `clippy` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eviction and pruning on governance/context hot paths where lock-gating must stay correct; mitigated by existing Evictable semantics, tests, and authoritative datastore/backfill.
> 
> **Overview**
> Introduces shared **`BoundedCache`** + **`Evictable`** and moves **`ContextManager`** hot maps (`contexts`, `applications`, `modules`, **`namespace_dags`**) onto it, replacing three ad-hoc eviction paths and capping **`namespace_dags`** (1024) with the same lock-aware eviction as contexts.
> 
> After a successful namespace governance apply, trims **in-memory** applied DAG history when applied count exceeds **8192**, keeping **4096** recent deltas; durable ops and peer backfill stay on RocksDB.
> 
> Adds unit tests for cache behavior and confirms **`prune_to_recent`** does not drop pending deltas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758826bb631b1e94b94df57cf00633c848b42c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->