### PR TITLE
fix(node): escape braces in p5 assert format string (master build red)

### DIFF
--- a/crates/node/src/sync/p5_partition_scenarios_tests.rs
+++ b/crates/node/src/sync/p5_partition_scenarios_tests.rs
@@ -741,7 +741,7 @@ fn writer_set_diverges_when_rotation_reconciled_via_hc_until_log_union() {
             .into_iter()
             .map(|k| (k, calimero_storage::entities::OpMask::FULL))
             .collect::<std::collections::BTreeMap<_, _>>(),
-        "the node that applied both rotations resolves node-1's later-HLC {A,C}"
+        "the node that applied both rotations resolves node-1's later-HLC {{A,C}}"
     );
     assert!(
         both_writers.contains_key(&carol) && !hc_writers_before.contains_key(&carol),


### PR DESCRIPTION
**master build is red** — 1-char fix.

A prior OpMask test-migration edit (#2739) collapsed an escaped `{{A,C}}` to `{A,C}` in an `assert_eq!` message in `p5_partition_scenarios_tests.rs:744`. That's an invalid Rust format string, so the node test target fails to compile:

```
error: invalid format string: expected `}`, found `,`
  --> crates/node/src/sync/p5_partition_scenarios_tests.rs:744:77
```

It surfaces as a bare `error:` (no `E####` code), which a narrow `error[E…` verification grep missed.

Fix: re-escape to `{{A,C}}`. Verified with **`cargo build --workspace --all-targets --tests` → exit 0** (CI's exact command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only string fix with no runtime or behavioral impact.
> 
> **Overview**
> Restores a **valid Rust format string** in an `assert_eq!` failure message in `p5_partition_scenarios_tests.rs` by changing the literal writer-set label from `{A,C}` back to `{{A,C}}`.
> 
> A prior edit had left a single brace pair, which Rust treats as format syntax and breaks compilation of the node test target (`expected `}`, found `,``). No test logic or assertions change—only the displayed message text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 046a25009d0892407653306d86670b324f3676a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->