### PR TITLE
refactor(context/execute): extract governance_position helper (increment 3)

### DIFF
--- a/crates/context/src/handlers/execute/governance_position.rs
+++ b/crates/context/src/handlers/execute/governance_position.rs
@@ -1,0 +1,137 @@
+//! Computes the [`GovernancePosition`] embedded in outbound state deltas for a
+//! group context (the governance-DAG head reference receivers use to gate
+//! membership). Extracted from the execute handler.
+
+use calimero_context_config::types::GovernancePosition;
+use calimero_governance_store::{MetaRepository, NamespaceRepository};
+use calimero_primitives::context::ContextId;
+use calimero_store::Store;
+
+/// Compute the [`GovernancePosition`] to embed in the next state delta from
+/// this context.
+///
+/// Returns `None` for non-group contexts (which have no governance DAG to
+/// reference) and on any read failure — receivers will surface the missing
+/// position via the apply-time membership check rather than silently
+/// relying on it.
+pub(super) fn compute_governance_position_for_context(
+    datastore: &Store,
+    context_id: &ContextId,
+) -> Option<GovernancePosition> {
+    let group_id = match calimero_governance_store::get_group_for_context(datastore, context_id) {
+        Ok(Some(gid)) => gid,
+        Ok(None) => return None,
+        Err(err) => {
+            tracing::warn!(
+                %context_id,
+                %err,
+                "compute_governance_position: get_group_for_context failed"
+            );
+            return None;
+        }
+    };
+
+    let namespace_id = match NamespaceRepository::new(datastore).resolve(&group_id) {
+        Ok(ns_id) => ns_id,
+        Err(err) => {
+            tracing::warn!(
+                %context_id,
+                group_id = ?group_id,
+                %err,
+                "compute_governance_position: resolve_namespace failed"
+            );
+            return None;
+        }
+    };
+
+    let dag =
+        calimero_governance_store::NamespaceDagService::new(datastore, namespace_id.to_bytes());
+
+    // Double-read pattern: governance ops can apply between reading heads
+    // and computing the state hash, producing an internally-inconsistent
+    // position whose hash and heads disagree. Re-read heads after the hash
+    // and bail if they changed — the receiver's heads-equal fast path
+    // treats hash mismatch as a hard rejection, so shipping a stale value
+    // would spuriously reject legitimate deltas. A true atomic read would
+    // require refactoring `compute_group_state_hash` and `read_head_record`
+    // to share a `Handle` (snapshot view); the double-read covers the
+    // race window with a single extra cheap read.
+    let heads_before = match dag.read_head_record() {
+        Ok(head) => head.parent_hashes,
+        Err(err) => {
+            tracing::warn!(
+                %context_id,
+                group_id = ?group_id,
+                %err,
+                "compute_governance_position: read_head_record failed (before)"
+            );
+            return None;
+        }
+    };
+
+    let group_state_hash = match MetaRepository::new(datastore).compute_state_hash(&group_id) {
+        Ok(hash) => hash,
+        Err(err) => {
+            tracing::warn!(
+                %context_id,
+                group_id = ?group_id,
+                %err,
+                "compute_governance_position: compute_group_state_hash failed"
+            );
+            return None;
+        }
+    };
+
+    let heads_after = match dag.read_head_record() {
+        Ok(head) => head.parent_hashes,
+        Err(err) => {
+            tracing::warn!(
+                %context_id,
+                group_id = ?group_id,
+                %err,
+                "compute_governance_position: read_head_record failed (after)"
+            );
+            return None;
+        }
+    };
+
+    // Set-equality, not Vec equality. Storage iteration order isn't guaranteed
+    // to be stable across two reads, so a Vec equality check would treat
+    // [h1, h2] vs [h2, h1] as a stale read and emit None for every state delta
+    // — receivers then reject the delta on the no-position-on-group-context
+    // anti-bypass branch and the wire wedges even when the underlying head
+    // set didn't actually change.
+    let heads_changed = {
+        use std::collections::HashSet;
+        heads_before.len() != heads_after.len()
+            || heads_before.iter().collect::<HashSet<_>>()
+                != heads_after.iter().collect::<HashSet<_>>()
+    };
+    if heads_changed {
+        tracing::warn!(
+            %context_id,
+            group_id = ?group_id,
+            "compute_governance_position: governance heads changed mid-read; \
+             skipping position to avoid hash/heads divergence"
+        );
+        return None;
+    }
+
+    match GovernancePosition::new(group_id, group_state_hash, heads_after) {
+        Ok(pos) => Some(pos),
+        Err(err) => {
+            // Local DAG has more heads than MAX_GOVERNANCE_DAG_HEADS allows
+            // on the wire — refuse to emit rather than ship a position that
+            // the receiver's bounded BorshDeserialize will reject. Indicates
+            // either pathological concurrent admin activity or local
+            // corruption; logging here surfaces it for operators.
+            tracing::warn!(
+                %context_id,
+                group_id = ?group_id,
+                %err,
+                "compute_governance_position: refusing to embed oversized position"
+            );
+            None
+        }
+    }
+}

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1,5 +1,5 @@
 use calimero_governance_store::{
-    CapabilitiesRepository, GroupKeyring, MetaRepository, MigrationsRepository, NamespaceRepository,
+    CapabilitiesRepository, GroupKeyring, MigrationsRepository, NamespaceRepository,
 };
 use std::borrow::Cow;
 // Removed: NonZeroUsize (replaced with CausalDelta)
@@ -27,7 +27,6 @@ use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_runtime::logic::Outcome;
 use calimero_storage::{
     delta::{CausalDelta, StorageDelta},
-    entities::StorageType,
     env::{with_runtime_env, RuntimeEnv},
     interface::Interface,
     store::MainStorage,
@@ -52,10 +51,12 @@ use crate::handlers::update_application::{
 use crate::ContextManager;
 use calimero_governance_store::metrics::ExecutionLabels;
 
+mod governance_position;
 mod signing;
 pub mod storage;
 mod upgrade_gate;
 
+use governance_position::compute_governance_position_for_context;
 pub(crate) use signing::{persist_signed_signatures, sign_authorized_actions};
 use storage::{ContextPrivateStorage, ContextStorage, ReadOnlyContextStorage};
 use upgrade_gate::{
@@ -1247,135 +1248,6 @@ impl ContextManager {
 enum CachedOrBlob {
     Cached(calimero_runtime::Module),
     Blob(calimero_primitives::application::ApplicationBlob),
-}
-
-/// Compute the [`GovernancePosition`] to embed in the next state delta from
-/// this context.
-///
-/// Returns `None` for non-group contexts (which have no governance DAG to
-/// reference) and on any read failure — receivers will surface the missing
-/// position via the apply-time membership check rather than silently
-/// relying on it.
-fn compute_governance_position_for_context(
-    datastore: &Store,
-    context_id: &ContextId,
-) -> Option<GovernancePosition> {
-    let group_id = match calimero_governance_store::get_group_for_context(datastore, context_id) {
-        Ok(Some(gid)) => gid,
-        Ok(None) => return None,
-        Err(err) => {
-            tracing::warn!(
-                %context_id,
-                %err,
-                "compute_governance_position: get_group_for_context failed"
-            );
-            return None;
-        }
-    };
-
-    let namespace_id = match NamespaceRepository::new(datastore).resolve(&group_id) {
-        Ok(ns_id) => ns_id,
-        Err(err) => {
-            tracing::warn!(
-                %context_id,
-                group_id = ?group_id,
-                %err,
-                "compute_governance_position: resolve_namespace failed"
-            );
-            return None;
-        }
-    };
-
-    let dag =
-        calimero_governance_store::NamespaceDagService::new(datastore, namespace_id.to_bytes());
-
-    // Double-read pattern: governance ops can apply between reading heads
-    // and computing the state hash, producing an internally-inconsistent
-    // position whose hash and heads disagree. Re-read heads after the hash
-    // and bail if they changed — the receiver's heads-equal fast path
-    // treats hash mismatch as a hard rejection, so shipping a stale value
-    // would spuriously reject legitimate deltas. A true atomic read would
-    // require refactoring `compute_group_state_hash` and `read_head_record`
-    // to share a `Handle` (snapshot view); the double-read covers the
-    // race window with a single extra cheap read.
-    let heads_before = match dag.read_head_record() {
-        Ok(head) => head.parent_hashes,
-        Err(err) => {
-            tracing::warn!(
-                %context_id,
-                group_id = ?group_id,
-                %err,
-                "compute_governance_position: read_head_record failed (before)"
-            );
-            return None;
-        }
-    };
-
-    let group_state_hash = match MetaRepository::new(datastore).compute_state_hash(&group_id) {
-        Ok(hash) => hash,
-        Err(err) => {
-            tracing::warn!(
-                %context_id,
-                group_id = ?group_id,
-                %err,
-                "compute_governance_position: compute_group_state_hash failed"
-            );
-            return None;
-        }
-    };
-
-    let heads_after = match dag.read_head_record() {
-        Ok(head) => head.parent_hashes,
-        Err(err) => {
-            tracing::warn!(
-                %context_id,
-                group_id = ?group_id,
-                %err,
-                "compute_governance_position: read_head_record failed (after)"
-            );
-            return None;
-        }
-    };
-
-    // Set-equality, not Vec equality. Storage iteration order isn't guaranteed
-    // to be stable across two reads, so a Vec equality check would treat
-    // [h1, h2] vs [h2, h1] as a stale read and emit None for every state delta
-    // — receivers then reject the delta on the no-position-on-group-context
-    // anti-bypass branch and the wire wedges even when the underlying head
-    // set didn't actually change.
-    let heads_changed = {
-        use std::collections::HashSet;
-        heads_before.len() != heads_after.len()
-            || heads_before.iter().collect::<HashSet<_>>()
-                != heads_after.iter().collect::<HashSet<_>>()
-    };
-    if heads_changed {
-        tracing::warn!(
-            %context_id,
-            group_id = ?group_id,
-            "compute_governance_position: governance heads changed mid-read; \
-             skipping position to avoid hash/heads divergence"
-        );
-        return None;
-    }
-
-    match GovernancePosition::new(group_id, group_state_hash, heads_after) {
-        Ok(pos) => Some(pos),
-        Err(err) => {
-            // Local DAG has more heads than MAX_GOVERNANCE_DAG_HEADS allows
-            // on the wire — refuse to emit rather than ship a position that
-            // the receiver's bounded BorshDeserialize will reject. Indicates
-            // either pathological concurrent admin activity or local
-            // corruption; logging here surfaces it for operators.
-            tracing::warn!(
-                %context_id,
-                group_id = ?group_id,
-                %err,
-                "compute_governance_position: refusing to embed oversized position"
-            );
-            None
-        }
-    }
 }
 
 async fn internal_execute(


### PR DESCRIPTION
## What

Increment 3 of splitting `context/src/handlers/execute/mod.rs`. Moves `compute_governance_position_for_context` into `governance_position.rs` — pure, behavior-preserving code movement (`mod.rs`: +3 / −131).

## Wiring

- `pub(super)`, re-imported into the execute flow (one caller in `internal_execute`).
- Drops two now-orphaned top-level imports: `MetaRepository` (the test module re-imports it locally) and `entities::StorageType`.
- `CachedOrBlob` stays in `mod.rs` — it belongs to the module-loading path, not governance computation.
- Explicit imports, no `use super::*`.

## Validation

- `cargo check -p calimero-context` clean (no new warnings).
- context lib tests: **107 passed**.

## Progress

`execute/mod.rs`: 2675 → **~2105 LOC** across #2733 (signing) + #2734 (upgrade_gate) + this. Submodules: `storage` (pre-existing) / `signing` / `upgrade_gate` / `governance_position`.

**What's left here is the deeper work:** the two god-functions — `internal_execute` (~514 lines) and the `Handler<ExecuteRequest>` actor-closure chain (~900 lines). Those need careful in-function decomposition (à la the `internal_handle_opened_stream` passes), not just free-function moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure code movement with no logic changes; governance embedding behavior stays on the existing `internal_execute` path.
> 
> **Overview**
> **Refactors** the execute handler by moving `compute_governance_position_for_context` out of `execute/mod.rs` into a new sibling module `governance_position.rs`, with the same `pub(super)` visibility and a direct import back into `internal_execute` (still the only call site).
> 
> `mod.rs` shrinks by wiring `mod governance_position` and dropping imports that only served the moved code (`MetaRepository` at the module top level; `entities::StorageType`). **`CachedOrBlob`** and the rest of the execute flow are unchanged — this is structure-only, not behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3880c3279b263433e63c1602cfc3476139342dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->