### PR TITLE
feat(wasm-abi,sdk): add #[app::view] read-only method intent to ABI

### DIFF
--- a/crates/sdk/macros/src/errors.rs
+++ b/crates/sdk/macros/src/errors.rs
@@ -122,6 +122,8 @@ pub enum ParseError<'a> {
         type_name: &'static str,
         explanation: &'static str,
     },
+    #[error("`#[app::view]` and `#[app::init]` are mutually exclusive — an initializer always writes state")]
+    ViewAndInitConflict,
 }
 
 impl AsRef<Self> for ParseError<'_> {

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -18,6 +18,11 @@ pub enum LogicMethod<'a> {
 
 pub enum Modifer {
     Init,
+    /// `#[app::view]` — app author declares the method read-only. Stored in
+    /// the compiled ABI so the node can take a shared read lock instead of an
+    /// exclusive write lock. Mutually exclusive with `Init` (an initializer
+    /// always writes state).
+    View,
 }
 
 pub struct PublicLogicMethod<'a> {
@@ -353,13 +358,26 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
         let mut is_init = false;
 
         for attr in &input.item.attrs {
-            if attr.path().segments.len() == 2
-                && attr.path().segments[0].ident == "app"
-                && attr.path().segments[1].ident == "init"
-            {
-                modifiers.push(Modifer::Init);
-                is_init = true;
+            if attr.path().segments.len() == 2 && attr.path().segments[0].ident == "app" {
+                match attr.path().segments[1].ident.to_string().as_str() {
+                    "init" => {
+                        modifiers.push(Modifer::Init);
+                        is_init = true;
+                    }
+                    "view" => {
+                        modifiers.push(Modifer::View);
+                    }
+                    _ => {}
+                }
             }
+        }
+
+        let is_view = modifiers.iter().any(|m| matches!(m, Modifer::View));
+        if is_init && is_view {
+            errors.subsume(SynError::new_spanned(
+                input.item,
+                ParseError::ViewAndInitConflict,
+            ));
         }
 
         match (&input.item.vis, is_init) {

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -6,7 +6,7 @@ use syn::{Item, ItemEnum, ItemImpl, ItemStruct, Type};
 
 use crate::normalize::{normalize_type, ResolvedLocal, TypeResolver};
 use crate::schema::{
-    Event, Field, Manifest, Method, Parameter, ScalarType, TypeDef, TypeRef, Variant,
+    Event, Field, Manifest, Method, MethodIntent, Parameter, ScalarType, TypeDef, TypeRef, Variant,
 };
 
 /// ABI emitter that processes Rust source code
@@ -287,6 +287,16 @@ fn has_app_state_attribute(attrs: &[syn::Attribute]) -> bool {
     })
 }
 
+/// Returns `true` when the method carries `#[app::view]`, declaring it as
+/// read-only — i.e. the app author guarantees it never mutates state.
+fn has_app_view_attribute(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        let path = attr.path();
+        let segments: Vec<_> = path.segments.iter().collect();
+        segments.len() == 2 && segments[0].ident == "app" && segments[1].ident == "view"
+    })
+}
+
 impl<'ast> Visit<'ast> for AbiEmitter {
     fn visit_item_struct(&mut self, item_struct: &'ast ItemStruct) {
         let struct_name = item_struct.ident.to_string();
@@ -490,6 +500,13 @@ impl<'ast> Visit<'ast> for AbiEmitter {
                         (Some(TypeRef::Scalar(ScalarType::Unit)), None)
                     };
 
+                    // Read/write intent from #[app::view]; default Unspecified.
+                    let intent = if has_app_view_attribute(&method.attrs) {
+                        MethodIntent::ReadOnly
+                    } else {
+                        MethodIntent::Unspecified
+                    };
+
                     // Create and store the method
                     let method = Method {
                         name: method_name,
@@ -497,6 +514,7 @@ impl<'ast> Visit<'ast> for AbiEmitter {
                         returns,
                         returns_nullable,
                         errors: Vec::new(),
+                        intent,
                     };
 
                     self.methods.push(method);

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -501,7 +501,14 @@ impl<'ast> Visit<'ast> for AbiEmitter {
                     };
 
                     // Read/write intent from #[app::view]; default Unspecified.
-                    let intent = if has_app_view_attribute(&method.attrs) {
+                    // init is always mutating regardless of any attribute — the
+                    // SDK macro rejects #[app::view] + #[app::init] at compile
+                    // time, but a non-SDK toolchain could produce both; guard
+                    // here so a rogue annotation can't cause the node to take a
+                    // shared read lock for an initializer that always writes.
+                    let intent = if method_name == "init" {
+                        MethodIntent::Unspecified
+                    } else if has_app_view_attribute(&method.attrs) {
                         MethodIntent::ReadOnly
                     } else {
                         MethodIntent::Unspecified

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -731,9 +731,26 @@ mod tests {
         let back: Method = serde_json::from_str(&json).unwrap();
         assert_eq!(back.intent, MethodIntent::ReadOnly);
 
+        // Mutating serialises as "mutating" and round-trips.
+        let m_mut = Method {
+            name: "mutate".to_owned(),
+            params: vec![],
+            returns: None,
+            returns_nullable: None,
+            errors: vec![],
+            intent: MethodIntent::Mutating,
+        };
+        let json_mut = serde_json::to_string(&m_mut).unwrap();
+        assert!(
+            json_mut.contains("mutating"),
+            "expected 'mutating' in {json_mut}"
+        );
+        let back_mut: Method = serde_json::from_str(&json_mut).unwrap();
+        assert_eq!(back_mut.intent, MethodIntent::Mutating);
+
         // Unspecified is omitted from JSON (backward-compatible wire format).
         let m2 = Method {
-            name: "mutate".to_owned(),
+            name: "unspecified".to_owned(),
             params: vec![],
             returns: None,
             returns_nullable: None,

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -64,6 +64,39 @@ pub struct Variant {
     pub payload: Option<TypeRef>,
 }
 
+/// Whether a method is guaranteed to only read state or may write it.
+///
+/// Used by the node to select a *shared* read lock (allowing parallel reads on
+/// one context) vs the default *exclusive* write lock. The fail-safe is
+/// [`Unspecified`](MethodIntent::Unspecified): unknown intent → write lock →
+/// exactly today's serialized behaviour; nothing breaks if a module predates
+/// this field.
+///
+/// Declare a method read-only with `#[app::view]` in the SDK. A `ReadOnly`
+/// method that nonetheless produces a non-empty state artifact is rejected
+/// post-execution as defence-in-depth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MethodIntent {
+    /// App explicitly declared this method as read-only (`#[app::view]`).
+    ReadOnly,
+    /// App explicitly declared this method as mutating (default for unannotated
+    /// methods; reserved for future `#[app::mutate]` if the opt-out is needed).
+    Mutating,
+    /// No declaration present (every pre-#2684 module, and unannotated methods
+    /// in annotated modules). The node treats this as write intent — fail-safe.
+    #[default]
+    Unspecified,
+}
+
+impl MethodIntent {
+    /// Returns `true` for the default value so `serde` skips the field on old
+    /// manifests, keeping them round-trip identical.
+    fn is_unspecified(&self) -> bool {
+        matches!(self, Self::Unspecified)
+    }
+}
+
 /// Method definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Method {
@@ -75,6 +108,11 @@ pub struct Method {
     pub returns_nullable: Option<bool>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub errors: Vec<Error>,
+    /// Read/write intent declared by the app author. Absent on modules compiled
+    /// before this field existed; treated as [`MethodIntent::Unspecified`]
+    /// (write lock) by the node.
+    #[serde(skip_serializing_if = "MethodIntent::is_unspecified", default)]
+    pub intent: MethodIntent,
 }
 
 /// Parameter in a method
@@ -640,6 +678,7 @@ mod tests {
             returns: Some(TypeRef::i32()),
             returns_nullable: None,
             errors: Vec::new(),
+            intent: MethodIntent::Unspecified,
         });
 
         // Serialize and deserialize
@@ -667,11 +706,49 @@ mod tests {
             returns: Some(TypeRef::string()),
             returns_nullable: None,
             errors: Vec::new(),
+            intent: MethodIntent::Unspecified,
         });
 
         assert_eq!(manifest.schema_version, "wasm-abi/1");
         assert_eq!(manifest.methods.len(), 1);
         assert_eq!(manifest.methods[0].name, "test_method");
         assert!(manifest.state_root.is_none());
+    }
+
+    #[test]
+    fn method_intent_round_trips_and_old_manifests_deserialize_as_unspecified() {
+        // ReadOnly serialises as "read_only" and round-trips.
+        let m = Method {
+            name: "query".to_owned(),
+            params: vec![],
+            returns: None,
+            returns_nullable: None,
+            errors: vec![],
+            intent: MethodIntent::ReadOnly,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(json.contains("read_only"), "expected 'read_only' in {json}");
+        let back: Method = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.intent, MethodIntent::ReadOnly);
+
+        // Unspecified is omitted from JSON (backward-compatible wire format).
+        let m2 = Method {
+            name: "mutate".to_owned(),
+            params: vec![],
+            returns: None,
+            returns_nullable: None,
+            errors: vec![],
+            intent: MethodIntent::Unspecified,
+        };
+        let json2 = serde_json::to_string(&m2).unwrap();
+        assert!(
+            !json2.contains("intent"),
+            "Unspecified must be omitted: {json2}"
+        );
+
+        // Old JSON without the intent field deserialises as Unspecified.
+        let old_json = r#"{"name":"old","params":[]}"#;
+        let old: Method = serde_json::from_str(old_json).unwrap();
+        assert_eq!(old.intent, MethodIntent::Unspecified);
     }
 }

--- a/crates/wasm-abi/src/validate.rs
+++ b/crates/wasm-abi/src/validate.rs
@@ -294,6 +294,7 @@ fn collect_refs_from_event(event: &Event, path: &str, refs: &mut Vec<(String, St
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::MethodIntent;
 
     #[test]
     fn test_valid_manifest() {
@@ -311,6 +312,7 @@ mod tests {
             returns: Some(TypeRef::u32()),
             returns_nullable: None,
             errors: vec![],
+            intent: MethodIntent::Unspecified,
         });
 
         assert!(validate_manifest(&manifest).is_ok());
@@ -335,6 +337,7 @@ mod tests {
             returns: Some(TypeRef::reference("NonExistentType")),
             returns_nullable: None,
             errors: vec![],
+            intent: MethodIntent::Unspecified,
         });
 
         assert!(validate_manifest(&manifest).is_err());

--- a/crates/wasm-abi/tests/invariants.rs
+++ b/crates/wasm-abi/tests/invariants.rs
@@ -1,4 +1,6 @@
-use calimero_wasm_abi::schema::{Error, Event, Manifest, Method, TypeDef, TypeRef, Variant};
+use calimero_wasm_abi::schema::{
+    Error, Event, Manifest, Method, MethodIntent, TypeDef, TypeRef, Variant,
+};
 use calimero_wasm_abi::validate::validate_manifest;
 
 #[test]
@@ -62,6 +64,7 @@ fn test_invariant_error_payload_structure() {
             code: "TEST_ERROR".to_string(),
             payload: Some(TypeRef::string()),
         }],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should pass validation
@@ -88,6 +91,7 @@ fn test_invariant_variable_bytes_no_size() {
         )),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should pass validation
@@ -118,6 +122,7 @@ fn test_invariant_map_string_key() {
         }),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should pass validation
@@ -146,6 +151,7 @@ fn test_invariant_no_dangling_refs() {
         }),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should pass validation
@@ -169,6 +175,7 @@ fn test_invariant_detects_dangling_refs() {
         }),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should fail validation
@@ -205,6 +212,7 @@ fn test_invariant_detects_dangling_refs_in_inner_type() {
         }),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should fail validation because NonExistentType is referenced in inner_type
@@ -234,6 +242,7 @@ fn test_invariant_deterministic_ordering() {
         returns: None,
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
     manifest.methods.push(Method {
         name: "a_method".to_string(),
@@ -241,6 +250,7 @@ fn test_invariant_deterministic_ordering() {
         returns: None,
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // This should fail validation because methods are not sorted

--- a/crates/wasm-abi/tests/schema_validation.rs
+++ b/crates/wasm-abi/tests/schema_validation.rs
@@ -1,3 +1,4 @@
+use calimero_wasm_abi::schema::{Method, MethodIntent};
 use jsonschema::JSONSchema;
 use serde_json::Value;
 
@@ -21,6 +22,7 @@ fn test_schema_validation_basic() {
         returns: Some(calimero_wasm_abi::schema::TypeRef::u32()),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     // Serialize to JSON
@@ -65,6 +67,7 @@ fn test_schema_validation_shared_storage_crdt_type() {
         returns: Some(shared),
         returns_nullable: None,
         errors: vec![],
+        intent: MethodIntent::Unspecified,
     });
 
     let manifest_json = serde_json::to_value(&manifest).unwrap();

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -303,6 +303,11 @@
           "items": {
             "$ref": "#/definitions/Error"
           }
+        },
+        "intent": {
+          "type": "string",
+          "enum": ["read_only", "mutating", "unspecified"],
+          "description": "Read/write intent declared by the app author. Absent on modules compiled before this field existed; treated as write intent by the node."
         }
       }
     },


### PR DESCRIPTION
## What

PR 1 of 3 for the parallel-read accelerator (issue #2684, epic #2022). Adds `#[app::view]` to the SDK and a `MethodIntent` tri-state to the WASM ABI so the node can eventually select a shared read lock for read-only calls instead of always taking the exclusive write lock.

**No runtime behavior change.** This PR affects only the ABI manifest and the macro parse layer. The lock-selection wiring comes in increment 2 of #2685 once this is merged.

## Changes

### `calimero-wasm-abi`

- **`schema.rs`** — new `MethodIntent` enum (`ReadOnly` / `Mutating` / `Unspecified`) + optional `intent` field on `Method`. Fail-safe: `Unspecified` is the default; it is omitted from JSON (`skip_serializing_if`), so old manifests deserialise unchanged and new manifests are readable by old nodes. No wire/RPC change.
- **`emitter.rs`** — `has_app_view_attribute` helper (mirrors `has_app_state_attribute`) detects `#[app::view]` on each public method; sets `MethodIntent::ReadOnly` on the emitted `Method`. Unannotated methods stay `Unspecified`.

### `calimero-sdk-macros`

- **`method.rs`** — `Modifer::View` added; parsed in the attribute loop exactly like `#[app::init]`.
- **`errors.rs`** — `ParseError::ViewAndInitConflict`: `#[app::view]` and `#[app::init]` are mutually exclusive (an initializer always writes state); conflict produces a compile-time diagnostic.
- **No generated-code change**: `Modifer::View` is recorded but does not alter the emitted `#[no_mangle]` shim in this PR. The code-gen hook lands in increment 2 when the execute path reads the intent.

## Backward compatibility

- Modules compiled before this PR have no `intent` field in their manifest → deserialises as `Unspecified` → write lock → exactly today's behaviour. No recompile required.
- New manifests with `ReadOnly` are ignored by old nodes (unrecognised field, serde skips it).

## Verification

- Builds: `calimero-wasm-abi`, `calimero-sdk-macros`
- `cargo fmt --check` clean (pre-commit hook passed)
- clippy: **2/4 warnings — identical to baseline** (stash-diff), zero new
- Tests: **115 passing, 0 failed** — including a new round-trip test verifying `ReadOnly` serialises as `"read_only"`, `Unspecified` is omitted from JSON, and old JSON without the field deserialises as `Unspecified`

## What comes next

- **#2685 increment 2** (needs this + #2684 remaining) — read-only method set cache in `ContextManager`, pre-lock query at `execute/mod.rs:108`, `ContextGuard::Read` minted, intent-aware/TTL eviction.

Part of #2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ABI and macro-only changes with fail-safe defaults; no execution or locking behavior changes until a follow-up PR wires the node.
> 
> **Overview**
> Adds **`#[app::view]`** so app authors can mark public methods as read-only, and threads that through the **WASM ABI** as optional per-method **`intent`** (`read_only` / `mutating` / `unspecified`). This is **metadata only** in this PR—no node lock or execute-path changes yet.
> 
> The SDK macro layer parses **`view`** like **`init`**, records **`Modifer::View`**, and **rejects** combining **`#[app::view]`** with **`#[app::init]`** at compile time. ABI emission sets **`ReadOnly`** when **`#[app::view]`** is present; **`init`** is forced to **`Unspecified`** even if mis-annotated. **`Unspecified`** is omitted from JSON and old manifests without **`intent`** deserialize the same way, preserving current write-lock behavior by default.
> 
> JSON Schema, fixtures, and tests were updated for the new field and serde round-trip / backward-compat behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa5124c3cb91ba8f1c539b0e5b26a37bbec641c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->