### PR TITLE
perf(context): RwLock per-context lock, default-to-write (no behavior change)

### DIFF
--- a/crates/context/primitives/src/lib.rs
+++ b/crates/context/primitives/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use calimero_primitives::context::ContextId;
-use tokio::sync::OwnedMutexGuard;
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard};
 
 pub mod client;
 pub mod group;
@@ -10,24 +10,42 @@ pub mod messages;
 
 /// An owned, per-context lock guard held across a context operation.
 ///
-/// This is a newtype over `OwnedMutexGuard<ContextId>` rather than the raw
-/// guard so that the single notion of "holding a context" lives behind one
-/// type: the guard is acquired in the manager, threaded through the entire
-/// WASM execution outside the actor, and can be handed back in as
-/// [`ContextAtomic::Held`] for a multi-call atomic batch. Centralizing it here
-/// is what lets the read/write-intent split (parallel reads) be introduced
-/// later without touching every call site.
+/// The per-context lock is an `RwLock`, so a held guard is either an exclusive
+/// *write* guard or a shared *read* guard. Keeping the single notion of
+/// "holding a context" behind this one type — acquired in the manager, threaded
+/// through the entire WASM execution outside the actor, and handed back in as
+/// [`ContextAtomic::Held`] for a multi-call atomic batch — is what lets the
+/// read/write-intent split (parallel reads) be introduced without touching
+/// every call site.
 ///
-/// Derefs to the locked [`ContextId`] so existing read sites keep working.
+/// Read guards are only ever minted once a method is *declared* read-only via
+/// the module ABI; until then every caller takes a write guard, so the lock
+/// behaves exactly like the prior exclusive mutex.
+///
+/// Derefs to the locked [`ContextId`] (identical for both variants) so existing
+/// read sites keep working.
 #[derive(Debug)]
-pub struct ContextGuard(OwnedMutexGuard<ContextId>);
+pub enum ContextGuard {
+    /// Exclusive guard — blocks all other access. The default for any call
+    /// whose read/write intent is not known to be read-only.
+    Write(OwnedRwLockWriteGuard<ContextId>),
+    /// Shared guard — coexists with other read guards on the same context.
+    Read(OwnedRwLockReadGuard<ContextId>),
+}
 
 impl ContextGuard {
-    /// Wrap an owned mutex guard. The guard keeps the per-context lock held for
-    /// the lifetime of this value.
+    /// Wrap an exclusive write guard. Keeps the lock held exclusively for the
+    /// lifetime of this value.
     #[must_use]
-    pub fn new(guard: OwnedMutexGuard<ContextId>) -> Self {
-        Self(guard)
+    pub fn write(guard: OwnedRwLockWriteGuard<ContextId>) -> Self {
+        Self::Write(guard)
+    }
+
+    /// Wrap a shared read guard. Keeps the lock held in shared mode for the
+    /// lifetime of this value.
+    #[must_use]
+    pub fn read(guard: OwnedRwLockReadGuard<ContextId>) -> Self {
+        Self::Read(guard)
     }
 }
 
@@ -35,7 +53,10 @@ impl Deref for ContextGuard {
     type Target = ContextId;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        match self {
+            Self::Write(guard) => guard,
+            Self::Read(guard) => guard,
+        }
     }
 }
 

--- a/crates/context/primitives/src/lib.rs
+++ b/crates/context/primitives/src/lib.rs
@@ -1,51 +1,34 @@
 use std::ops::Deref;
 
 use calimero_primitives::context::ContextId;
-use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard};
+use tokio::sync::OwnedRwLockWriteGuard;
 
 pub mod client;
 pub mod group;
 pub mod local_governance;
 pub mod messages;
 
-/// An owned, per-context lock guard held across a context operation.
+/// An owned, exclusive per-context lock guard held across a context operation.
 ///
-/// The per-context lock is an `RwLock`, so a held guard is either an exclusive
-/// *write* guard or a shared *read* guard. Keeping the single notion of
-/// "holding a context" behind this one type — acquired in the manager, threaded
-/// through the entire WASM execution outside the actor, and handed back in as
-/// [`ContextAtomic::Held`] for a multi-call atomic batch — is what lets the
-/// read/write-intent split (parallel reads) be introduced without touching
-/// every call site.
+/// The per-context lock is an `RwLock`, but every caller currently takes the
+/// exclusive *write* guard, so the lock behaves exactly like the prior mutex.
+/// Keeping the single notion of "holding a context" behind this one type —
+/// acquired in the manager, threaded through the entire WASM execution outside
+/// the actor, and handed back in as [`ContextAtomic::Held`] for a multi-call
+/// atomic batch — is what will let a shared read guard be introduced (parallel
+/// reads, gated on declared read-only method intent) without touching every
+/// call site.
 ///
-/// Read guards are only ever minted once a method is *declared* read-only via
-/// the module ABI; until then every caller takes a write guard, so the lock
-/// behaves exactly like the prior exclusive mutex.
-///
-/// Derefs to the locked [`ContextId`] (identical for both variants) so existing
-/// read sites keep working.
+/// Derefs to the locked [`ContextId`] so existing read sites keep working.
 #[derive(Debug)]
-pub enum ContextGuard {
-    /// Exclusive guard — blocks all other access. The default for any call
-    /// whose read/write intent is not known to be read-only.
-    Write(OwnedRwLockWriteGuard<ContextId>),
-    /// Shared guard — coexists with other read guards on the same context.
-    Read(OwnedRwLockReadGuard<ContextId>),
-}
+pub struct ContextGuard(OwnedRwLockWriteGuard<ContextId>);
 
 impl ContextGuard {
     /// Wrap an exclusive write guard. Keeps the lock held exclusively for the
     /// lifetime of this value.
     #[must_use]
-    pub fn write(guard: OwnedRwLockWriteGuard<ContextId>) -> Self {
-        Self::Write(guard)
-    }
-
-    /// Wrap a shared read guard. Keeps the lock held in shared mode for the
-    /// lifetime of this value.
-    #[must_use]
-    pub fn read(guard: OwnedRwLockReadGuard<ContextId>) -> Self {
-        Self::Read(guard)
+    pub fn new(guard: OwnedRwLockWriteGuard<ContextId>) -> Self {
+        Self(guard)
     }
 }
 
@@ -53,10 +36,7 @@ impl Deref for ContextGuard {
     type Target = ContextId;
 
     fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Write(guard) => guard,
-            Self::Read(guard) => guard,
-        }
+        &self.0
     }
 }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -23,7 +23,7 @@ use calimero_primitives::context::{Context, ContextId};
 use calimero_store::Store;
 use either::Either;
 use prometheus_client::registry::Registry;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use calimero_governance_store::metrics::Metrics;
 
@@ -224,32 +224,39 @@ impl ContextCacheStats {
     }
 }
 
-/// The per-context lock that serializes all operations on a single context.
+/// The per-context lock that serializes operations on a single context.
 ///
-/// This wraps the `Arc<Mutex<ContextId>>` so that the entire lifecycle of the
+/// This wraps the `Arc<RwLock<ContextId>>` so that the entire lifecycle of the
 /// lock — how it is acquired, the owned guard it hands out, and the
 /// reference-count rule that decides when its owning cache entry may be evicted
 /// — lives behind one type. Concentrating it here is the seam through which the
 /// idle/TTL eviction policy and the read/write-intent split (parallel reads)
-/// will later be introduced without disturbing every call site.
+/// are introduced without disturbing every call site.
+///
+/// The lock is an `RwLock`, but [`lock`](Self::lock) currently only ever takes
+/// the *write* (exclusive) guard, so it behaves exactly like the prior
+/// `Mutex` — every caller serializes. Shared read guards are introduced
+/// separately, gated on declared read-only method intent; until then there is
+/// no behavior change.
 #[derive(Clone, Debug)]
 struct ContextLock {
-    lock: Arc<Mutex<ContextId>>,
+    lock: Arc<RwLock<ContextId>>,
 }
 
 impl ContextLock {
     /// Create a fresh per-context lock keyed by `id`.
     fn new(id: ContextId) -> Self {
         Self {
-            lock: Arc::new(Mutex::new(id)),
+            lock: Arc::new(RwLock::new(id)),
         }
     }
 
-    /// Acquire the lock for this context.
+    /// Acquire the lock for this context in *exclusive* (write) mode.
     ///
-    /// This is a performance-optimized acquisition strategy. It first attempts
-    /// an optimistic, non-blocking `try_lock_owned()`, which is very fast when
-    /// the lock is uncontended.
+    /// This is the default acquisition for any call whose read/write intent is
+    /// not known to be read-only — i.e. every call today. It is a
+    /// performance-optimized strategy: it first attempts an optimistic,
+    /// non-blocking `try_write_owned()`, which is very fast when uncontended.
     ///
     /// # Returns
     ///
@@ -259,12 +266,12 @@ impl ContextLock {
     ///   resolves to a [`ContextGuard`] once it becomes available and must be
     ///   awaited by the caller.
     fn lock(&self) -> Either<ContextGuard, impl Future<Output = ContextGuard>> {
-        let Ok(guard) = self.lock.clone().try_lock_owned() else {
+        let Ok(guard) = self.lock.clone().try_write_owned() else {
             let lock = self.lock.clone();
-            return Either::Right(async move { ContextGuard::new(lock.lock_owned().await) });
+            return Either::Right(async move { ContextGuard::write(lock.write_owned().await) });
         };
 
-        Either::Left(ContextGuard::new(guard))
+        Either::Left(ContextGuard::write(guard))
     }
 
     /// Whether the owning cache entry may be evicted: true only while no
@@ -278,8 +285,8 @@ impl ContextLock {
     /// `strong_count == 1` (only the cache holds it).
     ///
     /// If we evicted a *live* entry, the next `get_or_fetch_context` would mint
-    /// a brand-new `Arc<Mutex>` for that context, and two concurrent operations
-    /// would then serialize on *different* mutexes — breaking the invariant and
+    /// a brand-new `Arc<RwLock>` for that context, and two concurrent operations
+    /// would then synchronize on *different* locks — breaking the invariant and
     /// corrupting state. Hence this lock-gated check.
     ///
     /// `strong_count` is racy in isolation, but the check is safe here because

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -268,10 +268,10 @@ impl ContextLock {
     fn lock(&self) -> Either<ContextGuard, impl Future<Output = ContextGuard>> {
         let Ok(guard) = self.lock.clone().try_write_owned() else {
             let lock = self.lock.clone();
-            return Either::Right(async move { ContextGuard::write(lock.write_owned().await) });
+            return Either::Right(async move { ContextGuard::new(lock.write_owned().await) });
         };
 
-        Either::Left(ContextGuard::write(guard))
+        Either::Left(ContextGuard::new(guard))
     }
 
     /// Whether the owning cache entry may be evicted: true only while no


### PR DESCRIPTION
## What

Increment 1 of #2685 (per-context-guard epic #2022). Swaps the per-context lock from `Mutex` to `RwLock` behind the existing `ContextLock` / `ContextGuard` types — the first step toward parallel reads on a single context.

**Deliberately behavior-neutral.** Every caller still takes the exclusive *write* guard, so an `RwLock` with no readers behaves exactly like the prior `Mutex`: all calls on a context serialize as before. Nothing observable changes, and no app is affected.

## Why this can land alone

The epic now uses a **fail-safe default: unknown read/write intent → write lock.** That makes the lock-type swap correct and behavior-neutral on its own, independent of the SDK/ABI annotation work (#2684). Shared read guards — and the declared-read-only intent that selects them — are layered on later (increment 2); until then this is pure groundwork.

## Changes

- `ContextLock` now wraps `Arc<RwLock<ContextId>>`; `lock()` takes the write guard via `try_write_owned()` (fast path) / `write_owned()` (contended), mirroring the prior `try_lock_owned()`/`lock_owned()` strategy.
- `ContextGuard` is a newtype over `OwnedRwLockWriteGuard<ContextId>` (was `OwnedMutexGuard`), still `Deref`ing to `ContextId`, so every execute-path site that reads `**guard` is unchanged. It stays write-only here; the shared-read variant is added in increment 2 (the PR that actually mints read guards), per the repo's no-dead-code rule.
- The `strong_count`-based eviction rule (#2606) is unaffected: an outstanding owned `RwLock` guard still holds a clone of the `Arc`, so a live entry is still `strong_count >= 2` and only an idle entry (`== 1`) is evictable.

## Verification

- Builds: `calimero-context-client`, `calimero-context`, `calimero-node`
- `cargo fmt --check` clean
- clippy: 32/6/1 warnings — **identical** to baseline (stash-diff), zero new
- Tests: all context unit + integration binaries green, 0 failures — including the eviction tests (`never_evicts_a_live_entry`, `evicts_one_idle_entry_at_cap`), which now exercise the RwLock write guard and confirm `strong_count == 2` for a held guard

## Not in this PR (increment 2, needs #2684)

Read-declared methods taking shared read guards, and the intent-aware/TTL eviction predicate (folded from #2683). See #2685 for the full plan.

Part of #2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical lock-type swap with exclusive acquisition unchanged; eviction and concurrency invariants stay the same, verified by existing tests.
> 
> **Overview**
> **Increment 1** toward parallel reads on a single context: the per-context synchronization primitive moves from `Mutex` to `RwLock` while **every acquisition path still takes an exclusive write guard**, so operations on one context remain fully serialized with no intended observable change.
> 
> `ContextLock` now holds `Arc<RwLock<ContextId>>` and `lock()` uses the same fast/contended pattern as before (`try_write_owned` / `write_owned`). `ContextGuard` is still a thin newtype over an owned guard, now `OwnedRwLockWriteGuard`, and still `Deref`s to `ContextId` for execute and atomic-batch call sites. Comments are updated to describe the future read-only intent path and to keep eviction semantics explicit (`Arc::strong_count` idle check unchanged).
> 
> This is groundwork for a later increment (shared read guards when method intent is read-only); that selection is **not** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f9d7803ae573f40f8ac542f11e87ebbf1337c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
