### PR TITLE
feat(network): membership-biased gossipsub peer scoring (PR 1/2, #2513)

### DIFF
--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -36,8 +36,8 @@ use crate::blob_types::BlobAuth;
 use crate::messages::{
     AnnounceBlob, Bootstrap, Dial, ListenOn, MeshPeerCount, MeshPeers, MeshStats, NetworkMessage,
     NetworkStatus, OpenStream, PeerCount, Publish, QueryBlob, RequestBlob,
-    SendSpecializedNodeInvitationResponse, SendSpecializedNodeVerificationRequest, Subscribe,
-    SubscribedPeers, Unsubscribe,
+    SendSpecializedNodeInvitationResponse, SendSpecializedNodeVerificationRequest, SetPeerScore,
+    Subscribe, SubscribedPeers, Unsubscribe,
 };
 use crate::network_status::NetworkStatusSnapshot;
 use crate::specialized_node_invite::{SpecializedNodeInvitationResponse, VerificationRequest};
@@ -136,6 +136,19 @@ impl NetworkClient {
             .expect("Mailbox not to be dropped");
 
         rx.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Push a peer's gossipsub application-specific score (#2513),
+    /// fire-and-forget. Used on membership-(de)verification paths to bias
+    /// the mesh toward verified members; it does not await a round-trip,
+    /// so it's cheap enough to call from the observation hot path. The
+    /// per-command `outcome` is `()`, so the receiver is simply dropped.
+    pub fn set_peer_score(&self, peer_id: libp2p::PeerId, score: f64) {
+        let (outcome, _rx) = oneshot::channel();
+        self.network_manager.do_send(NetworkMessage::SetPeerScore {
+            request: SetPeerScore { peer_id, score },
+            outcome,
+        });
     }
 
     pub async fn open_stream(&self, peer_id: libp2p::PeerId) -> eyre::Result<Stream> {

--- a/crates/network/primitives/src/messages.rs
+++ b/crates/network/primitives/src/messages.rs
@@ -171,6 +171,11 @@ pub enum NetworkMessage {
         request: SendSpecializedNodeInvitationResponse,
         outcome: oneshot::Sender<<SendSpecializedNodeInvitationResponse as actix::Message>::Result>,
     },
+    /// Set a peer's gossipsub application-specific score (membership bias).
+    SetPeerScore {
+        request: SetPeerScore,
+        outcome: oneshot::Sender<<SetPeerScore as actix::Message>::Result>,
+    },
 }
 
 /// Request to bootstrap the Kademlia DHT.
@@ -345,6 +350,19 @@ pub struct Subscribe(pub IdentTopic);
 
 impl actix::Message for Subscribe {
     type Result = eyre::Result<IdentTopic>;
+}
+
+/// Set a peer's gossipsub application-specific score (#2513). Pushed by
+/// the node when it (de)verifies a peer's membership; the network layer
+/// applies it via `gossipsub::Behaviour::set_application_score`.
+#[derive(Debug, Clone, Copy)]
+pub struct SetPeerScore {
+    pub peer_id: PeerId,
+    pub score: f64,
+}
+
+impl actix::Message for SetPeerScore {
+    type Result = ();
 }
 
 /// Request to unsubscribe from a gossipsub topic.

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -70,7 +70,7 @@ impl Behaviour {
             .with_quic()
             .with_relay_client(noise::Config::new, yamux::Config::default)?
             .with_behaviour(|key, relay_behaviour| {
-                let behaviour = Self {
+                let mut behaviour = Self {
                     autonat: {
                         autonat::Behaviour::new(
                             autonat::Config::default()
@@ -182,6 +182,28 @@ impl Behaviour {
                     ),
                 };
 
+                // Enable gossipsub application-specific peer scoring
+                // (#2513). The score is derived solely from our verified
+                // membership knowledge — the node pushes a positive
+                // app-specific score for peers it has authenticated as
+                // namespace/group members (anchors highest), pushed from
+                // `observe_peer_identity`. Mesh maintenance (graft/prune,
+                // opportunistic grafting) then prefers verified members
+                // for mesh slots and squeezes out an unverified
+                // non-forwarder.
+                //
+                // All non-app weights are zeroed (see
+                // `membership_peer_score_config`), so an unknown peer
+                // sits at exactly 0 — above every gating threshold — and
+                // is never graylisted for being unverified. That's the
+                // cold-start-safe form: boost the verified, never punish
+                // the unknown, and keep traffic-dependent penalties off.
+                let (score_params, score_thresholds) = membership_peer_score_config();
+                behaviour
+                    .gossipsub
+                    .with_peer_score(score_params, score_thresholds)
+                    .map_err(|e| eyre::eyre!("failed to enable gossipsub peer scoring: {e}"))?;
+
                 Ok(behaviour)
             })?
             .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30)))
@@ -194,5 +216,66 @@ impl Behaviour {
         }
 
         Ok(swarm)
+    }
+}
+
+/// Peer-score configuration for membership-biased mesh maintenance
+/// (#2513). Only the application-specific score contributes: every
+/// traffic- and behaviour-dependent weight is zeroed, so the score
+/// reflects *our verified-membership knowledge* and nothing else. In
+/// particular per-topic `mesh_message_deliveries` scoring stays off (no
+/// topic params), which avoids false-penalizing honest peers on quiet /
+/// low-traffic context topics.
+///
+/// Thresholds are the gossipsub defaults — every gating cutoff is ≤ 0
+/// (gossip −10, publish −50, graylist −80) — so an unknown peer at score
+/// 0 sits above all of them and is never suppressed for being unverified.
+/// The node only ever pushes non-negative app scores in this
+/// configuration (boost members, leave unknown at 0), so peer scoring can
+/// only *prefer*, never exclude.
+fn membership_peer_score_config() -> (gossipsub::PeerScoreParams, gossipsub::PeerScoreThresholds) {
+    let params = gossipsub::PeerScoreParams {
+        // The pushed app score is used as-is (the node tiers it: anchors
+        // highest, plain members positive, unknown left at 0).
+        app_specific_weight: 1.0,
+        // Disable every non-membership signal.
+        topics: std::collections::HashMap::new(),
+        ip_colocation_factor_weight: 0.0,
+        behaviour_penalty_weight: 0.0,
+        slow_peer_weight: 0.0,
+        ..Default::default()
+    };
+    (params, gossipsub::PeerScoreThresholds::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn membership_score_config_is_valid_and_cold_start_safe() {
+        let (params, thresholds) = membership_peer_score_config();
+        // `with_peer_score` rejects invalid params/thresholds at build —
+        // assert directly so a bad edit fails here, not deep in swarm init.
+        params.validate().expect("score params must validate");
+        thresholds
+            .validate()
+            .expect("score thresholds must validate");
+
+        // The load-bearing invariant: an unknown peer (no app score
+        // pushed) sits at exactly 0, which must be at or above every
+        // gating cutoff so it is never gossip-/publish-suppressed or
+        // graylisted for merely being unverified.
+        assert!(0.0 >= thresholds.gossip_threshold);
+        assert!(0.0 >= thresholds.publish_threshold);
+        assert!(0.0 >= thresholds.graylist_threshold);
+
+        // Only the app-specific signal contributes — no per-topic traffic
+        // scoring and no behaviour/IP/slow penalties that could
+        // false-penalize an honest peer on a quiet topic.
+        assert!(params.topics.is_empty());
+        assert_eq!(params.ip_colocation_factor_weight, 0.0);
+        assert_eq!(params.behaviour_penalty_weight, 0.0);
+        assert_eq!(params.slow_peer_weight, 0.0);
     }
 }

--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -19,6 +19,7 @@ mod query_blob;
 mod request_blob;
 mod send_specialized_node_invitation_response;
 mod send_specialized_node_verification_request;
+mod set_peer_score;
 mod subscribe;
 mod subscribed_peers;
 mod unsubscribe;
@@ -38,6 +39,9 @@ impl Handler<NetworkMessage> for NetworkManager {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::Subscribe { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::SetPeerScore { request, outcome } => {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::Unsubscribe { request, outcome } => {

--- a/crates/network/src/handlers/commands/set_peer_score.rs
+++ b/crates/network/src/handlers/commands/set_peer_score.rs
@@ -1,0 +1,24 @@
+use actix::{Context, Handler, Message};
+use calimero_network_primitives::messages::SetPeerScore;
+
+use crate::NetworkManager;
+
+impl Handler<SetPeerScore> for NetworkManager {
+    type Result = <SetPeerScore as Message>::Result;
+
+    fn handle(
+        &mut self,
+        SetPeerScore { peer_id, score }: SetPeerScore,
+        _ctx: &mut Context<Self>,
+    ) -> Self::Result {
+        // `set_application_score` returns false when peer scoring isn't
+        // active or the peer isn't in the score book yet — both benign:
+        // scoring is always enabled here, and a not-yet-known peer picks
+        // up its score when it next (re)connects and the node re-pushes.
+        let _applied = self
+            .swarm
+            .behaviour_mut()
+            .gossipsub
+            .set_application_score(&peer_id, score);
+    }
+}


### PR DESCRIPTION
## What

Network-layer foundation for #2513 (prioritize the gossipsub mesh toward verified network members). **PR 1 of 2** — soft scoring only. No node wiring yet; **no behaviour change in isolation** (with no scores pushed, every peer is at 0).

## How

- **`behaviour.rs`**: enable gossipsub `with_peer_score`. `membership_peer_score_config` **zeroes every non-app weight** — no per-topic traffic scoring, no IP-colocation / behaviour-penalty / slow-peer weights — so the score reflects *only our verified-membership knowledge*. This is the issue's "safe form": it avoids the `mesh_message_deliveries` footgun where a quiet/low-traffic context topic would false-penalize honest peers.
- **Cold-start safety**: default thresholds (gossip −10, publish −50, graylist −80) keep an unknown peer at score 0 *above* every gating cutoff — unknown peers are never suppressed or graylisted for being unverified. A unit test pins this invariant (`membership_score_config_is_valid_and_cold_start_safe`).
- **Command surface**: `NetworkMessage::SetPeerScore { peer_id, score }`, a fire-and-forget `NetworkClient::set_peer_score` (uses `do_send`, no round-trip — cheap on the membership-observation hot path), and a `Handler` that calls `gossipsub::set_application_score`.

## Scope (per discussion)

**Soft lever only.** With `flood_publish(true)`, broadcast already reaches all subscribers (bypassing the mesh), so scoring biases **mesh-slot occupancy + gossip (IHAVE/IWANT)** toward members rather than gating the publish path. The hard `add_explicit_peer` lever is intentionally out of scope.

## PR 2 (next)

Node pushes scores from the verified-member signal #2642 just made durable: positive for members (anchors highest, via `trusted_anchors`) from `observe_peer_identity`; cleared to neutral on the `MemberRemoved` `op_events` subscriber. Never negative for unknown (cold start stays neutral).

## Testing

70 `calimero-network` lib tests pass (+1 new). fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core gossipsub mesh maintenance at swarm build time; mitigated by boost-only app scores, default thresholds, and no callers pushing scores until PR 2.
> 
> **Overview**
> **Adds the network-layer plumbing for membership-biased gossipsub mesh (#2513, PR 1/2).** Swarm init now turns on `with_peer_score` using `membership_peer_score_config`, which keeps only the application-specific weight and zeros traffic/behaviour penalties so scores reflect pushed membership knowledge without penalizing quiet topics or unknown peers at score 0.
> 
> **New command surface:** `NetworkMessage::SetPeerScore`, fire-and-forget `NetworkClient::set_peer_score` (`do_send`), and a `NetworkManager` handler that calls `gossipsub::set_application_score`. A unit test asserts params validate and unknown peers at 0 stay above gossip/publish/graylist thresholds. **No node wiring in this PR** — until scores are pushed, behaviour is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a657d24a61139f5dd932c836242c0b1682cd5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->