### PR TITLE
feat: migration-UX core surfaces — Context version, AppVersionChanged, authored_remaining (6f, #2539)

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -210,6 +210,7 @@ jobs:
           - 30-migration-check-fail-abort
           - 31-admin-abort-logical
           - 32-authored-migrate-ux
+          - 33-authored-remaining-count
     env:
       WORKFLOW: ${{ matrix.workflow }}
     steps:

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -231,13 +231,21 @@ impl ContextRegistry {
             return Ok(None);
         };
 
+        // Resolve the application's semver from its ApplicationMeta row so the
+        // Context response carries it directly (skew #2 — bundle version). The
+        // row may be absent (e.g. uninstalled app); leave the version None then.
+        let application_version = handle
+            .get(&meta.application)?
+            .map(|app| app.version.to_string());
+
         let context = Context::with_service(
             *context_id,
             meta.application.application_id(),
             meta.root_hash.into(),
             meta.dag_heads.clone(),
             meta.service_name.as_deref().map(String::from),
-        );
+        )
+        .with_application_version(application_version);
 
         tracing::debug!(
             %context_id,
@@ -2120,5 +2128,74 @@ mod atomic_persist_tests {
             !has_delta(&store, &cid, DELTA_B),
             "dropped (uncommitted) batch must not persist"
         );
+    }
+}
+
+#[cfg(test)]
+mod get_context_version_tests {
+    use std::sync::Arc;
+
+    use calimero_primitives::application::ApplicationId;
+    use calimero_primitives::context::ContextId;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::{key, types, Store};
+
+    use super::ContextRegistry;
+
+    // get_context resolves ApplicationMeta.version (semver) onto Context.
+    #[test]
+    fn get_context_carries_application_version() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let app_id = ApplicationId::from([0xAA; 32]);
+        let app_key = key::ApplicationMeta::new(app_id);
+
+        let app_meta = types::ApplicationMeta::new(
+            key::BlobMeta::new([1u8; 32].into()),
+            1024,
+            "file://test.wasm".into(),
+            vec![].into(),
+            key::BlobMeta::new([2u8; 32].into()),
+            "com.test.app".into(),
+            "2.1.0".into(),
+            "signer".into(),
+        );
+        let cid = ContextId::from([0x07; 32]);
+        let ctx_meta = types::ContextMeta::new(app_key, [0u8; 32], vec![], None);
+        {
+            let mut handle = store.handle();
+            handle.put(&app_key, &app_meta).expect("seed app meta");
+            handle
+                .put(&key::ContextMeta::new(cid), &ctx_meta)
+                .expect("seed ctx meta");
+        }
+
+        let registry = ContextRegistry::new(store.clone());
+        let ctx = registry
+            .get_context(&cid)
+            .expect("get_context ok")
+            .expect("context present");
+        assert_eq!(ctx.application_version.as_deref(), Some("2.1.0"));
+    }
+
+    // A missing ApplicationMeta row leaves application_version None (not an error).
+    #[test]
+    fn get_context_without_app_meta_has_no_version() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let app_key = key::ApplicationMeta::new(ApplicationId::from([0xBB; 32]));
+        let cid = ContextId::from([0x08; 32]);
+        let ctx_meta = types::ContextMeta::new(app_key, [0u8; 32], vec![], None);
+        {
+            let mut handle = store.handle();
+            handle
+                .put(&key::ContextMeta::new(cid), &ctx_meta)
+                .expect("seed ctx meta");
+        }
+
+        let registry = ContextRegistry::new(store.clone());
+        let ctx = registry
+            .get_context(&cid)
+            .expect("get_context ok")
+            .expect("context present");
+        assert_eq!(ctx.application_version, None);
     }
 }

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1033,6 +1033,9 @@ pub struct MemberMigrationReport {
     pub synced_up_to_hlc: u64,
     /// Member-signed millis-since-epoch from the heartbeat itself.
     pub reported_at: u64,
+    /// Member's self-reported pending-authored count (best-effort; 6f). Counted
+    /// into the rollup's `members_pending_signature`.
+    pub authored_remaining: u64,
 }
 
 /// The migration state the rollup assigns a pinned-cohort member.
@@ -1083,6 +1086,11 @@ pub struct MigrationStatusRollup {
     /// `schema_version >= target && residue_auto == 0 && residue_identity == 0`.
     /// Any `unknown` (or any member still in progress) keeps this `false`.
     pub all_migrated: bool,
+    /// Count of pinned-cohort members reporting `authored_remaining > 0` — i.e.
+    /// members whose owners still have identity-gated entries to re-sign (6f,
+    /// skew #1 admin view). `unknown` members (no fresh heartbeat) are NOT
+    /// counted here; they surface via `unknown`. Best-effort / advisory.
+    pub members_pending_signature: usize,
 }
 
 /// Full migration-status answer for a namespace: the pinned cohort, the
@@ -1137,6 +1145,7 @@ pub fn compute_migration_status_rollup(
     let mut migrated = 0usize;
     let mut in_progress = 0usize;
     let mut unknown = 0usize;
+    let mut members_pending_signature = 0usize;
 
     for peer in closure {
         let report = report_for(peer);
@@ -1167,6 +1176,12 @@ pub fn compute_migration_status_rollup(
                 MemberMigrationState::Unknown
             }
             Some(r) => {
+                // Advisory skew-#1 count, independent of the migrated/in-progress
+                // gate: a member can be whole-root "migrated" yet still owe
+                // authored re-signatures (owner-driven convert is separate).
+                if r.authored_remaining > 0 {
+                    members_pending_signature += 1;
+                }
                 if r.schema_version >= target_version
                     && r.residue_auto == 0
                     && r.residue_identity == 0
@@ -1201,6 +1216,7 @@ pub fn compute_migration_status_rollup(
             unknown,
             total,
             all_migrated,
+            members_pending_signature,
         },
         members,
     }
@@ -1246,6 +1262,7 @@ mod migration_status_tests {
             residue_identity,
             synced_up_to_hlc: synced_up_to_seq,
             reported_at: 0,
+            authored_remaining: 0,
         }
     }
 

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -686,10 +686,17 @@ impl Handler<ExecuteRequest> for ContextManager {
                     "Method execution completed"
                 );
 
-                // After the owner converts their authored entries via
-                // migrate_my_entries, refresh the node-local authored_remaining
-                // from the summary's `remaining` so the heartbeat self-report
-                // (and the admin rollup) reflect the post-convert count (6f.8).
+                // After the owner converts their authored entries via the
+                // SDK-generated migrate_my_entries export, refresh the node-local
+                // authored_remaining from the summary's `remaining` so the
+                // heartbeat self-report (and the admin rollup) reflect the
+                // post-convert count (6f.8). This is self-reported advisory
+                // telemetry about THIS node's own pending count — never a gate —
+                // so the value is inherently self-attested (like the rest of the
+                // heartbeat); we only guard against a nonsense cast by saturating
+                // the u64→u32 instead of silently wrapping. Apps that wrap
+                // migrate_my_entries under another name simply won't refresh here
+                // (acceptable for advisory telemetry).
                 if method == "migrate_my_entries" {
                     if let Ok(Some(bytes)) = &outcome.returns {
                         if let Some(remaining) = serde_json::from_slice::<serde_json::Value>(bytes)
@@ -699,7 +706,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                             crate::handlers::update_application::persist_authored_remaining(
                                 &count_datastore,
                                 context_id,
-                                remaining as u32,
+                                u32::try_from(remaining).unwrap_or(u32::MAX),
                             );
                         }
                     }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -699,14 +699,23 @@ impl Handler<ExecuteRequest> for ContextManager {
                 // (acceptable for advisory telemetry).
                 if method == "migrate_my_entries" {
                     if let Ok(Some(bytes)) = &outcome.returns {
-                        if let Some(remaining) = serde_json::from_slice::<serde_json::Value>(bytes)
-                            .ok()
-                            .and_then(|v| v.get("remaining").and_then(serde_json::Value::as_u64))
-                        {
+                        // Only trust a well-formed MigrateMyEntriesSummary
+                        // ({converted, remaining}) — deserializing into the typed
+                        // shape (both u32 fields required) rejects an unrelated /
+                        // error JSON payload that merely happens to carry a
+                        // `remaining` key, so a malformed return never writes a
+                        // bogus authored_remaining.
+                        #[derive(serde::Deserialize)]
+                        struct MigrateSummary {
+                            #[allow(dead_code)]
+                            converted: u32,
+                            remaining: u32,
+                        }
+                        if let Ok(summary) = serde_json::from_slice::<MigrateSummary>(bytes) {
                             crate::handlers::update_application::persist_authored_remaining(
                                 &count_datastore,
                                 context_id,
-                                u32::try_from(remaining).unwrap_or(u32::MAX),
+                                summary.remaining,
                             );
                         }
                     }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -620,6 +620,11 @@ impl Handler<ExecuteRequest> for ContextManager {
             let node_client = act.node_client.clone();
             let context_client = act.context_client.clone();
 
+            // Cheap (Arc-backed) clone kept past internal_execute (which moves
+            // `datastore`) so a post-call migrate_my_entries can refresh the
+            // node-local authored_remaining count (6f.8 drop-after-convert).
+            let count_datastore = datastore.clone();
+
             async move {
                 let old_root_hash = context.root_hash;
 
@@ -680,6 +685,25 @@ impl Handler<ExecuteRequest> for ContextManager {
                     status,
                     "Method execution completed"
                 );
+
+                // After the owner converts their authored entries via
+                // migrate_my_entries, refresh the node-local authored_remaining
+                // from the summary's `remaining` so the heartbeat self-report
+                // (and the admin rollup) reflect the post-convert count (6f.8).
+                if method == "migrate_my_entries" {
+                    if let Ok(Some(bytes)) = &outcome.returns {
+                        if let Some(remaining) = serde_json::from_slice::<serde_json::Value>(bytes)
+                            .ok()
+                            .and_then(|v| v.get("remaining").and_then(serde_json::Value::as_u64))
+                        {
+                            crate::handlers::update_application::persist_authored_remaining(
+                                &count_datastore,
+                                context_id,
+                                remaining as u32,
+                            );
+                        }
+                    }
+                }
                 debug!(
                     %context_id,
                     %executor,

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -272,12 +272,18 @@ fn application_version(
     datastore: &calimero_store::Store,
     application_id: ApplicationId,
 ) -> Option<String> {
-    datastore
+    match datastore
         .handle()
         .get(&key::ApplicationMeta::new(application_id))
-        .ok()
-        .flatten()
-        .map(|meta| meta.version.to_string())
+    {
+        Ok(meta) => meta.map(|m| m.version.to_string()),
+        Err(err) => {
+            // Best-effort label: a read fault yields None (same as an absent
+            // row), but log it so a persistent store fault isn't fully silent.
+            debug!(%err, %application_id, "failed to read ApplicationMeta for version label");
+            None
+        }
+    }
 }
 
 /// Builds an `AppVersionChanged` node event for a context whose application id

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -251,22 +251,15 @@ async fn finalize_application_update(
 
     let mut handle = datastore.handle();
 
-    // Preserve the node-local authored_remaining across this rewrite: it tracks
-    // the owner's pending-authored count and is recomputed only at migrate /
-    // migrate_my_entries points, NOT on a code-only app update (6f.8). Building
-    // a fresh ContextMeta here would otherwise reset it to 0.
-    let prior_authored_remaining = handle
-        .get(&key::ContextMeta::new(context.id))?
-        .map_or(0, |m| m.authored_remaining);
-
-    let mut new_meta = types::ContextMeta::new(
-        key::ApplicationMeta::new(application.id),
-        *context.root_hash,
-        context.dag_heads.clone(),
-        context.service_name.as_deref().map(Box::from),
-    );
-    new_meta.authored_remaining = prior_authored_remaining;
-    handle.put(&key::ContextMeta::new(context.id), &new_meta)?;
+    handle.put(
+        &key::ContextMeta::new(context.id),
+        &types::ContextMeta::new(
+            key::ApplicationMeta::new(application.id),
+            *context.root_hash,
+            context.dag_heads.clone(),
+            context.service_name.as_deref().map(Box::from),
+        ),
+    )?;
 
     node_client.sync(Some(&context_id), None).await?;
 
@@ -1045,29 +1038,23 @@ async fn run_count_my_pending(
     }
 }
 
-/// Read-modify-write the node-local `ContextMeta.authored_remaining` for a
-/// context, preserving every other field. Best-effort: a missing row or store
-/// fault is logged and skipped (the heartbeat falls back to the prior value).
+/// Persist this node's owner's pending-authored count to the dedicated
+/// node-local `ContextAuthoredRemaining` key (read by the migration heartbeat).
+/// A single-value put on its own key — NOT folded into `ContextMeta`, so the
+/// hot per-write `ContextMeta` rewrite path cannot clobber it and there is no
+/// read-modify-write race. Best-effort: a store fault is logged and skipped.
 pub(crate) fn persist_authored_remaining(
     datastore: &calimero_store::Store,
     context_id: ContextId,
     authored_remaining: u32,
 ) {
     let mut handle = datastore.handle();
-    let key = key::ContextMeta::new(context_id);
-    match handle.get(&key) {
-        Ok(Some(mut meta)) => {
-            meta.authored_remaining = authored_remaining;
-            if let Err(err) = handle.put(&key, &meta) {
-                debug!(%context_id, %err, "failed to persist authored_remaining");
-            }
-        }
-        Ok(None) => {
-            debug!(%context_id, "context meta absent; skipping authored_remaining persist");
-        }
-        Err(err) => {
-            debug!(%context_id, %err, "failed to read context meta for authored_remaining persist");
-        }
+    let key = key::ContextAuthoredRemaining::new(context_id);
+    let value = types::ContextAuthoredRemaining {
+        count: authored_remaining,
+    };
+    if let Err(err) = handle.put(&key, &value) {
+        debug!(%context_id, %err, "failed to persist authored_remaining");
     }
 }
 

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -251,15 +251,22 @@ async fn finalize_application_update(
 
     let mut handle = datastore.handle();
 
-    handle.put(
-        &key::ContextMeta::new(context.id),
-        &types::ContextMeta::new(
-            key::ApplicationMeta::new(application.id),
-            *context.root_hash,
-            context.dag_heads.clone(),
-            context.service_name.as_deref().map(Box::from),
-        ),
-    )?;
+    // Preserve the node-local authored_remaining across this rewrite: it tracks
+    // the owner's pending-authored count and is recomputed only at migrate /
+    // migrate_my_entries points, NOT on a code-only app update (6f.8). Building
+    // a fresh ContextMeta here would otherwise reset it to 0.
+    let prior_authored_remaining = handle
+        .get(&key::ContextMeta::new(context.id))?
+        .map_or(0, |m| m.authored_remaining);
+
+    let mut new_meta = types::ContextMeta::new(
+        key::ApplicationMeta::new(application.id),
+        *context.root_hash,
+        context.dag_heads.clone(),
+        context.service_name.as_deref().map(Box::from),
+    );
+    new_meta.authored_remaining = prior_authored_remaining;
+    handle.put(&key::ContextMeta::new(context.id), &new_meta)?;
 
     node_client.sync(Some(&context_id), None).await?;
 
@@ -487,6 +494,10 @@ pub(crate) async fn update_application_with_migration(
     // post-commit AppVersionChanged from/to versions).
     let old_application_id = context.application_id;
 
+    // Set to the v2 module once a migration commits, so we can run
+    // `count_my_pending` over the committed v2 state after finalize (6f.8).
+    let mut pending_count_module: Option<calimero_runtime::Module> = None;
+
     // Execute migration if requested
     if let Some(migration_params) = migration {
         info!(
@@ -500,6 +511,8 @@ pub(crate) async fn update_application_with_migration(
         // its copy into `spawn_blocking`, so the migration_check below can run a
         // second `module.run` on the same already-compiled v2 artifact.
         let check_module = module.clone();
+        // A third cheap clone for the post-commit count_my_pending run (6f.8).
+        let count_module = check_module.clone();
 
         // Execute migration function via module.run(). Returns the UNCOMMITTED
         // staging buffer (`storage`) the migrate wrote into, plus the optional
@@ -596,6 +609,11 @@ pub(crate) async fn update_application_with_migration(
             state_size = new_state_bytes.len(),
             "Migration completed successfully"
         );
+
+        // The v2 state is committed; schedule the post-finalize authored_remaining
+        // recompute (6f.8). Reaching here means the check passed and committed —
+        // a failed check returns Err above and never gets here.
+        pending_count_module = Some(count_module);
     }
 
     finalize_application_update(
@@ -616,6 +634,23 @@ pub(crate) async fn update_application_with_migration(
         application_version(&datastore, application.id),
     ) {
         let _ = node_client.send_event(event);
+    }
+
+    // Post-commit: recompute this node's owner's pending-authored count over the
+    // committed v2 state and persist it for the heartbeat self-report (6f.8).
+    // Best-effort — a missing export / failure leaves the prior value untouched.
+    if let Some(module) = pending_count_module {
+        if let Some(count) = run_count_my_pending(
+            &datastore,
+            node_client.clone(),
+            context_id,
+            module,
+            public_key,
+        )
+        .await
+        {
+            persist_authored_remaining(&datastore, context_id, count);
+        }
     }
 
     Ok((application, context))
@@ -957,6 +992,83 @@ async fn run_migration_check(
     };
 
     Ok((decode_migration_check_verdict(outcome.returns)?, storage))
+}
+
+/// Run the app's `count_my_pending` export over the COMMITTED v2 state to read
+/// the executor's pending-authored count (the self-reported `authored_remaining`).
+/// Runs post-commit against a fresh buffer over the live store, under the
+/// applying identity, so `owned_by_me` resolves to this node's owner. Read-only
+/// (the export never commits). Best-effort: a missing export (non-authored app),
+/// a host error, or a pool-join failure all yield `None`.
+async fn run_count_my_pending(
+    datastore: &calimero_store::Store,
+    node_client: NodeClient,
+    context_id: ContextId,
+    module: calimero_runtime::Module,
+    executor_identity: PublicKey,
+) -> Option<u32> {
+    let storage = ContextStorage::from(datastore.clone(), context_id);
+    let outcome = global_runtime()
+        .spawn_blocking(move || {
+            let mut storage = storage;
+            let outcome = module.run(
+                context_id,
+                executor_identity,
+                "count_my_pending",
+                &[],
+                &mut storage,
+                None,
+                Some(node_client),
+            );
+            // Read-only call: scrub any thread-local delta it might have pushed.
+            clear_pending_delta();
+            outcome
+        })
+        .await;
+
+    match outcome {
+        // The export returns its u32 count as JSON via value_return. A missing
+        // export (non-authored app ⇒ Err(MethodNotFound)), an empty return, or a
+        // host error all mean "no count" — report None and leave the prior value.
+        Ok(Ok(rt_outcome)) => match rt_outcome.returns {
+            Ok(Some(bytes)) => serde_json::from_slice::<u32>(&bytes).ok(),
+            _ => None,
+        },
+        Ok(Err(e)) => {
+            debug!(%context_id, error = ?e, "count_my_pending host error; reporting no count");
+            None
+        }
+        Err(e) => {
+            debug!(%context_id, error = ?e, "count_my_pending task join failed; reporting no count");
+            None
+        }
+    }
+}
+
+/// Read-modify-write the node-local `ContextMeta.authored_remaining` for a
+/// context, preserving every other field. Best-effort: a missing row or store
+/// fault is logged and skipped (the heartbeat falls back to the prior value).
+pub(crate) fn persist_authored_remaining(
+    datastore: &calimero_store::Store,
+    context_id: ContextId,
+    authored_remaining: u32,
+) {
+    let mut handle = datastore.handle();
+    let key = key::ContextMeta::new(context_id);
+    match handle.get(&key) {
+        Ok(Some(mut meta)) => {
+            meta.authored_remaining = authored_remaining;
+            if let Err(err) = handle.put(&key, &meta) {
+                debug!(%context_id, %err, "failed to persist authored_remaining");
+            }
+        }
+        Ok(None) => {
+            debug!(%context_id, "context meta absent; skipping authored_remaining persist");
+        }
+        Err(err) => {
+            debug!(%context_id, %err, "failed to read context meta for authored_remaining persist");
+        }
+    }
 }
 
 /// Storage callback closures used by the `calimero-storage` runtime environment.

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -10,7 +10,8 @@ use calimero_prelude::ROOT_STORAGE_ENTRY_ID;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::{
-    ContextEvent, ContextEventPayload, ExecutionEvent, NodeEvent, StateMutationPayload,
+    AppVersionChangedPayload, ContextEvent, ContextEventPayload, ExecutionEvent, NodeEvent,
+    StateMutationPayload,
 };
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
@@ -265,6 +266,41 @@ async fn finalize_application_update(
     Ok(())
 }
 
+/// Resolves an application's semver from its `ApplicationMeta` row. `None` when
+/// the row is absent (e.g. uninstalled). Labels the `AppVersionChanged` event.
+fn application_version(
+    datastore: &calimero_store::Store,
+    application_id: ApplicationId,
+) -> Option<String> {
+    datastore
+        .handle()
+        .get(&key::ApplicationMeta::new(application_id))
+        .ok()
+        .flatten()
+        .map(|meta| meta.version.to_string())
+}
+
+/// Builds an `AppVersionChanged` node event for a context whose application id
+/// flipped, or `None` when it is unchanged. The id comparison IS the emit-once
+/// dedup (6f.5): a no-op re-apply with the same id emits nothing.
+fn app_version_changed_event(
+    context_id: ContextId,
+    old_application_id: ApplicationId,
+    new_application_id: ApplicationId,
+    from_version: Option<String>,
+    to_version: Option<String>,
+) -> Option<NodeEvent> {
+    (old_application_id != new_application_id).then(|| {
+        NodeEvent::Context(ContextEvent {
+            context_id,
+            payload: ContextEventPayload::AppVersionChanged(AppVersionChangedPayload {
+                from_version,
+                to_version,
+            }),
+        })
+    })
+}
+
 pub async fn update_application_id(
     datastore: calimero_store::Store,
     node_client: NodeClient,
@@ -287,6 +323,10 @@ pub async fn update_application_id(
     // Verify AppKey continuity (signerId match)
     verify_appkey_continuity(&datastore, &context, &application_id)?;
 
+    // Capture the pre-flip app id before finalize persists the new one, so the
+    // post-commit AppVersionChanged carries the correct from/to versions.
+    let old_application_id = context.application_id;
+
     finalize_application_update(
         &datastore,
         &node_client,
@@ -295,6 +335,17 @@ pub async fn update_application_id(
         &application,
     )
     .await?;
+
+    // Post-commit: notify subscribers the application version flipped (skew #2).
+    if let Some(event) = app_version_changed_event(
+        context_id,
+        old_application_id,
+        application.id,
+        application_version(&datastore, old_application_id),
+        application_version(&datastore, application.id),
+    ) {
+        let _ = node_client.send_event(event);
+    }
 
     Ok(application)
 }
@@ -426,6 +477,10 @@ pub(crate) async fn update_application_with_migration(
     // Verify AppKey continuity (signerId match)
     verify_appkey_continuity(&datastore, &context, &application_id)?;
 
+    // Pre-flip app id, captured before finalize persists the new one (for the
+    // post-commit AppVersionChanged from/to versions).
+    let old_application_id = context.application_id;
+
     // Execute migration if requested
     if let Some(migration_params) = migration {
         info!(
@@ -545,6 +600,17 @@ pub(crate) async fn update_application_with_migration(
         &application,
     )
     .await?;
+
+    // Post-commit: notify subscribers the application version flipped (skew #2).
+    if let Some(event) = app_version_changed_event(
+        context_id,
+        old_application_id,
+        application.id,
+        application_version(&datastore, old_application_id),
+        application_version(&datastore, application.id),
+    ) {
+        let _ = node_client.send_event(event);
+    }
 
     Ok((application, context))
 }
@@ -1185,8 +1251,10 @@ mod tests {
     use calimero_store::db::InMemoryDB;
     use calimero_store::{key, types, Store};
 
-    use super::verify_appkey_continuity;
+    use calimero_primitives::events::{ContextEvent, ContextEventPayload, NodeEvent};
+
     use super::ContextStorage;
+    use super::{app_version_changed_event, application_version, verify_appkey_continuity};
 
     /// Creates a test store with in-memory database.
     fn create_test_store() -> Store {
@@ -1249,6 +1317,66 @@ mod tests {
             "AppKey continuity check should pass with matching signerIds: {:?}",
             result.err()
         );
+    }
+
+    // application_version resolves ApplicationMeta.version (semver) for the emit.
+    #[test]
+    fn application_version_reads_semver_and_handles_missing() {
+        let store = create_test_store();
+        let app_id = ApplicationId::from([42u8; 32]);
+        store
+            .handle()
+            .put(
+                &key::ApplicationMeta::new(app_id),
+                &create_app_meta("signer"),
+            )
+            .expect("seed app meta");
+        assert_eq!(
+            application_version(&store, app_id).as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            application_version(&store, ApplicationId::from([99u8; 32])),
+            None
+        );
+    }
+
+    // No event when the application id did not actually change (6f.5 dedup).
+    #[test]
+    fn app_version_changed_event_skips_when_unchanged() {
+        let id = ApplicationId::from([1u8; 32]);
+        let ev = app_version_changed_event(
+            ContextId::from([7u8; 32]),
+            id,
+            id,
+            Some("1.0.0".to_owned()),
+            Some("1.0.0".to_owned()),
+        );
+        assert!(ev.is_none(), "no emit when app id unchanged");
+    }
+
+    // On a real flip, build the AppVersionChanged event with both versions.
+    #[test]
+    fn app_version_changed_event_on_flip() {
+        let ctx = ContextId::from([7u8; 32]);
+        let ev = app_version_changed_event(
+            ctx,
+            ApplicationId::from([1u8; 32]),
+            ApplicationId::from([2u8; 32]),
+            Some("1.0.0".to_owned()),
+            Some("2.0.0".to_owned()),
+        );
+        match ev {
+            Some(NodeEvent::Context(ContextEvent {
+                context_id,
+                payload: ContextEventPayload::AppVersionChanged(p),
+            })) => {
+                assert_eq!(context_id, ctx);
+                assert_eq!(p.from_version.as_deref(), Some("1.0.0"));
+                assert_eq!(p.to_version.as_deref(), Some("2.0.0"));
+            }
+            other => panic!("expected AppVersionChanged, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -599,6 +599,7 @@ fn signed_heartbeat(
         synced_up_to_hlc: 42,
         ts_millis: 1_700_000_000_000,
         signature: [0u8; 64],
+        authored_remaining: 0,
     };
     hb.signature = sk
         .sign(&hb.signable_bytes().expect("signable_bytes"))

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -210,31 +210,32 @@ pub struct SignedMigrationHeartbeat {
     pub authored_remaining: u64,
 }
 
-/// Read an optional trailing fixed-width LE value: `None` on a clean EOF (old
-/// heartbeat, no trailing field), `Some` when the full width is present, `Err`
-/// only on a genuine partial read. Distinguishes "absent" from "truncated" by
-/// bytes-read count, not by matching borsh's error-message text.
+/// Read an optional trailing fixed-width LE value: `None` when no trailing field
+/// is present (clean EOF before any byte — an old heartbeat), `Some` when the
+/// full width is present, `Err` on a genuine partial read. A leading 1-byte
+/// sentinel probe distinguishes "absent" from "present" without depending on
+/// `Read::read` returning `Ok(0)` exactly at the field boundary; once any byte
+/// is read, `read_exact` fills the rest and a short read is a hard error. No
+/// error-message-text matching (not stable across borsh versions).
 fn read_trailing<R: borsh::io::Read, const N: usize>(
     reader: &mut R,
 ) -> borsh::io::Result<Option<[u8; N]>> {
     let mut buf = [0u8; N];
-    let mut filled = 0;
-    while filled < N {
-        match reader.read(&mut buf[filled..]) {
-            Ok(0) => break,
-            Ok(n) => filled += n,
+    // Probe one byte. Loop over Interrupted; a true EOF here (0 bytes) means
+    // the trailing field is absent (old format).
+    let read_first = loop {
+        match reader.read(&mut buf[..1]) {
+            Ok(n) => break n,
             Err(e) if e.kind() == borsh::io::ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
         }
+    };
+    if read_first == 0 {
+        return Ok(None);
     }
-    match filled {
-        0 => Ok(None),
-        n if n == N => Ok(Some(buf)),
-        _ => Err(borsh::io::Error::new(
-            borsh::io::ErrorKind::InvalidData,
-            "truncated trailing field",
-        )),
-    }
+    // A byte was present ⇒ the field must be complete; a short read is an error.
+    reader.read_exact(&mut buf[1..])?;
+    Ok(Some(buf))
 }
 
 // Custom deserialize: `authored_remaining` is an unsigned trailing field added

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -210,11 +210,36 @@ pub struct SignedMigrationHeartbeat {
     pub authored_remaining: u64,
 }
 
+/// Read an optional trailing fixed-width LE value: `None` on a clean EOF (old
+/// heartbeat, no trailing field), `Some` when the full width is present, `Err`
+/// only on a genuine partial read. Distinguishes "absent" from "truncated" by
+/// bytes-read count, not by matching borsh's error-message text.
+fn read_trailing<R: borsh::io::Read, const N: usize>(
+    reader: &mut R,
+) -> borsh::io::Result<Option<[u8; N]>> {
+    let mut buf = [0u8; N];
+    let mut filled = 0;
+    while filled < N {
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(e) if e.kind() == borsh::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    match filled {
+        0 => Ok(None),
+        n if n == N => Ok(Some(buf)),
+        _ => Err(borsh::io::Error::new(
+            borsh::io::ErrorKind::InvalidData,
+            "truncated trailing field",
+        )),
+    }
+}
+
 // Custom deserialize: `authored_remaining` is an unsigned trailing field added
-// after the original layout. Read the original fields, then tolerate a short
-// trailing read (old heartbeat ⇒ 0). Matches the ContextMeta/ApplicationMeta
-// back-compat pattern (this borsh surfaces a short read as InvalidData
-// "Unexpected length", not UnexpectedEof — handle both).
+// after the original layout. Read the original fields, then tolerate a clean
+// EOF (old heartbeat ⇒ 0) by byte count rather than matching borsh's error text.
 impl BorshDeserialize for SignedMigrationHeartbeat {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let namespace_id = <[u8; 32]>::deserialize_reader(reader)?;
@@ -225,17 +250,8 @@ impl BorshDeserialize for SignedMigrationHeartbeat {
         let synced_up_to_hlc = u64::deserialize_reader(reader)?;
         let ts_millis = u64::deserialize_reader(reader)?;
         let signature = <[u8; 64]>::deserialize_reader(reader)?;
-        let authored_remaining = match u64::deserialize_reader(reader) {
-            Ok(v) => v,
-            Err(e) if e.kind() == borsh::io::ErrorKind::UnexpectedEof => 0,
-            Err(e)
-                if e.kind() == borsh::io::ErrorKind::InvalidData
-                    && e.to_string().contains("Unexpected length") =>
-            {
-                0
-            }
-            Err(e) => return Err(e),
-        };
+        // borsh integers are little-endian; absent trailing bytes ⇒ old hb ⇒ 0.
+        let authored_remaining = read_trailing::<_, 8>(reader)?.map_or(0, u64::from_le_bytes);
         Ok(Self {
             namespace_id,
             peer_pubkey,

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -190,6 +190,12 @@ pub struct SignableMigrationHeartbeat {
 /// `residue_auto == 0 && residue_identity == 0 && schema_version >= target`
 /// across every pinned cohort member is what a rollup reads as "all migrated";
 /// the signature prevents a peer from forging another peer's completion.
+// MAINTENANCE: this struct has a hand-written `BorshDeserialize` (below) that
+// reads these fields positionally. If you ADD / REMOVE / REORDER any field
+// here, update that impl in lockstep (new fields go AFTER authored_remaining as
+// another trailing read, or behind a version discriminant). The round-trip +
+// mixed-fleet tests (serialize via this derive, deserialize via the custom impl)
+// fail loudly on a desync — keep them in step.
 #[derive(Debug, Clone, BorshSerialize)]
 pub struct SignedMigrationHeartbeat {
     pub namespace_id: [u8; 32],

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -241,6 +241,16 @@ fn read_trailing<R: borsh::io::Read, const N: usize>(
 // Custom deserialize: `authored_remaining` is an unsigned trailing field added
 // after the original layout. Read the original fields, then tolerate a clean
 // EOF (old heartbeat ⇒ 0) by byte count rather than matching borsh's error text.
+//
+// FIELD ORDER CONTRACT: borsh is positional (no field names), so this reader
+// MUST deserialize the prefix fields in the exact order the derived
+// `BorshSerialize` above writes them — namespace_id, peer_pubkey, schema_version,
+// residue_auto, residue_identity, synced_up_to_hlc, ts_millis, signature — then
+// the trailing authored_remaining. Reordering/adding a field above without
+// updating this reader silently misreads. The round-trip + mixed-fleet tests
+// (which serialize via the derive and deserialize via this impl) guard against
+// such a desync; keep them in step. A future field should go AFTER
+// authored_remaining (another trailing read) or behind a version discriminant.
 impl BorshDeserialize for SignedMigrationHeartbeat {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let namespace_id = <[u8; 32]>::deserialize_reader(reader)?;

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -190,7 +190,7 @@ pub struct SignableMigrationHeartbeat {
 /// `residue_auto == 0 && residue_identity == 0 && schema_version >= target`
 /// across every pinned cohort member is what a rollup reads as "all migrated";
 /// the signature prevents a peer from forging another peer's completion.
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize)]
 pub struct SignedMigrationHeartbeat {
     pub namespace_id: [u8; 32],
     pub peer_pubkey: PublicKey,
@@ -200,6 +200,54 @@ pub struct SignedMigrationHeartbeat {
     pub synced_up_to_hlc: u64,
     pub ts_millis: u64,
     pub signature: [u8; 64],
+    /// Self-reported pending-authored count (sum across the publisher's
+    /// namespace contexts; 6f). DELIBERATELY OUTSIDE the signature and the
+    /// signable body: it is best-effort advisory telemetry (decision #3), not a
+    /// migration gate — the signed residue_* fields cover completion. Appended
+    /// as the trailing field so a heartbeat from an older node (which omits it)
+    /// still deserializes (EOF ⇒ 0) and verifies against the unchanged 7-field
+    /// signed body — full mixed-fleet compatibility, no version discriminator.
+    pub authored_remaining: u64,
+}
+
+// Custom deserialize: `authored_remaining` is an unsigned trailing field added
+// after the original layout. Read the original fields, then tolerate a short
+// trailing read (old heartbeat ⇒ 0). Matches the ContextMeta/ApplicationMeta
+// back-compat pattern (this borsh surfaces a short read as InvalidData
+// "Unexpected length", not UnexpectedEof — handle both).
+impl BorshDeserialize for SignedMigrationHeartbeat {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        let namespace_id = <[u8; 32]>::deserialize_reader(reader)?;
+        let peer_pubkey = PublicKey::deserialize_reader(reader)?;
+        let schema_version = u32::deserialize_reader(reader)?;
+        let residue_auto = u64::deserialize_reader(reader)?;
+        let residue_identity = u64::deserialize_reader(reader)?;
+        let synced_up_to_hlc = u64::deserialize_reader(reader)?;
+        let ts_millis = u64::deserialize_reader(reader)?;
+        let signature = <[u8; 64]>::deserialize_reader(reader)?;
+        let authored_remaining = match u64::deserialize_reader(reader) {
+            Ok(v) => v,
+            Err(e) if e.kind() == borsh::io::ErrorKind::UnexpectedEof => 0,
+            Err(e)
+                if e.kind() == borsh::io::ErrorKind::InvalidData
+                    && e.to_string().contains("Unexpected length") =>
+            {
+                0
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(Self {
+            namespace_id,
+            peer_pubkey,
+            schema_version,
+            residue_auto,
+            residue_identity,
+            synced_up_to_hlc,
+            ts_millis,
+            signature,
+            authored_remaining,
+        })
+    }
 }
 
 impl SignedMigrationHeartbeat {
@@ -482,6 +530,7 @@ mod tests {
             synced_up_to_hlc: 99,
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
+            authored_remaining: 0,
         };
         hb.signature = sk
             .sign(&hb.signable_bytes().expect("signable"))
@@ -504,6 +553,7 @@ mod tests {
             synced_up_to_hlc: 99,
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
+            authored_remaining: 0,
         };
         hb.signature = sk
             .sign(&hb.signable_bytes().expect("signable"))
@@ -513,6 +563,55 @@ mod tests {
         assert!(
             hb.verify_signature().is_err(),
             "verify must reject mutated `residue_identity`"
+        );
+    }
+
+    // 6f: authored_remaining is an UNSIGNED trailing field. A new heartbeat
+    // round-trips it; an old-format heartbeat (no trailing bytes) deserializes
+    // to 0 and still verifies (signature never covered it); tampering it does
+    // not break verification. This is the mixed-fleet back-compat guarantee.
+    #[test]
+    fn migration_heartbeat_authored_remaining_unsigned_and_eof_tolerant() {
+        let sk = PrivateKey::random(&mut rand::thread_rng());
+        let mut hb = SignedMigrationHeartbeat {
+            namespace_id: [9u8; 32],
+            peer_pubkey: sk.public_key(),
+            schema_version: 2,
+            residue_auto: 0,
+            residue_identity: 0,
+            synced_up_to_hlc: 50,
+            ts_millis: 1_700_000_000_000,
+            signature: [0u8; 64],
+            authored_remaining: 5,
+        };
+        hb.signature = sk
+            .sign(&hb.signable_bytes().expect("signable"))
+            .expect("sign")
+            .to_bytes();
+        assert!(hb.verify_signature().is_ok(), "freshly signed verifies");
+
+        // New heartbeat round-trips the field.
+        let bytes = borsh::to_vec(&hb).expect("ser");
+        let back = SignedMigrationHeartbeat::try_from_slice(&bytes).expect("de");
+        assert_eq!(back.authored_remaining, 5);
+        assert!(back.verify_signature().is_ok());
+
+        // Old-format heartbeat: drop the trailing u64. Defaults to 0 and the
+        // signature (over the unchanged 7-field body) still verifies.
+        let legacy = &bytes[..bytes.len() - core::mem::size_of::<u64>()];
+        let old = SignedMigrationHeartbeat::try_from_slice(legacy).expect("de legacy");
+        assert_eq!(old.authored_remaining, 0, "absent trailing field ⇒ 0");
+        assert!(
+            old.verify_signature().is_ok(),
+            "signature unaffected by the unsigned trailing field"
+        );
+
+        // Tampering the advisory field does not break verification.
+        let mut tampered = hb.clone();
+        tampered.authored_remaining = 999;
+        assert!(
+            tampered.verify_signature().is_ok(),
+            "authored_remaining is unsigned advisory telemetry"
         );
     }
 
@@ -542,6 +641,7 @@ mod tests {
             synced_up_to_hlc: hb_unsigned.synced_up_to_hlc,
             ts_millis: hb_unsigned.ts_millis,
             signature,
+            authored_remaining: 0,
         };
         assert!(
             hb.verify_signature().is_err(),
@@ -561,6 +661,7 @@ mod tests {
             synced_up_to_hlc: 1234,
             ts_millis: 42,
             signature: [5u8; 64],
+            authored_remaining: 0,
         });
         let bytes = borsh::to_vec(&envelope).expect("ser");
         let parsed: NamespaceTopicMsg = borsh::from_slice(&bytes).expect("de");

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -100,4 +100,7 @@ pub struct MigrationStatusReport {
     pub synced_up_to_hlc: u64,
     /// Member-signed millis-since-epoch from the heartbeat itself.
     pub reported_at: u64,
+    /// Member's self-reported pending-authored count (sum across its namespace
+    /// contexts); feeds the rollup's `membersPendingSignature` (6f).
+    pub authored_remaining: u64,
 }

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -62,6 +62,9 @@ pub struct CacheEntry {
     pub residue_identity: u64,
     /// Governance HLC the peer has synced/applied through.
     pub synced_up_to_hlc: u64,
+    /// Peer's self-reported pending-authored count (sum across its namespace
+    /// contexts). Surfaced in the rollup as `membersPendingSignature` (6f).
+    pub authored_remaining: u64,
     /// Peer-signed millis-since-epoch from the heartbeat itself.
     /// Authoritative per-peer ordering signal — used by `insert` to drop
     /// stale heartbeats that gossipsub may re-deliver out-of-order on mesh
@@ -85,6 +88,7 @@ pub fn cache_entry_to_report(entry: &CacheEntry) -> MigrationStatusReport {
         residue_identity: entry.residue_identity,
         synced_up_to_hlc: entry.synced_up_to_hlc,
         reported_at: entry.ts_millis,
+        authored_remaining: entry.authored_remaining,
     }
 }
 
@@ -182,6 +186,7 @@ impl MigrationStatusCache {
                 residue_auto: hb.residue_auto,
                 residue_identity: hb.residue_identity,
                 synced_up_to_hlc: hb.synced_up_to_hlc,
+                authored_remaining: hb.authored_remaining,
                 ts_millis: hb.ts_millis,
                 received_at: now,
             },
@@ -250,6 +255,12 @@ pub struct MigrationFacts {
     pub residue_auto: u64,
     pub residue_identity: u64,
     pub synced_up_to_hlc: u64,
+    /// Sum across this node's namespace contexts of each context's owner's
+    /// identity-gated entries still below target (the node-local count the
+    /// context handler persists into `ContextMeta.authored_remaining`). u64
+    /// like the residue fields (a per-namespace sum of per-context u32 counts).
+    /// Best-effort self-report — distinct from `residue_identity` (still 0).
+    pub authored_remaining: u64,
 }
 
 /// Decide whether the local node should emit an *on-change* heartbeat for a
@@ -271,6 +282,7 @@ pub fn should_emit_on_change(last: Option<MigrationFacts>, current: MigrationFac
             prev.schema_version != current.schema_version
                 || prev.residue_auto != current.residue_auto
                 || prev.residue_identity != current.residue_identity
+                || prev.authored_remaining != current.authored_remaining
         }
     }
 }
@@ -405,7 +417,17 @@ pub fn compute_namespace_migration_facts(
 
     let mut min_loaded: Option<u32> = None;
     let mut residue_auto: u64 = 0;
+    // Sum the per-context authored_remaining the context handler persisted
+    // (6f.8). A plain store read — no wasm, no committed-state iteration.
+    let mut authored_remaining: u64 = 0;
     for context_id in &contexts {
+        if let Ok(Some(meta)) = datastore
+            .handle()
+            .get(&calimero_store::key::ContextMeta::new(*context_id))
+        {
+            authored_remaining =
+                authored_remaining.saturating_add(u64::from(meta.authored_remaining));
+        }
         let Some(loaded) = loaded_context_version(datastore, context_id) else {
             continue;
         };
@@ -440,6 +462,7 @@ pub fn compute_namespace_migration_facts(
         residue_auto,
         residue_identity,
         synced_up_to_hlc: 0,
+        authored_remaining,
     }
 }
 
@@ -527,6 +550,7 @@ pub fn build_signed_heartbeat(
         residue_auto: facts.residue_auto,
         residue_identity: facts.residue_identity,
         synced_up_to_hlc: facts.synced_up_to_hlc,
+        authored_remaining: facts.authored_remaining,
         ts_millis,
         signature: [0u8; 64],
     };
@@ -759,6 +783,7 @@ mod tests {
             synced_up_to_hlc: 0,
             ts_millis,
             signature,
+            authored_remaining: 0,
         }
     }
 
@@ -934,6 +959,7 @@ mod tests {
             residue_auto: 0,
             residue_identity: 4,
             synced_up_to_hlc: 10,
+            authored_remaining: 0,
         };
         // First-ever emit (no prior) always fires.
         assert!(should_emit_on_change(None, base));
@@ -970,6 +996,7 @@ mod tests {
             residue_auto: 0,
             residue_identity: 0,
             synced_up_to_hlc: 10,
+            authored_remaining: 0,
         };
         let advanced = MigrationFacts {
             synced_up_to_hlc: 99,
@@ -994,6 +1021,7 @@ mod tests {
             residue_auto: 0,
             residue_identity: 3,
             synced_up_to_hlc: 10,
+            authored_remaining: 0,
         };
 
         let emit = record_facts_update(&mut last_emitted, NS, facts);
@@ -1225,6 +1253,7 @@ mod tests {
             residue_auto: 3,
             residue_identity: 1,
             synced_up_to_hlc: 77,
+            authored_remaining: 0,
         };
         let hb = build_signed_heartbeat(&sk, NS, facts, 1234).expect("sign");
         // The receiver's signature gate accepts it, and the cache then reads

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -417,16 +417,19 @@ pub fn compute_namespace_migration_facts(
 
     let mut min_loaded: Option<u32> = None;
     let mut residue_auto: u64 = 0;
-    // Sum the per-context authored_remaining the context handler persisted
-    // (6f.8). A plain store read — no wasm, no committed-state iteration.
+    // Sum the per-context authored_remaining the context handler persisted to
+    // the dedicated node-local key (6f.8). A plain store read — no wasm, no
+    // committed-state iteration. Absent row ⇒ 0.
     let mut authored_remaining: u64 = 0;
     for context_id in &contexts {
-        if let Ok(Some(meta)) = datastore
-            .handle()
-            .get(&calimero_store::key::ContextMeta::new(*context_id))
+        if let Ok(Some(entry)) =
+            datastore
+                .handle()
+                .get(&calimero_store::key::ContextAuthoredRemaining::new(
+                    *context_id,
+                ))
         {
-            authored_remaining =
-                authored_remaining.saturating_add(u64::from(meta.authored_remaining));
+            authored_remaining = authored_remaining.saturating_add(u64::from(entry.count));
         }
         let Some(loaded) = loaded_context_version(datastore, context_id) else {
             continue;

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -724,12 +724,14 @@ impl MigrationEmitter {
         let log_ns = ns_id;
         let log_schema = facts.schema_version;
         let log_residue = facts.residue_identity;
+        let log_authored = facts.authored_remaining;
         actix::spawn(async move {
             match net.publish(topic, bytes).await {
                 Ok(_) => tracing::debug!(
                     namespace_id = %hex::encode(log_ns),
                     schema_version = log_schema,
                     residue_identity = log_residue,
+                    authored_remaining = log_authored,
                     "migration heartbeat emitted"
                 ),
                 Err(err) => {

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -597,16 +597,21 @@ impl Actor for MigrationEmitter {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        // Periodic keep-alive re-publish for every namespace we have facts
-        // for. Edge-trigger emits arrive via `MigrationFactsUpdate`.
+        // Periodic keep-alive re-publish for every namespace we have facts for.
+        // RECOMPUTE facts from the store each tick (not a replay of the cached
+        // last_emitted), so node-local fact changes that don't fire a
+        // MigrationFactsUpdate — notably authored_remaining persisted after
+        // migrate_my_entries / a lazy migrate (6f) — self-heal within one
+        // interval instead of staying stale until an unrelated governance op.
+        // Edge-trigger emits via MigrationFactsUpdate still give immediate
+        // updates on governance applies.
         ctx.run_interval(self.interval, |this, _ctx| {
             let ns_ids: Vec<[u8; 32]> = this.last_emitted.keys().copied().collect();
             for ns_id in ns_ids {
-                if let Some(facts) = this.last_emitted.get(&ns_id).copied() {
-                    let facts = this.refresh_hlc(ns_id, facts);
-                    this.last_emitted.insert(ns_id, facts);
-                    this.publish_heartbeat(ns_id, facts);
-                }
+                let facts = compute_namespace_migration_facts(&this.datastore, ns_id);
+                let facts = this.refresh_hlc(ns_id, facts);
+                this.last_emitted.insert(ns_id, facts);
+                this.publish_heartbeat(ns_id, facts);
             }
         });
     }

--- a/crates/node/src/sync/manager/blob_fetch.rs
+++ b/crates/node/src/sync/manager/blob_fetch.rs
@@ -4,7 +4,11 @@
 //! god-file as an `impl SyncManager` fragment.
 
 use calimero_node_primitives::client::NodeClient;
+use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
+use calimero_primitives::events::{
+    AppVersionChangedPayload, ContextEvent, ContextEventPayload, NodeEvent,
+};
 use eyre::bail;
 use tracing::{debug, warn};
 
@@ -165,6 +169,12 @@ impl SyncManager {
                 context_app_id = %context.application_id,
                 "Installed application ID does not match context application ID, updating to installed ID"
             );
+            // Capture the pre-flip id for the AppVersionChanged emit below; this
+            // is a durable application flip (this node just learned, via blob
+            // sync, that its context's app changed), so it must notify
+            // subscribers like the update_application workers do.
+            let old_app_id = context.application_id;
+
             // Update context with the installed application ID for consistency
             context.application_id = installed_app_id;
 
@@ -186,11 +196,38 @@ impl SyncManager {
                 installed_app_id = %installed_app_id,
                 "Persisted ApplicationId update to database"
             );
+
+            // Notify subscribers of the version flip (skew #2). Best-effort, like
+            // the update_application emit. The guard above is the dedup (only a
+            // genuine id change reaches here). to_version comes straight off the
+            // installed Application; from_version resolves the old app row.
+            let event = NodeEvent::Context(ContextEvent {
+                context_id: *context_id,
+                payload: ContextEventPayload::AppVersionChanged(AppVersionChangedPayload {
+                    from_version: self.application_version(old_app_id),
+                    to_version: Some(installed_application.version.clone())
+                        .filter(|v| !v.is_empty()),
+                }),
+            });
+            let _ = self.node_client.send_event(event);
         }
 
         // Use the verified installed application
         *application = Some(installed_application);
 
         Ok(())
+    }
+
+    /// Resolves an application's semver from its `ApplicationMeta` row via the
+    /// context store; `None` when the row is absent. Labels the from-version of
+    /// the blob-sync `AppVersionChanged` emit (mirrors the context-handler
+    /// `application_version` helper).
+    fn application_version(&self, application_id: ApplicationId) -> Option<String> {
+        self.context_client
+            .datastore_handle()
+            .get(&calimero_store::key::ApplicationMeta::new(application_id))
+            .ok()
+            .flatten()
+            .map(|meta| meta.version.to_string())
     }
 }

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -118,6 +118,12 @@ pub struct Context {
     /// Used to track causal dependencies when creating new deltas
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub dag_heads: Vec<[u8; 32]>,
+    /// Resolved semver of the application this context runs (from
+    /// `ApplicationMeta.version`). Lets a frontend detect bundle skew in one
+    /// call. `None` when the application row is unavailable. Optional +
+    /// serde-default so older payloads deserialize unchanged.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub application_version: Option<String>,
 }
 
 impl Context {
@@ -136,6 +142,7 @@ impl Context {
             service_name: None,
             root_hash,
             dag_heads: Vec::new(),
+            application_version: None,
         }
     }
 
@@ -153,6 +160,7 @@ impl Context {
             service_name: None,
             root_hash,
             dag_heads,
+            application_version: None,
         }
     }
 
@@ -171,7 +179,16 @@ impl Context {
             service_name,
             root_hash,
             dag_heads,
+            application_version: None,
         }
+    }
+
+    /// Sets the resolved application semver (builder-style; `Context` is
+    /// `#[non_exhaustive]`, so callers in other crates set it via this method).
+    #[must_use]
+    pub fn with_application_version(mut self, application_version: Option<String>) -> Self {
+        self.application_version = application_version;
+        self
     }
 }
 

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -27,6 +27,22 @@ pub enum ContextEventPayload {
     /// changes phase (and as snapshot pages arrive). Lets a client waiting on
     /// initial state watch progress instead of polling `sync_status`.
     SyncStatus(SyncStatusPayload),
+    /// Fired once when a context's application version flips (a migrate/upgrade
+    /// applied). Lets a frontend react live to bundle skew (spec skew #2)
+    /// instead of polling. `contextId` rides on the flattened [`ContextEvent`].
+    AppVersionChanged(AppVersionChangedPayload),
+}
+
+/// Payload of a [`ContextEventPayload::AppVersionChanged`] event. Versions are
+/// the application semver before/after the flip; either may be `None` if the
+/// corresponding `ApplicationMeta` row was unavailable at emit time.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppVersionChangedPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_version: Option<String>,
 }
 
 /// Payload of a [`ContextEventPayload::SyncStatus`] event. Mirrors the fields
@@ -73,4 +89,39 @@ pub struct ExecutionXCall {
     pub target_context_id: ContextId,
     pub function: String,
     pub params: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // AppVersionChanged serializes with the PascalCase "AppVersionChanged" tag
+    // and camelCase data fields; contextId rides on the flattened ContextEvent.
+    #[test]
+    fn app_version_changed_tag_and_shape() {
+        let event = ContextEvent {
+            context_id: ContextId::from([0x01; 32]),
+            payload: ContextEventPayload::AppVersionChanged(AppVersionChangedPayload {
+                from_version: Some("1.0.0".to_owned()),
+                to_version: Some("2.0.0".to_owned()),
+            }),
+        };
+        let v = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(v["type"], "AppVersionChanged");
+        assert_eq!(v["data"]["fromVersion"], "1.0.0");
+        assert_eq!(v["data"]["toVersion"], "2.0.0");
+        assert!(v.get("contextId").is_some(), "contextId on the wrapper");
+    }
+
+    // None versions are omitted from the data object.
+    #[test]
+    fn app_version_changed_omits_none() {
+        let payload = ContextEventPayload::AppVersionChanged(AppVersionChangedPayload {
+            from_version: None,
+            to_version: Some("2.0.0".to_owned()),
+        });
+        let v = serde_json::to_value(&payload).expect("serialize");
+        assert!(v["data"].get("fromVersion").is_none());
+        assert_eq!(v["data"]["toVersion"], "2.0.0");
+    }
 }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -934,6 +934,7 @@ fn generate_migrate_my_entries_impl(
     };
 
     let mut field_loops: Vec<TokenStream> = Vec::new();
+    let mut count_loops: Vec<TokenStream> = Vec::new();
     for (idx, field) in fields.iter().enumerate() {
         let field_type = &field.ty;
         let type_str = quote! { #field_type }.to_string();
@@ -947,6 +948,38 @@ fn generate_migrate_my_entries_impl(
             let index = syn::Index::from(idx);
             quote! { self.#index }
         };
+
+        // Count-only twin of the migrate loop: tally the caller's still-stale
+        // owned entries without re-writing them (read-only, no signed delta).
+        let count_body = if type_str.contains("AuthoredMap") {
+            quote! {
+                let __keys: ::std::vec::Vec<_> = match #access.entries() {
+                    ::core::result::Result::Ok(__it) => __it.map(|(__k, _)| __k).collect(),
+                    ::core::result::Result::Err(_) => ::std::vec::Vec::new(),
+                };
+                for __k in __keys {
+                    let __owned = #access.owned_by_me(&__k).unwrap_or(false);
+                    let __stale =
+                        #access.entry_schema_version(&__k).ok().flatten().unwrap_or(0) < __target;
+                    if __owned && __stale {
+                        __pending = __pending.saturating_add(1);
+                    }
+                }
+            }
+        } else {
+            quote! {
+                let __len = #access.len().unwrap_or(0);
+                for __i in 0..__len {
+                    let __owned = #access.owned_by_me(__i).unwrap_or(false);
+                    let __stale =
+                        #access.entry_schema_version(__i).ok().flatten().unwrap_or(0) < __target;
+                    if __owned && __stale {
+                        __pending = __pending.saturating_add(1);
+                    }
+                }
+            }
+        };
+        count_loops.push(count_body);
 
         // `AuthoredVector` also contains the substring "Vector"; check the map
         // first, then fall to the vector shape (keyed-by-index vs keyed-by-key).
@@ -1025,6 +1058,19 @@ fn generate_migrate_my_entries_impl(
                     remaining: __remaining,
                 }
             }
+
+            /// Count the caller's own identity-gated entries still below the
+            /// target schema, WITHOUT converting them (read-only; no signed
+            /// delta). Read-only twin of `__calimero_migrate_my_entries`; the
+            /// node invokes the `count_my_pending` export to source the
+            /// self-reported `authored_remaining` heartbeat field.
+            #[doc(hidden)]
+            pub fn __calimero_count_my_pending(&self) -> u32 {
+                let __target = ::calimero_sdk::app::schema_version();
+                let mut __pending: u32 = 0;
+                #(#count_loops)*
+                __pending
+            }
         }
 
         // One signed RPC call (`app_call "migrate_my_entries"`) converts the
@@ -1058,6 +1104,39 @@ fn generate_migrate_my_entries_impl(
             };
             ::calimero_sdk::env::value_return(&__out);
             app.commit();
+        }
+
+        // Read-only export: returns the caller's pending-authored count as JSON
+        // `u32`. Invoked node-side (cheaply, no signed write, no commit) to
+        // source the `authored_remaining` heartbeat self-report.
+        #[cfg(target_arch = "wasm32")]
+        #[no_mangle]
+        pub extern "C" fn count_my_pending() {
+            ::calimero_sdk::env::setup_panic_hook();
+            ::calimero_sdk::env::init_logging();
+            ::calimero_sdk::event::register::<#ident #ty_generics>();
+            ::calimero_sdk::app::register_schema_version::<#ident #ty_generics>();
+
+            let ::core::option::Option::Some(app) =
+                ::calimero_storage::collections::Root::<#ident #ty_generics>::fetch()
+            else {
+                ::calimero_sdk::env::panic_str("Failed to find or read app state")
+            };
+            let __count = app.__calimero_count_my_pending();
+            let __out = {
+                #[allow(unused_imports)]
+                use ::calimero_sdk::__private::IntoResult;
+                match ::calimero_sdk::__private::WrappedReturn::new(__count)
+                    .into_result()
+                    .to_json()
+                {
+                    ::core::result::Result::Ok(__o) => __o,
+                    ::core::result::Result::Err(__e) => ::calimero_sdk::env::panic_str(
+                        &format!("Failed to serialize count_my_pending output: {:?}", __e)
+                    ),
+                }
+            };
+            ::calimero_sdk::env::value_return(&__out);
         }
     }
 }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1956,6 +1956,9 @@ pub struct MemberMigrationReportApiData {
     pub residue_identity: u64,
     pub synced_up_to_hlc: u64,
     pub reported_at: u64,
+    /// Member's self-reported pending-authored count (best-effort; 6f).
+    #[serde(default)]
+    pub authored_remaining: u64,
 }
 
 /// One per-member row in the migration-status rollup: a pinned-cohort member,
@@ -1984,6 +1987,10 @@ pub struct MigrationStatusRollupApiData {
     /// `true` iff every pinned-cohort member reported a converged schema with
     /// zero residue. Any `unknown` (or in-progress) member keeps this `false`.
     pub all_migrated: bool,
+    /// Count of members reporting `authored_remaining > 0` (owners with
+    /// identity-gated entries still to re-sign; 6f, skew #1). Best-effort.
+    #[serde(default)]
+    pub members_pending_signature: usize,
 }
 
 /// Migration-status answer returned by `GET .../groups/:namespace_id/migration-status`.

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2924,6 +2924,7 @@ mod tests {
                 unknown: 1,
                 total: 2,
                 all_migrated: false,
+                members_pending_signature: 1,
             },
             members: vec![
                 MemberMigrationStatusApiEntry {
@@ -2934,6 +2935,7 @@ mod tests {
                         residue_identity: 0,
                         synced_up_to_hlc: 7,
                         reported_at: 1_700_000_000,
+                        authored_remaining: 3,
                     }),
                     state: "migrated".into(),
                 },
@@ -2952,12 +2954,14 @@ mod tests {
         assert_eq!(json["rollup"]["allMigrated"], false);
         assert_eq!(json["rollup"]["migrated"], 1);
         assert_eq!(json["rollup"]["unknown"], 1);
+        assert_eq!(json["rollup"]["membersPendingSignature"], 1);
 
         let members = json["members"].as_array().unwrap();
         assert_eq!(members.len(), 2);
         assert_eq!(members[0]["state"], "migrated");
         assert_eq!(members[0]["report"]["schemaVersion"], 2);
         assert_eq!(members[0]["report"]["syncedUpToHlc"], 7);
+        assert_eq!(members[0]["report"]["authoredRemaining"], 3);
         // The unknown member has no fresh report — `report` is omitted.
         assert_eq!(members[1]["state"], "unknown");
         assert!(members[1].get("report").is_none());
@@ -2976,6 +2980,7 @@ mod tests {
                 unknown: 0,
                 total: 0,
                 all_migrated: false,
+                members_pending_signature: 0,
             },
             members: vec![],
         };

--- a/crates/server/src/admin/handlers/groups/get_migration_status.rs
+++ b/crates/server/src/admin/handlers/groups/get_migration_status.rs
@@ -54,6 +54,7 @@ pub async fn handler(
                         residue_identity: r.residue_identity,
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
+                        authored_remaining: r.authored_remaining,
                     },
                 )
             })
@@ -86,6 +87,7 @@ pub async fn handler(
                         residue_identity: r.residue_identity,
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
+                        authored_remaining: r.authored_remaining,
                     }),
                     state: m.state.as_str().to_owned(),
                 })
@@ -102,6 +104,7 @@ pub async fn handler(
                         unknown: status.rollup.unknown,
                         total: status.rollup.total,
                         all_migrated: status.rollup.all_migrated,
+                        members_pending_signature: status.rollup.members_pending_signature,
                     },
                     members,
                 },

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -28,8 +28,8 @@ pub use blobs::BlobMeta;
 pub use calimero_primitives::context::GroupMemberRole;
 use component::KeyComponents;
 pub use context::{
-    ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker, ContextMeta,
-    ContextPrivateState, ContextState,
+    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker,
+    ContextMeta, ContextPrivateState, ContextState,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -64,6 +64,55 @@ impl Debug for ContextMeta {
     }
 }
 
+/// Node-local per-context count of the owner's identity-gated entries still
+/// below the target schema (the heartbeat's `authored_remaining`; 6f). Lives in
+/// the node-local `ContextLocal` column — NOT synchronized, and deliberately
+/// separate from `ContextMeta` so the hot per-write `ContextMeta` rewrite path
+/// (every state-changing execute) cannot clobber this advisory counter.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextAuthoredRemaining(Key<ContextId>);
+
+impl ContextAuthoredRemaining {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId) -> Self {
+        Self(Key((*context_id).into()))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ContextAuthoredRemaining {
+    type Components = (ContextId,);
+
+    fn column() -> Column {
+        Column::ContextLocal
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ContextAuthoredRemaining {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ContextAuthoredRemaining {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextAuthoredRemaining")
+            .field("id", &self.context_id())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextConfig(Key<ContextId>);

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -11,8 +11,8 @@ mod group;
 pub use application::{ApplicationMeta, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
-    ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker, ContextMeta,
-    ContextPrivateState, ContextState,
+    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker,
+    ContextMeta, ContextPrivateState, ContextState,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -9,13 +9,53 @@ use crate::types::PredefinedEntry;
 
 pub type Hash = [u8; 32];
 
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
+#[derive(BorshSerialize, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ContextMeta {
     pub application: key::ApplicationMeta,
     pub root_hash: Hash,
     pub dag_heads: Vec<[u8; 32]>,
     pub service_name: Option<Box<str>>,
+    /// Best-effort count of THIS node's owner's identity-gated entries still
+    /// below the target schema (self-reported in the migration heartbeat as
+    /// `authored_remaining`). Node-local; recomputed at migrate-apply /
+    /// `migrate_my_entries` and preserved across other ContextMeta rewrites.
+    pub authored_remaining: u32,
+}
+
+// Custom deserialization: `authored_remaining` was appended after the initial
+// schema. Old on-disk rows end after `service_name`; tolerate EOF and default
+// to 0 so existing contexts deserialize unchanged. (ContextMeta is node-local,
+// so only on-disk back-compat matters — no cross-node wire concern.)
+impl BorshDeserialize for ContextMeta {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let application = key::ApplicationMeta::deserialize_reader(reader)?;
+        let root_hash = Hash::deserialize_reader(reader)?;
+        let dag_heads = Vec::<[u8; 32]>::deserialize_reader(reader)?;
+        let service_name = Option::<Box<str>>::deserialize_reader(reader)?;
+        // A short trailing read surfaces as either UnexpectedEof or (in this
+        // borsh version) InvalidData "Unexpected length of input" — both mean
+        // an old row with no authored_remaining; default to 0. Mirrors the
+        // ApplicationMeta `services` back-compat handling.
+        let authored_remaining = match u32::deserialize_reader(reader) {
+            Ok(v) => v,
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => 0,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::InvalidData
+                    && e.to_string().contains("Unexpected length") =>
+            {
+                0
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(Self {
+            application,
+            root_hash,
+            dag_heads,
+            service_name,
+            authored_remaining,
+        })
+    }
 }
 
 impl ContextMeta {
@@ -31,6 +71,7 @@ impl ContextMeta {
             root_hash,
             dag_heads,
             service_name,
+            authored_remaining: 0,
         }
     }
 }
@@ -208,4 +249,55 @@ impl ContextDagDelta {
 impl PredefinedEntry for key::ContextDagDelta {
     type Codec = Borsh;
     type DataType<'a> = ContextDagDelta;
+}
+
+#[cfg(test)]
+mod context_meta_backcompat {
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use calimero_primitives::application::ApplicationId;
+
+    use super::{ContextMeta, Hash};
+    use crate::key;
+
+    // The on-disk layout before `authored_remaining` was appended.
+    #[derive(BorshSerialize)]
+    struct OldContextMeta {
+        application: key::ApplicationMeta,
+        root_hash: Hash,
+        dag_heads: Vec<[u8; 32]>,
+        service_name: Option<Box<str>>,
+    }
+
+    // An old row (no authored_remaining bytes) deserializes with the field 0.
+    #[test]
+    fn old_row_defaults_authored_remaining_to_zero() {
+        let app = key::ApplicationMeta::new(ApplicationId::from([7u8; 32]));
+        let old = OldContextMeta {
+            application: app,
+            root_hash: [3u8; 32],
+            dag_heads: vec![[9u8; 32]],
+            service_name: Some("svc".into()),
+        };
+        let bytes = borsh::to_vec(&old).expect("serialize old");
+        let meta = ContextMeta::try_from_slice(&bytes).expect("deserialize new");
+        assert_eq!(meta.authored_remaining, 0);
+        assert_eq!(meta.application, app);
+        assert_eq!(meta.root_hash, [3u8; 32]);
+        assert_eq!(meta.service_name.as_deref(), Some("svc"));
+    }
+
+    // A new row round-trips the field.
+    #[test]
+    fn new_row_roundtrips_authored_remaining() {
+        let mut meta = ContextMeta::new(
+            key::ApplicationMeta::new(ApplicationId::from([7u8; 32])),
+            [0u8; 32],
+            vec![],
+            None,
+        );
+        meta.authored_remaining = 5;
+        let bytes = borsh::to_vec(&meta).expect("serialize new");
+        let back = ContextMeta::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(back.authored_remaining, 5);
+    }
 }

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -9,68 +9,13 @@ use crate::types::PredefinedEntry;
 
 pub type Hash = [u8; 32];
 
-#[derive(BorshSerialize, Clone, Debug, Eq, PartialEq)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ContextMeta {
     pub application: key::ApplicationMeta,
     pub root_hash: Hash,
     pub dag_heads: Vec<[u8; 32]>,
     pub service_name: Option<Box<str>>,
-    /// Best-effort count of THIS node's owner's identity-gated entries still
-    /// below the target schema (self-reported in the migration heartbeat as
-    /// `authored_remaining`). Node-local; recomputed at migrate-apply /
-    /// `migrate_my_entries` and preserved across other ContextMeta rewrites.
-    pub authored_remaining: u32,
-}
-
-/// Read an optional trailing fixed-width LE value from a borsh reader. Returns
-/// `None` on a clean EOF (old row with no trailing field), `Some` when the full
-/// width is present, and `Err` only on a genuine partial read (corruption).
-/// Distinguishes "absent" from "truncated" by bytes-read count rather than
-/// matching borsh's error-message text (which is not stable across versions).
-fn read_trailing<R: std::io::Read, const N: usize>(
-    reader: &mut R,
-) -> std::io::Result<Option<[u8; N]>> {
-    let mut buf = [0u8; N];
-    let mut filled = 0;
-    while filled < N {
-        match reader.read(&mut buf[filled..]) {
-            Ok(0) => break,
-            Ok(n) => filled += n,
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(e),
-        }
-    }
-    match filled {
-        0 => Ok(None),
-        n if n == N => Ok(Some(buf)),
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "truncated trailing field",
-        )),
-    }
-}
-
-// Custom deserialization: `authored_remaining` was appended after the initial
-// schema. Old on-disk rows end after `service_name`; tolerate EOF and default
-// to 0 so existing contexts deserialize unchanged. (ContextMeta is node-local,
-// so only on-disk back-compat matters — no cross-node wire concern.)
-impl BorshDeserialize for ContextMeta {
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let application = key::ApplicationMeta::deserialize_reader(reader)?;
-        let root_hash = Hash::deserialize_reader(reader)?;
-        let dag_heads = Vec::<[u8; 32]>::deserialize_reader(reader)?;
-        let service_name = Option::<Box<str>>::deserialize_reader(reader)?;
-        // borsh integers are little-endian; absent trailing bytes ⇒ old row ⇒ 0.
-        let authored_remaining = read_trailing::<_, 4>(reader)?.map_or(0, u32::from_le_bytes);
-        Ok(Self {
-            application,
-            root_hash,
-            dag_heads,
-            service_name,
-            authored_remaining,
-        })
-    }
 }
 
 impl ContextMeta {
@@ -86,7 +31,6 @@ impl ContextMeta {
             root_hash,
             dag_heads,
             service_name,
-            authored_remaining: 0,
         }
     }
 }
@@ -94,6 +38,27 @@ impl ContextMeta {
 impl PredefinedEntry for key::ContextMeta {
     type Codec = Borsh;
     type DataType<'a> = ContextMeta;
+}
+
+/// Value for [`key::ContextAuthoredRemaining`]: this node's owner's count of
+/// identity-gated entries still below the target schema (the heartbeat's
+/// `authored_remaining`; 6f). Node-local + advisory, written only by the
+/// post-migrate / `migrate_my_entries` persist and read by the heartbeat —
+/// kept off the hot `ContextMeta` write path so a per-write rewrite can't
+/// clobber it. A brand-new key, so a missing row reads as `None` (treated as
+/// 0); no on-disk back-compat shim needed.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "single advisory counter; additions would need a migration"
+)]
+pub struct ContextAuthoredRemaining {
+    pub count: u32,
+}
+
+impl PredefinedEntry for key::ContextAuthoredRemaining {
+    type Codec = Borsh;
+    type DataType<'a> = ContextAuthoredRemaining;
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
@@ -267,52 +232,17 @@ impl PredefinedEntry for key::ContextDagDelta {
 }
 
 #[cfg(test)]
-mod context_meta_backcompat {
-    use borsh::{BorshDeserialize, BorshSerialize};
-    use calimero_primitives::application::ApplicationId;
+mod context_authored_remaining_tests {
+    use borsh::BorshDeserialize;
 
-    use super::{ContextMeta, Hash};
-    use crate::key;
+    use super::ContextAuthoredRemaining;
 
-    // The on-disk layout before `authored_remaining` was appended.
-    #[derive(BorshSerialize)]
-    struct OldContextMeta {
-        application: key::ApplicationMeta,
-        root_hash: Hash,
-        dag_heads: Vec<[u8; 32]>,
-        service_name: Option<Box<str>>,
-    }
-
-    // An old row (no authored_remaining bytes) deserializes with the field 0.
+    // The dedicated counter value round-trips through borsh.
     #[test]
-    fn old_row_defaults_authored_remaining_to_zero() {
-        let app = key::ApplicationMeta::new(ApplicationId::from([7u8; 32]));
-        let old = OldContextMeta {
-            application: app,
-            root_hash: [3u8; 32],
-            dag_heads: vec![[9u8; 32]],
-            service_name: Some("svc".into()),
-        };
-        let bytes = borsh::to_vec(&old).expect("serialize old");
-        let meta = ContextMeta::try_from_slice(&bytes).expect("deserialize new");
-        assert_eq!(meta.authored_remaining, 0);
-        assert_eq!(meta.application, app);
-        assert_eq!(meta.root_hash, [3u8; 32]);
-        assert_eq!(meta.service_name.as_deref(), Some("svc"));
-    }
-
-    // A new row round-trips the field.
-    #[test]
-    fn new_row_roundtrips_authored_remaining() {
-        let mut meta = ContextMeta::new(
-            key::ApplicationMeta::new(ApplicationId::from([7u8; 32])),
-            [0u8; 32],
-            vec![],
-            None,
-        );
-        meta.authored_remaining = 5;
-        let bytes = borsh::to_vec(&meta).expect("serialize new");
-        let back = ContextMeta::try_from_slice(&bytes).expect("deserialize");
-        assert_eq!(back.authored_remaining, 5);
+    fn authored_remaining_roundtrips() {
+        let v = ContextAuthoredRemaining { count: 5 };
+        let bytes = borsh::to_vec(&v).expect("serialize");
+        let back = ContextAuthoredRemaining::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(back.count, 5);
     }
 }

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -23,6 +23,34 @@ pub struct ContextMeta {
     pub authored_remaining: u32,
 }
 
+/// Read an optional trailing fixed-width LE value from a borsh reader. Returns
+/// `None` on a clean EOF (old row with no trailing field), `Some` when the full
+/// width is present, and `Err` only on a genuine partial read (corruption).
+/// Distinguishes "absent" from "truncated" by bytes-read count rather than
+/// matching borsh's error-message text (which is not stable across versions).
+fn read_trailing<R: std::io::Read, const N: usize>(
+    reader: &mut R,
+) -> std::io::Result<Option<[u8; N]>> {
+    let mut buf = [0u8; N];
+    let mut filled = 0;
+    while filled < N {
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    match filled {
+        0 => Ok(None),
+        n if n == N => Ok(Some(buf)),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "truncated trailing field",
+        )),
+    }
+}
+
 // Custom deserialization: `authored_remaining` was appended after the initial
 // schema. Old on-disk rows end after `service_name`; tolerate EOF and default
 // to 0 so existing contexts deserialize unchanged. (ContextMeta is node-local,
@@ -33,21 +61,8 @@ impl BorshDeserialize for ContextMeta {
         let root_hash = Hash::deserialize_reader(reader)?;
         let dag_heads = Vec::<[u8; 32]>::deserialize_reader(reader)?;
         let service_name = Option::<Box<str>>::deserialize_reader(reader)?;
-        // A short trailing read surfaces as either UnexpectedEof or (in this
-        // borsh version) InvalidData "Unexpected length of input" — both mean
-        // an old row with no authored_remaining; default to 0. Mirrors the
-        // ApplicationMeta `services` back-compat handling.
-        let authored_remaining = match u32::deserialize_reader(reader) {
-            Ok(v) => v,
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => 0,
-            Err(e)
-                if e.kind() == std::io::ErrorKind::InvalidData
-                    && e.to_string().contains("Unexpected length") =>
-            {
-                0
-            }
-            Err(e) => return Err(e),
-        };
+        // borsh integers are little-endian; absent trailing bytes ⇒ old row ⇒ 0.
+        let authored_remaining = read_trailing::<_, 4>(reader)?.map_or(0, u32::from_le_bytes);
         Ok(Self {
             application,
             root_hash,

--- a/workflows/app-migration/33-authored-remaining-count.yml
+++ b/workflows/app-migration/33-authored-remaining-count.yml
@@ -1,0 +1,250 @@
+name: 33 — count_my_pending drives authored_remaining (PR-6f, deterministic)
+description: >
+  End-to-end proof of the skew-#1 count primitive (PR-6f): the SDK-generated
+  `count_my_pending` export — the source the node persists as
+  `ContextAuthoredRemaining` and gossips as the heartbeat's `authored_remaining`
+  (rolled up to the admin's `membersPendingSignature`).
+
+  Single node, deterministic, no heartbeat-timing dependence: it calls
+  `count_my_pending` directly (a callable read-only export, like
+  `migrate_my_entries`) and asserts its value across the migrate→convert
+  lifecycle. The owner seeds two identity-gated notes on v1, the namespace
+  cascades to v2 (schema flips to 2.0.0 but the per-entry schema_versions stay
+  at 1 until owner-driven convert), so:
+    - after the cascade, `count_my_pending` == 2 (both owned notes are below the
+      v2 target) — this is exactly what the node persists + reports as
+      authored_remaining, the admin's "2 pending signature";
+    - after one-tap `migrate_my_entries`, `count_my_pending` == 0 (both
+      converted) — authored_remaining drops to 0, membersPendingSignature clears.
+
+  The heartbeat self-report / rollup plumbing layered on this count
+  (compute_namespace_migration_facts sum, the unsigned trailing wire field with
+  mixed-fleet back-compat, and the members_pending_signature rollup) is
+  exhaustively unit-covered; this scenario pins the load-bearing wasm-level
+  count primitive that can only be validated against a real merod runtime. A
+  heartbeat-log assertion is intentionally NOT used here: emit is peer- and
+  interval-gated (publish needs a subscribed peer; periodic recompute is 30s),
+  which would make a log assertion flaky without adding coverage the unit tests
+  don't already provide.
+
+  Because migration_v2 defaults ON (PR-6b), the migration runs natively.
+
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 1
+  image: merod:local
+  prefix: app-migration-authored-count
+  base_port: 10260
+  base_rpc_port: 10360
+
+steps:
+  # Install v1 + v2 (the authored-migrate-ux fixtures: identity-gated notes,
+  # `version` declared so the macro emits migrate_my_entries + count_my_pending).
+  - name: Install scenario-authored-migrate-ux-v1
+    type: install_application
+    node: app-migration-authored-count-1
+    path: apps/migrations/scenario-authored-migrate-ux-v1/res/scenario_authored_migrate_ux_v1.wasm
+    dev: true
+    outputs:
+      app_v1: applicationId
+
+  - name: Install scenario-authored-migrate-ux-v2
+    type: install_application
+    node: app-migration-authored-count-1
+    path: apps/migrations/scenario-authored-migrate-ux-v2/res/scenario_authored_migrate_ux_v2.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  # Namespace (anchors v1) + descendant Open subgroup + context, all local.
+  - name: Create namespace (anchors app_v1)
+    type: create_namespace
+    node: app-migration-authored-count-1
+    application_id: "{{app_v1}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Capture admin key (for teardown)
+    type: get_namespace_identity
+    node: app-migration-authored-count-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      admin_key: publicKey
+
+  - name: Create descendant subgroup
+    type: create_group_in_namespace
+    node: app-migration-authored-count-1
+    namespace_id: "{{namespace_id}}"
+    group_name: "authored-count-subgroup"
+    outputs:
+      group_id: groupId
+
+  - name: Create context in subgroup (v1)
+    type: create_context
+    node: app-migration-authored-count-1
+    application_id: "{{app_v1}}"
+    group_id: "{{group_id}}"
+    outputs:
+      ctx_id: contextId
+
+  # Seed two owner-keyed identity-gated notes under v1 (each stamped schema 1).
+  - name: Seed owned note alpha
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: set_note
+    args:
+      key: "alpha"
+      text: "alpha-v1"
+
+  - name: Seed owned note bravo
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: set_note
+    args:
+      key: "bravo"
+      text: "bravo-v1"
+
+  - name: Read v1 schema (2 identity-gated notes)
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v1_schema: result
+
+  - name: Assert v1 schema shape
+    type: json_assert
+    statements:
+      - 'json_subset({{v1_schema}}, {"output": {"schema_version": "1.0.0", "note_count": 2}})'
+
+  # A migrate-carrying upgrade is only valid under LazyOnAccess (the initiating
+  # node still applies it on access); set it before the cascade, as scenarios
+  # 31/32 do.
+  - name: Set upgrade policy to lazy-on-access
+    type: update_group_settings
+    node: app-migration-authored-count-1
+    group_id: "{{namespace_id}}"
+    upgrade_policy: lazy_on_access
+
+  # Cascade the namespace v1 → v2. The owning node applies the migration: the
+  # state schema flips to 2.0.0, but the two notes keep their per-entry
+  # schema_version 1 until the owner re-signs them (owner-driven convert).
+  - name: Cascade namespace v1 → v2
+    type: upgrade_group
+    node: app-migration-authored-count-1
+    group_id: "{{namespace_id}}"
+    target_application_id: "{{app_v2}}"
+    migrate_method: migrate_v1_to_v2
+    cascade: true
+
+  - name: Wait for the cascade + migration to apply
+    type: wait
+    seconds: 8
+
+  - name: Read post-migration schema_info (now v2, notes carried through)
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v2_schema: result
+
+  - name: Assert state migrated to v2 (both notes carried)
+    type: json_assert
+    statements:
+      - 'json_subset({{v2_schema}}, {"output": {"schema_version": "2.0.0", "note_count": 2}})'
+
+  # ── The load-bearing check: count_my_pending == 2 BEFORE convert. ──
+  # Both owned notes are still below the v2 target schema, so the owner's
+  # pending-authored count (the source of authored_remaining) is 2.
+  - name: count_my_pending before convert
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: count_my_pending
+    outputs:
+      pending_before: result
+
+  - name: Assert two entries pending signature before convert
+    type: json_assert
+    statements:
+      - 'json_equal({{pending_before}}, {"output": 2})'
+
+  # One-tap owner-driven convert: re-signs both notes to the v2 schema.
+  - name: One-tap migrate_my_entries
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: migrate_my_entries
+    outputs:
+      convert_summary: result
+
+  - name: Assert the one-tap converted both notes, none left
+    type: json_assert
+    statements:
+      - 'json_equal({{convert_summary}}, {"output": {"converted": 2, "remaining": 0}})'
+
+  # ── count_my_pending == 0 AFTER convert. ──
+  # authored_remaining drops to 0; the admin's membersPendingSignature clears.
+  - name: count_my_pending after convert
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: count_my_pending
+    outputs:
+      pending_after: result
+
+  - name: Assert nothing pending signature after convert
+    type: json_assert
+    statements:
+      - 'json_equal({{pending_after}}, {"output": 0})'
+
+  # Idempotent re-tap: a second count is still 0 (nothing to do).
+  - name: count_my_pending is idempotent at zero
+    type: call
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    method: count_my_pending
+    outputs:
+      pending_again: result
+
+  - name: Assert count stays at zero
+    type: json_assert
+    statements:
+      - 'json_equal({{pending_again}}, {"output": 0})'
+
+  # Teardown.
+  - name: Delete context
+    type: delete_context
+    node: app-migration-authored-count-1
+    context_id: "{{ctx_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete subgroup
+    type: delete_group
+    node: app-migration-authored-count-1
+    group_id: "{{group_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Delete namespace
+    type: delete_namespace
+    node: app-migration-authored-count-1
+    namespace_id: "{{namespace_id}}"
+    requester: "{{admin_key}}"
+
+  - name: Uninstall v1
+    type: uninstall_application
+    node: app-migration-authored-count-1
+    application_id: "{{app_v1}}"
+
+  - name: Uninstall v2
+    type: uninstall_application
+    node: app-migration-authored-count-1
+    application_id: "{{app_v2}}"
+
+stop_all_nodes: false


### PR DESCRIPTION
## What

Layer **6f** of the migration-UX SDK track (#2539): the three small, additive **core** surfaces that turn the migration engine into developer/end-user experience. SDK consumer layers (mero-js 6g → mero-react 6h → mero-chat 6i) build on these in follow-up PRs. No change to the 6c convert mechanism, the HLC fence, or the migrate contract.

### Skew #2 — bundle version (frontend targets v1 while the app is v2)
- **`Context.application_version: Option<String>`** (semver) resolved from `ApplicationMeta.version` in `get_context` — one call instead of a context→app two-hop.
- **`AppVersionChanged` SSE event** (`ContextEventPayload` variant, tag `"AppVersionChanged"`, payload `{fromVersion, toVersion}`) emitted **once per applied app-id flip per context**, at the single chokepoint both the explicit-upgrade and lazy/cascade paths funnel through (`update_application_with_migration` / `update_application_id`), plus the blob-sync reconciliation path. Dedup is compare-before-assign (no extra state). The SSE filter forwards it unchanged (payload-agnostic).

### Skew #1 — authored data (owner's signed entries need re-signing)
- **`count_my_pending` wasm export** — SDK-macro-generated count-only twin of `migrate_my_entries` (gated on `#[app::state(version = N)]`, read-only).
- The **context handler** computes it (where the runtime is live — the `node` crate has no runtime) at migrate-apply / `migrate_my_entries` points and **persists** `ContextMeta.authored_remaining` (EOF-tolerant borsh back-compat; preserved across rewrites). The **node heartbeat** reads it (plain store read), threads it through the migration-status DTOs, and the rollup exposes **`membersPendingSignature`** (admin "N members still owe a signature"; `unknown` members not counted).
- The heartbeat field is an **unsigned trailing** field — deliberately outside the signed body (best-effort advisory telemetry; the signed `residue_*` cover the completion gate). An old-format heartbeat deserializes to `0` and verifies against the unchanged signed body → **full mixed-fleet compatibility, no version discriminator**.

## Design notes (corrections vs. the original spec)
- `authored_remaining` is **u32** per-context (`= MigrateMyEntriesSummary.remaining`) widening to **u64** for the per-namespace heartbeat sum (matching `residue_*`).
- `Context` carries **semver only** — the CRDT `u32` schema version is a distinct, wasm-side number space surfaced via the migration-status rollup, not conflated onto `Context`.
- The blob-sync app-id reconciliation emit was added after an adversarial review found it bypassed the worker chokepoint.

## Tests
Unit-tested throughout: Context version resolution; `AppVersionChanged` tag/shape + dedup + version resolution; `count_my_pending` generation (verified in a built wasm); `ContextMeta` borsh back-compat (old row → 0); heartbeat **mixed-fleet** verify (old/new/tampered); rollup `membersPendingSignature`. Full workspace builds; touched-crate suites green. The app-migration e2e matrix (30 scenarios) runs as a regression gate. A dedicated authored_remaining e2e (scenario 33) follows on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches application upgrade, blob-sync app-id reconciliation, and migration heartbeat wire format (backward-compatible trailing field); advisory telemetry only, but multiple emit and persistence paths must stay consistent.
> 
> **Overview**
> Adds **migration UX (6f)** surfaces for bundle skew and owner re-sign telemetry without changing migration gates.
> 
> **Skew #2 (bundle version):** `get_context` now attaches **`application_version`** (semver from `ApplicationMeta`). **`AppVersionChanged`** SSE events fire once per real application-id flip from upgrade paths and blob-sync reconciliation, with dedup when the id is unchanged.
> 
> **Skew #1 (authored re-sign):** The SDK macro emits read-only **`count_my_pending`** alongside `migrate_my_entries`. The node persists counts in a dedicated **`ContextAuthoredRemaining`** store key; post-migrate and `migrate_my_entries` refresh it (typed JSON summary). Migration heartbeats carry **`authored_remaining`** as an **unsigned trailing** borsh field (old peers deserialize as 0); the admin rollup exposes **`membersPendingSignature`**. The periodic heartbeat emitter **recomputes** facts from the store so local count updates are not stuck until governance changes.
> 
> CI adds e2e scenario **33-authored-remaining-count** for the wasm count lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b80d422fd95ccd4d0e58800bb061178888530f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->