### PR TITLE
refactor(node/sync): extract handshake submodule from the manager god-file (increment 3)

### DIFF
--- a/crates/node/src/sync/manager/handshake.rs
+++ b/crates/node/src/sync/manager/handshake.rs
@@ -1,0 +1,98 @@
+//! Sync handshake construction for [`SyncManager`]: building the local and
+//! remote `SyncHandshake` summaries (entity count + tree depth, with a
+//! DAG-heads fallback) used for protocol negotiation. Extracted from the
+//! manager god-file as an `impl SyncManager` fragment.
+
+use calimero_node_primitives::sync::{
+    build_handshake_from_raw, estimate_entity_count, estimate_max_depth, SyncHandshake,
+};
+use calimero_primitives::common::DIGEST_SIZE;
+use calimero_primitives::context::ContextId;
+
+use super::SyncManager;
+
+impl SyncManager {
+    /// Build `SyncHandshake` from local context state for protocol negotiation.
+    ///
+    /// Queries the real entity count and tree depth from the Merkle tree Index
+    /// via the storage bridge. Falls back to estimation from DAG heads if the
+    /// Index is not accessible (e.g., after snapshot sync with format mismatch).
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - The context to build a handshake for.
+    ///
+    /// # Returns
+    ///
+    /// A `SyncHandshake` containing the context's current state summary.
+    pub(super) fn build_local_handshake(
+        &self,
+        context: &calimero_primitives::context::Context,
+    ) -> SyncHandshake {
+        let root_hash = *context.root_hash;
+        let dag_heads = context.dag_heads.clone();
+
+        // Try to get real entity count and depth from the Merkle tree Index.
+        // This gives accurate protocol selection instead of guessing from dag_heads.
+        let (entity_count, max_depth) = self.query_tree_stats(&context.id).unwrap_or_else(|| {
+            // Fallback: estimate from dag_heads if Index is unavailable
+            let count = estimate_entity_count(root_hash, dag_heads.len());
+            let depth = estimate_max_depth(count);
+            (count, depth)
+        });
+
+        build_handshake_from_raw(root_hash, entity_count, max_depth, dag_heads)
+    }
+
+    /// Query real entity count and tree depth from the Merkle tree Index.
+    ///
+    /// Returns `Some((entity_count, max_depth))` on success, `None` if the
+    /// Index is unavailable (e.g., fresh node or deserialization mismatch).
+    fn query_tree_stats(&self, context_id: &ContextId) -> Option<(u64, u32)> {
+        use calimero_node_primitives::sync::create_runtime_env;
+        use calimero_storage::address::Id;
+        use calimero_storage::env::with_runtime_env;
+        use calimero_storage::index::Index;
+        use calimero_storage::store::MainStorage;
+
+        let store = self.context_client.datastore_handle().into_inner();
+        // SAFETY: identity is unused for read-only Index queries via RuntimeEnv
+        let identity = calimero_primitives::identity::PublicKey::from([0u8; 32]);
+        let env = create_runtime_env(&store, *context_id, identity);
+
+        let root_id = Id::new(*context_id.as_ref());
+
+        with_runtime_env(env, || {
+            // Check if root Index exists
+            let root_index = Index::<MainStorage>::get_index(root_id).ok().flatten()?;
+
+            // Count children (leaf entities) under root.
+            // Minimum 1 when root exists (consistent with fallback estimation).
+            let children = root_index.children().unwrap_or_default();
+            let entity_count = (children.len() as u64).max(1);
+
+            // Depth: 1 when root has data (consistent with fallback).
+            // For deeper trees, we'd need recursive traversal — tracked in #2054.
+            let max_depth = 1;
+
+            Some((entity_count, max_depth))
+        })
+    }
+
+    /// Build `SyncHandshake` from peer state for protocol negotiation.
+    ///
+    /// Uses shared estimation functions from `calimero_node_primitives::sync::state_machine`
+    /// to ensure consistent behavior between production (`SyncManager`) and simulation (`SimNode`).
+    pub(super) fn build_remote_handshake(
+        peer_root_hash: calimero_primitives::hash::Hash,
+        peer_dag_heads: &[[u8; DIGEST_SIZE]],
+    ) -> SyncHandshake {
+        let root_hash = *peer_root_hash;
+
+        // Use shared estimation functions for consistency with simulation
+        let entity_count = estimate_entity_count(root_hash, peer_dag_heads.len());
+        let max_depth = estimate_max_depth(entity_count);
+
+        build_handshake_from_raw(root_hash, entity_count, max_depth, peer_dag_heads.to_vec())
+    }
+}

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -37,10 +37,7 @@ use super::config::SyncConfig;
 // to `super::protocol_selector` (Phase 4). The run-loop + select! body
 // moved to `super::driver` (Phase 5). `SyncProtocol` from primitives is
 // still referenced here for protocol-selection types.
-use calimero_node_primitives::sync::{
-    build_handshake_from_raw, estimate_entity_count, estimate_max_depth, select_protocol,
-    SyncHandshake, SyncProtocol,
-};
+use calimero_node_primitives::sync::{select_protocol, SyncProtocol};
 
 /// Typed marker returned by [`SyncManager::recv`] when the responder
 /// indicates the context is not materialised locally on the receiving
@@ -348,90 +345,6 @@ impl SyncManager {
             Some(m) => m,
             None => NOOP.get_or_init(super::metrics::NoOpMetrics::default),
         }
-    }
-
-    /// Build `SyncHandshake` from local context state for protocol negotiation.
-    ///
-    /// Queries the real entity count and tree depth from the Merkle tree Index
-    /// via the storage bridge. Falls back to estimation from DAG heads if the
-    /// Index is not accessible (e.g., after snapshot sync with format mismatch).
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - The context to build a handshake for.
-    ///
-    /// # Returns
-    ///
-    /// A `SyncHandshake` containing the context's current state summary.
-    fn build_local_handshake(
-        &self,
-        context: &calimero_primitives::context::Context,
-    ) -> SyncHandshake {
-        let root_hash = *context.root_hash;
-        let dag_heads = context.dag_heads.clone();
-
-        // Try to get real entity count and depth from the Merkle tree Index.
-        // This gives accurate protocol selection instead of guessing from dag_heads.
-        let (entity_count, max_depth) = self.query_tree_stats(&context.id).unwrap_or_else(|| {
-            // Fallback: estimate from dag_heads if Index is unavailable
-            let count = estimate_entity_count(root_hash, dag_heads.len());
-            let depth = estimate_max_depth(count);
-            (count, depth)
-        });
-
-        build_handshake_from_raw(root_hash, entity_count, max_depth, dag_heads)
-    }
-
-    /// Query real entity count and tree depth from the Merkle tree Index.
-    ///
-    /// Returns `Some((entity_count, max_depth))` on success, `None` if the
-    /// Index is unavailable (e.g., fresh node or deserialization mismatch).
-    fn query_tree_stats(&self, context_id: &ContextId) -> Option<(u64, u32)> {
-        use calimero_node_primitives::sync::create_runtime_env;
-        use calimero_storage::address::Id;
-        use calimero_storage::env::with_runtime_env;
-        use calimero_storage::index::Index;
-        use calimero_storage::store::MainStorage;
-
-        let store = self.context_client.datastore_handle().into_inner();
-        // SAFETY: identity is unused for read-only Index queries via RuntimeEnv
-        let identity = calimero_primitives::identity::PublicKey::from([0u8; 32]);
-        let env = create_runtime_env(&store, *context_id, identity);
-
-        let root_id = Id::new(*context_id.as_ref());
-
-        with_runtime_env(env, || {
-            // Check if root Index exists
-            let root_index = Index::<MainStorage>::get_index(root_id).ok().flatten()?;
-
-            // Count children (leaf entities) under root.
-            // Minimum 1 when root exists (consistent with fallback estimation).
-            let children = root_index.children().unwrap_or_default();
-            let entity_count = (children.len() as u64).max(1);
-
-            // Depth: 1 when root has data (consistent with fallback).
-            // For deeper trees, we'd need recursive traversal — tracked in #2054.
-            let max_depth = 1;
-
-            Some((entity_count, max_depth))
-        })
-    }
-
-    /// Build `SyncHandshake` from peer state for protocol negotiation.
-    ///
-    /// Uses shared estimation functions from `calimero_node_primitives::sync::state_machine`
-    /// to ensure consistent behavior between production (`SyncManager`) and simulation (`SimNode`).
-    fn build_remote_handshake(
-        peer_root_hash: calimero_primitives::hash::Hash,
-        peer_dag_heads: &[[u8; DIGEST_SIZE]],
-    ) -> SyncHandshake {
-        let root_hash = *peer_root_hash;
-
-        // Use shared estimation functions for consistency with simulation
-        let entity_count = estimate_entity_count(root_hash, peer_dag_heads.len());
-        let max_depth = estimate_max_depth(entity_count);
-
-        build_handshake_from_raw(root_hash, entity_count, max_depth, peer_dag_heads.to_vec())
     }
 
     /// Run the sync-manager actor loop until the input channels close.
@@ -3239,6 +3152,7 @@ impl super::driver::SyncDriverDispatch for SyncManager {
 // `super::peers::partition_peers_anchor_first`.
 
 mod blob_fetch;
+mod handshake;
 mod namespace_join;
 mod namespace_sync;
 


### PR DESCRIPTION
## What

Increment 3 of splitting `sync/manager/mod.rs`. Moves the sync-handshake construction cluster into `handshake.rs` — pure, behavior-preserving code movement (`mod.rs`: −88 / +2; the +2 is `mod handshake;` plus collapsing the now-shorter `calimero_node_primitives::sync` import).

Moved (an `impl SyncManager` fragment):
- `build_local_handshake`, `build_remote_handshake` — `pub(super)` (called from the protocol-negotiation flow in mod.rs)
- `query_tree_stats` — private (used only within the cluster)

Also drops the `build_handshake_from_raw` / `estimate_entity_count` / `estimate_max_depth` / `SyncHandshake` imports from mod.rs that only the moved methods used.

## Validation

- `cargo check -p calimero-node` clean (no new warnings).
- node lib tests: **333 passed**.
- node `sync_sim`: **314 passed**.

## Progress

`sync/manager/mod.rs`: ~3250 → ~3165 LOC. Submodules: `namespace_join` / `namespace_sync` / `blob_fetch` / `handshake`.

**Remaining to finish the split:** the big one — decomposing the ~480-line `internal_handle_opened_stream` dispatcher (the original headline god-function). That'll be its own focused increment (extracting per-message-type handlers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure code movement with no logic changes; handshake behavior and protocol selection paths are unchanged.
> 
> **Overview**
> **Increment 3** of shrinking `sync/manager/mod.rs`: sync handshake construction now lives in a dedicated `handshake.rs` submodule instead of the manager module file.
> 
> The moved `impl SyncManager` helpers are **`build_local_handshake`** and **`build_remote_handshake`** (`pub(super)` for protocol negotiation in `handle_dag_sync`), plus private **`query_tree_stats`** (Merkle Index reads with DAG-head estimation fallback). `mod.rs` only adds `mod handshake;` and drops handshake-only imports from `calimero_node_primitives::sync`.
> 
> This is a **behavior-preserving move**—no changes to handshake logic or call sites beyond the module split (~88 lines out of `mod.rs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb946c83a12a5586399125bc179cfa54e7ff7f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->