### PR TITLE
test(node): end-to-end member_peers_for_context resolver (PR 6/6, #2642)

### DIFF
--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -779,38 +779,63 @@ async fn member_peers_for_context_resolves_cached_members_end_to_end() {
     let (sync_manager, store, node_state, _tmp) = build_standalone_sync_manager().await;
 
     let group_id = ContextGroupId::from([0x11; 32]);
+    let other_group = ContextGroupId::from([0xAA; 32]);
     let context_id = calimero_primitives::context::ContextId::from([0x22; 32]);
     calimero_context::group_store::register_context_in_group(&store, &group_id, &context_id)
         .expect("register context -> group");
 
+    // Real (random) member identities, matching the convention of the
+    // other tests in this file.
+    let admin_id = PrivateKey::random(&mut OsRng).public_key();
+    let member_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_second_id = PrivateKey::random(&mut OsRng).public_key();
+    let other_id = PrivateKey::random(&mut OsRng).public_key();
     let admin_peer = libp2p::PeerId::random();
     let member_peer = libp2p::PeerId::random();
+    let other_peer = libp2p::PeerId::random();
+
     // Seed the shared cache through the same gate the production receive
     // paths use (group + role at the cross-DAG cut).
-    node_state.observe_peer_identity(
+    let observe = |peer, identity, group, role| {
+        node_state.observe_peer_identity(
+            peer,
+            identity,
+            Some(ObservedMembership {
+                group_id: group,
+                role,
+            }),
+        );
+    };
+    observe(admin_peer, admin_id, group_id, GroupMemberRole::Admin);
+    observe(member_peer, member_id, group_id, GroupMemberRole::Member);
+    // Same peer observed again under a second identity at a weaker role —
+    // the dedup must keep the strongest role (Admin) for admin_peer,
+    // exercising dedup_peers_by_strongest_role through the full resolver.
+    observe(
         admin_peer,
-        PublicKey::from([0x33; 32]),
-        Some(ObservedMembership {
-            group_id,
-            role: GroupMemberRole::Admin,
-        }),
+        admin_second_id,
+        group_id,
+        GroupMemberRole::Member,
     );
-    node_state.observe_peer_identity(
-        member_peer,
-        PublicKey::from([0x44; 32]),
-        Some(ObservedMembership {
-            group_id,
-            role: GroupMemberRole::Member,
-        }),
-    );
+    // A member of a DIFFERENT group must not leak into this context's
+    // result (guards group-scoping of cached_member_peers_for_group).
+    observe(other_peer, other_id, other_group, GroupMemberRole::Admin);
 
     let resolved: std::collections::BTreeMap<_, _> = sync_manager
         .member_peers_for_context(&context_id)
         .into_iter()
         .collect();
-    assert_eq!(resolved.len(), 2, "both cached members resolved");
-    assert_eq!(resolved.get(&admin_peer), Some(&GroupMemberRole::Admin));
+    assert_eq!(resolved.len(), 2, "only this group's members resolve");
+    assert_eq!(
+        resolved.get(&admin_peer),
+        Some(&GroupMemberRole::Admin),
+        "dedup keeps the strongest role for a peer seen at two roles"
+    );
     assert_eq!(resolved.get(&member_peer), Some(&GroupMemberRole::Member));
+    assert!(
+        !resolved.contains_key(&other_peer),
+        "a member cached under a different group is excluded"
+    );
 
     // A context with no group mapping resolves to nothing (caller then
     // falls back to topic discovery).

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -35,6 +35,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
 use crate::arbiter_pool::ArbiterPool;
+use crate::peer_identity_cache::ObservedMembership;
 use crate::sync::{SyncConfig, SyncManager};
 use crate::{NodeManager, NodeState};
 
@@ -710,5 +711,114 @@ async fn group_topic_announce_is_not_routed_as_namespace_admission() {
             .expect("count"),
         1,
         "no member should be admitted from a group/ topic announce (owner only)"
+    );
+}
+
+/// Build a standalone `SyncManager` against an in-memory store, without
+/// the surrounding `NodeManager` actor — enough to exercise the
+/// synchronous peer-selection helpers (`member_peers_for_context`)
+/// end-to-end against real governance state. Returns the manager, the
+/// shared store, the shared `NodeState` (its peer-identity cache is an
+/// `Arc` shared with the manager's `state_access`, so seeding it here is
+/// visible to the manager), and the `TempDir` guard the blob fs needs.
+async fn build_standalone_sync_manager() -> (SyncManager, Store, NodeState, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+    let blob_store_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_store_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+
+    let node_recipient = LazyRecipient::<NodeMessage>::new();
+    let context_recipient = LazyRecipient::new();
+    let network_recipient = LazyRecipient::new();
+    let network_client = NetworkClient::new(network_recipient);
+    let (event_sender, _) = broadcast::channel(16);
+    let (ctx_sync_tx, ctx_sync_rx) = mpsc::channel(64);
+    let (ns_sync_tx, ns_sync_rx) = mpsc::channel(16);
+    let (ns_join_tx, ns_join_rx) = mpsc::channel(16);
+    let (open_subgroup_join_tx, open_subgroup_join_rx) = mpsc::channel(16);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client.clone(),
+        node_recipient,
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+    let context_client = ContextClient::new(store.clone(), node_client.clone(), context_recipient);
+    let node_state = NodeState::new(false, NodeMode::Standard);
+
+    let sync_manager = SyncManager::new(
+        SyncConfig::default(),
+        node_client,
+        context_client,
+        network_client,
+        node_state.clone(),
+        ctx_sync_rx,
+        ns_sync_rx,
+        ns_join_rx,
+        open_subgroup_join_rx,
+    );
+
+    (sync_manager, store, node_state, tmp)
+}
+
+/// End-to-end resolver (#2642): with a context registered to a group in
+/// the real governance store and the durable peer-identity cache seeded
+/// via the authenticated observe path, `member_peers_for_context`
+/// resolves `context → group → cached member peers`, deduped by role.
+#[tokio::test]
+async fn member_peers_for_context_resolves_cached_members_end_to_end() {
+    let (sync_manager, store, node_state, _tmp) = build_standalone_sync_manager().await;
+
+    let group_id = ContextGroupId::from([0x11; 32]);
+    let context_id = calimero_primitives::context::ContextId::from([0x22; 32]);
+    calimero_context::group_store::register_context_in_group(&store, &group_id, &context_id)
+        .expect("register context -> group");
+
+    let admin_peer = libp2p::PeerId::random();
+    let member_peer = libp2p::PeerId::random();
+    // Seed the shared cache through the same gate the production receive
+    // paths use (group + role at the cross-DAG cut).
+    node_state.observe_peer_identity(
+        admin_peer,
+        PublicKey::from([0x33; 32]),
+        Some(ObservedMembership {
+            group_id,
+            role: GroupMemberRole::Admin,
+        }),
+    );
+    node_state.observe_peer_identity(
+        member_peer,
+        PublicKey::from([0x44; 32]),
+        Some(ObservedMembership {
+            group_id,
+            role: GroupMemberRole::Member,
+        }),
+    );
+
+    let resolved: std::collections::BTreeMap<_, _> = sync_manager
+        .member_peers_for_context(&context_id)
+        .into_iter()
+        .collect();
+    assert_eq!(resolved.len(), 2, "both cached members resolved");
+    assert_eq!(resolved.get(&admin_peer), Some(&GroupMemberRole::Admin));
+    assert_eq!(resolved.get(&member_peer), Some(&GroupMemberRole::Member));
+
+    // A context with no group mapping resolves to nothing (caller then
+    // falls back to topic discovery).
+    let unregistered = calimero_primitives::context::ContextId::from([0x99; 32]);
+    assert!(
+        sync_manager
+            .member_peers_for_context(&unregistered)
+            .is_empty(),
+        "unregistered context yields no cached members"
     );
 }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -859,7 +859,7 @@ impl SyncManager {
     /// callers fall back to topic-subscriber discovery. A routing hint:
     /// `anchor_identities_for_context` (governance `trusted_anchors`,
     /// which includes the owner) stays authoritative for anchor status.
-    fn member_peers_for_context(
+    pub(crate) fn member_peers_for_context(
         &self,
         context_id: &ContextId,
     ) -> Vec<(PeerId, calimero_primitives::context::GroupMemberRole)> {


### PR DESCRIPTION
## What

PR **6 of 6** for #2642 — the final PR. Stacked on #2713 (PR 5).

Adds an end-to-end test of the resolver against **real governance state**: a `SyncManager` built over an in-memory store, a context registered to a group, the durable cache seeded via the authenticated `observe_peer_identity` gate, and `member_peers_for_context` asserted to resolve `context → group → cached member peers` (deduped by role). Also closes #2642.

## How

- `build_standalone_sync_manager()` in `local_governance_node_e2e.rs` — a leaner sibling of `boot_test_node` that constructs a `SyncManager` (real `NodeClient`/`ContextClient`/in-memory `Store`) without the surrounding `NodeManager` actor, returning the shared `Store` and `NodeState`. Because `NodeState` clones share the cache `Arc`, seeding it post-build is visible to the manager's `state_access`.
- `member_peers_for_context_resolves_cached_members_end_to_end` — registers a context→group via `register_context_in_group`, observes two members (Admin + Member) through the real gate, and asserts `member_peers_for_context` returns both peers with the right roles. Also asserts an unregistered context resolves to empty (caller then falls back to topic discovery). `member_peers_for_context` is bumped to `pub(crate)` so the e2e module can call it.

This exercises the real `get_group_for_context` composition (the one piece that couldn't be unit-tested without a store). The rest of the issue's checklist (f) is already covered across the stack: persist/restore round-trip (PR 2), TTL eviction (PR 1), rotation invalidation (PR 5), merge ordering + cold-cache passthrough (PR 4), the resolution seam (PR 3).

## Testing

Full `calimero-node` lib suite: **all pass** (incl. the new e2e test). fmt + clippy clean.

## The complete #2642 stack
1. #2708 — `PeerIdentityCache` type
2. #2710 — populate + persist + hydrate
3. #2711 — resolver + `SyncStateAccess` seam
4. #2712 — selection wiring (cold-cache member-first)
5. #2713 — `MemberRemoved` invalidation
6. this — end-to-end resolver test

Closes #2642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a crate-internal visibility bump; no production behavior change.
> 
> **Overview**
> Adds an end-to-end test for the **#2642** peer resolver: a lean `build_standalone_sync_manager()` harness wires a real in-memory governance store and shared `NodeState` into `SyncManager` without booting `NodeManager`.
> 
> The new test registers a context→group mapping, seeds the durable peer-identity cache via `observe_peer_identity`, and asserts `member_peers_for_context` returns the right group-scoped peers with **strongest-role dedup** and empty results for unregistered contexts. **`member_peers_for_context`** is exposed as **`pub(crate)`** so the e2e module can invoke it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4a9b144fa89539ce5b69cf8fc3b8de2431cf1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->