### PR TITLE
feat(storage): operation-aware ACLs (OpMask) — merge-time enforcement (PR 1/2)

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -25,7 +25,7 @@ use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
 use calimero_storage::delta::StorageDelta;
-use calimero_storage::entities::StorageType;
+use calimero_storage::entities::{OpMask, StorageType};
 use calimero_storage::rotation_log::{RotationLog, RotationLogEntry, RotationSnapshot};
 use calimero_storage::store::Key as StorageKey;
 use eyre::Result;
@@ -820,7 +820,7 @@ impl ContextStorageApplier {
     async fn resolve_effective_writers_for_delta(
         &self,
         delta: &CausalDelta<Vec<Action>>,
-    ) -> Result<BTreeMap<Id, BTreeSet<PublicKey>>> {
+    ) -> Result<BTreeMap<Id, BTreeMap<PublicKey, OpMask>>> {
         let mut shared_entities: BTreeSet<Id> = BTreeSet::new();
         // (member entity id, its anchor id). A `SharedMember` carries no writer
         // set of its own; it resolves the ANCHOR's writers and the result is
@@ -845,7 +845,7 @@ impl ContextStorageApplier {
             }
         }
 
-        let mut out: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
+        let mut out: BTreeMap<Id, BTreeMap<PublicKey, OpMask>> = BTreeMap::new();
         if shared_entities.is_empty() && members.is_empty() {
             return Ok(out);
         }
@@ -891,7 +891,7 @@ impl ContextStorageApplier {
         // has rotated. When the anchor is absent entirely, the fallback yields
         // the empty set and verification fails closed (the member is retried
         // once the anchor syncs).
-        let mut anchor_cache: BTreeMap<Id, Option<BTreeSet<PublicKey>>> = BTreeMap::new();
+        let mut anchor_cache: BTreeMap<Id, Option<BTreeMap<PublicKey, OpMask>>> = BTreeMap::new();
         for (member_id, anchor) in members {
             let resolved = match anchor_cache.get(&anchor) {
                 Some(cached) => cached.clone(),
@@ -1054,7 +1054,7 @@ pub(crate) fn seed_rotation_log_genesis_direct(
     context_client: &ContextClient,
     context_id: ContextId,
     entity_id: Id,
-    writers: BTreeSet<PublicKey>,
+    writers: BTreeMap<PublicKey, OpMask>,
 ) -> Result<()> {
     if load_rotation_log_direct(context_client, context_id, entity_id)?.is_some() {
         return Ok(());

--- a/crates/node/src/delta_store_head_hashes_test.rs
+++ b/crates/node/src/delta_store_head_hashes_test.rs
@@ -195,7 +195,7 @@ async fn add_local_applied_delta_self_logs_own_rotations() {
         .expect("add genesis");
     assert_eq!(
         log_entries(),
-        vec![writers(&[alice])],
+        vec![calimero_storage::entities::full_mask(writers(&[alice]))],
         "genesis Add must self-log a bootstrap entry"
     );
 
@@ -208,7 +208,10 @@ async fn add_local_applied_delta_self_logs_own_rotations() {
         .expect("add rotation");
     assert_eq!(
         log_entries(),
-        vec![writers(&[alice]), writers(&[alice, bob])],
+        vec![
+            calimero_storage::entities::full_mask(writers(&[alice])),
+            calimero_storage::entities::full_mask(writers(&[alice, bob]))
+        ],
         "writer-set change must self-log a rotation entry"
     );
 
@@ -221,7 +224,10 @@ async fn add_local_applied_delta_self_logs_own_rotations() {
         .expect("add value-write");
     assert_eq!(
         log_entries(),
-        vec![writers(&[alice]), writers(&[alice, bob])],
+        vec![
+            calimero_storage::entities::full_mask(writers(&[alice])),
+            calimero_storage::entities::full_mask(writers(&[alice, bob]))
+        ],
         "a value-write that doesn't change writers must NOT append a rotation entry"
     );
 }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -975,7 +975,10 @@ mod tests {
     fn extract_author_shared_with_signer_hint_returns_signer() {
         let signer = PublicKey::from([9u8; 32]);
         let st = StorageType::Shared {
-            writers: BTreeSet::from([signer]),
+            writers: std::collections::BTreeMap::from([(
+                signer,
+                calimero_storage::entities::OpMask::FULL,
+            )]),
             signature_data: Some(SignatureData {
                 signer: Some(signer),
                 signature: [0u8; 64],
@@ -993,7 +996,10 @@ mod tests {
         // Older actions can omit the signer hint — caller treats `None`
         // as "defer to per-action signature verification inside apply_action."
         let st = StorageType::Shared {
-            writers: BTreeSet::from([PublicKey::from([1u8; 32])]),
+            writers: std::collections::BTreeMap::from([(
+                PublicKey::from([1u8; 32]),
+                calimero_storage::entities::OpMask::FULL,
+            )]),
             signature_data: Some(SignatureData {
                 signer: None,
                 signature: [0u8; 64],

--- a/crates/node/src/sync/p3_dag_causal_tests.rs
+++ b/crates/node/src/sync/p3_dag_causal_tests.rs
@@ -211,7 +211,10 @@ fn verifier_with_dag_context_uses_rotation_log() {
             delta_id: d1,
             delta_hlc: hlc(hlc_at(0)),
             signer: Some(alice),
-            new_writers: [alice].into_iter().collect(),
+            new_writers: [alice]
+                .into_iter()
+                .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+                .collect(),
             writers_nonce: 1,
         },
     )
@@ -268,7 +271,10 @@ fn verifier_with_dag_context_rejects_non_causal_writer() {
             delta_id: d1,
             delta_hlc: hlc(hlc_at(0)),
             signer: Some(alice),
-            new_writers: [alice].into_iter().collect(),
+            new_writers: [alice]
+                .into_iter()
+                .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+                .collect(),
             writers_nonce: 1,
         },
     )
@@ -324,7 +330,13 @@ fn write_hook_appends_on_bootstrap_with_ctx() {
     assert_eq!(log.entries.len(), 1);
     assert_eq!(log.entries[0].delta_id, [0xAA; 32]);
     assert_eq!(log.entries[0].signer, Some(alice));
-    assert_eq!(log.entries[0].new_writers, [alice].into_iter().collect());
+    assert_eq!(
+        log.entries[0].new_writers,
+        [alice]
+            .into_iter()
+            .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+            .collect::<std::collections::BTreeMap<_, _>>()
+    );
 }
 
 /// Same bootstrap but with empty ctx (no delta_id) — the log stays empty.
@@ -462,7 +474,10 @@ fn write_hook_appends_on_writer_set_change() {
     assert_eq!(log.entries[1].delta_id, d1);
     assert_eq!(
         log.entries[1].new_writers,
-        [alice, bob].into_iter().collect()
+        [alice, bob]
+            .into_iter()
+            .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+            .collect::<std::collections::BTreeMap<_, _>>()
     );
 }
 

--- a/crates/node/src/sync/p5_partition_scenarios_tests.rs
+++ b/crates/node/src/sync/p5_partition_scenarios_tests.rs
@@ -55,7 +55,9 @@ fn hlc(ns: u64) -> HybridTimestamp {
 /// `ApplyContext`, then `Interface::apply_action`.
 fn deliver<S: StorageAdaptor>(delta: &Delta, dag: &Dag) -> Result<(), StorageError> {
     let entity_id = delta.action.id();
-    let effective_writers: Option<BTreeSet<PublicKey>> = match rotation_log::load::<S>(entity_id)? {
+    let effective_writers: Option<
+        std::collections::BTreeMap<PublicKey, calimero_storage::entities::OpMask>,
+    > = match rotation_log::load::<S>(entity_id)? {
         Some(log) => {
             rotation_log_reader::writers_at(&log, &delta.parents, |a, b| dag.happens_before(a, b))
         }
@@ -92,7 +94,7 @@ fn writers_at_frontier<S: StorageAdaptor, F>(
     id: Id,
     frontier: &[[u8; 32]],
     happens_before: F,
-) -> Option<BTreeSet<PublicKey>>
+) -> Option<std::collections::BTreeMap<PublicKey, calimero_storage::entities::OpMask>>
 where
     F: Fn(&[u8; 32], &[u8; 32]) -> bool,
 {
@@ -432,7 +434,10 @@ fn concurrent_conflicting_rotations_deterministic_convergence() {
     assert_eq!(carol_writers, dave_writers, "deterministic convergence");
     assert_eq!(
         carol_writers,
-        [bob].into_iter().collect(),
+        [bob]
+            .into_iter()
+            .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+            .collect::<std::collections::BTreeMap<_, _>>(),
         "D2 (HLC 21) wins over D1 (HLC 20)"
     );
 }
@@ -595,7 +600,10 @@ fn long_partition_reconciliation_converges() {
     // other (siblings of g0). HLC tiebreak picks R1 — winner is {Bob, Dave}.
     assert_eq!(
         left_writers,
-        [bob, dave].into_iter().collect(),
+        [bob, dave]
+            .into_iter()
+            .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+            .collect::<std::collections::BTreeMap<_, _>>(),
         "R1 (HLC 25) wins HLC tiebreak vs L1 (HLC 20)"
     );
 }

--- a/crates/node/src/sync/rotation_log_reader.rs
+++ b/crates/node/src/sync/rotation_log_reader.rs
@@ -12,9 +12,10 @@
 //! `&RotationLog` in. The DAG-ancestry closure is supplied by the caller
 //! (typically wrapping the node's `CoreDagStore::happens_before`).
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use calimero_primitives::identity::PublicKey;
+use calimero_storage::entities::OpMask;
 use calimero_storage::rotation_log::{RotationLog, RotationLogEntry};
 
 /// Returns the writer set from the most recently *appended* entry in
@@ -27,7 +28,7 @@ use calimero_storage::rotation_log::{RotationLog, RotationLogEntry};
 ///
 /// Returns `None` if the log has no entries and no snapshot.
 #[must_use]
-pub fn latest_writers(log: &RotationLog) -> Option<BTreeSet<PublicKey>> {
+pub fn latest_writers(log: &RotationLog) -> Option<BTreeMap<PublicKey, OpMask>> {
     if let Some(entry) = log.entries.last() {
         return Some(entry.new_writers.clone());
     }
@@ -65,7 +66,7 @@ pub fn writers_at<F>(
     log: &RotationLog,
     causal_parents: &[[u8; 32]],
     happens_before: F,
-) -> Option<BTreeSet<PublicKey>>
+) -> Option<BTreeMap<PublicKey, OpMask>>
 where
     F: Fn(&[u8; 32], &[u8; 32]) -> bool,
 {
@@ -122,6 +123,7 @@ where
 mod tests {
     use core::num::NonZeroU128;
 
+    use calimero_storage::entities::OpMask;
     use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
     use calimero_storage::rotation_log::{RotationLog, RotationLogEntry, RotationSnapshot};
 
@@ -147,7 +149,11 @@ mod tests {
             delta_id: [delta_id; 32],
             delta_hlc: HybridTimestamp::new(ts),
             signer: Some(pk(signer)),
-            new_writers: writers.iter().copied().map(pk).collect(),
+            new_writers: writers
+                .iter()
+                .copied()
+                .map(|b| (pk(b), OpMask::FULL))
+                .collect(),
             writers_nonce: nonce,
         }
     }
@@ -174,7 +180,7 @@ mod tests {
         ]);
         assert_eq!(
             latest_writers(&log),
-            Some([0xBB].into_iter().map(pk).collect())
+            Some([0xBB].into_iter().map(|b| (pk(b), OpMask::FULL)).collect())
         );
     }
 
@@ -187,7 +193,7 @@ mod tests {
         ]);
         assert_eq!(
             writers_at(&log, &[], |_, _| false),
-            Some([0xBB].into_iter().map(pk).collect())
+            Some([0xBB].into_iter().map(|b| (pk(b), OpMask::FULL)).collect())
         );
     }
 
@@ -204,10 +210,26 @@ mod tests {
         let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
 
         let writers = writers_at(&log, &[[1; 32]], happens_before);
-        assert_eq!(writers, Some([0xAA, 0xBB].into_iter().map(pk).collect()));
+        assert_eq!(
+            writers,
+            Some(
+                [0xAA, 0xBB]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
+        );
 
         let writers = writers_at(&log, &[[2; 32]], happens_before);
-        assert_eq!(writers, Some([0xBB, 0xCC].into_iter().map(pk).collect()));
+        assert_eq!(
+            writers,
+            Some(
+                [0xBB, 0xCC]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
+        );
     }
 
     #[test]
@@ -221,7 +243,10 @@ mod tests {
 
         let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
         let writers = writers_at(&log, &[[1; 32], [2; 32]], none_precede);
-        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
+        assert_eq!(
+            writers,
+            Some([0xBB].into_iter().map(|b| (pk(b), OpMask::FULL)).collect())
+        );
     }
 
     #[test]
@@ -236,7 +261,11 @@ mod tests {
             delta_id: [delta_id; 32],
             delta_hlc: identical_ts,
             signer: Some(pk(signer)),
-            new_writers: writers.iter().copied().map(pk).collect(),
+            new_writers: writers
+                .iter()
+                .copied()
+                .map(|b| (pk(b), OpMask::FULL))
+                .collect(),
             writers_nonce: 10,
         };
         let log = log_of(vec![mk(1, 0xAA, &[0xAA, 0xCC]), mk(2, 0xBB, &[0xBB, 0xDD])]);
@@ -244,7 +273,15 @@ mod tests {
         let none_precede = |_: &[u8; 32], _: &[u8; 32]| false;
         let writers = writers_at(&log, &[[1; 32], [2; 32]], none_precede);
         // 0xAA is smaller → wins.
-        assert_eq!(writers, Some([0xAA, 0xCC].into_iter().map(pk).collect()));
+        assert_eq!(
+            writers,
+            Some(
+                [0xAA, 0xCC]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
+        );
     }
 
     #[test]
@@ -258,7 +295,10 @@ mod tests {
 
         let happens_before = |a: &[u8; 32], b: &[u8; 32]| a == &[1; 32] && b == &[2; 32];
         let writers = writers_at(&log, &[[2; 32]], happens_before);
-        assert_eq!(writers, Some([0xBB].into_iter().map(pk).collect()));
+        assert_eq!(
+            writers,
+            Some([0xBB].into_iter().map(|b| (pk(b), OpMask::FULL)).collect())
+        );
     }
 
     #[test]
@@ -273,7 +313,8 @@ mod tests {
     #[test]
     fn writers_at_falls_back_to_snapshot_when_entries_unreachable() {
         // P6 compaction wrote a snapshot but no live entries reach the query.
-        let snap_writers: BTreeSet<PublicKey> = [0xEE].into_iter().map(pk).collect();
+        let snap_writers: BTreeMap<PublicKey, OpMask> =
+            [0xEE].into_iter().map(|b| (pk(b), OpMask::FULL)).collect();
         let log = RotationLog {
             snapshot: Some(RotationSnapshot {
                 writers: snap_writers.clone(),
@@ -326,10 +367,18 @@ mod tests {
         // this is what makes them converge.
         assert_eq!(from_node1, from_node2);
         // ...and it is the HLC winner R2 = {B, C}.
-        assert_eq!(from_node1, Some([0xBB, 0xCC].into_iter().map(pk).collect()));
+        assert_eq!(
+            from_node1,
+            Some(
+                [0xBB, 0xCC]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
+        );
         // C is in both concurrent sets, so it survives whichever wins — the
         // property the e2e relies on to pick a guaranteed-authorized settler.
-        assert!(from_node1.unwrap().contains(&pk(0xCC)));
+        assert!(from_node1.unwrap().contains_key(&pk(0xCC)));
     }
 
     #[test]
@@ -358,11 +407,17 @@ mod tests {
         // Deterministic convergence to the settled set on every node...
         assert_eq!(from_node1, from_node2);
         let resolved = from_node1.expect("settled writer set");
-        assert_eq!(resolved, [0xAA, 0xCC].into_iter().map(pk).collect());
+        assert_eq!(
+            resolved,
+            [0xAA, 0xCC]
+                .into_iter()
+                .map(|b| (pk(b), OpMask::FULL))
+                .collect()
+        );
         // ...and B is retroactively revoked everywhere (the bonus the e2e
         // asserts by rejecting B's post-settle write).
-        assert!(!resolved.contains(&pk(0xBB)));
-        assert!(resolved.contains(&pk(0xAA)));
-        assert!(resolved.contains(&pk(0xCC)));
+        assert!(!resolved.contains_key(&pk(0xBB)));
+        assert!(resolved.contains_key(&pk(0xAA)));
+        assert!(resolved.contains_key(&pk(0xCC)));
     }
 }

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -1,6 +1,6 @@
 //! Snapshot sync protocol for full state bootstrap.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Instant;
 
 use borsh::BorshDeserialize;
@@ -554,8 +554,10 @@ impl SyncManager {
         // members against that authenticated map once the stream completes. A
         // member still only persists after its writers are authenticated (the
         // anchor's own record is signature-verified in pass 1).
-        let mut anchor_writers: HashMap<Id, BTreeSet<calimero_primitives::identity::PublicKey>> =
-            HashMap::new();
+        let mut anchor_writers: HashMap<
+            Id,
+            BTreeMap<calimero_primitives::identity::PublicKey, calimero_storage::entities::OpMask>,
+        > = HashMap::new();
         let mut deferred_members: Vec<(Id, Vec<u8>, Vec<u8>)> = Vec::new();
 
         loop {

--- a/crates/node/tests/dag_causal_runtime_env_probe.rs
+++ b/crates/node/tests/dag_causal_runtime_env_probe.rs
@@ -55,7 +55,10 @@ fn dummy_entry() -> RotationLogEntry {
         delta_id: [0xAB; 32],
         delta_hlc: HybridTimestamp::new(ts),
         signer: Some(pk(0xAA)),
-        new_writers: [pk(0xAA), pk(0xBB)].into_iter().collect(),
+        new_writers: [pk(0xAA), pk(0xBB)]
+            .into_iter()
+            .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+            .collect(),
         writers_nonce: 1,
     }
 }

--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -158,7 +158,7 @@ impl SharedRotationApplier {
     async fn resolve_effective_writers(
         &self,
         delta: &CausalDelta<Vec<Action>>,
-    ) -> BTreeMap<Id, BTreeSet<PublicKey>> {
+    ) -> BTreeMap<Id, BTreeMap<PublicKey, calimero_storage::entities::OpMask>> {
         // Collect Shared-entity ids touched by this delta.
         let mut shared_entities: BTreeSet<Id> = BTreeSet::new();
         for action in &delta.payload {
@@ -173,7 +173,8 @@ impl SharedRotationApplier {
             }
         }
 
-        let mut out: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
+        let mut out: BTreeMap<Id, BTreeMap<PublicKey, calimero_storage::entities::OpMask>> =
+            BTreeMap::new();
         if shared_entities.is_empty() {
             return out;
         }

--- a/crates/storage/src/action.rs
+++ b/crates/storage/src/action.rs
@@ -282,10 +282,13 @@ fn hash_authorization_for_payload(hasher: &mut Sha256, metadata: &Metadata) {
                                   // already an outlier; we never need 2^32 writers).
             let writers_count = u32::try_from(writers.len()).unwrap_or(u32::MAX);
             hasher.update(writers_count.to_le_bytes());
-            // Writers serialized deterministically: BTreeSet iteration
-            // is sorted, so this is stable across signer / verifier.
-            for writer in writers {
+            // Writers serialized deterministically: BTreeMap iteration is sorted
+            // by key, so this is stable across signer / verifier. Each writer's
+            // OpMask is committed with its key, so a peer cannot forge or
+            // escalate a mask — the masks are part of the signed authorization.
+            for (writer, mask) in writers {
                 hasher.update(writer.as_ref() as &[u8; 32]);
+                hasher.update([mask.bits()]);
             }
             // sig-data presence tag — see "Domain separation" in the
             // function doc.
@@ -381,7 +384,7 @@ mod tests {
             created_at: 100,
             updated_at: nonce.into(),
             storage_type: StorageType::Shared {
-                writers,
+                writers: crate::entities::full_mask(writers),
                 signature_data: Some(SignatureData {
                     nonce,
                     signature: [0; 64],

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -60,7 +60,7 @@ use calimero_primitives::identity::PublicKey;
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
 use super::{compute_collection_id, compute_id, Collection, StoreError};
 use crate::address::Id;
-use crate::entities::{ChildInfo, Data, Element, SignatureData, StorageType};
+use crate::entities::{ChildInfo, Data, Element, OpMask, SignatureData, StorageType};
 use crate::env;
 use crate::index::Index;
 use crate::interface::{Interface, StorageError};
@@ -254,7 +254,9 @@ where
         // explicit) and persist.
         self.inner
             .reassign_deterministic_id_with_crdt_type(field_name, CrdtType::SharedStorage);
-        self.inner.element_mut().set_shared_domain(writers.clone());
+        self.inner
+            .element_mut()
+            .set_shared_domain_scoped(writers.clone());
         let _saved = <Interface<MainStorage>>::save(&mut self.inner)
             .expect("failed to persist relocated WriterSetCell wrapper");
 
@@ -398,7 +400,7 @@ where
     /// act on has an index entry (construction and sync-apply both write one);
     /// if neither source has a writer set, fail closed with the empty set rather
     /// than trust unverified bytes.
-    fn current_writers(&self) -> BTreeSet<PublicKey> {
+    fn current_writers(&self) -> BTreeMap<PublicKey, OpMask> {
         if let Ok(Some(log)) = rotation_log::load::<S>(self.inner.id()) {
             if let Some(writers) = rotation_log::resolve_local(&log) {
                 return writers;
@@ -421,12 +423,19 @@ where
              entry — failing closed with an empty writer set (missing/corrupt \
              index, or wrapper not yet synced)"
         );
-        BTreeSet::new()
+        BTreeMap::new()
     }
 
-    /// Read the current writer set. Public so callers can present a
-    /// "members with edit rights" UI and compute incremental rotations.
+    /// Read the current writer set (membership only). Public so callers can
+    /// present a "members with edit rights" UI and compute incremental
+    /// rotations. Use [`capabilities`](Self::capabilities) for the per-writer
+    /// [`OpMask`]s.
     pub fn writers(&self) -> BTreeSet<PublicKey> {
+        self.current_writers().into_keys().collect()
+    }
+
+    /// The current writers with their [`OpMask`]s.
+    pub fn capabilities(&self) -> BTreeMap<PublicKey, OpMask> {
         self.current_writers()
     }
 
@@ -463,7 +472,7 @@ where
     pub fn insert(&mut self, value: T) -> Result<Option<T>, StoreError> {
         let executor: PublicKey = env::executor_id().into();
         let writers = self.current_writers();
-        if !writers.contains(&executor) {
+        if !writers.contains_key(&executor) {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Executor is not a writer of this WriterSetCell".to_owned(),
             )));
@@ -503,6 +512,21 @@ where
     /// Returns `ActionNotAllowed` if `frozen`, if `new_writers` is empty, or if
     /// the executor is not currently in the writer set.
     pub fn rotate_writers(&mut self, new_writers: BTreeSet<PublicKey>) -> Result<(), StoreError> {
+        // Convenience: every writer gets `OpMask::FULL` (today's behaviour).
+        self.rotate_writers_scoped(new_writers.into_iter().map(|w| (w, OpMask::FULL)).collect())
+    }
+
+    /// Rotate the writer set with explicit per-writer [`OpMask`]s. Same rules and
+    /// merge semantics as [`rotate_writers`](Self::rotate_writers); the masks are
+    /// committed into the signed rotation and enforced at merge.
+    ///
+    /// # Errors
+    /// Returns `ActionNotAllowed` if `frozen`, if `new_writers` is empty, or if
+    /// the executor is not currently in the writer set.
+    pub fn rotate_writers_scoped(
+        &mut self,
+        new_writers: BTreeMap<PublicKey, OpMask>,
+    ) -> Result<(), StoreError> {
         if self.frozen {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Cannot rotate writers of frozen WriterSetCell".to_owned(),
@@ -515,7 +539,7 @@ where
         }
         let executor: PublicKey = env::executor_id().into();
         let writers = self.current_writers();
-        if !writers.contains(&executor) {
+        if !writers.contains_key(&executor) {
             return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
                 "Executor is not a current writer".to_owned(),
             )));
@@ -533,7 +557,7 @@ where
         // point) and appends the new set to the wrapper's rotation log.
         self.inner
             .element_mut()
-            .set_shared_domain(new_writers.clone());
+            .set_shared_domain_scoped(new_writers);
         let _saved = <Interface<S>>::save(&mut self.inner)?;
 
         // Members are NOT re-stamped. The value entry and every collection
@@ -722,7 +746,7 @@ mod tests {
         assert_member_of(storage_type_of(value_id));
         assert_eq!(
             anchor_writers(storage_type_of(wrapper_id)),
-            writers(&[ALICE])
+            crate::entities::full_mask(writers(&[ALICE]))
         );
 
         // Rotation updates the anchor only; the value entry is byte-untouched.
@@ -730,7 +754,7 @@ mod tests {
         assert_member_of(storage_type_of(value_id));
         assert_eq!(
             anchor_writers(storage_type_of(wrapper_id)),
-            writers(&[ALICE, BOB])
+            crate::entities::full_mask(writers(&[ALICE, BOB]))
         );
 
         // The newly-added writer can write — authorization resolves from the

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1418,7 +1418,9 @@ mod tests {
             .expect("insert into guarded map");
         let guarded_id = <UnorderedMap<String, String> as Data>::id(&guarded);
         match child_storage_type(guarded_id, "k") {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            StorageType::Shared { writers: w, .. } => {
+                assert_eq!(w, crate::entities::full_mask(writers.clone()))
+            }
             other => panic!("guarded map entry must inherit Shared, got {other:?}"),
         }
     }
@@ -1465,7 +1467,9 @@ mod tests {
 
         let guarded_id = <UnorderedMap<String, String> as Data>::id(&guarded);
         match child_storage_type(guarded_id, "k") {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            StorageType::Shared { writers: w, .. } => {
+                assert_eq!(w, crate::entities::full_mask(writers.clone()))
+            }
             other => panic!("entry/or_default entry must inherit Shared, got {other:?}"),
         }
     }

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -581,7 +581,9 @@ mod tests {
                 .expect("load member entry")
                 .expect("member entry exists");
         match entry.storage.metadata.storage_type {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            StorageType::Shared { writers: w, .. } => {
+                assert_eq!(w, crate::entities::full_mask(writers.clone()))
+            }
             other => panic!("set member must inherit Shared, got {other:?}"),
         }
     }

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -5,7 +5,6 @@
 
 use core::cell::RefCell;
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::io;
 
 use borsh::{to_vec, BorshDeserialize, BorshSerialize};
@@ -14,7 +13,7 @@ use sha2::{Digest, Sha256};
 
 use crate::action::Action;
 use crate::address::Id;
-use crate::entities::{Metadata, SignatureData, StorageType};
+use crate::entities::{Metadata, OpMask, SignatureData, StorageType};
 use crate::env;
 use crate::integration::Comparison;
 use crate::logical_clock::HybridTimestamp;
@@ -172,7 +171,7 @@ pub enum StorageDelta {
         /// signatures against the entry for the action's entity id;
         /// non-Shared entities (User / Frozen / Public) are absent
         /// from the map.
-        effective_writers: BTreeMap<Id, BTreeSet<PublicKey>>,
+        effective_writers: BTreeMap<Id, BTreeMap<PublicKey, OpMask>>,
     },
 }
 
@@ -467,8 +466,11 @@ mod borsh_roundtrip_tests {
         let writer2 = PublicKey::from([0xBB_u8; 32]);
 
         let mut effective_writers = BTreeMap::new();
-        let _ = effective_writers.insert(entity_a, BTreeSet::from([writer1, writer2]));
-        let _ = effective_writers.insert(entity_b, BTreeSet::from([writer1]));
+        let _ = effective_writers.insert(
+            entity_a,
+            BTreeMap::from([(writer1, OpMask::FULL), (writer2, OpMask::FULL)]),
+        );
+        let _ = effective_writers.insert(entity_b, BTreeMap::from([(writer1, OpMask::FULL)]));
 
         let original = StorageDelta::CausalActions {
             actions: vec![make_action(0xFE)],

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -362,8 +362,21 @@ impl Element {
         self.update(); // Mark as dirty
     }
 
-    /// Helper to set the storage domain to `Shared` (an anchor entity).
+    /// Helper to set the storage domain to `Shared` (an anchor entity). Every
+    /// writer gets [`OpMask::FULL`] — the default group-writable behaviour. Use
+    /// [`set_shared_domain_scoped`](Self::set_shared_domain_scoped) to grant
+    /// restricted masks.
     pub fn set_shared_domain(&mut self, writers: BTreeSet<PublicKey>) {
+        self.metadata.storage_type = StorageType::Shared {
+            writers: full_mask(writers),
+            signature_data: None, // Will be signed later
+        };
+        self.update(); // Mark as dirty
+    }
+
+    /// Like [`set_shared_domain`](Self::set_shared_domain) but with explicit
+    /// per-writer [`OpMask`]s.
+    pub fn set_shared_domain_scoped(&mut self, writers: BTreeMap<PublicKey, OpMask>) {
         self.metadata.storage_type = StorageType::Shared {
             writers,
             signature_data: None, // Will be signed later
@@ -427,6 +440,72 @@ pub struct SignatureData {
     pub signer: Option<PublicKey>,
 }
 
+/// A per-principal **operation mask** for writer-set-guarded storage: which
+/// classes of mutation a given writer may perform, enforced at merge.
+///
+/// A `u8` bitset of three independent bits. The named combos ([`WRITE`],
+/// [`FULL`]) are just unions of those bits — the merge check only ever tests
+/// individual bits via [`contains`](OpMask::contains).
+///
+/// `INSERT` and `UPDATE` are deliberately *not* split yet: distinguishing them
+/// requires resolving entity existence at the causal cut (a convergence concern,
+/// not a compatibility one), so a single [`WRITE`] bit covers all upserts until
+/// that lands.
+///
+/// [`WRITE`]: OpMask::WRITE
+/// [`FULL`]: OpMask::FULL
+/// [`contains`]: OpMask::contains
+#[derive(
+    BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash,
+)]
+pub struct OpMask(u8);
+
+impl OpMask {
+    /// Add or edit a value / collection entry (`Add`/`Update`).
+    pub const WRITE: Self = Self(0b0000_0001);
+    /// Remove a value / collection entry (`DeleteRef`).
+    pub const DELETE: Self = Self(0b0000_0010);
+    /// Rotate the writer set / grant / revoke.
+    pub const ADMIN: Self = Self(0b0000_0100);
+
+    /// No permissions.
+    pub const NONE: Self = Self(0);
+    /// Every permission. The default a writer gets when granted without an
+    /// explicit mask, so plain group-writable storage behaves as before.
+    pub const FULL: Self = Self(0b0000_0111);
+
+    /// Whether `self` grants every bit in `needed`.
+    #[must_use]
+    pub const fn contains(self, needed: Self) -> bool {
+        (self.0 & needed.0) == needed.0
+    }
+
+    /// Union of two masks.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// The raw bits — for committing the mask into a signed payload.
+    #[must_use]
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+}
+
+/// Build a writer map granting every key [`OpMask::FULL`] — the default
+/// group-writable behaviour (every writer may do anything).
+#[must_use]
+pub fn full_mask(keys: BTreeSet<PublicKey>) -> BTreeMap<PublicKey, OpMask> {
+    keys.into_iter().map(|k| (k, OpMask::FULL)).collect()
+}
+
+impl Default for OpMask {
+    fn default() -> Self {
+        Self::FULL
+    }
+}
+
 /// Defines the type of storage and its associated authorization rules.
 /// Enum to define the storage domain and its associated data.
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -454,8 +533,12 @@ pub enum StorageType {
     /// O(1) and retroactively revokes access for the entire subtree without
     /// changing any member's bytes (no per-entity churn → no split-brain).
     Shared {
-        /// The set of public keys authorized to write or rotate.
-        writers: BTreeSet<PublicKey>,
+        /// The public keys authorized to write or rotate, each with its
+        /// [`OpMask`] (which operations it may perform). The map keys are the
+        /// writer set (membership); a key's mask defaults to [`OpMask::FULL`]
+        /// when granted without restriction, so plain group-writable storage is
+        /// unchanged.
+        writers: BTreeMap<PublicKey, OpMask>,
         /// A signature and nonce. The signature must be from a key in `writers`
         /// (the *currently stored* set, not the action's claimed set).
         signature_data: Option<SignatureData>,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -38,7 +38,7 @@ mod tests;
 
 use core::fmt::Debug;
 use core::marker::PhantomData;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use borsh::{from_slice, to_vec};
 use calimero_primitives::identity::PublicKey;
@@ -48,7 +48,7 @@ use tracing::{debug, info, warn};
 
 use crate::address::Id;
 use crate::constants;
-use crate::entities::{ChildInfo, Data, Metadata, SignatureData, StorageType};
+use crate::entities::{ChildInfo, Data, Metadata, OpMask, SignatureData, StorageType};
 use crate::env::time_now;
 use crate::index::Index;
 use crate::store::{Key, MainStorage, StorageAdaptor};
@@ -88,7 +88,7 @@ pub struct ApplyContext {
     /// `Some`, the verifier validates the signature against this set and
     /// skips the v2 stored-writers fallback. Resolved by the node sync
     /// layer per #2266.
-    pub effective_writers: Option<BTreeSet<PublicKey>>,
+    pub effective_writers: Option<BTreeMap<PublicKey, OpMask>>,
 
     /// Hash of the `CausalDelta` containing the action being applied. Used
     /// by the rotation-log write hook to record the originating delta on
@@ -245,7 +245,7 @@ impl<S: StorageAdaptor> Interface<S> {
     /// anchors created post-P4. It remains for local execution (correct there)
     /// and for legacy anchors whose log predates P4 (a vanishing set after a
     /// state reset).
-    fn resolve_anchor_writers(anchor: Id) -> BTreeSet<PublicKey> {
+    fn resolve_anchor_writers(anchor: Id) -> BTreeMap<PublicKey, OpMask> {
         if let Ok(Some(log)) = crate::rotation_log::load::<S>(anchor) {
             if let Some(writers) = crate::rotation_log::resolve_local(&log) {
                 return writers;
@@ -256,7 +256,38 @@ impl<S: StorageAdaptor> Interface<S> {
                 return writers;
             }
         }
-        BTreeSet::new()
+        BTreeMap::new()
+    }
+
+    /// The [`OpMask`] an action requires of its signer to be authorized.
+    /// `Add`/`Update` are a single `WRITE` capability for now (INSERT vs UPDATE
+    /// is not split — see the OpMask design); `DeleteRef` requires `DELETE`.
+    fn required_op_mask(action: &crate::action::Action) -> OpMask {
+        use crate::action::Action;
+        match action {
+            Action::Add { .. } | Action::Update { .. } => OpMask::WRITE,
+            Action::DeleteRef { .. } => OpMask::DELETE,
+            Action::Compare { .. } => OpMask::NONE,
+        }
+    }
+
+    /// Enforce that the verified `signer` holds `required` in the resolved
+    /// capability map. Runs **after** signature verification, so the signer is
+    /// known to be a current writer; this is the operation-granularity gate. An
+    /// absent signer (shouldn't happen post-verify) fails closed.
+    fn enforce_op_mask(
+        signer: &PublicKey,
+        required: OpMask,
+        writers: &BTreeMap<PublicKey, OpMask>,
+    ) -> Result<(), StorageError> {
+        let granted = writers.get(signer).copied().unwrap_or(OpMask::NONE);
+        if granted.contains(required) {
+            Ok(())
+        } else {
+            Err(StorageError::ActionNotAllowed(
+                "Signer is a writer but lacks the required operation capability".to_owned(),
+            ))
+        }
     }
 
     /// Verify the writer's signature on a snapshot-supplied entity
@@ -363,10 +394,10 @@ impl<S: StorageAdaptor> Interface<S> {
                 // Fast path: signer hint + verify once. Slow path:
                 // linear scan over writers. Mirrors `apply_action`.
                 let verified = match sig_data.signer {
-                    Some(hint) if writers.contains(&hint) => {
+                    Some(hint) if writers.contains_key(&hint) => {
                         crate::env::ed25519_verify(&sig_data.signature, hint.digest(), &payload)
                     }
-                    _ => writers.iter().any(|w| {
+                    _ => writers.keys().any(|w| {
                         crate::env::ed25519_verify(&sig_data.signature, w.digest(), &payload)
                     }),
                 };
@@ -393,10 +424,10 @@ impl<S: StorageAdaptor> Interface<S> {
                 // fail closed rather than accept an unverifiable member.
                 let writers = Self::resolve_anchor_writers(*anchor);
                 let verified = match sig_data.signer {
-                    Some(hint) if writers.contains(&hint) => {
+                    Some(hint) if writers.contains_key(&hint) => {
                         crate::env::ed25519_verify(&sig_data.signature, hint.digest(), &payload)
                     }
-                    _ => writers.iter().any(|w| {
+                    _ => writers.keys().any(|w| {
                         crate::env::ed25519_verify(&sig_data.signature, w.digest(), &payload)
                     }),
                 };
@@ -438,7 +469,7 @@ impl<S: StorageAdaptor> Interface<S> {
         id: crate::address::Id,
         data: &[u8],
         metadata: &crate::entities::Metadata,
-        writers: &BTreeSet<PublicKey>,
+        writers: &BTreeMap<PublicKey, OpMask>,
     ) -> Result<(), StorageError> {
         use crate::action::Action;
         use crate::entities::StorageType;
@@ -462,11 +493,11 @@ impl<S: StorageAdaptor> Interface<S> {
         };
         let payload = action.payload_for_signing();
         let verified = match sig_data.signer {
-            Some(hint) if writers.contains(&hint) => {
+            Some(hint) if writers.contains_key(&hint) => {
                 crate::env::ed25519_verify(&sig_data.signature, hint.digest(), &payload)
             }
             _ => writers
-                .iter()
+                .keys()
                 .any(|w| crate::env::ed25519_verify(&sig_data.signature, w.digest(), &payload)),
         };
         if verified {
@@ -1101,15 +1132,16 @@ impl<S: StorageAdaptor> Interface<S> {
                         // `authoritative_writers` is now the
                         // DAG-causal answer when available.
                         let payload = action.payload_for_signing();
-                        let verified = match sig_data.signer {
-                            Some(hint) if authoritative_writers.contains(&hint) => {
+                        let signer = match sig_data.signer {
+                            Some(hint) if authoritative_writers.contains_key(&hint) => {
                                 crate::env::ed25519_verify(
                                     &sig_data.signature,
                                     hint.digest(),
                                     &payload,
                                 )
+                                .then_some(hint)
                             }
-                            _ => authoritative_writers.iter().any(|w| {
+                            _ => authoritative_writers.keys().copied().find(|w| {
                                 crate::env::ed25519_verify(
                                     &sig_data.signature,
                                     w.digest(),
@@ -1117,9 +1149,16 @@ impl<S: StorageAdaptor> Interface<S> {
                                 )
                             }),
                         };
-                        if !verified {
+                        let Some(signer) = signer else {
                             return Err(StorageError::InvalidSignature);
-                        }
+                        };
+                        // Operation-granularity gate: the signer is a current
+                        // writer, but must also hold the capability for THIS op.
+                        Self::enforce_op_mask(
+                            &signer,
+                            Self::required_op_mask(&action),
+                            &authoritative_writers,
+                        )?;
 
                         // P3 of #2233: rotation-log write hook.
                         //
@@ -1245,15 +1284,16 @@ impl<S: StorageAdaptor> Interface<S> {
                         // Verify signature first (same hint-fast-path / scan as
                         // Shared), against the anchor-resolved set.
                         let payload = action.payload_for_signing();
-                        let verified = match sig_data.signer {
-                            Some(hint) if authoritative_writers.contains(&hint) => {
+                        let signer = match sig_data.signer {
+                            Some(hint) if authoritative_writers.contains_key(&hint) => {
                                 crate::env::ed25519_verify(
                                     &sig_data.signature,
                                     hint.digest(),
                                     &payload,
                                 )
+                                .then_some(hint)
                             }
-                            _ => authoritative_writers.iter().any(|w| {
+                            _ => authoritative_writers.keys().copied().find(|w| {
                                 crate::env::ed25519_verify(
                                     &sig_data.signature,
                                     w.digest(),
@@ -1261,9 +1301,15 @@ impl<S: StorageAdaptor> Interface<S> {
                                 )
                             }),
                         };
-                        if !verified {
+                        let Some(signer) = signer else {
                             return Err(StorageError::InvalidSignature);
-                        }
+                        };
+                        // Operation-granularity gate (member resolves the anchor's masks).
+                        Self::enforce_op_mask(
+                            &signer,
+                            Self::required_op_mask(&action),
+                            &authoritative_writers,
+                        )?;
 
                         if !skip_nonce && new_nonce < last_nonce {
                             tracing::warn!(
@@ -1437,7 +1483,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // Slow path (no hint): linear scan (matches Add/Update arm).
                                 let payload = action.payload_for_signing();
                                 let signer = match sig_data.signer {
-                                    Some(hint) if existing_writers.contains(&hint) => {
+                                    Some(hint) if existing_writers.contains_key(&hint) => {
                                         if crate::env::ed25519_verify(
                                             &sig_data.signature,
                                             hint.digest(),
@@ -1448,7 +1494,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                             None
                                         }
                                     }
-                                    _ => existing_writers.iter().copied().find(|w| {
+                                    _ => existing_writers.keys().copied().find(|w| {
                                         crate::env::ed25519_verify(
                                             &sig_data.signature,
                                             w.digest(),
@@ -1456,9 +1502,12 @@ impl<S: StorageAdaptor> Interface<S> {
                                         )
                                     }),
                                 };
-                                if signer.is_none() {
-                                    return Err(StorageError::InvalidSignature);
-                                }
+                                let signer = match signer {
+                                    Some(s) => s,
+                                    None => return Err(StorageError::InvalidSignature),
+                                };
+                                // Operation-granularity gate: deletes need DELETE.
+                                Self::enforce_op_mask(&signer, OpMask::DELETE, &existing_writers)?;
 
                                 // Replay protection (per-entity monotonic nonce).
                                 //
@@ -1476,7 +1525,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                 let last_nonce = *existing_metadata.updated_at;
                                 if new_nonce <= last_nonce {
                                     let placeholder = existing_writers
-                                        .iter()
+                                        .keys()
                                         .copied()
                                         .next()
                                         .unwrap_or_else(|| [0u8; 32].into());
@@ -1530,7 +1579,7 @@ impl<S: StorageAdaptor> Interface<S> {
 
                                 let payload = action.payload_for_signing();
                                 let signer = match sig_data.signer {
-                                    Some(hint) if existing_writers.contains(&hint) => {
+                                    Some(hint) if existing_writers.contains_key(&hint) => {
                                         if crate::env::ed25519_verify(
                                             &sig_data.signature,
                                             hint.digest(),
@@ -1541,7 +1590,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                             None
                                         }
                                     }
-                                    _ => existing_writers.iter().copied().find(|w| {
+                                    _ => existing_writers.keys().copied().find(|w| {
                                         crate::env::ed25519_verify(
                                             &sig_data.signature,
                                             w.digest(),
@@ -1549,16 +1598,19 @@ impl<S: StorageAdaptor> Interface<S> {
                                         )
                                     }),
                                 };
-                                if signer.is_none() {
-                                    return Err(StorageError::InvalidSignature);
-                                }
+                                let signer = match signer {
+                                    Some(s) => s,
+                                    None => return Err(StorageError::InvalidSignature),
+                                };
+                                // Operation-granularity gate: deletes need DELETE.
+                                Self::enforce_op_mask(&signer, OpMask::DELETE, &existing_writers)?;
 
                                 // Replay protection (strict `<=` Err, as Shared).
                                 let new_nonce = sig_data.nonce;
                                 let last_nonce = *existing_metadata.updated_at;
                                 if new_nonce <= last_nonce {
                                     let placeholder = existing_writers
-                                        .iter()
+                                        .keys()
                                         .copied()
                                         .next()
                                         .unwrap_or_else(|| [0u8; 32].into());
@@ -1836,7 +1888,7 @@ impl<S: StorageAdaptor> Interface<S> {
         id: Id,
         metadata: &Metadata,
         ctx: &ApplyContext,
-        pre_apply_writers: Option<BTreeSet<PublicKey>>,
+        pre_apply_writers: Option<BTreeMap<PublicKey, OpMask>>,
     ) -> Result<(), StorageError> {
         // Only Shared entities have a rotation log.
         let StorageType::Shared {
@@ -2311,7 +2363,7 @@ impl<S: StorageAdaptor> Interface<S> {
         {
             let executor: calimero_primitives::identity::PublicKey =
                 crate::env::executor_id().into();
-            if stored.contains(&executor) {
+            if stored.contains_key(&executor) {
                 Some((stored.clone(), executor))
             } else {
                 None
@@ -2338,7 +2390,7 @@ impl<S: StorageAdaptor> Interface<S> {
                 let executor: calimero_primitives::identity::PublicKey =
                     crate::env::executor_id().into();
                 let writers = Self::resolve_anchor_writers(*anchor);
-                if writers.contains(&executor) {
+                if writers.contains_key(&executor) {
                     Some((*anchor, executor))
                 } else {
                     None
@@ -3066,11 +3118,11 @@ impl<S: StorageAdaptor> Interface<S> {
             let stored_has_executor = <Index<S>>::get_metadata(id)?
                 .as_ref()
                 .map(|m| match &m.storage_type {
-                    StorageType::Shared { writers, .. } => writers.contains(&executor),
+                    StorageType::Shared { writers, .. } => writers.contains_key(&executor),
                     _ => false,
                 })
                 .unwrap_or(false);
-            let claimed_has_executor = claimed_writers.contains(&executor);
+            let claimed_has_executor = claimed_writers.contains_key(&executor);
             if stored_has_executor || claimed_has_executor {
                 Some((claimed_writers.clone(), executor))
             } else {
@@ -3098,7 +3150,7 @@ impl<S: StorageAdaptor> Interface<S> {
             if let StorageType::SharedMember { anchor, .. } = &metadata.storage_type {
                 let executor: calimero_primitives::identity::PublicKey =
                     crate::env::executor_id().into();
-                if Self::resolve_anchor_writers(*anchor).contains(&executor) {
+                if Self::resolve_anchor_writers(*anchor).contains_key(&executor) {
                     Some((*anchor, executor))
                 } else {
                     None

--- a/crates/storage/src/rotation_log.rs
+++ b/crates/storage/src/rotation_log.rs
@@ -25,12 +25,13 @@
 //! The threshold (epic suggests 1000 entries) is a P6 measurement; the shape
 //! is fixed here so the on-disk format doesn't need a breaking change later.
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
 use crate::address::Id;
+use crate::entities::OpMask;
 use crate::error::StorageError;
 use crate::logical_clock::HybridTimestamp;
 use crate::store::{Key, StorageAdaptor};
@@ -73,10 +74,10 @@ pub struct RotationLogEntry {
     /// treated as "larger than any").
     pub signer: Option<PublicKey>,
 
-    /// Resolved writer set after this rotation. `BTreeSet` so the on-wire
-    /// representation is canonical (sorted), matching the rest of the
-    /// `Shared` storage path.
-    pub new_writers: BTreeSet<PublicKey>,
+    /// Resolved writer set after this rotation, each writer with its
+    /// [`OpMask`]. `BTreeMap` so the on-wire representation is canonical
+    /// (sorted by key), matching the rest of the `Shared` storage path.
+    pub new_writers: BTreeMap<PublicKey, OpMask>,
 
     /// Per-entity monotonic counter at the time of rotation. Preserved for
     /// debugging and v2 compatibility; the ADR rule does not depend on it.
@@ -92,7 +93,7 @@ pub struct RotationLogEntry {
 pub struct RotationSnapshot {
     /// Writer set as-of the boundary. When a query's `causal_parents` only
     /// reach into the compacted region, this is the answer.
-    pub writers: BTreeSet<PublicKey>,
+    pub writers: BTreeMap<PublicKey, OpMask>,
 
     /// Index into the original (uncompacted) entry stream that the snapshot
     /// represents. Compacted entries had indices `[0, cutoff_index)`; live
@@ -235,7 +236,7 @@ pub fn append<S: StorageAdaptor>(id: Id, entry: RotationLogEntry) -> Result<(), 
 /// Returns `None` only when the log has neither entries nor a compaction
 /// snapshot.
 #[must_use]
-pub fn resolve_local(log: &RotationLog) -> Option<BTreeSet<PublicKey>> {
+pub fn resolve_local(log: &RotationLog) -> Option<BTreeMap<PublicKey, OpMask>> {
     if let Some(entry) = log.entries.iter().max_by(|a, b| {
         // HLC first (causally monotonic post-#2635), then signer as the
         // ADR-0001 tiebreak: smaller signer bytes win, `None` (unsigned legacy)
@@ -294,7 +295,11 @@ mod tests {
             delta_id: [delta_id; 32],
             delta_hlc: HybridTimestamp::new(ts),
             signer: Some(pk(signer)),
-            new_writers: writers.iter().copied().map(pk).collect(),
+            new_writers: writers
+                .iter()
+                .copied()
+                .map(|b| (pk(b), OpMask::FULL))
+                .collect(),
             writers_nonce: nonce,
         }
     }
@@ -374,7 +379,12 @@ mod tests {
         ]);
         assert_eq!(
             resolve_local(&log),
-            Some([0xAA, 0xBB].into_iter().map(pk).collect())
+            Some(
+                [0xAA, 0xBB]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
         );
     }
 
@@ -393,7 +403,12 @@ mod tests {
         // ...and it is the HLC winner R2 = {B, C}.
         assert_eq!(
             resolve_local(&node1),
-            Some([0xBB, 0xCC].into_iter().map(pk).collect())
+            Some(
+                [0xBB, 0xCC]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
         );
     }
 
@@ -410,7 +425,11 @@ mod tests {
                 delta_id: [delta_id; 32],
                 delta_hlc: HybridTimestamp::new(ts),
                 signer: Some(pk(signer)),
-                new_writers: writers.iter().copied().map(pk).collect(),
+                new_writers: writers
+                    .iter()
+                    .copied()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect(),
                 writers_nonce: 1,
             }
         };
@@ -421,14 +440,20 @@ mod tests {
         // 0xAA < 0xBB → {A, C} wins; order-independent.
         assert_eq!(
             resolve_local(&log),
-            Some([0xAA, 0xCC].into_iter().map(pk).collect())
+            Some(
+                [0xAA, 0xCC]
+                    .into_iter()
+                    .map(|b| (pk(b), OpMask::FULL))
+                    .collect()
+            )
         );
     }
 
     #[test]
     fn resolve_local_falls_back_to_snapshot() {
         // Compacted log with no live entries → the snapshot's writer set.
-        let snap: BTreeSet<PublicKey> = [0xEE].into_iter().map(pk).collect();
+        let snap: BTreeMap<PublicKey, OpMask> =
+            [0xEE].into_iter().map(|b| (pk(b), OpMask::FULL)).collect();
         let log = RotationLog {
             snapshot: Some(RotationSnapshot {
                 writers: snap.clone(),

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -333,7 +333,7 @@ pub fn build_signed_shared_action(
         created_at: hlc_ns,
         updated_at: hlc_ns.into(),
         storage_type: StorageType::Shared {
-            writers,
+            writers: crate::entities::full_mask(writers),
             signature_data: Some(SignatureData {
                 signature: [0; 64],
                 nonce: hlc_ns,

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1379,7 +1379,7 @@ mod verify_snapshot_entity_signature_tests {
             created_at: 0,
             updated_at: 0.into(),
             storage_type: StorageType::Shared {
-                writers,
+                writers: crate::entities::full_mask(writers.clone()),
                 signature_data: None,
             },
             crdt_type: None,
@@ -1393,7 +1393,7 @@ mod verify_snapshot_entity_signature_tests {
             created_at: 0,
             updated_at: 0.into(),
             storage_type: StorageType::Shared {
-                writers,
+                writers: crate::entities::full_mask(writers.clone()),
                 signature_data: Some(SignatureData {
                     signature: [0u8; 64],
                     nonce: 42,
@@ -1489,7 +1489,7 @@ mod update_signature_in_place_tests {
 
     fn shared_signed(writers: BTreeSet<PublicKey>, sig: [u8; 64]) -> StorageType {
         StorageType::Shared {
-            writers,
+            writers: crate::entities::full_mask(writers),
             signature_data: Some(SignatureData {
                 signature: sig,
                 nonce: 1,
@@ -1511,7 +1511,7 @@ mod update_signature_in_place_tests {
 
     fn shared_unsigned(writers: BTreeSet<PublicKey>) -> StorageType {
         StorageType::Shared {
-            writers,
+            writers: crate::entities::full_mask(writers),
             signature_data: None,
         }
     }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1462,7 +1462,7 @@ mod shared_storage_rotation_authentication {
             vec![],
         );
         let ctx = ApplyContext {
-            effective_writers: Some(writers.clone()),
+            effective_writers: Some(crate::entities::full_mask(writers.clone())),
             delta_id: None,
             delta_hlc: None,
         };
@@ -1478,7 +1478,8 @@ mod shared_storage_rotation_authentication {
         match stored.storage_type {
             StorageType::Shared { writers: w, .. } => {
                 assert_eq!(
-                    w, writers,
+                    w,
+                    crate::entities::full_mask(writers.clone()),
                     "writer set must be unchanged after forged rotation"
                 );
             }
@@ -1535,7 +1536,9 @@ mod shared_storage_rotation_authentication {
 
         let stored = <Index<MainStorage>>::get_metadata(id).unwrap().unwrap();
         match stored.storage_type {
-            StorageType::Shared { writers: w, .. } => assert_eq!(w, writers),
+            StorageType::Shared { writers: w, .. } => {
+                assert_eq!(w, crate::entities::full_mask(writers.clone()))
+            }
             other => panic!("expected Shared storage_type, got {other:?}"),
         }
     }
@@ -1588,7 +1591,7 @@ mod shared_storage_rotation_authentication {
             ID::from(core::num::NonZeroU128::new(1).unwrap()),
         ));
         let ctx = ApplyContext {
-            effective_writers: Some(writers),
+            effective_writers: Some(crate::entities::full_mask(writers.clone())),
             delta_id: Some([0xD1; 32]),
             delta_hlc: Some(delta_hlc),
         };
@@ -1602,7 +1605,7 @@ mod shared_storage_rotation_authentication {
             .expect("rotation log must exist after an accepted rotation");
         assert_eq!(
             log.entries.last().expect("a rotation entry").new_writers,
-            new_writers,
+            crate::entities::full_mask(new_writers.clone()),
             "accepted rotation must record the new writer set in the rotation log"
         );
     }
@@ -1647,12 +1650,12 @@ mod shared_storage_rotation_authentication {
         MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
 
         let pre_ctx = || ApplyContext {
-            effective_writers: Some(pre.clone()),
+            effective_writers: Some(crate::entities::full_mask(pre.clone())),
             delta_id: None,
             delta_hlc: None,
         };
         let post_ctx = || ApplyContext {
-            effective_writers: Some(post.clone()),
+            effective_writers: Some(crate::entities::full_mask(post.clone())),
             delta_id: None,
             delta_hlc: None,
         };
@@ -1765,6 +1768,83 @@ mod shared_storage_rotation_authentication {
         let ok_delete = build_signed_member_delete(member, anchor, &alice_sk, n0 + 3_000_000);
         MainInterface::apply_action(ok_delete, &ApplyContext::empty())
             .expect("a writer's member delete must be accepted");
+    }
+
+    /// OpMask gate: a writer holding `WRITE` but not `DELETE` may update a
+    /// member entry, but a (validly-signed) delete from that same writer is
+    /// rejected at merge — "write but not delete", enforced at apply time.
+    #[test]
+    fn member_write_capability_allows_update_but_not_delete() {
+        use crate::entities::OpMask;
+
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let anchor = Id::new([0xA0; 32]);
+        let member = Id::new([0x3E; 32]);
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+        let n0 = env::time_now();
+
+        // Bootstrap anchor {alice} + a member written by alice.
+        let bootstrap = build_signed_shared_action(
+            true,
+            anchor,
+            b"anchor".to_vec(),
+            writers.clone(),
+            n0,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(bootstrap, &ApplyContext::empty()).unwrap();
+        let member_add = build_signed_member_action(
+            true,
+            member,
+            anchor,
+            b"v".to_vec(),
+            n0 + 1_000_000,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(member_add, &ApplyContext::empty()).unwrap();
+
+        // Alice's resolved capability is WRITE-only (no DELETE).
+        let write_only = |id, hlc| crate::interface::ApplyContext {
+            effective_writers: Some([(alice, OpMask::WRITE)].into_iter().collect()),
+            delta_id: id,
+            delta_hlc: hlc,
+        };
+
+        // An update is permitted (WRITE ⊇ WRITE).
+        let member_update = build_signed_member_action(
+            false,
+            member,
+            anchor,
+            b"v2".to_vec(),
+            n0 + 2_000_000,
+            &alice_sk,
+            vec![root.clone()],
+        );
+        MainInterface::apply_action(member_update, &write_only(None, None))
+            .expect("a WRITE-capable writer's update must be accepted");
+
+        // The same writer's (validly-signed) delete is refused at the op-gate.
+        let del = build_signed_member_delete(member, anchor, &alice_sk, n0 + 3_000_000);
+        let result = MainInterface::apply_action(del, &write_only(None, None));
+        assert!(
+            matches!(result, Err(StorageError::ActionNotAllowed(_))),
+            "a writer lacking DELETE must be refused at the op-gate, got {result:?}"
+        );
+
+        // With FULL capability, the delete is accepted.
+        let full = crate::interface::ApplyContext {
+            effective_writers: Some([(alice, OpMask::FULL)].into_iter().collect()),
+            delta_id: None,
+            delta_hlc: None,
+        };
+        let del2 = build_signed_member_delete(member, anchor, &alice_sk, n0 + 4_000_000);
+        MainInterface::apply_action(del2, &full).expect("FULL writer's delete must be accepted");
     }
 
     /// Snapshot verification of a member resolves the anchor's writers (the

--- a/crates/storage/src/tests/sync_batch_resilience.rs
+++ b/crates/storage/src/tests/sync_batch_resilience.rs
@@ -32,7 +32,7 @@ use crate::action::Action;
 use crate::address::Id;
 use crate::collections::Root;
 use crate::delta::StorageDelta;
-use crate::entities::{ChildInfo, Metadata, StorageType};
+use crate::entities::{ChildInfo, Metadata, OpMask, StorageType};
 use crate::index::Index;
 use crate::interface::{ApplyContext, Interface};
 use crate::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
@@ -86,7 +86,7 @@ fn unsigned_shared_add(
             created_at: hlc_ns,
             updated_at: hlc_ns.into(),
             storage_type: StorageType::Shared {
-                writers,
+                writers: crate::entities::full_mask(writers.clone()),
                 signature_data: None, // <- the bug trigger
             },
             crdt_type: None,
@@ -126,8 +126,8 @@ fn unsigned_shared_action_does_not_abort_the_sync_batch() {
     // The receiver's per-action `effective_writers` map (#2266). The good
     // action verifies against {Alice}; the bad one is rejected before any
     // writer check, so its entry is irrelevant.
-    let mut effective_writers: BTreeMap<Id, BTreeSet<PublicKey>> = BTreeMap::new();
-    let _ = effective_writers.insert(good_id, writers.clone());
+    let mut effective_writers: BTreeMap<Id, BTreeMap<PublicKey, OpMask>> = BTreeMap::new();
+    let _ = effective_writers.insert(good_id, crate::entities::full_mask(writers.clone()));
 
     let payload = to_vec(&StorageDelta::CausalActions {
         actions: vec![bad, good],

--- a/crates/storage/src/tests/write_hook_stale_writers.rs
+++ b/crates/storage/src/tests/write_hook_stale_writers.rs
@@ -83,7 +83,7 @@ fn ctx(delta_id: [u8; 32], delta_hlc_ns: u64) -> ApplyContext {
 /// rotated out of the locally-stored set between authoring and delivery.
 fn ctx_ew(delta_id: [u8; 32], delta_hlc_ns: u64, effective: BTreeSet<PublicKey>) -> ApplyContext {
     ApplyContext {
-        effective_writers: Some(effective),
+        effective_writers: Some(crate::entities::full_mask(effective)),
         delta_id: Some(delta_id),
         delta_hlc: Some(hlc(delta_hlc_ns)),
     }
@@ -297,7 +297,7 @@ fn shared_equal_nonce_different_writers_converge_regardless_of_order() {
 /// signatures verify regardless of the local stored set at apply time.
 fn apply_concurrent_rotations_in_order<const SCOPE: usize>(
     r1_first: bool,
-) -> Vec<BTreeSet<PublicKey>> {
+) -> Vec<std::collections::BTreeMap<PublicKey, crate::entities::OpMask>> {
     crate::env::reset_for_testing();
     let root = setup_root::<S<SCOPE>>();
 
@@ -392,7 +392,7 @@ fn concurrent_rotations_converge_in_log_regardless_of_apply_order() {
     let alice = pubkey_of(&make_signing_key(0xA1));
     let bob = pubkey_of(&make_signing_key(0xB2));
     let dave = pubkey_of(&make_signing_key(0xD4));
-    let with_dave: BTreeSet<PublicKey> = [bob, dave].into_iter().collect();
+    let with_dave = crate::entities::full_mask([bob, dave].into_iter().collect());
 
     // Node X applies R1 (higher nonce) first, then R2 (lower nonce → stale).
     let x = apply_concurrent_rotations_in_order::<411>(true);


### PR DESCRIPTION
Adds **per-principal operation masks** to writer-set-guarded storage, enforced at merge — so a writer can be granted `WRITE` without `DELETE` ("write but not delete"), the headline gap from #2541. The data-plane slice of #2541; consumer of the components epic #2687.

**This is PR 1/2 — the protocol enforcement layer.** App-facing grant ergonomics (`grant_capability` / `ProtocolAuthorizer` / op-granular `AccessControl`) and the 2-node adversarial merobox e2e follow in PR 2/2.

Design doc: `docs/design/opmask-operation-aware-acls.md` (in the components branch); summary below.

## Representation (alpha: in-place, no migration)
- New `OpMask(u8)` in `entities.rs`: `WRITE`/`DELETE`/`ADMIN` bits + `FULL`, plus `full_mask` (grant FULL to a key set = the default group-writable behaviour).
- `StorageType::Shared.writers`: `BTreeSet<PublicKey>` → `BTreeMap<PublicKey, OpMask>`. A plain `Shared`/`SharedStorage` grants every writer `FULL`, so **existing apps are behaviour-unchanged**. `storage_type` is hash-neutral → no root-hash churn.

## Signed + resolved
- `payload_for_signing` commits each writer's key **and** mask → masks are tamper-proof (a peer can't forge/escalate a mask).
- `RotationLogEntry`/`RotationSnapshot`/`resolve_local`/`writers_at`/`resolve_anchor_writers`/`ApplyContext.effective_writers` all carry the mask map. `writers_at` keeps its name; the resolution rule is unchanged (concurrent rotations still pick one HLC winner).

## The gate (the feature)
- `required_op_mask(action)`: Add/Update → `WRITE`, DeleteRef → `DELETE`.
- `enforce_op_mask(signer, required, writers)`: fail-closed.
- Wired **after** signature verification in every apply arm (Shared + SharedMember upsert, both DeleteRef); the upsert arms now capture the verifying signer.
- `INSERT` vs `UPDATE` is deliberately one `WRITE` bit — the split needs existence-at-causal-cut (a convergence concern, not compat), deferred.
- Snapshot/standalone verify is membership-only for now (the apply path is the threat surface); op-gating it is a noted follow-up.

`WriterSetCell` gains `rotate_writers_scoped(map)` (the primitive for non-FULL grants) + `capabilities()`; `writers()` still returns the key set for app compat.

## Tests
- **Storage lib: 595 green**, incl. `member_write_capability_allows_update_but_not_delete` — a WRITE-only writer's update is accepted but its validly-signed delete is rejected at the gate, and FULL restores it, **proven through the real apply path with real signatures**.
- **Node lib: 335 green** — rotation/`writers_at`/p3/p5/snapshot sync tests unchanged (no regression in the split-brain-sensitive layer).
- Whole workspace builds.

Tracking: #2541 (umbrella) · #2687 (components epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization data structures and merge-time gates across storage, rotation logs, and node sync—security-critical paths where a bug could allow unauthorized writes or break convergence.
> 
> **Overview**
> Introduces **per-writer operation masks** (`OpMask`) for `Shared` / writer-set storage so merge can allow membership without granting every mutation (e.g. **write without delete**).
> 
> **Representation:** `StorageType::Shared.writers` and rotation-log snapshots/entries move from `BTreeSet<PublicKey>` to `BTreeMap<PublicKey, OpMask>`. `full_mask` and default `OpMask::FULL` keep plain group-writable behaviour unchanged. `payload_for_signing` now commits each writer key **and** mask so masks cannot be forged on the wire.
> 
> **Enforcement:** `ApplyContext.effective_writers`, node `writers_at` / `resolve_effective_writers_for_delta`, and snapshot anchor maps carry the same map. After ed25519 verification, `required_op_mask` + `enforce_op_mask` gate `Add`/`Update` (`WRITE`) and `DeleteRef` (`DELETE`) on Shared and SharedMember apply paths.
> 
> **API:** `Element::set_shared_domain_scoped`, `WriterSetCell::rotate_writers_scoped` / `capabilities()`; existing `rotate_writers` / `writers()` stay FULL / keys-only for compat.
> 
> Tests and node sync helpers are updated to the new map shape; new apply-path test proves WRITE-only rejects deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afce5e90b8099767c1b0f89e3ff06f3f6f53e74a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->