### PR TITLE
ci(ai-reviewer): bump pin to fix AutoDocs doc-PR quality

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -60,7 +60,7 @@ jobs:
       # prevent an upstream change from running with this repo's secrets.
       # Bump deliberately when adopting new reviewer features.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@25f51a9d76278b55cbfed813fb35a80ae2c458e9
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@2031b0dbe18eea1da4ff550a389fe80b48defbd1
 
       - name: Determine PR number and agent count
         id: pr

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -60,7 +60,7 @@ jobs:
       # prevent an upstream change from running with this repo's secrets.
       # Bump deliberately when adopting new reviewer features.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@2031b0dbe18eea1da4ff550a389fe80b48defbd1
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@06d0a027b59caba85269b5a63bac4b0e53ffa0ea
 
       - name: Determine PR number and agent count
         id: pr

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,16 +1,18 @@
 name: Doc Auto-Update
 
 # Inlined from calimero-network/ai-code-reviewer reusable workflow at
-# SHA 25f51a9d76278b55cbfed813fb35a80ae2c458e9, with one fix:
+# SHA 2031b0dbe18eea1da4ff550a389fe80b48defbd1, with one fix:
 # `cache: pip` removed from `actions/setup-python@v5`. The upstream sets
 # it unconditionally, but setup-python's pip cache requires a
 # requirements.txt or pyproject.toml in the calling repo — neither
 # exists here (core is Rust), so every run failed with:
 #   No file in /home/runner/work/core/core matched to
 #   [**/requirements.txt or **/pyproject.toml]
-# Tracked for an upstream fix; once that lands and we bump the pinned
-# install SHA, this can revert to a thin caller invoking the reusable
-# workflow.
+# As of the bumped SHA the upstream omits `cache: pip` too, so this can
+# revert to a thin caller (`uses: calimero-network/ai-code-reviewer/
+# .github/workflows/doc-update.yaml@<sha>`) in a follow-up. We keep the
+# inlined copy for now because its PR-detection (commits/{sha}/pulls)
+# is more accurate than the upstream grep+`gh pr list --limit 1`.
 
 on:
   push:
@@ -56,7 +58,7 @@ jobs:
       # Pinned to the same SHA as ai-review.yaml so both workflows install
       # the audited version of ai-code-reviewer. Bump deliberately.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@25f51a9d76278b55cbfed813fb35a80ae2c458e9
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@2031b0dbe18eea1da4ff550a389fe80b48defbd1
 
       - name: Get merged PR number
         id: pr

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,7 +1,7 @@
 name: Doc Auto-Update
 
 # Inlined from calimero-network/ai-code-reviewer reusable workflow at
-# SHA 2031b0dbe18eea1da4ff550a389fe80b48defbd1, with one fix:
+# SHA 06d0a027b59caba85269b5a63bac4b0e53ffa0ea, with one fix:
 # `cache: pip` removed from `actions/setup-python@v5`. The upstream sets
 # it unconditionally, but setup-python's pip cache requires a
 # requirements.txt or pyproject.toml in the calling repo — neither
@@ -58,7 +58,7 @@ jobs:
       # Pinned to the same SHA as ai-review.yaml so both workflows install
       # the audited version of ai-code-reviewer. Bump deliberately.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@2031b0dbe18eea1da4ff550a389fe80b48defbd1
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@06d0a027b59caba85269b5a63bac4b0e53ffa0ea
 
       - name: Get merged PR number
         id: pr


### PR DESCRIPTION
## What & why

The **AutoDocs** workflow (`doc-update.yaml`, using `ai-code-reviewer`) either failed to open documentation PRs or opened low-quality / nonsensical ones. Root cause: **`core` pins `ai-code-reviewer` to a stale revision that predates every HTML doc-generation fix.**

Both workflows pinned:

```
ai-code-reviewer.git@25f51a9d…   # 2026-05-11
```

…but `ai-code-reviewer` `master` is `2031b0dbe…` (2026-05-20) — **17 commits ahead**, including the entire doc-quality fix series. This PR bumps both pins to `2031b0d`.

## What the stale pin was doing

At `25f51a9`, HTML doc updates were generated as **full-file rewrites**:

| Problem at pinned SHA | Effect | Fixed on master by |
|---|---|---|
| "Return the COMPLETE updated HTML file" + `max_tokens=8192` | Non-trivial pages **truncated mid-file** → broken HTML committed | `c419242` — switch to targeted **FIND/REPLACE** patches |
| `_MAX_DOC_CHARS_HTML = 20_000` input cap | Model never saw the tail of larger pages → **silently dropped sections** | `388dde8` — raise cap to **100K** |
| No preamble stripping | Model chatter ("Here is the updated file…") **written into the page** (core#2296 class) | `388dde8` — strip preamble |
| FIND text whitespace mismatches | Patches failed to apply | `ef7d103` — whitespace-normalized FIND fallback |
| Shared `docs/auto-<sha>` branch | Concurrent/re-run **branch collisions** | `d1aec53` — per-PR branch + reset-on-rerun |

**Evidence in this repo:** auto-doc PRs **#2394/#2395/#2396** all reused branch `docs/auto-461dc8d`, and **#2394** ("docs: auto-update…") bundled unrelated Rust source (`crates/merod/src/cli.rs`, `crates/config/src/lib.rs`, …) into what should have been a single-HTML-file doc PR.

> Note on "no PR at all": the tool's `has_open_doc_update_pr` idempotency guard skips **every** subsequent run while *any* `docs/auto-*` PR is left open. So one bad PR left sitting open silently blocks all later merges until it's closed/merged — worth keeping the auto-doc PR queue clean.

## Changes

- `.github/workflows/doc-update.yaml` — bump install SHA `25f51a9` → `2031b0d`; update the header SHA reference and note the `cache: pip` issue is now resolved upstream.
- `.github/workflows/ai-review.yaml` — bump install SHA `25f51a9` → `2031b0d` (kept in lockstep; the same 17 commits also carry install-from-source and review fixes).

## Risk / rollout

- Workflow-only change; no Rust/runtime impact.
- The inlined `doc-update.yaml` is kept (not reverted to a thin `uses:` caller) because its `commits/{sha}/pulls` PR detection is more accurate than upstream's `grep + gh pr list --limit 1`. Reverting to a thin caller is a reasonable **follow-up** now that the upstream `cache: pip` blocker is gone.
- Recommend a `workflow_dispatch` **dry-run** against a recent merged PR after this lands to confirm clean FIND/REPLACE output before trusting auto-merge-less PRs.

## Follow-up (separate PR, in `ai-code-reviewer`)

`get_html_files_in_dirs` is non-recursive, so `architecture/crates/*.html` (9 crate pages) are never scanned — only top-level `architecture/*.html`. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin and comment updates; no application or runtime code changes.
> 
> **Overview**
> **Bumps the pinned `calimero-network/ai-code-reviewer` install revision** in both `ai-review.yaml` and `doc-update.yaml` from `25f51a9…` to `06d0a027…`, keeping the two workflows on the same audited SHA so CI picks up newer reviewer and AutoDocs behavior (e.g. doc-generation fixes described in the PR rationale).
> 
> Updates the **header comment** in `doc-update.yaml` to reference the new upstream SHA and notes that upstream no longer forces `cache: pip` (matching this repo’s existing workaround). The inlined workflow is **still kept** for now because local PR detection via `commits/{sha}/pulls` is preferred over upstream’s fallback; reverting to a thin `uses:` caller is called out as a possible follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a3d4216fae49e6911ff750e6ecd57dea549f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->