### PR TITLE
feat(node): push membership-derived gossipsub scores (PR 2/2, #2513)

### DIFF
--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -36,8 +36,8 @@ use crate::blob_types::BlobAuth;
 use crate::messages::{
     AnnounceBlob, Bootstrap, Dial, ListenOn, MeshPeerCount, MeshPeers, MeshStats, NetworkMessage,
     NetworkStatus, OpenStream, PeerCount, Publish, QueryBlob, RequestBlob,
-    SendSpecializedNodeInvitationResponse, SendSpecializedNodeVerificationRequest, Subscribe,
-    SubscribedPeers, Unsubscribe,
+    SendSpecializedNodeInvitationResponse, SendSpecializedNodeVerificationRequest, SetPeerScore,
+    Subscribe, SubscribedPeers, Unsubscribe,
 };
 use crate::network_status::NetworkStatusSnapshot;
 use crate::specialized_node_invite::{SpecializedNodeInvitationResponse, VerificationRequest};
@@ -136,6 +136,19 @@ impl NetworkClient {
             .expect("Mailbox not to be dropped");
 
         rx.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Push a peer's gossipsub application-specific score (#2513),
+    /// fire-and-forget. Used on membership-(de)verification paths to bias
+    /// the mesh toward verified members; it does not await a round-trip,
+    /// so it's cheap enough to call from the observation hot path. The
+    /// per-command `outcome` is `()`, so the receiver is simply dropped.
+    pub fn set_peer_score(&self, peer_id: libp2p::PeerId, score: f64) {
+        let (outcome, _rx) = oneshot::channel();
+        self.network_manager.do_send(NetworkMessage::SetPeerScore {
+            request: SetPeerScore { peer_id, score },
+            outcome,
+        });
     }
 
     pub async fn open_stream(&self, peer_id: libp2p::PeerId) -> eyre::Result<Stream> {

--- a/crates/network/primitives/src/messages.rs
+++ b/crates/network/primitives/src/messages.rs
@@ -171,6 +171,11 @@ pub enum NetworkMessage {
         request: SendSpecializedNodeInvitationResponse,
         outcome: oneshot::Sender<<SendSpecializedNodeInvitationResponse as actix::Message>::Result>,
     },
+    /// Set a peer's gossipsub application-specific score (membership bias).
+    SetPeerScore {
+        request: SetPeerScore,
+        outcome: oneshot::Sender<<SetPeerScore as actix::Message>::Result>,
+    },
 }
 
 /// Request to bootstrap the Kademlia DHT.
@@ -345,6 +350,19 @@ pub struct Subscribe(pub IdentTopic);
 
 impl actix::Message for Subscribe {
     type Result = eyre::Result<IdentTopic>;
+}
+
+/// Set a peer's gossipsub application-specific score (#2513). Pushed by
+/// the node when it (de)verifies a peer's membership; the network layer
+/// applies it via `gossipsub::Behaviour::set_application_score`.
+#[derive(Debug, Clone, Copy)]
+pub struct SetPeerScore {
+    pub peer_id: PeerId,
+    pub score: f64,
+}
+
+impl actix::Message for SetPeerScore {
+    type Result = ();
 }
 
 /// Request to unsubscribe from a gossipsub topic.

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -70,7 +70,7 @@ impl Behaviour {
             .with_quic()
             .with_relay_client(noise::Config::new, yamux::Config::default)?
             .with_behaviour(|key, relay_behaviour| {
-                let behaviour = Self {
+                let mut behaviour = Self {
                     autonat: {
                         autonat::Behaviour::new(
                             autonat::Config::default()
@@ -182,6 +182,28 @@ impl Behaviour {
                     ),
                 };
 
+                // Enable gossipsub application-specific peer scoring
+                // (#2513). The score is derived solely from our verified
+                // membership knowledge — the node pushes a positive
+                // app-specific score for peers it has authenticated as
+                // namespace/group members (anchors highest), pushed from
+                // `observe_peer_identity`. Mesh maintenance (graft/prune,
+                // opportunistic grafting) then prefers verified members
+                // for mesh slots and squeezes out an unverified
+                // non-forwarder.
+                //
+                // All non-app weights are zeroed (see
+                // `membership_peer_score_config`), so an unknown peer
+                // sits at exactly 0 — above every gating threshold — and
+                // is never graylisted for being unverified. That's the
+                // cold-start-safe form: boost the verified, never punish
+                // the unknown, and keep traffic-dependent penalties off.
+                let (score_params, score_thresholds) = membership_peer_score_config();
+                behaviour
+                    .gossipsub
+                    .with_peer_score(score_params, score_thresholds)
+                    .map_err(|e| eyre::eyre!("failed to enable gossipsub peer scoring: {e}"))?;
+
                 Ok(behaviour)
             })?
             .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30)))
@@ -194,5 +216,66 @@ impl Behaviour {
         }
 
         Ok(swarm)
+    }
+}
+
+/// Peer-score configuration for membership-biased mesh maintenance
+/// (#2513). Only the application-specific score contributes: every
+/// traffic- and behaviour-dependent weight is zeroed, so the score
+/// reflects *our verified-membership knowledge* and nothing else. In
+/// particular per-topic `mesh_message_deliveries` scoring stays off (no
+/// topic params), which avoids false-penalizing honest peers on quiet /
+/// low-traffic context topics.
+///
+/// Thresholds are the gossipsub defaults — every gating cutoff is ≤ 0
+/// (gossip −10, publish −50, graylist −80) — so an unknown peer at score
+/// 0 sits above all of them and is never suppressed for being unverified.
+/// The node only ever pushes non-negative app scores in this
+/// configuration (boost members, leave unknown at 0), so peer scoring can
+/// only *prefer*, never exclude.
+fn membership_peer_score_config() -> (gossipsub::PeerScoreParams, gossipsub::PeerScoreThresholds) {
+    let params = gossipsub::PeerScoreParams {
+        // The pushed app score is used as-is (the node tiers it: anchors
+        // highest, plain members positive, unknown left at 0).
+        app_specific_weight: 1.0,
+        // Disable every non-membership signal.
+        topics: std::collections::HashMap::new(),
+        ip_colocation_factor_weight: 0.0,
+        behaviour_penalty_weight: 0.0,
+        slow_peer_weight: 0.0,
+        ..Default::default()
+    };
+    (params, gossipsub::PeerScoreThresholds::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn membership_score_config_is_valid_and_cold_start_safe() {
+        let (params, thresholds) = membership_peer_score_config();
+        // `with_peer_score` rejects invalid params/thresholds at build —
+        // assert directly so a bad edit fails here, not deep in swarm init.
+        params.validate().expect("score params must validate");
+        thresholds
+            .validate()
+            .expect("score thresholds must validate");
+
+        // The load-bearing invariant: an unknown peer (no app score
+        // pushed) sits at exactly 0, which must be at or above every
+        // gating cutoff so it is never gossip-/publish-suppressed or
+        // graylisted for merely being unverified.
+        assert!(0.0 >= thresholds.gossip_threshold);
+        assert!(0.0 >= thresholds.publish_threshold);
+        assert!(0.0 >= thresholds.graylist_threshold);
+
+        // Only the app-specific signal contributes — no per-topic traffic
+        // scoring and no behaviour/IP/slow penalties that could
+        // false-penalize an honest peer on a quiet topic.
+        assert!(params.topics.is_empty());
+        assert_eq!(params.ip_colocation_factor_weight, 0.0);
+        assert_eq!(params.behaviour_penalty_weight, 0.0);
+        assert_eq!(params.slow_peer_weight, 0.0);
     }
 }

--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -19,6 +19,7 @@ mod query_blob;
 mod request_blob;
 mod send_specialized_node_invitation_response;
 mod send_specialized_node_verification_request;
+mod set_peer_score;
 mod subscribe;
 mod subscribed_peers;
 mod unsubscribe;
@@ -38,6 +39,9 @@ impl Handler<NetworkMessage> for NetworkManager {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::Subscribe { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::SetPeerScore { request, outcome } => {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::Unsubscribe { request, outcome } => {

--- a/crates/network/src/handlers/commands/set_peer_score.rs
+++ b/crates/network/src/handlers/commands/set_peer_score.rs
@@ -1,0 +1,24 @@
+use actix::{Context, Handler, Message};
+use calimero_network_primitives::messages::SetPeerScore;
+
+use crate::NetworkManager;
+
+impl Handler<SetPeerScore> for NetworkManager {
+    type Result = <SetPeerScore as Message>::Result;
+
+    fn handle(
+        &mut self,
+        SetPeerScore { peer_id, score }: SetPeerScore,
+        _ctx: &mut Context<Self>,
+    ) -> Self::Result {
+        // `set_application_score` returns false when peer scoring isn't
+        // active or the peer isn't in the score book yet — both benign:
+        // scoring is always enabled here, and a not-yet-known peer picks
+        // up its score when it next (re)connects and the node re-pushes.
+        let _applied = self
+            .swarm
+            .behaviour_mut()
+            .gossipsub
+            .set_application_score(&peer_id, score);
+    }
+}

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -105,6 +105,37 @@ pub(crate) struct ResolvedMember {
     pub(crate) peers: Vec<PeerId>,
 }
 
+/// How strongly to bias the gossipsub mesh toward a peer (#2513),
+/// derived from the verified role of a member identity it hosts. `Ord`
+/// ranks `Anchor` above `Member`, so a peer hosting several members is
+/// scored at its strongest tier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PeerScoreTier {
+    Member,
+    Anchor,
+}
+
+impl PeerScoreTier {
+    /// Tier for a member's observed role: `Admin`/`ReadOnlyTee` are the
+    /// trusted-anchor roles, `Member`/`ReadOnly` are plain members.
+    pub(crate) fn from_role(role: &GroupMemberRole) -> Self {
+        match role {
+            GroupMemberRole::Admin | GroupMemberRole::ReadOnlyTee => Self::Anchor,
+            GroupMemberRole::Member | GroupMemberRole::ReadOnly => Self::Member,
+        }
+    }
+
+    /// The gossipsub application-specific score for this tier. Both are
+    /// positive (above every gating threshold); anchors score higher so
+    /// mesh maintenance prefers them for slots.
+    pub(crate) fn score(self) -> f64 {
+        match self {
+            Self::Anchor => 20.0,
+            Self::Member => 10.0,
+        }
+    }
+}
+
 /// In-memory member-identity cache: one bucket per group, snapshotted to
 /// disk per group by the node layer.
 #[derive(Default, Debug)]

--- a/crates/node/src/peer_identity_cache.rs
+++ b/crates/node/src/peer_identity_cache.rs
@@ -487,6 +487,18 @@ mod tests {
     }
 
     #[test]
+    fn peer_score_tier_ranks_anchor_above_member() {
+        // The reconciler picks a peer's strongest tier via `Ord`/`max`, so
+        // pin the ordering (the derive relies on declaration order).
+        assert!(PeerScoreTier::Anchor > PeerScoreTier::Member);
+        assert_eq!(
+            PeerScoreTier::Member.max(PeerScoreTier::Anchor),
+            PeerScoreTier::Anchor
+        );
+        assert!(PeerScoreTier::Anchor.score() > PeerScoreTier::Member.score());
+    }
+
+    #[test]
     fn record_inserts_and_refreshes_last_seen() {
         let mut c = PeerIdentityCache::default();
         c.record(group(1), pk(1), peer(1), GroupMemberRole::Member, 100);

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -8,15 +8,19 @@
 //! signal survives a restart so anchor-preferred sync selection works on
 //! a cold cache instead of falling back to random topic subscribers.
 
+use std::collections::BTreeMap;
+
 use calimero_context_config::types::ContextGroupId;
 use calimero_governance_store::op_events::{self, OpEvent};
+use calimero_network_primitives::client::NetworkClient;
 use calimero_store::key::Generic as GenericKey;
 use calimero_store::slice::Slice;
 use calimero_store::types::GenericData;
 use calimero_store::Store;
+use libp2p::PeerId;
 use tracing::{debug, info, warn};
 
-use crate::peer_identity_cache::{PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
+use crate::peer_identity_cache::{PeerIdentityCache, PeerScoreTier, PEER_IDENTITY_TTL_SECS};
 use crate::state::{now_unix_secs, NodeState};
 
 /// How often the snapshot tick writes the cache to disk. Matches the
@@ -119,7 +123,11 @@ pub(crate) fn hydrate(state: &NodeState, store: &Store) {
 /// dropping it does not cancel the task (tokio detaches it), which runs
 /// until the runtime is dropped. A future graceful shutdown could
 /// `abort()` it.
-pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task::JoinHandle<()> {
+pub(crate) fn spawn_snapshot_tick(
+    state: NodeState,
+    store: Store,
+    network: NetworkClient,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(SNAPSHOT_INTERVAL);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -131,8 +139,71 @@ pub(crate) fn spawn_snapshot_tick(state: NodeState, store: Store) -> tokio::task
         loop {
             let _ = interval.tick().await;
             persist(&state, &store);
+            reconcile_peer_scores(&state, &network);
         }
     })
+}
+
+/// Diff the desired per-peer gossipsub score tier (derived from the
+/// cache) against the last-pushed tracker (#2513). Returns the peers
+/// whose tier changed (with the new tier) and the peers that dropped out
+/// of the cache entirely (to be cleared to 0). Pure and transition-
+/// guarded: an unchanged peer produces no update. The caller does the
+/// network pushes and tracker mutation.
+fn compute_score_updates(
+    cache: &PeerIdentityCache,
+    tracker: &BTreeMap<PeerId, PeerScoreTier>,
+    now_secs: u64,
+    ttl_secs: u64,
+) -> (Vec<(PeerId, PeerScoreTier)>, Vec<PeerId>) {
+    // Desired tier per peer = the strongest tier across every group/member
+    // it currently hosts.
+    let mut desired: BTreeMap<PeerId, PeerScoreTier> = BTreeMap::new();
+    for group in cache.groups() {
+        for member in cache.members_for_group(group, now_secs, ttl_secs) {
+            let tier = PeerScoreTier::from_role(&member.role);
+            for peer in member.peers {
+                let entry = desired.entry(peer).or_insert(tier);
+                *entry = (*entry).max(tier);
+            }
+        }
+    }
+    let pushes = desired
+        .iter()
+        .filter(|(peer, tier)| tracker.get(peer) != Some(tier))
+        .map(|(peer, tier)| (*peer, *tier))
+        .collect();
+    let clears = tracker
+        .keys()
+        .filter(|peer| !desired.contains_key(peer))
+        .copied()
+        .collect();
+    (pushes, clears)
+}
+
+/// Reconcile gossipsub peer scores against current cached membership and
+/// push the deltas to the network layer (#2513). Runs on the snapshot
+/// tick: new/upgraded members get a positive score, members that left
+/// the cache (removed via `MemberRemoved`, or aged out) get cleared to 0.
+fn reconcile_peer_scores(state: &NodeState, network: &NetworkClient) {
+    let now = now_unix_secs();
+    let (pushes, clears) = {
+        let cache = state.lock_peer_identity_cache();
+        let tracker = state.lock_peer_scores();
+        compute_score_updates(&cache, &tracker, now, PEER_IDENTITY_TTL_SECS)
+    };
+    if pushes.is_empty() && clears.is_empty() {
+        return;
+    }
+    let mut tracker = state.lock_peer_scores();
+    for (peer, tier) in pushes {
+        network.set_peer_score(peer, tier.score());
+        let _ = tracker.insert(peer, tier);
+    }
+    for peer in clears {
+        network.set_peer_score(peer, 0.0);
+        let _ = tracker.remove(&peer);
+    }
 }
 
 /// Apply one op-apply event to the cache. Currently only `MemberRemoved`
@@ -215,6 +286,53 @@ mod tests {
 
     fn store() -> Store {
         Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    #[test]
+    fn compute_score_updates_diffs_desired_against_tracker() {
+        let mut cache = PeerIdentityCache::default();
+        let group = ContextGroupId::from([1u8; 32]);
+        let admin_peer = PeerId::random();
+        let member_peer = PeerId::random();
+        cache.record(
+            group,
+            PublicKey::from([1u8; 32]),
+            admin_peer,
+            GroupMemberRole::Admin,
+            100,
+        );
+        cache.record(
+            group,
+            PublicKey::from([2u8; 32]),
+            member_peer,
+            GroupMemberRole::Member,
+            100,
+        );
+
+        // Empty tracker → both peers are fresh pushes at their tiers.
+        let empty = BTreeMap::new();
+        let (pushes, clears) = compute_score_updates(&cache, &empty, 100, 1000);
+        let pushed: BTreeMap<_, _> = pushes.into_iter().collect();
+        assert_eq!(pushed.get(&admin_peer), Some(&PeerScoreTier::Anchor));
+        assert_eq!(pushed.get(&member_peer), Some(&PeerScoreTier::Member));
+        assert!(clears.is_empty());
+
+        // Tracker already matches → no pushes (transition guard).
+        let matched = BTreeMap::from([
+            (admin_peer, PeerScoreTier::Anchor),
+            (member_peer, PeerScoreTier::Member),
+        ]);
+        let (pushes, clears) = compute_score_updates(&cache, &matched, 100, 1000);
+        assert!(pushes.is_empty(), "unchanged tiers produce no push");
+        assert!(clears.is_empty());
+
+        // A peer the tracker scored but the cache no longer holds → clear.
+        let stranger = PeerId::random();
+        let mut stale = matched.clone();
+        let _ = stale.insert(stranger, PeerScoreTier::Member);
+        let (pushes, clears) = compute_score_updates(&cache, &stale, 100, 1000);
+        assert!(pushes.is_empty());
+        assert_eq!(clears, vec![stranger], "dropped peer is cleared");
     }
 
     #[test]

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -136,28 +136,34 @@ pub(crate) fn spawn_snapshot_tick(
         // yet at startup, and `persist` would just no-op on the empty
         // cache anyway).
         let _ = interval.tick().await;
+        let mut ticks: u64 = 0;
         loop {
             let _ = interval.tick().await;
             persist(&state, &store);
-            reconcile_peer_scores(&state, &network);
+            // Transition-guarded diff most ticks; a full re-push every
+            // `SCORE_FULL_RESYNC_TICKS` to re-converge gossipsub's
+            // connection-scoped scores (see `reconcile_peer_scores`).
+            ticks = ticks.wrapping_add(1);
+            let force_full = ticks % SCORE_FULL_RESYNC_TICKS == 0;
+            reconcile_peer_scores(&state, &network, force_full);
         }
     })
 }
 
-/// Diff the desired per-peer gossipsub score tier (derived from the
-/// cache) against the last-pushed tracker (#2513). Returns the peers
-/// whose tier changed (with the new tier) and the peers that dropped out
-/// of the cache entirely (to be cleared to 0). Pure and transition-
-/// guarded: an unchanged peer produces no update. The caller does the
-/// network pushes and tracker mutation.
-fn compute_score_updates(
+/// Re-push every desired peer score (not just transitions) once every N
+/// snapshot ticks, to recover any drift from gossipsub's
+/// connection-scoped scores. At a 30s tick, 20 ≈ every 10 minutes —
+/// cheap (a handful of `do_send`s) and well off the hot path.
+const SCORE_FULL_RESYNC_TICKS: u64 = 20;
+
+/// Desired gossipsub score tier per peer, derived from current cached
+/// membership: each peer's tier is the strongest across every group /
+/// member identity it hosts.
+fn desired_score_tiers(
     cache: &PeerIdentityCache,
-    tracker: &BTreeMap<PeerId, PeerScoreTier>,
     now_secs: u64,
     ttl_secs: u64,
-) -> (Vec<(PeerId, PeerScoreTier)>, Vec<PeerId>) {
-    // Desired tier per peer = the strongest tier across every group/member
-    // it currently hosts.
+) -> BTreeMap<PeerId, PeerScoreTier> {
     let mut desired: BTreeMap<PeerId, PeerScoreTier> = BTreeMap::new();
     for group in cache.groups() {
         for member in cache.members_for_group(group, now_secs, ttl_secs) {
@@ -168,9 +174,22 @@ fn compute_score_updates(
             }
         }
     }
+    desired
+}
+
+/// Diff `desired` against the last-pushed `tracker`. Returns the peers to
+/// (re)push (with their tier) and the peers to clear to 0 (tracked but no
+/// longer desired). Pure. With `force_full`, every desired peer is
+/// re-pushed regardless of the tracker — the periodic self-heal (see
+/// `reconcile_peer_scores`).
+fn compute_score_updates(
+    desired: &BTreeMap<PeerId, PeerScoreTier>,
+    tracker: &BTreeMap<PeerId, PeerScoreTier>,
+    force_full: bool,
+) -> (Vec<(PeerId, PeerScoreTier)>, Vec<PeerId>) {
     let pushes = desired
         .iter()
-        .filter(|(peer, tier)| tracker.get(peer) != Some(tier))
+        .filter(|(peer, tier)| force_full || tracker.get(peer) != Some(tier))
         .map(|(peer, tier)| (*peer, *tier))
         .collect();
     let clears = tracker
@@ -182,27 +201,46 @@ fn compute_score_updates(
 }
 
 /// Reconcile gossipsub peer scores against current cached membership and
-/// push the deltas to the network layer (#2513). Runs on the snapshot
-/// tick: new/upgraded members get a positive score, members that left
-/// the cache (removed via `MemberRemoved`, or aged out) get cleared to 0.
-fn reconcile_peer_scores(state: &NodeState, network: &NetworkClient) {
+/// push the deltas to the network layer (#2513). New/upgraded members get
+/// a positive score; members that left the cache (removed via
+/// `MemberRemoved` or TTL-aged) are cleared to 0.
+///
+/// `force_full` re-pushes every desired score regardless of the tracker.
+/// gossipsub's app score is connection-scoped (dropped when a peer
+/// disconnects) and `set_application_score` is a fire-and-forget
+/// `do_send` we can't observe the result of, so the tracker can drift
+/// from what gossipsub actually holds (a member that reconnected, or a
+/// push applied before the peer was in the score book). The snapshot tick
+/// runs the cheap transition-guarded diff most ticks and a periodic
+/// `force_full` to re-converge — scores are best-effort hints, so this
+/// eventual consistency is sufficient.
+///
+/// Locking: the cache and tracker are each locked only for synchronous
+/// computation/mutation; the network pushes happen with no lock held.
+pub(crate) fn reconcile_peer_scores(state: &NodeState, network: &NetworkClient, force_full: bool) {
     let now = now_unix_secs();
-    let (pushes, clears) = {
+    let desired = {
         let cache = state.lock_peer_identity_cache();
-        let tracker = state.lock_peer_scores();
-        compute_score_updates(&cache, &tracker, now, PEER_IDENTITY_TTL_SECS)
+        desired_score_tiers(&cache, now, PEER_IDENTITY_TTL_SECS)
     };
-    if pushes.is_empty() && clears.is_empty() {
-        return;
-    }
-    let mut tracker = state.lock_peer_scores();
+    // Diff and update the tracker to the new desired state under one lock
+    // pass (no gap, no network I/O held across the lock).
+    let (pushes, clears) = {
+        let mut tracker = state.lock_peer_scores();
+        let (pushes, clears) = compute_score_updates(&desired, &tracker, force_full);
+        for peer in &clears {
+            let _ = tracker.remove(peer);
+        }
+        for (peer, tier) in &pushes {
+            let _ = tracker.insert(*peer, *tier);
+        }
+        (pushes, clears)
+    };
     for (peer, tier) in pushes {
         network.set_peer_score(peer, tier.score());
-        let _ = tracker.insert(peer, tier);
     }
     for peer in clears {
         network.set_peer_score(peer, 0.0);
-        let _ = tracker.remove(&peer);
     }
 }
 
@@ -309,9 +347,11 @@ mod tests {
             100,
         );
 
+        let desired = desired_score_tiers(&cache, 100, 1000);
+
         // Empty tracker → both peers are fresh pushes at their tiers.
         let empty = BTreeMap::new();
-        let (pushes, clears) = compute_score_updates(&cache, &empty, 100, 1000);
+        let (pushes, clears) = compute_score_updates(&desired, &empty, false);
         let pushed: BTreeMap<_, _> = pushes.into_iter().collect();
         assert_eq!(pushed.get(&admin_peer), Some(&PeerScoreTier::Anchor));
         assert_eq!(pushed.get(&member_peer), Some(&PeerScoreTier::Member));
@@ -322,15 +362,19 @@ mod tests {
             (admin_peer, PeerScoreTier::Anchor),
             (member_peer, PeerScoreTier::Member),
         ]);
-        let (pushes, clears) = compute_score_updates(&cache, &matched, 100, 1000);
+        let (pushes, clears) = compute_score_updates(&desired, &matched, false);
         assert!(pushes.is_empty(), "unchanged tiers produce no push");
         assert!(clears.is_empty());
+
+        // force_full re-pushes everything regardless of the tracker.
+        let (pushes, _) = compute_score_updates(&desired, &matched, true);
+        assert_eq!(pushes.len(), 2, "force_full re-pushes all desired peers");
 
         // A peer the tracker scored but the cache no longer holds → clear.
         let stranger = PeerId::random();
         let mut stale = matched.clone();
         let _ = stale.insert(stranger, PeerScoreTier::Member);
-        let (pushes, clears) = compute_score_updates(&cache, &stale, 100, 1000);
+        let (pushes, clears) = compute_score_updates(&desired, &stale, false);
         assert!(pushes.is_empty());
         assert_eq!(clears, vec![stranger], "dropped peer is cleared");
     }

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -232,6 +232,9 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     // membership signal on a cold cache instead of waiting for live
     // traffic to refill it. Then snapshot it back periodically.
     crate::peer_identity_persist::hydrate(&node_state, &datastore);
+    // Apply gossipsub scores for the just-hydrated members immediately,
+    // rather than waiting for the first snapshot tick (~30s).
+    crate::peer_identity_persist::reconcile_peer_scores(&node_state, &network_client, true);
     let _peer_identity_tick = crate::peer_identity_persist::spawn_snapshot_tick(
         node_state.clone(),
         datastore.clone(),

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -232,8 +232,11 @@ pub async fn start(config: NodeConfig) -> eyre::Result<()> {
     // membership signal on a cold cache instead of waiting for live
     // traffic to refill it. Then snapshot it back periodically.
     crate::peer_identity_persist::hydrate(&node_state, &datastore);
-    let _peer_identity_tick =
-        crate::peer_identity_persist::spawn_snapshot_tick(node_state.clone(), datastore.clone());
+    let _peer_identity_tick = crate::peer_identity_persist::spawn_snapshot_tick(
+        node_state.clone(),
+        datastore.clone(),
+        network_client.clone(),
+    );
     // Drop removed members from the cache promptly on `MemberRemoved`,
     // rather than waiting for their entries to age out via TTL.
     let _peer_identity_invalidation =

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -18,7 +18,9 @@ use tracing::{debug, warn};
 
 use crate::constants;
 use crate::delta_store::DeltaStore;
-use crate::peer_identity_cache::{ObservedMembership, PeerIdentityCache, PEER_IDENTITY_TTL_SECS};
+use crate::peer_identity_cache::{
+    ObservedMembership, PeerIdentityCache, PeerScoreTier, PEER_IDENTITY_TTL_SECS,
+};
 use crate::run::NodeMode;
 use crate::specialized_node_invite_state::{
     new_pending_specialized_node_invites, PendingSpecializedNodeInvites,
@@ -170,6 +172,12 @@ pub(crate) struct NodeState {
     /// `observe_peer_identity` gate, and never a trust gate — see that
     /// field's trust-model docs.
     pub(crate) peer_identity_cache: Arc<Mutex<PeerIdentityCache>>,
+    /// Last gossipsub app-specific score tier pushed to the network layer
+    /// per peer (#2513). The reconciler on the snapshot tick diffs the
+    /// desired tiers (derived from `peer_identity_cache`) against this and
+    /// pushes only the changes, so a peer's score is updated on a
+    /// membership *transition* rather than on every observed op.
+    pub(crate) peer_scores: Arc<Mutex<BTreeMap<PeerId, PeerScoreTier>>>,
     /// Per-context reconcile-after-divergence attempt state. Used by the
     /// sync manager to apply exponential backoff between successive
     /// reconcile attempts for the same context, so a persistently
@@ -238,6 +246,7 @@ impl NodeState {
             governance_pending: Arc::new(DashMap::new()),
             peer_identities: Arc::new(DashMap::new()),
             peer_identity_cache: Arc::new(Mutex::new(PeerIdentityCache::default())),
+            peer_scores: Arc::new(Mutex::new(BTreeMap::new())),
             reconcile_attempts: Arc::new(DashMap::new()),
             sync_status: Arc::new(DashMap::new()),
         }
@@ -299,6 +308,15 @@ impl NodeState {
     /// across synchronous work (no `.await` in scope).
     pub(crate) fn lock_peer_identity_cache(&self) -> MutexGuard<'_, PeerIdentityCache> {
         self.peer_identity_cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Lock the per-peer score-tier tracker, recovering a poisoned guard
+    /// (same rationale as `lock_peer_identity_cache`). Held only across
+    /// synchronous work in the score reconciler.
+    pub(crate) fn lock_peer_scores(&self) -> MutexGuard<'_, BTreeMap<PeerId, PeerScoreTier>> {
+        self.peer_scores
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
     }


### PR DESCRIPTION
## What

PR **2 of 2** for #2513. Stacked on #2722 (PR 1). Wires the node's verified-member signal — durable since #2642 — into the gossipsub peer scoring PR 1 enabled.

## How — reconcile on the snapshot tick (transition-guarded)

Rather than pushing a score on every observed op (hot path), scores are **reconciled on the existing 30s peer-identity snapshot tick** by diffing the desired tiers (derived from the durable cache) against a tracker, and pushing only the deltas. This handles add *and* remove uniformly via the cache diff — no hot-path push, no separate clear path:

- **`PeerScoreTier { Member, Anchor }`** — `Anchor` = `Admin`/`ReadOnlyTee` (the `trusted_anchors` roles), `Member` = `Member`/`ReadOnly`. Scores: Anchor 20, Member 10 — both positive, above every gating threshold. A peer hosting several members is scored at its strongest tier.
- **`NodeState.peer_scores`** tracks the last tier pushed per peer.
- **`reconcile_peer_scores`** (on the tick): new/upgraded members get a positive score; members that left the cache (removed via `MemberRemoved`, or TTL-aged) are cleared to 0. The diff logic is a pure, unit-tested `compute_score_updates`.

A peer's score thus changes only on a **membership transition**, at most once per tick — no per-op churn. Cold-start peers never get scored negative (the issue's requirement); unknown stays at 0.

## Testing

25 `calimero-node` lib tests pass (+1: `compute_score_updates_diffs_desired_against_tracker` — fresh push, transition no-op, clear-on-drop). fmt + clippy clean.

## Result (#2513 complete with PR 1)

Soft scoring end-to-end: the gossipsub mesh now biases slot occupancy + gossip toward verified members/anchors, derived purely from our membership knowledge. (Per scope discussion: `flood_publish` means broadcast still reaches all subscribers; this hardens mesh maintenance, not the publish path. The `add_explicit_peer` hard lever is intentionally out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gossipsub mesh maintenance behavior for all nodes and depends on best-effort score reconciliation; mis-tuned tiers could skew mesh preference but the design only boosts verified peers and never graylists unknowns at 0.
> 
> **Overview**
> Completes **#2513** by pushing **verified membership** from the durable peer-identity cache into gossipsub **application-specific peer scores**, so mesh graft/prune prefers anchors and members without penalizing unknown peers (score stays at 0).
> 
> The **network** stack adds a fire-and-forget `SetPeerScore` command that calls `gossipsub::set_application_score`, and enables peer scoring at swarm build with **`membership_peer_score_config`** (app weight only; traffic/behavior penalties zeroed) plus a unit test that unknown peers sit above gating thresholds.
> 
> The **node** derives **`PeerScoreTier`** (Anchor 20 / Member 10 from `Admin`/`ReadOnlyTee` vs `Member`/`ReadOnly`), tracks last-pushed tiers in **`NodeState.peer_scores`**, and **`reconcile_peer_scores`** on the existing 30s identity snapshot tick: transition-guarded diffs most ticks, periodic full re-push (~10 min), clears scores when members leave the cache. Startup runs a **full reconcile** right after cache hydrate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ed0dbd6e9d62887fe38fb8061815f8a72e5ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->