### PR TITLE
refactor(node/sync): extract inbound member-authorization out of internal_handle_opened_stream

### DIFF
--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2725,6 +2725,90 @@ impl SyncManager {
         }
     }
 
+    /// Authorize the dialing peer as a sync-eligible member of `context_id` —
+    /// direct context/group membership, or inheritance-eligible parent
+    /// membership (`Open` subgroups). On an unknown member, refresh context
+    /// config and request a one-shot governance catch-up from the peer before
+    /// giving up. Returns `Ok(false)` (caller should close the stream) only if
+    /// the peer is still unauthorized afterward.
+    async fn verify_inbound_member(
+        &self,
+        context_id: ContextId,
+        their_identity: PublicKey,
+        peer_id: PeerId,
+    ) -> eyre::Result<bool> {
+        let mut _updated = None;
+
+        // Issue #2256: also accept inheritance-eligible parent members
+        // for sync auth. `has_member` only knows direct context-membership
+        // and direct group-membership; the parent-walk for `Open` subgroups
+        // lives in `calimero-context::group_store`, which we have access
+        // to here at the node layer.
+        let is_inherited_member = || -> eyre::Result<bool> {
+            let store = self.context_client.datastore();
+            let Some(group_id) =
+                calimero_context::group_store::get_group_for_context(store, &context_id)?
+            else {
+                return Ok(false);
+            };
+            MembershipRepository::new(store).is_member(&group_id, &their_identity)
+        };
+
+        if !self
+            .context_client
+            .has_member(&context_id, &their_identity)?
+            && !is_inherited_member()?
+        {
+            _updated = Some(
+                self.context_client
+                    .sync_context_config(context_id, None)
+                    .await?,
+            );
+
+            if !self
+                .context_client
+                .has_member(&context_id, &their_identity)?
+                && !is_inherited_member()?
+            {
+                // The peer may have just published MemberAdded for themselves
+                // (or their side of the governance DAG is ahead of ours) and
+                // gossipsub hasn't delivered it yet. Instead of waiting and
+                // hoping the gossip arrives, ask this peer directly for the
+                // current namespace governance state on a separate stream —
+                // it's the fastest path out of the "unknown member" state and
+                // avoids a 30 s stall waiting for `NamespaceStateHeartbeat`.
+                //
+                // Fire-and-forget governance propagation (issue #2237) is the
+                // underlying bug; this is a narrower mitigation in the
+                // responder path that converts the terminal close into an
+                // active catch-up request.
+                self.request_governance_catchup_from_peer(peer_id, &context_id, &their_identity)
+                    .await;
+
+                if !self
+                    .context_client
+                    .has_member(&context_id, &their_identity)?
+                    && !is_inherited_member()?
+                {
+                    // Catch-up didn't resolve it (peer returned nothing, peer
+                    // also doesn't know, or the op chain isn't valid locally).
+                    // Close gracefully — the initiator retries on their next
+                    // sync interval. Demoted from warn to debug because this
+                    // is expected during mesh formation and would otherwise
+                    // spam logs on every cold join.
+                    debug!(
+                        %context_id,
+                        %their_identity,
+                        "unknown context member after namespace backfill request, closing stream"
+                    );
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
     async fn internal_handle_opened_stream(
         &self,
         peer_id: PeerId,
@@ -2800,73 +2884,11 @@ impl SyncManager {
             return Ok(None);
         };
 
-        let mut _updated = None;
-
-        // Issue #2256: also accept inheritance-eligible parent members
-        // for sync auth. `has_member` only knows direct context-membership
-        // and direct group-membership; the parent-walk for `Open` subgroups
-        // lives in `calimero-context::group_store`, which we have access
-        // to here at the node layer.
-        let is_inherited_member = || -> eyre::Result<bool> {
-            let store = self.context_client.datastore();
-            let Some(group_id) =
-                calimero_context::group_store::get_group_for_context(store, &context_id)?
-            else {
-                return Ok(false);
-            };
-            MembershipRepository::new(store).is_member(&group_id, &their_identity)
-        };
-
         if !self
-            .context_client
-            .has_member(&context_id, &their_identity)?
-            && !is_inherited_member()?
+            .verify_inbound_member(context_id, their_identity, peer_id)
+            .await?
         {
-            _updated = Some(
-                self.context_client
-                    .sync_context_config(context_id, None)
-                    .await?,
-            );
-
-            if !self
-                .context_client
-                .has_member(&context_id, &their_identity)?
-                && !is_inherited_member()?
-            {
-                // The peer may have just published MemberAdded for themselves
-                // (or their side of the governance DAG is ahead of ours) and
-                // gossipsub hasn't delivered it yet. Instead of waiting and
-                // hoping the gossip arrives, ask this peer directly for the
-                // current namespace governance state on a separate stream —
-                // it's the fastest path out of the "unknown member" state and
-                // avoids a 30 s stall waiting for `NamespaceStateHeartbeat`.
-                //
-                // Fire-and-forget governance propagation (issue #2237) is the
-                // underlying bug; this is a narrower mitigation in the
-                // responder path that converts the terminal close into an
-                // active catch-up request.
-                self.request_governance_catchup_from_peer(peer_id, &context_id, &their_identity)
-                    .await;
-
-                if !self
-                    .context_client
-                    .has_member(&context_id, &their_identity)?
-                    && !is_inherited_member()?
-                {
-                    // Catch-up didn't resolve it (peer returned nothing, peer
-                    // also doesn't know, or the op chain isn't valid locally).
-                    // Close gracefully — the initiator retries on their next
-                    // sync interval. Demoted from warn to debug because this
-                    // is expected during mesh formation and would otherwise
-                    // spam logs on every cold join.
-                    debug!(
-                        %context_id,
-                        %their_identity,
-                        "unknown context member after namespace backfill request, closing stream"
-                    );
-                    return Ok(Some(()));
-                }
-            }
+            return Ok(Some(()));
         }
 
         // Note: Concurrent syncs are already prevented by SyncState tracking


### PR DESCRIPTION
## What

Second decomposition pass on the inbound-stream dispatcher (follow-up to #2731). The member-authorization guard moves into a `verify_inbound_member` helper.

The guard logic: *is the dialing peer a sync-eligible member of this context — direct, or inheritance-eligible parent membership for `Open` subgroups — and if not, refresh context config and request a one-shot governance catch-up from the peer before giving up.* The dispatcher now reads:

```rust
if !self.verify_inbound_member(context_id, their_identity, peer_id).await? {
    return Ok(Some(()));
}
```

## Behavior-preserving

- Params are `Copy`, so the moved body is verbatim; the lone unauthorized `return Ok(Some(()))` becomes `return Ok(false)`, and the fall-through (authorized) becomes `Ok(true)`.
- Kept in `mod.rs` (same impl block) so it inherits the module's imports.

`internal_handle_opened_stream`: **~350 → ~290 lines** (was ~480 before #2731).

## Validation

- `cargo check -p calimero-node` clean (no new warnings).
- node lib tests: **335 passed**
- node `sync_sim`: **314 passed**

## Note

Function-decomposition pass (readability/testability), not a file-size move — the dispatcher is now ~290 lines of mostly the protocol-dispatch `match`, with the materialization wait (#2731) and member-auth (this PR) factored into named helpers. A later pass could relocate the dispatcher + helpers to an `inbound_stream` submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with explicit behavior parity; only touches inbound stream dispatch structure in `mod.rs`, not auth rules or protocol logic.
> 
> **Overview**
> Pulls inbound sync **member authorization** out of `internal_handle_opened_stream` into a new **`verify_inbound_member`** helper on `SyncManager`, continuing the inbound-stream dispatcher cleanup after materialization wait extraction (#2731).
> 
> The helper keeps the same policy: treat the dialer as allowed if they are a direct context/group member or an **Open** subgroup inheritance-eligible parent member; otherwise refresh context config, optionally run **one-shot governance catch-up** from the peer, and only then decide. **`Ok(true)`** means proceed; **`Ok(false)`** replaces the previous early **`return Ok(Some(()))`** when the peer stays unknown (stream closed gracefully).
> 
> `internal_handle_opened_stream` now calls a single guard instead of ~70 lines of inline checks, shrinking the dispatcher without changing sync auth or catch-up behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1b70d533cfacdda8ea44b4ae92a4b034c99059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->