### PR TITLE
fix(sync): verify HashComparison convergence against peer's live root (#2607)

### DIFF
--- a/crates/node/src/sync/hash_comparison.rs
+++ b/crates/node/src/sync/hash_comparison.rs
@@ -27,6 +27,7 @@ use calimero_node_primitives::sync::{
 };
 use calimero_primitives::context::ContextId;
 use calimero_primitives::crdt::CrdtType;
+use calimero_primitives::hash::Hash;
 use calimero_storage::address::Id;
 use calimero_storage::env::{with_runtime_env, RuntimeEnv};
 use calimero_storage::index::Index;
@@ -255,6 +256,35 @@ impl SyncManager {
                     requests_handled += 1;
 
                     info!(%context_id, applied, total, "Applied pushed tombstones (delete-wins)");
+                }
+
+                InitPayload::DagHeadsRequest { .. } => {
+                    // End-of-session convergence re-read for the initiator's
+                    // post-sync check. Re-read our root NOW — after applying
+                    // every leaf/tombstone pushed in this session — so the
+                    // initiator compares against our live post-merge state
+                    // instead of the root it captured at handshake (which goes
+                    // stale the moment either side moves, producing both the
+                    // forever-WARN false negative and the divergence-masking
+                    // false positive).
+                    let current_root = with_runtime_env(runtime_env.clone(), || {
+                        Index::<MainStorage>::get_hashes_for(Id::new(*context_id.as_ref()))
+                            .ok()
+                            .flatten()
+                            .map(|(full, _)| full)
+                            .unwrap_or([0; 32])
+                    });
+
+                    let msg = StreamMessage::Message {
+                        sequence_id: sqx.next(),
+                        payload: MessagePayload::DagHeadsResponse {
+                            dag_heads: Vec::new(),
+                            root_hash: Hash::from(current_root),
+                        },
+                        next_nonce: super::helpers::generate_nonce(),
+                    };
+                    transport.send(&msg).await?;
+                    requests_handled += 1;
                 }
 
                 _ => {

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -52,6 +52,7 @@ use calimero_node_primitives::sync::{
 };
 use calimero_primitives::context::ContextId;
 use calimero_primitives::crdt::CrdtType;
+use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::address::Id;
 use calimero_storage::env::with_runtime_env;
@@ -606,34 +607,41 @@ async fn run_initiator_impl<T: SyncTransport>(
         );
     }
 
+    // Re-read the peer's CURRENT root before closing, so the convergence
+    // check below compares against the peer's live state rather than the
+    // root captured at handshake.
+    //
+    // The handshake root goes stale the moment either side moves: after a
+    // bidirectional reconcile the initiator pushed local-only leaves /
+    // tombstones, so the peer's root advanced past the captured value; the
+    // peer may also have applied its own concurrent writes. Comparing a
+    // converged session against that stale snapshot has two failure modes,
+    // both observed in production:
+    //   - false negative: a session that fully converged reports
+    //     `root_hash_verified = false`, producing the WARN that fires on
+    //     every interval-sync tick "forever";
+    //   - false positive: a session that merely re-reached the stale
+    //     snapshot reports `verified = true` while the peer has actually
+    //     moved on, masking a real divergence.
+    // Both collapse to "the guard never asked the peer where it is now."
+    // One extra request closes the gap.
+    //
+    // Falls back to the captured handshake root when the peer does not
+    // answer — an older peer closes the stream on the unrecognized request,
+    // and a transport error is non-fatal here — preserving prior behaviour
+    // for mixed-version clusters.
+    let peer_current_root = match query_peer_current_root(transport, context_id, identity).await {
+        Ok(Some(root)) => root,
+        Ok(None) | Err(_) => remote_root_hash,
+    };
+
     // Close the transport to signal completion to the responder
     transport.close().await?;
 
-    // Post-sync convergence check (#2407). We compare the local
-    // root against the remote root the initiator started with, but
-    // do NOT treat mismatch as fatal:
-    //
-    // - Pull-only convergence: local should equal remote_root_hash.
-    // - Bidirectional sync: the initiator pushed local-only data to
-    //   the peer, so the peer's root advanced past
-    //   `remote_root_hash` (which we captured at handshake) — the
-    //   initiator's post-sync root won't match that stale value,
-    //   even though both peers have converged to the same NEW root.
-    // - Concurrent local writes between handshake and now: same
-    //   shape — local moves on, won't match captured remote.
-    //
-    // We can't distinguish "real divergence bug (#2407)" from
-    // "legitimate bidirectional drift" without a second handshake
-    // round-trip. So instead: set the flag, surface mismatch at
-    // WARN level (was: silent debug), and let the sync manager /
-    // metrics consumer react to *patterns* of unverified syncs.
-    // The bug #2407 documents is a node logging this WARN every
-    // second forever — that's now visible in logs and via the
-    // `root_hash_verified` stats field.
     let local_root_hash = with_runtime_env(runtime_env.clone(), || {
         get_local_root_hash_for_context(context_id)
     })?;
-    stats.root_hash_verified = local_root_hash == remote_root_hash;
+    stats.root_hash_verified = local_root_hash == peer_current_root;
 
     info!(
         %context_id,
@@ -649,19 +657,56 @@ async fn run_initiator_impl<T: SyncTransport>(
         warn!(
             %context_id,
             local_hash = %hex::encode(&local_root_hash[..8]),
-            remote_hash = %hex::encode(&remote_root_hash[..8]),
+            peer_hash = %hex::encode(&peer_current_root[..8]),
             nodes_compared = stats.nodes_compared,
             entities_merged = stats.entities_merged,
             entities_pushed = stats.entities_pushed,
             nodes_skipped = stats.nodes_skipped,
-            "HashComparison sync did not match remote handshake root (#2407). \
-             Legitimate in bidirectional sync (peer's root advanced after our push) \
-             or with concurrent local writes; persistent occurrences of this WARN \
-             across many interval-sync ticks indicate a real merge convergence bug."
+            "HashComparison sync did not converge with the peer's live root. \
+             Compared against the peer's post-sync root (re-read at session end), \
+             so a mismatch here means the two nodes are genuinely divergent — \
+             persistent occurrences across interval-sync ticks indicate a real \
+             merge convergence bug rather than benign handshake drift."
         );
     }
 
     Ok(stats)
+}
+
+/// Ask the peer for its current root hash at the end of a HashComparison
+/// session, after both sides have applied every merge/push in this exchange.
+///
+/// Reuses the `DagHeadsRequest` / `DagHeadsResponse` pair (which already
+/// carries the peer's live `root_hash`) so no new wire message is needed. The
+/// initiator uses the returned root as the post-sync convergence target.
+///
+/// Returns `Ok(None)` when the peer closes the stream or replies with an
+/// unexpected payload — an older peer that does not handle this mid-session
+/// request — so the caller can fall back to the handshake root.
+async fn query_peer_current_root<T: SyncTransport>(
+    transport: &mut T,
+    context_id: ContextId,
+    identity: PublicKey,
+) -> Result<Option<[u8; 32]>> {
+    let request = StreamMessage::Init {
+        context_id,
+        party_id: identity,
+        payload: InitPayload::DagHeadsRequest { context_id },
+        next_nonce: generate_nonce(),
+    };
+    transport.send(&request).await?;
+
+    let Some(response) = transport.recv().await? else {
+        return Ok(None);
+    };
+
+    match response {
+        StreamMessage::Message {
+            payload: MessagePayload::DagHeadsResponse { root_hash, .. },
+            ..
+        } => Ok(Some(*root_hash)),
+        _ => Ok(None),
+    }
 }
 
 // =============================================================================
@@ -896,6 +941,35 @@ async fn run_responder_impl<T: SyncTransport>(
                 requests_handled += 1;
 
                 info!(%context_id, applied, total, "Applied pushed tombstones (delete-wins)");
+            }
+
+            InitPayload::DagHeadsRequest { .. } => {
+                // End-of-session convergence re-read for the initiator's
+                // post-sync check. Re-read our root NOW — after applying every
+                // leaf/tombstone pushed in this session — instead of reusing
+                // the value captured at the top of this responder, so the
+                // initiator compares against our live post-merge state rather
+                // than a stale snapshot.
+                let current_root = with_runtime_env(runtime_env.clone(), || {
+                    Index::<MainStorage>::get_hashes_for(Id::new(*context_id.as_ref()))
+                        .ok()
+                        .flatten()
+                        .map(|(full, _)| full)
+                        .unwrap_or([0; 32])
+                });
+
+                let msg = StreamMessage::Message {
+                    sequence_id,
+                    payload: MessagePayload::DagHeadsResponse {
+                        dag_heads: Vec::new(),
+                        root_hash: Hash::from(current_root),
+                    },
+                    next_nonce: generate_nonce(),
+                };
+
+                transport.send(&msg).await?;
+                sequence_id += 1;
+                requests_handled += 1;
             }
 
             _ => {

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -1752,4 +1752,246 @@ mod tests {
             "error message should mention not_found; got: {msg}"
         );
     }
+
+    /// Like `execute_hash_comparison_sync`, but lets the caller inject the
+    /// exact `remote_root_hash` the initiator carries into the post-sync
+    /// convergence guard, and returns the *raw* `HashComparisonStats` (the
+    /// `SimSyncStats` wrapper drops `root_hash_verified`).
+    ///
+    /// In production, `remote_root_hash` is the peer's root captured at
+    /// handshake time. If the peer advances *after* the handshake (e.g. a
+    /// cross-DAG governance buffer drains), this captured value goes stale
+    /// while the responder still serves its live tree — which is exactly the
+    /// condition we reproduce here.
+    async fn run_hash_comparison_with_remote_root(
+        initiator: &mut SimNode,
+        responder: &SimNode,
+        remote_root_hash: [u8; 32],
+    ) -> Result<HashComparisonStats> {
+        let (mut init_stream, mut resp_stream) = SimStream::pair();
+
+        let initiator_store = initiator.storage().store();
+        let responder_store = responder.storage().store();
+        let initiator_context = initiator.context_id();
+        let responder_context = responder.context_id();
+        let identity = PublicKey::from([0u8; 32]);
+
+        // The stale handshake snapshot — NOT re-derived from the responder's
+        // current state.
+        let config = HashComparisonConfig {
+            remote_root_hash,
+            context_client: None,
+        };
+
+        let initiator_fut = async {
+            HashComparisonProtocol::run_initiator(
+                &mut init_stream,
+                initiator_store,
+                initiator_context,
+                identity,
+                config,
+            )
+            .await
+        };
+
+        let responder_fut = async {
+            let first_msg = resp_stream
+                .recv()
+                .await?
+                .ok_or_else(|| eyre::eyre!("Stream closed before first message"))?;
+            let first_request = match first_msg {
+                StreamMessage::Init {
+                    payload:
+                        InitPayload::TreeNodeRequest {
+                            node_id, max_depth, ..
+                        },
+                    ..
+                } => HashComparisonFirstRequest { node_id, max_depth },
+                _ => bail!("Expected TreeNodeRequest Init message"),
+            };
+            HashComparisonProtocol::run_responder(
+                &mut resp_stream,
+                responder_store,
+                responder_context,
+                identity,
+                first_request,
+            )
+            .await
+        };
+
+        let (init_result, resp_result) = tokio::join!(initiator_fut, responder_fut);
+        resp_result.wrap_err("responder failed")?;
+        init_result.wrap_err("initiator failed")
+    }
+
+    /// **BUG REPRODUCTION (#2607)**: the post-sync convergence guard compares
+    /// the local root against the `remote_root_hash` captured at handshake,
+    /// rather than the peer's root *as it stands after the sync*. So
+    /// `root_hash_verified` tracks a stale snapshot, not actual convergence.
+    ///
+    /// This is the failure mode the guard's own comment documents but treats
+    /// as unavoidable ("we can't distinguish a real divergence bug from
+    /// legitimate bidirectional drift without a second handshake round-trip"):
+    ///
+    /// 1. At handshake the initiator captures the responder's root,
+    ///    `bob_handshake_root` (bob holds only the shared base entity).
+    /// 2. Alice holds the base entity plus several local-only entities, so she
+    ///    pushes them to bob during the bidirectional reconcile.
+    /// 3. Both nodes converge byte-for-byte to a NEW root that is strictly
+    ///    past `bob_handshake_root`. They are genuinely IN SYNC.
+    /// 4. The guard evaluates `local (new_root) == bob_handshake_root` and
+    ///    reports `root_hash_verified == false` — even though the peers fully
+    ///    converged. In production this is the WARN that fires every
+    ///    interval-sync tick "forever"; the identical stale comparison is also
+    ///    what lets `verified == true` mask a *real* divergence elsewhere.
+    ///
+    /// Regression contract: after the fix re-derives the comparison from the
+    /// peer's CURRENT root (a second root exchange), this fully-converged sync
+    /// must report `root_hash_verified == true`. This test FAILS against
+    /// current `master` (verified is wrongly false).
+    #[tokio::test]
+    async fn test_verify_guard_uses_stale_handshake_root() {
+        let ctx = shared_context();
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let mut bob = SimNode::new_in_context("bob", ctx);
+
+        // Shared base entity: both non-empty, equal root at handshake.
+        let base_id = EntityId::from_u64(1000);
+        alice.insert_entity_with_metadata(base_id, b"base".to_vec(), EntityMetadata::default());
+        bob.insert_entity_with_metadata(base_id, b"base".to_vec(), EntityMetadata::default());
+        assert_eq!(alice.root_hash(), bob.root_hash());
+
+        // (1) The root the initiator captures at handshake = bob's CURRENT
+        //     root. The responder can serve this tree (no not_found), so the
+        //     DFS completes normally.
+        let bob_handshake_root = bob.root_hash();
+
+        // (2) Alice writes local-only entities she will push to bob.
+        for i in 1..=5 {
+            alice.insert_entity_with_metadata(
+                EntityId::from_u64(i),
+                format!("seed-{i}").into_bytes(),
+                EntityMetadata::default(),
+            );
+        }
+        assert_ne!(alice.root_hash(), bob_handshake_root);
+
+        // (3) Bidirectional HashComparison: alice pushes her extras, both
+        //     converge to a NEW root past the captured snapshot.
+        let stats = run_hash_comparison_with_remote_root(&mut alice, &bob, bob_handshake_root)
+            .await
+            .expect("sync should succeed");
+
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "alice and bob must be fully converged after the bidirectional sync"
+        );
+        let converged_root = alice.root_hash();
+        assert_ne!(
+            converged_root, bob_handshake_root,
+            "precondition: convergence advanced both nodes past the handshake snapshot"
+        );
+
+        // (4) THE BUG: despite perfect convergence, the guard reports
+        //     unverified because it compared `converged_root == bob_handshake_root`.
+        assert!(
+            stats.root_hash_verified,
+            "root_hash_verified must be true after a fully-converged sync; \
+             it is false here only because the guard compared the local root \
+             against the STALE handshake snapshot instead of the peer's \
+             post-sync root (#2607)"
+        );
+    }
+
+    /// **BUG REPRODUCTION (#2607), pull-dominant variant**: the same stale-root
+    /// guard fires its false-negative WARN even when the initiator is mostly
+    /// *pulling*, as long as it also contributes anything that moves the peer
+    /// past the handshake snapshot.
+    ///
+    /// This is the "fully-converged pull where the peer advanced" shape — the
+    /// closest reproduction of the production WARN that fires every
+    /// interval-sync tick. The initiator pulls the bulk of the divergent state
+    /// from the peer and pushes a single local-only entity back; the push
+    /// advances the peer's root past what the initiator captured at handshake,
+    /// so the post-sync comparison against that captured value reports
+    /// `root_hash_verified == false` despite the nodes being byte-identical.
+    ///
+    /// Distinct from `test_verify_guard_uses_stale_handshake_root` (where the
+    /// initiator is a strict superset and only pushes): here the initiator
+    /// genuinely merges remote leaves (`entities_transferred > 0`) *and*
+    /// advances the peer, exercising both directions.
+    ///
+    /// Regression contract: after the fix re-reads the peer's CURRENT root,
+    /// this fully-converged sync must report `root_hash_verified == true`.
+    /// FAILS against current `master` (verified is wrongly false).
+    #[tokio::test]
+    async fn test_verify_guard_false_negative_on_converged_pull() {
+        let ctx = shared_context();
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let mut bob = SimNode::new_in_context("bob", ctx);
+
+        // Shared base entity: equal root at handshake.
+        let base_id = EntityId::from_u64(2000);
+        alice.insert_entity_with_metadata(base_id, b"base".to_vec(), EntityMetadata::default());
+        bob.insert_entity_with_metadata(base_id, b"base".to_vec(), EntityMetadata::default());
+        assert_eq!(alice.root_hash(), bob.root_hash());
+
+        // Bob holds the bulk of the divergent state — alice will PULL these.
+        for i in 1..=3 {
+            bob.insert_entity_with_metadata(
+                EntityId::from_u64(i),
+                format!("bob-{i}").into_bytes(),
+                EntityMetadata::default(),
+            );
+        }
+
+        // The root captured at handshake = bob's CURRENT root (servable, so the
+        // DFS root request does not hit not_found). Bob does not change again
+        // until alice's push lands mid-session.
+        let bob_handshake_root = bob.root_hash();
+
+        // Alice contributes a single local-only entity she will PUSH, which
+        // advances bob's root past the captured snapshot.
+        alice.insert_entity_with_metadata(
+            EntityId::from_u64(99),
+            b"alice-only".to_vec(),
+            EntityMetadata::default(),
+        );
+
+        let stats = run_hash_comparison_with_remote_root(&mut alice, &bob, bob_handshake_root)
+            .await
+            .expect("sync should succeed");
+
+        // Fully converged, byte-for-byte.
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "alice and bob must be fully converged"
+        );
+        let converged_root = alice.root_hash();
+
+        // This was a real pull (alice merged bob's three entities)...
+        assert!(
+            stats.entities_merged >= 3,
+            "alice should have pulled bob's divergent leaves, got {}",
+            stats.entities_merged
+        );
+        // ...and the peer genuinely advanced past the captured snapshot.
+        assert_ne!(
+            converged_root, bob_handshake_root,
+            "precondition: bob advanced past the handshake snapshot it served"
+        );
+
+        // THE BUG: the guard compares the converged local root against the
+        // stale `bob_handshake_root` and reports the sync unverified — the
+        // forever-WARN false negative.
+        assert!(
+            stats.root_hash_verified,
+            "root_hash_verified must be true after a fully-converged pull; \
+             it is false here only because the guard compared the local root \
+             against the STALE handshake snapshot instead of the peer's \
+             post-sync root (#2607)"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Closes #2607. The HashComparison post-sync convergence guard does:

```rust
stats.root_hash_verified = local_root_hash == remote_root_hash;
```

…where `remote_root_hash` is the peer's root **captured at handshake**, not the peer's root as it stands when the session ends. That snapshot goes stale the moment either side moves, and the guard never re-asks the peer where it is now. Two failure modes, both seen on `master`:

- **False negative (the forever-WARN):** after a bidirectional reconcile the initiator pushed local-only leaves/tombstones, advancing the peer past the captured value — so a *fully-converged* session reports `root_hash_verified = false` and logs "did not match handshake root" on every interval-sync tick.
- **False positive (divergence masking):** a session that merely re-reached the stale snapshot reports `verified = true` while the peer has actually moved on. This is the symptom in the issue's `group-subgroup` data point — `root_hash_verified=true` logged while the roots stayed permanently apart.

The guard's own comment admitted it couldn't tell real divergence from benign drift "without a second handshake round-trip."

## Fix

Add exactly that second root exchange, reusing the existing `DagHeadsRequest` / `DagHeadsResponse` pair (which already carries the peer's live `root_hash`) — **no new wire message, no borsh change**:

- **Initiator** (`hash_comparison_protocol.rs`, shared by prod + sim): before closing, re-reads the peer's current root and compares `local_root_hash == peer_current_root`. Falls back to the handshake root if the peer doesn't answer (an older peer closes the stream on the unrecognized mid-session request) — preserving prior behaviour for mixed-version clusters.
- **Responders** — both the production one (`SyncManager::handle_tree_node_request` in `hash_comparison.rs`) and the sync-sim one (`run_responder_impl`): handle the request by **re-reading the root *after* applying this session's pushes**, so the value reflects the live post-merge state.
- Updated the mismatch WARN to reflect that it now compares against the peer's live root (a mismatch now means genuine divergence, not benign handshake drift).

## Tests

Two deterministic repros in `crates/node/tests/sync_sim/protocol.rs` that drive the **production** protocol over the in-memory sim. Both **fail on `master`** (nodes byte-identical, yet the guard reports unverified) and **pass with the fix**:

- `test_verify_guard_uses_stale_handshake_root` — bidirectional push: initiator is a superset, pushes its extras, both converge past the snapshot.
- `test_verify_guard_false_negative_on_converged_pull` — pull-dominant mutual divergence: initiator pulls the peer's leaves *and* pushes one entity that advances the peer.

A small `run_hash_comparison_with_remote_root` driver was added because the existing `SimSyncStats` wrapper drops the `root_hash_verified` field.

### Verification
- `cargo test -p calimero-node --test sync_sim` → **314/314 pass**
- node lib `hash_comparison` unit tests → 6/6 pass
- `cargo fmt --check` clean; node lib clippy clean

## Scope / caveats

This fixes the **guard's correctness** — it stops lying in both directions. It does not by itself resolve the *originating* divergences (e.g. the cross-DAG governance buffer in #2625, or a genuinely stuck pull-only session); rather, it makes `root_hash_verified` a trustworthy signal that those are happening instead of masking them. The change costs one extra request/response per HC session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-sync verification on a critical sync path; mitigated by reusing existing wire messages, handshake fallback for old peers, and targeted sim regressions, with one extra round-trip per session.
> 
> **Overview**
> Fixes **HashComparison** post-sync convergence so `root_hash_verified` compares the local Merkle root to the peer’s **live** root after the session, not the root frozen at handshake.
> 
> Before session end, the initiator sends an extra **`DagHeadsRequest`** (existing wire pair; no new message types). Production and sim **responders** answer with **`DagHeadsResponse`** after re-reading the index root **after** all in-session merges/pushes. **`query_peer_current_root`** on the initiator drives that; if the peer ignores it or the stream ends, comparison falls back to the handshake root for mixed-version clusters. The mismatch **WARN** now states that a failure means genuine divergence, not bidirectional drift.
> 
> **Sim tests** (`run_hash_comparison_with_remote_root` plus two #2607 cases) lock in fully converged push- and pull-heavy syncs reporting `root_hash_verified == true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94353c29b908d9369660a936a802e3d7fc775cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->