### PR TITLE
feat(node): prefer durably-cached members in sync selection (PR 4/6, #2642)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
  "calimero-context-config",
  "calimero-crypto",
  "calimero-dag",
+ "calimero-governance-store",
  "calimero-network",
  "calimero-network-primitives",
  "calimero-node-primitives",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,6 +35,7 @@ zeroize.workspace = true
 calimero-context.workspace = true
 calimero-context-config.workspace = true
 calimero-context-client.workspace = true
+calimero-governance-store.workspace = true
 calimero-runtime.workspace = true
 calimero-crypto.workspace = true
 calimero-blobstore.workspace = true

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -35,6 +35,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
 use crate::arbiter_pool::ArbiterPool;
+use crate::peer_identity_cache::ObservedMembership;
 use crate::sync::{SyncConfig, SyncManager};
 use crate::{NodeManager, NodeState};
 
@@ -710,5 +711,139 @@ async fn group_topic_announce_is_not_routed_as_namespace_admission() {
             .expect("count"),
         1,
         "no member should be admitted from a group/ topic announce (owner only)"
+    );
+}
+
+/// Build a standalone `SyncManager` against an in-memory store, without
+/// the surrounding `NodeManager` actor — enough to exercise the
+/// synchronous peer-selection helpers (`member_peers_for_context`)
+/// end-to-end against real governance state. Returns the manager, the
+/// shared store, the shared `NodeState` (its peer-identity cache is an
+/// `Arc` shared with the manager's `state_access`, so seeding it here is
+/// visible to the manager), and the `TempDir` guard the blob fs needs.
+async fn build_standalone_sync_manager() -> (SyncManager, Store, NodeState, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+    let blob_store_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_store_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+
+    let node_recipient = LazyRecipient::<NodeMessage>::new();
+    let context_recipient = LazyRecipient::new();
+    let network_recipient = LazyRecipient::new();
+    let network_client = NetworkClient::new(network_recipient);
+    let (event_sender, _) = broadcast::channel(16);
+    let (ctx_sync_tx, ctx_sync_rx) = mpsc::channel(64);
+    let (ns_sync_tx, ns_sync_rx) = mpsc::channel(16);
+    let (ns_join_tx, ns_join_rx) = mpsc::channel(16);
+    let (open_subgroup_join_tx, open_subgroup_join_rx) = mpsc::channel(16);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client.clone(),
+        node_recipient,
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+    let context_client = ContextClient::new(store.clone(), node_client.clone(), context_recipient);
+    let node_state = NodeState::new(false, NodeMode::Standard);
+
+    let sync_manager = SyncManager::new(
+        SyncConfig::default(),
+        node_client,
+        context_client,
+        network_client,
+        node_state.clone(),
+        ctx_sync_rx,
+        ns_sync_rx,
+        ns_join_rx,
+        open_subgroup_join_rx,
+    );
+
+    (sync_manager, store, node_state, tmp)
+}
+
+/// End-to-end resolver (#2642): with a context registered to a group in
+/// the real governance store and the durable peer-identity cache seeded
+/// via the authenticated observe path, `member_peers_for_context`
+/// resolves `context → group → cached member peers`, deduped by role.
+#[tokio::test]
+async fn member_peers_for_context_resolves_cached_members_end_to_end() {
+    let (sync_manager, store, node_state, _tmp) = build_standalone_sync_manager().await;
+
+    let group_id = ContextGroupId::from([0x11; 32]);
+    let other_group = ContextGroupId::from([0xAA; 32]);
+    let context_id = calimero_primitives::context::ContextId::from([0x22; 32]);
+    calimero_context::group_store::register_context_in_group(&store, &group_id, &context_id)
+        .expect("register context -> group");
+
+    // Real (random) member identities, matching the convention of the
+    // other tests in this file.
+    let admin_id = PrivateKey::random(&mut OsRng).public_key();
+    let member_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_second_id = PrivateKey::random(&mut OsRng).public_key();
+    let other_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_peer = libp2p::PeerId::random();
+    let member_peer = libp2p::PeerId::random();
+    let other_peer = libp2p::PeerId::random();
+
+    // Seed the shared cache through the same gate the production receive
+    // paths use (group + role at the cross-DAG cut).
+    let observe = |peer, identity, group, role| {
+        node_state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role,
+            }),
+        );
+    };
+    observe(admin_peer, admin_id, group_id, GroupMemberRole::Admin);
+    observe(member_peer, member_id, group_id, GroupMemberRole::Member);
+    // Same peer observed again under a second identity at a weaker role —
+    // the dedup must keep the strongest role (Admin) for admin_peer,
+    // exercising dedup_peers_by_strongest_role through the full resolver.
+    observe(
+        admin_peer,
+        admin_second_id,
+        group_id,
+        GroupMemberRole::Member,
+    );
+    // A member of a DIFFERENT group must not leak into this context's
+    // result (guards group-scoping of cached_member_peers_for_group).
+    observe(other_peer, other_id, other_group, GroupMemberRole::Admin);
+
+    let resolved: std::collections::BTreeMap<_, _> = sync_manager
+        .member_peers_for_context(&context_id)
+        .into_iter()
+        .collect();
+    assert_eq!(resolved.len(), 2, "only this group's members resolve");
+    assert_eq!(
+        resolved.get(&admin_peer),
+        Some(&GroupMemberRole::Admin),
+        "dedup keeps the strongest role for a peer seen at two roles"
+    );
+    assert_eq!(resolved.get(&member_peer), Some(&GroupMemberRole::Member));
+    assert!(
+        !resolved.contains_key(&other_peer),
+        "a member cached under a different group is excluded"
+    );
+
+    // A context with no group mapping resolves to nothing (caller then
+    // falls back to topic discovery).
+    let unregistered = calimero_primitives::context::ContextId::from([0x99; 32]);
+    assert!(
+        sync_manager
+            .member_peers_for_context(&unregistered)
+            .is_empty(),
+        "unregistered context yields no cached members"
     );
 }

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -48,11 +48,6 @@
 //! `PeerAddrCache`: pure data + TTL here, with the snapshot tick and
 //! startup hydration wired by the node layer.
 
-// The type lands on its own for reviewability; population, persistence,
-// and selection wiring follow in subsequent PRs, so its API is unused
-// (dead-code) in the meantime.
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, BTreeSet};
 
 use calimero_context_config::types::ContextGroupId;
@@ -176,10 +171,16 @@ impl PeerIdentityCache {
     }
 
     /// Identities observed on `peer` across **all** groups — the reverse
-    /// direction `partition_peers_anchor_first` uses to flag whether a
-    /// discovered peer hosts an anchor identity. No freshness filter: the
-    /// caller intersects this with an authoritative anchor set, so a
-    /// slightly stale identity can only fail to match, never mis-match.
+    /// direction a future selection refinement can use to flag whether a
+    /// discovered peer hosts an anchor identity, straight from the durable
+    /// cache. No freshness filter: the caller intersects this with an
+    /// authoritative anchor set, so a slightly stale identity can only
+    /// fail to match, never mis-match.
+    ///
+    /// Not yet wired — selection currently reads the in-memory
+    /// `peer_identities` reverse view for this; retained (and tested) as
+    /// the cache-backed counterpart for when that path moves to the cache.
+    #[allow(dead_code)]
     pub(crate) fn identities_for_peer(&self, peer: &PeerId) -> BTreeSet<PublicKey> {
         let mut out = BTreeSet::new();
         for g in self.groups.values() {
@@ -316,8 +317,7 @@ impl PeerIdentityCache {
         ttl_secs: u64,
     ) -> PersistedPeerIdentityCache {
         let groups = self
-            .groups
-            .keys()
+            .groups()
             .filter_map(|group| {
                 let entries = self.to_persisted(group, now_secs, ttl_secs);
                 (!entries.is_empty()).then(|| PersistedGroup {
@@ -347,6 +347,29 @@ impl PeerIdentityCache {
             cache.load_group_from_persisted(group, g.entries, now_secs, ttl_secs);
         }
         cache
+    }
+
+    /// Drop a member from a group's bucket — invoked when governance
+    /// emits `MemberRemoved`, so the removed identity stops being
+    /// preferred for sync (and stops being re-persisted) without waiting
+    /// for TTL. If the group's bucket empties, the group is removed.
+    ///
+    /// Only the cache's per-group *membership* view is touched; the
+    /// `peer_identities` reverse view is left intact, because the peer
+    /// still controls that identity — removal changes group membership,
+    /// not key ownership, and anchor status is re-derived from the
+    /// now-updated governance `trusted_anchors`.
+    pub(crate) fn remove_member(&mut self, group: &ContextGroupId, identity: &PublicKey) {
+        let now_empty = match self.groups.get_mut(group) {
+            Some(g) => {
+                let _ = g.members.remove(identity);
+                g.members.is_empty()
+            }
+            None => false,
+        };
+        if now_empty {
+            let _ = self.groups.remove(group);
+        }
     }
 
     /// All `(peer, identity)` pairs currently held, across every group —
@@ -683,6 +706,29 @@ mod tests {
             BTreeSet::from([group(2)]),
             "only the well-formed group id loads"
         );
+    }
+
+    #[test]
+    fn remove_member_drops_identity_and_empties_group() {
+        let mut c = PeerIdentityCache::default();
+        c.record(group(1), pk(1), peer(1), GroupMemberRole::Admin, 100);
+        c.record(group(1), pk(2), peer(2), GroupMemberRole::Member, 100);
+
+        c.remove_member(&group(1), &pk(1));
+        let members = c.members_for_group(&group(1), 100, 1000);
+        assert_eq!(members.len(), 1);
+        assert_eq!(
+            members[0].identity,
+            pk(2),
+            "only the removed member is gone"
+        );
+
+        // Removing the last member drops the group bucket entirely.
+        c.remove_member(&group(1), &pk(2));
+        assert_eq!(c.groups().count(), 0, "emptied group is removed");
+
+        // Removing from an absent group is a no-op.
+        c.remove_member(&group(2), &pk(9));
     }
 
     #[test]

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -8,11 +8,13 @@
 //! signal survives a restart so anchor-preferred sync selection works on
 //! a cold cache instead of falling back to random topic subscribers.
 
+use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::op_events::{self, OpEvent};
 use calimero_store::key::Generic as GenericKey;
 use calimero_store::slice::Slice;
 use calimero_store::types::GenericData;
 use calimero_store::Store;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::peer_identity_cache::{PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
 use crate::state::{now_unix_secs, NodeState};
@@ -118,6 +120,70 @@ pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task
     })
 }
 
+/// Apply one op-apply event to the cache. Currently only `MemberRemoved`
+/// is actionable: it drops the removed member from its group's bucket so
+/// a removed member stops being preferred for sync (and stops being
+/// re-persisted) promptly, rather than after the 24h TTL. Other events
+/// are ignored. Kept separate from the async loop so it's unit-testable.
+fn apply_invalidation_event(state: &NodeState, event: &OpEvent) {
+    if let OpEvent::MemberRemoved { group_id, member } = event {
+        // Only the durable cache's per-group membership view is dropped.
+        // The in-memory `peer_identities` reverse view is deliberately
+        // left intact: the peer still *controls* that identity (removal
+        // changes group membership, not key ownership), and that view is
+        // only ever intersected with the authoritative `trusted_anchors`
+        // set at selection time — which no longer lists the removed member
+        // — so a stale reverse entry can't make the peer an anchor. The
+        // `member_removed_event_drops_cached_member` test pins this
+        // (asserts the reverse view is untouched) so a future "cleanup"
+        // doesn't silently change it.
+        state
+            .lock_peer_identity_cache()
+            .remove_member(&ContextGroupId::from(*group_id), member);
+        debug!(
+            group_id = %hex::encode(group_id),
+            %member,
+            "dropped removed member from peer-identity cache"
+        );
+    }
+}
+
+/// Spawn the cache-invalidation task: subscribe to governance op-apply
+/// events and drop removed members from the cache. The first node-side
+/// `op_events` subscriber. A dropped (lagged) event is harmless — the
+/// missed member ages out via TTL and is re-derived from the DAG on
+/// restart — so the loop just logs and continues. Holds a strong
+/// `NodeState` for the runtime's lifetime, like the snapshot tick.
+///
+/// `op_events::subscribe()` is called **synchronously here, before
+/// spawning**, so the receiver starts buffering immediately rather than
+/// at some later point when the task first gets scheduled — minimizing
+/// the startup window in which a `MemberRemoved` could be missed.
+///
+/// The returned handle may be dropped (the caller stores it as `_…`); the
+/// task then runs detached until the broadcast channel closes
+/// (`RecvError::Closed`), i.e. for the process lifetime. There is no
+/// graceful-shutdown path because a missed late event is harmless (TTL
+/// covers it); a caller that wanted one could `abort()` the handle.
+pub(crate) fn spawn_invalidation_task(state: NodeState) -> tokio::task::JoinHandle<()> {
+    let mut rx = op_events::subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => apply_invalidation_event(&state, &event),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "peer-identity invalidation subscriber lagged; missed MemberRemoved \
+                         events age out via TTL and are re-derived on restart"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -177,6 +243,55 @@ mod tests {
         assert_eq!(members[0].identity, identity);
         assert_eq!(members[0].role, GroupMemberRole::Admin);
         assert_eq!(members[0].peers, vec![peer]);
+    }
+
+    #[test]
+    // Exercises the handler directly (`apply_invalidation_event`) rather
+    // than via `spawn_invalidation_task` + `op_events::notify` — the
+    // `op_events` channel is a process-wide singleton shared across
+    // parallel tests, so driving the sync handler directly keeps this
+    // test isolated. Prefer this pattern for invalidation-logic tests.
+    #[test]
+    fn member_removed_event_drops_cached_member() {
+        let state = NodeState::new(false, NodeMode::Standard);
+        let group = ContextGroupId::from([7u8; 32]);
+        let member = PublicKey::from([9u8; 32]);
+        let peer = PeerId::random();
+        state.observe_peer_identity(
+            peer,
+            member,
+            Some(ObservedMembership {
+                group_id: group,
+                role: GroupMemberRole::Admin,
+            }),
+        );
+        let cached = |s: &NodeState| {
+            !s.lock_peer_identity_cache()
+                .members_for_group(&group, now_unix_secs(), PEER_IDENTITY_TTL_SECS)
+                .is_empty()
+        };
+        assert!(cached(&state), "seeded");
+
+        apply_invalidation_event(
+            &state,
+            &OpEvent::MemberRemoved {
+                group_id: [7u8; 32],
+                member,
+            },
+        );
+        assert!(!cached(&state), "MemberRemoved dropped the cached member");
+
+        // Intentional: the in-memory reverse view is NOT cleared — the peer
+        // still controls the identity, and anchor status is re-derived from
+        // trusted_anchors at selection time (see apply_invalidation_event).
+        // Pinned here so a future "cleanup" doesn't silently change it.
+        assert!(
+            state
+                .peer_identities
+                .get(&peer)
+                .is_some_and(|ids| ids.contains(&member)),
+            "reverse view deliberately retained after MemberRemoved"
+        );
     }
 
     #[test]

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -234,6 +234,10 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     crate::peer_identity_persist::hydrate(&node_state, &datastore);
     let _peer_identity_tick =
         crate::peer_identity_persist::spawn_snapshot_tick(node_state.clone(), datastore.clone());
+    // Drop removed members from the cache promptly on `MemberRemoved`,
+    // rather than waiting for their entries to age out via TTL.
+    let _peer_identity_invalidation =
+        crate::peer_identity_persist::spawn_invalidation_task(node_state.clone());
 
     // Drain locally-applied delta notifications from the execute path
     // and register them into the in-memory DeltaStore. Replaces the

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -668,7 +668,7 @@ impl SyncManager {
             ?mesh_elapsed,
             is_uninitialized,
             source = ?source,
-            "Mesh peer discovery succeeded"
+            "Peer discovery yielded candidates"
         );
 
         if is_uninitialized {
@@ -738,6 +738,18 @@ impl SyncManager {
             if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
                 return Ok(result);
             }
+        }
+
+        // On the cold-start cache fallback (topic meshes were empty; we
+        // dialed durably-cached members directly), a total failure means
+        // "no reachable peer right now", not "sync failed against live
+        // peers". Surface the benign `NoPeersAvailable` so the caller
+        // doesn't apply exponential backoff — we want prompt retry while
+        // the mesh forms, matching the pre-fix empty-mesh behaviour. The
+        // normal path (had live mesh peers, all failed) still bails so a
+        // genuine sync failure backs off.
+        if source == super::peers::PeerSource::PersistentCache {
+            return Err(eyre::Error::new(NoPeersAvailable { context_id }));
         }
 
         bail!("Failed to sync with any peer for context {}", context_id)

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -859,7 +859,7 @@ impl SyncManager {
     /// callers fall back to topic-subscriber discovery. A routing hint:
     /// `anchor_identities_for_context` (governance `trusted_anchors`,
     /// which includes the owner) stays authoritative for anchor status.
-    fn member_peers_for_context(
+    pub(crate) fn member_peers_for_context(
         &self,
         context_id: &ContextId,
     ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -611,17 +611,55 @@ impl SyncManager {
             )))
         };
 
-        let outcome = super::peers::discover_mesh_peers_with_namespace_fallback(
+        // Durably-cached member peers for this context's group — the
+        // cold-start signal that survives a restart. Empty when nothing
+        // is cached, in which case topic discovery below carries the
+        // selection exactly as before.
+        let cached_members: Vec<libp2p::PeerId> = self
+            .member_peers_for_context(&context_id)
+            .into_iter()
+            .map(|(peer, _role)| peer)
+            .collect();
+
+        let discovery = super::peers::discover_mesh_peers_with_namespace_fallback(
             &*self.sync_network,
             context_id,
             max_retries,
             std::time::Duration::from_millis(retry_delay_ms),
             resolve_namespace_topic,
         )
-        .await?;
-        let peers = outcome.peers;
-        let final_attempt = outcome.attempts;
-        let mesh_elapsed = outcome.elapsed;
+        .await;
+
+        let (peers, final_attempt, mesh_elapsed, source) = match discovery {
+            Ok(outcome) => {
+                // Members first, then topic-discovered peers not already
+                // present. `partition_peers_anchor_first` below still
+                // orders anchors within the merged set, so this only
+                // changes which non-anchor peers we reach for first.
+                let peers = Self::merge_members_first(cached_members, outcome.peers);
+                (peers, outcome.attempts, outcome.elapsed, outcome.source)
+            }
+            Err(err) => {
+                // Topic discovery came up empty. If the durable cache has
+                // members, dial them directly — they're real members and
+                // reachable via the address cache / DHT even before a mesh
+                // forms. Otherwise preserve the benign "no peers" outcome.
+                if cached_members.is_empty() {
+                    return Err(err);
+                }
+                debug!(
+                    %context_id,
+                    count = cached_members.len(),
+                    "mesh discovery empty; falling back to durably-cached member peers"
+                );
+                (
+                    cached_members,
+                    0,
+                    std::time::Duration::ZERO,
+                    super::peers::PeerSource::PersistentCache,
+                )
+            }
+        };
 
         info!(
             %context_id,
@@ -629,7 +667,7 @@ impl SyncManager {
             attempts = final_attempt,
             ?mesh_elapsed,
             is_uninitialized,
-            source = ?outcome.source,
+            source = ?source,
             "Mesh peer discovery succeeded"
         );
 
@@ -809,7 +847,6 @@ impl SyncManager {
     /// callers fall back to topic-subscriber discovery. A routing hint:
     /// `anchor_identities_for_context` (governance `trusted_anchors`,
     /// which includes the owner) stays authoritative for anchor status.
-    #[allow(dead_code)] // wired into peer selection in a follow-up
     fn member_peers_for_context(
         &self,
         context_id: &ContextId,
@@ -830,7 +867,6 @@ impl SyncManager {
     /// [`GroupMemberRole`] (it's a group `Meta` field) so it doesn't
     /// appear here — owner preference is applied via the authoritative
     /// `trusted_anchors` set at selection time, not from this hint.
-    #[allow(dead_code)] // used by `member_peers_for_context`, wired in a follow-up
     fn role_rank(role: &calimero_primitives::context::GroupMemberRole) -> u8 {
         use calimero_primitives::context::GroupMemberRole::{Admin, Member, ReadOnly, ReadOnlyTee};
         match role {
@@ -845,7 +881,6 @@ impl SyncManager {
     /// strongest role (a peer hosting several member identities is
     /// returned once, tagged with its most-anchor role). Output is
     /// sorted by `PeerId` for determinism.
-    #[allow(dead_code)] // used by `member_peers_for_context`, wired in a follow-up
     fn dedup_peers_by_strongest_role(
         pairs: Vec<(PeerId, calimero_primitives::context::GroupMemberRole)>,
     ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {
@@ -862,6 +897,21 @@ impl SyncManager {
             }
         }
         best.into_iter().collect()
+    }
+
+    /// Merge cached member peers ahead of topic-discovered peers: the
+    /// members come first (cold-start preference for real members), then
+    /// any discovered peer not already in the list, preserving discovery
+    /// order. Deduplicates so a peer that's both a cached member and a
+    /// current subscriber appears once, up front.
+    fn merge_members_first(members: Vec<PeerId>, discovered: Vec<PeerId>) -> Vec<PeerId> {
+        let mut merged = members;
+        for peer in discovered {
+            if !merged.contains(&peer) {
+                merged.push(peer);
+            }
+        }
+        merged
     }
 
     /// Find a peer that has state (non-zero root_hash and non-empty DAG heads)

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -36,6 +36,31 @@ fn dedup_peers_keeps_strongest_role() {
     assert_eq!(map.get(&q), Some(&GroupMemberRole::ReadOnlyTee));
 }
 
+/// `merge_members_first` puts cached members ahead of discovered peers,
+/// preserves discovery order for the rest, and dedups the overlap.
+#[test]
+fn merge_members_first_orders_and_dedups() {
+    use libp2p::PeerId;
+
+    let m1 = PeerId::random();
+    let m2 = PeerId::random();
+    let d1 = PeerId::random();
+
+    // m2 also appears among discovered → must not be duplicated.
+    let merged = SyncManager::merge_members_first(vec![m1, m2], vec![d1, m2]);
+    assert_eq!(
+        merged,
+        vec![m1, m2, d1],
+        "members first, discovered appended once"
+    );
+
+    // No cached members → discovery order is preserved verbatim.
+    assert_eq!(
+        SyncManager::merge_members_first(vec![], vec![d1, m1]),
+        vec![d1, m1]
+    );
+}
+
 // =========================================================================
 // Tests for handshake estimation fallback
 // =========================================================================

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -42,6 +42,11 @@ pub(crate) enum PeerSource {
     /// namespace topic mesh as a fallback (namespace meshes are
     /// established earlier during join with a grace period).
     NamespaceFallback,
+    /// Both topic meshes were empty, but the durable peer-identity cache
+    /// held members of this context's group to dial directly — the
+    /// cold-start fallback that lets a freshly-restarted node target real
+    /// members before any gossipsub mesh has formed.
+    PersistentCache,
 }
 
 /// Outcome of the discovery loop: the peer list plus diagnostics


### PR DESCRIPTION
## What

PR **4 of 6** for #2642. Stacked on #2711 (PR 3). **This is the first PR in the stack that changes runtime behaviour.**

Wires `member_peers_for_context` into the sync peer-selection path so a node prefers **durably-cached real members** of a context's group, with topic discovery preserved as the fallback.

## How (`SyncManager::initiate_sync` selection)

1. Resolve `cached_members = member_peers_for_context(context_id)` (durable cache, empty when cold).
2. Run topic discovery (`discover_mesh_peers_with_namespace_fallback`) as before.
3. Merge:
   - **Discovery succeeds** → `merge_members_first(cached_members, discovered)`: members first, then discovered peers not already present, deduped. `partition_peers_anchor_first` still orders anchors within the merged set.
   - **Discovery returns empty** (the typed no-peers error) → if `cached_members` is non-empty, dial them directly (real members, reachable via the address cache / DHT even before a mesh forms); otherwise preserve the existing benign "no peers" outcome by returning the error unchanged.
4. New `PeerSource::PersistentCache` telemetry variant for the empty-mesh-but-cached-members case.

**When the cache is cold (empty), behaviour is byte-for-byte identical to before** — `merge_members_first([], discovered) == discovered`, and the empty-mesh path returns the same error. So this is a strict improvement that only activates once observations have been persisted (PRs 1–3).

The cached `role` isn't used for ordering here — anchor ordering stays driven by `anchor_identities_for_context` (governance `trusted_anchors`, which includes the owner). The cache only supplies *which peers to consider*.

## Scope note

Wires the **main sync selection** path. The #2625 governance-backfill peer pick is a candidate for the same treatment but is left for a follow-up to keep this PR focused.

## Testing

Full `calimero-node` lib suite: **all pass**. New pure tests: `merge_members_first_orders_and_dedups` (ordering + dedup + empty-members passthrough); plus PR 3's resolver/seam tests now exercised on the live path. fmt + clippy clean.

## Follow-up PRs
5. Invalidation (node-side `MemberRemoved` subscriber; TTL already in PR 1).
6. Integration tests (cold-cache anchor-first end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default sync peer discovery when a populated peer-identity cache exists; empty cache preserves prior behavior, and invalidation is best-effort with TTL fallback.
> 
> **Overview**
> **Sync peer selection** now resolves durably cached group members via `member_peers_for_context` before gossipsub mesh discovery. When discovery succeeds, `merge_members_first` puts cached members ahead of topic peers (anchor ordering unchanged). When meshes are empty but the cache has members, the node dials those peers directly and reports `PeerSource::PersistentCache`; if every dial fails in that mode it returns benign `NoPeersAvailable` instead of backing off like a real sync failure.
> 
> **Cache invalidation** subscribes to governance `MemberRemoved` (`calimero-governance-store` + `spawn_invalidation_task` at startup) and calls `PeerIdentityCache::remove_member` without clearing the in-memory `peer_identities` reverse map.
> 
> Tests cover merge ordering, end-to-end resolver wiring, and invalidation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec65fc7f55467fad38541c09b9c368da300fb4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->