### PR TITLE
fix(storage): use child's own ancestors when adding local-only child in compare_trees

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2052,7 +2052,16 @@ impl<S: StorageAdaptor> Interface<S> {
                                 actions.1.push(Action::Add {
                                     id: *child_id,
                                     data: local_child,
-                                    ancestors: <Index<S>>::get_ancestors_of(id)?,
+                                    // Ancestors of the entity being added (the
+                                    // child), not its parent `id` — apply
+                                    // rebuilds the path down to `*child_id` and
+                                    // links it under `ancestors[0]` (its
+                                    // immediate parent). Using `id` here dropped
+                                    // the immediate parent from the chain,
+                                    // orphaning the child on the receiver (the
+                                    // "collection entirely missing" arm below
+                                    // already does this correctly).
+                                    ancestors: <Index<S>>::get_ancestors_of(*child_id)?,
                                     metadata,
                                 });
                             }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -509,6 +509,26 @@ mod interface__comparison {
             ]
         );
         local_para2.element_mut().is_dirty = true;
+        // Para2 is a local-only child within a collection both sides share, so
+        // it takes the "child missing from foreign" arm. Its Add must carry
+        // para2's *own* ancestor chain — i.e. its immediate parent, the page —
+        // exactly like the "collection entirely missing" arm does for para3
+        // below. Regression guard: this previously asserted `ancestors: vec![]`,
+        // which only held because the parent is the root page (whose ancestors
+        // are empty); the action was being built from the parent's ancestors
+        // instead of the child's, orphaning para2 on the receiver.
+        let local_para2_ancestor_hash = {
+            let Action::Add { ancestors, .. } = foreign_actions[1].clone() else {
+                panic!("Expected para2 to be added to foreign");
+            };
+            assert_eq!(ancestors.len(), 1, "para2 must carry exactly its parent");
+            assert_eq!(
+                ancestors[0].id(),
+                local_page.id(),
+                "para2's ancestor must be its immediate parent (the page)"
+            );
+            ancestors[0].merkle_hash()
+        };
         assert_eq!(
             foreign_actions,
             vec![
@@ -516,11 +536,15 @@ mod interface__comparison {
                 Action::Compare {
                     id: local_para1.id()
                 },
-                // Para2 needs to be added to foreign
+                // Para2 needs to be added to foreign, under its parent page
                 Action::Add {
                     id: local_para2.id(),
                     data: to_vec(&local_para2).unwrap(),
-                    ancestors: vec![],
+                    ancestors: vec![ChildInfo::new(
+                        local_page.id(),
+                        local_para2_ancestor_hash,
+                        local_page.element().metadata.clone(),
+                    )],
                     metadata: local_para2.element().metadata.clone(),
                 },
                 // Para3 needs to be added locally, but we don't have the data, so we compare

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -517,6 +517,12 @@ mod interface__comparison {
         // which only held because the parent is the root page (whose ancestors
         // are empty); the action was being built from the parent's ancestors
         // instead of the child's, orphaning para2 on the receiver.
+        // Expected ancestor hash, derived independently of the action under
+        // test: the page's own full Merkle hash, which is what
+        // `get_ancestors_of` records for the parent entry.
+        let expected_page_hash = MainInterface::generate_comparison_data(Some(local_page.id()))
+            .unwrap()
+            .full_hash;
         let local_para2_ancestor_hash = {
             let Action::Add { ancestors, .. } = foreign_actions[1].clone() else {
                 panic!("Expected para2 to be added to foreign");
@@ -526,6 +532,11 @@ mod interface__comparison {
                 ancestors[0].id(),
                 local_page.id(),
                 "para2's ancestor must be its immediate parent (the page)"
+            );
+            assert_eq!(
+                ancestors[0].merkle_hash(),
+                expected_page_hash,
+                "para2's ancestor hash must be the page's full Merkle hash"
             );
             ancestors[0].merkle_hash()
         };


### PR DESCRIPTION
## Problem

`compare_trees` (hash-comparison / state-based sync) has two arms that add a **local-only child** to the remote side. They build the *same* `Action::Add` but disagree on the `ancestors` field:

| Arm | Code | Correct? |
|---|---|---|
| Collection entirely missing from foreign | `get_ancestors_of(child.id())` | ✅ |
| Child missing from a collection both sides share | `get_ancestors_of(id)` ← the **parent** | ❌ |

The apply path (`interface.rs`, `Action::Add`/`Update` handling) walks `ancestors` in reverse to rebuild the path down to the added entity, then links it under `ancestors[0]` — its **immediate parent**. Passing the *parent's* ancestor chain drops the immediate parent, so the receiver:

- links the child to its **grandparent**, or
- **orphans** it entirely when the parent is a root,

…producing exactly the tree-shape divergence this function exists to reconcile.

## Why it wasn't caught

`compare_trees__with_collections` asserted `ancestors: vec![]` for the local-only child. That vec is empty **only because the test's parent is a root node** (`get_ancestors_of(root) == []`) — the assertion was encoding the buggy output. The bug fully manifests for any non-root parent (3+ level trees).

## Fix

- Use `get_ancestors_of(*child_id)` in the offending arm (matches the sibling arm).
- Correct the test to require the parent ancestor, with `len == 1` / `id == page` guards so it can't silently regress.

I audited all 5 `get_ancestors_of` call sites; the other 4 correctly target their own entity. This arm was the only offender.

## Validation

Reproduced by applying the one-line fix and watching `compare_trees__with_collections` fail at exactly the para2 ancestors assertion (`[]` → `[page]`), then corrected the assertion.

- storage lib: **571 passed**
- storage integration: **11 passed**
- node `sync_sim` (convergence, partitions, snapshots): **308 passed**
- node `dag_storage_integration`: **14 passed**
- node `concurrent_branches_root_hash`: **2 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes state-based sync tree repair logic; incorrect ancestor chains break convergence, but the fix is a one-line alignment with an existing correct code path and is covered by expanded unit tests.
> 
> **Overview**
> **Hash-comparison sync** (`compare_trees`) now builds `Action::Add` for a **local-only child** in a shared collection using **`get_ancestors_of(*child_id)`** instead of **`get_ancestors_of(id)`** (the parent). Apply walks `ancestors` to rebuild the path and attach under the immediate parent; the old call omitted that parent and could **orphan** the child on the receiver.
> 
> The **“collection entirely missing”** arm already used the child’s ancestors; this change makes the **“child missing from foreign map”** arm consistent.
> 
> **`compare_trees__with_collections`** now expects **para2**’s add to include a single ancestor (**the page**) with the correct id and Merkle hash, so the test no longer passes when `ancestors` is empty only because the parent is root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d93c2832cd54afc674c040973fe21611b3ab01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->