### PR TITLE
feat(context): non-freezing migrations behind `migration_v2` flag (PR-6a, #2539)

### DIFF
--- a/crates/context/src/config.rs
+++ b/crates/context/src/config.rs
@@ -8,4 +8,52 @@ use serde::{Deserialize, Serialize};
 pub struct ContextConfig {
     #[serde(rename = "config")]
     pub client: ClientConfig,
+
+    /// Master switch for the PR-6 hybrid zero-downtime migration framework,
+    /// threaded into [`crate::ContextManagerConfig::migration_v2`] at node
+    /// startup. Absent (`#[serde(default)]` → `false`) in every existing
+    /// `config.toml`, so master behavior — the namespace-cascade write-freeze
+    /// — is preserved until an operator sets `[context] migration_v2 = true`.
+    #[serde(default)]
+    pub migration_v2: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContextConfig;
+
+    /// The on-disk `[context]` section that ships in every existing
+    /// `config.toml` (only the client signer). It must still deserialize, and
+    /// the absent `migration_v2` must default to `false` so master behavior —
+    /// the namespace-cascade write-freeze — is preserved (backward-compat).
+    const LEGACY_CONTEXT_SECTION: &str = r#"{
+        "config": { "signer": { "self": {} } }
+    }"#;
+
+    #[test]
+    fn migration_v2_defaults_off_when_absent() {
+        let cfg: ContextConfig = serde_json::from_str(LEGACY_CONTEXT_SECTION)
+            .expect("legacy [context] section must still deserialize");
+
+        assert!(
+            !cfg.migration_v2,
+            "absent migration_v2 must default off so existing configs are unchanged"
+        );
+    }
+
+    #[test]
+    fn migration_v2_threads_when_set() {
+        let cfg: ContextConfig = serde_json::from_str(
+            r#"{
+                "config": { "signer": { "self": {} } },
+                "migration_v2": true
+            }"#,
+        )
+        .expect("[context] section with migration_v2 must deserialize");
+
+        assert!(
+            cfg.migration_v2,
+            "migration_v2 = true must thread through to the resolved config"
+        );
+    }
 }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -126,7 +126,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                     .load(&group_id)
                 {
                     Ok(Some(upgrade)) => {
-                        if upgrade_blocks_write(&upgrade.status) {
+                        if should_block(self.config.migration_v2, &upgrade.status) {
                             if is_state_op {
                                 // Known write — refuse before execution.
                                 warn!(
@@ -2174,6 +2174,16 @@ fn upgrade_blocks_write(status: &calimero_store::key::GroupUpgradeStatus) -> boo
     )
 }
 
+/// Whether the cascade write-gate should fire, given the `migration_v2` flag.
+///
+/// Equal to `!migration_v2 && upgrade_blocks_write(status)`: with the flag OFF
+/// (the default) the group-wide `InProgress` freeze is byte-for-byte the same
+/// as today; with the flag ON the freeze is lifted entirely (PR-6b's
+/// absorb-don't-drop is what keeps stragglers safe once the freeze is gone).
+fn should_block(migration_v2: bool, status: &calimero_store::key::GroupUpgradeStatus) -> bool {
+    !migration_v2 && upgrade_blocks_write(status)
+}
+
 /// Post-execution write-gate decision: during an in-progress upgrade a pure read
 /// (`produced_write == false`) is served from the pre-migration root; a
 /// side-effecting call is refused. Write-intent is derived post-execution (a
@@ -2302,7 +2312,10 @@ mod tests {
     use calimero_store::key::GroupMetaValue;
     use calimero_store::Store;
 
-    use super::{resolve_producing_app_key, upgrade_blocks_write, upgrade_rejects_committed_write};
+    use super::{
+        resolve_producing_app_key, should_block, upgrade_blocks_write,
+        upgrade_rejects_committed_write,
+    };
     use calimero_store::key::GroupUpgradeStatus;
 
     fn fresh_store() -> Store {
@@ -2468,6 +2481,49 @@ mod tests {
                 failed: 0,
             }),
             "today's group-wide freeze: InProgress must block state-op writes"
+        );
+    }
+
+    // PR-6a Task 6a.3: the cascade write-freeze is gated behind `migration_v2`.
+    // `should_block` is `!migration_v2 && upgrade_blocks_write(status)`: with the
+    // flag OFF the freeze is unchanged (master behavior); with the flag ON the
+    // group-wide `InProgress` freeze stops blocking writes (PR-6b's
+    // absorb-don't-drop later keeps stragglers safe once the freeze is gone).
+    #[test]
+    fn should_block_flag_off_in_progress_blocks() {
+        assert!(
+            should_block(
+                false,
+                &GroupUpgradeStatus::InProgress {
+                    total: 1,
+                    completed: 0,
+                    failed: 0,
+                },
+            ),
+            "flag OFF: InProgress must still block writes (unchanged)"
+        );
+    }
+
+    #[test]
+    fn should_block_flag_on_in_progress_does_not_block() {
+        assert!(
+            !should_block(
+                true,
+                &GroupUpgradeStatus::InProgress {
+                    total: 1,
+                    completed: 0,
+                    failed: 0,
+                },
+            ),
+            "flag ON: InProgress must not freeze writes group-wide"
+        );
+    }
+
+    #[test]
+    fn should_block_flag_off_completed_does_not_block() {
+        assert!(
+            !should_block(false, &GroupUpgradeStatus::Completed { completed_at: None }),
+            "Completed never blocks, regardless of the flag"
         );
     }
 }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -2452,4 +2452,22 @@ mod tests {
             "migration_v2 must default off so master behavior is unchanged"
         );
     }
+
+    // PR-6a Task 6a.2: characterize today's group-wide freeze. With
+    // `migration_v2` OFF (the default), `InProgress` blocks *all* writes —
+    // including state-op writes such as `__calimero_sync_next`. This is the
+    // freeze that namespace cascades impose group-wide. Locking it here proves
+    // 6a.3 (which gates this behind `migration_v2`) only changes flag-ON
+    // behavior; the flag-OFF contract stays exactly as it is today.
+    #[test]
+    fn flag_off_inprogress_blocks_state_op_write() {
+        assert!(
+            upgrade_blocks_write(&GroupUpgradeStatus::InProgress {
+                total: 1,
+                completed: 0,
+                failed: 0,
+            }),
+            "today's group-wide freeze: InProgress must block state-op writes"
+        );
+    }
 }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -2439,4 +2439,17 @@ mod tests {
             "a read outside any in-progress upgrade must not be gated"
         );
     }
+
+    // PR-6a Task 6a.1: the `migration_v2` feature flag must default OFF so
+    // master behavior is completely unchanged until the flag is flipped (after
+    // 6b lands). The flag lives on `ContextManagerConfig` — the same
+    // runtime-tunable knobs struct threaded into this handler via `self.config`.
+    #[test]
+    fn migration_v2_flag_defaults_off() {
+        let cfg = crate::ContextManagerConfig::default();
+        assert!(
+            !cfg.migration_v2,
+            "migration_v2 must default off so master behavior is unchanged"
+        );
+    }
 }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -144,6 +144,19 @@ impl Handler<ExecuteRequest> for ContextManager {
                             // pre-migration root; reject post-execution only if
                             // it actually mutates state (a write). Reads pass.
                             block_writes_for_group = Some(group_id);
+                        } else if self.config.migration_v2 && upgrade_blocks_write(&upgrade.status)
+                        {
+                            // The freeze that would otherwise apply was
+                            // intentionally bypassed by `migration_v2`. Emit a
+                            // signal so a canary operator can tell the freeze was
+                            // skipped by the flag (not a missing upgrade row);
+                            // stragglers are absorbed rather than dropped once
+                            // PR-6b lands.
+                            debug!(
+                                %context_id,
+                                ?group_id,
+                                "migration_v2: bypassing InProgress write-freeze (flag on)"
+                            );
                         }
                     }
                     Ok(None) => {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -108,8 +108,10 @@ use calimero_context_client::local_governance::AckRouter;
 /// Distinct from the on-disk [`config::ContextConfig`] (which holds the
 /// chain/client config). This struct centralises timing constants that
 /// were previously hard-coded in handler modules so future operator
-/// tooling can override them without source patches. Defaults match the
-/// values that shipped with #2237 Phase 12.
+/// tooling can override them without source patches, plus behavioral
+/// feature flags (e.g. [`Self::migration_v2`]) that gate in-progress
+/// framework work. Timing defaults match the values that shipped with
+/// #2237 Phase 12; feature flags default off.
 #[derive(Clone, Copy, Debug)]
 pub struct ContextManagerConfig {
     /// How long `join_group` will wait for a `KeyDelivery` op to arrive

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -121,12 +121,24 @@ pub struct ContextManagerConfig {
     /// admin + their `publish_and_await_ack` budget", not the full
     /// gossipsub heartbeat reconciliation window.
     pub key_delivery_fallback_wait: Duration,
+
+    /// Master switch for the PR-6 hybrid zero-downtime migration framework.
+    ///
+    /// Defaults to `false` so master behavior is completely unchanged: with the
+    /// flag off, a namespace-cascade migration keeps the group-wide
+    /// `InProgress` write-freeze (see [`handlers::execute`]'s
+    /// `upgrade_blocks_write`). When flipped on — only legal in a deployment
+    /// once PR-6a *and* PR-6b have landed — the cascade no longer freezes
+    /// writes group-wide; each context migrates lazily/briefly and stragglers
+    /// are absorbed rather than dropped.
+    pub migration_v2: bool,
 }
 
 impl Default for ContextManagerConfig {
     fn default() -> Self {
         Self {
             key_delivery_fallback_wait: Duration::from_secs(5),
+            migration_v2: false,
         }
     }
 }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -430,6 +430,16 @@ impl ContextManager {
         self
     }
 
+    /// Override the [`ContextManagerConfig::migration_v2`] master switch.
+    /// Builder-style so node startup can thread the operator's
+    /// `[context] migration_v2` config through while tests (and any caller that
+    /// doesn't set it) keep the default-off behavior. See [`Self::with_vm_limits`].
+    #[must_use]
+    pub fn with_migration_v2(mut self, migration_v2: bool) -> Self {
+        self.config.migration_v2 = migration_v2;
+        self
+    }
+
     /// Get this node's identity for the namespace (root group) that contains `group_id`.
     /// Returns `None` if no identity has been stored for that namespace yet.
     pub fn node_namespace_identity(

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -289,6 +289,7 @@ impl InitCommand {
             BlobStoreConfig::new("blobs".into()),
             ContextConfig {
                 client: client_config,
+                migration_v2: false,
             },
         );
 

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -209,7 +209,8 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
         context_client.clone(),
         Some(&mut registry),
     )
-    .with_vm_limits(config.vm_limits);
+    .with_vm_limits(config.vm_limits)
+    .with_migration_v2(config.context.migration_v2);
 
     let _ignored = Actor::start_in_arbiter(&arbiter_pool.get().await?, move |ctx| {
         assert!(context_recipient.init(ctx), "failed to initialize");


### PR DESCRIPTION
## What

First PR of the **PR-6 hybrid zero-downtime migration train** (#2539). Introduces a `migration_v2` feature flag (**default off**) and gates the namespace-cascade write-freeze behind it.

- With the flag **off** (the default), behavior is byte-for-byte unchanged: a namespace cascade still sets `GroupUpgradeStatus::InProgress` and the execute gate freezes writes group-wide for the duration of the cascade.
- With the flag **on**, an `InProgress` cascade no longer blocks writes — the gate decision becomes `should_block(migration_v2, status) = !migration_v2 && upgrade_blocks_write(status)`.

## Why

Today a namespace migration freezes **writes across the whole group for the entire cascade** — the stop-the-world cost (#2644 already freed reads). This is the first step toward near-zero-downtime migrations: lift that freeze so each context migrates lazily without a cluster-wide write pause.

The flag stays **default-off** deliberately: removing the freeze is only *safe* once the straggler-safety net (absorb-don't-drop) lands in the next PR — otherwise a write issued during a migration could be dropped by the HLC schema fence. So this PR lands the mechanism inert; the default flips on once absorb-don't-drop is in.

## Contents

- `migration_v2: bool` on `ContextManagerConfig` (default off), threaded to the execute handler.
- Operator/config exposure: `[context] migration_v2` (serde-default-off, backward-compatible) → `ContextManager::with_migration_v2(..)` → wired at node startup. Lets a deployment opt-in (e.g. a canary) ahead of the global default flip.
- `should_block` gate helper + the gate swap in `execute/mod.rs`.
- A characterization test locking today's freeze, plus `should_block` flag on/off unit tests and config backward-compat tests.

## Testing

- Full `calimero-context` lib suite: **89 passed, 0 failed** (incl. `should_block` flag-on/off, the InProgress characterization guard, and config default-off/threads-when-set).
- `merod` builds clean across crates; `cargo fmt --all --check` clean.
- Flag-off path is proven unchanged by the characterization + `should_block(false, ..)` tests, so no behavioral regression.

The live "writes-available during a migration" end-to-end test lands with the absorb-don't-drop PR, where the flag's default is flipped on and the existing migration matrix exercises the new behavior directly (no special harness setup needed).

## Train

Part of the stacked train 6a → 6b (absorb-don't-drop) → 6c (identity-gated owner-driven + completion visibility) → 6d (soak + migration_check). This is 6a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execute-time upgrade gating during group migrations; default-off preserves current freeze, but enabling the flag removes cluster-wide write protection before PR-6b straggler safety lands.
> 
> **Overview**
> Adds a **default-off** `migration_v2` operator switch on `[context]` / `ContextManagerConfig`, wired at node startup into the execute path’s group-upgrade write gate.
> 
> **Flag off (default):** `should_block` equals today’s behavior — `GroupUpgradeStatus::InProgress` still freezes writes group-wide (including state-ops like `__calimero_sync_next`).
> 
> **Flag on:** that cascade freeze is lifted (`should_block` is `!migration_v2 && upgrade_blocks_write`); a debug log marks when an `InProgress` upgrade would have frozen writes but did not.
> 
> Includes serde backward-compat on `ContextConfig`, `with_migration_v2` on `ContextManager`, `merod init` seeding `false`, and unit/characterization tests locking default-off and flag on/off gate semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c8d5b84a54d384c563da990b7ba508ec0f9cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->