### PR TITLE
feat(node): populate + persist PeerIdentityCache (PR 2/6, #2642)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
  "calimero-context-config",
  "calimero-crypto",
  "calimero-dag",
+ "calimero-governance-store",
  "calimero-network",
  "calimero-network-primitives",
  "calimero-node-primitives",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,6 +35,7 @@ zeroize.workspace = true
 calimero-context.workspace = true
 calimero-context-config.workspace = true
 calimero-context-client.workspace = true
+calimero-governance-store.workspace = true
 calimero-runtime.workspace = true
 calimero-crypto.workspace = true
 calimero-blobstore.workspace = true

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -139,7 +139,14 @@ pub(super) fn handle_namespace_governance_delta(
                 // signature verified, the nonce was monotonic, and the
                 // op applied successfully. Consumed by anchor-preferred
                 // sync peer selection. See `NodeState::peer_identities`.
-                node_state.observe_peer_identity(source, signer);
+                //
+                // `None`: this path doesn't carry the signer's group +
+                // role cheaply, so the observation updates only the
+                // in-memory reverse view. The durable cache is populated
+                // from the state-delta path (which has both) — the deltas
+                // that follow a member's governance op re-observe them
+                // there, so cold-start coverage is unaffected.
+                node_state.observe_peer_identity(source, signer, None);
 
                 // Governance-pending active drain: a governance op that just applied may
                 // unblock state deltas previously buffered as `Unknown`.

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -19,6 +19,7 @@ use libp2p::PeerId;
 use tracing::{debug, info, warn};
 
 use crate::delta_store::DeltaStore;
+use crate::peer_identity_cache::ObservedMembership;
 use crate::utils::choose_stream;
 
 mod crypto;
@@ -1708,7 +1709,17 @@ pub async fn handle_state_delta(
                 // signature verified AND the author is an authorized
                 // member at the named cut. Consumed by anchor-preferred
                 // sync peer selection. See `NodeState::peer_identities`.
-                node_state.observe_peer_identity(source, author_id);
+                //
+                // This path has the group + role at the cut, so it also
+                // writes through to the durable `peer_identity_cache`.
+                node_state.observe_peer_identity(
+                    source,
+                    author_id,
+                    Some(ObservedMembership {
+                        group_id: pos.group_id,
+                        role,
+                    }),
+                );
             }
             Ok(MembershipStatus::Removed { last_role }) => {
                 warn!(

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -26,6 +26,7 @@ pub mod network_event_channel;
 pub mod network_event_processor;
 mod node_metrics;
 mod peer_identity_cache;
+mod peer_identity_persist;
 pub mod readiness;
 mod run;
 mod specialized_node_invite_state;

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -35,6 +35,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
 use crate::arbiter_pool::ArbiterPool;
+use crate::peer_identity_cache::ObservedMembership;
 use crate::sync::{SyncConfig, SyncManager};
 use crate::{NodeManager, NodeState};
 
@@ -710,5 +711,139 @@ async fn group_topic_announce_is_not_routed_as_namespace_admission() {
             .expect("count"),
         1,
         "no member should be admitted from a group/ topic announce (owner only)"
+    );
+}
+
+/// Build a standalone `SyncManager` against an in-memory store, without
+/// the surrounding `NodeManager` actor — enough to exercise the
+/// synchronous peer-selection helpers (`member_peers_for_context`)
+/// end-to-end against real governance state. Returns the manager, the
+/// shared store, the shared `NodeState` (its peer-identity cache is an
+/// `Arc` shared with the manager's `state_access`, so seeding it here is
+/// visible to the manager), and the `TempDir` guard the blob fs needs.
+async fn build_standalone_sync_manager() -> (SyncManager, Store, NodeState, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+    let blob_store_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_store_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+
+    let node_recipient = LazyRecipient::<NodeMessage>::new();
+    let context_recipient = LazyRecipient::new();
+    let network_recipient = LazyRecipient::new();
+    let network_client = NetworkClient::new(network_recipient);
+    let (event_sender, _) = broadcast::channel(16);
+    let (ctx_sync_tx, ctx_sync_rx) = mpsc::channel(64);
+    let (ns_sync_tx, ns_sync_rx) = mpsc::channel(16);
+    let (ns_join_tx, ns_join_rx) = mpsc::channel(16);
+    let (open_subgroup_join_tx, open_subgroup_join_rx) = mpsc::channel(16);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client.clone(),
+        node_recipient,
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+    let context_client = ContextClient::new(store.clone(), node_client.clone(), context_recipient);
+    let node_state = NodeState::new(false, NodeMode::Standard);
+
+    let sync_manager = SyncManager::new(
+        SyncConfig::default(),
+        node_client,
+        context_client,
+        network_client,
+        node_state.clone(),
+        ctx_sync_rx,
+        ns_sync_rx,
+        ns_join_rx,
+        open_subgroup_join_rx,
+    );
+
+    (sync_manager, store, node_state, tmp)
+}
+
+/// End-to-end resolver (#2642): with a context registered to a group in
+/// the real governance store and the durable peer-identity cache seeded
+/// via the authenticated observe path, `member_peers_for_context`
+/// resolves `context → group → cached member peers`, deduped by role.
+#[tokio::test]
+async fn member_peers_for_context_resolves_cached_members_end_to_end() {
+    let (sync_manager, store, node_state, _tmp) = build_standalone_sync_manager().await;
+
+    let group_id = ContextGroupId::from([0x11; 32]);
+    let other_group = ContextGroupId::from([0xAA; 32]);
+    let context_id = calimero_primitives::context::ContextId::from([0x22; 32]);
+    calimero_context::group_store::register_context_in_group(&store, &group_id, &context_id)
+        .expect("register context -> group");
+
+    // Real (random) member identities, matching the convention of the
+    // other tests in this file.
+    let admin_id = PrivateKey::random(&mut OsRng).public_key();
+    let member_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_second_id = PrivateKey::random(&mut OsRng).public_key();
+    let other_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_peer = libp2p::PeerId::random();
+    let member_peer = libp2p::PeerId::random();
+    let other_peer = libp2p::PeerId::random();
+
+    // Seed the shared cache through the same gate the production receive
+    // paths use (group + role at the cross-DAG cut).
+    let observe = |peer, identity, group, role| {
+        node_state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role,
+            }),
+        );
+    };
+    observe(admin_peer, admin_id, group_id, GroupMemberRole::Admin);
+    observe(member_peer, member_id, group_id, GroupMemberRole::Member);
+    // Same peer observed again under a second identity at a weaker role —
+    // the dedup must keep the strongest role (Admin) for admin_peer,
+    // exercising dedup_peers_by_strongest_role through the full resolver.
+    observe(
+        admin_peer,
+        admin_second_id,
+        group_id,
+        GroupMemberRole::Member,
+    );
+    // A member of a DIFFERENT group must not leak into this context's
+    // result (guards group-scoping of cached_member_peers_for_group).
+    observe(other_peer, other_id, other_group, GroupMemberRole::Admin);
+
+    let resolved: std::collections::BTreeMap<_, _> = sync_manager
+        .member_peers_for_context(&context_id)
+        .into_iter()
+        .collect();
+    assert_eq!(resolved.len(), 2, "only this group's members resolve");
+    assert_eq!(
+        resolved.get(&admin_peer),
+        Some(&GroupMemberRole::Admin),
+        "dedup keeps the strongest role for a peer seen at two roles"
+    );
+    assert_eq!(resolved.get(&member_peer), Some(&GroupMemberRole::Member));
+    assert!(
+        !resolved.contains_key(&other_peer),
+        "a member cached under a different group is excluded"
+    );
+
+    // A context with no group mapping resolves to nothing (caller then
+    // falls back to topic discovery).
+    let unregistered = calimero_primitives::context::ContextId::from([0x99; 32]);
+    assert!(
+        sync_manager
+            .member_peers_for_context(&unregistered)
+            .is_empty(),
+        "unregistered context yields no cached members"
     );
 }

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -297,13 +297,30 @@ pub(crate) struct PersistedGroup {
     pub(crate) entries: Vec<PersistedIdentityPeer>,
 }
 
+/// Current on-disk schema version. Bump on any incompatible change to
+/// the persisted format; `load_all_from_persisted` discards a blob whose
+/// version it doesn't recognise (rather than deserializing garbage),
+/// leaving the cache to refill from live traffic.
+pub(crate) const PERSIST_SCHEMA_VERSION: u32 = 1;
+
+fn current_schema_version() -> u32 {
+    PERSIST_SCHEMA_VERSION
+}
+
 /// Whole-cache on-disk form: every non-empty group bucket. Stored as a
 /// single blob under one `Generic` key (like `PeerAddrCache`) — the
 /// per-group structure lives *inside* the blob, which keeps load/snapshot
 /// to one get/put and avoids per-group key enumeration and stale-key
-/// pruning. A struct (not a bare `Vec`) leaves room to version the format.
+/// pruning.
+///
+/// `version` guards forward/backward compatibility: a blob written by an
+/// incompatible future schema is detected and dropped on load. Blobs
+/// written before this field existed deserialize with `version = 1` (the
+/// current format), so existing caches load unchanged.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct PersistedPeerIdentityCache {
+    #[serde(default = "current_schema_version")]
+    pub(crate) version: u32,
     pub(crate) groups: Vec<PersistedGroup>,
 }
 
@@ -326,7 +343,10 @@ impl PeerIdentityCache {
                 })
             })
             .collect();
-        PersistedPeerIdentityCache { groups }
+        PersistedPeerIdentityCache {
+            version: PERSIST_SCHEMA_VERSION,
+            groups,
+        }
     }
 
     /// Rebuild a cache from the single-blob form, dropping groups whose id
@@ -338,6 +358,14 @@ impl PeerIdentityCache {
         now_secs: u64,
         ttl_secs: u64,
     ) -> Self {
+        if blob.version != PERSIST_SCHEMA_VERSION {
+            debug!(
+                found = blob.version,
+                expected = PERSIST_SCHEMA_VERSION,
+                "peer-identity cache blob has an unrecognised schema version; ignoring it"
+            );
+            return Self::default();
+        }
         let mut cache = Self::default();
         for g in blob.groups {
             let Some(group) = parse_group_id(&g.group_id) else {
@@ -378,15 +406,19 @@ impl PeerIdentityCache {
     /// rows, and the reverse view is intersected with an authoritative
     /// anchor set downstream.
     pub(crate) fn all_peer_identity_pairs(&self) -> Vec<(PeerId, PublicKey)> {
-        let mut out = Vec::new();
+        // De-duplicate: the same `(peer, identity)` can be recorded in
+        // several groups (an identity that's a member of both a namespace
+        // root and a subgroup), and the caller would otherwise redo the
+        // insert and over-count the hydration log.
+        let mut out = BTreeSet::new();
         for g in self.groups.values() {
             for (identity, hosts) in &g.members {
                 for peer in hosts.peers.keys() {
-                    out.push((*peer, *identity));
+                    let _ = out.insert((*peer, *identity));
                 }
             }
         }
-        out
+        out.into_iter().collect()
     }
 }
 
@@ -679,6 +711,7 @@ mod tests {
     #[test]
     fn load_all_skips_unparseable_group_id() {
         let blob = PersistedPeerIdentityCache {
+            version: PERSIST_SCHEMA_VERSION,
             groups: vec![
                 PersistedGroup {
                     group_id: "not-hex".to_owned(),
@@ -706,6 +739,34 @@ mod tests {
             BTreeSet::from([group(2)]),
             "only the well-formed group id loads"
         );
+    }
+
+    #[test]
+    fn load_all_discards_blob_with_unrecognised_version() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        let mut blob = c.to_persisted_all(100, 1000);
+        assert_eq!(blob.version, PERSIST_SCHEMA_VERSION);
+        // Simulate a future, incompatible schema.
+        blob.version = PERSIST_SCHEMA_VERSION + 1;
+
+        let restored = PeerIdentityCache::load_all_from_persisted(blob, 100, 1000);
+        assert_eq!(
+            restored.groups().count(),
+            0,
+            "a blob with an unrecognised version is discarded, not misread"
+        );
+    }
+
+    #[test]
+    fn all_peer_identity_pairs_dedupes_same_identity_across_groups() {
+        let mut c = PeerIdentityCache::default();
+        // Same (peer, identity) recorded in two groups — must appear once.
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        c.record(group(2), pk(1), peer(1), GroupMemberRole::Member, 100);
+
+        let pairs = c.all_peer_identity_pairs();
+        assert_eq!(pairs, vec![(peer(1), pk(1))], "duplicate pair collapsed");
     }
 
     #[test]

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -276,6 +276,104 @@ impl PeerIdentityCache {
     }
 }
 
+/// The role a peer's identity was observed holding in a group, paired
+/// with the group, as passed to [`PeerIdentityCache::record`] from the
+/// authenticated observation gate. `None` at a call site that can't
+/// cheaply resolve the membership means the observation updates only the
+/// in-memory reverse view, not the persistent cache.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ObservedMembership {
+    pub(crate) group_id: ContextGroupId,
+    pub(crate) role: GroupMemberRole,
+}
+
+/// One group's persisted bucket: the group id (hex of its 32 bytes,
+/// since `ContextGroupId` has no `Display`) and its `(identity, peer)`
+/// rows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PersistedGroup {
+    pub(crate) group_id: String,
+    pub(crate) entries: Vec<PersistedIdentityPeer>,
+}
+
+/// Whole-cache on-disk form: every non-empty group bucket. Stored as a
+/// single blob under one `Generic` key (like `PeerAddrCache`) — the
+/// per-group structure lives *inside* the blob, which keeps load/snapshot
+/// to one get/put and avoids per-group key enumeration and stale-key
+/// pruning. A struct (not a bare `Vec`) leaves room to version the format.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct PersistedPeerIdentityCache {
+    pub(crate) groups: Vec<PersistedGroup>,
+}
+
+impl PeerIdentityCache {
+    /// Serialize every group's still-fresh entries into the single-blob
+    /// form. Groups with no fresh rows are omitted so the blob shrinks as
+    /// members age out.
+    pub(crate) fn to_persisted_all(
+        &self,
+        now_secs: u64,
+        ttl_secs: u64,
+    ) -> PersistedPeerIdentityCache {
+        let groups = self
+            .groups
+            .keys()
+            .filter_map(|group| {
+                let entries = self.to_persisted(group, now_secs, ttl_secs);
+                (!entries.is_empty()).then(|| PersistedGroup {
+                    group_id: hex::encode(group.to_bytes()),
+                    entries,
+                })
+            })
+            .collect();
+        PersistedPeerIdentityCache { groups }
+    }
+
+    /// Rebuild a cache from the single-blob form, dropping groups whose id
+    /// is unparseable and (per group) rows that are malformed or past
+    /// `ttl_secs`. A bad group id is logged at debug and skipped rather
+    /// than failing the whole load.
+    pub(crate) fn load_all_from_persisted(
+        blob: PersistedPeerIdentityCache,
+        now_secs: u64,
+        ttl_secs: u64,
+    ) -> Self {
+        let mut cache = Self::default();
+        for g in blob.groups {
+            let Some(group) = parse_group_id(&g.group_id) else {
+                debug!(group_id = %g.group_id, "skipping unparseable cached group id");
+                continue;
+            };
+            cache.load_group_from_persisted(group, g.entries, now_secs, ttl_secs);
+        }
+        cache
+    }
+
+    /// All `(peer, identity)` pairs currently held, across every group —
+    /// used to hydrate the in-memory reverse view (`peer_identities`)
+    /// after a load. No freshness filter: a load has already pruned stale
+    /// rows, and the reverse view is intersected with an authoritative
+    /// anchor set downstream.
+    pub(crate) fn all_peer_identity_pairs(&self) -> Vec<(PeerId, PublicKey)> {
+        let mut out = Vec::new();
+        for g in self.groups.values() {
+            for (identity, hosts) in &g.members {
+                for peer in hosts.peers.keys() {
+                    out.push((*peer, *identity));
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Parse a hex-encoded 32-byte group id back into a [`ContextGroupId`].
+fn parse_group_id(s: &str) -> Option<ContextGroupId> {
+    let bytes = hex::decode(s).ok()?;
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    Some(ContextGroupId::from(arr))
+}
+
 /// `last_seen_secs` is within `ttl_secs` of `now_secs`. A backwards clock
 /// jump (`now < last_seen`) counts as fresh — better to keep a
 /// possibly-good entry than drop it on a clock glitch.
@@ -511,5 +609,94 @@ mod tests {
 
         let listed: BTreeSet<ContextGroupId> = c.groups().copied().collect();
         assert_eq!(listed, BTreeSet::from([group(1), group(3)]));
+    }
+
+    #[test]
+    fn whole_blob_round_trips_across_groups() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        c.record(group(2), pk(2), peer(2), GroupMemberRole::ReadOnlyTee, 100);
+
+        let blob = c.to_persisted_all(100, 1000);
+        // JSON serialize/deserialize as the node-side persistence would.
+        let json = serde_json::to_string(&blob).expect("serialize");
+        let back: PersistedPeerIdentityCache = serde_json::from_str(&json).expect("deserialize");
+        let restored = PeerIdentityCache::load_all_from_persisted(back, 100, 1000);
+
+        assert_eq!(
+            restored.groups().copied().collect::<BTreeSet<_>>(),
+            BTreeSet::from([group(1), group(2)]),
+            "both groups survive the whole-blob round trip"
+        );
+        assert_eq!(
+            restored.members_for_group(&group(1), 100, 1000)[0].role,
+            GroupMemberRole::Admin
+        );
+        assert_eq!(
+            restored.members_for_group(&group(2), 100, 1000)[0].role,
+            GroupMemberRole::ReadOnlyTee
+        );
+    }
+
+    #[test]
+    fn to_persisted_all_omits_fully_stale_groups() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Member, 100); // stale at now=2000
+        c.record(group(2), pk(2), peer(2), GroupMemberRole::Member, 1900); // fresh
+
+        let blob = c.to_persisted_all(2000, 1000);
+        assert_eq!(blob.groups.len(), 1, "the all-stale group is dropped");
+        assert_eq!(
+            blob.groups[0].group_id,
+            hex::encode(group(2).to_bytes()),
+            "only the fresh group persists"
+        );
+    }
+
+    #[test]
+    fn load_all_skips_unparseable_group_id() {
+        let blob = PersistedPeerIdentityCache {
+            groups: vec![
+                PersistedGroup {
+                    group_id: "not-hex".to_owned(),
+                    entries: vec![PersistedIdentityPeer {
+                        identity: pk(1).to_string(),
+                        peer_id: peer(1).to_base58(),
+                        role: GroupMemberRole::Member,
+                        last_seen_secs: 100,
+                    }],
+                },
+                PersistedGroup {
+                    group_id: hex::encode(group(2).to_bytes()),
+                    entries: vec![PersistedIdentityPeer {
+                        identity: pk(2).to_string(),
+                        peer_id: peer(2).to_base58(),
+                        role: GroupMemberRole::Member,
+                        last_seen_secs: 100,
+                    }],
+                },
+            ],
+        };
+        let c = PeerIdentityCache::load_all_from_persisted(blob, 100, 1000);
+        assert_eq!(
+            c.groups().copied().collect::<BTreeSet<_>>(),
+            BTreeSet::from([group(2)]),
+            "only the well-formed group id loads"
+        );
+    }
+
+    #[test]
+    fn all_peer_identity_pairs_spans_groups() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        c.record(group(2), pk(2), peer(1), GroupMemberRole::Member, 100);
+
+        let pairs: BTreeSet<(PeerId, PublicKey)> =
+            c.all_peer_identity_pairs().into_iter().collect();
+        assert_eq!(
+            pairs,
+            BTreeSet::from([(peer(1), pk(1)), (peer(1), pk(2))]),
+            "hydration pairs cover every group"
+        );
     }
 }

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -48,11 +48,6 @@
 //! `PeerAddrCache`: pure data + TTL here, with the snapshot tick and
 //! startup hydration wired by the node layer.
 
-// The type lands on its own for reviewability; population, persistence,
-// and selection wiring follow in subsequent PRs, so its API is unused
-// (dead-code) in the meantime.
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, BTreeSet};
 
 use calimero_context_config::types::ContextGroupId;
@@ -176,10 +171,16 @@ impl PeerIdentityCache {
     }
 
     /// Identities observed on `peer` across **all** groups — the reverse
-    /// direction `partition_peers_anchor_first` uses to flag whether a
-    /// discovered peer hosts an anchor identity. No freshness filter: the
-    /// caller intersects this with an authoritative anchor set, so a
-    /// slightly stale identity can only fail to match, never mis-match.
+    /// direction a future selection refinement can use to flag whether a
+    /// discovered peer hosts an anchor identity, straight from the durable
+    /// cache. No freshness filter: the caller intersects this with an
+    /// authoritative anchor set, so a slightly stale identity can only
+    /// fail to match, never mis-match.
+    ///
+    /// Not yet wired — selection currently reads the in-memory
+    /// `peer_identities` reverse view for this; retained (and tested) as
+    /// the cache-backed counterpart for when that path moves to the cache.
+    #[allow(dead_code)]
     pub(crate) fn identities_for_peer(&self, peer: &PeerId) -> BTreeSet<PublicKey> {
         let mut out = BTreeSet::new();
         for g in self.groups.values() {
@@ -316,8 +317,7 @@ impl PeerIdentityCache {
         ttl_secs: u64,
     ) -> PersistedPeerIdentityCache {
         let groups = self
-            .groups
-            .keys()
+            .groups()
             .filter_map(|group| {
                 let entries = self.to_persisted(group, now_secs, ttl_secs);
                 (!entries.is_empty()).then(|| PersistedGroup {
@@ -347,6 +347,29 @@ impl PeerIdentityCache {
             cache.load_group_from_persisted(group, g.entries, now_secs, ttl_secs);
         }
         cache
+    }
+
+    /// Drop a member from a group's bucket — invoked when governance
+    /// emits `MemberRemoved`, so the removed identity stops being
+    /// preferred for sync (and stops being re-persisted) without waiting
+    /// for TTL. If the group's bucket empties, the group is removed.
+    ///
+    /// Only the cache's per-group *membership* view is touched; the
+    /// `peer_identities` reverse view is left intact, because the peer
+    /// still controls that identity — removal changes group membership,
+    /// not key ownership, and anchor status is re-derived from the
+    /// now-updated governance `trusted_anchors`.
+    pub(crate) fn remove_member(&mut self, group: &ContextGroupId, identity: &PublicKey) {
+        let now_empty = match self.groups.get_mut(group) {
+            Some(g) => {
+                let _ = g.members.remove(identity);
+                g.members.is_empty()
+            }
+            None => false,
+        };
+        if now_empty {
+            let _ = self.groups.remove(group);
+        }
     }
 
     /// All `(peer, identity)` pairs currently held, across every group —
@@ -683,6 +706,29 @@ mod tests {
             BTreeSet::from([group(2)]),
             "only the well-formed group id loads"
         );
+    }
+
+    #[test]
+    fn remove_member_drops_identity_and_empties_group() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        c.record(group(1), pk(2), peer(2), GroupMemberRole::Member, 100);
+
+        c.remove_member(&group(1), &pk(1));
+        let members = c.members_for_group(&group(1), 100, 1000);
+        assert_eq!(members.len(), 1);
+        assert_eq!(
+            members[0].identity,
+            pk(2),
+            "only the removed member is gone"
+        );
+
+        // Removing the last member drops the group bucket entirely.
+        c.remove_member(&group(1), &pk(2));
+        assert_eq!(c.groups().count(), 0, "emptied group is removed");
+
+        // Removing from an absent group is a no-op.
+        c.remove_member(&group(2), &pk(9));
     }
 
     #[test]

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -245,7 +245,6 @@ mod tests {
         assert_eq!(members[0].peers, vec![peer]);
     }
 
-    #[test]
     // Exercises the handler directly (`apply_invalidation_event`) rather
     // than via `spawn_invalidation_task` + `op_events::notify` — the
     // `op_events` channel is a process-wide singleton shared across

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -68,7 +68,11 @@ pub(crate) fn hydrate(state: &NodeState, store: &Store) {
         Ok(Some(data)) => match serde_json::from_slice(data.as_ref()) {
             Ok(blob) => blob,
             Err(err) => {
-                debug!(?err, "ignoring corrupt peer-identity cache blob in store");
+                // warn (not debug): a corrupt/partial blob silently loses
+                // every cold-start hint, which an operator should be able
+                // to see. Still best-effort — carry on with an empty cache
+                // that refills from live traffic.
+                warn!(?err, "ignoring corrupt peer-identity cache blob in store");
                 return;
             }
         },
@@ -82,7 +86,16 @@ pub(crate) fn hydrate(state: &NodeState, store: &Store) {
     let cache = PeerIdentityCache::load_all_from_persisted(blob, now, PEER_IDENTITY_TTL_SECS);
     let pairs = cache.all_peer_identity_pairs();
     let pair_count = pairs.len();
-    // Seed the in-memory reverse view consumed by `partition_peers_anchor_first`.
+
+    // Publish the durable cache FIRST, then seed the reverse view. Order
+    // matters for the (startup-only) case where an `observe_peer_identity`
+    // could run concurrently: once the cache is the new one, a concurrent
+    // observe records into it and isn't lost. We deliberately do NOT hold
+    // the cache lock across the `peer_identities` (DashMap) seeding — that
+    // would invert the lock order `observe_peer_identity` uses (DashMap
+    // then cache) and risk a deadlock. In practice hydrate runs at startup
+    // before the event loop dispatches ops, so no observer races it.
+    *state.lock_peer_identity_cache() = cache;
     for (peer, identity) in pairs {
         let _ = state
             .peer_identities
@@ -90,7 +103,6 @@ pub(crate) fn hydrate(state: &NodeState, store: &Store) {
             .or_default()
             .insert(identity);
     }
-    *state.lock_peer_identity_cache() = cache;
 
     if pair_count > 0 {
         info!(
@@ -103,7 +115,10 @@ pub(crate) fn hydrate(state: &NodeState, store: &Store) {
 /// Spawn the periodic snapshot task. Holds a strong `NodeState`/`Store`
 /// reference for the runtime's lifetime — a missed snapshot during
 /// shutdown is harmless, so no shutdown plumbing (same rationale as the
-/// metrics tick).
+/// metrics tick). The returned handle is stored as `_…` by the caller;
+/// dropping it does not cancel the task (tokio detaches it), which runs
+/// until the runtime is dropped. A future graceful shutdown could
+/// `abort()` it.
 pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(SNAPSHOT_INTERVAL);

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -8,11 +8,13 @@
 //! signal survives a restart so anchor-preferred sync selection works on
 //! a cold cache instead of falling back to random topic subscribers.
 
+use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::op_events::{self, OpEvent};
 use calimero_store::key::Generic as GenericKey;
 use calimero_store::slice::Slice;
 use calimero_store::types::GenericData;
 use calimero_store::Store;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::peer_identity_cache::{PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
 use crate::state::{now_unix_secs, NodeState};
@@ -118,6 +120,70 @@ pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task
     })
 }
 
+/// Apply one op-apply event to the cache. Currently only `MemberRemoved`
+/// is actionable: it drops the removed member from its group's bucket so
+/// a removed member stops being preferred for sync (and stops being
+/// re-persisted) promptly, rather than after the 24h TTL. Other events
+/// are ignored. Kept separate from the async loop so it's unit-testable.
+fn apply_invalidation_event(state: &NodeState, event: &OpEvent) {
+    if let OpEvent::MemberRemoved { group_id, member } = event {
+        // Only the durable cache's per-group membership view is dropped.
+        // The in-memory `peer_identities` reverse view is deliberately
+        // left intact: the peer still *controls* that identity (removal
+        // changes group membership, not key ownership), and that view is
+        // only ever intersected with the authoritative `trusted_anchors`
+        // set at selection time — which no longer lists the removed member
+        // — so a stale reverse entry can't make the peer an anchor. The
+        // `member_removed_event_drops_cached_member` test pins this
+        // (asserts the reverse view is untouched) so a future "cleanup"
+        // doesn't silently change it.
+        state
+            .lock_peer_identity_cache()
+            .remove_member(&ContextGroupId::from(*group_id), member);
+        debug!(
+            group_id = %hex::encode(group_id),
+            %member,
+            "dropped removed member from peer-identity cache"
+        );
+    }
+}
+
+/// Spawn the cache-invalidation task: subscribe to governance op-apply
+/// events and drop removed members from the cache. The first node-side
+/// `op_events` subscriber. A dropped (lagged) event is harmless — the
+/// missed member ages out via TTL and is re-derived from the DAG on
+/// restart — so the loop just logs and continues. Holds a strong
+/// `NodeState` for the runtime's lifetime, like the snapshot tick.
+///
+/// `op_events::subscribe()` is called **synchronously here, before
+/// spawning**, so the receiver starts buffering immediately rather than
+/// at some later point when the task first gets scheduled — minimizing
+/// the startup window in which a `MemberRemoved` could be missed.
+///
+/// The returned handle may be dropped (the caller stores it as `_…`); the
+/// task then runs detached until the broadcast channel closes
+/// (`RecvError::Closed`), i.e. for the process lifetime. There is no
+/// graceful-shutdown path because a missed late event is harmless (TTL
+/// covers it); a caller that wanted one could `abort()` the handle.
+pub(crate) fn spawn_invalidation_task(state: NodeState) -> tokio::task::JoinHandle<()> {
+    let mut rx = op_events::subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => apply_invalidation_event(&state, &event),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "peer-identity invalidation subscriber lagged; missed MemberRemoved \
+                         events age out via TTL and are re-derived on restart"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -177,6 +243,55 @@ mod tests {
         assert_eq!(members[0].identity, identity);
         assert_eq!(members[0].role, GroupMemberRole::Admin);
         assert_eq!(members[0].peers, vec![peer]);
+    }
+
+    #[test]
+    // Exercises the handler directly (`apply_invalidation_event`) rather
+    // than via `spawn_invalidation_task` + `op_events::notify` — the
+    // `op_events` channel is a process-wide singleton shared across
+    // parallel tests, so driving the sync handler directly keeps this
+    // test isolated. Prefer this pattern for invalidation-logic tests.
+    #[test]
+    fn member_removed_event_drops_cached_member() {
+        let state = NodeState::new(false, NodeMode::Standard);
+        let group = ContextGroupId::from([7u8; 32]);
+        let member = PublicKey::from([9u8; 32]);
+        let peer = PeerId::random();
+        state.observe_peer_identity(
+            peer,
+            member,
+            Some(ObservedMembership {
+                group_id: group,
+                role: GroupMemberRole::Admin,
+            }),
+        );
+        let cached = |s: &NodeState| {
+            !s.lock_peer_identity_cache()
+                .members_for_group(&group, now_unix_secs(), PEER_IDENTITY_TTL_SECS)
+                .is_empty()
+        };
+        assert!(cached(&state), "seeded");
+
+        apply_invalidation_event(
+            &state,
+            &OpEvent::MemberRemoved {
+                group_id: [7u8; 32],
+                member,
+            },
+        );
+        assert!(!cached(&state), "MemberRemoved dropped the cached member");
+
+        // Intentional: the in-memory reverse view is NOT cleared — the peer
+        // still controls the identity, and anchor status is re-derived from
+        // trusted_anchors at selection time (see apply_invalidation_event).
+        // Pinned here so a future "cleanup" doesn't silently change it.
+        assert!(
+            state
+                .peer_identities
+                .get(&peer)
+                .is_some_and(|ids| ids.contains(&member)),
+            "reverse view deliberately retained after MemberRemoved"
+        );
     }
 
     #[test]

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -1,0 +1,206 @@
+//! Datastore glue for [`PeerIdentityCache`]: snapshot it to a `Generic`
+//! key on a periodic tick, and hydrate it (plus the in-memory
+//! `peer_identities` reverse view) on startup.
+//!
+//! Mirrors the network crate's `PeerAddrCache` persistence: a single
+//! best-effort blob under one key, written on a tick and read on
+//! startup. The whole point is that the authenticated member→peer
+//! signal survives a restart so anchor-preferred sync selection works on
+//! a cold cache instead of falling back to random topic subscribers.
+
+use calimero_store::key::Generic as GenericKey;
+use calimero_store::slice::Slice;
+use calimero_store::types::GenericData;
+use calimero_store::Store;
+use tracing::{debug, info};
+
+use crate::peer_identity_cache::{PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
+use crate::state::{now_unix_secs, NodeState};
+
+/// How often the snapshot tick writes the cache to disk. Matches the
+/// metrics tick's cadence — frequent enough that a crash loses little,
+/// rare enough that the write is negligible against node activity.
+const SNAPSHOT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Datastore key for the single peer-identity-cache blob. 16-byte scope
+/// distinct from `PeerAddrCache`'s `calimero-peercch`; fragment is unused
+/// (one blob, like the address cache).
+fn store_key() -> GenericKey {
+    GenericKey::new(*b"calimero-idpeers", [0u8; 32])
+}
+
+/// Serialize the cache's still-fresh entries and write them to the store.
+/// Best-effort: a serialize/put failure is logged at debug and dropped —
+/// the cache is a routing hint, never load-bearing. Skips the write
+/// entirely when nothing is cached, to avoid churning an empty blob while
+/// the node is idle.
+pub(crate) fn persist(state: &NodeState, store: &Store) {
+    let blob = state
+        .lock_peer_identity_cache()
+        .to_persisted_all(now_unix_secs(), PEER_IDENTITY_TTL_SECS);
+    if blob.groups.is_empty() {
+        return;
+    }
+    let bytes = match serde_json::to_vec(&blob) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            debug!(?err, "failed to serialize peer-identity cache");
+            return;
+        }
+    };
+    let data = GenericData::from(Slice::from(bytes));
+    let mut handle = store.handle();
+    if let Err(err) = handle.put(&store_key(), &data) {
+        debug!(?err, "failed to persist peer-identity cache to store");
+    }
+}
+
+/// Load the cache from the store on startup and hydrate both it and the
+/// in-memory `peer_identities` reverse view, so anchor-preferred
+/// selection has a membership signal immediately rather than after live
+/// traffic refills it. Best-effort: a missing or corrupt blob leaves the
+/// caches empty (the pre-persistence behaviour) rather than failing.
+pub(crate) fn hydrate(state: &NodeState, store: &Store) {
+    let now = now_unix_secs();
+    let blob = match store.handle().get(&store_key()) {
+        Ok(Some(data)) => match serde_json::from_slice(data.as_ref()) {
+            Ok(blob) => blob,
+            Err(err) => {
+                debug!(?err, "ignoring corrupt peer-identity cache blob in store");
+                return;
+            }
+        },
+        Ok(None) => return, // nothing cached yet
+        Err(err) => {
+            debug!(?err, "failed to read peer-identity cache from store");
+            return;
+        }
+    };
+
+    let cache = PeerIdentityCache::load_all_from_persisted(blob, now, PEER_IDENTITY_TTL_SECS);
+    let pairs = cache.all_peer_identity_pairs();
+    let pair_count = pairs.len();
+    // Seed the in-memory reverse view consumed by `partition_peers_anchor_first`.
+    for (peer, identity) in pairs {
+        let _ = state
+            .peer_identities
+            .entry(peer)
+            .or_default()
+            .insert(identity);
+    }
+    *state.lock_peer_identity_cache() = cache;
+
+    if pair_count > 0 {
+        info!(
+            pair_count,
+            "hydrated peer-identity cache from store for cold-start member selection"
+        );
+    }
+}
+
+/// Spawn the periodic snapshot task. Holds a strong `NodeState`/`Store`
+/// reference for the runtime's lifetime — a missed snapshot during
+/// shutdown is harmless, so no shutdown plumbing (same rationale as the
+/// metrics tick).
+pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SNAPSHOT_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Consume the immediate first fire so the first snapshot lands at
+        // startup + INTERVAL, not instantly (nothing has been observed
+        // yet at startup, and `persist` would just no-op on the empty
+        // cache anyway).
+        let _ = interval.tick().await;
+        loop {
+            let _ = interval.tick().await;
+            persist(&state, &store);
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_primitives::context::GroupMemberRole;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_store::db::InMemoryDB;
+    use libp2p::PeerId;
+
+    use super::*;
+    use crate::peer_identity_cache::ObservedMembership;
+    use crate::run::NodeMode;
+
+    fn store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    #[test]
+    fn persist_then_hydrate_round_trips_through_store() {
+        let store = store();
+        let group = ContextGroupId::from([7u8; 32]);
+        let identity = PublicKey::from([9u8; 32]);
+        let peer = PeerId::random();
+
+        let state = NodeState::new(false, NodeMode::Standard);
+        state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role: GroupMemberRole::Admin,
+            }),
+        );
+        persist(&state, &store);
+
+        // A fresh node starts with empty caches, then hydrates from disk.
+        let restored = NodeState::new(false, NodeMode::Standard);
+        assert!(restored.peer_identities.is_empty(), "starts empty");
+        hydrate(&restored, &store);
+
+        // The in-memory reverse view (anchor-filter hot path) is seeded.
+        assert!(
+            restored
+                .peer_identities
+                .get(&peer)
+                .is_some_and(|ids| ids.contains(&identity)),
+            "reverse view hydrated"
+        );
+        // The durable cache is restored with group + role intact.
+        let members = restored.lock_peer_identity_cache().members_for_group(
+            &group,
+            now_unix_secs(),
+            PEER_IDENTITY_TTL_SECS,
+        );
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].identity, identity);
+        assert_eq!(members[0].role, GroupMemberRole::Admin);
+        assert_eq!(members[0].peers, vec![peer]);
+    }
+
+    #[test]
+    fn hydrate_with_no_blob_is_a_noop() {
+        let store = store();
+        let state = NodeState::new(false, NodeMode::Standard);
+        hydrate(&state, &store);
+        assert!(state.peer_identities.is_empty());
+        assert_eq!(state.lock_peer_identity_cache().groups().count(), 0);
+    }
+
+    #[test]
+    fn observation_without_membership_does_not_persist() {
+        let store = store();
+        let state = NodeState::new(false, NodeMode::Standard);
+        // Namespace-path style: in-memory only, no durable record.
+        state.observe_peer_identity(PeerId::random(), PublicKey::from([1u8; 32]), None);
+        persist(&state, &store);
+
+        // Nothing was written (empty cache → skipped), so a fresh node
+        // hydrates to empty.
+        let restored = NodeState::new(false, NodeMode::Standard);
+        hydrate(&restored, &store);
+        assert_eq!(restored.lock_peer_identity_cache().groups().count(), 0);
+        assert!(restored.peer_identities.is_empty());
+    }
+}

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -227,6 +227,14 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     let _metrics_tick =
         crate::node_metrics::spawn_metrics_tick(node_metrics.clone(), node_state.clone());
 
+    // Hydrate the persistent peer-identity cache from disk and seed the
+    // in-memory reverse view, so anchor-preferred sync selection has a
+    // membership signal on a cold cache instead of waiting for live
+    // traffic to refill it. Then snapshot it back periodically.
+    crate::peer_identity_persist::hydrate(&node_state, &datastore);
+    let _peer_identity_tick =
+        crate::peer_identity_persist::spawn_snapshot_tick(node_state.clone(), datastore.clone());
+
     // Drain locally-applied delta notifications from the execute path
     // and register them into the in-memory DeltaStore. Replaces the
     // per-interval-sync `load_persisted_deltas` rescan that existed

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -234,6 +234,10 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     crate::peer_identity_persist::hydrate(&node_state, &datastore);
     let _peer_identity_tick =
         crate::peer_identity_persist::spawn_snapshot_tick(node_state.clone(), datastore.clone());
+    // Drop removed members from the cache promptly on `MemberRemoved`,
+    // rather than waiting for their entries to age out via TTL.
+    let _peer_identity_invalidation =
+        crate::peer_identity_persist::spawn_invalidation_task(node_state.clone());
 
     // Drain locally-applied delta notifications from the execute path
     // and register them into the in-memory DeltaStore. Replaces the

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -283,13 +283,12 @@ impl NodeState {
             .insert(identity);
 
         if let Some(ObservedMembership { group_id, role }) = membership {
-            self.lock_peer_identity_cache().record(
-                group_id,
-                identity,
-                peer_id,
-                role,
-                now_unix_secs(),
-            );
+            // Read the clock before taking the lock so the guard isn't
+            // held across the `SystemTime::now()` syscall (keeps the
+            // critical section to the in-memory `record`).
+            let now = now_unix_secs();
+            self.lock_peer_identity_cache()
+                .record(group_id, identity, peer_id, role, now);
         }
     }
 

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -4,17 +4,21 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
+use calimero_context_config::types::ContextGroupId;
 use calimero_node_primitives::client::NodeClient;
 use calimero_node_primitives::SyncStatusSnapshot;
 use calimero_primitives::identity::PublicKey;
-use calimero_primitives::{blobs::BlobId, context::ContextId};
+use calimero_primitives::{
+    blobs::BlobId,
+    context::{ContextId, GroupMemberRole},
+};
 use dashmap::DashMap;
 use libp2p::PeerId;
 use tracing::{debug, warn};
 
 use crate::constants;
 use crate::delta_store::DeltaStore;
-use crate::peer_identity_cache::{ObservedMembership, PeerIdentityCache};
+use crate::peer_identity_cache::{ObservedMembership, PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
 use crate::run::NodeMode;
 use crate::specialized_node_invite_state::{
     new_pending_specialized_node_invites, PendingSpecializedNodeInvites,
@@ -750,6 +754,23 @@ impl crate::sync::state_access::SyncStateAccess for NodeState {
         self.peer_identities.get(peer_id).map(|entry| entry.clone())
     }
 
+    fn cached_member_peers_for_group(
+        &self,
+        group: &ContextGroupId,
+    ) -> Vec<(PeerId, GroupMemberRole)> {
+        self.lock_peer_identity_cache()
+            .members_for_group(group, now_unix_secs(), PEER_IDENTITY_TTL_SECS)
+            .into_iter()
+            .flat_map(|member| {
+                let role = member.role;
+                member
+                    .peers
+                    .into_iter()
+                    .map(move |peer| (peer, role.clone()))
+            })
+            .collect()
+    }
+
     fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
         crate::sync::reconcile_remaining_cooldown(&self.reconcile_attempts, context_id)
     }
@@ -770,6 +791,40 @@ mod tests {
     use calimero_storage::logical_clock::HybridTimestamp;
 
     use super::*;
+
+    /// An observation carrying membership populates the durable cache so
+    /// `cached_member_peers_for_group` returns the (peer, role); an
+    /// observation with `None` membership does not.
+    #[test]
+    fn cached_member_peers_reflects_observed_membership() {
+        use crate::sync::state_access::SyncStateAccess;
+
+        let state = NodeState::new(false, NodeMode::Standard);
+        let group = ContextGroupId::from([3u8; 32]);
+        let identity = PublicKey::from([4u8; 32]);
+        let peer = PeerId::random();
+
+        state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role: GroupMemberRole::Admin,
+            }),
+        );
+        assert_eq!(
+            state.cached_member_peers_for_group(&group),
+            vec![(peer, GroupMemberRole::Admin)]
+        );
+
+        // Membership-less observation (namespace path) doesn't reach the
+        // per-group durable cache.
+        state.observe_peer_identity(PeerId::random(), PublicKey::from([5u8; 32]), None);
+        assert_eq!(
+            state.cached_member_peers_for_group(&group),
+            vec![(peer, GroupMemberRole::Admin)]
+        );
+    }
 
     fn buffered(id: u8, source_peer: PeerId) -> BufferedDelta {
         BufferedDelta {

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
@@ -14,11 +14,24 @@ use tracing::{debug, warn};
 
 use crate::constants;
 use crate::delta_store::DeltaStore;
+use crate::peer_identity_cache::{ObservedMembership, PeerIdentityCache};
 use crate::run::NodeMode;
 use crate::specialized_node_invite_state::{
     new_pending_specialized_node_invites, PendingSpecializedNodeInvites,
 };
 use crate::sync::SyncManager;
+
+/// Current wall-clock unix seconds, used to stamp `last_seen` on cached
+/// peer-identity observations. Wall-clock (not a monotonic `Instant`) so
+/// freshness survives a process restart — the whole point of the cache.
+/// A pre-epoch clock degrades to 0 (everything looks maximally old) rather
+/// than panicking.
+pub(crate) fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 /// Cached blob with access tracking for eviction
 #[derive(Debug, Clone)]
@@ -143,6 +156,16 @@ pub(crate) struct NodeState {
     /// `(peer_id, identity)` pairs observed, which is itself bounded by
     /// group member count.
     pub(crate) peer_identities: Arc<DashMap<PeerId, BTreeSet<PublicKey>>>,
+    /// Durable backing for `peer_identities`: the same authenticated
+    /// observations, structured per group with role + `last_seen`, so the
+    /// membership signal survives a restart instead of being rebuilt from
+    /// scratch by live traffic. `peer_identities` above stays the O(1) hot
+    /// read path for anchor-preferred selection; this is snapshotted to a
+    /// `Generic` datastore key on a tick and hydrated (into both itself and
+    /// `peer_identities`) on startup. Written only from the authenticated
+    /// `observe_peer_identity` gate, and never a trust gate — see that
+    /// field's trust-model docs.
+    pub(crate) peer_identity_cache: Arc<Mutex<PeerIdentityCache>>,
     /// Per-context reconcile-after-divergence attempt state. Used by the
     /// sync manager to apply exponential backoff between successive
     /// reconcile attempts for the same context, so a persistently
@@ -210,6 +233,7 @@ impl NodeState {
             sync_sessions: Arc::new(DashMap::new()),
             governance_pending: Arc::new(DashMap::new()),
             peer_identities: Arc::new(DashMap::new()),
+            peer_identity_cache: Arc::new(Mutex::new(PeerIdentityCache::default())),
             reconcile_attempts: Arc::new(DashMap::new()),
             sync_status: Arc::new(DashMap::new()),
         }
@@ -234,12 +258,46 @@ impl NodeState {
     /// authored by `identity`. Called from receive paths after the
     /// message verifies and applies — see field-level docs on
     /// `peer_identities` for the trust model. Idempotent.
-    pub(crate) fn observe_peer_identity(&self, peer_id: PeerId, identity: PublicKey) {
+    ///
+    /// `membership` carries the group + role the caller resolved at the
+    /// authenticated cut, when it has them cheaply (the state-delta path
+    /// does; the namespace-governance path passes `None`). When present,
+    /// the observation is also written through to the durable
+    /// `peer_identity_cache` so it survives a restart; when absent, only
+    /// the in-memory reverse view is updated (no regression — that view is
+    /// rebuilt from live traffic as before).
+    pub(crate) fn observe_peer_identity(
+        &self,
+        peer_id: PeerId,
+        identity: PublicKey,
+        membership: Option<ObservedMembership>,
+    ) {
         let _inserted = self
             .peer_identities
             .entry(peer_id)
             .or_default()
             .insert(identity);
+
+        if let Some(ObservedMembership { group_id, role }) = membership {
+            self.lock_peer_identity_cache().record(
+                group_id,
+                identity,
+                peer_id,
+                role,
+                now_unix_secs(),
+            );
+        }
+    }
+
+    /// Lock the durable peer-identity cache, recovering the guard even if
+    /// a prior holder panicked. The cache is a best-effort routing hint,
+    /// so a poisoned lock should degrade to "use what's there" rather than
+    /// propagate a panic into sync selection. The guard is only ever held
+    /// across synchronous work (no `.await` in scope).
+    pub(crate) fn lock_peer_identity_cache(&self) -> MutexGuard<'_, PeerIdentityCache> {
+        self.peer_identity_cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Push a state delta into the governance-pending buffer. Called when

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -5,6 +5,7 @@
 use calimero_context::group_store::{
     CapabilitiesRepository, GroupKeyring, MembershipRepository, MetaRepository, NamespaceRepository,
 };
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use calimero_context_client::client::ContextClient;
@@ -15,7 +16,7 @@ use calimero_node_primitives::client::{NamespaceJoinParams, NodeClient, OpenSubg
 use calimero_node_primitives::join_bundle::JoinBundle;
 use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 use calimero_primitives::common::DIGEST_SIZE;
-use calimero_primitives::context::ContextId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use eyre::bail;
 use eyre::WrapErr;
@@ -862,7 +863,7 @@ impl SyncManager {
     pub(crate) fn member_peers_for_context(
         &self,
         context_id: &ContextId,
-    ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
+    ) -> Vec<(PeerId, GroupMemberRole)> {
         let store = self.context_client.datastore_handle().into_inner();
         let Ok(Some(group_id)) =
             calimero_context::group_store::get_group_for_context(&store, context_id)
@@ -875,17 +876,20 @@ impl SyncManager {
     }
 
     /// Anchor-preference ordering of a cached role: higher binds the
-    /// peer more strongly to the trusted-anchor set. Owner isn't a
-    /// [`GroupMemberRole`] (it's a group `Meta` field) so it doesn't
-    /// appear here — owner preference is applied via the authoritative
-    /// `trusted_anchors` set at selection time, not from this hint.
-    fn role_rank(role: &calimero_primitives::context::GroupMemberRole) -> u8 {
-        use calimero_primitives::context::GroupMemberRole::{Admin, Member, ReadOnly, ReadOnlyTee};
+    /// peer more strongly to the trusted-anchor set. The table mirrors
+    /// `MembershipRepository::trusted_anchors` (Owner ∪ Admins ∪
+    /// ReadOnlyTee) — `Admin` and `ReadOnlyTee` are anchors and rank above
+    /// the non-anchor `ReadOnly`/`Member`; keep it in sync if that set
+    /// changes. Owner isn't a [`GroupMemberRole`] (it's a group `Meta`
+    /// field) so it doesn't appear here — owner preference is applied via
+    /// the authoritative `trusted_anchors` set at selection time, not from
+    /// this hint.
+    fn role_rank(role: &GroupMemberRole) -> u8 {
         match role {
-            Admin => 3,
-            ReadOnlyTee => 2,
-            ReadOnly => 1,
-            Member => 0,
+            GroupMemberRole::Admin => 3,
+            GroupMemberRole::ReadOnlyTee => 2,
+            GroupMemberRole::ReadOnly => 1,
+            GroupMemberRole::Member => 0,
         }
     }
 
@@ -894,19 +898,17 @@ impl SyncManager {
     /// returned once, tagged with its most-anchor role). Output is
     /// sorted by `PeerId` for determinism.
     fn dedup_peers_by_strongest_role(
-        pairs: Vec<(PeerId, calimero_primitives::context::GroupMemberRole)>,
-    ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
-        let mut best: std::collections::BTreeMap<
-            PeerId,
-            calimero_primitives::context::GroupMemberRole,
-        > = std::collections::BTreeMap::new();
+        pairs: Vec<(PeerId, GroupMemberRole)>,
+    ) -> Vec<(PeerId, GroupMemberRole)> {
+        let mut best: BTreeMap<PeerId, GroupMemberRole> = BTreeMap::new();
         for (peer, role) in pairs {
-            match best.get(&peer) {
-                Some(existing) if Self::role_rank(existing) >= Self::role_rank(&role) => {}
-                _ => {
-                    let _ = best.insert(peer, role);
-                }
-            }
+            best.entry(peer)
+                .and_modify(|existing| {
+                    if Self::role_rank(&role) > Self::role_rank(existing) {
+                        *existing = role.clone();
+                    }
+                })
+                .or_insert(role);
         }
         best.into_iter().collect()
     }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -611,17 +611,55 @@ impl SyncManager {
             )))
         };
 
-        let outcome = super::peers::discover_mesh_peers_with_namespace_fallback(
+        // Durably-cached member peers for this context's group — the
+        // cold-start signal that survives a restart. Empty when nothing
+        // is cached, in which case topic discovery below carries the
+        // selection exactly as before.
+        let cached_members: Vec<libp2p::PeerId> = self
+            .member_peers_for_context(&context_id)
+            .into_iter()
+            .map(|(peer, _role)| peer)
+            .collect();
+
+        let discovery = super::peers::discover_mesh_peers_with_namespace_fallback(
             &*self.sync_network,
             context_id,
             max_retries,
             std::time::Duration::from_millis(retry_delay_ms),
             resolve_namespace_topic,
         )
-        .await?;
-        let peers = outcome.peers;
-        let final_attempt = outcome.attempts;
-        let mesh_elapsed = outcome.elapsed;
+        .await;
+
+        let (peers, final_attempt, mesh_elapsed, source) = match discovery {
+            Ok(outcome) => {
+                // Members first, then topic-discovered peers not already
+                // present. `partition_peers_anchor_first` below still
+                // orders anchors within the merged set, so this only
+                // changes which non-anchor peers we reach for first.
+                let peers = Self::merge_members_first(cached_members, outcome.peers);
+                (peers, outcome.attempts, outcome.elapsed, outcome.source)
+            }
+            Err(err) => {
+                // Topic discovery came up empty. If the durable cache has
+                // members, dial them directly — they're real members and
+                // reachable via the address cache / DHT even before a mesh
+                // forms. Otherwise preserve the benign "no peers" outcome.
+                if cached_members.is_empty() {
+                    return Err(err);
+                }
+                debug!(
+                    %context_id,
+                    count = cached_members.len(),
+                    "mesh discovery empty; falling back to durably-cached member peers"
+                );
+                (
+                    cached_members,
+                    0,
+                    std::time::Duration::ZERO,
+                    super::peers::PeerSource::PersistentCache,
+                )
+            }
+        };
 
         info!(
             %context_id,
@@ -629,8 +667,8 @@ impl SyncManager {
             attempts = final_attempt,
             ?mesh_elapsed,
             is_uninitialized,
-            source = ?outcome.source,
-            "Mesh peer discovery succeeded"
+            source = ?source,
+            "Peer discovery yielded candidates"
         );
 
         if is_uninitialized {
@@ -700,6 +738,18 @@ impl SyncManager {
             if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
                 return Ok(result);
             }
+        }
+
+        // On the cold-start cache fallback (topic meshes were empty; we
+        // dialed durably-cached members directly), a total failure means
+        // "no reachable peer right now", not "sync failed against live
+        // peers". Surface the benign `NoPeersAvailable` so the caller
+        // doesn't apply exponential backoff — we want prompt retry while
+        // the mesh forms, matching the pre-fix empty-mesh behaviour. The
+        // normal path (had live mesh peers, all failed) still bails so a
+        // genuine sync failure backs off.
+        if source == super::peers::PeerSource::PersistentCache {
+            return Err(eyre::Error::new(NoPeersAvailable { context_id }));
         }
 
         bail!("Failed to sync with any peer for context {}", context_id)
@@ -796,6 +846,84 @@ impl SyncManager {
         MembershipRepository::new(&store)
             .trusted_anchors(group_id)
             .unwrap_or_default()
+    }
+
+    /// Resolve the cached member peers for the group that owns
+    /// `context_id`: peers we've durably observed hosting members of
+    /// that group, deduped to one entry per peer carrying its strongest
+    /// observed role. Drives cold-start member-preferred dialing before
+    /// live traffic has refilled the in-memory reverse view.
+    ///
+    /// Empty when the context isn't registered to a group, the store
+    /// read fails, or the durable cache holds nothing for the group —
+    /// callers fall back to topic-subscriber discovery. A routing hint:
+    /// `anchor_identities_for_context` (governance `trusted_anchors`,
+    /// which includes the owner) stays authoritative for anchor status.
+    pub(crate) fn member_peers_for_context(
+        &self,
+        context_id: &ContextId,
+    ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
+        let store = self.context_client.datastore_handle().into_inner();
+        let Ok(Some(group_id)) =
+            calimero_context::group_store::get_group_for_context(&store, context_id)
+        else {
+            return Vec::new();
+        };
+        Self::dedup_peers_by_strongest_role(
+            self.state_access.cached_member_peers_for_group(&group_id),
+        )
+    }
+
+    /// Anchor-preference ordering of a cached role: higher binds the
+    /// peer more strongly to the trusted-anchor set. Owner isn't a
+    /// [`GroupMemberRole`] (it's a group `Meta` field) so it doesn't
+    /// appear here — owner preference is applied via the authoritative
+    /// `trusted_anchors` set at selection time, not from this hint.
+    fn role_rank(role: &calimero_primitives::context::GroupMemberRole) -> u8 {
+        use calimero_primitives::context::GroupMemberRole::{Admin, Member, ReadOnly, ReadOnlyTee};
+        match role {
+            Admin => 3,
+            ReadOnlyTee => 2,
+            ReadOnly => 1,
+            Member => 0,
+        }
+    }
+
+    /// Collapse `(peer, role)` pairs to one entry per peer, keeping the
+    /// strongest role (a peer hosting several member identities is
+    /// returned once, tagged with its most-anchor role). Output is
+    /// sorted by `PeerId` for determinism.
+    fn dedup_peers_by_strongest_role(
+        pairs: Vec<(PeerId, calimero_primitives::context::GroupMemberRole)>,
+    ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
+        let mut best: std::collections::BTreeMap<
+            PeerId,
+            calimero_primitives::context::GroupMemberRole,
+        > = std::collections::BTreeMap::new();
+        for (peer, role) in pairs {
+            match best.get(&peer) {
+                Some(existing) if Self::role_rank(existing) >= Self::role_rank(&role) => {}
+                _ => {
+                    let _ = best.insert(peer, role);
+                }
+            }
+        }
+        best.into_iter().collect()
+    }
+
+    /// Merge cached member peers ahead of topic-discovered peers: the
+    /// members come first (cold-start preference for real members), then
+    /// any discovered peer not already in the list, preserving discovery
+    /// order. Deduplicates so a peer that's both a cached member and a
+    /// current subscriber appears once, up front.
+    fn merge_members_first(members: Vec<PeerId>, discovered: Vec<PeerId>) -> Vec<PeerId> {
+        let mut merged = members;
+        for peer in discovered {
+            if !merged.contains(&peer) {
+                merged.push(peer);
+            }
+        }
+        merged
     }
 
     /// Find a peer that has state (non-zero root_hash and non-empty DAG heads)

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -17,6 +17,50 @@ fn build_estimated_handshake(root_hash: [u8; 32], dag_heads: Vec<[u8; 32]>) -> S
     build_handshake_from_raw(root_hash, entity_count, max_depth, dag_heads)
 }
 
+/// `dedup_peers_by_strongest_role` collapses a peer's multiple role
+/// observations to its strongest, regardless of input order.
+#[test]
+fn dedup_peers_keeps_strongest_role() {
+    use calimero_primitives::context::GroupMemberRole;
+    use libp2p::PeerId;
+
+    let p = PeerId::random();
+    let q = PeerId::random();
+    let out = SyncManager::dedup_peers_by_strongest_role(vec![
+        (p, GroupMemberRole::Member),
+        (p, GroupMemberRole::Admin), // strongest for p
+        (q, GroupMemberRole::ReadOnlyTee),
+    ]);
+    let map: std::collections::BTreeMap<_, _> = out.into_iter().collect();
+    assert_eq!(map.get(&p), Some(&GroupMemberRole::Admin));
+    assert_eq!(map.get(&q), Some(&GroupMemberRole::ReadOnlyTee));
+}
+
+/// `merge_members_first` puts cached members ahead of discovered peers,
+/// preserves discovery order for the rest, and dedups the overlap.
+#[test]
+fn merge_members_first_orders_and_dedups() {
+    use libp2p::PeerId;
+
+    let m1 = PeerId::random();
+    let m2 = PeerId::random();
+    let d1 = PeerId::random();
+
+    // m2 also appears among discovered → must not be duplicated.
+    let merged = SyncManager::merge_members_first(vec![m1, m2], vec![d1, m2]);
+    assert_eq!(
+        merged,
+        vec![m1, m2, d1],
+        "members first, discovered appended once"
+    );
+
+    // No cached members → discovery order is preserved verbatim.
+    assert_eq!(
+        SyncManager::merge_members_first(vec![], vec![d1, m1]),
+        vec![d1, m1]
+    );
+}
+
 // =========================================================================
 // Tests for handshake estimation fallback
 // =========================================================================

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -42,6 +42,11 @@ pub(crate) enum PeerSource {
     /// namespace topic mesh as a fallback (namespace meshes are
     /// established earlier during join with a grace period).
     NamespaceFallback,
+    /// Both topic meshes were empty, but the durable peer-identity cache
+    /// held members of this context's group to dial directly — the
+    /// cold-start fallback that lets a freshly-restarted node target real
+    /// members before any gossipsub mesh has formed.
+    PersistentCache,
 }
 
 /// Outcome of the discovery loop: the peer list plus diagnostics

--- a/crates/node/src/sync/state_access.rs
+++ b/crates/node/src/sync/state_access.rs
@@ -22,8 +22,9 @@
 use std::collections::BTreeSet;
 use std::time::Duration;
 
+use calimero_context_config::types::ContextGroupId;
 use calimero_node_primitives::delta_buffer::BufferedDelta;
-use calimero_primitives::context::ContextId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use libp2p::PeerId;
 
@@ -82,6 +83,21 @@ pub(crate) trait SyncStateAccess: Send + Sync {
     /// returned set is a clone — callers iterate it without holding
     /// the underlying `DashMap` shard lock.
     fn peer_identities(&self, peer_id: &PeerId) -> Option<BTreeSet<PublicKey>>;
+
+    /// Member peers cached for `group`, each paired with the role its
+    /// hosted identity holds there — the durable, restart-surviving
+    /// cold-start signal that lets sync prefer real members before live
+    /// traffic has rebuilt the in-memory reverse view.
+    ///
+    /// Empty when nothing is cached for the group (the caller falls back
+    /// to topic-subscriber discovery). A peer may appear more than once
+    /// if it hosts several member identities; callers dedup by strongest
+    /// role. This is a routing hint — governance `trusted_anchors`
+    /// remains authoritative for who is actually an anchor.
+    fn cached_member_peers_for_group(
+        &self,
+        group: &ContextGroupId,
+    ) -> Vec<(PeerId, GroupMemberRole)>;
 
     /// Remaining cooldown for the reconcile-after-divergence path on
     /// `context_id`, plus the current `consecutive_failures` count.

--- a/crates/node/src/sync/state_access_mock.rs
+++ b/crates/node/src/sync/state_access_mock.rs
@@ -14,8 +14,9 @@
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::time::Duration;
 
+use calimero_context_config::types::ContextGroupId;
 use calimero_node_primitives::delta_buffer::BufferedDelta;
-use calimero_primitives::context::ContextId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use libp2p::PeerId;
 use parking_lot::Mutex;
@@ -36,6 +37,7 @@ pub(crate) enum SyncStateAccessCall {
     EndSyncSession(ContextId),
     CancelSyncSession(ContextId),
     PeerIdentities(PeerId),
+    CachedMemberPeersForGroup(ContextGroupId),
     ReconcileRemainingCooldown(ContextId),
     RecordReconcileSuccess(ContextId),
     RecordReconcileFailure(ContextId),
@@ -49,6 +51,7 @@ pub(crate) enum SyncStateAccessCall {
 pub(crate) struct MockSyncStateAccess {
     delta_stores: Mutex<HashMap<ContextId, DeltaStore>>,
     peer_identities: Mutex<HashMap<PeerId, BTreeSet<PublicKey>>>,
+    member_peers: Mutex<HashMap<ContextGroupId, Vec<(PeerId, GroupMemberRole)>>>,
     end_sync_session_responses: Mutex<HashMap<ContextId, VecDeque<Option<Vec<BufferedDelta>>>>>,
     reconcile_cooldowns: Mutex<HashMap<ContextId, (Duration, u32)>>,
     failure_counts: Mutex<HashMap<ContextId, u32>>,
@@ -61,6 +64,15 @@ impl MockSyncStateAccess {
     /// reports `created=false`.
     pub(crate) fn insert_delta_store(&self, context_id: ContextId, store: DeltaStore) {
         let _replaced = self.delta_stores.lock().insert(context_id, store);
+    }
+
+    /// Inject a `cached_member_peers_for_group` response for `group`.
+    pub(crate) fn insert_member_peers(
+        &self,
+        group: ContextGroupId,
+        peers: Vec<(PeerId, GroupMemberRole)>,
+    ) {
+        let _replaced = self.member_peers.lock().insert(group, peers);
     }
 
     /// Inject a `peer_identities` response for `peer`.
@@ -182,6 +194,20 @@ impl SyncStateAccess for MockSyncStateAccess {
         self.peer_identities.lock().get(peer_id).cloned()
     }
 
+    fn cached_member_peers_for_group(
+        &self,
+        group: &ContextGroupId,
+    ) -> Vec<(PeerId, GroupMemberRole)> {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::CachedMemberPeersForGroup(*group));
+        self.member_peers
+            .lock()
+            .get(group)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
         self.calls
             .lock()
@@ -228,6 +254,27 @@ mod tests {
 
     fn ctx(byte: u8) -> ContextId {
         ContextId::from([byte; 32])
+    }
+
+    #[test]
+    fn cached_member_peers_returns_injected_and_records_call() {
+        let mock = MockSyncStateAccess::default();
+        let group = ContextGroupId::from([1u8; 32]);
+        let peer = PeerId::random();
+        mock.insert_member_peers(group, vec![(peer, GroupMemberRole::Admin)]);
+
+        assert_eq!(
+            mock.cached_member_peers_for_group(&group),
+            vec![(peer, GroupMemberRole::Admin)]
+        );
+        // Unseeded group → empty.
+        assert!(mock
+            .cached_member_peers_for_group(&ContextGroupId::from([2u8; 32]))
+            .is_empty());
+        assert!(mock
+            .calls()
+            .iter()
+            .any(|c| matches!(c, SyncStateAccessCall::CachedMemberPeersForGroup(_))));
     }
 
     #[test]


### PR DESCRIPTION
## What

PR **2 of 6** for #2642 (persist the authenticated identity↔PeerId map so sync dials real context members on a cold cache). Stacked on #2708 (PR 1).

This PR **populates** the `PeerIdentityCache` from the authenticated observation gate, **persists** it to RocksDB on a tick, and **hydrates** it (plus the in-memory reverse view) on startup. Behaviour change is confined to: the cache now survives a restart.

## How

- **`NodeState`** gains `peer_identity_cache: Arc<Mutex<PeerIdentityCache>>` (the durable backing) alongside the existing `peer_identities` DashMap (kept as the O(1) hot read path for `partition_peers_anchor_first`). A `lock_peer_identity_cache()` accessor recovers the guard on poison (best-effort hint, never panics into selection).
- **`observe_peer_identity`** grows an `Option<ObservedMembership>` arg. The **state-delta path** has the group + role at the cross-DAG cut, so it passes `Some(..)` and writes through to the durable cache. The **namespace-governance path** doesn't carry them cheaply, so it passes `None` (in-memory reverse view only) — the state deltas that follow a member's governance op re-observe them with full context, so cold-start coverage is unaffected.
- **Persistence** (`peer_identity_persist.rs`): one best-effort JSON blob under a `Generic` key (`calimero-idpeers`), mirroring `PeerAddrCache`. The per-group structure lives *inside* the blob, keeping load/snapshot to one get/put. A 30s `spawn_snapshot_tick` (modeled on the metrics tick) writes it; `hydrate()` loads it on startup and seeds both caches.

## Storage layout note

I used a **single blob** containing the per-group buckets, rather than one RocksDB key per group. It preserves the exact per-group structure (and role granularity) the design calls for, but avoids per-group key enumeration + stale-key pruning on a `Generic` keyspace shared with `PeerAddrCache`. Happy to switch to per-group keys if preferred.

`std::sync::Mutex` (not `parking_lot`) because `parking_lot` is deliberately a dev-only dependency here (kept out of production binaries).

## Testing

`cargo test -p calimero-node --lib peer_identity` — 20 passed (13 cache + 4 blob round-trip + 3 persist/hydrate through an in-memory `Store`). fmt + clippy clean.

## Follow-up PRs
3. `member_peers_for_context` resolver (+ `SyncStateAccess` method).
4. Selection wiring (cold-cache member-first, topic-discovery fallback preserved).
5. Invalidation (node-side `MemberRemoved` subscriber; TTL already here).
6. Integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync peer selection and startup hydration paths; mistakes could mis-route dials or stale member hints, though the design treats the cache as a non-authoritative routing hint with TTL and governance invalidation.
> 
> **Overview**
> Adds a **durable `PeerIdentityCache`** on `NodeState` (alongside the existing in-memory `peer_identities` map) so authenticated `(peer, identity, group, role)` observations survive restarts. **`observe_peer_identity`** now takes optional `ObservedMembership`: the **state-delta** path passes group + role and writes through to the cache; the **namespace-governance** path passes `None` and only updates the in-memory reverse view.
> 
> **Persistence** (`peer_identity_persist.rs`): one JSON blob under a `Generic` store key, **hydrated at node startup** (seeding both caches), **snapshotted every 30s**, and **invalidated on `MemberRemoved`** via `calimero-governance-store` op events. The cache module gains schema-versioned serialize/load, `remove_member`, and hydration helpers.
> 
> **Sync selection** uses the cache on cold start: **`member_peers_for_context`** resolves `context → group → cached (peer, role)` with strongest-role dedup; discovery **merges cached members ahead of topic mesh peers**, and when mesh discovery fails but the cache has members, dials them with a new **`PeerSource::PersistentCache`** path that returns **`NoPeersAvailable`** (not hard sync failure) so retries stay aggressive. **`SyncStateAccess::cached_member_peers_for_group`** wires this through mocks and an e2e test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 171b2369937edc1edb74bf42c42f3007009553c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->