### PR TITLE
feat(storage): SharedStorage→PermissionedStorage inversion + AccessControl component

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -16,6 +16,7 @@ on:
       - "apps/scaffolding-e2e/**"
       - "apps/xcall-example/**"
       - "apps/kv-store-with-shared-storage/**"
+      - "apps/components-demo/**"
       - ".github/workflows/e2e-rust-apps.yml"
 
   pull_request:
@@ -25,6 +26,7 @@ on:
       - "apps/scaffolding-e2e/**"
       - "apps/xcall-example/**"
       - "apps/kv-store-with-shared-storage/**"
+      - "apps/components-demo/**"
       - ".github/workflows/e2e-rust-apps.yml"
 
   workflow_dispatch:
@@ -112,6 +114,11 @@ jobs:
           cd apps/kv-store-with-shared-storage
           ./build.sh
 
+      - name: Build components-demo app
+        run: |
+          cd apps/components-demo
+          ./build.sh
+
       - name: Upload app artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -126,6 +133,9 @@ jobs:
             apps/kv-store-with-shared-storage/res/*.wasm
             apps/kv-store-with-shared-storage/res/abi.json
             apps/kv-store-with-shared-storage/res/state-schema.json
+            apps/components-demo/res/*.wasm
+            apps/components-demo/res/abi.json
+            apps/components-demo/res/state-schema.json
           retention-days: 1
 
   # ── Test phase: run each workflow in parallel ──
@@ -267,6 +277,9 @@ jobs:
           - workflow: shared-storage
             file: workflows/test_shared_storage.yml
             app: kv-store-with-shared-storage
+          - workflow: components-demo
+            file: workflows/components-demo.yml
+            app: components-demo
           - workflow: kv-store-joiner-cold
             file: workflows/kv-store-joiner-cold.yml
             app: scaffolding-e2e

--- a/apps/components-demo/src/lib.rs
+++ b/apps/components-demo/src/lib.rs
@@ -61,18 +61,22 @@ impl ComponentsDemo {
         Ok(self.roles.has_role(&role, &who)?)
     }
 
-    /// e2e-support method (not for production). Attempt to grant a role,
-    /// returning whether the local admin guard accepted it (`true`) or refused
-    /// it (`false`) instead of trapping — so the adversarial workflow can assert
-    /// a non-admin is refused without failing the RPC call itself. A real app
-    /// should propagate the error (use `grant_role`). The authoritative
-    /// rejection of a *forged grant delta* that bypasses this gate happens at
-    /// merge (same writer-set-guarded mechanism the settings adversarial proves).
+    /// e2e-support method (not for production). Reports whether the caller is
+    /// allowed to grant (i.e. is an admin) as a bool instead of trapping, so the
+    /// adversarial workflow can assert a non-admin is refused without failing the
+    /// RPC call. A real app should just call `grant_role` and propagate the
+    /// error. Authorization is checked explicitly here (rather than swallowing
+    /// the error from `grant`) so a genuine storage error still propagates rather
+    /// than masquerading as a refusal. The authoritative rejection of a *forged
+    /// grant delta* that bypasses this gate happens at merge (the same
+    /// writer-set-guarded mechanism the settings adversarial step proves).
     pub fn try_grant_role(&mut self, role: String, who: PublicKey) -> app::Result<bool> {
-        match self.roles.grant(&role, who) {
-            Ok(()) => Ok(true),
-            Err(_) => Ok(false),
+        let me: PublicKey = env::executor_id().into();
+        if !self.roles.is_admin(&me) {
+            return Ok(false);
         }
+        self.roles.grant(&role, who)?;
+        Ok(true)
     }
 
     /// Owner-only write. The guard fails fast; the boundary is that `config` is

--- a/apps/components-demo/src/lib.rs
+++ b/apps/components-demo/src/lib.rs
@@ -61,6 +61,20 @@ impl ComponentsDemo {
         Ok(self.roles.has_role(&role, &who)?)
     }
 
+    /// e2e-support method (not for production). Attempt to grant a role,
+    /// returning whether the local admin guard accepted it (`true`) or refused
+    /// it (`false`) instead of trapping — so the adversarial workflow can assert
+    /// a non-admin is refused without failing the RPC call itself. A real app
+    /// should propagate the error (use `grant_role`). The authoritative
+    /// rejection of a *forged grant delta* that bypasses this gate happens at
+    /// merge (same writer-set-guarded mechanism the settings adversarial proves).
+    pub fn try_grant_role(&mut self, role: String, who: PublicKey) -> app::Result<bool> {
+        match self.roles.grant(&role, who) {
+            Ok(()) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
     /// Owner-only write. The guard fails fast; the boundary is that `config` is
     /// a writer-set-guarded entity whose sole writer is the owner.
     pub fn set_config(&mut self, value: String) -> app::Result<()> {

--- a/apps/components-demo/src/lib.rs
+++ b/apps/components-demo/src/lib.rs
@@ -1,18 +1,22 @@
 //! Example app for the access-control components.
 //!
-//! Demonstrates two of the `calimero_storage` components:
+//! Demonstrates three `calimero_storage` components:
 //! - [`Ownable`] — a single-owner config cell with transferable ownership.
 //! - [`PermissionedStorage`] — a group-writable settings map.
+//! - [`AccessControl`] — an admin-managed role registry.
 //!
-//! The guards in the methods (`only_owner`) are fail-fast UX. The real
-//! authorization boundary is at merge: the components store data inside
-//! writer-set-guarded entities, so a peer that hand-crafts a delta around this
-//! WASM still has an unauthorized write rejected when honest nodes apply it.
+//! The guards in the methods (`only_owner`, the admin checks inside
+//! `AccessControl`) are fail-fast UX. The real authorization boundary is at
+//! merge: the components store data inside writer-set-guarded entities, so a
+//! peer that hand-crafts a delta around this WASM still has an unauthorized
+//! write rejected when honest nodes apply it.
 
 use std::collections::BTreeSet;
 
 use calimero_sdk::{app, env, PublicKey};
-use calimero_storage::collections::{LwwRegister, Ownable, PermissionedStorage, UnorderedMap};
+use calimero_storage::collections::{
+    AccessControl, LwwRegister, Ownable, PermissionedStorage, UnorderedMap,
+};
 
 #[app::state]
 pub struct ComponentsDemo {
@@ -22,18 +26,39 @@ pub struct ComponentsDemo {
     /// Group-writable settings. Every entry inherits the writer domain, so a
     /// non-writer's forged entry is rejected at merge — not just the wrapper.
     settings: PermissionedStorage<UnorderedMap<String, LwwRegister<String>>>,
+    /// Role registry. The installer is the sole initial admin; admins grant /
+    /// revoke roles, and a non-admin's forged grant is rejected at merge.
+    roles: AccessControl,
 }
 
 #[app::logic]
 impl ComponentsDemo {
-    /// The installer becomes the config owner and the sole settings writer.
+    /// The installer becomes the config owner, sole settings writer, and admin.
     #[app::init]
     pub fn init() -> ComponentsDemo {
         let me: PublicKey = env::executor_id().into();
         ComponentsDemo {
             config: Ownable::new_owned_by(me),
             settings: PermissionedStorage::new(BTreeSet::from([me]), false),
+            roles: AccessControl::new(me),
         }
+    }
+
+    /// Grant a role to a member. Admin-only (fail-fast here, enforced at merge).
+    pub fn grant_role(&mut self, role: String, who: PublicKey) -> app::Result<()> {
+        self.roles.grant(&role, who)?;
+        Ok(())
+    }
+
+    /// Revoke a role from a member. Admin-only.
+    pub fn revoke_role(&mut self, role: String, who: PublicKey) -> app::Result<()> {
+        self.roles.revoke(&role, &who)?;
+        Ok(())
+    }
+
+    /// Whether a member holds a role (anyone may query).
+    pub fn has_role(&self, role: String, who: PublicKey) -> app::Result<bool> {
+        Ok(self.roles.has_role(&role, &who)?)
     }
 
     /// Owner-only write. The guard fails fast; the boundary is that `config` is
@@ -117,6 +142,32 @@ mod tests {
             .unwrap();
         assert_eq!(app.view(|s| s.get_config()).unwrap(), "by-other");
         assert!(app.call(|s| s.set_config("nope".to_owned())).is_err());
+    }
+
+    #[test]
+    fn admin_grants_role_non_admin_cannot() {
+        let mut app = TestHost::new(ComponentsDemo::init);
+        let other: PublicKey = OTHER.into();
+
+        // Admin (the installer) grants a role.
+        app.call(|s| s.grant_role("editor".to_owned(), other))
+            .unwrap();
+        assert!(app
+            .view(|s| s.has_role("editor".to_owned(), other))
+            .unwrap());
+
+        // A non-admin's grant is rejected by the fail-fast guard (and would be
+        // at merge). Merge-time enforcement needs a 2-node e2e (design §6.3).
+        let third: PublicKey = [0x33; 32].into();
+        let denied = app.call_as(OTHER, |s| s.grant_role("editor".to_owned(), third));
+        assert!(denied.is_err());
+
+        // Admin can revoke.
+        app.call(|s| s.revoke_role("editor".to_owned(), other))
+            .unwrap();
+        assert!(!app
+            .view(|s| s.has_role("editor".to_owned(), other))
+            .unwrap());
     }
 
     #[test]

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -1,0 +1,171 @@
+description: Access-control components (Ownable / PermissionedStorage / AccessControl) e2e
+name: Components demo workflow
+
+# Proves the components' core claim end-to-end across two nodes: authorized
+# writes converge, and an UNAUTHORIZED write is rejected at merge (not just by
+# the fail-fast API guard). The adversarial step is last because it deliberately
+# diverges the forging node.
+
+stop_all_nodes: false
+restart: false
+wait_timeout: 120
+
+nodes:
+  chain_id: testnet-1
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: new-calimero-node
+
+steps:
+  # Node 1 installs; the installer is config owner, sole settings writer, admin.
+  - name: Install Application on Node 1
+    type: install_application
+    node: new-calimero-node-1
+    path: "./res/components_demo.wasm"
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Mesh
+    type: create_mesh
+    context_node: new-calimero-node-1
+    application_id: '{{app_id}}'
+    path: "./res/components_demo.wasm"
+    nodes:
+      - new-calimero-node-2
+    capability: member
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+
+  # ============================================
+  # Ownable — owner writes config, it converges to node 2.
+  # ============================================
+
+  - name: Node 1 (owner) sets config
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: set_config
+    args:
+      value: "owner-config"
+
+  - name: Wait for config to sync
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - new-calimero-node-1
+      - new-calimero-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node 2 reads the owner's config
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: get_config
+    outputs:
+      node2_config: result
+
+  - name: Assert config converged to node 2
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_config}}, {"output": "owner-config"})'
+
+  # ============================================
+  # AccessControl — admin (node 1) grants node 2 the "editor" role; it converges.
+  # ============================================
+
+  - name: Node 1 (admin) grants editor to node 2
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: grant_role
+    args:
+      role: "editor"
+      who: "{{public_key_new-calimero-node-2}}"
+
+  - name: Wait for the grant to sync
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - new-calimero-node-1
+      - new-calimero-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node 2 sees its editor role
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: has_role
+    args:
+      role: "editor"
+      who: "{{public_key_new-calimero-node-2}}"
+    outputs:
+      node2_has_editor: result
+
+  - name: Assert the grant converged to node 2
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_has_editor}}, {"output": true})'
+
+  # ============================================
+  # AccessControl fail-fast — node 2 is an editor but NOT an admin, so its grant
+  # attempt is refused at the API surface (the call errors).
+  # ============================================
+
+  - name: Node 2 (non-admin) attempts to grant a role
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: try_grant_role
+    args:
+      role: "editor"
+      who: "{{public_key_new-calimero-node-1}}"
+    outputs:
+      node2_grant_accepted: result
+
+  - name: Assert node 2's non-admin grant was refused
+    type: json_assert
+    statements:
+      - 'json_equal({{node2_grant_accepted}}, {"output": false})'
+
+  # ============================================
+  # Adversarial (LAST — deliberately diverges node 2). Node 2 is NOT a writer of
+  # the settings map (only node 1 is), so its forged settings write is applied
+  # locally but rejected by node 1 at MERGE — proving the boundary is merge-time
+  # signature verification, not the fail-fast guard. `settings_set` has no local
+  # admin/owner guard (it just writes the guarded entity), so this exercises the
+  # merge path exactly like a hand-crafted delta would. The AccessControl grant
+  # registry above is the same writer-set-guarded map shape, so this proves the
+  # same enforcement that protects role grants. Nothing convergent may follow.
+  # ============================================
+
+  - name: Node 2 (non-writer) forges a settings write
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: settings_set
+    args:
+      key: "evil"
+      value: "forged"
+
+  - name: Let the forged delta attempt (and fail) to propagate
+    type: wait
+    seconds: 20
+
+  - name: Node 1 reads the entry the non-writer tried to set
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: settings_get
+    args:
+      key: "evil"
+    outputs:
+      node1_evil_read: result
+
+  - name: Assert the non-writer's forged settings write did NOT reach node 1
+    type: json_assert
+    statements:
+      - 'json_equal({{node1_evil_read}}, {"output": null})'

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -115,14 +115,17 @@ steps:
   # attempt is refused at the API surface (the call errors).
   # ============================================
 
+  # Grantee is node 2's own key (the only pubkey template merobox exposes); the
+  # point is that node 2 is a non-admin, so the grant is refused regardless of
+  # who the grantee is.
   - name: Node 2 (non-admin) attempts to grant a role
     type: call
     node: new-calimero-node-2
     context_id: '{{context_id}}'
     method: try_grant_role
     args:
-      role: "editor"
-      who: "{{public_key_new-calimero-node-1}}"
+      role: "viewer"
+      who: "{{public_key_new-calimero-node-2}}"
     outputs:
       node2_grant_accepted: result
 

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -140,9 +140,16 @@ steps:
   # locally but rejected by node 1 at MERGE — proving the boundary is merge-time
   # signature verification, not the fail-fast guard. `settings_set` has no local
   # admin/owner guard (it just writes the guarded entity), so this exercises the
-  # merge path exactly like a hand-crafted delta would. The AccessControl grant
-  # registry above is the same writer-set-guarded map shape, so this proves the
-  # same enforcement that protects role grants. Nothing convergent may follow.
+  # merge path exactly like a hand-crafted delta would.
+  #
+  # This is the *direct* merge-enforcement proof for PermissionedStorage. For
+  # AccessControl it is a PROXY proof: the role registry is the identical
+  # `SharedStorage<UnorderedMap<..>>` guarded-entry shape, so it inherits the
+  # same merge rejection exercised here — and that mechanism is also covered
+  # directly by storage-layer adversarial unit tests (forged Shared/SharedMember
+  # writes rejected). A forged `grant_role` can't be driven here because the
+  # fail-fast `only_admin()` guard rejects it before it reaches the merge path.
+  # Nothing convergent may follow.
   # ============================================
 
   - name: Node 2 (non-writer) forges a settings write

--- a/crates/sdk/macros/src/private.rs
+++ b/crates/sdk/macros/src/private.rs
@@ -41,9 +41,10 @@ use sha2::{Digest, Sha256};
 ///   `PNCounter`, `ReplicatedGrowableArray`) — CRDTs exist for
 ///   multi-writer conflict resolution; in single-writer private
 ///   storage their merge semantics are unused complexity.
-/// - Access-control collections (`SharedStorage`, `UserStorage`,
-///   `FrozenStorage`) — cross-writer mutability, per-user
-///   separation, and immutability all assume the synced tree.
+/// - Access-control collections (`SharedStorage`, `PermissionedStorage`,
+///   `Ownable`, `AccessControl`, `UserStorage`, `FrozenStorage`) —
+///   cross-writer mutability, per-user separation, and immutability
+///   all assume the synced tree.
 /// - Authored collections (`AuthoredMap`, `AuthoredVector`) —
 ///   carry per-entry authorship which is a sync-side concern.
 ///
@@ -109,6 +110,22 @@ const PRIVATE_INCOMPATIBLE: &[(&str, &str)] = &[
     (
         "SharedStorage",
         "models single-signature shared/causal reconciliation; pointless with one writer.",
+    ),
+    (
+        // `PermissionedStorage<T, A>` is the base `SharedStorage` is now an alias
+        // of; `Ownable` is its single-owner alias. Both wrap a syncing,
+        // writer-set-guarded entity, so they have no place in node-local private
+        // storage (their data would still enter the synced tree).
+        "PermissionedStorage",
+        "is writer-set-guarded shared storage; its data syncs, so it cannot live in a private namespace.",
+    ),
+    (
+        "Ownable",
+        "is single-owner shared storage (a SharedStorage alias); its data syncs, so it cannot live in a private namespace.",
+    ),
+    (
+        "AccessControl",
+        "is a writer-set-guarded role registry backed by shared storage; its data syncs, so it cannot live in a private namespace.",
     ),
     (
         "UserStorage",
@@ -632,6 +649,9 @@ mod tests {
 
     const EXCLUDED_ACCESS_CONTROL_TYPES: &[&str] = &[
         "SharedStorage<String>",
+        "PermissionedStorage<String>",
+        "Ownable<String>",
+        "AccessControl",
         "UserStorage<String>",
         "FrozenStorage<String>",
         "AuthoredMap<String, String>",

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -915,6 +915,11 @@ fn generate_assign_deterministic_ids_impl(
             // a substring of `SharedStorage`.
             || type_str.contains("PermissionedStorage")
             || type_str.contains("Ownable")
+            // `AccessControl` wraps a single guarded storage; its
+            // `reassign_deterministic_id` delegates to it. The macro does not
+            // recurse into nested structs, so without this its inner storage
+            // keeps a random id and diverges across nodes.
+            || type_str.contains("AccessControl")
             // `AuthoredVector` is already matched by the `"Vector"` substring above;
             // `AuthoredMap` is NOT a substring of any entry, so it must be listed
             // explicitly or its outer wrapper id stays `Id::random()` and a

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -65,6 +65,8 @@ pub mod permissioned;
 pub use permissioned::{
     Authorizer, Op, Ownable, OwnerAcl, PermissionedStorage, SharedStorage, WriterSetAcl,
 };
+pub mod access_control;
+pub use access_control::AccessControl;
 mod authored_common;
 pub mod authored_map;
 pub use authored_map::AuthoredMap;

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -60,9 +60,11 @@ pub use error::StoreError;
 pub mod user;
 pub use user::UserStorage;
 pub mod shared;
-pub use shared::SharedStorage;
+pub use shared::WriterSetCell;
 pub mod permissioned;
-pub use permissioned::{Authorizer, Op, Ownable, OwnerAcl, PermissionedStorage, WriterSetAcl};
+pub use permissioned::{
+    Authorizer, Op, Ownable, OwnerAcl, PermissionedStorage, SharedStorage, WriterSetAcl,
+};
 mod authored_common;
 pub mod authored_map;
 pub use authored_map::AuthoredMap;

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -109,6 +109,8 @@ impl AccessControl {
                 "Role name must not contain a NUL byte".to_owned(),
             )));
         }
+        // Byte length (not char count) — role names become storage keys, so the
+        // encoded size is the relevant bound.
         if role.len() > MAX_ROLE_NAME_LEN {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Role name exceeds the maximum length".to_owned(),
@@ -248,9 +250,11 @@ impl AccessControl {
     /// Grant `role` to `who`. Only an admin may; enforced at merge (the registry
     /// entry inherits the admin writer set).
     ///
+    /// Idempotent in effect (holding the role after any number of grants) but
+    /// not in storage: each call writes a fresh `LwwRegister` and emits a delta.
     /// Concurrent `grant`/`revoke` of the same `(role, member)` from different
     /// admins resolve last-writer-wins by the `LwwRegister` timestamp — there is
-    /// no semantic tie-break.
+    /// no semantic tie-break, and a re-grant refreshes that timestamp.
     ///
     /// # Errors
     /// `ActionNotAllowed` if the executor is not an admin or `role` contains the

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -43,6 +43,11 @@ use crate::interface::StorageError;
 /// key is unambiguous without escaping.
 const ROLE_MEMBER_SEP: char = '\0';
 
+/// Upper bound on a role name's length. Role names are admin-supplied and become
+/// part of a storage key; a bound keeps key sizes sane and caps how much a
+/// (compromised) admin can inflate the registry per entry.
+const MAX_ROLE_NAME_LEN: usize = 128;
+
 /// The registry value type: a last-writer-wins boolean. `true` = the member
 /// currently holds the role; `false` = revoked. Storing a flag (rather than
 /// removing the entry) keeps membership a plain LWW merge with no tombstone.
@@ -91,14 +96,22 @@ impl AccessControl {
         self.grants.reassign_deterministic_id(field_name);
     }
 
-    /// Reject role names containing the separator byte. Without this a role
-    /// name like `"editor\0<hex>"` could craft a key that collides with a
-    /// different `(role, member)` pair — a privilege-confusion vector. Called by
-    /// every role method before a key is built.
+    /// Validate a role name. Rejects names containing the separator byte
+    /// (`ROLE_MEMBER_SEP`) — without this a name like `"editor\0<hex>"` could
+    /// craft a key that collides with a different `(role, member)` pair, a
+    /// privilege-confusion vector — and names longer than [`MAX_ROLE_NAME_LEN`].
+    /// The separator check references the same constant the key uses, so it
+    /// stays correct if the separator is ever changed. Called by every role
+    /// method before a key is built.
     fn check_role(role: &str) -> Result<(), StoreError> {
         if role.contains(ROLE_MEMBER_SEP) {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Role name must not contain a NUL byte".to_owned(),
+            )));
+        }
+        if role.len() > MAX_ROLE_NAME_LEN {
+            return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Role name exceeds the maximum length".to_owned(),
             )));
         }
         Ok(())
@@ -181,8 +194,11 @@ impl AccessControl {
             return self.only_admin();
         }
         // `rotate_writers` also rejects an empty set, but bail early with a
-        // clearer message before attempting the rotation.
+        // clearer message before attempting the rotation. Authorize first so a
+        // non-admin gets "not an admin" rather than learning the set is down to
+        // its last member.
         if admins.is_empty() {
+            self.only_admin()?;
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Cannot revoke the last admin".to_owned(),
             )));
@@ -423,5 +439,19 @@ mod tests {
         assert!(ac.grant("editor\0evil", BOB.into()).is_err());
         assert!(ac.revoke("editor\0evil", &BOB.into()).is_err());
         assert!(ac.has_role("editor\0evil", &BOB.into()).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn over_long_role_name_is_rejected() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        let long = "r".repeat(super::MAX_ROLE_NAME_LEN + 1);
+        assert!(ac.grant(&long, BOB.into()).is_err());
+        // A name at the limit is fine.
+        let ok = "r".repeat(super::MAX_ROLE_NAME_LEN);
+        assert!(ac.grant(&ok, BOB.into()).is_ok());
     }
 }

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -38,9 +38,9 @@ use crate::entities::{ChildInfo, Data, Element};
 use crate::env;
 use crate::interface::StorageError;
 
-/// Separator between the role name and the member key in a registry key. A NUL
-/// byte cannot appear in a well-formed role name, so the composite key is
-/// unambiguous without escaping.
+/// Separator between the role name and the member key in a registry key. Role
+/// names containing this byte are rejected (see `check_role`), so the composite
+/// key is unambiguous without escaping.
 const ROLE_MEMBER_SEP: char = '\0';
 
 /// The registry value type: a last-writer-wins boolean. `true` = the member
@@ -91,8 +91,22 @@ impl AccessControl {
         self.grants.reassign_deterministic_id(field_name);
     }
 
+    /// Reject role names containing the separator byte. Without this a role
+    /// name like `"editor\0<hex>"` could craft a key that collides with a
+    /// different `(role, member)` pair — a privilege-confusion vector. Called by
+    /// every role method before a key is built.
+    fn check_role(role: &str) -> Result<(), StoreError> {
+        if role.contains(ROLE_MEMBER_SEP) {
+            return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Role name must not contain a NUL byte".to_owned(),
+            )));
+        }
+        Ok(())
+    }
+
     /// Composite registry key for `(role, member)`. Member is hex of its 32
-    /// bytes — a stable, separator-free encoding.
+    /// bytes — a stable, separator-free encoding. Callers must `check_role`
+    /// first so `role` cannot contain the separator.
     fn key(role: &str, member: &PublicKey) -> String {
         let member_hex = hex::encode(member.as_ref() as &[u8; 32]);
         format!("{role}{ROLE_MEMBER_SEP}{member_hex}")
@@ -126,7 +140,13 @@ impl AccessControl {
     }
 
     /// Add `who` to the admin set via an authenticated writer-set rotation.
-    /// Only a current admin may; enforced at merge.
+    /// Only a current admin may.
+    ///
+    /// The admin check is the single `guard(Op::Admin)` inside
+    /// [`rotate_writers`](SharedStorage::rotate_writers) — no separate
+    /// `only_admin()` here, matching the one-gate-per-method rule (unlike
+    /// `grant`/`revoke`, whose collection-insert path is not locally gated and
+    /// so need the explicit fail-fast).
     ///
     /// # Errors
     /// `ActionNotAllowed` if the executor is not a current admin.
@@ -137,7 +157,13 @@ impl AccessControl {
     }
 
     /// Remove `who` from the admin set via an authenticated rotation. Only a
-    /// current admin may; enforced at merge. The set may not become empty.
+    /// current admin may; the set may not become empty.
+    ///
+    /// The empty-set guard is **best-effort at the API surface**: two admins
+    /// concurrently revoking each other both pass their local check, and the
+    /// rotations merge per ADR 0001 — the result could drop to one admin. The
+    /// merge layer (`rotate_writers` rejecting an empty set) is the backstop;
+    /// this local check just gives a clear early error in the common case.
     ///
     /// # Errors
     /// `ActionNotAllowed` if the executor is not a current admin, or if removing
@@ -159,9 +185,15 @@ impl AccessControl {
 
     /// Whether `who` currently holds `role`.
     ///
+    /// Returns `false` for both "never granted" and "granted then revoked" —
+    /// the registry is a current-membership boolean, not a history, so callers
+    /// cannot distinguish those two states.
+    ///
     /// # Errors
-    /// Propagates a storage error from the registry lookup.
+    /// `ActionNotAllowed` if `role` contains the separator byte; propagates a
+    /// storage error from the registry lookup.
     pub fn has_role(&self, role: &str, who: &PublicKey) -> Result<bool, StoreError> {
+        Self::check_role(role)?;
         let key = Self::key(role, who);
         Ok(self
             .grants
@@ -191,11 +223,16 @@ impl AccessControl {
     /// Grant `role` to `who`. Only an admin may; enforced at merge (the registry
     /// entry inherits the admin writer set).
     ///
+    /// Concurrent `grant`/`revoke` of the same `(role, member)` from different
+    /// admins resolve last-writer-wins by the `LwwRegister` timestamp — there is
+    /// no semantic tie-break.
+    ///
     /// # Errors
-    /// `ActionNotAllowed` if the executor is not an admin; propagates a storage
-    /// error from the write.
+    /// `ActionNotAllowed` if the executor is not an admin or `role` contains the
+    /// separator byte; propagates a storage error from the write.
     pub fn grant(&mut self, role: &str, who: PublicKey) -> Result<(), StoreError> {
         self.only_admin()?;
+        Self::check_role(role)?;
         let key = Self::key(role, &who);
         let _ = self.grants.get_mut()?.insert(key, LwwRegister::new(true))?;
         Ok(())
@@ -204,11 +241,18 @@ impl AccessControl {
     /// Revoke `role` from `who` (sets the present-flag to `false`). Only an admin
     /// may; enforced at merge.
     ///
+    /// A revoke writes `false` rather than removing the entry (so membership is
+    /// a plain LWW boolean with no tombstone). One consequence: a registry that
+    /// sees many distinct `(role, member)` pairs over its lifetime accumulates a
+    /// `false` entry per pair and does not shrink; this is acceptable for the
+    /// expected scale (a context's member/role count), not for unbounded churn.
+    ///
     /// # Errors
-    /// `ActionNotAllowed` if the executor is not an admin; propagates a storage
-    /// error from the write.
+    /// `ActionNotAllowed` if the executor is not an admin or `role` contains the
+    /// separator byte; propagates a storage error from the write.
     pub fn revoke(&mut self, role: &str, who: &PublicKey) -> Result<(), StoreError> {
         self.only_admin()?;
+        Self::check_role(role)?;
         let key = Self::key(role, who);
         let _ = self
             .grants
@@ -328,5 +372,47 @@ mod tests {
 
         assert!(!ac.has_role("editor", &BOB.into()).unwrap());
         assert!(ac.has_role("viewer", &BOB.into()).unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn only_role_gates_on_held_role() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+        ac.grant("editor", BOB.into()).unwrap();
+
+        // Alice (admin, but no editor role) is refused; Bob (editor) passes.
+        assert!(ac.only_role("editor").is_err());
+        env::set_executor_id(BOB);
+        assert!(ac.only_role("editor").is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn revoke_then_check_in_same_execution_is_false() {
+        // grant -> revoke -> has_role within one execution must read `false`
+        // (the registry is read from storage, not a stale in-memory snapshot).
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        ac.grant("editor", BOB.into()).unwrap();
+        assert!(ac.has_role("editor", &BOB.into()).unwrap());
+        ac.revoke("editor", &BOB.into()).unwrap();
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn role_name_with_separator_is_rejected() {
+        // A NUL in the role name could otherwise craft a colliding key.
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        assert!(ac.grant("editor\0evil", BOB.into()).is_err());
+        assert!(ac.revoke("editor\0evil", &BOB.into()).is_err());
+        assert!(ac.has_role("editor\0evil", &BOB.into()).is_err());
     }
 }

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -142,17 +142,22 @@ impl AccessControl {
     /// Add `who` to the admin set via an authenticated writer-set rotation.
     /// Only a current admin may.
     ///
-    /// The admin check is the single `guard(Op::Admin)` inside
-    /// [`rotate_writers`](SharedStorage::rotate_writers) — no separate
-    /// `only_admin()` here, matching the one-gate-per-method rule (unlike
-    /// `grant`/`revoke`, whose collection-insert path is not locally gated and
-    /// so need the explicit fail-fast).
+    /// One authorization gate per path: `rotate_writers`'s `guard(Op::Admin)`
+    /// when the set actually changes, or `only_admin()` on the idempotent no-op
+    /// path (where no rotation runs). Never both — matching the one-gate rule.
+    /// (Unlike `grant`/`revoke`, whose collection-insert path is not locally
+    /// gated and so always need the explicit fail-fast.)
     ///
     /// # Errors
     /// `ActionNotAllowed` if the executor is not a current admin.
     pub fn grant_admin(&mut self, who: PublicKey) -> Result<(), StoreError> {
         let mut admins = self.grants.writers();
-        let _ = admins.insert(who);
+        if !admins.insert(who) {
+            // Already an admin: no set change, so skip the (otherwise no-op)
+            // rotation — but still authorize the caller, since on this path
+            // `rotate_writers` wouldn't run to provide the gate.
+            return self.only_admin();
+        }
         self.grants.rotate_writers(admins)
     }
 
@@ -170,7 +175,11 @@ impl AccessControl {
     /// `who` would leave no admins.
     pub fn revoke_admin(&mut self, who: &PublicKey) -> Result<(), StoreError> {
         let mut admins = self.grants.writers();
-        let _ = admins.remove(who);
+        if !admins.remove(who) {
+            // `who` is not an admin: no set change, so skip the no-op rotation —
+            // but still authorize the caller (the rotation gate wouldn't run).
+            return self.only_admin();
+        }
         // `rotate_writers` also rejects an empty set, but bail early with a
         // clearer message before attempting the rotation.
         if admins.is_empty() {

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -113,7 +113,7 @@ impl AccessControl {
         // encoded size is the relevant bound.
         if role.len() > MAX_ROLE_NAME_LEN {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
-                "Role name exceeds the maximum length".to_owned(),
+                format!("Role name exceeds the maximum length ({MAX_ROLE_NAME_LEN} bytes)"),
             )));
         }
         Ok(())
@@ -162,6 +162,11 @@ impl AccessControl {
     /// path (where no rotation runs). Never both — matching the one-gate rule.
     /// (Unlike `grant`/`revoke`, whose collection-insert path is not locally
     /// gated and so always need the explicit fail-fast.)
+    ///
+    /// Concurrent `grant_admin` calls from two admins are last-rotation-wins per
+    /// the writer-set rotation merge (ADR 0001): both rotate from the same base
+    /// set, so only one added admin may survive the merge. Re-run if a specific
+    /// admin must end up in the set.
     ///
     /// # Errors
     /// `ActionNotAllowed` if the executor is not a current admin.

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -1,0 +1,332 @@
+//! Role-based access control as a merge-enforced membership registry.
+//!
+//! [`AccessControl`] tracks which members hold which named roles, backed by a
+//! single [`SharedStorage`] whose **writer set is the admin tier**. Granting or
+//! revoking a role mutates the guarded registry, so — like every component here
+//! — the authoritative check is at merge: a non-admin's hand-crafted grant delta
+//! is rejected because the registry entries are writer-set-guarded. Admin
+//! changes are a writer-set rotation (O(1), authenticated). `only_role` /
+//! `only_admin` are fail-fast API guards that mirror what merge enforces.
+//!
+//! # Model
+//!
+//! - **Admins** are exactly the writer set of the backing storage. Any admin may
+//!   grant/revoke any role (a single admin tier, like OpenZeppelin's
+//!   `DEFAULT_ADMIN_ROLE`). Change the admin set with
+//!   [`grant_admin`](AccessControl::grant_admin) /
+//!   [`revoke_admin`](AccessControl::revoke_admin) (authenticated rotation).
+//! - **Roles** are named member sets recorded in the guarded registry. A grant
+//!   is a present-flag entry (`true`); a revoke sets it to `false` rather than
+//!   removing, so membership is a last-writer-wins boolean and never needs a
+//!   tombstone. [`has_role`](AccessControl::has_role) is the lookup app guards
+//!   use.
+//!
+//! To make a role actually gate *writes to specific data*, store that data in
+//! its own [`SharedStorage`] and rotate its writers to the role's members; this
+//! registry is the source of truth for "who is in role R", and `only_role` is
+//! the fail-fast guard at the API surface.
+
+use std::collections::BTreeSet;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_primitives::identity::PublicKey;
+
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
+use super::permissioned::SharedStorage;
+use super::{LwwRegister, StoreError, UnorderedMap};
+use crate::entities::{ChildInfo, Data, Element};
+use crate::env;
+use crate::interface::StorageError;
+
+/// Separator between the role name and the member key in a registry key. A NUL
+/// byte cannot appear in a well-formed role name, so the composite key is
+/// unambiguous without escaping.
+const ROLE_MEMBER_SEP: char = '\0';
+
+/// The registry value type: a last-writer-wins boolean. `true` = the member
+/// currently holds the role; `false` = revoked. Storing a flag (rather than
+/// removing the entry) keeps membership a plain LWW merge with no tombstone.
+type Grant = LwwRegister<bool>;
+
+/// Role-based access control backed by a single writer-set-guarded registry.
+///
+/// The backing [`SharedStorage`]'s writers are the admin tier; role grants are
+/// entries in its guarded map. See the [module docs](self) for the model.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct AccessControl {
+    /// `role\0member_hex -> LwwRegister<bool>`. Writers of this storage are the
+    /// admins; entries inherit the writer domain and are verified at merge.
+    #[borsh(bound(serialize = "", deserialize = ""))]
+    grants: SharedStorage<UnorderedMap<String, Grant>>,
+}
+
+impl core::fmt::Debug for AccessControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AccessControl")
+            .field("grants", &self.grants)
+            .finish()
+    }
+}
+
+impl AccessControl {
+    /// Create an `AccessControl` with `admin` as the sole initial admin. Use for
+    /// nested fields; the `#[app::state]` macro canonicalises the id via
+    /// [`reassign_deterministic_id`](Self::reassign_deterministic_id).
+    pub fn new(admin: PublicKey) -> Self {
+        Self {
+            grants: SharedStorage::new(BTreeSet::from([admin]), false),
+        }
+    }
+
+    /// Create an `AccessControl` administered by the current executor (the
+    /// common case in `init`).
+    pub fn new_admin_caller() -> Self {
+        let me: PublicKey = env::executor_id().into();
+        Self::new(me)
+    }
+
+    /// Canonicalise the backing storage id from `field_name`. Called by the
+    /// `#[app::state]` macro after `init()` so every node derives the same id.
+    pub fn reassign_deterministic_id(&mut self, field_name: &str) {
+        self.grants.reassign_deterministic_id(field_name);
+    }
+
+    /// Composite registry key for `(role, member)`. Member is hex of its 32
+    /// bytes — a stable, separator-free encoding.
+    fn key(role: &str, member: &PublicKey) -> String {
+        let member_hex = hex::encode(member.as_ref() as &[u8; 32]);
+        format!("{role}{ROLE_MEMBER_SEP}{member_hex}")
+    }
+
+    // --- admin tier (the writer set) ---
+
+    /// The current admin set (the backing storage's writers).
+    pub fn admins(&self) -> BTreeSet<PublicKey> {
+        self.grants.writers()
+    }
+
+    /// Whether `who` is an admin.
+    pub fn is_admin(&self, who: &PublicKey) -> bool {
+        self.grants.writers().contains(who)
+    }
+
+    /// Fail-fast admin guard. NOT the security boundary — merge is.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the current executor is not an admin.
+    pub fn only_admin(&self) -> Result<(), StoreError> {
+        let me: PublicKey = env::executor_id().into();
+        if self.is_admin(&me) {
+            Ok(())
+        } else {
+            Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Executor is not an admin".to_owned(),
+            )))
+        }
+    }
+
+    /// Add `who` to the admin set via an authenticated writer-set rotation.
+    /// Only a current admin may; enforced at merge.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not a current admin.
+    pub fn grant_admin(&mut self, who: PublicKey) -> Result<(), StoreError> {
+        let mut admins = self.grants.writers();
+        let _ = admins.insert(who);
+        self.grants.rotate_writers(admins)
+    }
+
+    /// Remove `who` from the admin set via an authenticated rotation. Only a
+    /// current admin may; enforced at merge. The set may not become empty.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not a current admin, or if removing
+    /// `who` would leave no admins.
+    pub fn revoke_admin(&mut self, who: &PublicKey) -> Result<(), StoreError> {
+        let mut admins = self.grants.writers();
+        let _ = admins.remove(who);
+        // `rotate_writers` also rejects an empty set, but bail early with a
+        // clearer message before attempting the rotation.
+        if admins.is_empty() {
+            return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Cannot revoke the last admin".to_owned(),
+            )));
+        }
+        self.grants.rotate_writers(admins)
+    }
+
+    // --- named roles (registry entries) ---
+
+    /// Whether `who` currently holds `role`.
+    ///
+    /// # Errors
+    /// Propagates a storage error from the registry lookup.
+    pub fn has_role(&self, role: &str, who: &PublicKey) -> Result<bool, StoreError> {
+        let key = Self::key(role, who);
+        Ok(self
+            .grants
+            .get()?
+            .get(&key)?
+            .map(|v| *v.get())
+            .unwrap_or(false))
+    }
+
+    /// Fail-fast guard: the current executor must hold `role`. NOT the security
+    /// boundary — merge is.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the current executor does not hold `role`;
+    /// propagates a storage error from the lookup.
+    pub fn only_role(&self, role: &str) -> Result<(), StoreError> {
+        let me: PublicKey = env::executor_id().into();
+        if self.has_role(role, &me)? {
+            Ok(())
+        } else {
+            Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Executor does not hold the required role".to_owned(),
+            )))
+        }
+    }
+
+    /// Grant `role` to `who`. Only an admin may; enforced at merge (the registry
+    /// entry inherits the admin writer set).
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not an admin; propagates a storage
+    /// error from the write.
+    pub fn grant(&mut self, role: &str, who: PublicKey) -> Result<(), StoreError> {
+        self.only_admin()?;
+        let key = Self::key(role, &who);
+        let _ = self.grants.get_mut()?.insert(key, LwwRegister::new(true))?;
+        Ok(())
+    }
+
+    /// Revoke `role` from `who` (sets the present-flag to `false`). Only an admin
+    /// may; enforced at merge.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not an admin; propagates a storage
+    /// error from the write.
+    pub fn revoke(&mut self, role: &str, who: &PublicKey) -> Result<(), StoreError> {
+        self.only_admin()?;
+        let key = Self::key(role, who);
+        let _ = self
+            .grants
+            .get_mut()?
+            .insert(key, LwwRegister::new(false))?;
+        Ok(())
+    }
+}
+
+// `Data`/`Mergeable`/`CrdtMeta` delegate to the backing storage so `AccessControl`
+// can be nested directly in `#[app::state]`, mirroring `PermissionedStorage`.
+impl Data for AccessControl {
+    fn collections(&self) -> std::collections::BTreeMap<String, Vec<ChildInfo>> {
+        self.grants.collections()
+    }
+
+    fn element(&self) -> &Element {
+        self.grants.element()
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        self.grants.element_mut()
+    }
+}
+
+impl Mergeable for AccessControl {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.grants.merge(&other.grants)
+    }
+}
+
+impl CrdtMeta for AccessControl {
+    fn crdt_type() -> CrdtType {
+        CrdtType::SharedStorage
+    }
+    fn storage_strategy() -> StorageStrategy {
+        StorageStrategy::Structured
+    }
+    fn can_contain_crdts() -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::AccessControl;
+    use crate::collections::Root;
+    use crate::env;
+
+    const ALICE: [u8; 32] = [0x11; 32];
+    const BOB: [u8; 32] = [0x22; 32];
+    const CAROL: [u8; 32] = [0x33; 32];
+
+    #[test]
+    #[serial]
+    fn admin_can_grant_and_revoke_roles() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        assert!(ac.is_admin(&ALICE.into()));
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+
+        ac.grant("editor", BOB.into()).unwrap();
+        assert!(ac.has_role("editor", &BOB.into()).unwrap());
+
+        ac.revoke("editor", &BOB.into()).unwrap();
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn non_admin_cannot_grant() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        // Bob is not an admin — the fail-fast guard rejects his grant.
+        env::set_executor_id(BOB);
+        assert!(ac.grant("editor", CAROL.into()).is_err());
+        assert!(ac.only_admin().is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn admin_tier_rotation() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        ac.grant_admin(BOB.into()).unwrap();
+        assert!(ac.is_admin(&BOB.into()));
+
+        // Bob, now an admin, can grant.
+        env::set_executor_id(BOB);
+        ac.grant("editor", CAROL.into()).unwrap();
+        assert!(ac.has_role("editor", &CAROL.into()).unwrap());
+
+        // An admin can drop another admin, but not the last one.
+        ac.revoke_admin(&ALICE.into()).unwrap();
+        assert!(!ac.is_admin(&ALICE.into()));
+        assert!(ac.revoke_admin(&BOB.into()).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn roles_are_independent() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        ac.grant("editor", BOB.into()).unwrap();
+        ac.grant("viewer", BOB.into()).unwrap();
+        ac.revoke("editor", &BOB.into()).unwrap();
+
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+        assert!(ac.has_role("viewer", &BOB.into()).unwrap());
+    }
+}

--- a/crates/storage/src/collections/permissioned.rs
+++ b/crates/storage/src/collections/permissioned.rs
@@ -1,7 +1,7 @@
 //! Policy-parameterised access-controlled storage.
 //!
 //! [`PermissionedStorage<T, A>`] is a thin policy layer over
-//! [`SharedStorage<T>`](super::shared::SharedStorage): it reuses the proven
+//! [`WriterSetCell<T>`](super::shared::WriterSetCell): it reuses the proven
 //! writer-set storage primitive — value held in its own `SharedMember`-stamped
 //! entity, writes signed and **verified at merge** against the writer set — and
 //! adds an [`Authorizer`] `A` that decides, at the API surface, whether the
@@ -13,16 +13,17 @@
 //! [`Interface`](crate::interface::Interface) against the entity's writer set.
 //! A malicious peer that hand-crafts a delta around the WASM still has its write
 //! rejected at merge if the signer is not a writer — exactly as for a bare
-//! `SharedStorage`. The [`Authorizer`] is **fail-fast UX sugar**: it lets a
+//! `WriterSetCell`. The [`Authorizer`] is **fail-fast UX sugar**: it lets a
 //! method reject an unauthorised caller early with a clear error, using the same
 //! writer set the merge check resolves. It must therefore only express policies
 //! that reduce to what merge enforces (writer-set membership today); a policy
 //! merge cannot replay would be advisory only.
 //!
 //! Keeping the policy in the type parameter is what lets the components derive
-//! from one base: the group-writable form is
-//! `PermissionedStorage<T, WriterSetAcl>` (the default), and a single-owner cell
-//! is [`Ownable<T>`] = `PermissionedStorage<T, OwnerAcl>`.
+//! from one base: the group-writable form [`SharedStorage<T>`] is the default
+//! `PermissionedStorage<T, WriterSetAcl>`, and a single-owner cell is
+//! [`Ownable<T>`] = `PermissionedStorage<T, OwnerAcl>`. (`WriterSetCell` is the
+//! underlying storage mechanism these all wrap — not used directly by apps.)
 //!
 //! # Security model — what you MUST store inside the wrapper
 //!
@@ -42,7 +43,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
-use super::shared::SharedStorage;
+use super::shared::WriterSetCell;
 use super::StoreError;
 use crate::entities::{ChildInfo, Data, Element, SignatureData};
 use crate::env;
@@ -112,9 +113,9 @@ impl Authorizer for OwnerAcl {
     }
 }
 
-/// Access-controlled storage: a [`SharedStorage<T>`] plus an [`Authorizer`]
+/// Access-controlled storage: a [`WriterSetCell<T>`] plus an [`Authorizer`]
 /// policy `A`. The group-writable form (default `A = WriterSetAcl`) behaves like
-/// `SharedStorage`; specialised policies derive components such as [`Ownable`].
+/// `WriterSetCell`; specialised policies derive components such as [`Ownable`].
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct PermissionedStorage<T, A = WriterSetAcl>
 where
@@ -122,7 +123,7 @@ where
     A: Authorizer,
 {
     #[borsh(bound(serialize = "", deserialize = ""))]
-    inner: SharedStorage<T, MainStorage>,
+    inner: WriterSetCell<T, MainStorage>,
     /// Zero-sized policy marker; never serialised.
     #[borsh(skip)]
     _policy: PhantomData<A>,
@@ -151,7 +152,7 @@ where
     /// `init`.
     pub fn new(writers: BTreeSet<PublicKey>, frozen: bool) -> Self {
         Self {
-            inner: SharedStorage::new(writers, frozen),
+            inner: WriterSetCell::new(writers, frozen),
             _policy: PhantomData,
         }
     }
@@ -164,7 +165,7 @@ where
         frozen: bool,
     ) -> Self {
         Self {
-            inner: SharedStorage::new_with_field_name(field_name, writers, frozen),
+            inner: WriterSetCell::new_with_field_name(field_name, writers, frozen),
             _policy: PhantomData,
         }
     }
@@ -216,7 +217,7 @@ where
     pub fn insert(&mut self, value: T) -> Result<Option<T>, StoreError> {
         // Apply the policy at the API surface so a custom `Authorizer` that
         // restricts `Op::Write` more narrowly than plain membership is honoured
-        // — the whole point of the seam. `SharedStorage::insert` then performs
+        // — the whole point of the seam. `WriterSetCell::insert` then performs
         // the authoritative membership check that peers re-verify at merge.
         self.guard(Op::Write)?;
         self.inner.insert(value)
@@ -245,7 +246,7 @@ where
     /// executor is not a current writer.
     pub fn rotate_writers(&mut self, new_writers: BTreeSet<PublicKey>) -> Result<(), StoreError> {
         // Single API-surface policy gate (honours a custom `Authorizer`).
-        // `SharedStorage::rotate_writers` is authoritative: it re-checks
+        // `WriterSetCell::rotate_writers` is authoritative: it re-checks
         // membership and enforces the frozen / non-empty rules.
         self.guard(Op::Admin)?;
         self.inner.rotate_writers(new_writers)
@@ -270,7 +271,7 @@ where
 }
 
 // `Data` so a `PermissionedStorage` can be nested in `#[app::state]`; the
-// wrapper entity is the inner `SharedStorage`'s element.
+// wrapper entity is the inner `WriterSetCell`'s element.
 impl<T, A> Data for PermissionedStorage<T, A>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable + Default,
@@ -289,7 +290,7 @@ where
     }
 }
 
-// Root-state merge is a no-op, exactly as for `SharedStorage`: the value is a
+// Root-state merge is a no-op, exactly as for `WriterSetCell`: the value is a
 // separate entity (merged per-entity) and the writer set converges via the
 // verified rotation log. Delegated so the semantics stay identical.
 impl<T, A> Mergeable for PermissionedStorage<T, A>
@@ -320,9 +321,16 @@ where
 
 /// A single-owner storage cell: [`PermissionedStorage`] under the [`OwnerAcl`]
 /// policy. Enforcement rides the same merge-time writer-set check as any
-/// `SharedStorage`; ownership is a one-key writer set, and **transfer is a
+/// `WriterSetCell`; ownership is a one-key writer set, and **transfer is a
 /// signed, authenticated rotation** — the capability `UserStorage` lacks.
 pub type Ownable<T> = PermissionedStorage<T, OwnerAcl>;
+
+/// Group-writable storage: any member of the writer set may read and write, the
+/// set is rotatable by a current writer, and every write is verified at merge
+/// against it. This is [`PermissionedStorage`] under the default [`WriterSetAcl`]
+/// policy — `SharedStorage<T>` and `PermissionedStorage<T, WriterSetAcl>` are the
+/// same type. The ergonomic name most apps use.
+pub type SharedStorage<T> = PermissionedStorage<T, WriterSetAcl>;
 
 impl<T> PermissionedStorage<T, OwnerAcl>
 where

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -1,13 +1,13 @@
 //! Group-writable storage with an authenticated, mutable writer set.
 //!
-//! `SharedStorage<T>` wraps a single value writable by any signer in the
+//! `WriterSetCell<T>` wraps a single value writable by any signer in the
 //! current writer set. The writer set itself is rotatable by a current writer
 //! (unless `frozen`). Trust mirrors `UserStorage<T>`: the runtime signs each
 //! write, peers verify the signature against the writer set at merge time.
 //!
 //! # Why this is a handle, not an inline value
 //!
-//! `SharedStorage<T>` is modeled on [`Root<T>`](super::root::Root): it is a
+//! `WriterSetCell<T>` is modeled on [`Root<T>`](super::root::Root): it is a
 //! thin handle over a [`Collection`] that holds the value as a single,
 //! `Shared`-stamped child entry. Borsh-serializing the wrapper therefore emits
 //! **only its `Element`** (id + metadata) — a reference — exactly like any
@@ -81,13 +81,13 @@ const VALUE_KEY: &[u8] = b"__calimero_shared_value__";
 /// the value body never rides root state.
 ///
 /// When `T` is a **collection** (`UnorderedMap`, `UnorderedSet`, …), in-place
-/// edits MUST go through [`get_mut`](SharedStorage::get_mut): it re-establishes
+/// edits MUST go through [`get_mut`](WriterSetCell::get_mut): it re-establishes
 /// the `SharedMember{anchor}` domain on the collection element so every entry
 /// inserted through it is guarded at merge. Members carry no writer set — they
 /// resolve the anchor's writers — so rotating the anchor retroactively revokes
 /// the whole subtree without re-stamping any entry.
 #[derive(BorshSerialize, BorshDeserialize)]
-pub struct SharedStorage<
+pub struct WriterSetCell<
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor = MainStorage,
 > {
@@ -113,13 +113,13 @@ pub struct SharedStorage<
     _adaptor: core::marker::PhantomData<S>,
 }
 
-impl<T, S> core::fmt::Debug for SharedStorage<T, S>
+impl<T, S> core::fmt::Debug for WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable + core::fmt::Debug,
     S: StorageAdaptor,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SharedStorage")
+        f.debug_struct("WriterSetCell")
             .field("inner", &self.inner)
             .field("frozen", &self.frozen)
             .field("value", &self.value)
@@ -127,21 +127,21 @@ where
     }
 }
 
-impl<T> SharedStorage<T, MainStorage>
+impl<T> WriterSetCell<T, MainStorage>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable + Default,
 {
-    /// Create a new SharedStorage with a random ID and the given initial
+    /// Create a new WriterSetCell with a random ID and the given initial
     /// writer set. Use this for nested fields; the `#[app::state]` macro
     /// canonicalises the id via [`reassign_deterministic_id`] after `init`.
     ///
-    /// [`reassign_deterministic_id`]: SharedStorage::reassign_deterministic_id
+    /// [`reassign_deterministic_id`]: WriterSetCell::reassign_deterministic_id
     pub fn new(writers: BTreeSet<PublicKey>, frozen: bool) -> Self {
         let inner = Collection::new_shared(None, None, CrdtType::SharedStorage, writers.clone());
         Self::from_inner(inner, writers, frozen)
     }
 
-    /// Create a new SharedStorage with a deterministic ID derived from
+    /// Create a new WriterSetCell with a deterministic ID derived from
     /// `field_name`. Use this for top-level state fields.
     pub fn new_with_field_name(
         field_name: &str,
@@ -194,7 +194,7 @@ where
                     signature_data: None,
                 },
             )
-            .expect("failed to write initial SharedStorage value");
+            .expect("failed to write initial WriterSetCell value");
         Self {
             inner,
             frozen,
@@ -228,7 +228,7 @@ where
         let carried_value: T = match self
             .inner
             .get(old_value_id)
-            .expect("read SharedStorage value during reassign")
+            .expect("read WriterSetCell value during reassign")
         {
             Some(value) => value,
             None => {
@@ -239,7 +239,7 @@ where
                 tracing::warn!(
                     target: "storage::shared",
                     old_value_id = %old_value_id,
-                    "SharedStorage value entry missing during reassign — \
+                    "WriterSetCell value entry missing during reassign — \
                      relocating a default (possible storage corruption)"
                 );
                 T::default()
@@ -256,7 +256,7 @@ where
             .reassign_deterministic_id_with_crdt_type(field_name, CrdtType::SharedStorage);
         self.inner.element_mut().set_shared_domain(writers.clone());
         let _saved = <Interface<MainStorage>>::save(&mut self.inner)
-            .expect("failed to persist relocated SharedStorage wrapper");
+            .expect("failed to persist relocated WriterSetCell wrapper");
 
         // Re-write the value entry under the new wrapper id (always), stamped as
         // a member anchored to the new wrapper id.
@@ -272,12 +272,12 @@ where
                     signature_data: None,
                 },
             )
-            .expect("failed to relocate SharedStorage value");
+            .expect("failed to relocate WriterSetCell value");
         *self.value.borrow_mut() = Some(value);
     }
 }
 
-impl<T, S> SharedStorage<T, S>
+impl<T, S> WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable + Default,
     S: StorageAdaptor,
@@ -307,7 +307,7 @@ where
         let value = slot.get_or_insert_with(|| {
             self.inner
                 .get(self.value_id())
-                .expect("read SharedStorage value")
+                .expect("read WriterSetCell value")
                 .unwrap_or_default()
         });
         #[expect(unsafe_code, reason = "necessary for caching, mirrors Root::get")]
@@ -316,7 +316,7 @@ where
     }
 }
 
-impl<T, S> SharedStorage<T, S>
+impl<T, S> WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable + Default + Data,
     S: StorageAdaptor,
@@ -330,7 +330,7 @@ where
     /// reload. The entries carry no writer set; they resolve the anchor's
     /// writers at verify time, so a rotation revokes the whole subtree at once.
     /// Only collections (which implement [`Data`]) get this; a scalar value is
-    /// edited via [`insert`](SharedStorage::insert) instead.
+    /// edited via [`insert`](WriterSetCell::insert) instead.
     ///
     /// # Errors
     /// Currently infallible; the `Result` is preserved for forward compatibility.
@@ -352,7 +352,7 @@ where
     }
 }
 
-impl<T, S> SharedStorage<T, S>
+impl<T, S> WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable + Default,
     S: StorageAdaptor,
@@ -417,7 +417,7 @@ where
         tracing::warn!(
             target: "storage::shared",
             wrapper_id = %self.inner.id(),
-            "SharedStorage current_writers found no rotation log or Shared index \
+            "WriterSetCell current_writers found no rotation log or Shared index \
              entry — failing closed with an empty writer set (missing/corrupt \
              index, or wrapper not yet synced)"
         );
@@ -465,7 +465,7 @@ where
         let writers = self.current_writers();
         if !writers.contains(&executor) {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
-                "Executor is not a writer of this SharedStorage".to_owned(),
+                "Executor is not a writer of this WriterSetCell".to_owned(),
             )));
         }
 
@@ -505,7 +505,7 @@ where
     pub fn rotate_writers(&mut self, new_writers: BTreeSet<PublicKey>) -> Result<(), StoreError> {
         if self.frozen {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
-                "Cannot rotate writers of frozen SharedStorage".to_owned(),
+                "Cannot rotate writers of frozen WriterSetCell".to_owned(),
             )));
         }
         if new_writers.is_empty() {
@@ -556,9 +556,9 @@ where
     }
 }
 
-// Implement Data so SharedStorage can be nested in #[app::state]; the wrapper
+// Implement Data so WriterSetCell can be nested in #[app::state]; the wrapper
 // entity is the inner collection's element.
-impl<T, S> Data for SharedStorage<T, S>
+impl<T, S> Data for WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor,
@@ -580,7 +580,7 @@ where
 // value is a separate entity (merged per-entity), the writer set converges via
 // the rotation log, and `frozen` is genesis-immutable and deliberately not
 // adopted from the peer (so a forged root-state delta can't freeze rotation).
-impl<T, S> Mergeable for SharedStorage<T, S>
+impl<T, S> Mergeable for WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor,
@@ -602,7 +602,7 @@ where
     }
 }
 
-impl<T, S> CrdtMeta for SharedStorage<T, S>
+impl<T, S> CrdtMeta for WriterSetCell<T, S>
 where
     T: BorshSerialize + BorshDeserialize + Mergeable,
     S: StorageAdaptor,
@@ -626,7 +626,7 @@ mod tests {
     use calimero_primitives::identity::PublicKey;
     use serial_test::serial;
 
-    use super::SharedStorage;
+    use super::WriterSetCell;
     use crate::collections::crdt_meta::{MergeError, Mergeable};
     use crate::collections::Root;
     use crate::env;
@@ -670,9 +670,9 @@ mod tests {
         let _root: Root<TestVal> = Root::new(TestVal::default);
 
         let expected = compute_collection_id(None, "doc");
-        let a = SharedStorage::<TestVal>::new_with_field_name("doc", writers(&[ALICE]), false);
+        let a = WriterSetCell::<TestVal>::new_with_field_name("doc", writers(&[ALICE]), false);
         assert_eq!(a.element().id(), expected);
-        let b = SharedStorage::<TestVal>::new_with_field_name("doc", writers(&[ALICE]), false);
+        let b = WriterSetCell::<TestVal>::new_with_field_name("doc", writers(&[ALICE]), false);
         assert_eq!(
             b.element().id(),
             expected,
@@ -698,7 +698,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE]), false));
         s.insert(TestVal(1)).unwrap();
 
         let wrapper_id = s.element().id();
@@ -754,7 +754,7 @@ mod tests {
         type Map = UnorderedMap<String, LwwRegister<String>>;
 
         let ws = writers(&[[7u8; 32]]);
-        let mut guarded = Root::new(|| SharedStorage::<Map>::new(ws.clone(), false));
+        let mut guarded = Root::new(|| WriterSetCell::<Map>::new(ws.clone(), false));
 
         // Edit the inner map in place through the guarded `get_mut`, which
         // re-establishes the writer domain on the map element first.
@@ -765,7 +765,7 @@ mod tests {
             .expect("insert");
 
         // The entry must be anchored to the wrapper — the whole subtree is
-        // guarded at merge, not just the SharedStorage wrapper entity. It
+        // guarded at merge, not just the WriterSetCell wrapper entity. It
         // carries no inline writer set: the anchor pointer is the domain, and
         // writers resolve from the anchor's rotation log.
         let wrapper_id = guarded.element().id();
@@ -779,7 +779,7 @@ mod tests {
         match entry.storage.metadata.storage_type {
             StorageType::SharedMember { anchor, .. } => assert_eq!(anchor, wrapper_id),
             other => panic!(
-                "SharedStorage<Map> entry must be a SharedMember anchored to the wrapper, \
+                "WriterSetCell<Map> entry must be a SharedMember anchored to the wrapper, \
                  got {other:?}"
             ),
         }
@@ -791,7 +791,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
+        let s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE, BOB]), false));
         assert_eq!(s.get().unwrap(), &TestVal::default());
     }
 
@@ -801,7 +801,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE, BOB]), false));
         s.insert(TestVal(42)).expect("alice (writer) inserts");
         assert_eq!(s.get().unwrap(), &TestVal(42));
     }
@@ -812,7 +812,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[BOB, CAROL]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[BOB, CAROL]), false));
         let err = s
             .insert(TestVal(42))
             .expect_err("alice (not writer) must be rejected");
@@ -829,7 +829,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE, BOB]), false));
         s.insert(TestVal(1)).unwrap();
 
         s.rotate_writers(writers(&[BOB, CAROL]))
@@ -853,7 +853,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE]), false));
         s.insert(TestVal(1)).unwrap();
 
         env::set_executor_id(BOB);
@@ -869,7 +869,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE, BOB]), false));
         s.insert(TestVal(1)).unwrap();
 
         let err = s
@@ -891,7 +891,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), false));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE, BOB]), false));
 
         // Bootstrap-time writer set is observable.
         assert_eq!(s.writers(), writers(&[ALICE, BOB]));
@@ -909,7 +909,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE]), true));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE]), true));
 
         assert!(s.is_frozen());
         assert_eq!(s.writers(), writers(&[ALICE]));
@@ -938,8 +938,8 @@ mod tests {
         env::set_executor_id(ALICE);
         // Establish ROOT so the wrapper's `add_child_to(ROOT)` succeeds.
         let _root: Root<TestVal> = Root::new(TestVal::default);
-        let mut a = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
-        let b = SharedStorage::<TestVal>::new(writers(&[ALICE]), true);
+        let mut a = WriterSetCell::<TestVal>::new(writers(&[ALICE]), false);
+        let b = WriterSetCell::<TestVal>::new(writers(&[ALICE]), true);
 
         Mergeable::merge(&mut a, &b).unwrap();
         assert!(
@@ -950,8 +950,8 @@ mod tests {
         // Reverse direction: a locally-frozen instance stays frozen (merge
         // doesn't clear it either — it just doesn't touch `frozen`).
         let _root2: Root<TestVal> = Root::new(TestVal::default);
-        let mut a2 = SharedStorage::<TestVal>::new(writers(&[ALICE]), true);
-        let b2 = SharedStorage::<TestVal>::new(writers(&[ALICE]), false);
+        let mut a2 = WriterSetCell::<TestVal>::new(writers(&[ALICE]), true);
+        let b2 = WriterSetCell::<TestVal>::new(writers(&[ALICE]), false);
         Mergeable::merge(&mut a2, &b2).unwrap();
         assert!(a2.frozen, "merge must not clear a locally-set frozen");
     }
@@ -962,7 +962,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut s = Root::new(|| SharedStorage::<TestVal>::new(writers(&[ALICE, BOB]), true));
+        let mut s = Root::new(|| WriterSetCell::<TestVal>::new(writers(&[ALICE, BOB]), true));
         s.insert(TestVal(1)).unwrap();
 
         let err = s

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -555,6 +555,18 @@ fn normalize_scalar_type(
             crdt_type: Some(CrdtCollectionType::ReplicatedGrowableArray),
             inner_type: None,
         }),
+        // `AccessControl` is a non-generic component backed by a writer-set-
+        // guarded `map<string, bool>` registry (role grants). Surface that shape
+        // with `crdt_type = SharedStorage` so the writer-ACL is visible, matching
+        // the other guarded wrappers.
+        "AccessControl" => Ok(TypeRef::Collection {
+            collection: CollectionType::Map {
+                key: Box::new(TypeRef::Scalar(ScalarType::String)),
+                value: Box::new(TypeRef::Scalar(ScalarType::Bool)),
+            },
+            crdt_type: Some(CrdtCollectionType::SharedStorage),
+            inner_type: None,
+        }),
         _ => {
             // Check if it's a local type
             resolver.resolve_local(&ident.to_string()).map_or_else(


### PR DESCRIPTION
Lands two stacked changes on master together (the child PR #2706 was merged into this branch, so this PR now carries both commits):

## 1. Inversion — `SharedStorage<T> = PermissionedStorage<T, WriterSetAcl>`

Inverts the base/derived relationship from #2700 so the access-control components form one hierarchy over a single mechanism, matching the intended design where `PermissionedStorage<T, A>` is the base.

- Rename the writer-set storage **struct** `SharedStorage` → `WriterSetCell` (the mechanism: value in its own `SharedMember` entity, signed writes verified at merge, rotatable writer set). Logic **byte-identical** — pure rename.
- `CrdtType::SharedStorage` enum variant **preserved** (wire/persisted-state compatibility).
- `PermissionedStorage<T, A>` wraps `WriterSetCell`; add `pub type SharedStorage<T> = PermissionedStorage<T, WriterSetAcl>`.
- **Source-compatible**: every call site uses the 1-arg `SharedStorage<T>` form, so no app/node/test edits.

## 2. `AccessControl` — merge-enforced role registry

Third component from #2687 (after `Ownable`/`PermissionedStorage`).

- Backed by a single writer-set-guarded map whose **writer set is the admin tier** (OpenZeppelin-style single admin tier: any admin manages any role).
- `grant`/`revoke` record a last-writer-wins present-flag per `(role, member)` — no tombstone; `has_role` is the app guard's lookup.
- Admin changes (`grant_admin`/`revoke_admin`) are **authenticated writer-set rotations** — O(1), last admin cannot be removed.
- Enforcement at merge, like the other components: a non-admin's hand-crafted grant delta is rejected because registry entries inherit the admin writer domain. `only_admin`/`only_role` are fail-fast API guards.
- Built on the proven `SharedStorage<UnorderedMap<String, LwwRegister<V>>>` shape — no nested collections. Macro `is_collection_type` + wasm-abi normalizer learn `AccessControl` (the macro doesn't recurse into nested structs).

## Tests

- Full storage lib suite (581) green; wasm-abi green; clippy + fmt clean.
- `components-demo` exercises all three components with `TestHost` tests and builds on wasm with the ABI emitter.
- All `SharedStorage`-using apps build unchanged.

## Deferred (still on #2687)

`Pausable` (advisory) and the `OpMask` protocol extension (§8, gated on #2541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core storage types and merge-time authorization primitives; risk is mitigated by the `SharedStorage` alias preserving call sites and new e2e/unit coverage.
> 
> **Overview**
> This PR reshapes the storage access-control stack and adds a third demo component. The writer-set **struct** is renamed to `WriterSetCell`; **`SharedStorage<T>`** is now a type alias for `PermissionedStorage<T, WriterSetAcl>` wrapping that cell, so app call sites keep the one-argument `SharedStorage` API while `PermissionedStorage` / `Ownable` sit on the same hierarchy.
> 
> A new **`AccessControl`** collection provides an admin-tier writer set over a guarded role registry (`grant` / `revoke` / `has_role`, plus admin rotation). The **`components-demo`** app wires it in with unit tests and a **two-node e2e** workflow (convergence, non-admin refusal, merge-time rejection of forged `PermissionedStorage` writes). **CI** builds the demo and runs that workflow.
> 
> **SDK macros** treat `AccessControl` like other guarded wrappers for deterministic IDs and forbid it in `#[app::private]`; **wasm-abi** surfaces `AccessControl` as a guarded map shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11a72fa91187ea43302337e4c180288d6aec4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->