### PR TITLE
feat(context): finer self-purge reconcile observability (closes #2686)

### DIFF
--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -74,7 +74,10 @@ use tokio::task::AbortHandle;
 use tracing::{debug, error, info, warn};
 
 use calimero_governance_store;
-use calimero_governance_store::metrics::{record_purge_failure, PurgeBranch, PurgeFailureClass};
+use calimero_governance_store::metrics::{
+    record_events_dropped, record_purge_failure, record_reconcile_outcome, PurgeBranch,
+    PurgeFailureClass, ReconcileOutcome,
+};
 use calimero_governance_store::op_events::{self, OpEvent};
 use calimero_governance_store::{
     MembershipRepository, NamespaceRepository, PendingSelfPurgeRepository,
@@ -174,6 +177,12 @@ async fn run(store: Store, node_client: NodeClient) {
                      NOT complete it; the residual local key material persists (bounded, \
                      not a forward-secrecy hole — FS is held by key rotation)"
                 );
+                // #2686: surface the silent-residue count as a metric so
+                // operators can alert on it — the `warn!` above is not
+                // machine-queryable. Counts BY the broadcast-reported skip,
+                // since each dropped `TeeMemberRemoved` is a separate
+                // un-reconcilable eviction.
+                record_events_dropped(skipped);
                 continue;
             }
             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -369,6 +378,7 @@ async fn reconcile_sweep(store: &Store, node_client: &NodeClient) {
     let scanned = pending.len();
     let mut reconciled = 0usize;
     let mut cleared_stale = 0usize;
+    let mut stale_clear_failed = 0usize;
     let mut retained = 0usize;
     let mut skipped = 0usize;
 
@@ -389,8 +399,10 @@ async fn reconcile_sweep(store: &Store, node_client: &NodeClient) {
                 // the counter (review nit).
                 if purge_namespace_for_self(store, node_client, ns_id).await {
                     reconciled += 1;
+                    record_reconcile_outcome(ReconcileOutcome::Reconciled);
                 } else {
                     retained += 1;
+                    record_reconcile_outcome(ReconcileOutcome::Retained);
                 }
             }
             ReconcileDecision::ClearStaleMarker(reason) => {
@@ -399,21 +411,39 @@ async fn reconcile_sweep(store: &Store, node_client: &NodeClient) {
                     %reason,
                     "self-purge reconcile: clearing stale marker WITHOUT purging"
                 );
-                clear_marker(store, &ns_id);
-                cleared_stale += 1;
+                // #2686: distinguish a successful stale-marker clear from a
+                // failed one. A failed clear is benign (the next restart
+                // re-evaluates the already-clean / re-admitted namespace and
+                // retries the clear), but operators should be able to see it.
+                if clear_marker(store, &ns_id) {
+                    cleared_stale += 1;
+                    record_reconcile_outcome(ReconcileOutcome::ClearedStale);
+                } else {
+                    stale_clear_failed += 1;
+                    record_reconcile_outcome(ReconcileOutcome::StaleClearFailed);
+                }
             }
             ReconcileDecision::Skip => {
-                // A read error somewhere — already logged + metered inside
-                // `reconcile_decision`. Keep the marker; the next restart
-                // retries.
+                // A read error made the decision uncertain — already logged
+                // inside `reconcile_decision` (which is now pure, #2686: it no
+                // longer records a purge-step failure for these reconcile
+                // read-errors). Keep the marker; the next restart retries.
+                // `skipped` is the correct signal for these read-uncertainty
+                // cases, NOT `self_purge_failures_total`.
                 skipped += 1;
+                record_reconcile_outcome(ReconcileOutcome::Skipped);
             }
         }
     }
 
     info!(
         scanned,
-        reconciled, cleared_stale, retained, skipped, "self-purge reconcile sweep complete"
+        reconciled,
+        cleared_stale,
+        stale_clear_failed,
+        retained,
+        skipped,
+        "self-purge reconcile sweep complete"
     );
 }
 
@@ -459,7 +489,13 @@ pub(crate) enum ReconcileDecision {
 ///     `ClearStaleMarker` — do NOT purge a healthy member.
 ///   * Any read error ⇒ `Skip` (never purge on uncertainty).
 ///
-/// Pure store reads; no mutation.
+/// Pure store reads; no mutation AND no metrics side-effect (#2686). This
+/// function deliberately does NOT call `record_purge_failure` on its
+/// read-error paths: a reconcile read-error is uncertainty, not a purge-step
+/// (delete) failure, and labelling it as one inflated
+/// `self_purge_failures_total`. The sweep records those `Skip` decisions via
+/// the `self_purge_reconcile_total{outcome="skipped"}` counter instead — the
+/// correct signal for reconcile read-uncertainty.
 pub(crate) fn reconcile_decision(store: &Store, ns_id: ContextGroupId) -> ReconcileDecision {
     let ns_hex = hex::encode(ns_id.to_bytes());
 
@@ -490,7 +526,10 @@ pub(crate) fn reconcile_decision(store: &Store, ns_id: ContextGroupId) -> Reconc
                 "self-purge reconcile: failed to re-check pending-self-purge marker \
                  — skipping (will retry on next restart; NOT purging on uncertainty)"
             );
-            record_purge_failure(PurgeBranch::Namespace, PurgeFailureClass::ContextCleanup);
+            // #2686: NO `record_purge_failure` here — this is a reconcile
+            // read-error (uncertainty), not a purge-step failure. The sweep
+            // records the resulting `Skip` as
+            // `self_purge_reconcile_total{outcome="skipped"}`.
             return ReconcileDecision::Skip;
         }
     }
@@ -509,7 +548,9 @@ pub(crate) fn reconcile_decision(store: &Store, ns_id: ContextGroupId) -> Reconc
                 "self-purge reconcile: failed to read namespace identity for a marked \
                  namespace — skipping (will retry on next restart; NOT purging on uncertainty)"
             );
-            record_purge_failure(PurgeBranch::Namespace, PurgeFailureClass::ContextCleanup);
+            // #2686: NO `record_purge_failure` here — reconcile read-error,
+            // not a purge-step failure. Recorded as `outcome="skipped"` by the
+            // sweep.
             return ReconcileDecision::Skip;
         }
     };
@@ -533,7 +574,9 @@ pub(crate) fn reconcile_decision(store: &Store, ns_id: ContextGroupId) -> Reconc
                  — skipping (keeping marker; will retry on next restart; NOT purging \
                  on uncertainty)"
             );
-            record_purge_failure(PurgeBranch::Namespace, PurgeFailureClass::ContextCleanup);
+            // #2686: NO `record_purge_failure` here — reconcile read-error,
+            // not a purge-step failure. Recorded as `outcome="skipped"` by the
+            // sweep.
             ReconcileDecision::Skip
         }
     }
@@ -543,7 +586,11 @@ pub(crate) fn reconcile_decision(store: &Store, ns_id: ContextGroupId) -> Reconc
 /// non-fatal: a stale marker just means the next reconcile re-evaluates the
 /// (already-clean / re-admitted) namespace and tries to clear it again. Logged
 /// so it is visible, but it does not block the sweep.
-fn clear_marker(store: &Store, ns_id: &ContextGroupId) {
+///
+/// Returns `true` iff the clear succeeded (#2686). The reconcile sweep uses
+/// this to distinguish a `cleared_stale` outcome from a `stale_clear_failed`
+/// one rather than counting `cleared_stale` regardless of the result.
+fn clear_marker(store: &Store, ns_id: &ContextGroupId) -> bool {
     if let Err(e) = PendingSelfPurgeRepository::new(store).clear(ns_id) {
         warn!(
             namespace = %hex::encode(ns_id.to_bytes()),
@@ -551,6 +598,9 @@ fn clear_marker(store: &Store, ns_id: &ContextGroupId) {
             "self-purge: failed to clear pending-self-purge marker — stale marker will be \
              re-evaluated on the next reconcile (harmless)"
         );
+        false
+    } else {
+        true
     }
 }
 
@@ -681,6 +731,12 @@ async fn handle_member_removed(
 ///
 /// Sync: store operations only, no async work. Split out so tests can
 /// drive it without standing up a `NodeClient` mock.
+///
+/// Scope note (#2686): this stays sync / no-`Result` on purpose. Subgroup-step
+/// failures are already captured by `record_purge_failure(Subgroup, …)`; the
+/// retry-surface refactor (returning `Result<()>` so a subgroup-scoped
+/// reconcile can complete a failed subgroup-only purge) belongs with the
+/// subgroup-reconcile work in #2726, not here.
 ///
 /// Mirrors the per-group cleanup sequence in
 /// `handlers/delete_namespace.rs:74-90` for a single group:
@@ -1716,6 +1772,44 @@ mod tests {
             .identity_record(&ns_id)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn clear_marker_returns_true_on_success() {
+        // #2686: `clear_marker` now returns whether the clear succeeded so the
+        // reconcile sweep can distinguish `cleared_stale` from
+        // `stale_clear_failed`. Happy path: a present marker clears and the
+        // function reports success, leaving no marker. (A failing clear can't
+        // be cheaply provoked with the InMemoryDB — `clear` is an idempotent
+        // delete that returns Ok even on an absent key — so we cover the
+        // success path here; the false branch is exercised in the metrics
+        // recorder test `self_purge_reconcile_register_and_encode`.)
+        let store = empty_store();
+        let ns_id = ContextGroupId::from([0x55u8; 32]);
+        PendingSelfPurgeRepository::new(&store)
+            .mark(&ns_id)
+            .unwrap();
+        assert!(PendingSelfPurgeRepository::new(&store)
+            .is_marked(&ns_id)
+            .unwrap());
+
+        assert!(
+            clear_marker(&store, &ns_id),
+            "clear_marker MUST return true when the clear succeeds"
+        );
+        assert!(
+            !PendingSelfPurgeRepository::new(&store)
+                .is_marked(&ns_id)
+                .unwrap(),
+            "marker MUST be gone after a successful clear"
+        );
+
+        // Idempotent: clearing an already-absent marker is still a success
+        // (the underlying delete is an idempotent no-op).
+        assert!(
+            clear_marker(&store, &ns_id),
+            "clear_marker MUST return true on an already-absent marker (idempotent)"
+        );
     }
 
     #[test]

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -100,6 +100,29 @@ pub(crate) struct SelfPurgeFailureLabels {
     pub(crate) class: &'static str,
 }
 
+/// Labels for self-purge reconcile-sweep outcomes (#2686).
+///
+/// `outcome` is one per marked namespace the startup sweep processes, one
+/// of:
+///   - `"reconciled"`: marker present + still-evicted, and the namespace
+///     purge fully completed.
+///   - `"retained"`: marker present + still-evicted, but the purge returned
+///     false (signing-key failure); the marker is kept for the next restart.
+///   - `"cleared_stale"`: the marker was stale (already purged / re-admitted)
+///     and the clear succeeded.
+///   - `"stale_clear_failed"`: the marker was stale but the clear itself
+///     failed (the next restart re-evaluates and retries the clear).
+///   - `"skipped"`: a read error made the decision uncertain; the marker is
+///     kept (never purge on uncertainty) for the next restart.
+///
+/// As with [`SelfPurgeFailureLabels`], `outcome` is a `&'static str` sourced
+/// from the closed [`ReconcileOutcome`] enum via [`ReconcileOutcome::as_label`],
+/// so the label set allocates nothing per `record_reconcile_outcome` call.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct SelfPurgeReconcileLabels {
+    pub(crate) outcome: &'static str,
+}
+
 #[derive(Clone, Debug)]
 struct GroupStoreMetricSink {
     namespace_retry_events: Family<NamespaceRetryLabels, Counter>,
@@ -109,6 +132,8 @@ struct GroupStoreMetricSink {
     governance_handler_delivery_total: Family<GovernanceHandlerDeliveryLabels, Counter>,
     governance_handler_delivery_seconds: Family<GovernanceHandlerDeliveryLabels, Histogram>,
     self_purge_failures: Family<SelfPurgeFailureLabels, Counter>,
+    self_purge_reconcile: Family<SelfPurgeReconcileLabels, Counter>,
+    self_purge_events_dropped: Counter,
 }
 
 static GROUP_STORE_METRICS: OnceLock<GroupStoreMetricSink> = OnceLock::new();
@@ -251,6 +276,41 @@ impl Metrics {
             self_purge_failures.clone(),
         );
 
+        // #2686: reconcile-sweep outcomes. One increment per marked
+        // namespace the startup sweep processes, sliced by `outcome`. The
+        // `outcome="retained"` series is the operator alerting signal — a
+        // namespace stuck `retained` across restarts means a signing-key
+        // purge keeps failing and forward-secrecy residue lingers on disk.
+        // `outcome="stale_clear_failed"` flags markers the sweep could not
+        // clear (benign — re-evaluated next restart). The reconcile read-
+        // uncertainty cases land in `outcome="skipped"` (NOT in
+        // `self_purge_failures_total`, which is reserved for genuine
+        // purge-step delete failures).
+        let self_purge_reconcile = Family::<SelfPurgeReconcileLabels, Counter>::default();
+        group_store_registry.register(
+            "self_purge_reconcile_total",
+            "Self-purge startup reconcile-sweep outcomes, one per marked \
+             namespace processed, sliced by outcome (reconciled / retained / \
+             cleared_stale / stale_clear_failed / skipped)",
+            self_purge_reconcile.clone(),
+        );
+
+        // #2686: count of self-purge op-events dropped by the broadcast
+        // `Lagged` arm. A dropped `TeeMemberRemoved` writes no
+        // pending-self-purge marker, so the marker-gated reconcile cannot
+        // recover it — silent residue. A nonzero rate means the self-purge
+        // subscriber fell >1024 events behind (the broadcast capacity) and
+        // some evictions may have left un-reconcilable on-disk residue
+        // (bounded; not a forward-secrecy hole — FS is held by key rotation).
+        let self_purge_events_dropped = Counter::default();
+        group_store_registry.register(
+            "self_purge_events_dropped_total",
+            "Self-purge op-events dropped by the broadcast Lagged arm; a \
+             dropped TeeMemberRemoved writes no reconcile marker (un-recoverable \
+             residue, bounded)",
+            self_purge_events_dropped.clone(),
+        );
+
         let _ = GROUP_STORE_METRICS.set(GroupStoreMetricSink {
             namespace_retry_events: namespace_retry_events.clone(),
             namespace_decode_events: namespace_decode_events.clone(),
@@ -259,6 +319,8 @@ impl Metrics {
             governance_handler_delivery_total: governance_handler_delivery_total.clone(),
             governance_handler_delivery_seconds: governance_handler_delivery_seconds.clone(),
             self_purge_failures: self_purge_failures.clone(),
+            self_purge_reconcile: self_purge_reconcile.clone(),
+            self_purge_events_dropped: self_purge_events_dropped.clone(),
         });
 
         Self {
@@ -424,6 +486,71 @@ pub fn record_purge_failure(branch: PurgeBranch, class: PurgeFailureClass) {
         .inc();
 }
 
+/// The outcome of processing a single marked namespace in the self-purge
+/// startup reconcile sweep (#2686). Exactly one is recorded per marked
+/// namespace the sweep visits. Distinct from [`PurgeFailureClass`]: these
+/// are sweep-level outcomes, NOT purge-step (delete) failures — read-error
+/// uncertainty lands in [`ReconcileOutcome::Skipped`], not in
+/// `self_purge_failures_total`.
+#[derive(Clone, Copy, Debug)]
+pub enum ReconcileOutcome {
+    /// Marker present + still-evicted, and the namespace purge fully
+    /// completed.
+    Reconciled,
+    /// Marker present + still-evicted, but the purge returned false
+    /// (signing-key failure); the marker is kept for the next restart.
+    Retained,
+    /// The marker was stale (already purged / re-admitted) and the clear
+    /// succeeded.
+    ClearedStale,
+    /// The marker was stale but the clear itself failed (re-evaluated and
+    /// retried on the next restart).
+    StaleClearFailed,
+    /// A read error made the decision uncertain — the marker is kept (never
+    /// purge on uncertainty) for the next restart.
+    Skipped,
+}
+
+impl ReconcileOutcome {
+    fn as_label(self) -> &'static str {
+        match self {
+            ReconcileOutcome::Reconciled => "reconciled",
+            ReconcileOutcome::Retained => "retained",
+            ReconcileOutcome::ClearedStale => "cleared_stale",
+            ReconcileOutcome::StaleClearFailed => "stale_clear_failed",
+            ReconcileOutcome::Skipped => "skipped",
+        }
+    }
+}
+
+/// Record a self-purge reconcile-sweep outcome for one marked namespace.
+/// No-op until [`Metrics::new`] has installed the process-global sink.
+///
+/// Called from `calimero-context`'s `self_purge::reconcile_sweep` (#2686),
+/// exactly once per marked namespace processed.
+pub fn record_reconcile_outcome(outcome: ReconcileOutcome) {
+    let Some(metrics) = GROUP_STORE_METRICS.get() else {
+        return;
+    };
+    metrics
+        .self_purge_reconcile
+        .get_or_create(&SelfPurgeReconcileLabels {
+            outcome: outcome.as_label(),
+        })
+        .inc();
+}
+
+/// Record `n` self-purge op-events dropped by the broadcast `Lagged` arm
+/// (#2686). No-op until [`Metrics::new`] has installed the process-global
+/// sink. Called from `calimero-context`'s `self_purge::run` `Lagged` arm
+/// with the broadcast-reported skip count.
+pub fn record_events_dropped(n: u64) {
+    let Some(metrics) = GROUP_STORE_METRICS.get() else {
+        return;
+    };
+    metrics.self_purge_events_dropped.inc_by(n);
+}
+
 #[cfg(test)]
 mod tests {
     use prometheus_client::encoding::text::encode;
@@ -515,5 +642,89 @@ mod tests {
         // And the public recorder must not panic whether or not the global
         // sink is installed.
         record_purge_failure(PurgeBranch::Subgroup, PurgeFailureClass::SigningKey);
+    }
+
+    /// The `self_purge_reconcile_total` family registers against a fresh
+    /// registry and ALL `outcome` labels round-trip through the text encoder.
+    ///
+    /// As with `self_purge_failures_register_and_encode`, we build the family
+    /// + registry locally rather than going through the process-global
+    /// `GROUP_STORE_METRICS` sink (a `OnceLock` another test may have set), so
+    /// the assertion targets *this* registry. The label-building logic
+    /// (`ReconcileOutcome::as_label`) is what we assert on; the
+    /// no-op-without-sink behaviour of the public recorder is covered by the
+    /// early-return and exercised below.
+    #[test]
+    fn self_purge_reconcile_register_and_encode() {
+        let mut registry = Registry::default();
+        let family = Family::<SelfPurgeReconcileLabels, Counter>::default();
+        registry.register(
+            "self_purge_reconcile",
+            "Self-purge reconcile-sweep outcomes by outcome",
+            family.clone(),
+        );
+
+        for outcome in [
+            ReconcileOutcome::Reconciled,
+            ReconcileOutcome::Retained,
+            ReconcileOutcome::ClearedStale,
+            ReconcileOutcome::StaleClearFailed,
+            ReconcileOutcome::Skipped,
+        ] {
+            family
+                .get_or_create(&SelfPurgeReconcileLabels {
+                    outcome: outcome.as_label(),
+                })
+                .inc();
+        }
+
+        let mut out = String::new();
+        encode(&mut out, &registry).expect("encode registry");
+
+        for label in [
+            "reconciled",
+            "retained",
+            "cleared_stale",
+            "stale_clear_failed",
+            "skipped",
+        ] {
+            assert!(
+                out.contains(&format!("outcome=\"{label}\"")),
+                "missing reconcile outcome label {label}:\n{out}"
+            );
+        }
+
+        // The public recorder must not panic whether or not the global sink
+        // is installed.
+        record_reconcile_outcome(ReconcileOutcome::Reconciled);
+        record_reconcile_outcome(ReconcileOutcome::StaleClearFailed);
+    }
+
+    /// The `self_purge_events_dropped_total` counter registers against a
+    /// fresh registry and `inc_by` round-trips through the text encoder.
+    /// Also asserts the public recorder is a safe no-op without/with a sink.
+    #[test]
+    fn self_purge_events_dropped_register_and_encode() {
+        let mut registry = Registry::default();
+        let counter = Counter::<u64>::default();
+        registry.register(
+            "self_purge_events_dropped",
+            "Self-purge op-events dropped by the broadcast Lagged arm",
+            counter.clone(),
+        );
+
+        counter.inc_by(5);
+
+        let mut out = String::new();
+        encode(&mut out, &registry).expect("encode registry");
+        assert!(
+            out.contains("self_purge_events_dropped_total 5"),
+            "missing dropped-events counter:\n{out}"
+        );
+
+        // Public recorder must not panic whether or not the global sink is
+        // installed (including the n=0 edge).
+        record_events_dropped(0);
+        record_events_dropped(3);
     }
 }


### PR DESCRIPTION
Closes #2686. Follow-up to #2724/#2725.

The basic `self_purge_failures_total{branch,class}` counter shipped in #2724. This adds the finer observability signals deferred during the #2724/#2725 review.

## New metrics (under `context.group_store`)
- **`self_purge_reconcile_total{outcome}`** — exactly one increment per marked namespace the startup reconcile sweep processes:
  - `reconciled` — purge fully completed
  - `retained` — `Purge` decided but signing-key purge failed; marker kept for next restart
  - `cleared_stale` — stale marker cleared
  - `stale_clear_failed` — `clear_marker` errored
  - `skipped` — `reconcile_decision` returned `Skip` (read-error uncertainty)

  Operators can now alert on namespaces stuck `retained` across restarts — the previous log-only tally couldn't surface that.
- **`self_purge_events_dropped_total`** — incremented by the skip count in the broadcast `Lagged` arm. A dropped `TeeMemberRemoved` writes no marker and is unrecoverable by the reconcile, so silent residue accumulation is now observable (was `warn!`-only).

## Cleanups (also review-deferred to #2686)
- `clear_marker` now returns `bool`; the sweep records `cleared_stale` only on a successful clear, `stale_clear_failed` otherwise.
- **`reconcile_decision` is now genuinely pure** — removed its `record_purge_failure` calls on the three read-error paths. They mislabeled reconcile *uncertainty* as purge-step *failures* (inflating `self_purge_failures_total`) and broke the documented "pure store reads" contract. Those read-errors now surface correctly as the `skipped` reconcile outcome. `cascade_namespace_state` / `purge_subgroup_for_self` keep their `record_purge_failure` (genuine purge-step failures).

## Scope note
`purge_subgroup_for_self` stays sync / no-`Result`: subgroup-step failures are already metered via `record_purge_failure(Subgroup, …)`, and the retry-surface refactor belongs with the subgroup reconcile in **#2726**. (Documented in a comment.)

## Tests
Register/encode tests for both new metric families (all `outcome` labels round-trip the Prometheus encoder; recorders no-op safely with/without a sink), `clear_marker` return-value coverage. All existing self_purge + metrics tests green. 1.88 fmt + clippy clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and metric-classification changes only; purge/reconcile behavior is unchanged aside from not mis-counting reconcile read errors as purge failures.
> 
> **Overview**
> Adds **finer self-purge observability** under `context.group_store`: **`self_purge_reconcile_total{outcome}`** (one increment per marked namespace in the startup sweep — `reconciled`, `retained`, `cleared_stale`, `stale_clear_failed`, `skipped`) and **`self_purge_events_dropped_total`** when the op-event subscriber hits broadcast `Lagged`.
> 
> The reconcile sweep now **records those outcomes** and logs **`stale_clear_failed`** separately. **`clear_marker`** returns **`bool`** so `cleared_stale` is only counted on success.
> 
> **`reconcile_decision`** no longer calls **`record_purge_failure`** on read-error paths; reconcile uncertainty is tracked via **`outcome="skipped"`** instead of inflating **`self_purge_failures_total`**. Tests cover Prometheus registration/encoding for the new series and **`clear_marker`**’s return value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf26ccb7cac9dd040fb092da0c6a25a021e58d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->