### PR TITLE
feat(node): member_peers_for_context resolver + SyncStateAccess seam (PR 3/6, #2642)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
  "calimero-context-config",
  "calimero-crypto",
  "calimero-dag",
+ "calimero-governance-store",
  "calimero-network",
  "calimero-network-primitives",
  "calimero-node-primitives",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,6 +35,7 @@ zeroize.workspace = true
 calimero-context.workspace = true
 calimero-context-config.workspace = true
 calimero-context-client.workspace = true
+calimero-governance-store.workspace = true
 calimero-runtime.workspace = true
 calimero-crypto.workspace = true
 calimero-blobstore.workspace = true

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -35,6 +35,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
 use crate::arbiter_pool::ArbiterPool;
+use crate::peer_identity_cache::ObservedMembership;
 use crate::sync::{SyncConfig, SyncManager};
 use crate::{NodeManager, NodeState};
 
@@ -710,5 +711,139 @@ async fn group_topic_announce_is_not_routed_as_namespace_admission() {
             .expect("count"),
         1,
         "no member should be admitted from a group/ topic announce (owner only)"
+    );
+}
+
+/// Build a standalone `SyncManager` against an in-memory store, without
+/// the surrounding `NodeManager` actor — enough to exercise the
+/// synchronous peer-selection helpers (`member_peers_for_context`)
+/// end-to-end against real governance state. Returns the manager, the
+/// shared store, the shared `NodeState` (its peer-identity cache is an
+/// `Arc` shared with the manager's `state_access`, so seeding it here is
+/// visible to the manager), and the `TempDir` guard the blob fs needs.
+async fn build_standalone_sync_manager() -> (SyncManager, Store, NodeState, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+    let blob_store_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_store_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+
+    let node_recipient = LazyRecipient::<NodeMessage>::new();
+    let context_recipient = LazyRecipient::new();
+    let network_recipient = LazyRecipient::new();
+    let network_client = NetworkClient::new(network_recipient);
+    let (event_sender, _) = broadcast::channel(16);
+    let (ctx_sync_tx, ctx_sync_rx) = mpsc::channel(64);
+    let (ns_sync_tx, ns_sync_rx) = mpsc::channel(16);
+    let (ns_join_tx, ns_join_rx) = mpsc::channel(16);
+    let (open_subgroup_join_tx, open_subgroup_join_rx) = mpsc::channel(16);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client.clone(),
+        node_recipient,
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+    let context_client = ContextClient::new(store.clone(), node_client.clone(), context_recipient);
+    let node_state = NodeState::new(false, NodeMode::Standard);
+
+    let sync_manager = SyncManager::new(
+        SyncConfig::default(),
+        node_client,
+        context_client,
+        network_client,
+        node_state.clone(),
+        ctx_sync_rx,
+        ns_sync_rx,
+        ns_join_rx,
+        open_subgroup_join_rx,
+    );
+
+    (sync_manager, store, node_state, tmp)
+}
+
+/// End-to-end resolver (#2642): with a context registered to a group in
+/// the real governance store and the durable peer-identity cache seeded
+/// via the authenticated observe path, `member_peers_for_context`
+/// resolves `context → group → cached member peers`, deduped by role.
+#[tokio::test]
+async fn member_peers_for_context_resolves_cached_members_end_to_end() {
+    let (sync_manager, store, node_state, _tmp) = build_standalone_sync_manager().await;
+
+    let group_id = ContextGroupId::from([0x11; 32]);
+    let other_group = ContextGroupId::from([0xAA; 32]);
+    let context_id = calimero_primitives::context::ContextId::from([0x22; 32]);
+    calimero_context::group_store::register_context_in_group(&store, &group_id, &context_id)
+        .expect("register context -> group");
+
+    // Real (random) member identities, matching the convention of the
+    // other tests in this file.
+    let admin_id = PrivateKey::random(&mut OsRng).public_key();
+    let member_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_second_id = PrivateKey::random(&mut OsRng).public_key();
+    let other_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_peer = libp2p::PeerId::random();
+    let member_peer = libp2p::PeerId::random();
+    let other_peer = libp2p::PeerId::random();
+
+    // Seed the shared cache through the same gate the production receive
+    // paths use (group + role at the cross-DAG cut).
+    let observe = |peer, identity, group, role| {
+        node_state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role,
+            }),
+        );
+    };
+    observe(admin_peer, admin_id, group_id, GroupMemberRole::Admin);
+    observe(member_peer, member_id, group_id, GroupMemberRole::Member);
+    // Same peer observed again under a second identity at a weaker role —
+    // the dedup must keep the strongest role (Admin) for admin_peer,
+    // exercising dedup_peers_by_strongest_role through the full resolver.
+    observe(
+        admin_peer,
+        admin_second_id,
+        group_id,
+        GroupMemberRole::Member,
+    );
+    // A member of a DIFFERENT group must not leak into this context's
+    // result (guards group-scoping of cached_member_peers_for_group).
+    observe(other_peer, other_id, other_group, GroupMemberRole::Admin);
+
+    let resolved: std::collections::BTreeMap<_, _> = sync_manager
+        .member_peers_for_context(&context_id)
+        .into_iter()
+        .collect();
+    assert_eq!(resolved.len(), 2, "only this group's members resolve");
+    assert_eq!(
+        resolved.get(&admin_peer),
+        Some(&GroupMemberRole::Admin),
+        "dedup keeps the strongest role for a peer seen at two roles"
+    );
+    assert_eq!(resolved.get(&member_peer), Some(&GroupMemberRole::Member));
+    assert!(
+        !resolved.contains_key(&other_peer),
+        "a member cached under a different group is excluded"
+    );
+
+    // A context with no group mapping resolves to nothing (caller then
+    // falls back to topic discovery).
+    let unregistered = calimero_primitives::context::ContextId::from([0x99; 32]);
+    assert!(
+        sync_manager
+            .member_peers_for_context(&unregistered)
+            .is_empty(),
+        "unregistered context yields no cached members"
     );
 }

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -48,11 +48,6 @@
 //! `PeerAddrCache`: pure data + TTL here, with the snapshot tick and
 //! startup hydration wired by the node layer.
 
-// The type lands on its own for reviewability; population, persistence,
-// and selection wiring follow in subsequent PRs, so its API is unused
-// (dead-code) in the meantime.
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, BTreeSet};
 
 use calimero_context_config::types::ContextGroupId;
@@ -176,10 +171,16 @@ impl PeerIdentityCache {
     }
 
     /// Identities observed on `peer` across **all** groups — the reverse
-    /// direction `partition_peers_anchor_first` uses to flag whether a
-    /// discovered peer hosts an anchor identity. No freshness filter: the
-    /// caller intersects this with an authoritative anchor set, so a
-    /// slightly stale identity can only fail to match, never mis-match.
+    /// direction a future selection refinement can use to flag whether a
+    /// discovered peer hosts an anchor identity, straight from the durable
+    /// cache. No freshness filter: the caller intersects this with an
+    /// authoritative anchor set, so a slightly stale identity can only
+    /// fail to match, never mis-match.
+    ///
+    /// Not yet wired — selection currently reads the in-memory
+    /// `peer_identities` reverse view for this; retained (and tested) as
+    /// the cache-backed counterpart for when that path moves to the cache.
+    #[allow(dead_code)]
     pub(crate) fn identities_for_peer(&self, peer: &PeerId) -> BTreeSet<PublicKey> {
         let mut out = BTreeSet::new();
         for g in self.groups.values() {
@@ -316,8 +317,7 @@ impl PeerIdentityCache {
         ttl_secs: u64,
     ) -> PersistedPeerIdentityCache {
         let groups = self
-            .groups
-            .keys()
+            .groups()
             .filter_map(|group| {
                 let entries = self.to_persisted(group, now_secs, ttl_secs);
                 (!entries.is_empty()).then(|| PersistedGroup {
@@ -347,6 +347,29 @@ impl PeerIdentityCache {
             cache.load_group_from_persisted(group, g.entries, now_secs, ttl_secs);
         }
         cache
+    }
+
+    /// Drop a member from a group's bucket — invoked when governance
+    /// emits `MemberRemoved`, so the removed identity stops being
+    /// preferred for sync (and stops being re-persisted) without waiting
+    /// for TTL. If the group's bucket empties, the group is removed.
+    ///
+    /// Only the cache's per-group *membership* view is touched; the
+    /// `peer_identities` reverse view is left intact, because the peer
+    /// still controls that identity — removal changes group membership,
+    /// not key ownership, and anchor status is re-derived from the
+    /// now-updated governance `trusted_anchors`.
+    pub(crate) fn remove_member(&mut self, group: &ContextGroupId, identity: &PublicKey) {
+        let now_empty = match self.groups.get_mut(group) {
+            Some(g) => {
+                let _ = g.members.remove(identity);
+                g.members.is_empty()
+            }
+            None => false,
+        };
+        if now_empty {
+            let _ = self.groups.remove(group);
+        }
     }
 
     /// All `(peer, identity)` pairs currently held, across every group —
@@ -683,6 +706,29 @@ mod tests {
             BTreeSet::from([group(2)]),
             "only the well-formed group id loads"
         );
+    }
+
+    #[test]
+    fn remove_member_drops_identity_and_empties_group() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        c.record(group(1), pk(2), peer(2), GroupMemberRole::Member, 100);
+
+        c.remove_member(&group(1), &pk(1));
+        let members = c.members_for_group(&group(1), 100, 1000);
+        assert_eq!(members.len(), 1);
+        assert_eq!(
+            members[0].identity,
+            pk(2),
+            "only the removed member is gone"
+        );
+
+        // Removing the last member drops the group bucket entirely.
+        c.remove_member(&group(1), &pk(2));
+        assert_eq!(c.groups().count(), 0, "emptied group is removed");
+
+        // Removing from an absent group is a no-op.
+        c.remove_member(&group(2), &pk(9));
     }
 
     #[test]

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -8,11 +8,13 @@
 //! signal survives a restart so anchor-preferred sync selection works on
 //! a cold cache instead of falling back to random topic subscribers.
 
+use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::op_events::{self, OpEvent};
 use calimero_store::key::Generic as GenericKey;
 use calimero_store::slice::Slice;
 use calimero_store::types::GenericData;
 use calimero_store::Store;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::peer_identity_cache::{PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
 use crate::state::{now_unix_secs, NodeState};
@@ -118,6 +120,70 @@ pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task
     })
 }
 
+/// Apply one op-apply event to the cache. Currently only `MemberRemoved`
+/// is actionable: it drops the removed member from its group's bucket so
+/// a removed member stops being preferred for sync (and stops being
+/// re-persisted) promptly, rather than after the 24h TTL. Other events
+/// are ignored. Kept separate from the async loop so it's unit-testable.
+fn apply_invalidation_event(state: &NodeState, event: &OpEvent) {
+    if let OpEvent::MemberRemoved { group_id, member } = event {
+        // Only the durable cache's per-group membership view is dropped.
+        // The in-memory `peer_identities` reverse view is deliberately
+        // left intact: the peer still *controls* that identity (removal
+        // changes group membership, not key ownership), and that view is
+        // only ever intersected with the authoritative `trusted_anchors`
+        // set at selection time — which no longer lists the removed member
+        // — so a stale reverse entry can't make the peer an anchor. The
+        // `member_removed_event_drops_cached_member` test pins this
+        // (asserts the reverse view is untouched) so a future "cleanup"
+        // doesn't silently change it.
+        state
+            .lock_peer_identity_cache()
+            .remove_member(&ContextGroupId::from(*group_id), member);
+        debug!(
+            group_id = %hex::encode(group_id),
+            %member,
+            "dropped removed member from peer-identity cache"
+        );
+    }
+}
+
+/// Spawn the cache-invalidation task: subscribe to governance op-apply
+/// events and drop removed members from the cache. The first node-side
+/// `op_events` subscriber. A dropped (lagged) event is harmless — the
+/// missed member ages out via TTL and is re-derived from the DAG on
+/// restart — so the loop just logs and continues. Holds a strong
+/// `NodeState` for the runtime's lifetime, like the snapshot tick.
+///
+/// `op_events::subscribe()` is called **synchronously here, before
+/// spawning**, so the receiver starts buffering immediately rather than
+/// at some later point when the task first gets scheduled — minimizing
+/// the startup window in which a `MemberRemoved` could be missed.
+///
+/// The returned handle may be dropped (the caller stores it as `_…`); the
+/// task then runs detached until the broadcast channel closes
+/// (`RecvError::Closed`), i.e. for the process lifetime. There is no
+/// graceful-shutdown path because a missed late event is harmless (TTL
+/// covers it); a caller that wanted one could `abort()` the handle.
+pub(crate) fn spawn_invalidation_task(state: NodeState) -> tokio::task::JoinHandle<()> {
+    let mut rx = op_events::subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => apply_invalidation_event(&state, &event),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "peer-identity invalidation subscriber lagged; missed MemberRemoved \
+                         events age out via TTL and are re-derived on restart"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -177,6 +243,55 @@ mod tests {
         assert_eq!(members[0].identity, identity);
         assert_eq!(members[0].role, GroupMemberRole::Admin);
         assert_eq!(members[0].peers, vec![peer]);
+    }
+
+    #[test]
+    // Exercises the handler directly (`apply_invalidation_event`) rather
+    // than via `spawn_invalidation_task` + `op_events::notify` — the
+    // `op_events` channel is a process-wide singleton shared across
+    // parallel tests, so driving the sync handler directly keeps this
+    // test isolated. Prefer this pattern for invalidation-logic tests.
+    #[test]
+    fn member_removed_event_drops_cached_member() {
+        let state = NodeState::new(false, NodeMode::Standard);
+        let group = ContextGroupId::from([7u8; 32]);
+        let member = PublicKey::from([9u8; 32]);
+        let peer = PeerId::random();
+        state.observe_peer_identity(
+            peer,
+            member,
+            Some(ObservedMembership {
+                group_id: group,
+                role: GroupMemberRole::Admin,
+            }),
+        );
+        let cached = |s: &NodeState| {
+            !s.lock_peer_identity_cache()
+                .members_for_group(&group, now_unix_secs(), PEER_IDENTITY_TTL_SECS)
+                .is_empty()
+        };
+        assert!(cached(&state), "seeded");
+
+        apply_invalidation_event(
+            &state,
+            &OpEvent::MemberRemoved {
+                group_id: [7u8; 32],
+                member,
+            },
+        );
+        assert!(!cached(&state), "MemberRemoved dropped the cached member");
+
+        // Intentional: the in-memory reverse view is NOT cleared — the peer
+        // still controls the identity, and anchor status is re-derived from
+        // trusted_anchors at selection time (see apply_invalidation_event).
+        // Pinned here so a future "cleanup" doesn't silently change it.
+        assert!(
+            state
+                .peer_identities
+                .get(&peer)
+                .is_some_and(|ids| ids.contains(&member)),
+            "reverse view deliberately retained after MemberRemoved"
+        );
     }
 
     #[test]

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -234,6 +234,10 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     crate::peer_identity_persist::hydrate(&node_state, &datastore);
     let _peer_identity_tick =
         crate::peer_identity_persist::spawn_snapshot_tick(node_state.clone(), datastore.clone());
+    // Drop removed members from the cache promptly on `MemberRemoved`,
+    // rather than waiting for their entries to age out via TTL.
+    let _peer_identity_invalidation =
+        crate::peer_identity_persist::spawn_invalidation_task(node_state.clone());
 
     // Drain locally-applied delta notifications from the execute path
     // and register them into the in-memory DeltaStore. Replaces the

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -4,17 +4,21 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use calimero_blobstore::BlobManager as BlobStore;
 use calimero_context_client::client::ContextClient;
+use calimero_context_config::types::ContextGroupId;
 use calimero_node_primitives::client::NodeClient;
 use calimero_node_primitives::SyncStatusSnapshot;
 use calimero_primitives::identity::PublicKey;
-use calimero_primitives::{blobs::BlobId, context::ContextId};
+use calimero_primitives::{
+    blobs::BlobId,
+    context::{ContextId, GroupMemberRole},
+};
 use dashmap::DashMap;
 use libp2p::PeerId;
 use tracing::{debug, warn};
 
 use crate::constants;
 use crate::delta_store::DeltaStore;
-use crate::peer_identity_cache::{ObservedMembership, PeerIdentityCache};
+use crate::peer_identity_cache::{ObservedMembership, PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
 use crate::run::NodeMode;
 use crate::specialized_node_invite_state::{
     new_pending_specialized_node_invites, PendingSpecializedNodeInvites,
@@ -750,6 +754,23 @@ impl crate::sync::state_access::SyncStateAccess for NodeState {
         self.peer_identities.get(peer_id).map(|entry| entry.clone())
     }
 
+    fn cached_member_peers_for_group(
+        &self,
+        group: &ContextGroupId,
+    ) -> Vec<(PeerId, GroupMemberRole)> {
+        self.lock_peer_identity_cache()
+            .members_for_group(group, now_unix_secs(), PEER_IDENTITY_TTL_SECS)
+            .into_iter()
+            .flat_map(|member| {
+                let role = member.role;
+                member
+                    .peers
+                    .into_iter()
+                    .map(move |peer| (peer, role.clone()))
+            })
+            .collect()
+    }
+
     fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
         crate::sync::reconcile_remaining_cooldown(&self.reconcile_attempts, context_id)
     }
@@ -770,6 +791,40 @@ mod tests {
     use calimero_storage::logical_clock::HybridTimestamp;
 
     use super::*;
+
+    /// An observation carrying membership populates the durable cache so
+    /// `cached_member_peers_for_group` returns the (peer, role); an
+    /// observation with `None` membership does not.
+    #[test]
+    fn cached_member_peers_reflects_observed_membership() {
+        use crate::sync::state_access::SyncStateAccess;
+
+        let state = NodeState::new(false, NodeMode::Standard);
+        let group = ContextGroupId::from([3u8; 32]);
+        let identity = PublicKey::from([4u8; 32]);
+        let peer = PeerId::random();
+
+        state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role: GroupMemberRole::Admin,
+            }),
+        );
+        assert_eq!(
+            state.cached_member_peers_for_group(&group),
+            vec![(peer, GroupMemberRole::Admin)]
+        );
+
+        // Membership-less observation (namespace path) doesn't reach the
+        // per-group durable cache.
+        state.observe_peer_identity(PeerId::random(), PublicKey::from([5u8; 32]), None);
+        assert_eq!(
+            state.cached_member_peers_for_group(&group),
+            vec![(peer, GroupMemberRole::Admin)]
+        );
+    }
 
     fn buffered(id: u8, source_peer: PeerId) -> BufferedDelta {
         BufferedDelta {

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -798,6 +798,72 @@ impl SyncManager {
             .unwrap_or_default()
     }
 
+    /// Resolve the cached member peers for the group that owns
+    /// `context_id`: peers we've durably observed hosting members of
+    /// that group, deduped to one entry per peer carrying its strongest
+    /// observed role. Drives cold-start member-preferred dialing before
+    /// live traffic has refilled the in-memory reverse view.
+    ///
+    /// Empty when the context isn't registered to a group, the store
+    /// read fails, or the durable cache holds nothing for the group —
+    /// callers fall back to topic-subscriber discovery. A routing hint:
+    /// `anchor_identities_for_context` (governance `trusted_anchors`,
+    /// which includes the owner) stays authoritative for anchor status.
+    #[allow(dead_code)] // wired into peer selection in a follow-up
+    fn member_peers_for_context(
+        &self,
+        context_id: &ContextId,
+    ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
+        let store = self.context_client.datastore_handle().into_inner();
+        let Ok(Some(group_id)) =
+            calimero_context::group_store::get_group_for_context(&store, context_id)
+        else {
+            return Vec::new();
+        };
+        Self::dedup_peers_by_strongest_role(
+            self.state_access.cached_member_peers_for_group(&group_id),
+        )
+    }
+
+    /// Anchor-preference ordering of a cached role: higher binds the
+    /// peer more strongly to the trusted-anchor set. Owner isn't a
+    /// [`GroupMemberRole`] (it's a group `Meta` field) so it doesn't
+    /// appear here — owner preference is applied via the authoritative
+    /// `trusted_anchors` set at selection time, not from this hint.
+    #[allow(dead_code)] // used by `member_peers_for_context`, wired in a follow-up
+    fn role_rank(role: &calimero_primitives::context::GroupMemberRole) -> u8 {
+        use calimero_primitives::context::GroupMemberRole::{Admin, Member, ReadOnly, ReadOnlyTee};
+        match role {
+            Admin => 3,
+            ReadOnlyTee => 2,
+            ReadOnly => 1,
+            Member => 0,
+        }
+    }
+
+    /// Collapse `(peer, role)` pairs to one entry per peer, keeping the
+    /// strongest role (a peer hosting several member identities is
+    /// returned once, tagged with its most-anchor role). Output is
+    /// sorted by `PeerId` for determinism.
+    #[allow(dead_code)] // used by `member_peers_for_context`, wired in a follow-up
+    fn dedup_peers_by_strongest_role(
+        pairs: Vec<(PeerId, calimero_primitives::context::GroupMemberRole)>,
+    ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
+        let mut best: std::collections::BTreeMap<
+            PeerId,
+            calimero_primitives::context::GroupMemberRole,
+        > = std::collections::BTreeMap::new();
+        for (peer, role) in pairs {
+            match best.get(&peer) {
+                Some(existing) if Self::role_rank(existing) >= Self::role_rank(&role) => {}
+                _ => {
+                    let _ = best.insert(peer, role);
+                }
+            }
+        }
+        best.into_iter().collect()
+    }
+
     /// Find a peer that has state (non-zero root_hash and non-empty DAG heads)
     ///
     /// This is critical for bootstrapping newly joined nodes. Without this,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -611,17 +611,55 @@ impl SyncManager {
             )))
         };
 
-        let outcome = super::peers::discover_mesh_peers_with_namespace_fallback(
+        // Durably-cached member peers for this context's group — the
+        // cold-start signal that survives a restart. Empty when nothing
+        // is cached, in which case topic discovery below carries the
+        // selection exactly as before.
+        let cached_members: Vec<libp2p::PeerId> = self
+            .member_peers_for_context(&context_id)
+            .into_iter()
+            .map(|(peer, _role)| peer)
+            .collect();
+
+        let discovery = super::peers::discover_mesh_peers_with_namespace_fallback(
             &*self.sync_network,
             context_id,
             max_retries,
             std::time::Duration::from_millis(retry_delay_ms),
             resolve_namespace_topic,
         )
-        .await?;
-        let peers = outcome.peers;
-        let final_attempt = outcome.attempts;
-        let mesh_elapsed = outcome.elapsed;
+        .await;
+
+        let (peers, final_attempt, mesh_elapsed, source) = match discovery {
+            Ok(outcome) => {
+                // Members first, then topic-discovered peers not already
+                // present. `partition_peers_anchor_first` below still
+                // orders anchors within the merged set, so this only
+                // changes which non-anchor peers we reach for first.
+                let peers = Self::merge_members_first(cached_members, outcome.peers);
+                (peers, outcome.attempts, outcome.elapsed, outcome.source)
+            }
+            Err(err) => {
+                // Topic discovery came up empty. If the durable cache has
+                // members, dial them directly — they're real members and
+                // reachable via the address cache / DHT even before a mesh
+                // forms. Otherwise preserve the benign "no peers" outcome.
+                if cached_members.is_empty() {
+                    return Err(err);
+                }
+                debug!(
+                    %context_id,
+                    count = cached_members.len(),
+                    "mesh discovery empty; falling back to durably-cached member peers"
+                );
+                (
+                    cached_members,
+                    0,
+                    std::time::Duration::ZERO,
+                    super::peers::PeerSource::PersistentCache,
+                )
+            }
+        };
 
         info!(
             %context_id,
@@ -629,8 +667,8 @@ impl SyncManager {
             attempts = final_attempt,
             ?mesh_elapsed,
             is_uninitialized,
-            source = ?outcome.source,
-            "Mesh peer discovery succeeded"
+            source = ?source,
+            "Peer discovery yielded candidates"
         );
 
         if is_uninitialized {
@@ -700,6 +738,18 @@ impl SyncManager {
             if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
                 return Ok(result);
             }
+        }
+
+        // On the cold-start cache fallback (topic meshes were empty; we
+        // dialed durably-cached members directly), a total failure means
+        // "no reachable peer right now", not "sync failed against live
+        // peers". Surface the benign `NoPeersAvailable` so the caller
+        // doesn't apply exponential backoff — we want prompt retry while
+        // the mesh forms, matching the pre-fix empty-mesh behaviour. The
+        // normal path (had live mesh peers, all failed) still bails so a
+        // genuine sync failure backs off.
+        if source == super::peers::PeerSource::PersistentCache {
+            return Err(eyre::Error::new(NoPeersAvailable { context_id }));
         }
 
         bail!("Failed to sync with any peer for context {}", context_id)
@@ -809,8 +859,7 @@ impl SyncManager {
     /// callers fall back to topic-subscriber discovery. A routing hint:
     /// `anchor_identities_for_context` (governance `trusted_anchors`,
     /// which includes the owner) stays authoritative for anchor status.
-    #[allow(dead_code)] // wired into peer selection in a follow-up
-    fn member_peers_for_context(
+    pub(crate) fn member_peers_for_context(
         &self,
         context_id: &ContextId,
     ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
@@ -830,7 +879,6 @@ impl SyncManager {
     /// [`GroupMemberRole`] (it's a group `Meta` field) so it doesn't
     /// appear here — owner preference is applied via the authoritative
     /// `trusted_anchors` set at selection time, not from this hint.
-    #[allow(dead_code)] // used by `member_peers_for_context`, wired in a follow-up
     fn role_rank(role: &calimero_primitives::context::GroupMemberRole) -> u8 {
         use calimero_primitives::context::GroupMemberRole::{Admin, Member, ReadOnly, ReadOnlyTee};
         match role {
@@ -845,7 +893,6 @@ impl SyncManager {
     /// strongest role (a peer hosting several member identities is
     /// returned once, tagged with its most-anchor role). Output is
     /// sorted by `PeerId` for determinism.
-    #[allow(dead_code)] // used by `member_peers_for_context`, wired in a follow-up
     fn dedup_peers_by_strongest_role(
         pairs: Vec<(PeerId, calimero_primitives::context::GroupMemberRole)>,
     ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
@@ -862,6 +909,21 @@ impl SyncManager {
             }
         }
         best.into_iter().collect()
+    }
+
+    /// Merge cached member peers ahead of topic-discovered peers: the
+    /// members come first (cold-start preference for real members), then
+    /// any discovered peer not already in the list, preserving discovery
+    /// order. Deduplicates so a peer that's both a cached member and a
+    /// current subscriber appears once, up front.
+    fn merge_members_first(members: Vec<PeerId>, discovered: Vec<PeerId>) -> Vec<PeerId> {
+        let mut merged = members;
+        for peer in discovered {
+            if !merged.contains(&peer) {
+                merged.push(peer);
+            }
+        }
+        merged
     }
 
     /// Find a peer that has state (non-zero root_hash and non-empty DAG heads)

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -17,6 +17,25 @@ fn build_estimated_handshake(root_hash: [u8; 32], dag_heads: Vec<[u8; 32]>) -> S
     build_handshake_from_raw(root_hash, entity_count, max_depth, dag_heads)
 }
 
+/// `dedup_peers_by_strongest_role` collapses a peer's multiple role
+/// observations to its strongest, regardless of input order.
+#[test]
+fn dedup_peers_keeps_strongest_role() {
+    use calimero_primitives::context::GroupMemberRole;
+    use libp2p::PeerId;
+
+    let p = PeerId::random();
+    let q = PeerId::random();
+    let out = SyncManager::dedup_peers_by_strongest_role(vec![
+        (p, GroupMemberRole::Member),
+        (p, GroupMemberRole::Admin), // strongest for p
+        (q, GroupMemberRole::ReadOnlyTee),
+    ]);
+    let map: std::collections::BTreeMap<_, _> = out.into_iter().collect();
+    assert_eq!(map.get(&p), Some(&GroupMemberRole::Admin));
+    assert_eq!(map.get(&q), Some(&GroupMemberRole::ReadOnlyTee));
+}
+
 // =========================================================================
 // Tests for handshake estimation fallback
 // =========================================================================

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -36,6 +36,31 @@ fn dedup_peers_keeps_strongest_role() {
     assert_eq!(map.get(&q), Some(&GroupMemberRole::ReadOnlyTee));
 }
 
+/// `merge_members_first` puts cached members ahead of discovered peers,
+/// preserves discovery order for the rest, and dedups the overlap.
+#[test]
+fn merge_members_first_orders_and_dedups() {
+    use libp2p::PeerId;
+
+    let m1 = PeerId::random();
+    let m2 = PeerId::random();
+    let d1 = PeerId::random();
+
+    // m2 also appears among discovered → must not be duplicated.
+    let merged = SyncManager::merge_members_first(vec![m1, m2], vec![d1, m2]);
+    assert_eq!(
+        merged,
+        vec![m1, m2, d1],
+        "members first, discovered appended once"
+    );
+
+    // No cached members → discovery order is preserved verbatim.
+    assert_eq!(
+        SyncManager::merge_members_first(vec![], vec![d1, m1]),
+        vec![d1, m1]
+    );
+}
+
 // =========================================================================
 // Tests for handshake estimation fallback
 // =========================================================================

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -42,6 +42,11 @@ pub(crate) enum PeerSource {
     /// namespace topic mesh as a fallback (namespace meshes are
     /// established earlier during join with a grace period).
     NamespaceFallback,
+    /// Both topic meshes were empty, but the durable peer-identity cache
+    /// held members of this context's group to dial directly — the
+    /// cold-start fallback that lets a freshly-restarted node target real
+    /// members before any gossipsub mesh has formed.
+    PersistentCache,
 }
 
 /// Outcome of the discovery loop: the peer list plus diagnostics

--- a/crates/node/src/sync/state_access.rs
+++ b/crates/node/src/sync/state_access.rs
@@ -22,8 +22,9 @@
 use std::collections::BTreeSet;
 use std::time::Duration;
 
+use calimero_context_config::types::ContextGroupId;
 use calimero_node_primitives::delta_buffer::BufferedDelta;
-use calimero_primitives::context::ContextId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use libp2p::PeerId;
 
@@ -82,6 +83,21 @@ pub(crate) trait SyncStateAccess: Send + Sync {
     /// returned set is a clone — callers iterate it without holding
     /// the underlying `DashMap` shard lock.
     fn peer_identities(&self, peer_id: &PeerId) -> Option<BTreeSet<PublicKey>>;
+
+    /// Member peers cached for `group`, each paired with the role its
+    /// hosted identity holds there — the durable, restart-surviving
+    /// cold-start signal that lets sync prefer real members before live
+    /// traffic has rebuilt the in-memory reverse view.
+    ///
+    /// Empty when nothing is cached for the group (the caller falls back
+    /// to topic-subscriber discovery). A peer may appear more than once
+    /// if it hosts several member identities; callers dedup by strongest
+    /// role. This is a routing hint — governance `trusted_anchors`
+    /// remains authoritative for who is actually an anchor.
+    fn cached_member_peers_for_group(
+        &self,
+        group: &ContextGroupId,
+    ) -> Vec<(PeerId, GroupMemberRole)>;
 
     /// Remaining cooldown for the reconcile-after-divergence path on
     /// `context_id`, plus the current `consecutive_failures` count.

--- a/crates/node/src/sync/state_access_mock.rs
+++ b/crates/node/src/sync/state_access_mock.rs
@@ -14,8 +14,9 @@
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::time::Duration;
 
+use calimero_context_config::types::ContextGroupId;
 use calimero_node_primitives::delta_buffer::BufferedDelta;
-use calimero_primitives::context::ContextId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use libp2p::PeerId;
 use parking_lot::Mutex;
@@ -36,6 +37,7 @@ pub(crate) enum SyncStateAccessCall {
     EndSyncSession(ContextId),
     CancelSyncSession(ContextId),
     PeerIdentities(PeerId),
+    CachedMemberPeersForGroup(ContextGroupId),
     ReconcileRemainingCooldown(ContextId),
     RecordReconcileSuccess(ContextId),
     RecordReconcileFailure(ContextId),
@@ -49,6 +51,7 @@ pub(crate) enum SyncStateAccessCall {
 pub(crate) struct MockSyncStateAccess {
     delta_stores: Mutex<HashMap<ContextId, DeltaStore>>,
     peer_identities: Mutex<HashMap<PeerId, BTreeSet<PublicKey>>>,
+    member_peers: Mutex<HashMap<ContextGroupId, Vec<(PeerId, GroupMemberRole)>>>,
     end_sync_session_responses: Mutex<HashMap<ContextId, VecDeque<Option<Vec<BufferedDelta>>>>>,
     reconcile_cooldowns: Mutex<HashMap<ContextId, (Duration, u32)>>,
     failure_counts: Mutex<HashMap<ContextId, u32>>,
@@ -61,6 +64,15 @@ impl MockSyncStateAccess {
     /// reports `created=false`.
     pub(crate) fn insert_delta_store(&self, context_id: ContextId, store: DeltaStore) {
         let _replaced = self.delta_stores.lock().insert(context_id, store);
+    }
+
+    /// Inject a `cached_member_peers_for_group` response for `group`.
+    pub(crate) fn insert_member_peers(
+        &self,
+        group: ContextGroupId,
+        peers: Vec<(PeerId, GroupMemberRole)>,
+    ) {
+        let _replaced = self.member_peers.lock().insert(group, peers);
     }
 
     /// Inject a `peer_identities` response for `peer`.
@@ -182,6 +194,20 @@ impl SyncStateAccess for MockSyncStateAccess {
         self.peer_identities.lock().get(peer_id).cloned()
     }
 
+    fn cached_member_peers_for_group(
+        &self,
+        group: &ContextGroupId,
+    ) -> Vec<(PeerId, GroupMemberRole)> {
+        self.calls
+            .lock()
+            .push(SyncStateAccessCall::CachedMemberPeersForGroup(*group));
+        self.member_peers
+            .lock()
+            .get(group)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     fn reconcile_remaining_cooldown(&self, context_id: &ContextId) -> Option<(Duration, u32)> {
         self.calls
             .lock()
@@ -228,6 +254,27 @@ mod tests {
 
     fn ctx(byte: u8) -> ContextId {
         ContextId::from([byte; 32])
+    }
+
+    #[test]
+    fn cached_member_peers_returns_injected_and_records_call() {
+        let mock = MockSyncStateAccess::default();
+        let group = ContextGroupId::from([1u8; 32]);
+        let peer = PeerId::random();
+        mock.insert_member_peers(group, vec![(peer, GroupMemberRole::Admin)]);
+
+        assert_eq!(
+            mock.cached_member_peers_for_group(&group),
+            vec![(peer, GroupMemberRole::Admin)]
+        );
+        // Unseeded group → empty.
+        assert!(mock
+            .cached_member_peers_for_group(&ContextGroupId::from([2u8; 32]))
+            .is_empty());
+        assert!(mock
+            .calls()
+            .iter()
+            .any(|c| matches!(c, SyncStateAccessCall::CachedMemberPeersForGroup(_))));
     }
 
     #[test]


### PR DESCRIPTION
## What

PR **3 of 6** for #2642. Stacked on #2710 (PR 2).

Adds the **resolution seam** that lets sync read the durable cache: a `SyncStateAccess::cached_member_peers_for_group` method and a `SyncManager::member_peers_for_context` resolver. **No dialing behaviour change yet** — the resolver is `#[allow(dead_code)]` until PR 4 wires it into peer selection.

## How

- **`SyncStateAccess::cached_member_peers_for_group(group) -> Vec<(PeerId, GroupMemberRole)>`** — the mockable seam. Production (`NodeState`) reads the durable `PeerIdentityCache.members_for_group` (fresh entries only) and flattens to (peer, role); `MockSyncStateAccess` gains `insert_member_peers` + records the call.
- **`SyncManager::member_peers_for_context(context_id)`** resolves `context → group` (`get_group_for_context`), reads the seam, and dedups to one entry per peer keeping its **strongest observed role** (`dedup_peers_by_strongest_role` + `role_rank`, both pure/tested). Empty when the context isn't group-registered or the cache is cold — caller will fall back to topic discovery (PR 4).
- **Owner** isn't a `GroupMemberRole` (it's a group `Meta` field), so it's not stored or ranked here — owner preference comes from the authoritative `trusted_anchors` set (which already includes the owner) at selection time. The cached role is a hint; `trusted_anchors` stays authoritative.

## Testing

Full `calimero-node` lib suite: **327 passed, 0 failed**. New tests: `cached_member_peers_reflects_observed_membership` (NodeState observe → seam), `cached_member_peers_returns_injected_and_records_call` (mock), `dedup_peers_keeps_strongest_role` (pure). fmt + clippy clean.

## Follow-up PRs
4. Selection wiring — feed `member_peers_for_context` ahead of topic discovery in `partition_peers_anchor_first` / the namespace fallback (cold-cache member-first), topic discovery preserved as fallback.
5. Invalidation (node-side `MemberRemoved` subscriber).
6. Integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sync peer discovery and cold-start fallback behavior; mistakes could mis-order peers or backoff incorrectly, though anchor checks and governance remain authoritative.
> 
> **Overview**
> Wires **#2642** cold-start member-aware sync peer selection beyond the resolver seam: sync now prefers **durably cached group members** before gossipsub topic peers, and keeps that cache aligned with governance removals.
> 
> **Peer selection (`SyncManager`)** resolves `member_peers_for_context` (context → group → `PeerIdentityCache`), **dedupes by strongest role**, and **merges cached members ahead of** mesh/namespace discovery. If both topic meshes are empty but the cache has members, it dials them with source **`PeerSource::PersistentCache`**; if every dial fails on that path it returns **`NoPeersAvailable`** (no aggressive backoff) instead of treating it as a hard sync failure.
> 
> **Cache lifecycle**: `PeerIdentityCache::remove_member` drops a group bucket entry on **`MemberRemoved`**; `peer_identity_persist` subscribes to **`calimero-governance-store` `op_events`** via `spawn_invalidation_task` at node startup (reverse `peer_identities` view intentionally left). Module-level **`dead_code`** on the cache is removed now that the API is used.
> 
> **Dependencies & tests**: `calimero-governance-store` on `calimero-node`; unit/e2e coverage for dedup/merge, invalidation, `cached_member_peers_for_group`, and standalone `member_peers_for_context` e2e.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2be5ff63f75679d8fb53749eac1aed604466182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->