### PR TITLE
refactor(node/state_delta): extract store_setup submodule (increment 4)

### DIFF
--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -22,6 +22,7 @@ use crate::utils::choose_stream;
 mod buffering;
 mod crypto;
 mod events;
+mod store_setup;
 mod verify;
 
 pub(crate) use buffering::{
@@ -37,6 +38,9 @@ use events::{
     emit_state_mutation_event_parsed, execute_cascaded_events, execute_event_handlers_parsed,
     parse_events_payload, CascadeOutcome,
 };
+// `choose_owned_identity` is also reached by the sibling `buffering` module via
+// `super::` (re-exported through this import).
+use store_setup::{choose_owned_identity, init_delta_store, DeltaStoreSetup};
 pub(crate) use verify::{verify_position_group_id_matches_context, GroupIdCheck};
 
 pub(crate) struct StateDeltaMessage {
@@ -1073,134 +1077,6 @@ pub async fn handle_state_delta(
         false,
     )
     .await
-}
-
-struct DeltaStoreSetup {
-    store: DeltaStore,
-    is_uninitialized: bool,
-}
-
-async fn choose_owned_identity(
-    context_client: &ContextClient,
-    context_id: &ContextId,
-) -> Result<PublicKey> {
-    let identities = context_client.get_context_members(context_id, Some(true));
-    let Some((our_identity, _)) = choose_stream(identities, &mut rand::thread_rng())
-        .await
-        .transpose()?
-    else {
-        bail!("no owned identities found for context: {}", context_id);
-    };
-
-    Ok(our_identity)
-}
-
-async fn init_delta_store(
-    node_state: &crate::NodeState,
-    node_clients: &crate::NodeClients,
-    context_id: ContextId,
-    our_identity: PublicKey,
-    root_hash: Hash,
-    sync_timeout: std::time::Duration,
-) -> Result<DeltaStoreSetup> {
-    let is_uninitialized = root_hash == Hash::default();
-
-    let (delta_store_ref, is_new_store) = {
-        let mut is_new = false;
-        let delta_store = node_state
-            .delta_stores
-            .entry(context_id)
-            .or_insert_with(|| {
-                is_new = true;
-                DeltaStore::new(
-                    [0u8; 32],
-                    node_clients.context.clone(),
-                    context_id,
-                    our_identity,
-                )
-            });
-
-        (delta_store.clone(), is_new)
-    };
-
-    if is_new_store {
-        let init_result = async {
-            // `load_persisted_deltas` surfaces any records with
-            // `applied: true, events: Some(..)` — crash-leftovers
-            // whose handlers never completed. Merged with the normal
-            // cascade events below so a single handler pass covers both
-            // (#2185). Share the DB scan with the DAG restore to avoid
-            // a second full-table iteration (#2194 review).
-            let pending_handler_events = match delta_store_ref.load_persisted_deltas().await {
-                Ok(result) => {
-                    if !result.pending_handler_events.is_empty() {
-                        info!(
-                            %context_id,
-                            pending_count = result.pending_handler_events.len(),
-                            "Replaying handlers interrupted by crash before events were cleared"
-                        );
-                    }
-                    result.pending_handler_events
-                }
-                Err(e) => {
-                    warn!(
-                        ?e,
-                        %context_id,
-                        "Failed to load persisted deltas, starting with empty DAG"
-                    );
-                    Vec::new()
-                }
-            };
-
-            let missing_result = delta_store_ref.get_missing_parents().await;
-            if !missing_result.missing_ids.is_empty() {
-                warn!(
-                    %context_id,
-                    missing_count = missing_result.missing_ids.len(),
-                    "Missing parents after loading persisted deltas - will request from network"
-                );
-            }
-
-            // The two sources are disjoint by construction:
-            // `pending_handler_events` are records that were `applied:
-            // true` on disk before this init ran, so they're restored
-            // into the DAG as already-applied by `load_persisted_deltas`
-            // and can't show up in `get_missing_parents`'s
-            // pending→applied diff. Concat directly.
-            let mut events_to_run = missing_result.cascaded_events;
-            events_to_run.extend(pending_handler_events);
-
-            execute_cascaded_events(
-                &events_to_run,
-                &node_clients.node,
-                &node_clients.context,
-                &context_id,
-                &our_identity,
-                sync_timeout,
-                "initial load",
-                None,
-                &delta_store_ref,
-            )
-            .await
-        }
-        .await;
-
-        if let Err(err) = init_result {
-            warn!(
-                %context_id,
-                ?err,
-                "Initial delta store setup failed - removing store to retry on next delta"
-            );
-            // Remove the store so the next delta triggers a fresh init with retry
-            node_state.delta_stores.remove(&context_id);
-            return Err(err);
-        }
-    }
-
-    Ok(DeltaStoreSetup {
-        store: delta_store_ref,
-        is_uninitialized,
-    })
 }
 
 #[cfg(test)]

--- a/crates/node/src/handlers/state_delta/store_setup.rs
+++ b/crates/node/src/handlers/state_delta/store_setup.rs
@@ -1,0 +1,146 @@
+//! Delta-store setup for state-delta handling: resolving the node's owned
+//! identity for a context and constructing/locating the per-context
+//! `DeltaStore` (including first-time initialization and crash recovery).
+//!
+//! Extracted from the state-delta handler; the apply path and the
+//! buffered-delta replay path call these before applying.
+
+use calimero_context_client::client::ContextClient;
+use calimero_primitives::context::ContextId;
+use calimero_primitives::hash::Hash;
+use calimero_primitives::identity::PublicKey;
+use eyre::{bail, Result};
+use tracing::{info, warn};
+
+use crate::delta_store::DeltaStore;
+use crate::utils::choose_stream;
+
+use super::execute_cascaded_events;
+
+pub(super) struct DeltaStoreSetup {
+    pub(super) store: DeltaStore,
+    pub(super) is_uninitialized: bool,
+}
+
+pub(super) async fn choose_owned_identity(
+    context_client: &ContextClient,
+    context_id: &ContextId,
+) -> Result<PublicKey> {
+    let identities = context_client.get_context_members(context_id, Some(true));
+    let Some((our_identity, _)) = choose_stream(identities, &mut rand::thread_rng())
+        .await
+        .transpose()?
+    else {
+        bail!("no owned identities found for context: {}", context_id);
+    };
+
+    Ok(our_identity)
+}
+
+pub(super) async fn init_delta_store(
+    node_state: &crate::NodeState,
+    node_clients: &crate::NodeClients,
+    context_id: ContextId,
+    our_identity: PublicKey,
+    root_hash: Hash,
+    sync_timeout: std::time::Duration,
+) -> Result<DeltaStoreSetup> {
+    let is_uninitialized = root_hash == Hash::default();
+
+    let (delta_store_ref, is_new_store) = {
+        let mut is_new = false;
+        let delta_store = node_state
+            .delta_stores
+            .entry(context_id)
+            .or_insert_with(|| {
+                is_new = true;
+                DeltaStore::new(
+                    [0u8; 32],
+                    node_clients.context.clone(),
+                    context_id,
+                    our_identity,
+                )
+            });
+
+        (delta_store.clone(), is_new)
+    };
+
+    if is_new_store {
+        let init_result = async {
+            // `load_persisted_deltas` surfaces any records with
+            // `applied: true, events: Some(..)` — crash-leftovers
+            // whose handlers never completed. Merged with the normal
+            // cascade events below so a single handler pass covers both
+            // (#2185). Share the DB scan with the DAG restore to avoid
+            // a second full-table iteration (#2194 review).
+            let pending_handler_events = match delta_store_ref.load_persisted_deltas().await {
+                Ok(result) => {
+                    if !result.pending_handler_events.is_empty() {
+                        info!(
+                            %context_id,
+                            pending_count = result.pending_handler_events.len(),
+                            "Replaying handlers interrupted by crash before events were cleared"
+                        );
+                    }
+                    result.pending_handler_events
+                }
+                Err(e) => {
+                    warn!(
+                        ?e,
+                        %context_id,
+                        "Failed to load persisted deltas, starting with empty DAG"
+                    );
+                    Vec::new()
+                }
+            };
+
+            let missing_result = delta_store_ref.get_missing_parents().await;
+            if !missing_result.missing_ids.is_empty() {
+                warn!(
+                    %context_id,
+                    missing_count = missing_result.missing_ids.len(),
+                    "Missing parents after loading persisted deltas - will request from network"
+                );
+            }
+
+            // The two sources are disjoint by construction:
+            // `pending_handler_events` are records that were `applied:
+            // true` on disk before this init ran, so they're restored
+            // into the DAG as already-applied by `load_persisted_deltas`
+            // and can't show up in `get_missing_parents`'s
+            // pending→applied diff. Concat directly.
+            let mut events_to_run = missing_result.cascaded_events;
+            events_to_run.extend(pending_handler_events);
+
+            execute_cascaded_events(
+                &events_to_run,
+                &node_clients.node,
+                &node_clients.context,
+                &context_id,
+                &our_identity,
+                sync_timeout,
+                "initial load",
+                None,
+                &delta_store_ref,
+            )
+            .await
+        }
+        .await;
+
+        if let Err(err) = init_result {
+            warn!(
+                %context_id,
+                ?err,
+                "Initial delta store setup failed - removing store to retry on next delta"
+            );
+            // Remove the store so the next delta triggers a fresh init with retry
+            node_state.delta_stores.remove(&context_id);
+            return Err(err);
+        }
+    }
+
+    Ok(DeltaStoreSetup {
+        store: delta_store_ref,
+        is_uninitialized,
+    })
+}


### PR DESCRIPTION
## What

Increment 4 of splitting `crates/node/src/handlers/state_delta/mod.rs`. Moves the delta-store setup cluster into `store_setup.rs` — pure, behavior-preserving code movement (`mod.rs`: **+4** wiring lines / **−128** moved).

Moved:
- `DeltaStoreSetup` (struct; fields `pub(super)` for the apply-path destructure)
- `choose_owned_identity` — also reached by the sibling `buffering` module via `super::` (re-exported through mod.rs's import)
- `init_delta_store`

## Wiring

Explicit imports in `store_setup.rs` (no `use super::*`), per the convention established in this series. `execute_cascaded_events` is reached via `super::` (it lives in the sibling `events` module). Call sites, the sibling `buffering` module, and the in-module test suite are unchanged.

## Validation

- `cargo check -p calimero-node` clean (no new warnings).
- node lib tests: **304 passed**.
- node `sync_sim`: **314 passed**.
- `mod.rs` diff is wiring only; 127 lines moved verbatim.

## Progress

`mod.rs`: 3084 → ~2956 LOC. The handler is now organized as `crypto` / `verify` / `events` / `buffering` / `store_setup` submodules. What deliberately remains in `mod.rs`: the two orchestrators (`handle_state_delta`, `apply_authorized_state_delta`), plus `request_missing_deltas` and `ensure_application_available` (sync/blob concerns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8360d4c1c92b864e6af55db3c54120b381c2e0b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->