### PR TITLE
refactor(context/execute): extract upgrade_gate submodule from the execute god-file (increment 2)

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -18,7 +18,7 @@ use calimero_context_config::types::{ContextGroupId, GovernancePosition};
 use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::alias::Alias;
 use calimero_primitives::application::ApplicationId;
-use calimero_primitives::context::{Context, ContextId, UpgradePolicy};
+use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::{
     ContextEvent, ContextEventPayload, ExecutionEvent, NodeEvent, StateMutationPayload,
 };
@@ -26,7 +26,6 @@ use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_runtime::logic::Outcome;
 use calimero_storage::{
-    action::Action,
     delta::{CausalDelta, StorageDelta},
     entities::StorageType,
     env::{with_runtime_env, RuntimeEnv},
@@ -48,16 +47,21 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::ContextError;
 use crate::handlers::update_application::{
-    create_storage_callbacks, update_application_id, update_application_with_migration,
+    update_application_id, update_application_with_migration,
 };
 use crate::ContextManager;
 use calimero_governance_store::metrics::ExecutionLabels;
 
 mod signing;
 pub mod storage;
+mod upgrade_gate;
 
 pub(crate) use signing::{persist_signed_signatures, sign_authorized_actions};
 use storage::{ContextPrivateStorage, ContextStorage, ReadOnlyContextStorage};
+use upgrade_gate::{
+    maybe_lazy_upgrade, resolve_producing_app_key, should_block, upgrade_blocks_write,
+    upgrade_rejects_committed_write,
+};
 
 impl Handler<ExecuteRequest> for ContextManager {
     type Result = ActorResponse<Self, <ExecuteRequest as Message>::Result>;
@@ -1996,153 +2000,6 @@ fn substitute_aliases_in_payload(
     result.extend_from_slice(remaining);
 
     Ok(result)
-}
-
-/// Returns `true` when a group-upgrade status should block ALL writes
-/// (both user calls and state-op writes such as `__calimero_sync_next`).
-///
-/// Only `GroupUpgradeStatus::InProgress` blocks.  `Completed` (with or
-/// without a timestamp) never blocks.  This is the single source of truth
-/// for the cascade-upgrade write-gate decision.
-///
-/// # Safety invariants
-///
-/// * `LazyOnAccess` upgrades write `Completed` directly (never `InProgress`),
-///   so this fn never returns `true` during a lazy migration.
-/// * The eager propagator's own writes go through `UpdateApplicationRequest`
-///   → `handlers::update_application`, which bypasses the execute gate
-///   entirely — no deadlock is possible.
-/// * Sync-pipeline (`__calimero_sync_next`) failures during `InProgress` are
-///   retried by the periodic sync cycle once the upgrade reaches `Completed`.
-fn upgrade_blocks_write(status: &calimero_store::key::GroupUpgradeStatus) -> bool {
-    matches!(
-        status,
-        calimero_store::key::GroupUpgradeStatus::InProgress { .. }
-    )
-}
-
-/// Whether the cascade write-gate should fire, given the `migration_v2` flag.
-///
-/// Equal to `!migration_v2 && upgrade_blocks_write(status)`: with the flag OFF
-/// the group-wide `InProgress` freeze applies; with it ON the freeze is lifted
-/// (absorb-don't-drop keeps stragglers safe instead).
-fn should_block(migration_v2: bool, status: &calimero_store::key::GroupUpgradeStatus) -> bool {
-    !migration_v2 && upgrade_blocks_write(status)
-}
-
-/// Post-execution write-gate decision: during an in-progress upgrade a pure read
-/// (`produced_write == false`) is served from the pre-migration root; a
-/// side-effecting call is refused. Write-intent is derived post-execution (a
-/// committed `root_hash` or queued `xcalls`) because no read-vs-write flag exists
-/// upstream (`ExecuteRequest`, RPC, SDK, ABI).
-fn upgrade_rejects_committed_write(block_writes: bool, produced_write: bool) -> bool {
-    block_writes && produced_write
-}
-
-/// Checks if a context belongs to a group with LazyOnAccess policy and
-/// needs an upgrade or migration.
-///
-/// Returns `(target_application_id, migrate_method, group_id)` when an
-/// upgrade should be performed.  The `group_id` is included so the caller
-/// can record a per-context migration marker after a successful run.
-fn maybe_lazy_upgrade(
-    datastore: &Store,
-    context_id: &ContextId,
-    current_application_id: &ApplicationId,
-) -> Option<(
-    ApplicationId,
-    Option<String>,
-    calimero_context_config::types::ContextGroupId,
-)> {
-    use calimero_governance_store;
-
-    // 1. Check if context belongs to a group
-    let group_id = match calimero_governance_store::get_group_for_context(datastore, context_id) {
-        Ok(Some(gid)) => gid,
-        Ok(None) => return None, // not in a group
-        Err(err) => {
-            debug!(%err, %context_id, "failed to check group for context during lazy upgrade");
-            return None;
-        }
-    };
-
-    // 2. Load group metadata
-    let meta = match MetaRepository::new(datastore).load(&group_id) {
-        Ok(Some(m)) => m,
-        Ok(None) => return None, // group deleted?
-        Err(err) => {
-            debug!(%err, ?group_id, "failed to load group meta during lazy upgrade");
-            return None;
-        }
-    };
-
-    // 3. Check policy is LazyOnAccess
-    if !matches!(meta.upgrade_policy, UpgradePolicy::LazyOnAccess) {
-        return None;
-    }
-
-    // 4. Extract migration method from group meta (set during upgrade)
-    let migrate_method = meta
-        .migration
-        .as_ref()
-        .and_then(|bytes| String::from_utf8(bytes.clone()).ok());
-
-    // 5. Compare current vs target application
-    if *current_application_id == meta.target_application_id {
-        // IDs match — only proceed if there is a pending migration that
-        // hasn't been applied to this context yet.
-        let Some(ref method) = migrate_method else {
-            return None; // no migration, context is already up to date
-        };
-
-        // Check per-context marker set after a successful migration run.
-        let already_applied = MigrationsRepository::new(datastore)
-            .last_migration(&group_id, context_id)
-            .ok()
-            .flatten()
-            .map(|last| last == *method)
-            .unwrap_or(false);
-
-        if already_applied {
-            return None; // migration was already applied to this context
-        }
-        // Fall through: migration is pending.
-    }
-
-    info!(
-        %context_id,
-        ?group_id,
-        %current_application_id,
-        target_app=%meta.target_application_id,
-        "lazy upgrade triggered for context"
-    );
-
-    Some((meta.target_application_id, migrate_method, group_id))
-}
-
-/// The blob-derived app key the sender is executing under — `GroupMeta.app_key`
-/// for the context's owning group (`app_key = blob_id(bytecode)` at group
-/// creation / upgrade time).  This is the schema-version discriminator that
-/// changes on every app upgrade; `application_id` is version-stable and
-/// cannot distinguish v1 from v2 of the same application.
-///
-/// Returns `Some(app_key)` for group-context deltas; `None` for non-group
-/// contexts (no owning group) or when the group meta row cannot be loaded
-/// (store error is propagated to the caller as `Err`).
-///
-/// Stamped onto the state-delta broadcast so receivers can fence
-/// stale-schema deltas after a cascade migration.  The fence itself lives
-/// in Tasks 8/9 — this function is the testable store-boundary helper.
-fn resolve_producing_app_key(
-    datastore: &Store,
-    context_id: &ContextId,
-) -> eyre::Result<Option<[u8; 32]>> {
-    let Some(gid) = calimero_governance_store::get_group_for_context(datastore, context_id)? else {
-        return Ok(None);
-    };
-    Ok(MetaRepository::new(datastore)
-        .load(&gid)?
-        .map(|m| m.app_key))
 }
 
 #[cfg(test)]

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -1,0 +1,160 @@
+//! Cascade-upgrade write-gate decisions for context execution: whether a
+//! group-upgrade status blocks writes, whether a committed write should be
+//! rejected mid-upgrade, the lazy-on-access migration trigger, and the
+//! producing-app-key resolver. Extracted from the execute handler.
+
+use calimero_governance_store::{MetaRepository, MigrationsRepository};
+use calimero_primitives::application::ApplicationId;
+use calimero_primitives::context::{ContextId, UpgradePolicy};
+use calimero_store::Store;
+use tracing::{debug, info};
+
+/// Returns `true` when a group-upgrade status should block ALL writes
+/// (both user calls and state-op writes such as `__calimero_sync_next`).
+///
+/// Only `GroupUpgradeStatus::InProgress` blocks.  `Completed` (with or
+/// without a timestamp) never blocks.  This is the single source of truth
+/// for the cascade-upgrade write-gate decision.
+///
+/// # Safety invariants
+///
+/// * `LazyOnAccess` upgrades write `Completed` directly (never `InProgress`),
+///   so this fn never returns `true` during a lazy migration.
+/// * The eager propagator's own writes go through `UpdateApplicationRequest`
+///   → `handlers::update_application`, which bypasses the execute gate
+///   entirely — no deadlock is possible.
+/// * Sync-pipeline (`__calimero_sync_next`) failures during `InProgress` are
+///   retried by the periodic sync cycle once the upgrade reaches `Completed`.
+pub(super) fn upgrade_blocks_write(status: &calimero_store::key::GroupUpgradeStatus) -> bool {
+    matches!(
+        status,
+        calimero_store::key::GroupUpgradeStatus::InProgress { .. }
+    )
+}
+
+/// Whether the cascade write-gate should fire, given the `migration_v2` flag.
+///
+/// Equal to `!migration_v2 && upgrade_blocks_write(status)`: with the flag OFF
+/// the group-wide `InProgress` freeze applies; with it ON the freeze is lifted
+/// (absorb-don't-drop keeps stragglers safe instead).
+pub(super) fn should_block(
+    migration_v2: bool,
+    status: &calimero_store::key::GroupUpgradeStatus,
+) -> bool {
+    !migration_v2 && upgrade_blocks_write(status)
+}
+
+/// Post-execution write-gate decision: during an in-progress upgrade a pure read
+/// (`produced_write == false`) is served from the pre-migration root; a
+/// side-effecting call is refused. Write-intent is derived post-execution (a
+/// committed `root_hash` or queued `xcalls`) because no read-vs-write flag exists
+/// upstream (`ExecuteRequest`, RPC, SDK, ABI).
+pub(super) fn upgrade_rejects_committed_write(block_writes: bool, produced_write: bool) -> bool {
+    block_writes && produced_write
+}
+
+/// Checks if a context belongs to a group with LazyOnAccess policy and
+/// needs an upgrade or migration.
+///
+/// Returns `(target_application_id, migrate_method, group_id)` when an
+/// upgrade should be performed.  The `group_id` is included so the caller
+/// can record a per-context migration marker after a successful run.
+pub(super) fn maybe_lazy_upgrade(
+    datastore: &Store,
+    context_id: &ContextId,
+    current_application_id: &ApplicationId,
+) -> Option<(
+    ApplicationId,
+    Option<String>,
+    calimero_context_config::types::ContextGroupId,
+)> {
+    use calimero_governance_store;
+
+    // 1. Check if context belongs to a group
+    let group_id = match calimero_governance_store::get_group_for_context(datastore, context_id) {
+        Ok(Some(gid)) => gid,
+        Ok(None) => return None, // not in a group
+        Err(err) => {
+            debug!(%err, %context_id, "failed to check group for context during lazy upgrade");
+            return None;
+        }
+    };
+
+    // 2. Load group metadata
+    let meta = match MetaRepository::new(datastore).load(&group_id) {
+        Ok(Some(m)) => m,
+        Ok(None) => return None, // group deleted?
+        Err(err) => {
+            debug!(%err, ?group_id, "failed to load group meta during lazy upgrade");
+            return None;
+        }
+    };
+
+    // 3. Check policy is LazyOnAccess
+    if !matches!(meta.upgrade_policy, UpgradePolicy::LazyOnAccess) {
+        return None;
+    }
+
+    // 4. Extract migration method from group meta (set during upgrade)
+    let migrate_method = meta
+        .migration
+        .as_ref()
+        .and_then(|bytes| String::from_utf8(bytes.clone()).ok());
+
+    // 5. Compare current vs target application
+    if *current_application_id == meta.target_application_id {
+        // IDs match — only proceed if there is a pending migration that
+        // hasn't been applied to this context yet.
+        let Some(ref method) = migrate_method else {
+            return None; // no migration, context is already up to date
+        };
+
+        // Check per-context marker set after a successful migration run.
+        let already_applied = MigrationsRepository::new(datastore)
+            .last_migration(&group_id, context_id)
+            .ok()
+            .flatten()
+            .map(|last| last == *method)
+            .unwrap_or(false);
+
+        if already_applied {
+            return None; // migration was already applied to this context
+        }
+        // Fall through: migration is pending.
+    }
+
+    info!(
+        %context_id,
+        ?group_id,
+        %current_application_id,
+        target_app=%meta.target_application_id,
+        "lazy upgrade triggered for context"
+    );
+
+    Some((meta.target_application_id, migrate_method, group_id))
+}
+
+/// The blob-derived app key the sender is executing under — `GroupMeta.app_key`
+/// for the context's owning group (`app_key = blob_id(bytecode)` at group
+/// creation / upgrade time).  This is the schema-version discriminator that
+/// changes on every app upgrade; `application_id` is version-stable and
+/// cannot distinguish v1 from v2 of the same application.
+///
+/// Returns `Some(app_key)` for group-context deltas; `None` for non-group
+/// contexts (no owning group) or when the group meta row cannot be loaded
+/// (store error is propagated to the caller as `Err`).
+///
+/// Stamped onto the state-delta broadcast so receivers can fence
+/// stale-schema deltas after a cascade migration.  The fence itself lives
+/// in Tasks 8/9 — this function is the testable store-boundary helper.
+pub(super) fn resolve_producing_app_key(
+    datastore: &Store,
+    context_id: &ContextId,
+) -> eyre::Result<Option<[u8; 32]>> {
+    let Some(gid) = calimero_governance_store::get_group_for_context(datastore, context_id)? else {
+        return Ok(None);
+    };
+    Ok(MetaRepository::new(datastore)
+        .load(&gid)?
+        .map(|m| m.app_key))
+}


### PR DESCRIPTION
## What

Increment 2 of splitting `context/src/handlers/execute/mod.rs`. Moves the cascade-upgrade write-gate cluster into `upgrade_gate.rs` — pure, behavior-preserving code movement (`mod.rs`: **+7 / −150**).

Moved (free predicates/helpers):
- `upgrade_blocks_write`, `should_block`, `upgrade_rejects_committed_write`, `maybe_lazy_upgrade`, `resolve_producing_app_key`

## Wiring

- All `pub(super)`; the execute flow re-imports them, which also keeps the inline test module's `use super::{..}` resolving (the upgrade-predicate unit tests stay in `mod.rs`).
- Drops three imports (`UpgradePolicy`, `action::Action`, `create_storage_callbacks`) that only the moved helpers used.
- Explicit imports in `upgrade_gate.rs`, no `use super::*`.

## Validation

- `cargo check -p calimero-context` clean (no new warnings).
- context lib tests: **107 passed** — including the upgrade-predicate tests (`upgrade_blocks_write_*`, `should_block_*`).

## Progress

`execute/mod.rs`: 2675 → ~2235 LOC across #2733 (signing) + this. Submodules: `storage` (pre-existing) / `signing` / `upgrade_gate`. Remaining: `compute_governance_position_for_context`, then the two god-functions (`internal_execute` ~514 lines, the `Handler` actor-closure chain ~900 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure module extraction with identical logic and passing tests; no changes to execute or upgrade-gate behavior.
> 
> **Overview**
> **Increment 2** of splitting the execute handler: cascade-upgrade write-gate logic moves out of `execute/mod.rs` into a new **`upgrade_gate`** submodule.
> 
> The new module holds **`upgrade_blocks_write`**, **`should_block`**, **`upgrade_rejects_committed_write`**, **`maybe_lazy_upgrade`**, and **`resolve_producing_app_key`** (same behavior and docs as before). The execute handler declares `mod upgrade_gate` and re-imports those helpers for the `Handler` path and **`internal_execute`**. Upgrade-predicate unit tests stay in `mod.rs` and still resolve via `super::{…}`.
> 
> `mod.rs` drops imports that only the moved code needed (`UpgradePolicy`, `action::Action`, `create_storage_callbacks`). **`upgrade_gate.rs`** uses explicit crate imports and `pub(super)` visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5242f9aebcfe894143340f3b3bc0f41d77cfd6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->