### PR TITLE
test(node): give MockSyncNetwork per-topic subscriber queues

### DIFF
--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -210,7 +210,7 @@ mod tests {
         let p1 = PeerId::random();
         let p2 = PeerId::random();
         // Sticky-last on mesh_peers means every round sees this pair.
-        mock.push_mesh_peers(vec![p1, p2]);
+        mock.push_subscribed_peers(vec![p1, p2]);
         let (open_timeout, retries, retry_delay) = defaults();
         // Each round tries every peer (3 × 2 = 6 attempts) and the
         // deadline guard fires before any extra inner-loop attempt.
@@ -254,7 +254,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn hanging_peers_are_interrupted_by_per_peer_timeout() {
         let mock = MockSyncNetwork::default();
-        mock.push_mesh_peers(vec![PeerId::random(), PeerId::random()]);
+        mock.push_subscribed_peers(vec![PeerId::random(), PeerId::random()]);
         // Every peer hangs far longer than open_timeout; tokio's
         // timeout should fire each time and we move on.
         for i in 0..20 {
@@ -296,7 +296,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn empty_mesh_every_round_returns_err() {
         let mock = MockSyncNetwork::default();
-        // No `push_mesh_peers` calls → mesh_peers returns Vec::new()
+        // No `push_subscribed_peers` calls → subscribed_peers returns Vec::new()
         // (the "never seeded" path; production-legitimate when the
         // mesh hasn't formed yet).
 
@@ -328,7 +328,7 @@ mod tests {
         let mock = MockSyncNetwork::default();
         // 10 peers — far more than DEADLINE_MAX_PEERS_PER_ROUND (4).
         let many_peers: Vec<PeerId> = (0..10).map(|_| PeerId::random()).collect();
-        mock.push_mesh_peers(many_peers);
+        mock.push_subscribed_peers(many_peers);
         // Every peer hangs for the full open_timeout — so the
         // per-peer cost lower-bound is open_timeout.
         for i in 0..50 {
@@ -401,7 +401,7 @@ mod tests {
         let mock = MockSyncNetwork::default();
         let p1 = PeerId::random();
         let p2 = PeerId::random();
-        mock.push_mesh_peers(vec![p1, p2]);
+        mock.push_subscribed_peers(vec![p1, p2]);
         let mut excluded = HashSet::new();
         excluded.insert(p1);
         excluded.insert(p2);
@@ -449,12 +449,12 @@ mod tests {
         let kept = PeerId::random();
         let blocked = PeerId::random();
         // `mesh_peers` is sticky-last in the mock (see module doc): a
-        // single `push_mesh_peers` call seeds the same list for every
+        // single `push_subscribed_peers` call seeds the same list for every
         // round. The test budget below (`retries` open_stream Errs)
         // depends on that — if sticky-last ever changes to return an
         // empty list after the first read, the assertion below would
         // pass vacuously instead of guarding the filter behaviour.
-        mock.push_mesh_peers(vec![kept, blocked]);
+        mock.push_subscribed_peers(vec![kept, blocked]);
         let mut excluded = HashSet::new();
         excluded.insert(blocked);
 
@@ -497,7 +497,7 @@ mod tests {
         let mock = MockSyncNetwork::default();
         // Three candidates in the (sticky) mesh; all are tried in
         // round 1 since 3 < DEADLINE_MAX_PEERS_PER_ROUND.
-        mock.push_mesh_peers(vec![PeerId::random(), PeerId::random(), PeerId::random()]);
+        mock.push_subscribed_peers(vec![PeerId::random(), PeerId::random(), PeerId::random()]);
         // The mock ignores peer identity and pops responses in order:
         // the first two opens fail, the third succeeds.
         mock.push_open_stream_err("peer down")

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -73,6 +73,25 @@ pub(crate) enum OpenStreamResponse {
     SleepThenErr(Duration, String),
 }
 
+/// Draw one response from a sticky-last queue: while more than one
+/// entry remains, pop the front; on the final entry, clone (don't pop)
+/// so repeated reads keep returning it — matching production
+/// "subscriber set is stable after discovery completes". Shared by the
+/// per-topic and shared-queue paths so the semantic lives in one place.
+///
+/// The `0` arm is a defensive fallback that is unreachable in normal
+/// use: a per-topic queue key is only created by
+/// `push_subscribed_peers_for` (which always pushes ≥1 entry) and the
+/// last entry is never popped, so a seeded queue never drains to empty;
+/// the shared queue only reaches 0 when it was never seeded at all.
+fn sticky_last(queue: &mut VecDeque<Vec<PeerId>>) -> Vec<PeerId> {
+    match queue.len() {
+        0 => Vec::new(),
+        1 => queue.front().cloned().unwrap_or_default(),
+        _ => queue.pop_front().unwrap_or_default(),
+    }
+}
+
 /// See module doc for exhaustion semantics.
 ///
 /// **Mutex choice**: `parking_lot::Mutex` (not `std::sync::Mutex`)
@@ -91,22 +110,26 @@ pub(crate) struct MockSyncNetwork {
     /// ordering of cross-topic calls.
     subscribed_peers_by_topic: Mutex<HashMap<TopicHash, VecDeque<Vec<PeerId>>>>,
     open_stream_responses: Mutex<VecDeque<OpenStreamResponse>>,
-    /// `subscribed_peers` call count (across all topics) — needed to
-    /// distinguish "queued 1 sticky-last entry and the code under test
-    /// called subscribed_peers ≥1 times" (consumed) from "queued 1
-    /// entry and the code under test never called it at all"
-    /// (silently-unused shared queue).
+    /// Count of reads served by the **shared** queue specifically —
+    /// needed to distinguish "queued 1 sticky-last entry and the
+    /// shared queue was read ≥1 times" (consumed) from "queued 1 entry
+    /// and the shared queue was never read" (silently-unused queue).
+    ///
+    /// Counts only shared-queue fallthrough reads, NOT per-topic reads:
+    /// a per-topic read must not satisfy the shared queue's
+    /// "seeded but never read" guard, or seeding both and querying only
+    /// the per-topic topic would leave a shared leak undetected.
     ///
     /// No analogous counter exists for `open_stream`: it has no
     /// sticky-last semantic, so "seeded but never called" already
     /// fails `assert_all_consumed`'s `open_stream_remaining > 0`
     /// check without needing a separate guard.
-    subscribed_peers_calls: Mutex<u32>,
-    /// Per-topic call counts, for the same "seeded but never called"
-    /// guard applied to each per-topic queue independently — the
-    /// global `subscribed_peers_calls` can't tell whether a *specific*
-    /// topic's queue was ever read.
-    subscribed_peers_calls_by_topic: Mutex<HashMap<TopicHash, u32>>,
+    shared_queue_reads: Mutex<u32>,
+    /// Per-topic read counts, for the same "seeded but never read"
+    /// guard applied to each per-topic queue independently — a single
+    /// global counter can't tell whether a *specific* topic's queue
+    /// was ever read.
+    subscribed_peers_reads_by_topic: Mutex<HashMap<TopicHash, u32>>,
 }
 
 impl MockSyncNetwork {
@@ -198,7 +221,7 @@ impl MockSyncNetwork {
     #[track_caller]
     pub(crate) fn assert_all_consumed(&self) {
         let shared_remaining = self.subscribed_peers_responses.lock().len();
-        let shared_calls = *self.subscribed_peers_calls.lock();
+        let shared_reads = *self.shared_queue_reads.lock();
         let open_stream_remaining = self.open_stream_responses.lock().len();
 
         if shared_remaining > 1 {
@@ -208,26 +231,24 @@ impl MockSyncNetwork {
                  than expected)",
             );
         }
-        // Sticky-last guard: if anything was queued on the shared
-        // queue and the code under test never called subscribed_peers
-        // (against any topic that fell through to it), the queue still
-        // has 1 entry but `shared_calls == 0` — flag that, otherwise
-        // the unconsumed-1-entry case is indistinguishable from the
-        // healthy steady-state read. A per-topic call still bumps the
-        // global counter, so this is a lower-bound guard (it can't
-        // mis-fire), and the per-topic loop below catches the more
-        // precise "this topic's queue was never read".
-        if shared_remaining > 0 && shared_calls == 0 {
+        // Sticky-last guard: if anything was queued on the shared queue
+        // but it was never read, the queue still has 1 entry while
+        // `shared_reads == 0` — flag that, otherwise the unconsumed-1
+        // case is indistinguishable from the healthy steady-state read.
+        // `shared_reads` counts shared-queue reads only (per-topic reads
+        // don't bump it), so a test that queries only per-topic queues
+        // can't mask a never-read shared queue.
+        if shared_remaining > 0 && shared_reads == 0 {
             panic!(
                 "MockSyncNetwork: `subscribed_peers` shared queue was seeded with {shared_remaining} \
-                 entries but the code under test never called it",
+                 entries but the code under test never read it",
             );
         }
         // Same two checks, applied to each per-topic queue. The
-        // per-topic call map lets us tell "this topic was never
+        // per-topic read map lets us tell "this topic was never
         // queried" apart from "queried, drew its single sticky entry".
         let by_topic = self.subscribed_peers_by_topic.lock();
-        let calls_by_topic = self.subscribed_peers_calls_by_topic.lock();
+        let reads_by_topic = self.subscribed_peers_reads_by_topic.lock();
         for (topic, queue) in by_topic.iter() {
             let remaining = queue.len();
             if remaining > 1 {
@@ -237,7 +258,7 @@ impl MockSyncNetwork {
                      test made fewer calls than expected)",
                 );
             }
-            if remaining > 0 && calls_by_topic.get(topic).copied().unwrap_or(0) == 0 {
+            if remaining > 0 && reads_by_topic.get(topic).copied().unwrap_or(0) == 0 {
                 panic!(
                     "MockSyncNetwork: `subscribed_peers` was seeded with {remaining} entries for \
                      topic {topic:?} but the code under test never queried it",
@@ -256,68 +277,28 @@ impl MockSyncNetwork {
 #[async_trait]
 impl SyncNetwork for MockSyncNetwork {
     async fn subscribed_peers(&self, topic: TopicHash) -> Vec<PeerId> {
-        *self.subscribed_peers_calls.lock() += 1;
-
         // Per-topic queue takes precedence: if this topic was seeded
-        // via `push_subscribed_peers_for`, draw from its own queue
-        // (sticky-last). Otherwise fall through to the shared queue so
-        // topic-agnostic callers keep working. The whole match runs
-        // under one lock with no `.await` in scope, so cloning the
-        // sticky entry inline is fine.
-        let served = {
+        // via `push_subscribed_peers_for`, draw from its own queue.
+        // Both paths use the shared `sticky_last` helper; the locks are
+        // held only across synchronous work (no `.await` in scope).
+        let per_topic = {
             let mut by_topic = self.subscribed_peers_by_topic.lock();
-            by_topic.get_mut(&topic).map(|queue| match queue.len() {
-                0 => Vec::new(),
-                // Last entry: clone (don't pop) so repeated reads keep
-                // returning the final value — matches "subscriber set
-                // is stable after discovery completes".
-                1 => queue.front().cloned().unwrap_or_default(),
-                _ => queue.pop_front().unwrap_or_default(),
-            })
+            by_topic.get_mut(&topic).map(sticky_last)
         };
-        if let Some(peers) = served {
+        if let Some(peers) = per_topic {
             *self
-                .subscribed_peers_calls_by_topic
+                .subscribed_peers_reads_by_topic
                 .lock()
                 .entry(topic)
                 .or_insert(0) += 1;
             return peers;
         }
 
-        // Shared, topic-agnostic queue (fallthrough). Pull out a
-        // borrow indicator under the lock and do the (possibly-cloning)
-        // work after dropping it. Keeps the critical section minimal
-        // and bounded to synchronous operations.
-        enum Take {
-            Empty,
-            Stick,
-            Pop(Vec<PeerId>),
-        }
-        let take = {
-            let mut queue = self.subscribed_peers_responses.lock();
-            match queue.len() {
-                0 => Take::Empty,
-                // Last entry: clone *after* dropping the lock so
-                // repeated reads keep returning the final value
-                // (matches "subscriber set is stable after discovery
-                // completes" production behaviour).
-                1 => Take::Stick,
-                _ => Take::Pop(queue.pop_front().unwrap_or_default()),
-            }
-        };
-        match take {
-            Take::Empty => Vec::new(),
-            Take::Stick => {
-                // Re-lock briefly just to clone the last entry —
-                // bounded work, no `.await` in scope.
-                self.subscribed_peers_responses
-                    .lock()
-                    .front()
-                    .cloned()
-                    .unwrap_or_default()
-            }
-            Take::Pop(peers) => peers,
-        }
+        // Shared, topic-agnostic fallthrough. Count the read HERE (not
+        // before the per-topic check) so a per-topic read can't satisfy
+        // the shared queue's "seeded but never read" guard.
+        *self.shared_queue_reads.lock() += 1;
+        sticky_last(&mut self.subscribed_peers_responses.lock())
     }
 
     async fn open_stream(&self, _peer_id: PeerId) -> eyre::Result<Stream> {
@@ -541,12 +522,28 @@ mod tests {
     /// that queues a single shared-queue entry but never exercises
     /// the discovery path would have passed `assert_all_consumed`
     /// without complaint (sticky-last accepts 1 leftover). With the
-    /// call-count guard, "seeded but never called" panics loudly.
+    /// read-count guard, "seeded but never read" panics loudly.
     #[tokio::test]
-    #[should_panic(expected = "never called it")]
-    async fn assert_all_consumed_panics_on_shared_seeded_but_never_called() {
+    #[should_panic(expected = "never read it")]
+    async fn assert_all_consumed_panics_on_shared_seeded_but_never_read() {
         let mock = MockSyncNetwork::default();
         mock.push_subscribed_peers(vec![PeerId::random()]);
+        mock.assert_all_consumed();
+    }
+
+    /// Regression: a per-topic read must NOT satisfy the shared queue's
+    /// "seeded but never read" guard. Seed both queues, query only the
+    /// per-topic topic — the shared queue is never read, so the guard
+    /// must still fire even though *a* read happened.
+    #[tokio::test]
+    #[should_panic(expected = "shared queue was seeded")]
+    async fn assert_all_consumed_detects_shared_leak_despite_per_topic_read() {
+        let mock = MockSyncNetwork::default();
+        let topic = TopicHash::from_raw("ctx");
+        mock.push_subscribed_peers_for(topic.clone(), vec![PeerId::random()])
+            .push_subscribed_peers(vec![PeerId::random()]);
+        // Only the per-topic queue is read.
+        let _ = mock.subscribed_peers(topic).await;
         mock.assert_all_consumed();
     }
 

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -1,22 +1,42 @@
 //! Scriptable mock for [`super::SyncNetwork`].
 //!
-//! `mesh_peers` returns recorded peer lists; `open_stream` returns
-//! recorded errors, hangs, or — via `Stream::test_pair()` behind the
-//! `test-utils` feature — a real `Ok(Stream)`. The success arm lets
-//! tests cover the discovery loop's recovery path (a peer succeeds
-//! after earlier ones fail), not just its give-up paths.
+//! `subscribed_peers` returns recorded peer lists; `open_stream`
+//! returns recorded errors, hangs, or — via `Stream::test_pair()`
+//! behind the `test-utils` feature — a real `Ok(Stream)`. The success
+//! arm lets tests cover the discovery loop's recovery path (a peer
+//! succeeds after earlier ones fail), not just its give-up paths.
+//!
+//! ## Per-topic vs shared queues
+//!
+//! `subscribed_peers` is scripted two ways:
+//!
+//! - **Per-topic** ([`MockSyncNetwork::push_subscribed_peers_for`]):
+//!   responses are keyed by `TopicHash`, so a test can say "context
+//!   topic returns empty, namespace topic returns peers" — the two
+//!   draw from independent queues. This is what the discovery code's
+//!   namespace-fallback path needs, since it queries two distinct
+//!   topics and the outcome depends on which one yields peers.
+//! - **Shared** ([`MockSyncNetwork::push_subscribed_peers`]): a
+//!   single topic-agnostic queue, used by tests that don't care which
+//!   topic was requested. When a topic has no per-topic queue seeded,
+//!   `subscribed_peers` falls through to this shared queue, so the
+//!   simpler callers keep working unchanged.
+//!
+//! Per-topic queues take precedence; the shared queue is the
+//! fallthrough.
 //!
 //! ## Exhaustion semantics
 //!
 //! The two methods behave **asymmetrically** when their queue is
 //! drained. This is intentional and matches production:
 //!
-//! - `mesh_peers` — **sticky last**: if N entries are queued and the
-//!   method is called >N times, every call past N returns the Nth
-//!   value. Matches production "mesh stable after discovery
-//!   completes" behaviour — a sync loop polling `mesh_peers` while
-//!   waiting for a peer to come up sees the same answer until the
-//!   mesh actually changes, so the mock shouldn't suddenly start
+//! - `subscribed_peers` — **sticky last** (per queue, shared or
+//!   per-topic): if N entries are queued and the method draws from
+//!   that queue >N times, every draw past N returns the Nth value.
+//!   Matches production "subscriber set stable after discovery
+//!   completes" behaviour — a sync loop polling `subscribed_peers`
+//!   while waiting for a peer to come up sees the same answer until
+//!   the set actually changes, so the mock shouldn't suddenly start
 //!   returning empty when the test forgets to script another tick.
 //! - `open_stream` — **error on exhaust**: every call past the
 //!   scripted count returns `Err("…no queued response")`. Each
@@ -28,7 +48,7 @@
 //! against either method should use [`MockSyncNetwork::assert_all_consumed`]
 //! after running the code under test.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -61,24 +81,53 @@ pub(crate) enum OpenStreamResponse {
 /// the synchronous pop in each method; never across `.await`.
 #[derive(Default)]
 pub(crate) struct MockSyncNetwork {
-    mesh_peers_responses: Mutex<VecDeque<Vec<PeerId>>>,
+    /// Shared, topic-agnostic queue. Used when no per-topic queue is
+    /// seeded for the requested topic (see `subscribed_peers_by_topic`).
+    subscribed_peers_responses: Mutex<VecDeque<Vec<PeerId>>>,
+    /// Per-topic queues. When a queue exists for the requested topic
+    /// it takes precedence over the shared queue, letting a test
+    /// script distinct responses per topic (e.g. context-topic empty,
+    /// namespace-topic populated) without relying on the global
+    /// ordering of cross-topic calls.
+    subscribed_peers_by_topic: Mutex<HashMap<TopicHash, VecDeque<Vec<PeerId>>>>,
     open_stream_responses: Mutex<VecDeque<OpenStreamResponse>>,
-    /// `mesh_peers` call count — needed to distinguish "queued 1
-    /// sticky-last entry and the code under test called mesh_peers
-    /// ≥1 times" (consumed) from "queued 1 entry and the code under
-    /// test never called mesh_peers at all" (silently-unused queue).
+    /// `subscribed_peers` call count (across all topics) — needed to
+    /// distinguish "queued 1 sticky-last entry and the code under test
+    /// called subscribed_peers ≥1 times" (consumed) from "queued 1
+    /// entry and the code under test never called it at all"
+    /// (silently-unused shared queue).
     ///
     /// No analogous counter exists for `open_stream`: it has no
     /// sticky-last semantic, so "seeded but never called" already
     /// fails `assert_all_consumed`'s `open_stream_remaining > 0`
     /// check without needing a separate guard.
-    mesh_peers_calls: Mutex<u32>,
+    subscribed_peers_calls: Mutex<u32>,
+    /// Per-topic call counts, for the same "seeded but never called"
+    /// guard applied to each per-topic queue independently — the
+    /// global `subscribed_peers_calls` can't tell whether a *specific*
+    /// topic's queue was ever read.
+    subscribed_peers_calls_by_topic: Mutex<HashMap<TopicHash, u32>>,
 }
 
 impl MockSyncNetwork {
-    /// Queue a response for the next `mesh_peers` call.
-    pub(crate) fn push_mesh_peers(&self, peers: Vec<PeerId>) -> &Self {
-        self.mesh_peers_responses.lock().push_back(peers);
+    /// Queue a response on the shared, topic-agnostic queue. Served to
+    /// any topic that has no per-topic queue seeded. Use this for tests
+    /// that don't distinguish topics.
+    pub(crate) fn push_subscribed_peers(&self, peers: Vec<PeerId>) -> &Self {
+        self.subscribed_peers_responses.lock().push_back(peers);
+        self
+    }
+
+    /// Queue a response on the per-topic queue for `topic`. Calls to
+    /// `subscribed_peers(topic)` draw from this queue (sticky-last)
+    /// instead of the shared one, so a test can script context- and
+    /// namespace-topic responses independently.
+    pub(crate) fn push_subscribed_peers_for(&self, topic: TopicHash, peers: Vec<PeerId>) -> &Self {
+        self.subscribed_peers_by_topic
+            .lock()
+            .entry(topic)
+            .or_default()
+            .push_back(peers);
         self
     }
 
@@ -127,13 +176,14 @@ impl MockSyncNetwork {
     /// Checks:
     ///
     /// - `open_stream`: queue must be empty.
-    /// - `mesh_peers`: queue must have ≤1 entry left (the
-    ///   sticky-last steady state), AND if any entries were
-    ///   queued the code under test must have called
-    ///   `mesh_peers` at least once. The latter catches "test
-    ///   queued a single sticky-last entry but never exercised
-    ///   the discovery path at all" — without the call-count
-    ///   guard the assertion would pass silently in that case.
+    /// - `subscribed_peers` (shared queue, and each per-topic queue
+    ///   independently): the queue must have ≤1 entry left (the
+    ///   sticky-last steady state), AND if any entries were queued the
+    ///   code under test must have drawn from that queue at least once.
+    ///   The latter catches "test queued a single sticky-last entry but
+    ///   never exercised the discovery path at all" — without the
+    ///   call-count guard the assertion would pass silently in that
+    ///   case.
     ///
     /// `#[track_caller]` so panics point at the test's call
     /// site, not inside this helper.
@@ -147,28 +197,52 @@ impl MockSyncNetwork {
     /// ```
     #[track_caller]
     pub(crate) fn assert_all_consumed(&self) {
-        let mesh_remaining = self.mesh_peers_responses.lock().len();
-        let mesh_calls = *self.mesh_peers_calls.lock();
+        let shared_remaining = self.subscribed_peers_responses.lock().len();
+        let shared_calls = *self.subscribed_peers_calls.lock();
         let open_stream_remaining = self.open_stream_responses.lock().len();
 
-        if mesh_remaining > 1 {
+        if shared_remaining > 1 {
             panic!(
-                "MockSyncNetwork: {} unconsumed `mesh_peers` responses queued (sticky-last \
-                 leaves 1 by design; >1 means the code under test made fewer calls than expected)",
-                mesh_remaining
+                "MockSyncNetwork: {shared_remaining} unconsumed `subscribed_peers` responses queued \
+                 (sticky-last leaves 1 by design; >1 means the code under test made fewer calls \
+                 than expected)",
             );
         }
-        // Sticky-last guard: if anything was queued and the code
-        // under test never called mesh_peers, the queue still has
-        // 1 entry but `mesh_calls == 0` — flag that, otherwise the
-        // unconsumed-1-entry case is indistinguishable from the
-        // healthy steady-state read.
-        if mesh_remaining > 0 && mesh_calls == 0 {
+        // Sticky-last guard: if anything was queued on the shared
+        // queue and the code under test never called subscribed_peers
+        // (against any topic that fell through to it), the queue still
+        // has 1 entry but `shared_calls == 0` — flag that, otherwise
+        // the unconsumed-1-entry case is indistinguishable from the
+        // healthy steady-state read. A per-topic call still bumps the
+        // global counter, so this is a lower-bound guard (it can't
+        // mis-fire), and the per-topic loop below catches the more
+        // precise "this topic's queue was never read".
+        if shared_remaining > 0 && shared_calls == 0 {
             panic!(
-                "MockSyncNetwork: `mesh_peers` was seeded with {} entries but the code under \
-                 test never called it",
-                mesh_remaining
+                "MockSyncNetwork: `subscribed_peers` shared queue was seeded with {shared_remaining} \
+                 entries but the code under test never called it",
             );
+        }
+        // Same two checks, applied to each per-topic queue. The
+        // per-topic call map lets us tell "this topic was never
+        // queried" apart from "queried, drew its single sticky entry".
+        let by_topic = self.subscribed_peers_by_topic.lock();
+        let calls_by_topic = self.subscribed_peers_calls_by_topic.lock();
+        for (topic, queue) in by_topic.iter() {
+            let remaining = queue.len();
+            if remaining > 1 {
+                panic!(
+                    "MockSyncNetwork: {remaining} unconsumed `subscribed_peers` responses queued \
+                     for topic {topic:?} (sticky-last leaves 1 by design; >1 means the code under \
+                     test made fewer calls than expected)",
+                );
+            }
+            if remaining > 0 && calls_by_topic.get(topic).copied().unwrap_or(0) == 0 {
+                panic!(
+                    "MockSyncNetwork: `subscribed_peers` was seeded with {remaining} entries for \
+                     topic {topic:?} but the code under test never queried it",
+                );
+            }
         }
         if open_stream_remaining > 0 {
             panic!(
@@ -181,28 +255,51 @@ impl MockSyncNetwork {
 
 #[async_trait]
 impl SyncNetwork for MockSyncNetwork {
-    // Trait method is `subscribed_peers` (the sync layer now selects from
-    // the full subscriber set, not the grafted mesh); the mock's internal
-    // queue keeps its historical `mesh_peers_*` field names — they're just
-    // the response store and renaming them would churn unrelated tests.
-    async fn subscribed_peers(&self, _topic: TopicHash) -> Vec<PeerId> {
-        *self.mesh_peers_calls.lock() += 1;
-        // Pull out a borrow indicator under the lock and do the
-        // (possibly-cloning) work after dropping it. Keeps the
-        // critical section minimal and bounded to synchronous
-        // operations regardless of how the work below evolves.
+    async fn subscribed_peers(&self, topic: TopicHash) -> Vec<PeerId> {
+        *self.subscribed_peers_calls.lock() += 1;
+
+        // Per-topic queue takes precedence: if this topic was seeded
+        // via `push_subscribed_peers_for`, draw from its own queue
+        // (sticky-last). Otherwise fall through to the shared queue so
+        // topic-agnostic callers keep working. The whole match runs
+        // under one lock with no `.await` in scope, so cloning the
+        // sticky entry inline is fine.
+        let served = {
+            let mut by_topic = self.subscribed_peers_by_topic.lock();
+            by_topic.get_mut(&topic).map(|queue| match queue.len() {
+                0 => Vec::new(),
+                // Last entry: clone (don't pop) so repeated reads keep
+                // returning the final value — matches "subscriber set
+                // is stable after discovery completes".
+                1 => queue.front().cloned().unwrap_or_default(),
+                _ => queue.pop_front().unwrap_or_default(),
+            })
+        };
+        if let Some(peers) = served {
+            *self
+                .subscribed_peers_calls_by_topic
+                .lock()
+                .entry(topic)
+                .or_insert(0) += 1;
+            return peers;
+        }
+
+        // Shared, topic-agnostic queue (fallthrough). Pull out a
+        // borrow indicator under the lock and do the (possibly-cloning)
+        // work after dropping it. Keeps the critical section minimal
+        // and bounded to synchronous operations.
         enum Take {
             Empty,
             Stick,
             Pop(Vec<PeerId>),
         }
         let take = {
-            let mut queue = self.mesh_peers_responses.lock();
+            let mut queue = self.subscribed_peers_responses.lock();
             match queue.len() {
                 0 => Take::Empty,
                 // Last entry: clone *after* dropping the lock so
                 // repeated reads keep returning the final value
-                // (matches "mesh is stable after discovery
+                // (matches "subscriber set is stable after discovery
                 // completes" production behaviour).
                 1 => Take::Stick,
                 _ => Take::Pop(queue.pop_front().unwrap_or_default()),
@@ -213,7 +310,7 @@ impl SyncNetwork for MockSyncNetwork {
             Take::Stick => {
                 // Re-lock briefly just to clone the last entry —
                 // bounded work, no `.await` in scope.
-                self.mesh_peers_responses
+                self.subscribed_peers_responses
                     .lock()
                     .front()
                     .cloned()
@@ -244,12 +341,12 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn mesh_peers_returns_queued_value_then_repeats_last() {
+    async fn shared_queue_returns_queued_value_then_repeats_last() {
         let mock = MockSyncNetwork::default();
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
-        mock.push_mesh_peers(vec![peer_a])
-            .push_mesh_peers(vec![peer_b]);
+        mock.push_subscribed_peers(vec![peer_a])
+            .push_subscribed_peers(vec![peer_b]);
 
         let topic = TopicHash::from_raw("test");
         assert_eq!(mock.subscribed_peers(topic.clone()).await, vec![peer_a]);
@@ -260,7 +357,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mesh_peers_empty_when_never_seeded() {
+    async fn subscribed_peers_empty_when_never_seeded() {
         let mock = MockSyncNetwork::default();
         assert!(mock
             .subscribed_peers(TopicHash::from_raw("x"))
@@ -268,17 +365,17 @@ mod tests {
             .is_empty());
     }
 
-    /// Explicit boundary test for the `match queue.len()` arms in
-    /// `mesh_peers`: seed N entries, call N+1 times, the (N+1)th
+    /// Explicit boundary test for the `match queue.len()` arms in the
+    /// shared-queue path: seed N entries, call N+1 times, the (N+1)th
     /// should return the Nth value (the "sticky last" semantic).
     /// Catches off-by-one regressions in the pop-vs-clone branch.
     #[tokio::test]
-    async fn mesh_peers_sticky_last_at_len_1_boundary() {
+    async fn shared_queue_sticky_last_at_len_1_boundary() {
         let mock = MockSyncNetwork::default();
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
-        mock.push_mesh_peers(vec![peer_a])
-            .push_mesh_peers(vec![peer_b]);
+        mock.push_subscribed_peers(vec![peer_a])
+            .push_subscribed_peers(vec![peer_b]);
 
         let topic = TopicHash::from_raw("test");
         // Call 1: 2 entries queued → pop_front returns first.
@@ -287,6 +384,74 @@ mod tests {
         assert_eq!(mock.subscribed_peers(topic.clone()).await, vec![peer_b]);
         // Call 3: still 1 entry left (cloning didn't pop) → same value again.
         assert_eq!(mock.subscribed_peers(topic).await, vec![peer_b]);
+    }
+
+    /// Per-topic queues are independent: a response seeded for one
+    /// topic is never served to a different topic. This is the core
+    /// capability that lets discovery tests script "context topic
+    /// empty, namespace topic populated".
+    #[tokio::test]
+    async fn per_topic_queues_are_independent() {
+        let mock = MockSyncNetwork::default();
+        let ctx_peer = PeerId::random();
+        let ns_peer = PeerId::random();
+        let ctx_topic = TopicHash::from_raw("ctx");
+        let ns_topic = TopicHash::from_raw("ns");
+
+        mock.push_subscribed_peers_for(ctx_topic.clone(), vec![ctx_peer])
+            .push_subscribed_peers_for(ns_topic.clone(), vec![ns_peer]);
+
+        // Each topic draws only from its own queue, regardless of the
+        // order the two topics are queried in.
+        assert_eq!(mock.subscribed_peers(ns_topic.clone()).await, vec![ns_peer]);
+        assert_eq!(
+            mock.subscribed_peers(ctx_topic.clone()).await,
+            vec![ctx_peer]
+        );
+        // Sticky-last applies per topic.
+        assert_eq!(mock.subscribed_peers(ctx_topic).await, vec![ctx_peer]);
+        assert_eq!(mock.subscribed_peers(ns_topic).await, vec![ns_peer]);
+    }
+
+    /// A topic with a per-topic queue draws from it; a topic without
+    /// one falls through to the shared queue. The two coexist in a
+    /// single mock.
+    #[tokio::test]
+    async fn per_topic_takes_precedence_then_shared_fallthrough() {
+        let mock = MockSyncNetwork::default();
+        let seeded = PeerId::random();
+        let shared = PeerId::random();
+        let seeded_topic = TopicHash::from_raw("seeded");
+
+        mock.push_subscribed_peers_for(seeded_topic.clone(), vec![seeded])
+            .push_subscribed_peers(vec![shared]);
+
+        // Seeded topic → its own queue.
+        assert_eq!(mock.subscribed_peers(seeded_topic).await, vec![seeded]);
+        // Any other topic → shared queue.
+        assert_eq!(
+            mock.subscribed_peers(TopicHash::from_raw("other")).await,
+            vec![shared]
+        );
+    }
+
+    /// Per-topic sequencing: seed `[empty, populated]` for a topic and
+    /// confirm the first read is empty, the second (sticky-last)
+    /// populated — the shape the discovery retry→intersection path
+    /// relies on for a single topic queried across phases.
+    #[tokio::test]
+    async fn per_topic_sticky_last_sequence() {
+        let mock = MockSyncNetwork::default();
+        let peer = PeerId::random();
+        let topic = TopicHash::from_raw("ctx");
+
+        mock.push_subscribed_peers_for(topic.clone(), vec![])
+            .push_subscribed_peers_for(topic.clone(), vec![peer]);
+
+        assert!(mock.subscribed_peers(topic.clone()).await.is_empty());
+        assert_eq!(mock.subscribed_peers(topic.clone()).await, vec![peer]);
+        // Sticky-last: repeats the final populated entry.
+        assert_eq!(mock.subscribed_peers(topic).await, vec![peer]);
     }
 
     #[tokio::test]
@@ -341,13 +506,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn assert_all_consumed_passes_with_sticky_last_mesh_entry() {
-        // Sticky-last semantic: leaving the last `mesh_peers` entry
-        // unconsumed is by design (steady-state mesh after
+    async fn assert_all_consumed_passes_with_sticky_last_shared_entry() {
+        // Sticky-last semantic: leaving the last shared-queue entry
+        // unconsumed is by design (steady-state subscriber set after
         // discovery), so the assertion accepts ≤1 remaining.
         let mock = MockSyncNetwork::default();
         let peer = PeerId::random();
-        mock.push_mesh_peers(vec![peer]);
+        mock.push_subscribed_peers(vec![peer]);
         let _ = mock.subscribed_peers(TopicHash::from_raw("x")).await;
         mock.assert_all_consumed();
     }
@@ -361,26 +526,66 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "unconsumed `mesh_peers` responses")]
-    async fn assert_all_consumed_panics_on_excess_mesh_peers() {
+    #[should_panic(expected = "unconsumed `subscribed_peers` responses")]
+    async fn assert_all_consumed_panics_on_excess_shared_responses() {
         let mock = MockSyncNetwork::default();
         let p1 = PeerId::random();
         let p2 = PeerId::random();
         // 2 entries queued, none consumed → sticky-last allows 1, panics on >1.
-        mock.push_mesh_peers(vec![p1]).push_mesh_peers(vec![p2]);
+        mock.push_subscribed_peers(vec![p1])
+            .push_subscribed_peers(vec![p2]);
         mock.assert_all_consumed();
     }
 
     /// Catches the silent footgun the previous version had: a test
-    /// that queues a single `mesh_peers` entry but never exercises
+    /// that queues a single shared-queue entry but never exercises
     /// the discovery path would have passed `assert_all_consumed`
     /// without complaint (sticky-last accepts 1 leftover). With the
     /// call-count guard, "seeded but never called" panics loudly.
     #[tokio::test]
     #[should_panic(expected = "never called it")]
-    async fn assert_all_consumed_panics_on_mesh_peers_seeded_but_never_called() {
+    async fn assert_all_consumed_panics_on_shared_seeded_but_never_called() {
         let mock = MockSyncNetwork::default();
-        mock.push_mesh_peers(vec![PeerId::random()]);
+        mock.push_subscribed_peers(vec![PeerId::random()]);
+        mock.assert_all_consumed();
+    }
+
+    /// Per-topic leak detection mirrors the shared-queue checks: a
+    /// topic queue with >1 unconsumed entry (code made fewer calls
+    /// than scripted) panics.
+    #[tokio::test]
+    #[should_panic(expected = "fewer calls than expected")]
+    async fn assert_all_consumed_panics_on_excess_per_topic_responses() {
+        let mock = MockSyncNetwork::default();
+        let topic = TopicHash::from_raw("ctx");
+        mock.push_subscribed_peers_for(topic.clone(), vec![PeerId::random()])
+            .push_subscribed_peers_for(topic, vec![PeerId::random()]);
+        mock.assert_all_consumed();
+    }
+
+    /// A per-topic queue seeded but never queried panics — the global
+    /// call counter can't catch this (another topic may have bumped
+    /// it), so the per-topic call map is what flags it.
+    #[tokio::test]
+    #[should_panic(expected = "never queried it")]
+    async fn assert_all_consumed_panics_on_per_topic_seeded_but_never_queried() {
+        let mock = MockSyncNetwork::default();
+        // Query a *different* topic (via the shared fallthrough) so the
+        // global call counter is non-zero, proving the per-topic guard
+        // is what fires.
+        mock.push_subscribed_peers_for(TopicHash::from_raw("never"), vec![PeerId::random()]);
+        let _ = mock.subscribed_peers(TopicHash::from_raw("other")).await;
+        mock.assert_all_consumed();
+    }
+
+    /// Sticky-last leftover on a per-topic queue that *was* queried is
+    /// accepted, same as the shared queue.
+    #[tokio::test]
+    async fn assert_all_consumed_passes_with_sticky_last_per_topic_entry() {
+        let mock = MockSyncNetwork::default();
+        let topic = TopicHash::from_raw("ctx");
+        mock.push_subscribed_peers_for(topic.clone(), vec![PeerId::random()]);
+        let _ = mock.subscribed_peers(topic).await;
         mock.assert_all_consumed();
     }
 }

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -293,12 +293,14 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn discovery_returns_context_mesh_on_first_attempt() {
         let mock = MockSyncNetwork::default();
+        let context_id = ctx(0xAA);
+        let context_topic = TopicHash::from_raw(context_id);
         let peer = dummy_peer(1);
-        mock.push_mesh_peers(vec![peer]);
+        mock.push_subscribed_peers_for(context_topic, vec![peer]);
 
         let outcome = discover_mesh_peers_with_namespace_fallback(
             &mock,
-            ctx(0xAA),
+            context_id,
             3,
             Duration::from_millis(50),
             || None,
@@ -317,7 +319,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn discovery_errs_when_context_empty_and_no_namespace_fallback() {
         let mock = MockSyncNetwork::default();
-        // No `push_mesh_peers` → mock returns empty.
+        // Nothing seeded → mock returns empty for every topic.
 
         let result = discover_mesh_peers_with_namespace_fallback(
             &mock,
@@ -338,12 +340,8 @@ mod tests {
     /// Both meshes empty (context topic exhausted retries AND the
     /// namespace fallback also returned no peers) → Err. Distinct
     /// from `discovery_errs_when_context_empty_and_no_namespace_fallback`,
-    /// which exercises the no-resolver branch.
-    ///
-    /// The positive `NamespaceFallback` case (context empty, namespace
-    /// returns peers) is tracked in #2426 — `MockSyncNetwork` today
-    /// ignores its topic argument, so per-topic responses aren't
-    /// expressible. That test will land with the mock change.
+    /// which exercises the no-resolver branch. Neither topic is seeded,
+    /// so both fall through to the (empty) shared queue.
     #[tokio::test(start_paused = true)]
     async fn discovery_errs_when_both_meshes_empty() {
         let mock = MockSyncNetwork::default();
@@ -364,42 +362,39 @@ mod tests {
         );
     }
 
-    /// #2422 Options 3/4 intersection filter: the namespace-fallback
-    /// arm now intersects ns_peers with the context-topic mesh, so a
-    /// namespace member who DIDN'T subscribe to the context (auto-follow
-    /// opted out, JoinContext in flight, etc.) is filtered out and not
-    /// dialed.
+    /// The namespace-fallback arm intersects the namespace peer set
+    /// with the context-topic subscribers, so a namespace member who
+    /// DIDN'T subscribe to the context (auto-follow opted out,
+    /// JoinContext in flight, etc.) is filtered out and not dialed.
     ///
-    /// `MockSyncNetwork` ignores its topic argument and returns queued
-    /// responses in order, so we set up the queue to mirror the three
-    /// calls the production code makes:
-    ///   1. Context-topic retry loop — returns empty (sticky-last on
-    ///      empty queue), exhausts the retry budget.
-    ///   2. ns_topic mesh_peers call — returns the namespace peer set.
-    ///   3. context-topic mesh_peers call (the new intersection lookup)
-    ///      — returns the subset that actually subscribes.
-    /// The intersection should equal step (2) ∩ step (3).
+    /// Per-topic queues let each topic be scripted independently:
+    ///   - context topic: empty for both retry attempts, then the
+    ///     subscriber subset for the post-fallback intersection lookup
+    ///     (three reads of the same topic across phases → a three-entry
+    ///     sticky-last sequence);
+    ///   - namespace topic: the full namespace peer set.
+    /// The result should be namespace_peers ∩ context_subscribers.
     #[tokio::test(start_paused = true)]
     async fn discovery_filters_namespace_peers_by_context_subscription() {
         let mock = MockSyncNetwork::default();
         let follower = dummy_peer(1);
         let opted_out = dummy_peer(2);
 
-        // The retry loop runs `max_retries` times. Each call pops
-        // one queued response (sticky-last). Seed the queue:
-        //   [empty, empty, ns_peers=[follower, opted_out], ctx_subs=[follower]]
-        // The first two satisfy the retry-loop's empty results; the
-        // third satisfies the ns_peers query; the fourth satisfies
-        // the new context-topic intersection query.
-        mock.push_mesh_peers(vec![])
-            .push_mesh_peers(vec![])
-            .push_mesh_peers(vec![follower, opted_out])
-            .push_mesh_peers(vec![follower]);
-
+        let context_id = ctx(0xAA);
+        let context_topic = TopicHash::from_raw(context_id);
         let ns_topic = TopicHash::from_raw("ns/fake");
+
+        // Context topic: two empty reads exhaust the retry budget, then
+        // the intersection lookup sees only `follower` subscribed.
+        mock.push_subscribed_peers_for(context_topic.clone(), vec![])
+            .push_subscribed_peers_for(context_topic.clone(), vec![])
+            .push_subscribed_peers_for(context_topic, vec![follower])
+            // Namespace topic: both candidates are namespace members.
+            .push_subscribed_peers_for(ns_topic.clone(), vec![follower, opted_out]);
+
         let outcome = discover_mesh_peers_with_namespace_fallback(
             &mock,
-            ctx(0xAA),
+            context_id,
             2,
             Duration::from_millis(10),
             || Some(ns_topic),
@@ -425,16 +420,19 @@ mod tests {
         let opted_out_a = dummy_peer(1);
         let opted_out_b = dummy_peer(2);
 
-        // Retry loop: empty, empty. Then ns_peers = [a, b]; ctx_subs = [].
-        mock.push_mesh_peers(vec![])
-            .push_mesh_peers(vec![])
-            .push_mesh_peers(vec![opted_out_a, opted_out_b])
-            .push_mesh_peers(vec![]);
-
+        let context_id = ctx(0xAA);
+        let context_topic = TopicHash::from_raw(context_id);
         let ns_topic = TopicHash::from_raw("ns/fake");
+
+        // Context topic empty throughout (retries AND the intersection
+        // lookup → no context subscribers); namespace topic has two
+        // peers, both of which fail the intersection.
+        mock.push_subscribed_peers_for(context_topic, vec![])
+            .push_subscribed_peers_for(ns_topic.clone(), vec![opted_out_a, opted_out_b]);
+
         let result = discover_mesh_peers_with_namespace_fallback(
             &mock,
-            ctx(0xAA),
+            context_id,
             2,
             Duration::from_millis(10),
             || Some(ns_topic),


### PR DESCRIPTION
## What

Gives `MockSyncNetwork` per-topic response queues so sync discovery tests can script per-topic behaviour directly, instead of seeding a single shared queue to mirror the production call sequence.

Closes #2688.

## Why

`MockSyncNetwork::subscribed_peers(&self, _topic)` ignored its `topic` argument and popped from one shared queue. A test that wanted "context topic returns empty, namespace topic returns peers" couldn't express it — both queries drew from the same queue. The namespace-fallback discovery tests worked around this by seeding the single queue to mirror the exact sequence of calls the production code makes (`[empty, empty, ns_peers, ctx_subs]`), coupling them to implementation call ordering and retry count. The field names were also stale (`mesh_peers_*`) after the `mesh_peers` → `subscribed_peers` rename.

## What changed

- **Per-topic queues** (`push_subscribed_peers_for(topic, peers)`): keyed by `TopicHash`, take precedence over the shared queue. The shared queue (`push_subscribed_peers`) is kept as a fallthrough, so topic-agnostic callers/tests are unchanged.
- `subscribed_peers` now honors the requested topic.
- `assert_all_consumed`'s "≤1 sticky leftover" and "seeded-but-never-called" leak checks now apply per-topic as well as to the shared queue (via a per-topic call-count map).
- Finished the historical `mesh_peers_*` → `subscribed_peers_*` rename (fields, helpers, panic messages, module doc).
- Rewrote the discovery tests in `sync/peers.rs` to seed per topic instead of by global call order; removed the stale tracking-issue comments.
- Mechanical `push_mesh_peers` → `push_subscribed_peers` rename in `manager/namespace_join.rs` (8 sites).

Non-behaviour-changing for production code — this is test infrastructure only.

## Testing

- `cargo test -p calimero-node --lib sync::` — **191 passed, 0 failed**, including the rewritten discovery tests and 6 new per-topic mock unit tests (independence, precedence/fallthrough, per-topic sticky-last, three per-topic leak-detection cases).
- `cargo fmt --check` clean; `cargo clippy` clean on all authored lines.

## Follow-up

Unblocks the cold-cache member-selection test plan in #2642, which adds tests over the same `partition_peers_anchor_first` / namespace-fallback discovery paths and needs per-topic subscriber distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test mocks and unit tests; production `SyncNetwork` implementations are untouched.
> 
> **Overview**
> **`MockSyncNetwork`** now honors **`TopicHash`** for **`subscribed_peers`**: **`push_subscribed_peers_for`** scripts per-topic sticky-last queues (with shared **`push_subscribed_peers`** as fallthrough), a shared **`sticky_last`** helper, and stricter **`assert_all_consumed`** (per-topic read counts so a per-topic query cannot hide an unused shared queue).
> 
> **Discovery tests** in **`sync/peers.rs`** seed context vs namespace topics independently instead of one global call-order queue; stale issue comments are removed. **`namespace_join`** tests only rename **`push_mesh_peers`** → **`push_subscribed_peers`**. New mock unit tests cover independence, precedence, and leak detection.
> 
> No production sync behavior changes—test infrastructure only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3953c348ef8e739abfccd4cafe36877f17922db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->