### PR TITLE
fix(node/state_delta): startup absorb-recovery skips a failing context instead of aborting the rest

### DIFF
--- a/crates/node/src/handlers/state_delta/buffering.rs
+++ b/crates/node/src/handlers/state_delta/buffering.rs
@@ -624,10 +624,24 @@ where
     let mut total = 0usize;
     for context_id in context_ids {
         let replay = replay.clone();
-        total += drain_absorbed_records(store, &context_id, move |buffered| {
+        // Warn-and-continue rather than `?`: one context's drain failure (a
+        // corrupt store entry, an apply error) must not strand every *other*
+        // context's stragglers for this boot. Mirrors the live
+        // `drain_all_absorbed` path, which calls the infallible `drain_absorbed`
+        // per context. The AbsorbBuffer is durable, so a skipped context is
+        // retried on the next binary-advance hook or restart.
+        match drain_absorbed_records(store, &context_id, move |buffered| {
             replay(context_id, buffered)
         })
-        .await?;
+        .await
+        {
+            Ok(n) => total += n,
+            Err(err) => warn!(
+                %context_id,
+                %err,
+                "absorb recovery: drain failed for context; skipping (durable buffer will retry)"
+            ),
+        }
     }
     Ok(total)
 }


### PR DESCRIPTION
## What

`recover_absorbed_records` (the boot-time durable AbsorbBuffer scan) propagated a per-context `drain_absorbed_records` error via `?`, so one context whose drain hit a **store-level** error (corrupt meta, enumerate/delete failure) aborted the whole startup scan — skipping every *remaining* context's straggler deltas for that boot. The live binary-advance path (`drain_all_absorbed`) already warn-and-continues per context; this makes startup recovery consistent.

```rust
// before
total += drain_absorbed_records(...).await?;          // one bad context aborts the loop
// after
match drain_absorbed_records(...).await {
    Ok(n) => total += n,
    Err(err) => warn!(..., "drain failed for context; skipping (durable buffer will retry)"),
}
```

## Severity / scope

Low. The AbsorbBuffer is durable, so a skipped context is retried on the next binary-advance hook or restart — this just stops one per-context fault from gating the others on a given boot. Replay/apply errors are *already* warn-and-continued inside `drain_absorbed_records` (they don't propagate), so this only affects the rarer store-error path.

## Tests

No new unit test: the failure path requires a store-level fault, which the recovery test seam (it injects only the replay closure) can't produce. The change is behavior-preserving on the success path — the four existing `startup_recovery_*` tests pass unchanged (304 lib tests green).

## Context — the other two #2709 findings, intentionally not changed

This came out of review on #2709. I investigated all three findings; only this one warranted a change:

- **`drain_absorbed` `Ok(true)` "deletes soft-declined deltas" — not a bug.** The drain bypasses the fence, so no re-absorb. Re-buffered deltas are moved into the governance-pending buffer (replayed there); ReadOnly rejection and self-authored skips are *intentional* drops. The author's documented "consumed → delete" holds.
- **Startup double `enumerate_all_contexts()` — left as-is.** Startup-only perf; deduping it would require changing `recover_absorbed_records`'s signature and breaking the unit-test seam, not worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow resilience change in startup-only recovery; success path unchanged and failed contexts retry via the durable buffer.
> 
> **Overview**
> **Startup absorb recovery** no longer aborts the full boot scan when one context’s `drain_absorbed_records` fails. `recover_absorbed_records` now **warn-and-continues** per context (same pattern as live `drain_all_absorbed`), so other contexts’ durable AbsorbBuffer stragglers still drain on that boot.
> 
> Previously, a single context hitting a **store-level** drain error (e.g. corrupt meta, enumerate/delete failure) short-circuited the loop via `?` and left every remaining context’s buffered deltas untouched until the next restart or binary-advance hook. Skipped contexts retry later because the buffer is durable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5c3ec387a051a5efde56b28293075f3b453259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->