### PR TITLE
fix(storage): stop the benign LWW-fallback merge log reading as corruption (#2626)

### DIFF
--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -251,20 +251,21 @@ pub fn merge_root_state(
         }
         registry::MergeRegistryResult::AllFunctionsFailed => {
             // Merge functions are registered, but none could deserialize+merge
-            // these bytes. Dispatch is type-blind (no per-entity type hint yet,
-            // #1993), so two cases land here indistinguishably:
+            // these bytes. Dispatch is type-blind — there is no per-entity type
+            // hint to select a merger by, so every registered fn is tried and
+            // this arm is reached whenever none deserializes the bytes. Two
+            // cases land here indistinguishably:
             //   * EXPECTED (common): this entity's type simply has no custom
             //     CRDT merge, so plain LWW is the correct resolution — e.g. a
             //     routine `set`, or a root "shell" whose real data lives in
             //     child entities that merge on their own paths.
             //   * RARE: a custom-merge type's bytes are a genuine
             //     mismatch/corruption.
-            // This used to log a WARN reading "type mismatch or corrupt data",
-            // which made every routine write look like data loss and once sent
-            // a split-brain investigation down a false path (#2626). The benign
-            // case dominates, and a real corruption also surfaces downstream
-            // (hash divergence) and via the loud I5 `NoMergeFunctionRegistered`
-            // path above — so log at DEBUG with accurate wording instead.
+            // Log at DEBUG, not WARN: the benign case dominates (a WARN reading
+            // "type mismatch or corrupt data" here made every routine write look
+            // like data loss), and a real corruption still surfaces downstream
+            // as hash divergence and via the loud `NoMergeFunctionRegistered`
+            // error path above (which fires when NO merger is registered).
             tracing::debug!(
                 target: "calimero_storage::merge",
                 existing_ts,
@@ -670,5 +671,47 @@ mod typed_dispatch_tests {
             "expected SerializationError, got {:?}",
             result
         );
+    }
+
+    #[test]
+    #[serial]
+    fn merge_root_state_all_functions_failed_falls_back_to_lww() {
+        // The type-blind `merge_root_state` path (vs the typed one above): a
+        // merger IS registered, but the bytes don't deserialize as its type, so
+        // the registry returns `AllFunctionsFailed` and we resolve by LWW. This
+        // pins that fallback after the log-level change — it is the branch a
+        // routine `set` exercises in production.
+        env::reset_for_testing();
+        clear_merge_registry();
+        register_crdt_merge::<DispatchTestApp>();
+
+        // Neither side deserializes as DispatchTestApp (a 0xFFFFFFFF borsh
+        // length prefix overruns), so the one registered fn fails on both.
+        let existing = vec![0xff, 0xff, 0xff, 0xff];
+        let incoming = vec![0x01, 0x02, 0x03, 0x04];
+
+        // Non-bootstrap timestamps (created_at != existing_ts) so the
+        // accept-incoming fast-path is skipped and we reach the LWW fallback.
+        let newer_incoming = merge_root_state(
+            &existing, &incoming, /* created_at */ 50, /* existing_ts */ 100,
+            /* incoming_ts */ 200,
+        )
+        .expect("LWW fallback returns Ok");
+        assert_eq!(
+            newer_incoming, incoming,
+            "incoming_ts >= existing_ts → incoming wins"
+        );
+
+        let older_incoming = merge_root_state(
+            &existing, &incoming, /* created_at */ 50, /* existing_ts */ 200,
+            /* incoming_ts */ 100,
+        )
+        .expect("LWW fallback returns Ok");
+        assert_eq!(
+            older_incoming, existing,
+            "incoming_ts < existing_ts → existing wins"
+        );
+
+        clear_merge_registry();
     }
 }

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -250,19 +250,27 @@ pub fn merge_root_state(
             Err(MergeError::NoMergeFunctionRegistered)
         }
         registry::MergeRegistryResult::AllFunctionsFailed => {
-            // Merge functions are registered but none could merge the data.
-            // This typically happens when:
-            // - The data type doesn't match any registered type (test contamination)
-            // - Deserialization failed (corrupt data)
-            //
-            // Fall back to LWW to maintain backwards compatibility.
-            // The incoming value wins if timestamps are equal or incoming is newer.
-            //
-            // Per Delivery Contract Rule: any drop MUST be observable.
-            tracing::warn!(
+            // Merge functions are registered, but none could deserialize+merge
+            // these bytes. Dispatch is type-blind (no per-entity type hint yet,
+            // #1993), so two cases land here indistinguishably:
+            //   * EXPECTED (common): this entity's type simply has no custom
+            //     CRDT merge, so plain LWW is the correct resolution — e.g. a
+            //     routine `set`, or a root "shell" whose real data lives in
+            //     child entities that merge on their own paths.
+            //   * RARE: a custom-merge type's bytes are a genuine
+            //     mismatch/corruption.
+            // This used to log a WARN reading "type mismatch or corrupt data",
+            // which made every routine write look like data loss and once sent
+            // a split-brain investigation down a false path (#2626). The benign
+            // case dominates, and a real corruption also surfaces downstream
+            // (hash divergence) and via the loud I5 `NoMergeFunctionRegistered`
+            // path above — so log at DEBUG with accurate wording instead.
+            tracing::debug!(
                 target: "calimero_storage::merge",
-                "All registered merge functions failed, falling back to LWW. \
-                 This may indicate type mismatch or corrupt data."
+                existing_ts,
+                incoming_ts,
+                "no registered merge function matched this entity; resolving by \
+                 LWW (expected when the type has no custom CRDT merge)"
             );
             if incoming_ts >= existing_ts {
                 Ok(incoming.to_vec())


### PR DESCRIPTION
Closes #2626.

## Problem

`merge_root_state` logged, on routine writes (e.g. a plain `set`):

```
WARN calimero_storage::merge: All registered merge functions failed, falling back to LWW. This may indicate type mismatch or corrupt data.
```

even though the entity merges correctly right after. The message reads like data corruption but is benign in the common case — and during the `group-subgroup` split-brain investigation it sent the analysis down a false path before the real cause (a never-drained cross-DAG governance buffer) was found.

## Why it fires on normal writes

Merge dispatch is **type-blind** (no per-entity type hint yet — #1993): `try_merge_registered` tries every registered merge fn and returns `AllFunctionsFailed` whenever none can deserialize the bytes. That's the **normal** outcome for any entity whose type has no custom CRDT merge (a routine value write, or a root "shell" whose real data lives in child entities that merge on their own paths). The branch genuinely can't distinguish that benign case from a rare real corruption.

## Fix

Downgrade the line to **DEBUG** with accurate wording:

```
DEBUG calimero_storage::merge: no registered merge function matched this entity; resolving by LWW (expected when the type has no custom CRDT merge)
```

This is safe to quiet because genuine problems stay loud:
- a truly **un**registered root merger hits the I5 `NoMergeFunctionRegistered` **hard error** path (unchanged),
- built-in CRDT merge failures on non-root entities keep their richer `WARN` (id + crdt_type + error, `interface.rs`),
- real corruption also surfaces downstream as hash divergence.

Pure observability change — merge behaviour is untouched. Build + fmt clean; 87 merge unit tests green. Nothing asserted the old text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and test coverage only; root merge and LWW fallback behavior are unchanged.
> 
> **Overview**
> When `merge_root_state` hits **`AllFunctionsFailed`** (registered mergers exist but none deserialize the entity bytes), it still **falls back to LWW by timestamp** — unchanged behavior.
> 
> **Observability only:** the log moves from **`WARN`** (“type mismatch or corrupt data”) to **`DEBUG`** with wording that this is **expected** for entities without a custom CRDT merge (type-blind registry dispatch). Inline comments document why benign routine writes hit this branch.
> 
> A new unit test **`merge_root_state_all_functions_failed_falls_back_to_lww`** locks in LWW winner selection (`incoming_ts` vs `existing_ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea880b6a141b27fd228d73ce375a419fa4746f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->