### PR TITLE
feat(storage): op-granular roles — AccessControl::project_onto

### DIFF
--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -21,20 +21,31 @@
 //!   tombstone. [`has_role`](AccessControl::has_role) is the lookup app guards
 //!   use.
 //!
-//! To make a role actually gate *writes to specific data*, store that data in
-//! its own [`SharedStorage`] and rotate its writers to the role's members; this
-//! registry is the source of truth for "who is in role R", and `only_role` is
-//! the fail-fast guard at the API surface.
+//! # Op-granular roles ([`project_onto`](AccessControl::project_onto))
+//!
+//! A role can confer a *capability* on guarded data, not just membership. Give
+//! each role an [`OpMask`] (e.g. `editor = WRITE`, `moderator = WRITE | DELETE`)
+//! and call [`project_onto`](AccessControl::project_onto) to push those masks
+//! onto a [`PermissionedStorage`]'s capability map — each member gets the union
+//! of its roles' masks (admins keep [`OpMask::FULL`]). The masks are then
+//! signed and enforced at merge by
+//! [`ProtocolAuthorizer`](super::permissioned::ProtocolAuthorizer): a member
+//! with `WRITE` but not `DELETE` has a forged delete rejected by peers.
+//!
+//! Re-run `project_onto` after any role/admin change — the registry write and
+//! the projection are separate signed actions, so `data` converges to the new
+//! roles eventually (a transient skew between them is not a security gap; merge
+//! always enforces whatever `data`'s map currently resolves to).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
-use super::permissioned::SharedStorage;
+use super::permissioned::{Authorizer, PermissionedStorage, SharedStorage};
 use super::{LwwRegister, StoreError, UnorderedMap};
-use crate::entities::{ChildInfo, Data, Element};
+use crate::entities::{ChildInfo, Data, Element, OpMask};
 use crate::env;
 use crate::interface::StorageError;
 
@@ -294,6 +305,73 @@ impl AccessControl {
             .insert(key, LwwRegister::new(false))?;
         Ok(())
     }
+
+    // --- op-granular projection: roles -> per-writer masks on guarded data ---
+
+    /// Enumerate the current members of `role` (those whose grant flag is
+    /// `true`). O(total registry entries) — a prefix scan over `role\0`.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if `role` contains the separator byte; propagates a
+    /// storage error from the scan.
+    pub fn members_of(&self, role: &str) -> Result<Vec<PublicKey>, StoreError> {
+        Self::check_role(role)?;
+        let prefix = format!("{role}{ROLE_MEMBER_SEP}");
+        let mut out = Vec::new();
+        for (k, v) in self.grants.get()?.entries()? {
+            // The `\0` separator means `role="edit"` never prefix-matches
+            // `"editor\0..."`, so this is an exact role match.
+            let Some(hex_tail) = k.strip_prefix(&prefix) else {
+                continue;
+            };
+            if !*v.get() {
+                continue; // revoked
+            }
+            if let Ok(bytes) = hex::decode(hex_tail) {
+                if let Ok(arr) = <[u8; 32]>::try_from(bytes) {
+                    out.push(PublicKey::from(arr));
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Project role memberships onto `data`'s capability map: every member of a
+    /// role listed in `role_masks` receives that role's [`OpMask`] (the **union**
+    /// across all roles it holds), and the admins keep [`OpMask::FULL`] so they
+    /// can keep administering. This is one authenticated rotation of `data`, so
+    /// the caller must be authorised for `Op::Admin` on `data`; the resulting
+    /// masks are signed and enforced at merge by [`ProtocolAuthorizer`].
+    ///
+    /// Re-run after any role/admin change to keep `data` in sync (the registry
+    /// write and this projection are separate signed actions — see the module
+    /// docs on eventual consistency).
+    ///
+    /// # Errors
+    /// Propagates the registry scan error, or `ActionNotAllowed` if the executor
+    /// is not authorised to rotate `data`.
+    pub fn project_onto<T, A>(
+        &self,
+        role_masks: &[(&str, OpMask)],
+        data: &mut PermissionedStorage<T, A>,
+    ) -> Result<(), StoreError>
+    where
+        T: BorshSerialize + BorshDeserialize + Mergeable + Default,
+        A: Authorizer,
+    {
+        let mut caps: BTreeMap<PublicKey, OpMask> = BTreeMap::new();
+        for (role, mask) in role_masks {
+            for member in self.members_of(role)? {
+                let entry = caps.entry(member).or_insert(OpMask::NONE);
+                *entry = entry.union(*mask);
+            }
+        }
+        // Admins keep FULL so they never lock themselves out of `data`.
+        for admin in self.admins() {
+            let _ = caps.insert(admin, OpMask::FULL);
+        }
+        data.set_capabilities(caps)
+    }
 }
 
 // `Data`/`Mergeable`/`CrdtMeta` delegate to the backing storage so `AccessControl`
@@ -462,5 +540,88 @@ mod tests {
         // A name at the limit is fine.
         let ok = "r".repeat(super::MAX_ROLE_NAME_LEN);
         assert!(ac.grant(&ok, BOB.into()).is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn members_of_lists_current_holders() {
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut ac = Root::new(AccessControl::new_admin_caller);
+
+        ac.grant("editor", BOB.into()).unwrap();
+        ac.grant("editor", CAROL.into()).unwrap();
+        ac.grant("viewer", BOB.into()).unwrap();
+        ac.revoke("editor", &CAROL.into()).unwrap();
+
+        let mut editors = ac.members_of("editor").unwrap();
+        editors.sort();
+        assert_eq!(editors, vec![BOB.into()]); // Carol was revoked
+        assert_eq!(ac.members_of("viewer").unwrap(), vec![BOB.into()]);
+        assert!(ac.members_of("ghost").unwrap().is_empty());
+        // `editor` must not prefix-match a longer role name.
+        ac.grant("editorial", CAROL.into()).unwrap();
+        assert_eq!(ac.members_of("editor").unwrap(), vec![BOB.into()]);
+    }
+
+    #[test]
+    #[serial]
+    fn project_roles_grants_op_masks_on_data() {
+        use std::collections::BTreeSet;
+
+        use borsh::{BorshDeserialize, BorshSerialize};
+
+        use crate::collections::{LwwRegister, Op, PermissionedStorage, ProtocolAuthorizer};
+        use crate::entities::OpMask;
+
+        #[derive(BorshSerialize, BorshDeserialize)]
+        struct St {
+            ac: AccessControl,
+            data: PermissionedStorage<LwwRegister<String>, ProtocolAuthorizer>,
+        }
+
+        const ROLE_MASKS: &[(&str, OpMask)] = &[
+            ("editor", OpMask::WRITE),
+            ("moderator", OpMask::WRITE.union(OpMask::DELETE)),
+        ];
+
+        env::reset_for_testing();
+        env::set_executor_id(ALICE);
+        let mut s = Root::new(|| St {
+            ac: AccessControl::new(ALICE.into()),
+            data: PermissionedStorage::new(BTreeSet::from([ALICE.into()]), false),
+        });
+
+        s.ac.grant("editor", BOB.into()).unwrap();
+        s.ac.grant("moderator", CAROL.into()).unwrap();
+
+        {
+            let st = &mut *s;
+            st.ac.project_onto(ROLE_MASKS, &mut st.data).unwrap();
+        }
+
+        // Roles now confer the right ops on `data`, enforced via the mask map.
+        assert!(s.data.can(&BOB.into(), Op::Write), "editor may write");
+        assert!(
+            !s.data.can(&BOB.into(), Op::Delete),
+            "editor may NOT delete"
+        );
+        assert!(
+            s.data.can(&CAROL.into(), Op::Delete),
+            "moderator may delete"
+        );
+        assert!(s.data.can(&ALICE.into(), Op::Admin), "admin keeps FULL");
+
+        // Revoke Bob's editor role and re-project → he loses write on `data`.
+        s.ac.revoke("editor", &BOB.into()).unwrap();
+        {
+            let st = &mut *s;
+            st.ac.project_onto(ROLE_MASKS, &mut st.data).unwrap();
+        }
+        assert!(
+            !s.data.can(&BOB.into(), Op::Write),
+            "revoked editor loses write"
+        );
+        assert!(s.data.can(&CAROL.into(), Op::Delete), "moderator unchanged");
     }
 }

--- a/crates/storage/src/collections/permissioned.rs
+++ b/crates/storage/src/collections/permissioned.rs
@@ -315,6 +315,21 @@ where
         let _removed = caps.remove(who);
         self.inner.rotate_writers_scoped(caps)
     }
+
+    /// Replace the entire capability map in one authenticated rotation. Admin-
+    /// gated. Used by role projection ([`AccessControl::project_onto`]) to set a
+    /// collection's per-writer masks from role memberships in a single step.
+    ///
+    /// # Errors
+    /// `ActionNotAllowed` if frozen, not authorised for `Op::Admin`, or if `caps`
+    /// is empty.
+    pub fn set_capabilities(
+        &mut self,
+        caps: BTreeMap<PublicKey, OpMask>,
+    ) -> Result<(), StoreError> {
+        self.guard(Op::Admin)?;
+        self.inner.rotate_writers_scoped(caps)
+    }
 }
 
 impl<T, A> PermissionedStorage<T, A>


### PR DESCRIPTION
Bridges `AccessControl` roles to per-writer **capability masks** (OpMask), so a role can confer *what you may do* on guarded data — not just membership. Builds on the merged OpMask layer (`grant_capability` / `ProtocolAuthorizer`).

## The gap this closes
Before: a role was a yes/no label (`has_role`), and per-key data masks (`grant_capability`) existed — but the two didn't talk. "editor = write-but-not-delete" wasn't expressible from a role.

After: give each role an `OpMask` and project it onto the data.

```rust
const ROLE_MASKS: &[(&str, OpMask)] =
    &[("editor", OpMask::WRITE), ("moderator", OpMask::WRITE.union(OpMask::DELETE))];

acl.grant("editor", bob)?;                 // role membership (already merge-enforced)
acl.project_onto(ROLE_MASKS, &mut posts)?; // push masks onto posts' capability map
// → Bob may edit `posts`; a forged DeleteRef from Bob is rejected at merge.
```

## API added
- **`AccessControl::members_of(role)`** — enumerate current holders (prefix scan; the `\0` separator means `edit` never prefix-matches `editor`; revoked entries filtered).
- **`AccessControl::project_onto(role_masks, data)`** — each member gets the union of its roles' masks; admins keep `FULL`. One authenticated rotation of `data` (admin-gated); masks are signed + enforced at merge by `ProtocolAuthorizer`.
- **`PermissionedStorage::set_capabilities(map)`** — bulk capability set (the projection primitive).

## Semantics / honesty
- The registry write and the projection are **separate signed actions**, so `data` converges to the new roles *eventually*. A transient skew is **not** a security gap — merge always enforces whatever `data`'s capability map currently resolves to.
- Re-run `project_onto` after any role/admin change. O(members) per projection — fine at context scale.

## Tests
- `members_of_lists_current_holders` — revoked filtered, no prefix collision (`editor` vs `editorial`).
- `project_roles_grants_op_masks_on_data` — editor writes but can't delete, moderator deletes, admin `FULL`, revoke removes write.

Storage lib 614 green; `cargo build --workspace --all-targets --tests` clean; fmt + clippy clean.

Tracking: #2541 · #2687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how capability maps are derived from roles and bulk-rotated on guarded storage; enforcement still relies on existing admin-gated rotations and merge-time ProtocolAuthorizer checks, with documented transient registry/projection skew.
> 
> **Overview**
> Connects **`AccessControl` role membership** to **`PermissionedStorage` per-writer `OpMask`s**, so roles can mean *which ops* someone has on guarded data—not only `has_role` / `only_role` labels.
> 
> Adds **`AccessControl::members_of`** (prefix scan over `role\0…`, skips revoked grants, avoids `editor` vs `editorial` collisions) and **`AccessControl::project_onto`**, which unions each member’s role masks onto a target collection’s capability map and forces **admins to `OpMask::FULL`**. Projection is a separate **admin-gated** signed rotation; module docs call out **eventual consistency** between registry updates and the data map, with merge still enforcing whatever map is current.
> 
> Adds **`PermissionedStorage::set_capabilities`** as the bulk replace primitive (same path as `grant_capability` / `revoke_capability` via `rotate_writers_scoped`). New tests cover member enumeration and end-to-end projection with **`ProtocolAuthorizer`** (write vs delete, revoke + re-project).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5bb150317d4de99a4076d7d49c8dcba988b1579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->