### PR TITLE
refactor(network): drop ipify public-IP lookup for AutoNAT/identify + static config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,6 @@ dependencies = [
  "owo-colors 3.5.0",
  "prometheus-client",
  "rand 0.8.5",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -108,8 +108,10 @@ pub struct InitCommand {
 
     /// Static external multiaddr(s) to advertise (e.g.
     /// `/ip4/203.0.113.7/tcp/2428`). Seeded directly into the swarm's
-    /// external-address set when `--advertise-address` is set; otherwise
-    /// external addresses are discovered via identify + AutoNAT v2.
+    /// external-address set at startup; requires `--advertise-address`.
+    /// AutoNAT v2 always additionally discovers and confirms reachable
+    /// addresses regardless of this flag. Non-routable values (loopback /
+    /// unspecified / link-local) are ignored.
     #[clap(long = "external-address", value_name = "MULTIADDR")]
     pub external_address: Vec<Multiaddr>,
 

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -106,6 +106,13 @@ pub struct InitCommand {
     #[clap(overrides_with("no_mdns"))]
     pub advertise_address: bool,
 
+    /// Static external multiaddr(s) to advertise (e.g.
+    /// `/ip4/203.0.113.7/tcp/2428`). Seeded directly into the swarm's
+    /// external-address set when `--advertise-address` is set; otherwise
+    /// external addresses are discovered via identify + AutoNAT v2.
+    #[clap(long = "external-address", value_name = "MULTIADDR")]
+    pub external_address: Vec<Multiaddr>,
+
     #[clap(
         long,
         default_value = "3",
@@ -270,6 +277,7 @@ impl InitCommand {
                 DiscoveryConfig::new(
                     mdns,
                     self.advertise_address,
+                    self.external_address.clone(),
                     RendezvousConfig::new(self.rendezvous_registrations_limit),
                     RelayConfig::new(self.relay_registrations_limit),
                     AutonatConfig::new(

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -41,7 +41,6 @@ multiaddr.workspace = true
 owo-colors.workspace = true
 prometheus-client.workspace = true
 rand.workspace = true
-reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros"] }

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -167,6 +167,15 @@ pub struct DiscoveryConfig {
 
     pub advertise_address: bool,
 
+    /// Operator-configured external addresses, seeded directly into the
+    /// swarm's confirmed external-address set at init (gated on
+    /// `advertise_address`). This is the deterministic alternative to
+    /// AutoNAT-based discovery for known-static-IP / hosted deployments,
+    /// and supports both IPv4 and IPv6. When empty, external addresses
+    /// are discovered solely via identify + AutoNAT v2 confirmation.
+    #[serde(default)]
+    pub external_address: Vec<Multiaddr>,
+
     pub rendezvous: RendezvousConfig,
 
     pub relay: RelayConfig,
@@ -179,6 +188,7 @@ impl DiscoveryConfig {
     pub const fn new(
         mdns: bool,
         advertise_address: bool,
+        external_address: Vec<Multiaddr>,
         rendezvous: RendezvousConfig,
         relay: RelayConfig,
         autonat: AutonatConfig,
@@ -186,6 +196,7 @@ impl DiscoveryConfig {
         Self {
             mdns,
             advertise_address,
+            external_address,
             rendezvous,
             relay,
             autonat,
@@ -198,6 +209,7 @@ impl Default for DiscoveryConfig {
         Self {
             mdns: true,
             advertise_address: false,
+            external_address: Vec::new(),
             rendezvous: RendezvousConfig::default(),
             relay: RelayConfig::default(),
             autonat: AutonatConfig::default(),

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -1,6 +1,4 @@
-use core::net::Ipv4Addr;
-use core::time::Duration;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 use calimero_network_primitives::config::{AutonatConfig, RelayConfig, RendezvousConfig};
 use eyre::{bail, ContextCompat, Result as EyreResult, WrapErr as _};
@@ -55,7 +53,6 @@ pub struct Discovery {
     pub(crate) state: DiscoveryState,
     pub(crate) rendezvous_config: RendezvousConfig,
     pub(crate) relay_config: RelayConfig,
-    pub(crate) advertise: Option<AdvertiseState>,
     pub(crate) _autonat_config: AutonatConfig,
     /// Rotating offset into the under-connected rendezvous-key list, so
     /// successive `rendezvous_discover` calls cover different keys when
@@ -73,66 +70,21 @@ pub struct Discovery {
     pub(crate) reserved_topics: BTreeSet<String>,
 }
 
-#[derive(Debug)]
-pub struct AdvertiseState {
-    pub(crate) ip: Ipv4Addr,
-    pub(crate) ports: HashSet<u16>,
-}
-
 impl Discovery {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         rendezvous_config: &RendezvousConfig,
         relay_config: &RelayConfig,
         autonat_config: &AutonatConfig,
-        listening_on: &[Multiaddr],
         reserved_topics: BTreeSet<String>,
-    ) -> EyreResult<Self> {
-        let advertise = if listening_on.is_empty() {
-            None
-        } else {
-            let ports = listening_on
-                .iter()
-                .filter_map(|addr| {
-                    addr.iter().find_map(|p| match p {
-                        Protocol::Tcp(port) | Protocol::Udp(port) => Some(port),
-                        _ => None,
-                    })
-                })
-                .collect();
-
-            Some(AdvertiseState {
-                ip: Self::get_public_ip().await?,
-                ports,
-            })
-        };
-
-        let this = Self {
+    ) -> Self {
+        Self {
             state: DiscoveryState::default(),
             rendezvous_config: rendezvous_config.clone(),
             relay_config: relay_config.clone(),
-            advertise,
             _autonat_config: autonat_config.clone(),
             rendezvous_discover_cursor: 0,
             reserved_topics,
-        };
-
-        Ok(this)
-    }
-
-    async fn get_public_ip() -> EyreResult<Ipv4Addr> {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(3))
-            .build()?;
-
-        let ip_addr = client
-            .get("https://api.ipify.org")
-            .send()
-            .await?
-            .text()
-            .await?
-            .parse()?;
-
-        Ok(ip_addr)
+        }
     }
 }
 

--- a/crates/network/src/handlers/stream/swarm/identify.rs
+++ b/crates/network/src/handlers/stream/swarm/identify.rs
@@ -1,5 +1,4 @@
 use libp2p::identify::{Event, Info};
-use libp2p::Multiaddr;
 use libp2p_metrics::Recorder;
 use multiaddr::Protocol;
 use owo_colors::OwoColorize;
@@ -47,62 +46,27 @@ impl EventHandler<Event> for NetworkManager {
                 }
             }
 
-            // Branch 1: observed-address → external-address promotion.
-            //
-            // Only relevant for operators who configured the node with
-            // `advertise_address: true` AND have at least one listen
-            // address — that's the only case `self.discovery.advertise`
-            // is `Some(_)`. If the peer reports it observed us on an
-            // address that matches our advertised IP+port pair, we
-            // treat that as confirmation that we're publicly dialable
-            // there and promote it to a swarm external address.
-            if let Some(advertise_address) = &self.discovery.advertise {
-                let is_external_addr = observed_addr
-                    .iter()
-                    .fold((false, false), |(found_ip, found_port), p| {
-                        let found_ip = found_ip
-                            || match p {
-                                Protocol::Ip4(ipv4_addr) => ipv4_addr == advertise_address.ip,
-                                _ => false,
-                            };
+            // External-address promotion is left entirely to libp2p:
+            // `identify` reports each peer-observed address as a
+            // `NewExternalAddrCandidate`, and the AutoNAT v2 client
+            // probes those candidates and emits `ExternalAddrConfirmed`
+            // only for addresses that are actually dial-back reachable
+            // (handled in the swarm event handler). We deliberately do
+            // NOT `add_external_address(observed_addr)` here: a single
+            // peer's observation is unverified, and asserting it would
+            // bypass AutoNAT — advertising an address we can't prove is
+            // reachable. Operators who want a deterministic external
+            // address set it via `discovery.external_address`, which is
+            // seeded directly into the swarm at init.
 
-                        let found_port = found_port
-                            || match p {
-                                Protocol::Tcp(port) | Protocol::Udp(port) => {
-                                    advertise_address.ports.contains(&port)
-                                }
-                                _ => false,
-                            };
-
-                        (found_ip, found_port)
-                    })
-                    .eq(&(true, true));
-
-                if !self.swarm.external_addresses().any(|a| *a == observed_addr) && is_external_addr
-                {
-                    debug!(
-                        "Current external addresses: {:?}",
-                        self.swarm.external_addresses().collect::<Vec<&Multiaddr>>()
-                    );
-                    debug!(
-                        "Add observed address to external addresses: {:?}",
-                        observed_addr
-                    );
-                    self.swarm.add_external_address(observed_addr);
-                }
-            }
-
-            // Branch 2: opportunistic relay-reservation request.
+            // Opportunistic relay-reservation request.
             //
             // If the just-identified peer offers `/libp2p/circuit/-
             // relay/0.2.0/hop`, kick off a reservation request against
-            // it. This MUST run independently of branch 1: a node
-            // configured with `advertise_address: true` can still be
-            // behind a NAT (the `advertise_address.ip` field reflects
-            // what `api.ipify.org` returned, not what's actually
-            // dialable). Without an opportunistic reservation it would
-            // sit forever assuming reachability that AutoNAT later
-            // disproves — and by the time autonat reports failure,
+            // it. This runs regardless of external-address state: a node
+            // can still be behind a NAT until AutoNAT confirms a direct
+            // address. Without an opportunistic reservation it would sit
+            // unreachable until AutoNAT reports failure — and by then
             // there's no event-driven path that retries relay setup.
             //
             // Cost is bounded: `create_relay_reservation` short-

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -90,20 +90,25 @@ impl NetworkManager {
         reserved_topics: BTreeSet<String>,
         store: Option<Store>,
     ) -> eyre::Result<Self> {
-        let swarm = Behaviour::build_swarm(config)?;
+        let mut swarm = Behaviour::build_swarm(config)?;
+
+        // Seed operator-configured external addresses directly into the
+        // swarm's confirmed set. Deterministic, no third-party lookup —
+        // for known-static-IP / hosted deployments. When none are
+        // configured, external addresses are discovered via identify +
+        // AutoNAT v2 confirmation instead (see the identify handler).
+        if config.discovery.advertise_address {
+            for addr in &config.discovery.external_address {
+                swarm.add_external_address(addr.clone());
+            }
+        }
 
         let discovery = Discovery::new(
             &config.discovery.rendezvous,
             &config.discovery.relay,
             &config.discovery.autonat,
-            if config.discovery.advertise_address {
-                &config.swarm.listen
-            } else {
-                &[]
-            },
             reserved_topics,
-        )
-        .await?;
+        );
 
         let this = Self {
             swarm: Box::new(swarm),

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -23,11 +23,12 @@ use libp2p::kad::QueryId;
 use libp2p::swarm::{ConnectionId, Swarm};
 use libp2p::PeerId;
 use libp2p_metrics::Metrics;
+use multiaddr::{Multiaddr, Protocol};
 use prometheus_client::registry::Registry;
 use tokio::sync::oneshot;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
-use tracing::error;
+use tracing::{error, info, warn};
 
 use crate::handlers::stream::incoming::FromIncoming;
 
@@ -97,9 +98,26 @@ impl NetworkManager {
         // for known-static-IP / hosted deployments. When none are
         // configured, external addresses are discovered via identify +
         // AutoNAT v2 confirmation instead (see the identify handler).
+        //
+        // These bypass AutoNAT dial-back confirmation, so a typo or a
+        // stale entry would otherwise be advertised to every peer as
+        // reachable. Skip addresses that can never be reached by a remote
+        // peer (loopback / unspecified / link-local) rather than poison
+        // the swarm's external set with them; warn on private/ULA ranges,
+        // which are legitimate for same-network deployments but a common
+        // misconfiguration when a node is meant to be publicly reachable.
         if config.discovery.advertise_address {
             for addr in &config.discovery.external_address {
-                swarm.add_external_address(addr.clone());
+                if is_seedable_external_address(addr) {
+                    info!(%addr, "Seeding operator-configured external address");
+                    swarm.add_external_address(addr.clone());
+                } else {
+                    warn!(
+                        %addr,
+                        "Ignoring non-routable external_address (loopback / unspecified / \
+                         link-local): remote peers cannot dial it",
+                    );
+                }
             }
         }
 
@@ -125,6 +143,47 @@ impl NetworkManager {
 
         Ok(this)
     }
+}
+
+/// Whether an operator-configured external address is worth seeding into
+/// the swarm's confirmed external-address set.
+///
+/// Configured addresses skip AutoNAT dial-back confirmation, so we filter
+/// out the ones a remote peer can provably never reach — loopback,
+/// unspecified (`0.0.0.0` / `::`), and link-local — instead of advertising
+/// nonsense. Private (RFC-1918) and IPv6 unique-local (`fc00::/7`)
+/// addresses are kept, since they're valid for same-network / overlay
+/// deployments, but warned about because they're a frequent slip when the
+/// node is actually meant to be publicly reachable. Addresses with no IP
+/// component (e.g. a DNS multiaddr) are passed through unchanged.
+fn is_seedable_external_address(addr: &Multiaddr) -> bool {
+    for proto in addr.iter() {
+        match proto {
+            Protocol::Ip4(ip) => {
+                if ip.is_loopback() || ip.is_unspecified() || ip.is_link_local() {
+                    return false;
+                }
+                if ip.is_private() {
+                    warn!(%addr, "external_address is a private (RFC-1918) range; only reachable within the same network");
+                }
+            }
+            Protocol::Ip6(ip) => {
+                if ip.is_loopback() || ip.is_unspecified() {
+                    return false;
+                }
+                // Link-local fe80::/10 — never routable off-link.
+                if (ip.segments()[0] & 0xffc0) == 0xfe80 {
+                    return false;
+                }
+                // Unique-local fc00::/7 — site-scoped, not globally reachable.
+                if (ip.segments()[0] & 0xfe00) == 0xfc00 {
+                    warn!(%addr, "external_address is an IPv6 unique-local (fc00::/7) range; only reachable within the same network");
+                }
+            }
+            _ => {}
+        }
+    }
+    true
 }
 
 impl Actor for NetworkManager {
@@ -172,5 +231,36 @@ impl Actor for NetworkManager {
         // rendezvous rediscovery has a chance to run. Best-effort and
         // deduped at the swarm level; stale entries fail and age out.
         self.load_peer_cache_and_dial();
+    }
+}
+
+#[cfg(test)]
+mod external_address_tests {
+    use super::is_seedable_external_address;
+
+    fn seedable(s: &str) -> bool {
+        is_seedable_external_address(&s.parse().expect("valid multiaddr"))
+    }
+
+    #[test]
+    fn routable_addresses_are_seedable() {
+        assert!(seedable("/ip4/203.0.113.7/tcp/2428"));
+        assert!(seedable("/ip6/2001:db8::1/tcp/2428"));
+        // Private / unique-local are kept (warned), valid for overlays.
+        assert!(seedable("/ip4/10.0.0.5/tcp/2428"));
+        assert!(seedable("/ip4/192.168.1.20/udp/2428/quic-v1"));
+        assert!(seedable("/ip6/fd00::1/tcp/2428"));
+        // No IP component (DNS) is passed through.
+        assert!(seedable("/dns4/node.example.com/tcp/2428"));
+    }
+
+    #[test]
+    fn non_routable_addresses_are_skipped() {
+        assert!(!seedable("/ip4/127.0.0.1/tcp/2428"));
+        assert!(!seedable("/ip4/0.0.0.0/tcp/2428"));
+        assert!(!seedable("/ip4/169.254.1.1/tcp/2428"));
+        assert!(!seedable("/ip6/::1/tcp/2428"));
+        assert!(!seedable("/ip6/::/tcp/2428"));
+        assert!(!seedable("/ip6/fe80::1/tcp/2428"));
     }
 }

--- a/crates/network/tests/gossipsub_group_topic.rs
+++ b/crates/network/tests/gossipsub_group_topic.rs
@@ -27,6 +27,7 @@ fn network_config(keypair: Keypair, listen: Multiaddr) -> NetworkConfig {
         DiscoveryConfig::new(
             false,
             false,
+            Vec::new(),
             RendezvousConfig::default(),
             RelayConfig::default(),
             AutonatConfig::new(5, Duration::from_secs(10)),

--- a/crates/network/tests/relay_recovery.rs
+++ b/crates/network/tests/relay_recovery.rs
@@ -75,6 +75,7 @@ fn client_config(keypair: Keypair, listen: Multiaddr, bootstrap: Vec<Multiaddr>)
         DiscoveryConfig::new(
             false,
             false,
+            Vec::new(),
             RendezvousConfig::default(),
             RelayConfig::default(),
             AutonatConfig::new(5, Duration::from_secs(10)),

--- a/crates/network/tests/rendezvous_namespace.rs
+++ b/crates/network/tests/rendezvous_namespace.rs
@@ -42,6 +42,7 @@ fn client_config(keypair: Keypair, listen: Multiaddr) -> NetworkConfig {
             // rendezvous server — exactly what we're testing.
             false,
             false,
+            Vec::new(),
             RendezvousConfig::default(),
             RelayConfig::default(),
             AutonatConfig::new(5, Duration::from_secs(10)),


### PR DESCRIPTION
Closes #2531.

## What

Removes the third-party `https://api.ipify.org` HTTP call from public-IP discovery (`Discovery::get_public_ip`) and replaces it with the libp2p-native external-address path plus an optional operator-configured static address.

## Why

`get_public_ip()` sat on the `Discovery::new` constructor path. When `advertise_address = true` it:
- **coupled startup to a third party** — ipify down/blocked → `NetworkManager::new` errors → the node doesn't boot;
- **trusted unauthenticated plaintext** from a CDN (DNS-poison / MITM could spoof the IP);
- **phoned home** on every startup (privacy leak for a privacy-oriented network);
- was **IPv4-only**;
- and was **redundant** — the fetched IP was only used as a *filter* on identify's `observed_addr` before manually calling `add_external_address`, which bypasses AutoNAT.

The correct source of truth was already wired: `identify` emits each peer-observed address as a `NewExternalAddrCandidate`, the AutoNAT v2 client probes it, and the swarm only emits `ExternalAddrConfirmed` for dial-back-reachable addresses. The ipify filter was a weaker, untrusted parallel path.

## Changes

- Delete `Discovery::get_public_ip()` and the `AdvertiseState` IP/port filter; `Discovery::new` is no longer `async`/fallible.
- Remove the identify "Branch 1" ipify match + manual `add_external_address(observed_addr)`; rely on AutoNAT-confirmed candidates.
- Add `DiscoveryConfig.external_address: Vec<Multiaddr>` (`#[serde(default)]`, empty) — seeded directly into the swarm via `add_external_address` at init when `advertise_address` is set. Supports IPv4 **and** IPv6.
- Add a `merod init --external-address <MULTIADDR>` flag.
- Drop the now-unused `reqwest` dependency from `calimero-network` (its only user).

## Acceptance (per #2531)

- [x] No outbound call to `api.ipify.org` (or any IP-echo service) anywhere in the node.
- [x] `calimero-network` no longer depends on `reqwest`.
- [x] A node with `advertise_address = true` and no reachable IP-echo service still starts and advertises a correct external address once AutoNAT confirms one (or a configured address is set).
- [x] IPv6 external addresses are representable (`Multiaddr`).

## Back-compat

`advertise_address` defaults to `false` and `external_address` defaults to empty, so the common path and existing config files are unaffected. For nodes that opt in, behavior shifts from "ipify-detected IP filter" to "AutoNAT-confirmed observed address (+ optional configured address)" — strictly more trustworthy. The opportunistic relay reservation still covers the NAT'd case until AutoNAT confirms a direct address.

## Testing

- `cargo build -p calimero-network-primitives -p calimero-network -p merod` ✓
- `cargo build -p calimero-network --tests` ✓
- `cargo fmt --check` ✓ / `cargo clippy` clean (no new warnings)
- `cargo test -p calimero-network --lib` → 67/67 green
- `cargo test -p calimero-network-primitives --lib` green (incl. autonat_v2 `ExternalAddrConfirmed` tests; `test_dynamic_protocol_change` is a pre-existing `libp2p-swarm-test` timing flake — passes on rerun, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how advertised external addresses are chosen (trust and boot reliability), but defaults stay off and AutoNAT is the safer path; misconfigured static externals could advertise wrong dial addresses.
> 
> **Overview**
> Removes **startup-time public IP discovery** via `api.ipify.org` (`reqwest`) and the **`AdvertiseState` / identify filter** that promoted a single peer-observed address after matching that IP. **`Discovery::new`** is synchronous again; nodes no longer fail boot when an IP-echo service is unreachable.
> 
> **External reachability** now follows libp2p: identify supplies **AutoNAT v2 candidates** only (no manual `add_external_address` on observed addr). Operators can set **`discovery.external_address`** (and **`merod init --external-address`**) to seed confirmed externals at startup when **`advertise_address`** is on, with **filtering** for loopback / unspecified / link-local and warnings for private ranges. **`reqwest`** is dropped from **`calimero-network`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9595d33fd8f2f676ab95b35ff01be9a97cbdc640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->