### PR TITLE
feat(storage): AccessControl component (role registry)

### DIFF
--- a/apps/components-demo/src/lib.rs
+++ b/apps/components-demo/src/lib.rs
@@ -1,18 +1,22 @@
 //! Example app for the access-control components.
 //!
-//! Demonstrates two of the `calimero_storage` components:
+//! Demonstrates three `calimero_storage` components:
 //! - [`Ownable`] — a single-owner config cell with transferable ownership.
 //! - [`PermissionedStorage`] — a group-writable settings map.
+//! - [`AccessControl`] — an admin-managed role registry.
 //!
-//! The guards in the methods (`only_owner`) are fail-fast UX. The real
-//! authorization boundary is at merge: the components store data inside
-//! writer-set-guarded entities, so a peer that hand-crafts a delta around this
-//! WASM still has an unauthorized write rejected when honest nodes apply it.
+//! The guards in the methods (`only_owner`, the admin checks inside
+//! `AccessControl`) are fail-fast UX. The real authorization boundary is at
+//! merge: the components store data inside writer-set-guarded entities, so a
+//! peer that hand-crafts a delta around this WASM still has an unauthorized
+//! write rejected when honest nodes apply it.
 
 use std::collections::BTreeSet;
 
 use calimero_sdk::{app, env, PublicKey};
-use calimero_storage::collections::{LwwRegister, Ownable, PermissionedStorage, UnorderedMap};
+use calimero_storage::collections::{
+    AccessControl, LwwRegister, Ownable, PermissionedStorage, UnorderedMap,
+};
 
 #[app::state]
 pub struct ComponentsDemo {
@@ -22,18 +26,39 @@ pub struct ComponentsDemo {
     /// Group-writable settings. Every entry inherits the writer domain, so a
     /// non-writer's forged entry is rejected at merge — not just the wrapper.
     settings: PermissionedStorage<UnorderedMap<String, LwwRegister<String>>>,
+    /// Role registry. The installer is the sole initial admin; admins grant /
+    /// revoke roles, and a non-admin's forged grant is rejected at merge.
+    roles: AccessControl,
 }
 
 #[app::logic]
 impl ComponentsDemo {
-    /// The installer becomes the config owner and the sole settings writer.
+    /// The installer becomes the config owner, sole settings writer, and admin.
     #[app::init]
     pub fn init() -> ComponentsDemo {
         let me: PublicKey = env::executor_id().into();
         ComponentsDemo {
             config: Ownable::new_owned_by(me),
             settings: PermissionedStorage::new(BTreeSet::from([me]), false),
+            roles: AccessControl::new(me),
         }
+    }
+
+    /// Grant a role to a member. Admin-only (fail-fast here, enforced at merge).
+    pub fn grant_role(&mut self, role: String, who: PublicKey) -> app::Result<()> {
+        self.roles.grant(&role, who)?;
+        Ok(())
+    }
+
+    /// Revoke a role from a member. Admin-only.
+    pub fn revoke_role(&mut self, role: String, who: PublicKey) -> app::Result<()> {
+        self.roles.revoke(&role, &who)?;
+        Ok(())
+    }
+
+    /// Whether a member holds a role (anyone may query).
+    pub fn has_role(&self, role: String, who: PublicKey) -> app::Result<bool> {
+        Ok(self.roles.has_role(&role, &who)?)
     }
 
     /// Owner-only write. The guard fails fast; the boundary is that `config` is
@@ -117,6 +142,32 @@ mod tests {
             .unwrap();
         assert_eq!(app.view(|s| s.get_config()).unwrap(), "by-other");
         assert!(app.call(|s| s.set_config("nope".to_owned())).is_err());
+    }
+
+    #[test]
+    fn admin_grants_role_non_admin_cannot() {
+        let mut app = TestHost::new(ComponentsDemo::init);
+        let other: PublicKey = OTHER.into();
+
+        // Admin (the installer) grants a role.
+        app.call(|s| s.grant_role("editor".to_owned(), other))
+            .unwrap();
+        assert!(app
+            .view(|s| s.has_role("editor".to_owned(), other))
+            .unwrap());
+
+        // A non-admin's grant is rejected by the fail-fast guard (and would be
+        // at merge). Merge-time enforcement needs a 2-node e2e (design §6.3).
+        let third: PublicKey = [0x33; 32].into();
+        let denied = app.call_as(OTHER, |s| s.grant_role("editor".to_owned(), third));
+        assert!(denied.is_err());
+
+        // Admin can revoke.
+        app.call(|s| s.revoke_role("editor".to_owned(), other))
+            .unwrap();
+        assert!(!app
+            .view(|s| s.has_role("editor".to_owned(), other))
+            .unwrap());
     }
 
     #[test]

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -902,6 +902,11 @@ fn generate_assign_deterministic_ids_impl(
             // a substring of `SharedStorage`.
             || type_str.contains("PermissionedStorage")
             || type_str.contains("Ownable")
+            // `AccessControl` wraps a single guarded storage; its
+            // `reassign_deterministic_id` delegates to it. The macro does not
+            // recurse into nested structs, so without this its inner storage
+            // keeps a random id and diverges across nodes.
+            || type_str.contains("AccessControl")
             // `AuthoredVector` is already matched by the `"Vector"` substring above;
             // `AuthoredMap` is NOT a substring of any entry, so it must be listed
             // explicitly or its outer wrapper id stays `Id::random()` and a

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -65,6 +65,8 @@ pub mod permissioned;
 pub use permissioned::{
     Authorizer, Op, Ownable, OwnerAcl, PermissionedStorage, SharedStorage, WriterSetAcl,
 };
+pub mod access_control;
+pub use access_control::AccessControl;
 mod authored_common;
 pub mod authored_map;
 pub use authored_map::AuthoredMap;

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -1,0 +1,332 @@
+//! Role-based access control as a merge-enforced membership registry.
+//!
+//! [`AccessControl`] tracks which members hold which named roles, backed by a
+//! single [`SharedStorage`] whose **writer set is the admin tier**. Granting or
+//! revoking a role mutates the guarded registry, so — like every component here
+//! — the authoritative check is at merge: a non-admin's hand-crafted grant delta
+//! is rejected because the registry entries are writer-set-guarded. Admin
+//! changes are a writer-set rotation (O(1), authenticated). `only_role` /
+//! `only_admin` are fail-fast API guards that mirror what merge enforces.
+//!
+//! # Model
+//!
+//! - **Admins** are exactly the writer set of the backing storage. Any admin may
+//!   grant/revoke any role (a single admin tier, like OpenZeppelin's
+//!   `DEFAULT_ADMIN_ROLE`). Change the admin set with
+//!   [`grant_admin`](AccessControl::grant_admin) /
+//!   [`revoke_admin`](AccessControl::revoke_admin) (authenticated rotation).
+//! - **Roles** are named member sets recorded in the guarded registry. A grant
+//!   is a present-flag entry (`true`); a revoke sets it to `false` rather than
+//!   removing, so membership is a last-writer-wins boolean and never needs a
+//!   tombstone. [`has_role`](AccessControl::has_role) is the lookup app guards
+//!   use.
+//!
+//! To make a role actually gate *writes to specific data*, store that data in
+//! its own [`SharedStorage`] and rotate its writers to the role's members; this
+//! registry is the source of truth for "who is in role R", and `only_role` is
+//! the fail-fast guard at the API surface.
+
+use std::collections::BTreeSet;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_primitives::identity::PublicKey;
+
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
+use super::permissioned::SharedStorage;
+use super::{LwwRegister, StoreError, UnorderedMap};
+use crate::entities::{ChildInfo, Data, Element};
+use crate::env;
+use crate::interface::StorageError;
+
+/// Separator between the role name and the member key in a registry key. A NUL
+/// byte cannot appear in a well-formed role name, so the composite key is
+/// unambiguous without escaping.
+const ROLE_MEMBER_SEP: char = '\0';
+
+/// The registry value type: a last-writer-wins boolean. `true` = the member
+/// currently holds the role; `false` = revoked. Storing a flag (rather than
+/// removing the entry) keeps membership a plain LWW merge with no tombstone.
+type Grant = LwwRegister<bool>;
+
+/// Role-based access control backed by a single writer-set-guarded registry.
+///
+/// The backing [`SharedStorage`]'s writers are the admin tier; role grants are
+/// entries in its guarded map. See the [module docs](self) for the model.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct AccessControl {
+    /// `role\0member_hex -> LwwRegister<bool>`. Writers of this storage are the
+    /// admins; entries inherit the writer domain and are verified at merge.
+    #[borsh(bound(serialize = "", deserialize = ""))]
+    grants: SharedStorage<UnorderedMap<String, Grant>>,
+}
+
+impl core::fmt::Debug for AccessControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AccessControl")
+            .field("grants", &self.grants)
+            .finish()
+    }
+}
+
+impl AccessControl {
+    /// Create an `AccessControl` with `admin` as the sole initial admin. Use for
+    /// nested fields; the `#[app::state]` macro canonicalises the id via
+    /// [`reassign_deterministic_id`](Self::reassign_deterministic_id).
+    pub fn new(admin: PublicKey) -> Self {
+        Self {
+            grants: SharedStorage::new(BTreeSet::from([admin]), false),
+        }
+    }
+
+    /// Create an `AccessControl` administered by the current executor (the
+    /// common case in `init`).
+    pub fn new_admin_caller() -> Self {
+        let me: PublicKey = env::executor_id().into();
+        Self::new(me)
+    }
+
+    /// Canonicalise the backing storage id from `field_name`. Called by the
+    /// `#[app::state]` macro after `init()` so every node derives the same id.
+    pub fn reassign_deterministic_id(&mut self, field_name: &str) {
+        self.grants.reassign_deterministic_id(field_name);
+    }
+
+    /// Composite registry key for `(role, member)`. Member is hex of its 32
+    /// bytes — a stable, separator-free encoding.
+    fn key(role: &str, member: &PublicKey) -> String {
+        let member_hex = hex::encode(member.as_ref() as &[u8; 32]);
+        format!("{role}{ROLE_MEMBER_SEP}{member_hex}")
+    }
+
+    // --- admin tier (the writer set) ---
+
+    /// The current admin set (the backing storage's writers).
+    pub fn admins(&self) -> BTreeSet<PublicKey> {
+        self.grants.writers()
+    }
+
+    /// Whether `who` is an admin.
+    pub fn is_admin(&self, who: &PublicKey) -> bool {
+        self.grants.writers().contains(who)
+    }
+
+    /// Fail-fast admin guard. NOT the security boundary — merge is.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the current executor is not an admin.
+    pub fn only_admin(&self) -> Result<(), StoreError> {
+        let me: PublicKey = env::executor_id().into();
+        if self.is_admin(&me) {
+            Ok(())
+        } else {
+            Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Executor is not an admin".to_owned(),
+            )))
+        }
+    }
+
+    /// Add `who` to the admin set via an authenticated writer-set rotation.
+    /// Only a current admin may; enforced at merge.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not a current admin.
+    pub fn grant_admin(&mut self, who: PublicKey) -> Result<(), StoreError> {
+        let mut admins = self.grants.writers();
+        let _ = admins.insert(who);
+        self.grants.rotate_writers(admins)
+    }
+
+    /// Remove `who` from the admin set via an authenticated rotation. Only a
+    /// current admin may; enforced at merge. The set may not become empty.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not a current admin, or if removing
+    /// `who` would leave no admins.
+    pub fn revoke_admin(&mut self, who: &PublicKey) -> Result<(), StoreError> {
+        let mut admins = self.grants.writers();
+        let _ = admins.remove(who);
+        // `rotate_writers` also rejects an empty set, but bail early with a
+        // clearer message before attempting the rotation.
+        if admins.is_empty() {
+            return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Cannot revoke the last admin".to_owned(),
+            )));
+        }
+        self.grants.rotate_writers(admins)
+    }
+
+    // --- named roles (registry entries) ---
+
+    /// Whether `who` currently holds `role`.
+    ///
+    /// # Errors
+    /// Propagates a storage error from the registry lookup.
+    pub fn has_role(&self, role: &str, who: &PublicKey) -> Result<bool, StoreError> {
+        let key = Self::key(role, who);
+        Ok(self
+            .grants
+            .get()?
+            .get(&key)?
+            .map(|v| *v.get())
+            .unwrap_or(false))
+    }
+
+    /// Fail-fast guard: the current executor must hold `role`. NOT the security
+    /// boundary — merge is.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the current executor does not hold `role`;
+    /// propagates a storage error from the lookup.
+    pub fn only_role(&self, role: &str) -> Result<(), StoreError> {
+        let me: PublicKey = env::executor_id().into();
+        if self.has_role(role, &me)? {
+            Ok(())
+        } else {
+            Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "Executor does not hold the required role".to_owned(),
+            )))
+        }
+    }
+
+    /// Grant `role` to `who`. Only an admin may; enforced at merge (the registry
+    /// entry inherits the admin writer set).
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not an admin; propagates a storage
+    /// error from the write.
+    pub fn grant(&mut self, role: &str, who: PublicKey) -> Result<(), StoreError> {
+        self.only_admin()?;
+        let key = Self::key(role, &who);
+        let _ = self.grants.get_mut()?.insert(key, LwwRegister::new(true))?;
+        Ok(())
+    }
+
+    /// Revoke `role` from `who` (sets the present-flag to `false`). Only an admin
+    /// may; enforced at merge.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if the executor is not an admin; propagates a storage
+    /// error from the write.
+    pub fn revoke(&mut self, role: &str, who: &PublicKey) -> Result<(), StoreError> {
+        self.only_admin()?;
+        let key = Self::key(role, who);
+        let _ = self
+            .grants
+            .get_mut()?
+            .insert(key, LwwRegister::new(false))?;
+        Ok(())
+    }
+}
+
+// `Data`/`Mergeable`/`CrdtMeta` delegate to the backing storage so `AccessControl`
+// can be nested directly in `#[app::state]`, mirroring `PermissionedStorage`.
+impl Data for AccessControl {
+    fn collections(&self) -> std::collections::BTreeMap<String, Vec<ChildInfo>> {
+        self.grants.collections()
+    }
+
+    fn element(&self) -> &Element {
+        self.grants.element()
+    }
+
+    fn element_mut(&mut self) -> &mut Element {
+        self.grants.element_mut()
+    }
+}
+
+impl Mergeable for AccessControl {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.grants.merge(&other.grants)
+    }
+}
+
+impl CrdtMeta for AccessControl {
+    fn crdt_type() -> CrdtType {
+        CrdtType::SharedStorage
+    }
+    fn storage_strategy() -> StorageStrategy {
+        StorageStrategy::Structured
+    }
+    fn can_contain_crdts() -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::AccessControl;
+    use crate::collections::Root;
+    use crate::env;
+
+    const ALICE: [u8; 32] = [0x11; 32];
+    const BOB: [u8; 32] = [0x22; 32];
+    const CAROL: [u8; 32] = [0x33; 32];
+
+    #[test]
+    #[serial]
+    fn admin_can_grant_and_revoke_roles() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        assert!(ac.is_admin(&ALICE.into()));
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+
+        ac.grant("editor", BOB.into()).unwrap();
+        assert!(ac.has_role("editor", &BOB.into()).unwrap());
+
+        ac.revoke("editor", &BOB.into()).unwrap();
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn non_admin_cannot_grant() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        // Bob is not an admin — the fail-fast guard rejects his grant.
+        env::set_executor_id(BOB);
+        assert!(ac.grant("editor", CAROL.into()).is_err());
+        assert!(ac.only_admin().is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn admin_tier_rotation() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        ac.grant_admin(BOB.into()).unwrap();
+        assert!(ac.is_admin(&BOB.into()));
+
+        // Bob, now an admin, can grant.
+        env::set_executor_id(BOB);
+        ac.grant("editor", CAROL.into()).unwrap();
+        assert!(ac.has_role("editor", &CAROL.into()).unwrap());
+
+        // An admin can drop another admin, but not the last one.
+        ac.revoke_admin(&ALICE.into()).unwrap();
+        assert!(!ac.is_admin(&ALICE.into()));
+        assert!(ac.revoke_admin(&BOB.into()).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn roles_are_independent() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        ac.grant("editor", BOB.into()).unwrap();
+        ac.grant("viewer", BOB.into()).unwrap();
+        ac.revoke("editor", &BOB.into()).unwrap();
+
+        assert!(!ac.has_role("editor", &BOB.into()).unwrap());
+        assert!(ac.has_role("viewer", &BOB.into()).unwrap());
+    }
+}

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -555,6 +555,18 @@ fn normalize_scalar_type(
             crdt_type: Some(CrdtCollectionType::ReplicatedGrowableArray),
             inner_type: None,
         }),
+        // `AccessControl` is a non-generic component backed by a writer-set-
+        // guarded `map<string, bool>` registry (role grants). Surface that shape
+        // with `crdt_type = SharedStorage` so the writer-ACL is visible, matching
+        // the other guarded wrappers.
+        "AccessControl" => Ok(TypeRef::Collection {
+            collection: CollectionType::Map {
+                key: Box::new(TypeRef::Scalar(ScalarType::String)),
+                value: Box::new(TypeRef::Scalar(ScalarType::Bool)),
+            },
+            crdt_type: Some(CrdtCollectionType::SharedStorage),
+            inner_type: None,
+        }),
         _ => {
             // Check if it's a local type
             resolver.resolve_local(&ident.to_string()).map_or_else(


### PR DESCRIPTION
## What

Adds `AccessControl` — a merge-enforced role-based access-control registry — on the `PermissionedStorage` base. Third component from #2687 (after `Ownable`/`PermissionedStorage` in #2700).

> **Stacked on #2705** (the SharedStorage↔PermissionedStorage inversion). Review/merge that first; this PR's base auto-retargets to `master` once it lands. The first commit here is #2705; the second is AccessControl.

## Model

- Backed by a single writer-set-guarded map whose **writer set is the admin tier** — OpenZeppelin-style single admin tier: any admin manages any role.
- `grant`/`revoke` record a last-writer-wins present-flag per `(role, member)` (`true`/`false`), so membership needs no tombstone; `has_role` is the lookup app guards use.
- Admin changes (`grant_admin`/`revoke_admin`) are **authenticated writer-set rotations** — O(1), and the last admin cannot be removed.

## Enforcement

Identical to the other components: a non-admin's hand-crafted grant delta is rejected at merge because the registry entries inherit the admin writer domain. `only_admin`/`only_role` are fail-fast API guards that mirror what merge enforces.

## Plumbing

- Built on the proven `SharedStorage<UnorderedMap<String, LwwRegister<V>>>` shape (the one `kv-store-with-shared-storage` exercises) — no risky nested collections.
- Macro `is_collection_type` and the wasm-abi normalizer learn `AccessControl` (the macro does not recurse into nested structs, so without the entry its inner storage would keep a random id and diverge).

## Tests

- 4 storage unit/integration tests (admin grant/revoke, non-admin rejected, admin-tier rotation incl. last-admin guard, role independence).
- `components-demo` gains `grant_role`/`revoke_role`/`has_role` + a `TestHost` test (admin grants, non-admin rejected, revoke).
- Full storage suite (581) green; clippy + fmt clean; app builds on wasm with the ABI emitter.

## Deferred (still on #2687)

`Pausable` (advisory) and the `OpMask` protocol extension (§8, gated on #2541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization primitives (admin tier and role grants) with merge-time enforcement; risk is mitigated by following the existing `SharedStorage` pattern and unit/demo tests, but multi-node merge adversarial coverage is still deferred.
> 
> **Overview**
> Introduces **`AccessControl`**, a merge-enforced role registry on top of writer-set–guarded `SharedStorage`. **Admins** are the storage writers; **grants/revokes** store LWW `true`/`false` flags per `(role, member)` so membership merges without tombstones. **`grant_admin` / `revoke_admin`** rotate the admin writer set (with a last-admin guard).
> 
> **Plumbing:** re-export from `collections`, **`#[app::state]`** treats `AccessControl` like other wrappers for **deterministic entity IDs**, and the **WASM ABI** normalizer exposes it as `map<string, bool>` with `SharedStorage` CRDT metadata.
> 
> **`components-demo`** wires `roles` in `init` plus `grant_role` / `revoke_role` / `has_role` and a **TestHost** test (admin OK, non-admin denied). **Four storage unit tests** cover grant/revoke, non-admin rejection, admin rotation, and independent roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af90571554cc66e4ae2b6ed062e5be63035ac3e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->