### PR TITLE
fix(node): finish OpMask writer-map migration in test targets (master CI red)

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -2310,7 +2310,7 @@ mod tests {
     #[test]
     fn rotation_log_reconciliation_converges_divergent_shared_logs() {
         use core::num::NonZeroU128;
-        use std::collections::BTreeSet;
+        use std::collections::{BTreeMap, BTreeSet};
         use std::sync::Arc;
 
         use calimero_storage::action::Action;
@@ -2381,7 +2381,9 @@ mod tests {
                 Interface::<MainStorage>::apply_action(
                     bootstrap,
                     &ApplyContext {
-                        effective_writers: Some(genesis.clone()),
+                        effective_writers: Some(calimero_storage::entities::full_mask(
+                            genesis.clone(),
+                        )),
                         delta_id: Some([0xE0; 32]),
                         delta_hlc: Some(hlc(10)),
                     },
@@ -2401,7 +2403,9 @@ mod tests {
                     Interface::<MainStorage>::apply_action(
                         rotation,
                         &ApplyContext {
-                            effective_writers: Some(genesis.clone()),
+                            effective_writers: Some(calimero_storage::entities::full_mask(
+                                genesis.clone(),
+                            )),
                             delta_id: Some([0xE1; 32]),
                             delta_hlc: Some(hlc(30)),
                         },
@@ -2417,7 +2421,7 @@ mod tests {
         let full_env = create_runtime_env(&full, context_id, identity);
         let hc_env = create_runtime_env(&hc, context_id, identity);
 
-        let resolve = |env: &calimero_storage::env::RuntimeEnv| -> BTreeSet<PublicKey> {
+        let resolve = |env: &calimero_storage::env::RuntimeEnv| -> BTreeMap<PublicKey, calimero_storage::entities::OpMask> {
             with_runtime_env(env.clone(), || {
                 rotation_log::resolve_local(
                     &rotation_log::load::<MainStorage>(anchor_id)
@@ -2431,7 +2435,7 @@ mod tests {
         // Precondition: the HC node has NOT learned Carol (it only has bootstrap).
         let hc_before = resolve(&hc_env);
         assert!(
-            !hc_before.contains(&carol),
+            !hc_before.contains_key(&carol),
             "precondition: HC node lacks Carol; got {hc_before:?}"
         );
 
@@ -2456,7 +2460,7 @@ mod tests {
             "after the union both nodes resolve the same writer set"
         );
         assert!(
-            hc_after.contains(&carol),
+            hc_after.contains_key(&carol),
             "HC node now recognises Carol as a writer; got {hc_after:?}"
         );
     }

--- a/crates/node/src/sync/p5_partition_scenarios_tests.rs
+++ b/crates/node/src/sync/p5_partition_scenarios_tests.rs
@@ -737,11 +737,14 @@ fn writer_set_diverges_when_rotation_reconciled_via_hc_until_log_union() {
     // wins); the HC node, missing that rotation, resolves {Alice}.
     assert_eq!(
         both_writers,
-        [alice, carol].into_iter().collect(),
-        "the node that applied both rotations resolves node-1's later-HLC {{A,C}}"
+        [alice, carol]
+            .into_iter()
+            .map(|k| (k, calimero_storage::entities::OpMask::FULL))
+            .collect::<std::collections::BTreeMap<_, _>>(),
+        "the node that applied both rotations resolves node-1's later-HLC {A,C}"
     );
     assert!(
-        both_writers.contains(&carol) && !hc_writers_before.contains(&carol),
+        both_writers.contains_key(&carol) && !hc_writers_before.contains_key(&carol),
         "repro of the #2703 divergence: HC node lacks Carol because it never \
          received node-1's hash-neutral rotation (HC carries no rotation log); \
          both={both_writers:?} hc={hc_writers_before:?}"


### PR DESCRIPTION
**master CI is red** (the `Rust` / `CI` job — `cargo build --workspace --all-targets --tests`). This finishes the job.

## Why the earlier hotfix (#2738) missed these
The OpMask change (`Shared.writers`: `BTreeSet` → `BTreeMap<PublicKey, OpMask>`) needs every old-API site updated. #2738 fixed the *production* sites, but several lived in **test targets in the node crate** that only compile under `--all-targets`/`--tests`. A plain `cargo build --workspace` (what I'd verified) skips them; CI's `--all-targets --tests` catches them. (Same root cause as the original break: a wide type change vs. concurrently-merged code using the old API.)

## Fix (node test code only)
- `hash_comparison_protocol.rs` tests: `effective_writers: Some(genesis)` → `full_mask(genesis)`; a `resolve_local` closure return `BTreeSet` → `BTreeMap`; `.contains` → `.contains_key` (×3).
- `p5_partition_scenarios_tests.rs`: a `writers_at` expectation built as a set → mask map; `.contains` → `.contains_key`.

Verified: **`cargo build --workspace --all-targets --tests` clean** (CI's exact command); fmt clean. Merge to restore master CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or runtime behavior impact; restores master CI for the all-targets build.
> 
> **Overview**
> Completes the **OpMask / writer-map** migration in **node crate test targets** that only compile under CI’s `cargo build --workspace --all-targets --tests` (after #2738 fixed production code).
> 
> In **`hash_comparison_protocol`** rotation-log reconciliation test: `ApplyContext.effective_writers` now uses **`full_mask(genesis)`** instead of a raw `BTreeSet`; the `resolve_local` helper returns **`BTreeMap<PublicKey, OpMask>`** and assertions use **`contains_key`** instead of **`contains`**.
> 
> In **`p5_partition_scenarios_tests`**: the expected writer set for the “both rotations applied” node is built as a map with **`OpMask::FULL`** per key; the divergence check uses **`contains_key`** for Carol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e40b408c8ef5d9ddf88c0761bf185751e08af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->