### PR TITLE
fix(storage): un-break master — writable_by_me + test for OpMask writer map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8829,6 +8829,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scenario-authored-migrate-ux-v1"
+version = "0.0.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+ "calimero-wasm-abi",
+ "serde_json",
+]
+
+[[package]]
+name = "scenario-authored-migrate-ux-v2"
+version = "0.0.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+ "calimero-wasm-abi",
+ "serde_json",
+]
+
+[[package]]
 name = "scenario-authored-vector-v1"
 version = "0.0.0"
 dependencies = [

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -386,7 +386,7 @@ where
     /// rotation-log-aware path as the write gate.
     pub fn writable_by_me(&self) -> bool {
         let executor: PublicKey = env::executor_id().into();
-        self.current_writers().contains(&executor)
+        self.current_writers().contains_key(&executor)
     }
 
     /// The current writer set, resolved only from **verified** local sources.

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -439,7 +439,10 @@ mod metadata__needs_owner_convert {
     fn shared_meta(schema: Option<u32>) -> Metadata {
         let mut m = Metadata::new(1, 1);
         m.storage_type = StorageType::Shared {
-            writers: [key(0xBB)].into_iter().collect(),
+            writers: [key(0xBB)]
+                .into_iter()
+                .map(|k| (k, crate::entities::OpMask::FULL))
+                .collect(),
             signature_data: None,
         };
         m.schema_version = schema;


### PR DESCRIPTION
**`master` does not currently compile.** This is a 2-line fix.

## What happened
A semantic (not textual) merge conflict between two independently-green PRs:
- A migration PR added `WriterSetCell::writable_by_me()` (+ `schema_version`/`migrate_my_entries`) using the `BTreeSet` writer-set API (`current_writers().contains(&executor)`), and a `tests/entities.rs` `Shared`-stamp built with `[key].into_iter().collect()` (a set).
- **#2735** (OpMask) changed `Shared.writers` / `current_writers()` to `BTreeMap<PublicKey, OpMask>`.

Both passed CI on their own branches. The squash-merge of #2735 (`bbcc9f3a`) didn't reconcile the migration PR's two sites, so post-merge `master` fails to compile (`no method contains on BTreeMap`, and `BTreeMap can't be built from an iterator of PublicKey`).

## Fix
- `writable_by_me`: `.contains(&executor)` → `.contains_key(&executor)`.
- `tests/entities.rs`: build the writer map with `OpMask::FULL`.

Verified: `cargo build --workspace` clean, storage lib 612 tests green, fmt clean. Merge this to restore master before anything else lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API alignment for compile; writer gating behavior is unchanged (full mask still means full write rights).
> 
> **Overview**
> Restores **`master` compile** after the OpMask writer-set change (`Shared.writers` / `current_writers()` are now `BTreeMap<PublicKey, OpMask>` instead of a set).
> 
> **`WriterSetCell::writable_by_me`** now checks membership with **`.contains_key(&executor)`** instead of `.contains(&executor)` on the writer map.
> 
> In **`tests/entities`**, **`shared_meta`** builds the `Shared { writers }` stamp as a map of keys paired with **`OpMask::FULL`**, matching the new storage type.
> 
> `Cargo.lock` also picks up workspace entries for **`scenario-authored-migrate-ux-v1`** and **`-v2`** (lockfile-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d924fe0674ffd49ef7def4a72f6d4e05cf624a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->