### PR TITLE
refactor(node/state_delta): address review follow-ups (cascade ?-contract, emit signature, corrupt-blob loop)

### DIFF
--- a/crates/node/src/handlers/state_delta/events.rs
+++ b/crates/node/src/handlers/state_delta/events.rs
@@ -106,13 +106,32 @@ pub(super) async fn execute_cascaded_events(
                     phase = phase,
                     "Executing handlers for cascaded delta"
                 );
-                let all_succeeded = execute_event_handlers_parsed(
+                // Match-and-log rather than `?`: this function's contract
+                // (see the doc comment) is log-and-continue, because a `?`
+                // here would abort the cascade loop mid-batch *after* the
+                // DAG was mutated, leaving later cascaded deltas
+                // unprocessed. Treat a handler-execution error as "not all
+                // succeeded" so the events blob is kept for restart replay.
+                let all_succeeded = match execute_event_handlers_parsed(
                     &node_clients.context,
                     context_id,
                     our_identity,
                     &cascaded_payload,
                 )
-                .await?;
+                .await
+                {
+                    Ok(succeeded) => succeeded,
+                    Err(err) => {
+                        warn!(
+                            %context_id,
+                            delta_id = ?cascaded_id,
+                            error = %err,
+                            phase = phase,
+                            "Handler execution errored for cascaded delta; keeping events for restart replay"
+                        );
+                        false
+                    }
+                };
 
                 // Clear the DB's `events` blob only when every handler
                 // in the payload succeeded (#2185, #2194 review). On a
@@ -276,7 +295,7 @@ pub(super) fn emit_state_mutation_event_parsed(
     context_id: &ContextId,
     root_hash: Hash,
     events_payload: Vec<ExecutionEvent>,
-) -> Result<()> {
+) {
     let state_mutation = ContextEvent {
         context_id: *context_id,
         payload: ContextEventPayload::StateMutation(StateMutationPayload::with_root_and_events(
@@ -285,6 +304,9 @@ pub(super) fn emit_state_mutation_event_parsed(
         )),
     };
 
+    // Infallible to callers: a failed WebSocket emit is logged and
+    // swallowed (frontend notification is best-effort, not part of the
+    // node-to-node apply path), so there is no error for callers to handle.
     if let Err(e) = node_client.send_event(NodeEvent::Context(state_mutation)) {
         warn!(
             %context_id,
@@ -292,8 +314,6 @@ pub(super) fn emit_state_mutation_event_parsed(
             "Failed to emit state mutation event to WebSocket clients"
         );
     }
-
-    Ok(())
 }
 
 // ---- parse_events_payload ----

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -8,9 +8,7 @@ use calimero_context_config::types::GovernancePosition;
 use calimero_crypto::Nonce;
 use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::context::ContextId;
-use calimero_primitives::events::{
-    ContextEvent, ContextEventPayload, ExecutionEvent, NodeEvent, StateMutationPayload,
-};
+use calimero_primitives::events::ExecutionEvent;
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
@@ -658,7 +656,7 @@ pub(crate) async fn apply_authorized_state_delta(
         // Still emit events to WebSocket clients for consistency
         let events_payload = parse_events_payload(&events, &context_id);
         if let Some(payload) = events_payload {
-            emit_state_mutation_event_parsed(&node_clients.node, &context_id, root_hash, payload)?;
+            emit_state_mutation_event_parsed(&node_clients.node, &context_id, root_hash, payload);
         }
         return Ok(());
     }
@@ -873,6 +871,21 @@ pub(crate) async fn apply_authorized_state_delta(
 
     let events_payload = parse_events_payload(&events, &context_id);
 
+    // A present-but-undeserializable events blob will never parse on any
+    // future restart. Clear it once the delta is applied so
+    // `load_persisted_deltas` doesn't resurface it on every boot in a
+    // permanent warn-and-skip loop — mirrors the deserialization-error
+    // path in `execute_cascaded_events`. (`events == None` is the normal
+    // "no events" case and is left untouched.)
+    if applied && events.is_some() && events_payload.is_none() {
+        warn!(
+            %context_id,
+            delta_id = ?delta_id,
+            "Events blob failed to deserialize; clearing to prevent a permanent restart replay loop"
+        );
+        delta_store_ref.mark_events_executed(&delta_id);
+    }
+
     if applied && !handlers_already_executed {
         if let Some(ref payload) = events_payload {
             let is_author = author_id == our_identity;
@@ -933,7 +946,7 @@ pub(crate) async fn apply_authorized_state_delta(
     }
 
     if let Some(payload) = events_payload {
-        emit_state_mutation_event_parsed(&node_clients.node, &context_id, root_hash, payload)?;
+        emit_state_mutation_event_parsed(&node_clients.node, &context_id, root_hash, payload);
     }
 
     // Same log-and-continue policy: a cascade failure here must not abort the
@@ -2735,7 +2748,7 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
                     &context_id,
                     buffered.root_hash,
                     events,
-                )?;
+                );
             }
         }
     } else {


### PR DESCRIPTION
## What

Follow-up to the state_delta split, addressing the AI Code Reviewer findings on #2699. **Stacked on #2699.** Unlike the move PRs, this one intentionally contains the small *behavior* fixes that were deferred to keep those PRs pure.

| # | Severity | Fix |
|---|---|---|
| 1 | 🟡 | **Cascade `?`-contract violation.** `execute_cascaded_events` used `?` on the inner `execute_event_handlers_parsed` call, contradicting its own documented log-and-continue contract (a `?` there would abort the cascade loop mid-batch *after* the DAG was mutated). Now match-and-log; a handler error counts as "not all succeeded" so the events blob is kept for restart replay. |
| 2 | 💡 | **`parse_events_payload` corrupt-blob loop.** On the direct-apply path, a present-but-undeserializable events blob was never cleared, so `load_persisted_deltas` resurfaced it on every restart in a permanent warn-and-skip loop. The cascaded path already clears such blobs; made the direct-apply path consistent (clears once the delta is applied; `events == None` is left untouched). |
| 3 | 📝 | **`emit_state_mutation_event_parsed` signature.** Always returned `Ok(())` (the WebSocket emit is best-effort and swallowed). Changed return type to `()` and dropped the `?` at the three call sites. |

Also drops four now-unused event-type imports from `mod.rs` (owned by `events.rs` since the explicit-import conversion).

## Declined

- 🟡 *`applied_current` set before the `app_available` check* — the reviewer's own analysis notes this is "actually the correct recovery path" (`handlers_executed_for_current` stays `false`, so the main flow re-runs handlers). It's pre-existing, semantically-correct control flow in the consensus apply path; I'd rather not churn it for a "misleading signal" that behaves correctly. Left a note on the PR.

## Validation

- `cargo check -p calimero-node` clean.
- node lib tests: **274 passed**.
- node `sync_sim`: **314 passed** (covers the apply-path change in #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DAG apply, persisted event blobs, and restart replay semantics for handlers—important for correctness but localized and aligned with existing cascaded behavior.
> 
> **Overview**
> Follow-up on the **state_delta** split: tightens **event/handler** behavior on the DAG apply path without broad refactors.
> 
> **Cascaded handler errors** no longer use `?` on `execute_event_handlers_parsed` inside `execute_cascaded_events`. That matched the function’s documented **log-and-continue** contract: propagating would stop the cascade loop after the DAG was already updated and leave later cascaded deltas unprocessed. Errors are logged and treated as “not all succeeded,” so the persisted **events** blob stays for restart replay (same as partial handler failure).
> 
> On **direct apply**, if a delta is applied but the **events** bytes are present yet fail deserialization, the node now clears the blob via `mark_events_executed`—matching the cascaded path—so `load_persisted_deltas` does not warn-and-skip the same corrupt record on every boot.
> 
> **WebSocket** state-mutation emits are explicitly **infallible** to callers: `emit_state_mutation_event_parsed` returns `()` instead of always-`Ok` `Result`, and call sites drop unnecessary `?`. Unused event-type imports were removed from `mod.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19dc023d172de99becd7dfc3abda4c18eaf1cef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->