### PR TITLE
test(e2e): cross-node concurrent writer-rotation convergence (#2668)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -209,27 +209,9 @@ jobs:
           - workflow: hashcomparison-shared-user-reconcile
             file: workflows/hashcomparison-shared-user-reconcile.yml
             app: scaffolding-e2e
-          # The shared-storage-concurrent-rotation-converge workflow exists at
-          # `apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml`
-          # but is intentionally NOT registered in the matrix yet — same class
-          # of limitation as member-removed-partition-window-reconcile below.
-          # A genuinely-concurrent writer-set rotation needs node-1 and node-2
-          # to be RPC-reachable (so each can be told to rotate) yet unable to
-          # exchange libp2p traffic (so neither sees the other's rotation), and
-          # no current merobox primitive provides that:
-          #   * disconnect_node (bridge detach) also severs the published-port
-          #     DNAT, so a partitioned node can't be `call`ed at all;
-          #   * pause_container freezes the process but the kernel keeps
-          #     buffering inbound gossip, so on unpause the node drains the
-          #     competing rotation before it can rotate (verified: a DELTA_APPLY
-          #     fires immediately on unpause), turning the two rotations causal;
-          #   * stop/start re-syncs the competing rotation on boot.
-          # This needs a surgical peer-pair partition (iptables/tc drop on the
-          # libp2p swarm port to a specific peer IP, keeping the RPC port) —
-          # the same primitive member-removed-partition-window-reconcile wants.
-          # The concurrent-rotation convergence is covered by the unit/node
-          # tests #2665 added; the workflow is kept as the e2e spec + local
-          # repro for when that primitive lands.
+          - workflow: shared-storage-concurrent-rotation-converge
+            file: workflows/shared-storage-concurrent-rotation-converge.yml
+            app: scaffolding-e2e
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -209,6 +209,9 @@ jobs:
           - workflow: hashcomparison-shared-user-reconcile
             file: workflows/hashcomparison-shared-user-reconcile.yml
             app: scaffolding-e2e
+          - workflow: shared-storage-concurrent-rotation-converge
+            file: workflows/shared-storage-concurrent-rotation-converge.yml
+            app: scaffolding-e2e
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -209,9 +209,27 @@ jobs:
           - workflow: hashcomparison-shared-user-reconcile
             file: workflows/hashcomparison-shared-user-reconcile.yml
             app: scaffolding-e2e
-          - workflow: shared-storage-concurrent-rotation-converge
-            file: workflows/shared-storage-concurrent-rotation-converge.yml
-            app: scaffolding-e2e
+          # The shared-storage-concurrent-rotation-converge workflow exists at
+          # `apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml`
+          # but is intentionally NOT registered in the matrix yet — same class
+          # of limitation as member-removed-partition-window-reconcile below.
+          # A genuinely-concurrent writer-set rotation needs node-1 and node-2
+          # to be RPC-reachable (so each can be told to rotate) yet unable to
+          # exchange libp2p traffic (so neither sees the other's rotation), and
+          # no current merobox primitive provides that:
+          #   * disconnect_node (bridge detach) also severs the published-port
+          #     DNAT, so a partitioned node can't be `call`ed at all;
+          #   * pause_container freezes the process but the kernel keeps
+          #     buffering inbound gossip, so on unpause the node drains the
+          #     competing rotation before it can rotate (verified: a DELTA_APPLY
+          #     fires immediately on unpause), turning the two rotations causal;
+          #   * stop/start re-syncs the competing rotation on boot.
+          # This needs a surgical peer-pair partition (iptables/tc drop on the
+          # libp2p swarm port to a specific peer IP, keeping the RPC port) —
+          # the same primitive member-removed-partition-window-reconcile wants.
+          # The concurrent-rotation convergence is covered by the unit/node
+          # tests #2665 added; the workflow is kept as the e2e spec + local
+          # repro for when that primitive lands.
           - workflow: group-subgroup-visibility-inheritance
             file: workflows/group-subgroup-visibility-inheritance.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::len_without_is_empty)]
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
@@ -1275,6 +1275,23 @@ impl E2eKvStore {
         app::emit!(Event::SharedWriterAdded {
             writer: writer_bs58.clone(),
         });
+        Ok(())
+    }
+
+    /// Replace the entire writer set in one rotation (unlike `shared_add_writer`,
+    /// which only unions in a single key). Lets a test drop a writer — required
+    /// to exercise concurrent rotations that diverge on membership and to assert
+    /// retroactive revocation. The caller must be a current writer.
+    pub fn shared_rotate_writers(&mut self, writers: Vec<String>) -> app::Result<()> {
+        let mut new_writers = BTreeSet::new();
+        for w in &writers {
+            let pk: PublicKey = w.parse()?;
+            let _inserted = new_writers.insert(pk);
+        }
+        self.shared_data.rotate_writers(new_writers)?;
+        for w in writers {
+            app::emit!(Event::SharedWriterAdded { writer: w });
+        }
         Ok(())
     }
 

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -179,6 +179,32 @@ steps:
 
   # ---------- Baseline: writer set {A, B} + member entries ----------
 
+  # Settle all three at the genesis context state (sole writer {A}) BEFORE the
+  # first rotation. This is load-bearing. A cold joiner seeds its rotation log
+  # with the writer set as-of its join boundary ({A} here). If node-1 rotates
+  # while a joiner is still catching up, the joiner can converge the
+  # post-rotation tree via Snapshot/HashComparison WITHOUT ever applying the
+  # rotation as a delta — so the rotation is never appended to the joiner's
+  # rotation log, and `SharedStorage::writers()` (which reads the log ahead of
+  # the index) keeps returning the stale genesis set. The joiner then can't act
+  # as a writer even though the tree shows it as one. Settling first pins each
+  # joiner at the {A} genesis head, so the add-writer below arrives as a single
+  # forward-applied delta that DOES append to every node's rotation log.
+  - name: Settle all three at the genesis writer set {A}
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Brief settle at genesis
+    type: wait
+    seconds: 3
+
   - name: Node-1 seeds shared value
     type: call
     node: e2e-node-1
@@ -187,6 +213,9 @@ steps:
     args:
       value: "v0"
 
+  # Isolate the add-writer rotation with its own sync so every node
+  # forward-applies it as a single delta (and logs it) rather than folding it
+  # into a catch-up snapshot.
   - name: Node-1 adds B to the writer set ({A} -> {A, B})
     type: call
     node: e2e-node-1
@@ -195,8 +224,23 @@ steps:
     args:
       writer_bs58: '{{id_b}}'
 
-  # Member entries written before the rotations — must survive and
-  # converge across the partition + concurrent-rotation window.
+  - name: Converge the {A, B} rotation onto every node's rotation log
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Settle after the rotation
+    type: wait
+    seconds: 3
+
+  # Member entries written before the concurrent rotations — must survive and
+  # converge across the rotation window.
   - name: Node-1 writes member entry m1
     type: call
     node: e2e-node-1
@@ -215,7 +259,7 @@ steps:
       key: "m2"
       value: "pre-rotation-n2"
 
-  - name: Converge baseline ({A, B} + member entries)
+  - name: Converge member entries
     type: wait_for_sync
     context_id: '{{ctx}}'
     nodes:
@@ -226,11 +270,41 @@ steps:
     check_interval: 2
     trigger_sync: true
 
-  - name: Settle after baseline convergence
+  - name: Settle after member entries
     type: wait
     seconds: 3
 
-  # Sanity: every node sees {A, B} as the writer set (C not yet in).
+  # Precondition for the concurrent rotations: EVERY node — including the
+  # joiners that must rotate below — resolves the writer set as {A, B}. node-2
+  # (B) in particular MUST see itself as a writer here, or it cannot rotate.
+  - name: Baseline — node-2 sees A as writer
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_a}}'
+    outputs:
+      base_a_n2: result
+  - name: Baseline — node-2 sees itself (B) as writer
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_b}}'
+    outputs:
+      base_b_n2: result
+  - name: Baseline — node-2 does NOT yet see C as writer
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_c}}'
+    outputs:
+      base_c_n2: result
+
   - name: Baseline — node-3 sees A as writer
     type: call
     node: e2e-node-3
@@ -240,7 +314,6 @@ steps:
       key_bs58: '{{id_a}}'
     outputs:
       base_a_n3: result
-
   - name: Baseline — node-3 sees B as writer
     type: call
     node: e2e-node-3
@@ -250,7 +323,6 @@ steps:
       key_bs58: '{{id_b}}'
     outputs:
       base_b_n3: result
-
   - name: Baseline — node-3 does NOT yet see C as writer
     type: call
     node: e2e-node-3
@@ -261,9 +333,12 @@ steps:
     outputs:
       base_c_n3: result
 
-  - name: Assert baseline writer set {A, B}
+  - name: Assert baseline writer set {A, B} on both joiners
     type: json_assert
     statements:
+      - 'json_equal({{base_a_n2}}, {"output": true})'
+      - 'json_equal({{base_b_n2}}, {"output": true})'
+      - 'json_equal({{base_c_n2}}, {"output": false})'
       - 'json_equal({{base_a_n3}}, {"output": true})'
       - 'json_equal({{base_b_n3}}, {"output": true})'
       - 'json_equal({{base_c_n3}}, {"output": false})'

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -1,5 +1,21 @@
 name: Shared Storage — Cross-Node Concurrent Writer Rotation Converges
 description: >
+  NOT REGISTERED IN CI (see the comment beside this file's entry in
+  .github/workflows/e2e-rust-apps.yml). A genuinely-concurrent
+  writer rotation needs node-1 and node-2 to be RPC-reachable yet
+  unable to exchange libp2p traffic, and no current merobox
+  primitive provides that: disconnect_node also kills the node's
+  RPC (published-port DNAT detaches with the bridge), pause_container
+  lets the kernel buffer the competing rotation and the node drains
+  it on unpause (a DELTA_APPLY fires immediately on resume, turning
+  the two rotations causal), and stop/start re-syncs it on boot. It
+  needs a surgical peer-pair partition (iptables/tc drop on the
+  libp2p swarm port, keeping the RPC port). Until that exists this
+  workflow is kept as the e2e spec + local repro; the pause
+  choreography below is the closest current approximation and
+  documents the intended scenario. The convergence guarantee itself
+  is covered by the unit/node tests #2665 added.
+
   Belt-and-suspenders integration coverage for the convergence
   guarantee #2665 establishes by composition. #2665 makes each node
   self-log its OWN rotations (alongside received ones), so the

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -353,6 +353,21 @@ steps:
         - '{{id_b}}'
         - '{{id_c}}'
 
+  # node-2 (B) is still a writer in its own {B, C} view, so this shared write
+  # is authorized locally — it is a write to the Shared *value* entity that is
+  # concurrent with node-1's branch. After the heal + settling rotation, the
+  # causally-latest legitimate write (node-1's "after-settle", further down)
+  # must win LWW, so this value must NOT survive on any node. The final
+  # assertion proves exactly that — exercising concurrent Shared-value
+  # convergence on top of the writer-set convergence.
+  - name: Node-2 writes the shared value while A and C are frozen
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_set
+    args:
+      value: "shared-by-b-split"
+
   - name: Node-2 writes member entry while A and C are frozen
     type: call
     node: e2e-node-2
@@ -606,6 +621,13 @@ steps:
     check_interval: 2
     trigger_sync: true
 
+  - name: node-1 reads final shared value
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_get
+    outputs:
+      shared_n1: result
   - name: node-2 reads final shared value
     type: call
     node: e2e-node-2
@@ -621,11 +643,14 @@ steps:
     outputs:
       shared_n3: result
 
-  # The legitimate writer's value converges on every node; the
-  # revoked writer's attempted value never appears anywhere.
-  - name: Assert revoked write never took effect; legit write converged
+  # The legitimate writer's value converges on every node — including the
+  # writer's own node-1. This also proves the revoked writer's rejected write
+  # ("by-revoked-b") and B's concurrent during-split shared write
+  # ("shared-by-b-split") both lost: neither appears anywhere.
+  - name: Assert revoked/concurrent writes never took effect; legit write converged
     type: json_assert
     statements:
+      - 'json_equal({{shared_n1}}, {"output": "after-settle"})'
       - 'json_equal({{shared_n2}}, {"output": "after-settle"})'
       - 'json_equal({{shared_n3}}, {"output": "after-settle"})'
 

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -1,21 +1,5 @@
 name: Shared Storage — Cross-Node Concurrent Writer Rotation Converges
 description: >
-  NOT REGISTERED IN CI (see the comment beside this file's entry in
-  .github/workflows/e2e-rust-apps.yml). A genuinely-concurrent
-  writer rotation needs node-1 and node-2 to be RPC-reachable yet
-  unable to exchange libp2p traffic, and no current merobox
-  primitive provides that: disconnect_node also kills the node's
-  RPC (published-port DNAT detaches with the bridge), pause_container
-  lets the kernel buffer the competing rotation and the node drains
-  it on unpause (a DELTA_APPLY fires immediately on resume, turning
-  the two rotations causal), and stop/start re-syncs it on boot. It
-  needs a surgical peer-pair partition (iptables/tc drop on the
-  libp2p swarm port, keeping the RPC port). Until that exists this
-  workflow is kept as the e2e spec + local repro; the pause
-  choreography below is the closest current approximation and
-  documents the intended scenario. The convergence guarantee itself
-  is covered by the unit/node tests #2665 added.
-
   Belt-and-suspenders integration coverage for the convergence
   guarantee #2665 establishes by composition. #2665 makes each node
   self-log its OWN rotations (alongside received ones), so the
@@ -31,74 +15,81 @@ description: >
     * B = node-2
     * C = node-3
 
-  Scenario
-  --------
-    1. node-1 creates the context (sole initial writer {A}) and adds
-       B, giving the SharedStorage writer set {A, B}. A few KV
-       "member entries" are written before the rotations.
-    2. The two rotations are forced DAG-concurrent with a careful
-       `docker pause` choreography (see the long comment at the
-       step below for why a real bridge-disconnect can't be used —
-       it would also sever the node's RPC). Net effect:
-         * node-1 (with node-3 live) rotates to {A, C}
-           — drops B, adds C.
-         * node-2 then rotates to {B, C} — drops A, adds C — from
-           the same pristine head, having never seen {A, C}.
-       Neither rotation is a causal ancestor of the other. Each
-       side also writes a KV entry in its window so data
-       convergence around the rotations is checked.
-    3. Unfreeze everyone. Both rotations merge on every node. The
-       storage tree (wrapper + value entity, re-stamped by each
-       rotation) reconciles by HLC-LWW, so `wait_for_sync` —
-       which converges `contextStateHash` across all three nodes —
-       is itself the root-hash convergence assertion.
+  Making the two rotations DAG-concurrent
+  ---------------------------------------
+  node-1 and node-2 must each rotate from the same head H without
+  having seen the other's rotation. We achieve that with merobox's
+  `disconnect_node` / `connect_node` fault-injection steps (the same
+  primitives the sync-resilience suite uses), with one rule: we
+  NEVER issue a `call` to a disconnected node (a detached node loses
+  its published-port RPC along with its bridge interface). Instead
+  we isolate the two NON-rotating nodes while each rotator acts, so
+  the rotating node is always connected (callable) yet the node it
+  rotates on never receives the other rotation:
+
+    1. Disconnect node-1 and node-3. node-2 (still connected)
+       rotates {A,B} -> {B,C}. Neither node-1 nor node-3 sees it.
+    2. Disconnect node-2; connect node-1. Now only node-1 is online,
+       and it is still at H (it was offline when {B,C} was created,
+       and {B,C}'s only holder — node-2 — is now offline, so it
+       can't be fetched). node-1 rotates {A,B} -> {A,C}: causally
+       CONCURRENT with {B,C}.
+    3. Reconnect node-2 and node-3. wait_for_sync converges all
+       three — the root-hash convergence assertion — with both
+       rotations merged.
     4. node-3 (C) issues a settling rotation to the definitive set
-       {A, C}. C is the linchpin: it is a member of BOTH concurrent
+       {A,C}. C is the linchpin: it is a member of BOTH concurrent
        sets, so whichever rotation wins the causal HLC tiebreak,
-       `writers_at` resolves to a set containing C on every node —
-       node-3's settling rotation is therefore authorized
-       everywhere. Being causally after both concurrent rotations,
-       it is the most-recently-applied entry in every node's
-       rotation log, which makes the app-visible writer set
-       deterministic across nodes (see note below).
+       `writers_at` resolves to a set containing C on every node, so
+       node-3's settling rotation is authorized everywhere. Being
+       causally after both, it is the most-recently-applied entry in
+       every node's rotation log, which makes the app-visible writer
+       set deterministic across nodes (see note below).
     5. Assert every node resolves the same writer set: A and C are
-       writers, B is NOT — i.e. retroactive revocation of B holds
-       under concurrency, on every node.
-    6. Assert the rotated-out writer's write is rejected: node-2
-       (B) calling `shared_set` fails on every node (it is no longer
-       in the writer set), while node-1 (A) writing succeeds and the
-       legitimate value converges.
+       writers, B is NOT — retroactive revocation of B holds under
+       concurrency, on every node.
+    6. Assert the rotated-out writer's write is rejected: node-2 (B)
+       calling `shared_set` fails on every node, while node-1 (A)
+       writing succeeds and the legitimate value converges.
 
-  Why the settling rotation (step 4) is needed for a deterministic
-  cross-node writer-set assertion: the app-facing `SharedStorage::
-  writers()` reads the rotation log's most-recently-*appended*
-  entry, which is per-node insertion order, NOT causal order (see
-  `SharedStorage::current_writers` — full local causal resolution is
-  the deferred P4 item; the causal `writers_at` is the merge-path
-  security boundary, not the local read). Under two concurrent
-  rotations the two nodes can legitimately append them in different
-  orders, so reading `writers()` immediately after the heal could
-  return {A,C} on one node and {B,C} on another even though the logs
-  hold the same entries and the merge-path authorization agrees. A
-  single causally-latest rotation collapses that ambiguity: it is
-  last on every node, so `writers()` converges deterministically.
-  The pre-settle convergence that #2665 actually guarantees — that
-  both rotations propagate, authenticate, and reconcile the storage
-  root — is asserted by the post-heal `wait_for_sync` in step 3.
+  Why a settling rotation is needed for a deterministic cross-node
+  writer-set assertion: the app-facing `SharedStorage::writers()`
+  reads the rotation log's most-recently-*appended* entry, which is
+  per-node insertion order, NOT causal order (`current_writers` —
+  full local causal resolution is the deferred P4 item; the causal
+  `writers_at` is the merge-path security boundary). Under two
+  concurrent rotations the nodes can legitimately append them in
+  different orders, so reading `writers()` right after the heal
+  could return {A,C} on one node and {B,C} on another even though
+  the logs hold the same entries. A single causally-latest rotation
+  collapses that ambiguity: it is last on every node. The pre-settle
+  convergence #2665 actually guarantees — that both rotations
+  propagate, authenticate, and reconcile the storage root — is
+  asserted by the post-heal `wait_for_sync`.
 
-  Why this is deterministic: at the moment each node rotates, every
-  node that holds the competing rotation is frozen (`docker pause`),
-  so the competing rotation provably cannot reach the rotating node
-  — there is no race window. A `call` is only ever issued against an
-  un-paused node, so RPC reachability is never in question. After
-  the heal, `wait_for_sync` with `trigger_sync` actively drives the
-  exchange of both rotations, so convergence does not depend on
-  gossip redelivery after unpause either.
+  Why a plain bridge (no NAT): the concurrent-rotation guarantee is
+  a CRDT/merge property — it has nothing to do with relay recovery,
+  which is the whole point of the NAT topology the sync-resilience
+  partition workflows use. A plain-bridge `disconnect_node` is a
+  sufficient libp2p partition here (the same primitive the
+  hashcomparison-shared-user-reconcile workflow relies on), and
+  plain-bridge reconnect re-establishes direct peer connections
+  quickly — no relay-reservation re-registration to wait on or flake
+  on. Since the choreography never calls a disconnected node, the
+  fact that detaching also drops the node's RPC does not matter.
+
+  Note: a plain-bridge detach is not a hermetically perfect
+  partition (a peer could in principle reach a detached node via the
+  host-published port). If the two rotations ever turn out NOT to be
+  concurrent, they reconcile causally and the convergence assertions
+  still hold — so the worst case is weaker coverage, never a false
+  pass. The fully-deterministic guarantee lives in the node-level
+  sim test that accompanies this workflow; this is the real-network
+  belt-and-suspenders on top.
 
   Relates: #2665, #2655, #2588, #2233.
 
 force_pull_image: false
-near_devnet: false
 
 nodes:
   count: 3
@@ -131,13 +122,23 @@ steps:
     outputs:
       ctx: contextId
 
-  # --- node-2 (B) joins ---
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
     node: e2e-node-1
     namespace_id: '{{ns}}'
     outputs:
       invite_node2: invitation
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Wait for namespace gossip
+    type: wait
+    seconds: 5
 
   - name: Node-2 joins namespace
     type: join_namespace
@@ -150,14 +151,6 @@ steps:
     node: e2e-node-2
     context_id: '{{ctx}}'
 
-  # --- node-3 (C) joins ---
-  - name: Invite node-3 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invite_node3: invitation
-
   - name: Node-3 joins namespace
     type: join_namespace
     node: e2e-node-3
@@ -169,23 +162,19 @@ steps:
     node: e2e-node-3
     context_id: '{{ctx}}'
 
-  # --- Capture each node's identity (A/B/C). Captured up front so the
-  #     pubkeys are available as template values even while a node is
-  #     later partitioned. ---
+  # Capture each node's identity (A/B/C).
   - name: Identity A (node-1)
     type: get_namespace_identity
     node: e2e-node-1
     namespace_id: '{{ns}}'
     outputs:
       id_a: publicKey
-
   - name: Identity B (node-2)
     type: get_namespace_identity
     node: e2e-node-2
     namespace_id: '{{ns}}'
     outputs:
       id_b: publicKey
-
   - name: Identity C (node-3)
     type: get_namespace_identity
     node: e2e-node-3
@@ -209,11 +198,8 @@ steps:
   - name: Settle all three at the genesis writer set {A}
     type: wait_for_sync
     context_id: '{{ctx}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-      - e2e-node-3
-    timeout: 90
+    nodes: [e2e-node-1, e2e-node-2, e2e-node-3]
+    timeout: 120
     check_interval: 2
     trigger_sync: true
 
@@ -230,8 +216,7 @@ steps:
       value: "v0"
 
   # Isolate the add-writer rotation with its own sync so every node
-  # forward-applies it as a single delta (and logs it) rather than folding it
-  # into a catch-up snapshot.
+  # forward-applies it as a single delta (and logs it).
   - name: Node-1 adds B to the writer set ({A} -> {A, B})
     type: call
     node: e2e-node-1
@@ -243,11 +228,8 @@ steps:
   - name: Converge the {A, B} rotation onto every node's rotation log
     type: wait_for_sync
     context_id: '{{ctx}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-      - e2e-node-3
-    timeout: 90
+    nodes: [e2e-node-1, e2e-node-2, e2e-node-3]
+    timeout: 120
     check_interval: 2
     trigger_sync: true
 
@@ -265,7 +247,6 @@ steps:
     args:
       key: "m1"
       value: "pre-rotation"
-
   - name: Node-2 writes member entry m2
     type: call
     node: e2e-node-2
@@ -278,11 +259,8 @@ steps:
   - name: Converge member entries
     type: wait_for_sync
     context_id: '{{ctx}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-      - e2e-node-3
-    timeout: 90
+    nodes: [e2e-node-1, e2e-node-2, e2e-node-3]
+    timeout: 120
     check_interval: 2
     trigger_sync: true
 
@@ -320,7 +298,6 @@ steps:
       key_bs58: '{{id_c}}'
     outputs:
       base_c_n2: result
-
   - name: Baseline — node-3 sees A as writer
     type: call
     node: e2e-node-3
@@ -359,81 +336,22 @@ steps:
       - 'json_equal({{base_b_n3}}, {"output": true})'
       - 'json_equal({{base_c_n3}}, {"output": false})'
 
-  # ---------- Drive the two rotations DAG-concurrent via docker pause ----------
-  #
-  # A real bridge-disconnect can't be used here: merobox reaches a node's RPC
-  # over the same Docker network as its gossip, so a partitioned node can't be
-  # *called* (its published-port DNAT target vanishes with the bridge). We need
-  # both rotating nodes reachable, yet neither must have seen the other's
-  # rotation. `docker pause` (SIGSTOP) freezes a container's whole process — it
-  # neither sends/processes gossip nor answers RPC while paused. We use only the
-  # gossip freeze and are careful to issue a `call` ONLY against an un-paused
-  # node, so RPC always reaches its target. The pause order below guarantees
-  # neither rotating node ever observes the other's rotation, with no race.
+  # ---------- Concurrent rotation, window 1: node-2 -> {B, C} ----------
+  # Isolate the two non-rotators (node-1, node-3) so node-2 can rotate while
+  # connected (callable) without either of them seeing it.
 
-  # Freeze B at the converged head H. From here, anything node-1 does is
-  # invisible to node-2.
-  - name: Pause node-2 (freeze B at head H)
-    type: pause_container
-    container: e2e-node-2
-
-  - name: Let the pause take effect
-    type: wait
-    seconds: 2
-
-  # node-1 (live, with live node-3) rotates {A, B} -> {A, C}: drops B, adds C.
-  # node-2 is frozen and never sees this.
-  - name: Node-1 rotates writer set to {A, C}
-    type: call
+  - name: Disconnect node-1 from the bridge
+    type: disconnect_node
     node: e2e-node-1
-    context_id: '{{ctx}}'
-    method: shared_rotate_writers
-    args:
-      writers:
-        - '{{id_a}}'
-        - '{{id_c}}'
+  - name: Disconnect node-3 from the bridge
+    type: disconnect_node
+    node: e2e-node-3
 
-  - name: Node-1 writes member entry while B is frozen
-    type: call
-    node: e2e-node-1
-    context_id: '{{ctx}}'
-    method: set
-    args:
-      key: "during"
-      value: "from-n1"
-
-  # Let node-3 apply node-1's rotation over gossip (node-2 still frozen).
-  - name: Settle so node-3 applies node-1's rotation
+  - name: Wait for libp2p to mark node-1/node-3 connections dead
     type: wait
-    seconds: 4
+    seconds: 20
 
-  # Freeze A and C. Now NO live node holds node-1's rotation, so when node-2
-  # wakes there is nobody to deliver it — node-2 will rotate from the pristine
-  # head H.
-  - name: Pause node-1 (freeze A at {A, C})
-    type: pause_container
-    container: e2e-node-1
-  - name: Pause node-3 (freeze C at {A, C})
-    type: pause_container
-    container: e2e-node-3
-
-  - name: Let both pauses take effect
-    type: wait
-    seconds: 2
-
-  # node-2 is now the ONLY live node and is still at head H (it was frozen
-  # before node-1's rotation existed and its only peers are frozen now, so it
-  # cannot fetch it).
-  - name: Unpause node-2 (B resumes at head H)
-    type: unpause_container
-    container: e2e-node-2
-
-  - name: Let node-2 resume (peers still frozen — it cannot learn node-1's rotation)
-    type: wait
-    seconds: 4
-
-  # node-2 rotates {A, B} -> {B, C}: drops A, adds C. Its parent is still H, so
-  # this is causally CONCURRENT with node-1's {A, C}.
+  # node-2 (the only connected node) rotates {A,B} -> {B,C}: drops A, adds C.
   - name: Node-2 rotates writer set to {B, C}
     type: call
     node: e2e-node-2
@@ -444,22 +362,19 @@ steps:
         - '{{id_b}}'
         - '{{id_c}}'
 
-  # node-2 (B) is still a writer in its own {B, C} view, so this shared write
-  # is authorized locally — it is a write to the Shared *value* entity that is
-  # concurrent with node-1's branch. After the heal + settling rotation, the
-  # causally-latest legitimate write (node-1's "after-settle", further down)
-  # must win LWW, so this value must NOT survive on any node. The final
-  # assertion proves exactly that — exercising concurrent Shared-value
-  # convergence on top of the writer-set convergence.
-  - name: Node-2 writes the shared value while A and C are frozen
+  # node-2 (B) is a writer in its own {B, C} view, so this shared write is
+  # authorized locally — a write to the Shared *value* entity concurrent with
+  # node-1's branch. After the heal + settling rotation, the causally-latest
+  # legitimate write (node-1's "after-settle") must win LWW, so this value must
+  # NOT survive on any node. The final assertion proves that.
+  - name: Node-2 writes the shared value during the split
     type: call
     node: e2e-node-2
     context_id: '{{ctx}}'
     method: shared_set
     args:
       value: "shared-by-b-split"
-
-  - name: Node-2 writes member entry while A and C are frozen
+  - name: Node-2 writes member entry during the split
     type: call
     node: e2e-node-2
     context_id: '{{ctx}}'
@@ -468,31 +383,63 @@ steps:
       key: "during2"
       value: "from-n2"
 
-  # ---------- Heal: unfreeze everyone; both rotations now merge ----------
+  # ---------- Concurrent rotation, window 2: node-1 -> {A, C} ----------
+  # Take node-2 (the sole holder of {B,C}) offline and bring node-1 back. node-1
+  # is still at H — it was offline when {B,C} was created, and {B,C}'s only
+  # holder is now offline — so it rotates from the pristine head, concurrently.
 
-  - name: Unpause node-1
-    type: unpause_container
-    container: e2e-node-1
-  - name: Unpause node-3
-    type: unpause_container
-    container: e2e-node-3
+  - name: Disconnect node-2 from the bridge
+    type: disconnect_node
+    node: e2e-node-2
+  - name: Reconnect node-1 to the bridge
+    type: connect_node
+    node: e2e-node-1
 
-  - name: Wait for libp2p mesh reformation
+  - name: Wait for node-1 to re-establish (its peers are offline; it stays at H)
     type: wait
-    seconds: 8
+    seconds: 20
 
-  # This is the root-hash convergence assertion: it only passes once
-  # all three nodes share the same contextStateHash, i.e. both
-  # concurrent rotations (and the surrounding data writes) have
-  # reconciled into an identical storage tree on every node.
+  # node-1 rotates {A,B} -> {A,C}: drops B, adds C. Causally CONCURRENT with
+  # node-2's {B,C} (node-1 never saw it).
+  - name: Node-1 rotates writer set to {A, C}
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_rotate_writers
+    args:
+      writers:
+        - '{{id_a}}'
+        - '{{id_c}}'
+  - name: Node-1 writes member entry during the split
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "during"
+      value: "from-n1"
+
+  # ---------- Heal: reconnect everyone; both rotations now merge ----------
+
+  - name: Reconnect node-2 to the bridge
+    type: connect_node
+    node: e2e-node-2
+  - name: Reconnect node-3 to the bridge
+    type: connect_node
+    node: e2e-node-3
+
+  - name: Wait for libp2p mesh to reform (direct connections)
+    type: wait
+    seconds: 20
+
+  # This is the root-hash convergence assertion: it only passes once all three
+  # nodes share the same contextStateHash, i.e. both concurrent rotations (and
+  # the surrounding data writes) have reconciled into an identical storage tree.
   - name: Converge after concurrent rotations
     type: wait_for_sync
     context_id: '{{ctx}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-      - e2e-node-3
-    timeout: 120
+    nodes: [e2e-node-1, e2e-node-2, e2e-node-3]
+    timeout: 180
     check_interval: 2
     trigger_sync: true
 
@@ -502,11 +449,10 @@ steps:
 
   # ---------- Settle to a deterministic resolved set {A, C} ----------
 
-  # node-3 (C) is in BOTH concurrent sets, so it is authorized to
-  # rotate on every node regardless of which concurrent rotation won
-  # the causal tiebreak. This rotation is causally after both, so it
-  # is the last log entry on every node — collapsing the
-  # insertion-order ambiguity in the app-visible writer set.
+  # node-3 (C) is in BOTH concurrent sets, so it is authorized to rotate on
+  # every node regardless of which concurrent rotation won the causal tiebreak.
+  # This rotation is causally after both, so it is the last log entry on every
+  # node — collapsing the insertion-order ambiguity in the app-visible set.
   - name: Node-3 issues settling rotation to {A, C}
     type: call
     node: e2e-node-3
@@ -520,10 +466,7 @@ steps:
   - name: Converge after settling rotation
     type: wait_for_sync
     context_id: '{{ctx}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-      - e2e-node-3
+    nodes: [e2e-node-1, e2e-node-2, e2e-node-3]
     timeout: 120
     check_interval: 2
     trigger_sync: true
@@ -681,8 +624,8 @@ steps:
 
   # ---------- Bonus: rotated-out writer (B) is rejected everywhere ----------
 
-  # node-2 (B) is no longer a writer. Its `shared_set` must be
-  # rejected locally (B not in the resolved set {A, C}).
+  # node-2 (B) is no longer a writer. Its `shared_set` must be rejected locally
+  # (B not in the resolved set {A, C}).
   - name: Node-2 (revoked B) attempts a shared write — must be rejected
     type: call
     node: e2e-node-2
@@ -704,11 +647,8 @@ steps:
   - name: Converge final shared value
     type: wait_for_sync
     context_id: '{{ctx}}'
-    nodes:
-      - e2e-node-1
-      - e2e-node-2
-      - e2e-node-3
-    timeout: 90
+    nodes: [e2e-node-1, e2e-node-2, e2e-node-3]
+    timeout: 120
     check_interval: 2
     trigger_sync: true
 
@@ -734,10 +674,9 @@ steps:
     outputs:
       shared_n3: result
 
-  # The legitimate writer's value converges on every node — including the
-  # writer's own node-1. This also proves the revoked writer's rejected write
-  # ("by-revoked-b") and B's concurrent during-split shared write
-  # ("shared-by-b-split") both lost: neither appears anywhere.
+  # The legitimate writer's value converges on every node (incl. node-1). This
+  # also proves the revoked write ("by-revoked-b") and B's concurrent
+  # during-split shared write ("shared-by-b-split") both lost — neither appears.
   - name: Assert revoked/concurrent writes never took effect; legit write converged
     type: json_assert
     statements:

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -20,14 +20,18 @@ description: >
     1. node-1 creates the context (sole initial writer {A}) and adds
        B, giving the SharedStorage writer set {A, B}. A few KV
        "member entries" are written before the rotations.
-    2. node-2 is partitioned off the Docker bridge. While split:
-         * node-1 (with node-3) rotates the writer set to {A, C}
+    2. The two rotations are forced DAG-concurrent with a careful
+       `docker pause` choreography (see the long comment at the
+       step below for why a real bridge-disconnect can't be used —
+       it would also sever the node's RPC). Net effect:
+         * node-1 (with node-3 live) rotates to {A, C}
            — drops B, adds C.
-         * node-2 (isolated) rotates to {B, C} — drops A, adds C.
-       Neither node sees the other's rotation: they are causally
-       concurrent. Each side also writes a KV entry during the
-       split so data convergence around the rotations is checked.
-    3. Heal the partition. Both rotations merge on every node. The
+         * node-2 then rotates to {B, C} — drops A, adds C — from
+           the same pristine head, having never seen {A, C}.
+       Neither rotation is a causal ancestor of the other. Each
+       side also writes a KV entry in its window so data
+       convergence around the rotations is checked.
+    3. Unfreeze everyone. Both rotations merge on every node. The
        storage tree (wrapper + value entity, re-stamped by each
        rotation) reconciles by HLC-LWW, so `wait_for_sync` —
        which converges `contextStateHash` across all three nodes —
@@ -66,11 +70,14 @@ description: >
   both rotations propagate, authenticate, and reconcile the storage
   root — is asserted by the post-heal `wait_for_sync` in step 3.
 
-  Why partition-based and deterministic: the disconnect only has to
-  make node-1's and node-2's rotations invisible to each other while
-  split (so they are causally concurrent). After the heal, sync
-  delivers both rotations to every node and the assertions depend
-  only on final convergence, not on any race against buffer drain.
+  Why this is deterministic: at the moment each node rotates, every
+  node that holds the competing rotation is frozen (`docker pause`),
+  so the competing rotation provably cannot reach the rotating node
+  — there is no race window. A `call` is only ever issued against an
+  un-paused node, so RPC reachability is never in question. After
+  the heal, `wait_for_sync` with `trigger_sync` actively drives the
+  exchange of both rotations, so convergence does not depend on
+  gossip redelivery after unpause either.
 
   Relates: #2665, #2655, #2588, #2233.
 
@@ -261,23 +268,30 @@ steps:
       - 'json_equal({{base_b_n3}}, {"output": true})'
       - 'json_equal({{base_c_n3}}, {"output": false})'
 
-  # ---------- Fault: partition node-2 (B) off the bridge ----------
+  # ---------- Drive the two rotations DAG-concurrent via docker pause ----------
+  #
+  # A real bridge-disconnect can't be used here: merobox reaches a node's RPC
+  # over the same Docker network as its gossip, so a partitioned node can't be
+  # *called* (its published-port DNAT target vanishes with the bridge). We need
+  # both rotating nodes reachable, yet neither must have seen the other's
+  # rotation. `docker pause` (SIGSTOP) freezes a container's whole process — it
+  # neither sends/processes gossip nor answers RPC while paused. We use only the
+  # gossip freeze and are careful to issue a `call` ONLY against an un-paused
+  # node, so RPC always reaches its target. The pause order below guarantees
+  # neither rotating node ever observes the other's rotation, with no race.
 
-  - name: Partition node-2 from the bridge
-    type: script
-    script: scripts/disconnect-node-from-bridge.sh
-    target: local
-    args:
-      - e2e-node-2
+  # Freeze B at the converged head H. From here, anything node-1 does is
+  # invisible to node-2.
+  - name: Pause node-2 (freeze B at head H)
+    type: pause_container
+    container: e2e-node-2
 
-  - name: Brief settle so libp2p notices the partition
+  - name: Let the pause take effect
     type: wait
-    seconds: 3
+    seconds: 2
 
-  # ---------- Concurrent rotations (neither side sees the other) ----------
-
-  # node-1 (connected to node-3) rotates {A, B} -> {A, C}: drops B,
-  # adds C.
+  # node-1 (live, with live node-3) rotates {A, B} -> {A, C}: drops B, adds C.
+  # node-2 is frozen and never sees this.
   - name: Node-1 rotates writer set to {A, C}
     type: call
     node: e2e-node-1
@@ -288,8 +302,47 @@ steps:
         - '{{id_a}}'
         - '{{id_c}}'
 
-  # node-2 (isolated) rotates {A, B} -> {B, C}: drops A, adds C.
-  # Causally concurrent with node-1's rotation above.
+  - name: Node-1 writes member entry while B is frozen
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "during"
+      value: "from-n1"
+
+  # Let node-3 apply node-1's rotation over gossip (node-2 still frozen).
+  - name: Settle so node-3 applies node-1's rotation
+    type: wait
+    seconds: 4
+
+  # Freeze A and C. Now NO live node holds node-1's rotation, so when node-2
+  # wakes there is nobody to deliver it — node-2 will rotate from the pristine
+  # head H.
+  - name: Pause node-1 (freeze A at {A, C})
+    type: pause_container
+    container: e2e-node-1
+  - name: Pause node-3 (freeze C at {A, C})
+    type: pause_container
+    container: e2e-node-3
+
+  - name: Let both pauses take effect
+    type: wait
+    seconds: 2
+
+  # node-2 is now the ONLY live node and is still at head H (it was frozen
+  # before node-1's rotation existed and its only peers are frozen now, so it
+  # cannot fetch it).
+  - name: Unpause node-2 (B resumes at head H)
+    type: unpause_container
+    container: e2e-node-2
+
+  - name: Let node-2 resume (peers still frozen — it cannot learn node-1's rotation)
+    type: wait
+    seconds: 4
+
+  # node-2 rotates {A, B} -> {B, C}: drops A, adds C. Its parent is still H, so
+  # this is causally CONCURRENT with node-1's {A, C}.
   - name: Node-2 rotates writer set to {B, C}
     type: call
     node: e2e-node-2
@@ -300,17 +353,7 @@ steps:
         - '{{id_b}}'
         - '{{id_c}}'
 
-  # Data writes around the rotations, one per side of the partition.
-  - name: Node-1 writes member entry during split
-    type: call
-    node: e2e-node-1
-    context_id: '{{ctx}}'
-    method: set
-    args:
-      key: "during"
-      value: "from-n1"
-
-  - name: Node-2 writes member entry during split
+  - name: Node-2 writes member entry while A and C are frozen
     type: call
     node: e2e-node-2
     context_id: '{{ctx}}'
@@ -319,14 +362,14 @@ steps:
       key: "during2"
       value: "from-n2"
 
-  # ---------- Heal: both concurrent rotations now merge everywhere ----------
+  # ---------- Heal: unfreeze everyone; both rotations now merge ----------
 
-  - name: Heal node-2's partition
-    type: script
-    script: scripts/connect-node-to-bridge.sh
-    target: local
-    args:
-      - e2e-node-2
+  - name: Unpause node-1
+    type: unpause_container
+    container: e2e-node-1
+  - name: Unpause node-3
+    type: unpause_container
+    container: e2e-node-3
 
   - name: Wait for libp2p mesh reformation
     type: wait

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -84,8 +84,11 @@ description: >
   concurrent, they reconcile causally and the convergence assertions
   still hold — so the worst case is weaker coverage, never a false
   pass. The fully-deterministic guarantee lives in the node-level
-  sim test that accompanies this workflow; this is the real-network
-  belt-and-suspenders on top.
+  sim test that accompanies this workflow
+  (crates/node/src/sync/rotation_log_reader.rs); this is the
+  real-network belt-and-suspenders on top. A direct primitive that
+  would simplify this (cut libp2p between a peer pair while keeping
+  RPC) is tracked in calimero-network/merobox#278.
 
   Relates: #2665, #2655, #2588, #2233.
 

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -1,0 +1,589 @@
+name: Shared Storage — Cross-Node Concurrent Writer Rotation Converges
+description: >
+  Belt-and-suspenders integration coverage for the convergence
+  guarantee #2665 establishes by composition. #2665 makes each node
+  self-log its OWN rotations (alongside received ones), so the
+  causal `writers_at` resolution is total and symmetric across
+  nodes. That is covered by unit/node tests; the one angle not
+  exercised there is a genuinely-concurrent, multi-node rotation
+  that has to converge end-to-end over real sync. This workflow is
+  that test.
+
+  Identities (each held by exactly one node, so each can actually
+  execute writes and have them accepted/rejected):
+    * A = node-1
+    * B = node-2
+    * C = node-3
+
+  Scenario
+  --------
+    1. node-1 creates the context (sole initial writer {A}) and adds
+       B, giving the SharedStorage writer set {A, B}. A few KV
+       "member entries" are written before the rotations.
+    2. node-2 is partitioned off the Docker bridge. While split:
+         * node-1 (with node-3) rotates the writer set to {A, C}
+           — drops B, adds C.
+         * node-2 (isolated) rotates to {B, C} — drops A, adds C.
+       Neither node sees the other's rotation: they are causally
+       concurrent. Each side also writes a KV entry during the
+       split so data convergence around the rotations is checked.
+    3. Heal the partition. Both rotations merge on every node. The
+       storage tree (wrapper + value entity, re-stamped by each
+       rotation) reconciles by HLC-LWW, so `wait_for_sync` —
+       which converges `contextStateHash` across all three nodes —
+       is itself the root-hash convergence assertion.
+    4. node-3 (C) issues a settling rotation to the definitive set
+       {A, C}. C is the linchpin: it is a member of BOTH concurrent
+       sets, so whichever rotation wins the causal HLC tiebreak,
+       `writers_at` resolves to a set containing C on every node —
+       node-3's settling rotation is therefore authorized
+       everywhere. Being causally after both concurrent rotations,
+       it is the most-recently-applied entry in every node's
+       rotation log, which makes the app-visible writer set
+       deterministic across nodes (see note below).
+    5. Assert every node resolves the same writer set: A and C are
+       writers, B is NOT — i.e. retroactive revocation of B holds
+       under concurrency, on every node.
+    6. Assert the rotated-out writer's write is rejected: node-2
+       (B) calling `shared_set` fails on every node (it is no longer
+       in the writer set), while node-1 (A) writing succeeds and the
+       legitimate value converges.
+
+  Why the settling rotation (step 4) is needed for a deterministic
+  cross-node writer-set assertion: the app-facing `SharedStorage::
+  writers()` reads the rotation log's most-recently-*appended*
+  entry, which is per-node insertion order, NOT causal order (see
+  `SharedStorage::current_writers` — full local causal resolution is
+  the deferred P4 item; the causal `writers_at` is the merge-path
+  security boundary, not the local read). Under two concurrent
+  rotations the two nodes can legitimately append them in different
+  orders, so reading `writers()` immediately after the heal could
+  return {A,C} on one node and {B,C} on another even though the logs
+  hold the same entries and the merge-path authorization agrees. A
+  single causally-latest rotation collapses that ambiguity: it is
+  last on every node, so `writers()` converges deterministically.
+  The pre-settle convergence that #2665 actually guarantees — that
+  both rotations propagate, authenticate, and reconcile the storage
+  root — is asserted by the post-heal `wait_for_sync` in step 3.
+
+  Why partition-based and deterministic: the disconnect only has to
+  make node-1's and node-2's rotations invisible to each other while
+  split (so they are causally concurrent). After the heal, sync
+  delivers both rotations to every node and the assertions depend
+  only on final convergence, not on any race against buffer drain.
+
+  Relates: #2665, #2655, #2588, #2233.
+
+force_pull_image: false
+near_devnet: false
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: e2e-node
+
+steps:
+  # ---------- Setup: context with writer set {A} ----------
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      ns: namespaceId
+
+  - name: Create context on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{ns}}'
+    outputs:
+      ctx: contextId
+
+  # --- node-2 (B) joins ---
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_node2: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_node2}}'
+
+  - name: Node-2 joins context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+
+  # --- node-3 (C) joins ---
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_node3: invitation
+
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_node3}}'
+
+  - name: Node-3 joins context
+    type: join_context
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+
+  # --- Capture each node's identity (A/B/C). Captured up front so the
+  #     pubkeys are available as template values even while a node is
+  #     later partitioned. ---
+  - name: Identity A (node-1)
+    type: get_namespace_identity
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      id_a: publicKey
+
+  - name: Identity B (node-2)
+    type: get_namespace_identity
+    node: e2e-node-2
+    namespace_id: '{{ns}}'
+    outputs:
+      id_b: publicKey
+
+  - name: Identity C (node-3)
+    type: get_namespace_identity
+    node: e2e-node-3
+    namespace_id: '{{ns}}'
+    outputs:
+      id_c: publicKey
+
+  # ---------- Baseline: writer set {A, B} + member entries ----------
+
+  - name: Node-1 seeds shared value
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_set
+    args:
+      value: "v0"
+
+  - name: Node-1 adds B to the writer set ({A} -> {A, B})
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_add_writer
+    args:
+      writer_bs58: '{{id_b}}'
+
+  # Member entries written before the rotations — must survive and
+  # converge across the partition + concurrent-rotation window.
+  - name: Node-1 writes member entry m1
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "m1"
+      value: "pre-rotation"
+
+  - name: Node-2 writes member entry m2
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "m2"
+      value: "pre-rotation-n2"
+
+  - name: Converge baseline ({A, B} + member entries)
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Settle after baseline convergence
+    type: wait
+    seconds: 3
+
+  # Sanity: every node sees {A, B} as the writer set (C not yet in).
+  - name: Baseline — node-3 sees A as writer
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_a}}'
+    outputs:
+      base_a_n3: result
+
+  - name: Baseline — node-3 sees B as writer
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_b}}'
+    outputs:
+      base_b_n3: result
+
+  - name: Baseline — node-3 does NOT yet see C as writer
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_c}}'
+    outputs:
+      base_c_n3: result
+
+  - name: Assert baseline writer set {A, B}
+    type: json_assert
+    statements:
+      - 'json_equal({{base_a_n3}}, {"output": true})'
+      - 'json_equal({{base_b_n3}}, {"output": true})'
+      - 'json_equal({{base_c_n3}}, {"output": false})'
+
+  # ---------- Fault: partition node-2 (B) off the bridge ----------
+
+  - name: Partition node-2 from the bridge
+    type: script
+    script: scripts/disconnect-node-from-bridge.sh
+    target: local
+    args:
+      - e2e-node-2
+
+  - name: Brief settle so libp2p notices the partition
+    type: wait
+    seconds: 3
+
+  # ---------- Concurrent rotations (neither side sees the other) ----------
+
+  # node-1 (connected to node-3) rotates {A, B} -> {A, C}: drops B,
+  # adds C.
+  - name: Node-1 rotates writer set to {A, C}
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_rotate_writers
+    args:
+      writers:
+        - '{{id_a}}'
+        - '{{id_c}}'
+
+  # node-2 (isolated) rotates {A, B} -> {B, C}: drops A, adds C.
+  # Causally concurrent with node-1's rotation above.
+  - name: Node-2 rotates writer set to {B, C}
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_rotate_writers
+    args:
+      writers:
+        - '{{id_b}}'
+        - '{{id_c}}'
+
+  # Data writes around the rotations, one per side of the partition.
+  - name: Node-1 writes member entry during split
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "during"
+      value: "from-n1"
+
+  - name: Node-2 writes member entry during split
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "during2"
+      value: "from-n2"
+
+  # ---------- Heal: both concurrent rotations now merge everywhere ----------
+
+  - name: Heal node-2's partition
+    type: script
+    script: scripts/connect-node-to-bridge.sh
+    target: local
+    args:
+      - e2e-node-2
+
+  - name: Wait for libp2p mesh reformation
+    type: wait
+    seconds: 8
+
+  # This is the root-hash convergence assertion: it only passes once
+  # all three nodes share the same contextStateHash, i.e. both
+  # concurrent rotations (and the surrounding data writes) have
+  # reconciled into an identical storage tree on every node.
+  - name: Converge after concurrent rotations
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 120
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Settle after concurrent-rotation convergence
+    type: wait
+    seconds: 5
+
+  # ---------- Settle to a deterministic resolved set {A, C} ----------
+
+  # node-3 (C) is in BOTH concurrent sets, so it is authorized to
+  # rotate on every node regardless of which concurrent rotation won
+  # the causal tiebreak. This rotation is causally after both, so it
+  # is the last log entry on every node — collapsing the
+  # insertion-order ambiguity in the app-visible writer set.
+  - name: Node-3 issues settling rotation to {A, C}
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_rotate_writers
+    args:
+      writers:
+        - '{{id_a}}'
+        - '{{id_c}}'
+
+  - name: Converge after settling rotation
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 120
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Settle after settling rotation
+    type: wait
+    seconds: 3
+
+  # ---------- Assert: identical resolved writer set on every node ----------
+  # A and C are writers, B is revoked — on node-1, node-2, AND node-3.
+
+  - name: node-1 — is A a writer?
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_a}}'
+    outputs:
+      a_n1: result
+  - name: node-1 — is B a writer?
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_b}}'
+    outputs:
+      b_n1: result
+  - name: node-1 — is C a writer?
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_c}}'
+    outputs:
+      c_n1: result
+
+  - name: node-2 — is A a writer?
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_a}}'
+    outputs:
+      a_n2: result
+  - name: node-2 — is B a writer?
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_b}}'
+    outputs:
+      b_n2: result
+  - name: node-2 — is C a writer?
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_c}}'
+    outputs:
+      c_n2: result
+
+  - name: node-3 — is A a writer?
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_a}}'
+    outputs:
+      a_n3: result
+  - name: node-3 — is B a writer?
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_b}}'
+    outputs:
+      b_n3: result
+  - name: node-3 — is C a writer?
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_is_writer
+    args:
+      key_bs58: '{{id_c}}'
+    outputs:
+      c_n3: result
+
+  - name: Assert all nodes resolved the same writer set {A, C} (B revoked)
+    type: json_assert
+    statements:
+      - 'json_equal({{a_n1}}, {"output": true})'
+      - 'json_equal({{c_n1}}, {"output": true})'
+      - 'json_equal({{b_n1}}, {"output": false})'
+      - 'json_equal({{a_n2}}, {"output": true})'
+      - 'json_equal({{c_n2}}, {"output": true})'
+      - 'json_equal({{b_n2}}, {"output": false})'
+      - 'json_equal({{a_n3}}, {"output": true})'
+      - 'json_equal({{c_n3}}, {"output": true})'
+      - 'json_equal({{b_n3}}, {"output": false})'
+
+  # ---------- Assert: member entries converged on every node ----------
+
+  - name: node-2 reads m1
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "m1"
+    outputs:
+      m1_n2: result
+  - name: node-3 reads m2
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "m2"
+    outputs:
+      m2_n3: result
+  - name: node-2 reads the during-split write from node-1
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "during"
+    outputs:
+      during_n2: result
+  - name: node-1 reads the during-split write from node-2
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "during2"
+    outputs:
+      during2_n1: result
+
+  - name: Assert member entries converged across the rotation window
+    type: json_assert
+    statements:
+      - 'json_equal({{m1_n2}}, {"output": "pre-rotation"})'
+      - 'json_equal({{m2_n3}}, {"output": "pre-rotation-n2"})'
+      - 'json_equal({{during_n2}}, {"output": "from-n1"})'
+      - 'json_equal({{during2_n1}}, {"output": "from-n2"})'
+
+  # ---------- Bonus: rotated-out writer (B) is rejected everywhere ----------
+
+  # node-2 (B) is no longer a writer. Its `shared_set` must be
+  # rejected locally (B not in the resolved set {A, C}).
+  - name: Node-2 (revoked B) attempts a shared write — must be rejected
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_set
+    args:
+      value: "by-revoked-b"
+    expected_failure: true
+
+  # Positive control: a current writer (A / node-1) can still write.
+  - name: Node-1 (A) writes shared value
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: shared_set
+    args:
+      value: "after-settle"
+
+  - name: Converge final shared value
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: node-2 reads final shared value
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: shared_get
+    outputs:
+      shared_n2: result
+  - name: node-3 reads final shared value
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: shared_get
+    outputs:
+      shared_n3: result
+
+  # The legitimate writer's value converges on every node; the
+  # revoked writer's attempted value never appears anywhere.
+  - name: Assert revoked write never took effect; legit write converged
+    type: json_assert
+    statements:
+      - 'json_equal({{shared_n2}}, {"output": "after-settle"})'
+      - 'json_equal({{shared_n3}}, {"output": "after-settle"})'
+
+stop_all_nodes: false

--- a/crates/node/src/sync/rotation_log_reader.rs
+++ b/crates/node/src/sync/rotation_log_reader.rs
@@ -286,4 +286,83 @@ mod tests {
         let writers = writers_at(&log, &[[1; 32]], |_, _| false);
         assert_eq!(writers, Some(snap_writers));
     }
+
+    // ---- Cross-node concurrent-rotation convergence (the #2668 guarantee) ----
+    //
+    // #2665 makes each node self-log its OWN rotations alongside received ones,
+    // so after sync every node holds the SAME SET of rotation-log entries — but
+    // in its own *insertion order* (a node appends its locally-created rotation
+    // when it executes, and a peer's when sync delivers it; two nodes that
+    // rotate concurrently append the pair in opposite orders). The convergence
+    // guarantee therefore rests on `writers_at` being a deterministic function
+    // of (entry set, causal parents) that is INVARIANT to insertion order. The
+    // tests above resolve a single ordering; these assert order-invariance
+    // directly — the property that makes two nodes agree end-to-end.
+    //
+    // Scenario mirrors the merobox e2e: genesis writers {A, B}; node-1 rotates
+    // -> {A, C} (R1) and node-2 rotates -> {B, C} (R2) concurrently; then a
+    // settling rotation -> {A, C} (R3) causally after both. A = 0xAA,
+    // B = 0xBB, C = 0xCC.
+
+    #[test]
+    fn writers_at_is_insertion_order_invariant_under_concurrent_rotations() {
+        // R1 {A,C} and R2 {B,C} are causally concurrent (neither precedes the
+        // other); R2 has the larger HLC, so it wins the tie.
+        let r1 = entry(1, 20, 0xAA, &[0xAA, 0xCC], 1);
+        let r2 = entry(2, 21, 0xBB, &[0xBB, 0xCC], 1);
+
+        // node-1 self-logged R1 first, then received R2; node-2 the reverse.
+        let log_node1 = log_of(vec![r1.clone(), r2.clone()]);
+        let log_node2 = log_of(vec![r2, r1]);
+
+        // Merged frontier sees both; they are concurrent, so nothing precedes.
+        let parents = [[1; 32], [2; 32]];
+        let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
+
+        let from_node1 = writers_at(&log_node1, &parents, none_precede);
+        let from_node2 = writers_at(&log_node2, &parents, none_precede);
+
+        // Both nodes resolve the SAME set despite opposite insertion order —
+        // this is what makes them converge.
+        assert_eq!(from_node1, from_node2);
+        // ...and it is the HLC winner R2 = {B, C}.
+        assert_eq!(from_node1, Some([0xBB, 0xCC].into_iter().map(pk).collect()));
+        // C is in both concurrent sets, so it survives whichever wins — the
+        // property the e2e relies on to pick a guaranteed-authorized settler.
+        assert!(from_node1.unwrap().contains(&pk(0xCC)));
+    }
+
+    #[test]
+    fn settling_rotation_converges_and_revokes_under_concurrency() {
+        // After the concurrent pair, a settling rotation R3 -> {A, C} is issued
+        // causally after BOTH (it builds on the merged frontier).
+        let r1 = entry(1, 20, 0xAA, &[0xAA, 0xCC], 1);
+        let r2 = entry(2, 21, 0xBB, &[0xBB, 0xCC], 1);
+        let r3 = entry(3, 30, 0xCC, &[0xAA, 0xCC], 2);
+
+        // Same entry set, opposite insertion order for the concurrent pair; R3
+        // is last on both (it is causally newest, so it is appended last
+        // everywhere).
+        let log_node1 = log_of(vec![r1.clone(), r2.clone(), r3.clone()]);
+        let log_node2 = log_of(vec![r2, r1, r3]);
+
+        // R1 and R2 both happen-before R3; R1 and R2 are concurrent.
+        let happens_before = |a: &[u8; 32], b: &[u8; 32]| {
+            (a == &[1; 32] && b == &[3; 32]) || (a == &[2; 32] && b == &[3; 32])
+        };
+        let parents = [[3; 32]];
+
+        let from_node1 = writers_at(&log_node1, &parents, happens_before);
+        let from_node2 = writers_at(&log_node2, &parents, happens_before);
+
+        // Deterministic convergence to the settled set on every node...
+        assert_eq!(from_node1, from_node2);
+        let resolved = from_node1.expect("settled writer set");
+        assert_eq!(resolved, [0xAA, 0xCC].into_iter().map(pk).collect());
+        // ...and B is retroactively revoked everywhere (the bonus the e2e
+        // asserts by rejecting B's post-settle write).
+        assert!(!resolved.contains(&pk(0xBB)));
+        assert!(resolved.contains(&pk(0xAA)));
+        assert!(resolved.contains(&pk(0xCC)));
+    }
 }


### PR DESCRIPTION
Closes #2668.

Follow-up to #2665 (DAG-causal rotation completion / #2233 epic). #2665 made each node self-log its **own** rotations so `writers_at` is total and symmetric across nodes — the fix for concurrent-rotation divergence. That's covered by unit/node tests; the one angle not exercised there is a **multi-node, genuinely-concurrent rotation** converging end-to-end over real sync. This adds that integration test.

## What's here

**New merobox workflow** `apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml` (3 nodes; identities A=node-1, B=node-2, C=node-3):

1. Context starts with SharedStorage writer set `{A, B}` plus a few KV "member entries".
2. node-2 is partitioned off the bridge. While split, **two nodes rotate concurrently** without seeing each other: node-1 → `{A, C}` (drops B), node-2 → `{B, C}` (drops A).
3. Heal. `wait_for_sync` across all three converges `contextStateHash` — **this is the root-hash convergence assertion** — with both rotations merged.
4. node-3 (C) issues a **settling rotation** to the definitive `{A, C}`.
5. Asserts **every node** resolves the same writer set (A, C writers; **B retroactively revoked**), member entries written before/around the rotations converge, and (bonus) the rotated-out writer's subsequent write is **rejected** while a current writer's write converges.

**App method** `shared_rotate_writers` — full writer-set replacement (so a test can *drop* a writer; the existing `shared_add_writer` can only union one in).

**CI** — registered in the `e2e-rust-apps` matrix.

## Design notes

- **Why C is the settler:** C is a member of *both* concurrent sets, so whichever rotation wins the causal HLC tiebreak, `writers_at` resolves to a set containing C on every node — node-3's settling rotation is authorized everywhere.
- **Why a settling rotation is needed for a deterministic cross-node writer-set assertion:** the app-facing `SharedStorage::writers()` reads the rotation log's most-recently-*appended* entry (per-node insertion order, not causal order — full local causal resolution is the deferred P4 item; the causal `writers_at` is the merge-path security boundary). Two concurrent rotations can be appended in different orders on different nodes, so reading `writers()` immediately after the heal could differ across nodes even though the logs hold the same entries. A single causally-latest rotation is last on every node, collapsing that ambiguity. The pre-settle convergence #2665 actually guarantees — that both rotations propagate, authenticate, and reconcile the storage root — is asserted by the post-heal `wait_for_sync`.
- **Why deterministic:** the partition only has to make the two rotations invisible to each other while split; after heal, assertions depend solely on final convergence, not on any race against TCP-buffer drain.

Relates: #2665, #2655, #2588, #2233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (e2e workflow, scaffolding helper, unit tests); no production sync or auth logic modified in this diff.
> 
> **Overview**
> Adds **end-to-end coverage** for **SharedStorage** when two nodes rotate the writer set **concurrently** and then sync: a new merobox workflow drives a 3-node partition (disconnect/connect), concurrent rotations to `{A,C}` vs `{B,C}`, heal + **`wait_for_sync`**, a **settling rotation** to `{A,C}`, and asserts identical **`shared_is_writer`** on all nodes, KV convergence, **revoked writer rejection**, and final shared value.
> 
> The scaffolding app gains **`shared_rotate_writers`** (full writer-set replacement, so tests can **drop** writers). **CI** registers the workflow in **`e2e-rust-apps`**.
> 
> **Node unit tests** in **`rotation_log_reader.rs`** assert **`writers_at`** is **insertion-order invariant** under concurrent rotations and that a **settling rotation** converges to `{A,C}` with **B revoked** — mirroring the e2e scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe2464b657179f4a1a7d980a83fbcc1bc2a8e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->