### PR TITLE
chore: bump version to 0.11.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
## Summary
- Bumps workspace version from 0.11.0-rc.1 to 0.11.0-rc.2

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no application or infrastructure logic modified.
> 
> **Overview**
> Bumps the **cargo-workspaces** shared release version in `Cargo.toml` from **`0.11.0-rc.1`** to **`0.11.0-rc.2`**, per the workspace metadata used when cutting releases (`docs/RELEASE.md`). No runtime or library code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f384298cb329ce0cabf3f8c39d7d12f6ec60f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->