### PR TITLE
fix(sync): reconcile Shared writer/capability rotation logs when roots match

### DIFF
--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -780,4 +780,54 @@ impl SyncManager {
 
         Ok(())
     }
+
+    /// Responder for a standalone `RotationLogSyncRequest` (core#2716).
+    ///
+    /// A peer whose Merkle root already matches ours took the `None` sync path,
+    /// so the rotation-log reconciliation that normally rides the end of a
+    /// HashComparison session never ran. It opens a fresh stream with this
+    /// request to converge hash-neutral writer/capability rotations. Mirrors
+    /// the in-HashComparison handler: union the initiator's `Shared` rotation
+    /// logs into ours, then reply with our own so the initiator unions them
+    /// too — one round-trip reconciles both directions.
+    pub async fn handle_rotation_log_sync_request(
+        &self,
+        context_id: ContextId,
+        logs: Vec<([u8; 32], Vec<u8>)>,
+        our_identity: PublicKey,
+        stream: &mut Stream,
+    ) -> Result<()> {
+        use calimero_node_primitives::sync::create_runtime_env;
+        use calimero_storage::env::with_runtime_env;
+
+        use super::hash_comparison_protocol::{
+            collect_local_shared_rotation_logs, union_received_rotation_logs,
+        };
+
+        let store = self.context_client.datastore_handle().into_inner();
+        let runtime_env = create_runtime_env(&store, context_id, our_identity);
+
+        let applied = with_runtime_env(runtime_env.clone(), || union_received_rotation_logs(&logs));
+        let local_logs = with_runtime_env(runtime_env, || {
+            collect_local_shared_rotation_logs(context_id)
+        });
+
+        let mut sqx = Sequencer::default();
+        let msg = StreamMessage::Message {
+            sequence_id: sqx.next(),
+            payload: MessagePayload::RotationLogSyncResponse { logs: local_logs },
+            next_nonce: super::helpers::generate_nonce(),
+        };
+        super::stream::send(stream, &msg, None).await?;
+
+        if applied > 0 {
+            info!(
+                %context_id,
+                applied,
+                "rotation-log sync (standalone responder): unioned initiator's Shared rotation logs"
+            );
+        }
+
+        Ok(())
+    }
 }

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -876,7 +876,11 @@ pub(crate) fn union_received_rotation_logs(logs: &[([u8; 32], Vec<u8>)]) -> usiz
 /// Best-effort and mixed-version safe: an older peer that doesn't understand
 /// `RotationLogSyncRequest` errors/closes the stream, which surfaces here as an
 /// `Err`/`None` and is swallowed by the caller — the session is unaffected.
-async fn reconcile_rotation_logs_with_peer<T: SyncTransport>(
+///
+/// Also driven standalone (on a fresh stream) by `SyncManager` from the
+/// protocol-selection `None` path, where the Merkle roots already match but
+/// hash-neutral rotations may still diverge (core#2716).
+pub(crate) async fn reconcile_rotation_logs_with_peer<T: SyncTransport>(
     transport: &mut T,
     context_id: ContextId,
     identity: PublicKey,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3067,14 +3067,26 @@ impl SyncManager {
                 // loop), never as a top-level stream init.
                 warn!("Received EntityDeletePush outside of HashComparison session, ignoring");
             }
-            InitPayload::RotationLogSyncRequest { .. } => {
-                // Rotation-log reconciliation (core#2716/#2703) only occurs as an
-                // end-of-session step inside an established HashComparison
-                // session (handled by the responder loop), never as a top-level
-                // stream init.
-                warn!(
-                    "Received RotationLogSyncRequest outside of HashComparison session, ignoring"
-                );
+            InitPayload::RotationLogSyncRequest {
+                context_id: req_context_id,
+                logs,
+            } => {
+                // Standalone rotation-log reconciliation (core#2716): a peer
+                // whose Merkle root already matches ours took the `None` sync
+                // path, so the in-HashComparison reconciliation never ran. It
+                // opens a fresh stream with this request to converge the
+                // hash-neutral writer/capability rotations. Mirror the
+                // end-of-HashComparison handler: union theirs, reply with ours.
+                if let Err(e) = self
+                    .handle_rotation_log_sync_request(req_context_id, logs, our_identity, stream)
+                    .await
+                {
+                    warn!(
+                        %req_context_id,
+                        error = %e,
+                        "standalone rotation-log sync responder failed"
+                    );
+                }
             }
             InitPayload::NamespaceBackfillRequest { .. } => {
                 unreachable!("handled by early return above")
@@ -3136,6 +3148,43 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
             .open_stream(peer)
             .await
             .wrap_err("open stream")
+    }
+
+    async fn reconcile_shared_rotation_logs(
+        &self,
+        context_id: ContextId,
+        peer: PeerId,
+        our_identity: PublicKey,
+    ) -> eyre::Result<()> {
+        use calimero_node_primitives::sync::create_runtime_env;
+        use calimero_storage::env::with_runtime_env;
+
+        let store = self.context_client.datastore_handle().into_inner();
+        let runtime_env = create_runtime_env(&store, context_id, our_identity);
+
+        // Common-case fast path: a context with no `Shared` anchors has
+        // nothing to reconcile, so don't even open a stream — non-shared
+        // syncs pay nothing for this.
+        let local_logs = with_runtime_env(runtime_env.clone(), || {
+            super::hash_comparison_protocol::collect_local_shared_rotation_logs(context_id)
+        });
+        if local_logs.is_empty() {
+            return Ok(());
+        }
+
+        let mut stream = self
+            .sync_network
+            .open_stream(peer)
+            .await
+            .wrap_err("open stream for rotation-log reconcile")?;
+        let mut transport = super::stream::StreamTransport::new(&mut stream);
+        super::hash_comparison_protocol::reconcile_rotation_logs_with_peer(
+            &mut transport,
+            context_id,
+            our_identity,
+            &runtime_env,
+        )
+        .await
     }
 
     async fn request_dag_heads_and_sync(

--- a/crates/node/src/sync/p5_partition_scenarios_tests.rs
+++ b/crates/node/src/sync/p5_partition_scenarios_tests.rs
@@ -741,7 +741,7 @@ fn writer_set_diverges_when_rotation_reconciled_via_hc_until_log_union() {
             .into_iter()
             .map(|k| (k, calimero_storage::entities::OpMask::FULL))
             .collect::<std::collections::BTreeMap<_, _>>(),
-        "the node that applied both rotations resolves node-1's later-HLC {A,C}"
+        "the node that applied both rotations resolves node-1's later-HLC {{A,C}}"
     );
     assert!(
         both_writers.contains_key(&carol) && !hc_writers_before.contains_key(&carol),

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -52,6 +52,21 @@ pub(crate) trait ProtocolDispatch {
     /// has left the responder in a protocol-specific state.
     async fn open_stream(&self, peer: PeerId) -> Result<Stream>;
 
+    /// Reconcile per-`Shared`-entity writer/capability rotation logs with the
+    /// peer on a FRESH stream. Invoked from the `None` selection arm: the
+    /// Merkle roots already match, but writer/capability rotations are
+    /// hash-neutral (core#2716), so equal roots do NOT imply equal writer
+    /// sets — and the in-`HashComparison` reconciliation this path skips never
+    /// runs. Best-effort; a no-op (no stream opened) for contexts that hold no
+    /// `Shared` anchors. Uses its own stream so it never disturbs the
+    /// handshake / DAG-heads exchange already in flight.
+    async fn reconcile_shared_rotation_logs(
+        &self,
+        context_id: ContextId,
+        peer: PeerId,
+        our_identity: PublicKey,
+    ) -> Result<()>;
+
     /// Send the DAG-heads request and let the peer drive a regular
     /// delta-sync over the same stream.
     async fn request_dag_heads_and_sync(
@@ -152,6 +167,27 @@ impl ProtocolSelector {
                     "No sync needed: {}",
                     selection.reason
                 );
+                // The Merkle roots match, but writer/capability rotations are
+                // hash-neutral (core#2716): equal roots do NOT imply equal
+                // Shared writer sets, and the rotation-log reconciliation that
+                // would catch the difference only runs inside HashComparison —
+                // which this path skips. Reconcile here too, on a fresh stream.
+                // Gate on roots being genuinely equal: `None` is also returned
+                // when the remote is fresh (Rule 2b), where there is nothing to
+                // reconcile. Best-effort — a transient failure retries next tick.
+                if local_root_hash == peer_root_hash {
+                    if let Err(e) = dispatch
+                        .reconcile_shared_rotation_logs(context_id, chosen_peer, our_identity)
+                        .await
+                    {
+                        debug!(
+                            %context_id,
+                            %chosen_peer,
+                            error = %e,
+                            "rotation-log reconciliation (roots match) failed; will retry next sync"
+                        );
+                    }
+                }
                 Ok(None)
             }
             SyncProtocol::Snapshot { compressed, .. } => {


### PR DESCRIPTION
## What

Writer-set (and #2738 capability) rotations on `SharedStorage` are **hash-neutral**: they change *who may write* but not the storage Merkle root. Sync judges convergence purely from that root — `select_protocol` Rule 1 returns `None` when roots match — and the only code that reconciles per-`Shared`-anchor rotation logs runs at the tail of a `HashComparison` session.

So once a node converges its entity tree via DeltaSync (or is already root-matched), it takes the `None` path on every subsequent sync and **never learns a peer's hash-neutral rotation**. Two nodes then report identical `root_hash` while `resolve_local` returns *different* writer sets — the split-brain the `shared-storage-concurrent-rotation-converge` e2e keeps catching, and (since #2738) the same hole governs per-writer `OpMask` capability grants/revokes.

This was diagnosed from run [27015331803](https://github.com/calimero-network/core/actions/runs/27015331803): `wait_for_sync` passed at **0.00s** (roots matched) yet node-2 resolved `{A}` while node-1/node-3 resolved `{A,C}` — node-2 reconciled via DeltaSync and then logged `"No sync needed: root hashes match"` every tick, so its rotation log never received node-1's `{A,C}` entry.

## Fix

Run the **existing** rotation-log reconciliation on the `None` path too, gated on (a) the roots being *genuinely* equal (so the "remote is fresh" `None` is excluded) and (b) the context actually holding `Shared` anchors (so non-shared syncs pay nothing). It reuses the existing `RotationLogSyncRequest`/`Response` round-trip on a fresh stream and implements the standalone responder branch that was previously a no-op (`"Received RotationLogSyncRequest outside of HashComparison session, ignoring"`).

**No wire-format or storage-hash change.**

- `protocol_selector.rs` — new `ProtocolDispatch::reconcile_shared_rotation_logs`; the `None` arm calls it when `local_root_hash == peer_root_hash`.
- `manager/mod.rs` — implements it (gated on local `Shared` anchors; opens a fresh stream) and implements the standalone `RotationLogSyncRequest` responder branch.
- `delta_request.rs` — `handle_rotation_log_sync_request` responder helper (union theirs, reply with ours).
- `hash_comparison_protocol.rs` — `reconcile_rotation_logs_with_peer` made `pub(crate)`.

A second commit escapes `{A,C}` → `{{A,C}}` in a `p5_partition_scenarios_tests` assert message — an invalid-format-string regression from #2739 that fails the `calimero-node` lib-test build (drop it if #2739 is fixed upstream first).

## Test

- `cargo check -p calimero-node` ✓
- `cargo clippy -p calimero-node --no-deps --all-targets` ✓ clean
- `cargo fmt --check` ✓
- `cargo test -p calimero-node --lib rotation` ✓ **19/19**, incl. `rotation_log_reconciliation_converges_divergent_shared_logs` and `writer_set_diverges_when_rotation_reconciled_via_hc_until_log_union`
- The `shared-storage-concurrent-rotation-converge` e2e is the integration regression (runs in CI against the built binary).

## Follow-up

While converged, a `Shared`-storage context now does one tiny reconcile round-trip per sync tick (no digest to short-circuit). Correct but slightly chatty — a `rotation_log_digest` in the handshake would gate it, but that needs a wire-format change so it's deferred. Worth a follow-up issue. This is also step 1 of a larger "unify the causal planes" direction (design doc to follow separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync convergence for Shared writer/capability state; failures are best-effort and retried, but incorrect reconciliation could leave divergent writer sets while roots still match.
> 
> **Overview**
> Fixes **split-brain on `Shared` storage** when Merkle roots already match: writer/capability rotations do not change the root, so sync kept choosing **`None`** and never ran the rotation-log union that only happened at the end of **HashComparison**.
> 
> When **`local_root_hash == peer_root_hash`**, the **`None`** arm now **best-effort** calls **`reconcile_shared_rotation_logs`** on a **separate stream** (skips opening a stream if there are no local `Shared` anchors). **`SyncManager`** implements that via the existing **`reconcile_rotation_logs_with_peer`** round-trip; **`handle_rotation_log_sync_request`** handles a **top-level** **`RotationLogSyncRequest`** (union peer logs, reply with ours) instead of ignoring it. **`reconcile_rotation_logs_with_peer`** is **`pub(crate)`** so both HC tail and this path share one implementation. No new wire messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd4abedb940132823d452c11ed206857d14ad06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->