### PR TITLE
fix(storage): don't let one rejected action abort the whole sync-merge batch (#2716, follow-up to #2718)

### DIFF
--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -341,7 +341,7 @@ where
                             updated_at = metadata.updated_at(),
                             "SYNC CHILD: Applying Action::Add for child entity"
                         );
-                        <Interface<S>>::apply_action(
+                        apply_child_action_lenient::<S>(
                             Action::Add {
                                 id,
                                 data,
@@ -367,7 +367,7 @@ where
                             updated_at = metadata.updated_at(),
                             "SYNC CHILD: Applying Action::Update for child entity"
                         );
-                        <Interface<S>>::apply_action(
+                        apply_child_action_lenient::<S>(
                             Action::Update {
                                 id,
                                 data,
@@ -379,7 +379,7 @@ where
                     }
                 }
                 Action::DeleteRef { .. } => {
-                    <Interface<S>>::apply_action(action, &action_ctx)?;
+                    apply_child_action_lenient::<S>(action, &action_ctx)?;
                 }
             };
         }
@@ -400,6 +400,71 @@ where
 
         Ok(())
     }
+}
+
+/// Apply one child action from a sync-merge batch, treating a per-action
+/// **verification rejection** as a skip rather than aborting the whole batch.
+///
+/// [`Root::sync`] runs inside the app's `__calimero_sync_next` export, whose
+/// host-side caller does `.expect("fatal: sync failed")` — so ANY `Err`
+/// returned from here becomes a fatal guest panic that aborts the ENTIRE delta.
+/// Every sibling action in the batch is lost and the node re-attempts the same
+/// delta forever. That is the #2716 split-brain: a single `Shared` action that
+/// arrived **unsigned** (`signature_data: None`) during a concurrent-rotation
+/// window made `apply_action` return `InvalidData`, which panic-looped every
+/// receiver — they never applied the peer's branch and never converged, while
+/// the branch's author (which had the signed original) sat at a divergent root.
+///
+/// A verification rejection means THIS action is unverifiable, unauthorized, or
+/// stale — it is not authoritative and must be dropped. Dropping it is the
+/// correct and secure outcome; the legitimately-signed copies and HashComparison
+/// reconcile the rest of the batch. Crucially it must NOT brick the merge. So
+/// we drop the rejected action (logged) and let the batch continue.
+///
+/// Structural / storage errors (deserialization, tree-state mismatch, store
+/// faults) are deliberately NOT skipped — those signal a malformed batch or a
+/// real storage fault, not a single bad action, and must still surface to the
+/// caller.
+fn apply_child_action_lenient<S: StorageAdaptor>(
+    action: Action,
+    ctx: &crate::interface::ApplyContext,
+) -> Result<(), StorageError> {
+    let id = action.id();
+    match <Interface<S>>::apply_action(action, ctx) {
+        Ok(()) => Ok(()),
+        Err(e) if is_skippable_apply_rejection(&e) => {
+            tracing::warn!(
+                target: "storage::root",
+                %id,
+                error = %e,
+                "sync-merge: dropping a rejected action (unverifiable / unauthorized \
+                 / stale — never authoritative) and continuing the batch; a hard \
+                 error here would abort the whole __calimero_sync_next merge and \
+                 brick convergence (#2716)"
+            );
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Whether a [`StorageError`] from `apply_action` is a per-action **verification
+/// rejection** that may be skipped without aborting the sync-merge batch (see
+/// [`apply_child_action_lenient`]).
+///
+/// These are policy decisions about a single action — the action is
+/// unverifiable, unauthorized, stale, or carries an invalid timestamp — so the
+/// action is dropped. Everything else (corruption, deserialization, tree
+/// mismatch, store faults) is a system/structural failure and still propagates.
+fn is_skippable_apply_rejection(e: &StorageError) -> bool {
+    matches!(
+        e,
+        StorageError::InvalidData(_)
+            | StorageError::InvalidSignature
+            | StorageError::NonceReplay(_)
+            | StorageError::ActionNotAllowed(_)
+            | StorageError::InvalidTimestamp(_, _)
+    )
 }
 
 impl<T, S> Deref for Root<T, S>

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -161,6 +161,10 @@ pub mod tests {
     /// RGA (Replicated Growable Array) CRDT tests.
     #[cfg(test)]
     pub mod rga;
+    /// Sync-merge batch resilience: a single rejected action (e.g. an unsigned
+    /// `Shared` action) must not abort the whole `Root::sync` batch (core#2716).
+    #[cfg(test)]
+    pub mod sync_batch_resilience;
     /// Storage-internal regression: the rotation-write hook depends on the
     /// stored-writers field staying frozen at bootstrap (see #2266 step 5).
     #[cfg(test)]

--- a/crates/storage/src/tests/sync_batch_resilience.rs
+++ b/crates/storage/src/tests/sync_batch_resilience.rs
@@ -1,0 +1,155 @@
+//! Regression for the core#2716 split-brain: a single rejected action in a
+//! sync-merge batch must NOT abort the whole batch.
+//!
+//! [`Root::sync`] runs inside the app's `__calimero_sync_next` export, whose
+//! host-side caller does `.expect("fatal: sync failed")`. So if applying ONE
+//! action in a [`StorageDelta::CausalActions`] batch returns `Err`, that error
+//! becomes a fatal guest panic that aborts the ENTIRE delta — every sibling
+//! action is lost and the node re-attempts the same delta forever.
+//!
+//! In the failing run (CI 26999653188) a `Shared` action arrived **unsigned**
+//! (`signature_data: None`) during a concurrent-writer-rotation window. Its
+//! `apply_action` returned `InvalidData("Remote Shared action must be signed")`,
+//! which panic-looped every receiver (750+ times) — they never applied the
+//! peer's branch and never converged, while the branch's author sat at a
+//! divergent root.
+//!
+//! The fix (`crate::collections::root`'s `apply_child_action_lenient`) drops a
+//! per-action *verification rejection* (unsigned / forged / stale /
+//! unauthorized — never authoritative) and lets the batch continue. The
+//! per-action `apply_action` contract is unchanged (it still returns the same
+//! `Err` — the security tests rely on that); only the batch wrapper stops
+//! treating it as fatal.
+
+use core::num::NonZeroU128;
+use std::collections::{BTreeMap, BTreeSet};
+
+use borsh::to_vec;
+use calimero_primitives::identity::PublicKey;
+use ed25519_dalek::SigningKey;
+
+use crate::action::Action;
+use crate::address::Id;
+use crate::collections::Root;
+use crate::delta::StorageDelta;
+use crate::entities::{ChildInfo, Metadata, StorageType};
+use crate::index::Index;
+use crate::interface::{ApplyContext, Interface};
+use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+use crate::store::MockedStorage;
+use crate::tests::common::{build_signed_shared_action, pubkey_of, EmptyData};
+use crate::{env, merge};
+
+type S = MockedStorage<4716>;
+
+fn make_signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn hlc(ns: u64) -> HybridTimestamp {
+    let node_id = ID::from(NonZeroU128::new(1).unwrap());
+    HybridTimestamp::new(Timestamp::new(NTP64(ns), node_id))
+}
+
+fn entity_id(seed: u8) -> Id {
+    Id::new([seed; 32])
+}
+
+/// Register the root state and seed the root index entry, returning the root
+/// `ChildInfo` to use as the `ancestors` of the child actions (so they pass the
+/// v2 `verify_ancestor_integrity` check at apply time).
+fn setup() -> ChildInfo {
+    env::reset_for_testing();
+    merge::register_crdt_merge::<EmptyData>();
+
+    let root_id = Id::root();
+    let root_meta = Metadata::default();
+    Index::<S>::add_root(ChildInfo::new(root_id, [0; 32], root_meta.clone())).unwrap();
+    let (full_hash, _) = Index::<S>::get_hashes_for(root_id).unwrap().unwrap();
+    ChildInfo::new(root_id, full_hash, root_meta)
+}
+
+/// A `Shared` `Add` action carrying NO signature (`signature_data: None`) — the
+/// exact shape that triggered the #2716 fatal `InvalidData` on apply. Built by
+/// hand because the signing helpers always attach a signature.
+fn unsigned_shared_add(
+    id: Id,
+    writers: BTreeSet<PublicKey>,
+    hlc_ns: u64,
+    root: &ChildInfo,
+) -> Action {
+    Action::Add {
+        id,
+        data: b"unsigned".to_vec(),
+        ancestors: vec![root.clone()],
+        metadata: Metadata {
+            created_at: hlc_ns,
+            updated_at: hlc_ns.into(),
+            storage_type: StorageType::Shared {
+                writers,
+                signature_data: None, // <- the bug trigger
+            },
+            crdt_type: None,
+            field_name: None,
+        },
+    }
+}
+
+/// #2716: an unsigned `Shared` action sitting FIRST in a `CausalActions` batch
+/// must not prevent a valid sibling action (applied later in the same batch)
+/// from being applied. Before the fix, the unsigned action's `InvalidData`
+/// propagated out of `Root::sync` (→ fatal panic in `__calimero_sync_next`) and
+/// the whole batch — including the valid sibling — was lost.
+#[test]
+fn unsigned_shared_action_does_not_abort_the_sync_batch() {
+    let root = setup();
+
+    let alice_sk = make_signing_key(0xA1);
+    let alice = pubkey_of(&alice_sk);
+    let writers: BTreeSet<PublicKey> = [alice].into_iter().collect();
+
+    let bad_id = entity_id(0xBA); // unsigned Shared — must be skipped
+    let good_id = entity_id(0x60); // valid signed Shared — must apply
+
+    // Bad action FIRST, so a batch-aborting error would prevent the good one.
+    let bad = unsigned_shared_add(bad_id, writers.clone(), 100, &root);
+    let good = build_signed_shared_action(
+        true,
+        good_id,
+        b"good".to_vec(),
+        writers.clone(),
+        200,
+        &alice_sk,
+        vec![root.clone()],
+    );
+
+    // The receiver's per-action `effective_writers` map (#2266). The good
+    // action verifies against {Alice}; the bad one is rejected before any
+    // writer check, so its entry is irrelevant.
+    let mut effective_writers: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
+    let _ = effective_writers.insert(good_id, writers.clone());
+
+    let payload = to_vec(&StorageDelta::CausalActions {
+        actions: vec![bad, good],
+        delta_id: [0xD1; 32],
+        delta_hlc: hlc(300),
+        effective_writers,
+    })
+    .unwrap();
+
+    // Must NOT return Err — that is what becomes the fatal panic in production.
+    Root::<EmptyData, S>::sync(&payload, &ApplyContext::empty())
+        .expect("a single unsigned action must not abort the whole sync batch (#2716)");
+
+    // The valid sibling applied despite the unsigned action ahead of it.
+    assert!(
+        Interface::<S>::find_by_id_raw(good_id).is_some(),
+        "the valid signed action must apply even though an unsigned action \
+         preceded it in the batch (#2716)"
+    );
+    // The unsigned action was dropped — never authoritative.
+    assert!(
+        Interface::<S>::find_by_id_raw(bad_id).is_none(),
+        "the unsigned Shared action must be dropped, not stored"
+    );
+}

--- a/crates/storage/src/tests/write_hook_stale_writers.rs
+++ b/crates/storage/src/tests/write_hook_stale_writers.rs
@@ -74,11 +74,13 @@ fn ctx(delta_id: [u8; 32], delta_hlc_ns: u64) -> ApplyContext {
     }
 }
 
-/// Apply context carrying the pre-resolved causal writer set (what the node
-/// sync layer passes from `writers_at(delta.parents)`), so a rotation's
-/// signature verifies against the set authorized at its causal point rather
-/// than the locally-stored set. Needed when a concurrent rotation is signed by
-/// a writer who has since been rotated out of the local stored set.
+/// Apply context carrying the pre-resolved causal writer set. In production
+/// this is populated by the node sync layer via `writers_at(delta.parents,
+/// happens_before)` (see `DeltaStore::resolve_effective_writers_for_delta`),
+/// so a rotation's signature verifies against the set authorized at its causal
+/// point rather than the locally-stored set. Use `ctx_ew` in tests that
+/// exercise concurrent-rotation scenarios where the signer may have been
+/// rotated out of the locally-stored set between authoring and delivery.
 fn ctx_ew(delta_id: [u8; 32], delta_hlc_ns: u64, effective: BTreeSet<PublicKey>) -> ApplyContext {
     ApplyContext {
         effective_writers: Some(effective),


### PR DESCRIPTION
Re-opens the fix for #2716. **#2718 was merged while its branch was still at the first commit** (the stale-nonce reorder), so the *actual* fix — pushed to that branch minutes later — never reached master. This PR carries that fix (cherry-picked onto current master), plus the small `ctx_ew` doc improvement that was also stranded.

#2718's stale-nonce reorder **is** on master and is a real latent fix, but on its own it does **not** fix the e2e — which is exactly why `shared-storage-concurrent-rotation-converge` is still red on master.

## The real root cause (from the failing-run node logs, CI 26999653188)

The issue hypothesized "rotation-log divergence → `InvalidSignature`". The logs show **0 `InvalidSignature`, 0 stale-nonce skips, 0 auth-skips**. What actually happens during the concurrent-rotation window:

- A `Shared` action reaches a peer **unsigned** (`signature_data: None`).
- `Interface::apply_action` correctly rejects it (`InvalidData("Remote Shared action must be signed")`), but that error propagates out of `Root::sync`, which runs inside the app's `__calimero_sync_next` export whose host caller does `.expect("fatal: sync failed")`.
- So **one bad action becomes a fatal guest panic that aborts the ENTIRE delta** — every sibling action is lost and the receiver re-attempts the same persisted parent delta forever.

In the run, node-1 and node-3 panic-looped **750+ times** (`Failed to load persisted parent delta into DAG: ApplyFail … "fatal: sync failed: InvalidData(\"Remote Shared action must be signed\")"`), never applied the peer's branch, never converged — while the branch author sat at a divergent root. The repeating `nodes_skipped=3, entities_pushed=0` HC cycles were the **symptom**, not the cause.

## Fix

`Root::apply_actions` now treats a per-action **verification rejection** (`InvalidData` / `InvalidSignature` / `NonceReplay` / `ActionNotAllowed` / `InvalidTimestamp`) as a skip — drop that action (logged) and continue the batch — instead of propagating it. Such an action is unverifiable, unauthorized, or stale → never authoritative → dropping it is the correct and secure outcome; the legitimately-signed copies + HashComparison reconcile the rest. Structural/storage errors (deserialization, tree-state mismatch, store faults) still propagate.

This also closes a broader liveness/DoS fragility: before this, a single forged or unsigned `Shared` action gossiped into any delta would brick convergence for **every** receiver.

The per-action `apply_action` contract is **unchanged** — it still returns the same `Err`. The security tests that assert `InvalidData`/`InvalidSignature` call `apply_action` directly and keep passing; only the batch wrapper (`Root::sync`) stops treating a per-action rejection as fatal.

## Tests

- New `unsigned_shared_action_does_not_abort_the_sync_batch`: an unsigned `Shared` action placed first in a `CausalActions` batch must not prevent a valid signed sibling from applying. Verified fails-before (`Root::sync` returns the propagated `InvalidData`) / passes-after.
- 587 `calimero-storage` lib tests green (incl. the existing `InvalidData`/`InvalidSignature` security tests, unchanged); `calimero-node` shared-sync + rotation tests green.
- `cargo fmt --check` clean; no new clippy.

The merobox e2e `shared-storage-concurrent-rotation-converge` is the end-to-end convergence guard.

> Note: I did not chase down *why* an action is emitted unsigned (suspected: the `!is_state_op` guard in `execute/mod.rs` skipping `sign_authorized_actions` for merge-derived actions). Dropping an unverifiable action is the correct behavior regardless of origin; if a residual *value* divergence ever shows up (vs the brick), that's the follow-up signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync convergence liveness for Shared storage during merge; rejected actions are dropped rather than failing the batch, while structural errors still fail closed.
> 
> **Overview**
> Fixes **#2716** split-brain where one bad child action during `Root::sync` could abort the entire sync-merge batch and trap receivers in a fatal `__calimero_sync_next` panic loop.
> 
> **`Root::apply_actions`** now routes child `Add`/`Update`/`DeleteRef` through **`apply_child_action_lenient`**, which still calls `Interface::apply_action` but **logs and drops** per-action **verification rejections** (`InvalidData`, `InvalidSignature`, `NonceReplay`, `ActionNotAllowed`, `InvalidTimestamp`) instead of returning `Err` for the whole delta. **Structural/storage failures** (deserialization, tree mismatch, store faults) still propagate. Direct `apply_action` behavior is unchanged for security tests.
> 
> Adds regression test **`unsigned_shared_action_does_not_abort_the_sync_batch`** and wires **`sync_batch_resilience`** into the test module; clarifies **`ctx_ew`** docs in `write_hook_stale_writers.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb523e1a17ab5719318a981a699bfff001777696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->