### PR TITLE
perf(node/sync): drop per-call String allocations in prometheus metrics

### DIFF
--- a/crates/node/src/sync/prometheus_metrics.rs
+++ b/crates/node/src/sync/prometheus_metrics.rs
@@ -85,28 +85,31 @@ fn sanitize_crdt_type(crdt_type: &str) -> &'static str {
 }
 
 /// Labels for protocol-specific metrics.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+///
+/// Label values are `&'static str` sourced from the `sanitize_*` allow-lists
+/// (or other compile-time-known strings), so recording a metric never allocates.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct ProtocolLabels {
-    protocol: String,
+    protocol: &'static str,
 }
 
 /// Labels for CRDT type metrics.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct CrdtLabels {
-    crdt_type: String,
+    crdt_type: &'static str,
 }
 
 /// Labels for phase timing metrics.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct PhaseLabels {
-    phase: String,
+    phase: &'static str,
 }
 
 /// Labels for sync outcome metrics.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct OutcomeLabels {
-    protocol: String,
-    outcome: String,
+    protocol: &'static str,
+    outcome: &'static str,
 }
 
 /// Prometheus-based sync metrics collector.
@@ -273,7 +276,7 @@ impl PrometheusSyncMetrics {
 impl SyncMetricsCollector for PrometheusSyncMetrics {
     fn record_message_sent(&self, protocol: &str, bytes: usize) {
         let labels = ProtocolLabels {
-            protocol: sanitize_protocol(protocol).to_string(),
+            protocol: sanitize_protocol(protocol),
         };
         self.messages_sent.get_or_create(&labels).inc();
         self.bytes_sent.get_or_create(&labels).inc_by(bytes as u64);
@@ -281,7 +284,7 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
 
     fn record_round_trip(&self, protocol: &str) {
         let labels = ProtocolLabels {
-            protocol: sanitize_protocol(protocol).to_string(),
+            protocol: sanitize_protocol(protocol),
         };
         self.round_trips.get_or_create(&labels).inc();
     }
@@ -292,7 +295,7 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
 
     fn record_merge(&self, crdt_type: &str) {
         let labels = CrdtLabels {
-            crdt_type: sanitize_crdt_type(crdt_type).to_string(),
+            crdt_type: sanitize_crdt_type(crdt_type),
         };
         self.merges_total.get_or_create(&labels).inc();
     }
@@ -304,7 +307,7 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
     fn record_phase_complete(&self, timer: PhaseTimer) {
         // Phase names are &'static str from our code, so no sanitization needed
         let labels = PhaseLabels {
-            phase: timer.phase().to_string(),
+            phase: timer.phase(),
         };
         self.phase_duration_seconds
             .get_or_create(&labels)
@@ -329,7 +332,7 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
 
     fn record_sync_start(&self, _context_id: &str, protocol: &str, _trigger: &str) {
         let labels = ProtocolLabels {
-            protocol: sanitize_protocol(protocol).to_string(),
+            protocol: sanitize_protocol(protocol),
         };
         self.sync_attempts_total.get_or_create(&labels).inc();
     }
@@ -343,8 +346,8 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
     ) {
         let sanitized = sanitize_protocol(protocol);
         let labels = OutcomeLabels {
-            protocol: sanitized.to_string(),
-            outcome: "success".to_string(),
+            protocol: sanitized,
+            outcome: "success",
         };
         self.sync_duration_seconds
             .get_or_create(&labels)
@@ -352,7 +355,7 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
 
         // Increment success counter
         let success_labels = ProtocolLabels {
-            protocol: sanitized.to_string(),
+            protocol: sanitized,
         };
         self.sync_successes_total
             .get_or_create(&success_labels)
@@ -361,14 +364,14 @@ impl SyncMetricsCollector for PrometheusSyncMetrics {
 
     fn record_sync_failure(&self, _context_id: &str, protocol: &str, _reason: &str) {
         let labels = ProtocolLabels {
-            protocol: sanitize_protocol(protocol).to_string(),
+            protocol: sanitize_protocol(protocol),
         };
         self.sync_failures_total.get_or_create(&labels).inc();
     }
 
     fn record_protocol_selected(&self, protocol: &str, _reason: &str, _divergence: f64) {
         let labels = ProtocolLabels {
-            protocol: sanitize_protocol(protocol).to_string(),
+            protocol: sanitize_protocol(protocol),
         };
         self.protocol_selections_total.get_or_create(&labels).inc();
     }


### PR DESCRIPTION
## Summary

Closes #2010.

Sync metric label structs in `crates/node/src/sync/prometheus_metrics.rs` held owned `String` fields, forcing a `.to_string()` allocation on **every** `record_*` call — even though the label values already originate as `&'static str` (from the `sanitize_*` allow-lists and `PhaseTimer::phase()`). `record_sync_complete` allocated the protocol name twice.

This switches the four label structs (`ProtocolLabels`, `CrdtLabels`, `PhaseLabels`, `OutcomeLabels`) to `&'static str` fields (and `Copy`), which `prometheus-client 0.23.1` supports via `EncodeLabelValue for &str` (encoding.rs:470). The result **removes every allocation on the metrics recording path outright**, rather than the interning / pre-allocated-label mitigations the issue had sketched. Label cardinality stays bounded by the `sanitize_*` allow-lists.

## Issue items addressed

- **#1 — per-call `.to_string()` on every record call:** eliminated; all call sites now pass the `&'static str` straight through.
- **#2 — duplicate `sanitized.to_string()` in `record_sync_complete`:** eliminated; `sanitized` is now `Copy` and reused in both label structs with zero allocations.
- **#3 — benchmark metric reconstruction (`sync_sim/benchmarks.rs`):** intentionally left as-is. The issue itself flags this as test-only code with a correct, acceptable trade-off — the per-message loop exists because `SyncMetricsCollector` records one message at a time while the sim only has aggregates. Changing it would mean adding bulk-record methods to the production trait purely for a benchmark.

## Verification

- `cargo fmt -p calimero-node --check` — clean
- `cargo test -p calimero-node --lib sync::prometheus_metrics` — 3/3 pass
- `cargo clippy -p calimero-node --lib` — exit 0, no new warnings in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with the same bounded label allow-lists; no sync protocol or data-path behavior changes.
> 
> **Overview**
> Removes **heap allocations** on every sync Prometheus `record_*` call by changing label structs (`ProtocolLabels`, `CrdtLabels`, `PhaseLabels`, `OutcomeLabels`) from owned `String` fields to **`&'static str`** (with **`Copy`**), matching values already produced by `sanitize_*` allow-lists and static outcomes like `"success"`.
> 
> All recording sites now pass those static strings through directly instead of `.to_string()`, including **`record_sync_complete`**, which no longer allocates the protocol label twice when updating duration and success counters. **Metric names and cardinality behavior are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c465faedde53ee6ceb3ef0cda5a19d1e6f509d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->