### PR TITLE
refactor(context): extract ContextGuard and ContextLock for the per-context lock

### DIFF
--- a/crates/context/primitives/src/lib.rs
+++ b/crates/context/primitives/src/lib.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use calimero_primitives::context::ContextId;
 use tokio::sync::OwnedMutexGuard;
 
@@ -6,6 +8,37 @@ pub mod group;
 pub mod local_governance;
 pub mod messages;
 
+/// An owned, per-context lock guard held across a context operation.
+///
+/// This is a newtype over `OwnedMutexGuard<ContextId>` rather than the raw
+/// guard so that the single notion of "holding a context" lives behind one
+/// type: the guard is acquired in the manager, threaded through the entire
+/// WASM execution outside the actor, and can be handed back in as
+/// [`ContextAtomic::Held`] for a multi-call atomic batch. Centralizing it here
+/// is what lets the read/write-intent split (parallel reads) be introduced
+/// later without touching every call site.
+///
+/// Derefs to the locked [`ContextId`] so existing read sites keep working.
+#[derive(Debug)]
+pub struct ContextGuard(OwnedMutexGuard<ContextId>);
+
+impl ContextGuard {
+    /// Wrap an owned mutex guard. The guard keeps the per-context lock held for
+    /// the lifetime of this value.
+    #[must_use]
+    pub fn new(guard: OwnedMutexGuard<ContextId>) -> Self {
+        Self(guard)
+    }
+}
+
+impl Deref for ContextGuard {
+    type Target = ContextId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Debug)]
 pub enum ContextAtomic {
     Lock,
@@ -13,4 +46,4 @@ pub enum ContextAtomic {
 }
 
 #[derive(Debug)]
-pub struct ContextAtomicKey(pub OwnedMutexGuard<ContextId>);
+pub struct ContextAtomicKey(pub ContextGuard);

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -11,22 +11,23 @@ use calimero_context_config::types::ContextGroupId;
 use calimero_context_config::MemberCapabilities;
 use calimero_node_primitives::client::NodeClient;
 
+use calimero_context_client::ContextGuard;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextConfigParams, ContextId};
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_storage::delta::{CausalDelta, StorageDelta};
 use calimero_store::{key, types, Store};
+use either::Either;
 use eyre::{bail, OptionExt};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, error, warn};
 
 use super::execute::execute;
 use super::execute::storage::{ContextPrivateStorage, ContextStorage};
 use crate::handlers::execute::{persist_signed_signatures, sign_authorized_actions};
-use crate::{BoundedCache, ContextManager, ContextMeta};
+use crate::{BoundedCache, ContextLock, ContextManager, ContextMeta};
 use calimero_governance_store::governance_broadcast::ObserveDelivery;
 
 impl Handler<CreateContextRequest> for ContextManager {
@@ -81,11 +82,10 @@ impl Handler<CreateContextRequest> for ContextManager {
 
         let group_id_for_response = group_id;
 
-        let guard = context
-            .lock
-            .clone()
-            .try_lock_owned()
-            .expect("logically exclusive");
+        let guard = match context.lock() {
+            Either::Left(guard) => guard,
+            Either::Right(_) => unreachable!("logically exclusive"),
+        };
 
         let mut context_meta = context.meta.clone();
         context_meta.service_name = service_name;
@@ -280,7 +280,7 @@ impl Prepared<'_> {
 
         let context = entry.insert(ContextMeta {
             meta,
-            lock: Arc::new(Mutex::new(context_id)),
+            lock: ContextLock::new(context_id),
         });
 
         Ok(Self {
@@ -311,7 +311,7 @@ async fn create_context(
     identity_secret: PrivateKey,
     sender_key: PrivateKey,
     init_params: Vec<u8>,
-    guard: OwnedMutexGuard<ContextId>,
+    guard: ContextGuard,
     group_id: ContextGroupId,
     name: Option<String>,
 ) -> eyre::Result<Hash> {

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -13,7 +13,7 @@ use calimero_context_client::client::ContextClient;
 use calimero_context_client::messages::{
     ExecuteError, ExecuteEvent, ExecuteRequest, ExecuteResponse, MigrationParams,
 };
-use calimero_context_client::{ContextAtomic, ContextAtomicKey};
+use calimero_context_client::{ContextAtomic, ContextAtomicKey, ContextGuard};
 use calimero_context_config::types::{ContextGroupId, GovernancePosition};
 use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::alias::Alias;
@@ -40,7 +40,6 @@ use eyre::{bail, WrapErr};
 use futures_util::future::TryFutureExt;
 use futures_util::io::Cursor;
 use memchr::memmem;
-use tokio::sync::OwnedMutexGuard;
 use tracing::{debug, error, info, warn};
 
 use crate::error::ContextError;
@@ -541,16 +540,15 @@ impl Handler<ExecuteRequest> for ContextManager {
         });
 
         // Re-fetch context after possible lazy upgrade (application_id may have changed)
-        let context_task = context_task.map(
-            move |guard_result: eyre::Result<OwnedMutexGuard<ContextId>>, act, _ctx| {
+        let context_task =
+            context_task.map(move |guard_result: eyre::Result<ContextGuard>, act, _ctx| {
                 let guard = guard_result?;
                 let Some(context) = act.get_or_fetch_context(&context_id)? else {
                     bail!(ContextError::ContextDeleted { context_id });
                 };
 
                 Ok((guard, context.meta.clone()))
-            },
-        );
+            });
 
         let module_task = context_task.and_then(move |(guard, context), act, _ctx| {
             act.get_module(context.application_id, context.service_name.clone())
@@ -1310,7 +1308,7 @@ async fn internal_execute(
     node_client: &NodeClient,
     _context_client: &ContextClient,
     module: calimero_runtime::Module,
-    guard: &OwnedMutexGuard<ContextId>,
+    guard: &ContextGuard,
     context: &mut Context,
     executor: PublicKey,
     method: Cow<'static, str>,
@@ -1797,7 +1795,7 @@ async fn internal_execute(
 }
 
 pub async fn execute(
-    context: &OwnedMutexGuard<ContextId>,
+    context: &ContextGuard,
     module: calimero_runtime::Module,
     executor: PublicKey,
     method: Cow<'static, str>,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -14,6 +14,7 @@ use actix::prelude::{ActorResponse, WrapFuture};
 use actix::{Actor, AsyncContext};
 use calimero_context_client::client::ContextClient;
 use calimero_context_client::local_governance::SignedNamespaceOp;
+use calimero_context_client::ContextGuard;
 use calimero_context_config::types::ContextGroupId;
 use calimero_dag::DagStore;
 use calimero_node_primitives::client::NodeClient;
@@ -22,7 +23,7 @@ use calimero_primitives::context::{Context, ContextId};
 use calimero_store::Store;
 use either::Either;
 use prometheus_client::registry::Registry;
-use tokio::sync::{Mutex, OwnedMutexGuard};
+use tokio::sync::Mutex;
 
 use calimero_governance_store::metrics::Metrics;
 
@@ -223,36 +224,85 @@ impl ContextCacheStats {
     }
 }
 
+/// The per-context lock that serializes all operations on a single context.
+///
+/// This wraps the `Arc<Mutex<ContextId>>` so that the entire lifecycle of the
+/// lock — how it is acquired, the owned guard it hands out, and the
+/// reference-count rule that decides when its owning cache entry may be evicted
+/// — lives behind one type. Concentrating it here is the seam through which the
+/// idle/TTL eviction policy and the read/write-intent split (parallel reads)
+/// will later be introduced without disturbing every call site.
+#[derive(Clone, Debug)]
+struct ContextLock {
+    lock: Arc<Mutex<ContextId>>,
+}
+
+impl ContextLock {
+    /// Create a fresh per-context lock keyed by `id`.
+    fn new(id: ContextId) -> Self {
+        Self {
+            lock: Arc::new(Mutex::new(id)),
+        }
+    }
+
+    /// Acquire the lock for this context.
+    ///
+    /// This is a performance-optimized acquisition strategy. It first attempts
+    /// an optimistic, non-blocking `try_lock_owned()`, which is very fast when
+    /// the lock is uncontended.
+    ///
+    /// # Returns
+    ///
+    /// An `Either` containing one of two possibilities:
+    /// - `Either::Left(ContextGuard)`: the lock was acquired immediately.
+    /// - `Either::Right(impl Future)`: the lock was contended; the future
+    ///   resolves to a [`ContextGuard`] once it becomes available and must be
+    ///   awaited by the caller.
+    fn lock(&self) -> Either<ContextGuard, impl Future<Output = ContextGuard>> {
+        let Ok(guard) = self.lock.clone().try_lock_owned() else {
+            let lock = self.lock.clone();
+            return Either::Right(async move { ContextGuard::new(lock.lock_owned().await) });
+        };
+
+        Either::Left(ContextGuard::new(guard))
+    }
+
+    /// Whether the owning cache entry may be evicted: true only while no
+    /// operation is in flight against this context.
+    ///
+    /// The guard handed out by [`lock`](Self::lock) is an *owned* guard held
+    /// outside the actor across the entire WASM execution — it can even be
+    /// passed back in as `ContextAtomic::Held(..)`. An outstanding guard holds a
+    /// clone of the `Arc`, so a context with an in-flight operation always has
+    /// `Arc::strong_count >= 2`; an idle, evictable lock is exactly
+    /// `strong_count == 1` (only the cache holds it).
+    ///
+    /// If we evicted a *live* entry, the next `get_or_fetch_context` would mint
+    /// a brand-new `Arc<Mutex>` for that context, and two concurrent operations
+    /// would then serialize on *different* mutexes — breaking the invariant and
+    /// corrupting state. Hence this lock-gated check.
+    fn is_idle(&self) -> bool {
+        Arc::strong_count(&self.lock) == 1
+    }
+}
+
 /// A metadata container for a single, in-memory context.
 ///
-/// It holds the context's core properties and an asynchronous mutex (`lock`).
+/// It holds the context's core properties and a per-context [`ContextLock`].
 /// This lock is crucial for serializing operations on this specific context,
 /// allowing the `ContextManager` to process requests for different contexts in parallel
 /// while ensuring data consistency for any single context.
 #[derive(Debug)]
 struct ContextMeta {
     meta: Context,
-    lock: Arc<Mutex<ContextId>>,
+    lock: ContextLock,
 }
 
-/// A context is evictable only while no operation is in flight against it.
-///
-/// Each [`ContextMeta`] carries a per-context `lock: Arc<Mutex<ContextId>>`
-/// that serializes all operations on that context. The guard is handed out as
-/// an *owned* guard (`try_lock_owned`/`lock_owned`) and is held outside the
-/// actor across the entire WASM execution — it can even be passed back in as
-/// `ContextAtomic::Held(..)`. An outstanding guard therefore holds a clone of
-/// the `Arc`, so a context with an in-flight operation always has
-/// `Arc::strong_count(&lock) >= 2`; an idle, evictable entry is exactly
-/// `strong_count == 1` (only the cache holds it).
-///
-/// If we evicted a *live* entry, the next `get_or_fetch_context` would mint a
-/// brand-new `Arc<Mutex>` for that context, and two concurrent operations would
-/// then serialize on *different* mutexes — breaking the invariant and
-/// corrupting state. Hence the lock-gated `is_idle`.
+/// A context is evictable only while no operation is in flight against it; the
+/// lock-gated rule lives on [`ContextLock::is_idle`].
 impl Evictable for ContextMeta {
     fn is_idle(&self) -> bool {
-        Arc::strong_count(&self.lock) == 1
+        self.lock.is_idle()
     }
 }
 
@@ -607,25 +657,9 @@ impl Actor for ContextManager {
 // are in lifecycle.rs
 
 impl ContextMeta {
-    /// Acquires an asynchronous lock for this specific context.
-    ///
-    /// This is a performance-optimized lock acquisition strategy. It first attempts an
-    /// optimistic, non-blocking `try_lock_owned()`. This is very fast if the lock is not contended.
-    ///
-    /// # Returns
-    ///
-    /// An `Either` enum containing one of two possibilities:
-    /// - `Either::Left(OwnedMutexGuard)`: If the lock was acquired immediately without waiting.
-    /// - `Either::Right(impl Future)`: If the lock was contended. This future will resolve
-    ///    to an `OwnedMutexGuard` once the lock becomes available. The caller must `.await` this future.
-    fn lock(
-        &self,
-    ) -> Either<OwnedMutexGuard<ContextId>, impl Future<Output = OwnedMutexGuard<ContextId>>> {
-        let Ok(guard) = self.lock.clone().try_lock_owned() else {
-            return Either::Right(self.lock.clone().lock_owned());
-        };
-
-        Either::Left(guard)
+    /// Acquire this context's lock; see [`ContextLock::lock`].
+    fn lock(&self) -> Either<ContextGuard, impl Future<Output = ContextGuard>> {
+        self.lock.lock()
     }
 }
 
@@ -732,12 +766,11 @@ impl ContextManager {
             };
             self.record_cache_access(false);
 
-            let lock = Arc::new(Mutex::new(*context_id));
             let _ = self.contexts.insert_new(
                 *context_id,
                 ContextMeta {
                     meta: context,
-                    lock,
+                    lock: ContextLock::new(*context_id),
                 },
             );
         }
@@ -821,15 +854,18 @@ mod cache_eviction_tests {
     fn idle_meta(id: ContextId) -> ContextMeta {
         ContextMeta {
             meta: Context::new(id, ApplicationId::from([0u8; 32]), Hash::default()),
-            lock: Arc::new(Mutex::new(id)),
+            lock: ContextLock::new(id),
         }
     }
 
     /// An entry with an outstanding owned guard → `strong_count == 2` (live,
     /// MUST NOT be evicted). The returned guard must be kept alive by the test.
-    fn live_meta(id: ContextId) -> (ContextMeta, OwnedMutexGuard<ContextId>) {
-        let lock = Arc::new(Mutex::new(id));
-        let guard = lock.clone().try_lock_owned().expect("fresh lock is free");
+    fn live_meta(id: ContextId) -> (ContextMeta, ContextGuard) {
+        let lock = ContextLock::new(id);
+        let guard = match lock.lock() {
+            Either::Left(guard) => guard,
+            Either::Right(_) => unreachable!("fresh lock is free"),
+        };
         let meta = ContextMeta {
             meta: Context::new(id, ApplicationId::from([0u8; 32]), Hash::default()),
             lock,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -281,6 +281,14 @@ impl ContextLock {
     /// a brand-new `Arc<Mutex>` for that context, and two concurrent operations
     /// would then serialize on *different* mutexes — breaking the invariant and
     /// corrupting state. Hence this lock-gated check.
+    ///
+    /// `strong_count` is racy in isolation, but the check is safe here because
+    /// the only consumer — `BoundedCache::evict_if_full` — runs it and the
+    /// subsequent `remove` synchronously (no `.await` between them) inside a
+    /// single `ContextManager` actor turn. New guards are only ever minted by
+    /// `lock()` on that same actor, so no acquisition can interleave between
+    /// this returning `true` and the eviction: an entry seen idle stays idle
+    /// until the eviction completes.
     fn is_idle(&self) -> bool {
         Arc::strong_count(&self.lock) == 1
     }


### PR DESCRIPTION
## What

First step of the per-context-guard epic #2022 (the second half of #2023, whose first half shipped as #2606). Pure refactor — concentrates the per-context lock's lifecycle behind two named types instead of a raw `Arc<Mutex<ContextId>>` threaded through the manager and the execute path. **No behavior change.**

## Why

`#2606` decides cache-eviction safety from `Arc::strong_count(&self.lock) == 1`, and the upcoming RwLock work (#2685) multiplies the number of concurrent holders of that same `Arc`. Both reason about the same lock from opposite ends, today via a raw type with no single place to change. Naming it is the prerequisite that makes intent-aware/TTL eviction (#2683) and the read/write split (#2685) tractable without two features racing on a raw `Arc`.

## Changes

- **`ContextGuard`** (`crates/context/primitives`) — newtype over `OwnedMutexGuard<ContextId>` with `Deref<Target = ContextId>`. `ContextAtomicKey` now wraps it, so "holding a context" lives behind one type. This is the seam where #2685 turns it into a read-or-write variant.
- **`ContextLock`** (`crates/context`) — wraps `Arc<Mutex<ContextId>>` and owns `lock()` (try-fast-then-await acquisition) and `is_idle()` (the `strong_count == 1` eviction rule, with its load-bearing doc comment moved onto it). The single file #2683 and #2685 will touch.
- `ContextMeta.lock` becomes a `ContextLock`; `Evictable` delegates to `is_idle()`. The execute path, `create_context`, and the acquire-context-lock handler flow `ContextGuard`; node-side holders are transparent (they only carry the opaque `ContextAtomicKey`).

## Verification

- Builds: `calimero-context-client`, `calimero-context`, `calimero-node`
- `cargo fmt --check` clean
- clippy: 33 → 32 warnings (removed one, zero new — confirmed via stash-diff against baseline)
- Tests: 82 unit + all integration binaries green, 0 failures — including the eviction tests (`evicts_one_idle_entry_at_cap`, `never_evicts_a_live_entry`, `no_eviction_when_all_entries_live`) that prove a held guard still yields `strong_count == 2`

## Scope guards

- No `Mutex`→`RwLock` (that's #2685), no TTL (#2683), no ABI/method-intent (#2684).
- The namespace-DAG lock (`Arc<Mutex<DagStore>>`) has the same `strong_count` pattern but is a different lock — left untouched; future unification candidate.

Part of #2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical type extraction with existing eviction tests unchanged; no auth, persistence, or lock-semantics changes beyond naming and module boundaries.
> 
> **Overview**
> This PR **refactors** how per-context serialization is represented—**no intended runtime behavior change**.
> 
> **`ContextGuard`** (in `calimero-context` primitives) wraps `OwnedMutexGuard<ContextId>` and derefs to `ContextId`, so “holding a context” is one type through WASM execution and `ContextAtomic::Held`. **`ContextAtomicKey`** now carries `ContextGuard` instead of the raw guard.
> 
> **`ContextLock`** (in `calimero-context`) owns the `Arc<Mutex<ContextId>>`, **`lock()`** (fast `try_lock_owned` then async `lock_owned`), and **`is_idle()`** (`Arc::strong_count == 1` for cache eviction). `ContextMeta` stores `ContextLock` instead of a bare `Arc<Mutex<…>>`; `Evictable` delegates to `is_idle()`.
> 
> Create, execute, and cache paths thread **`ContextGuard`**; tests and eviction wiring are updated to match. This sets up later work (read/write split, TTL eviction) without changing mutex semantics today.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0127398adbe47b1fbc575330159279338b30133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->