### PR TITLE
fix(storage): causal, order-invariant local writer-set gate (#2673)

### DIFF
--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -368,21 +368,23 @@ where
     /// The current writer set, resolved only from **verified** local sources.
     ///
     /// Resolution order:
-    /// 1. **Rotation log** (`rotation_log::load`). On a node that *received*
-    ///    rotations, the apply path appends every signature-verified rotation
-    ///    here, so the latest entry is the authoritative, verified writer set.
-    ///    (The full causal `writers_at(parents)` resolution is the node-side
-    ///    apply-time check; with no DAG context during local execution the
-    ///    most-recently-appended entry is the right local answer.)
+    /// 1. **Rotation log** (`rotation_log::load`), resolved via
+    ///    [`rotation_log::resolve_local`]. On a node that *received* rotations,
+    ///    the apply path appends every signature-verified rotation here.
+    ///    `resolve_local` picks the live entry that is **max by
+    ///    `(delta_hlc, signer)`** (falling back to the compaction snapshot when
+    ///    there are no live entries).
     ///
-    ///    Note this local gate is **best-effort under concurrent rotations**:
-    ///    "most-recently-appended" is this node's insertion order, which can
-    ///    differ from causal order if concurrent rotations arrive interleaved.
-    ///    A local `insert`/`rotate_writers` may then accept/reject against a set
-    ///    the merge-time verifier (which uses the proper causal `writers_at`)
-    ///    would resolve differently. The merge check is the security boundary;
-    ///    full local causal resolution is deferred to the concurrent-rotation
-    ///    work (P4).
+    ///    This is the local-execution gate (core#2673). It has no DAG context,
+    ///    so it cannot run the full causal `writers_at(parents)` the merge-time
+    ///    verifier uses — but because the HLC is causally monotonic since #2635
+    ///    (a rotation made after applying another carries a greater HLC), the
+    ///    `(delta_hlc, signer)` max coincides with the causal latest for any
+    ///    well-formed log, and — unlike the old `entries.last()` — it is
+    ///    **insertion-order invariant**, so two nodes that applied the same
+    ///    concurrent rotations gate against the *same* set. The merge check
+    ///    (`writers_at`) remains the security boundary for the pathological
+    ///    HLC-skew case; this gate is never weaker than `entries.last()` was.
     /// 2. **Index `storage_type`** — written by `add_child_to` at construction,
     ///    by `apply_action` for a received bootstrap/write, and by
     ///    [`Index::set_storage_type`] on the *originating* node's own rotation
@@ -398,11 +400,8 @@ where
     /// than trust unverified bytes.
     fn current_writers(&self) -> BTreeSet<PublicKey> {
         if let Ok(Some(log)) = rotation_log::load::<S>(self.inner.id()) {
-            if let Some(entry) = log.entries.last() {
-                return entry.new_writers.clone();
-            }
-            if let Some(snapshot) = log.snapshot {
-                return snapshot.writers;
+            if let Some(writers) = rotation_log::resolve_local(&log) {
+                return writers;
             }
         }
         if let Ok(Some(metadata)) = <Index<S>>::get_metadata(self.inner.id()) {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -223,13 +223,17 @@ impl<S: StorageAdaptor> Interface<S> {
     /// `writers_at(anchor_log, delta.parents)`, passed in via
     /// `effective_writers`.
     ///
-    /// The rotation log's *latest* entry is this node's insertion order, which
-    /// can differ from causal order under concurrent rotations — so this
-    /// fallback is **not** causally exact. It is therefore reserved for the
+    /// Resolution uses [`rotation_log::resolve_local`](crate::rotation_log::resolve_local):
+    /// the live entry that is max by `(delta_hlc, signer)`, or the compaction
+    /// snapshot when there are no live entries. This is **not** a full causal
+    /// cut (it has no `happens_before`), so it is reserved for the
     /// **local-execution / settled-state** gate, where "current writers" is the
-    /// right answer (a local writer acts under the current set). The
-    /// **merge-path** security boundary is the causal `writers_at(anchor_log,
-    /// delta.parents)` set passed as `effective_writers`.
+    /// right answer. The **merge-path** security boundary is the causal
+    /// `writers_at(anchor_log, delta.parents)` set passed as `effective_writers`.
+    /// Because the HLC is causally monotonic since #2635, the `(delta_hlc,
+    /// signer)` max coincides with the causal latest for a well-formed log, and
+    /// — unlike the prior `entries.last()` — it is insertion-order invariant, so
+    /// it converges across nodes under concurrent rotations (core#2673).
     ///
     /// As of the DAG-causal rotation completion (P4), every node records the
     /// genesis writer set **and its own rotations** in the log (the originator
@@ -243,11 +247,8 @@ impl<S: StorageAdaptor> Interface<S> {
     /// state reset).
     fn resolve_anchor_writers(anchor: Id) -> BTreeSet<PublicKey> {
         if let Ok(Some(log)) = crate::rotation_log::load::<S>(anchor) {
-            if let Some(entry) = log.entries.last() {
-                return entry.new_writers.clone();
-            }
-            if let Some(snapshot) = log.snapshot {
-                return snapshot.writers;
+            if let Some(writers) = crate::rotation_log::resolve_local(&log) {
+                return writers;
             }
         }
         if let Ok(Some(metadata)) = <Index<S>>::get_metadata(anchor) {

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -206,6 +206,58 @@ pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), 
     save::<S>(id, &log)
 }
 
+/// Resolve the writer set for the **local-execution gate** — the set
+/// `SharedStorage` checks in `insert` / `rotate_writers` *before* the action
+/// syncs (and the settled-state fallback in `Interface::resolve_anchor_writers`).
+///
+/// Unlike the merge-time resolver (`rotation_log_reader::writers_at` in the
+/// node crate), this has **no DAG and no `happens_before`**: it runs inside the
+/// WASM guest, which can read the rotation log but not the context DAG. Instead
+/// it leans on an invariant the HLC already provides. After the HLC
+/// receive-rule fix (#2635) the hybrid clock is **causally monotonic** — a
+/// rotation created after applying another always carries a strictly greater
+/// `delta_hlc`. So ADR-0001's ordering ("causal precedence, then HLC, then
+/// signer") collapses, for a well-formed log, to just **max by
+/// `(delta_hlc, signer)`** over the live entries, computable from the log alone.
+///
+/// Two properties this buys over the old `entries.last()` gate (core#2673):
+/// - **Insertion-order invariant.** `max_by` over the entry *set* is
+///   independent of the order this node happened to append them, so two nodes
+///   that applied the same concurrent rotations resolve the *same* writer set
+///   locally — the convergence the insertion-order gate lacked.
+/// - **Matches the merge verifier** for any log whose HLCs respect causality
+///   (the normal case post-#2635). If a pathological log violates HLC
+///   monotonicity (pre-#2635 data, or a clock pushed backwards) this may pick a
+///   different winner than the causal `writers_at`, but that only loosens the
+///   *local* gate; the merge path stays the security boundary and still rejects
+///   anything genuinely unauthorized. It is never weaker than `entries.last()`.
+///
+/// Returns `None` only when the log has neither entries nor a compaction
+/// snapshot.
+#[must_use]
+pub fn resolve_local(log: &RotationLog) -> Option<BTreeSet<PublicKey>> {
+    if let Some(entry) = log.entries.iter().max_by(|a, b| {
+        // HLC first (causally monotonic post-#2635), then signer as the
+        // ADR-0001 tiebreak: smaller signer bytes win, `None` (unsigned legacy)
+        // treated as larger so it loses ties. This mirrors the `(delta_hlc,
+        // signer)` tail of `rotation_log_reader::writers_at`, minus the
+        // `happens_before` steps the guest can't evaluate.
+        match a.delta_hlc.cmp(&b.delta_hlc) {
+            core::cmp::Ordering::Equal => {}
+            non_eq => return non_eq,
+        }
+        match (&a.signer, &b.signer) {
+            (Some(sa), Some(sb)) => sb.digest().cmp(sa.digest()),
+            (Some(_), None) => core::cmp::Ordering::Greater,
+            (None, Some(_)) => core::cmp::Ordering::Less,
+            (None, None) => core::cmp::Ordering::Equal,
+        }
+    }) {
+        return Some(entry.new_writers.clone());
+    }
+    log.snapshot.as_ref().map(|s| s.writers.clone())
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -296,5 +348,94 @@ mod tests {
         // The original entry stays put; nothing was overwritten.
         let log = load::<Store>(id).unwrap().unwrap();
         assert_eq!(log.entries, vec![e1]);
+    }
+
+    // ---- resolve_local: the DAG-free local-execution gate (core#2673) ----
+
+    fn log_of(entries: Vec<RotationLogEntry>) -> RotationLog {
+        RotationLog {
+            snapshot: None,
+            entries,
+        }
+    }
+
+    #[test]
+    fn resolve_local_none_when_empty() {
+        assert_eq!(resolve_local(&RotationLog::empty()), None);
+    }
+
+    #[test]
+    fn resolve_local_picks_max_hlc() {
+        // Sequential rotations: the later (greater-HLC) one wins, regardless of
+        // vector position.
+        let log = log_of(vec![
+            entry(2, 200, 0xBB, &[0xAA, 0xBB], 2),
+            entry(1, 100, 0xAA, &[0xAA], 1),
+        ]);
+        assert_eq!(
+            resolve_local(&log),
+            Some([0xAA, 0xBB].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn resolve_local_is_insertion_order_invariant() {
+        // The core#2673 property: two nodes append the same two concurrent
+        // rotations in opposite orders and must resolve the SAME writer set
+        // (the old `entries.last()` gate returned different sets per node).
+        let r1 = entry(1, 20, 0xAA, &[0xAA, 0xCC], 1); // {A, C}
+        let r2 = entry(2, 21, 0xBB, &[0xBB, 0xCC], 1); // {B, C}, larger HLC
+
+        let node1 = log_of(vec![r1.clone(), r2.clone()]); // self-logged R1, then got R2
+        let node2 = log_of(vec![r2, r1]); // self-logged R2, then got R1
+
+        assert_eq!(resolve_local(&node1), resolve_local(&node2));
+        // ...and it is the HLC winner R2 = {B, C}.
+        assert_eq!(
+            resolve_local(&node1),
+            Some([0xBB, 0xCC].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn resolve_local_hlc_tie_broken_by_signer() {
+        // Equal HLC (same time + same node ID) → smaller signer bytes win,
+        // matching `rotation_log_reader::writers_at`.
+        let identical = |delta_id: u8, signer: u8, writers: &[u8]| {
+            use core::num::NonZeroU128;
+
+            use crate::logical_clock::{Timestamp, ID, NTP64};
+            let ts = Timestamp::new(NTP64(50), ID::from(NonZeroU128::new(1).unwrap()));
+            RotationLogEntry {
+                delta_id: [delta_id; 32],
+                delta_hlc: HybridTimestamp::new(ts),
+                signer: Some(pk(signer)),
+                new_writers: writers.iter().copied().map(pk).collect(),
+                writers_nonce: 1,
+            }
+        };
+        let log = log_of(vec![
+            identical(1, 0xAA, &[0xAA, 0xCC]),
+            identical(2, 0xBB, &[0xBB, 0xDD]),
+        ]);
+        // 0xAA < 0xBB → {A, C} wins; order-independent.
+        assert_eq!(
+            resolve_local(&log),
+            Some([0xAA, 0xCC].into_iter().map(pk).collect())
+        );
+    }
+
+    #[test]
+    fn resolve_local_falls_back_to_snapshot() {
+        // Compacted log with no live entries → the snapshot's writer set.
+        let snap: BTreeSet<PublicKey> = [0xEE].into_iter().map(pk).collect();
+        let log = RotationLog {
+            snapshot: Some(RotationSnapshot {
+                writers: snap.clone(),
+                cutoff_index: 3,
+            }),
+            entries: Vec::new(),
+        };
+        assert_eq!(resolve_local(&log), Some(snap));
     }
 }


### PR DESCRIPTION
Closes #2673.

## What

The `SharedStorage` **local-execution gate** — the writer set checked by `insert`/`rotate_writers` *before* an action syncs (`current_writers`), and the settled-state fallback `Interface::resolve_anchor_writers` — resolved from the rotation log's most-recently-**appended** entry (`entries.last()`). That's this node's *insertion order*, not causal order, so under concurrent rotations two nodes gated against *different* sets. A local liveness/UX wrinkle (the merge verifier was always the security boundary); #2230 carved it out as P4.

This makes the local gate causal and **insertion-order invariant**.

## How — and why it needs no DAG plumbing

A full causal `writers_at(parents)` isn't reachable at local execution: `current_writers` runs inside the **WASM guest**, which can read the rotation log but not the context DAG. Plumbing a DAG `happens_before` down to the guest would mean a new host function across the SDK/runtime ABI — far too invasive for a local gate.

It isn't needed. Since the **HLC receive-rule fix (#2635)** the hybrid clock is causally monotonic: a rotation made after applying another carries a strictly greater `delta_hlc`. So ADR-0001's "causal precedence, then HLC, then signer" collapses, for a well-formed log, to just **max by `(delta_hlc, signer)`** over the live entries — computable from the log alone.

New `rotation_log::resolve_local` does exactly that (snapshot fallback when there are no live entries); both gate sites call it.

## Properties

- **Insertion-order invariant** — `max_by` over the entry *set* is independent of append order, so two nodes that applied the same concurrent rotations now gate against the **same** set. (This is precisely what the #2671 e2e had to work around with a "settling rotation"; that workaround is now belt-and-suspenders rather than necessary.)
- **Matches the merge verifier** for any HLC-monotonic log (the normal case post-#2635). A pathological HLC-skew log can only *loosen* the local gate, never the merge boundary — and it's never weaker than `entries.last()` was.
- **No security change**: the merge path (`writers_at` with a real `happens_before`) is untouched; `resolve_local` is only the local/settled-state gate. No ABI, runtime, or context changes — confined to the storage crate.

## Scope checklist (from the issue)

- ✅ writers_at-equivalent local semantics (via HLC monotonicity, no DAG).
- ✅ Disagreement behavior: optimistic — local resolves deterministically; merge stays the boundary (documented).
- ✅ Migration: none — same log is read; pre-#2635 / snapshot-only logs fall into the optimistic case / snapshot fallback (documented).
- ✅ e2e: the cross-node concurrent-rotation convergence e2e already exists (#2671); the new order-invariance unit tests are the deterministic counterpart.

## Tests

5 new `resolve_local` unit tests (order-invariance, max-HLC, signer tiebreak, snapshot fallback, empty); full storage suite 571 green; node compiles; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which writer set gates local SharedStorage writes and member verification fallbacks; merge-path `writers_at` is untouched, but incorrect edge cases could affect who can act before sync.
> 
> **Overview**
> Fixes **#2673** by changing how the **local-execution writer set** is derived from a `SharedStorage` rotation log. **`SharedStorage::current_writers`** and **`Interface::resolve_anchor_writers`** no longer use the last **appended** log entry (`entries.last()`); they call new **`rotation_log::resolve_local`**, which picks the live entry with the greatest **`(delta_hlc, signer)`** (ADR-0001 tiebreak, no DAG), or the compaction **snapshot** when there are no live entries.
> 
> That makes the pre-sync gate **insertion-order invariant**: nodes that applied the same concurrent rotations in different orders now agree on which writers to check for **`insert`** / **`rotate_writers`** and for **`SharedMember`** settled-state resolution. Merge-time **`writers_at`** / **`effective_writers`** are unchanged; this is a local liveness/consistency fix, not a new security boundary.
> 
> Five unit tests cover empty log, max-HLC, order invariance, signer tiebreak, and snapshot fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169efe280c948eae8fcde04662741255f9959e90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->