### PR TITLE
feat(wasm-abi): emit migration descriptor from app migrate declaration (#2539)

### DIFF
--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -6,7 +6,8 @@ use syn::{Item, ItemEnum, ItemImpl, ItemStruct, Type};
 
 use crate::normalize::{normalize_type, ResolvedLocal, TypeResolver};
 use crate::schema::{
-    Event, Field, Manifest, Method, MethodIntent, Parameter, ScalarType, TypeDef, TypeRef, Variant,
+    Event, Field, Manifest, Method, MethodIntent, MigrationAbi, Parameter, ScalarType, TypeDef,
+    TypeRef, Variant,
 };
 
 /// ABI emitter that processes Rust source code
@@ -295,6 +296,66 @@ fn has_app_view_attribute(attrs: &[syn::Attribute]) -> bool {
         let segments: Vec<_> = path.segments.iter().collect();
         segments.len() == 2 && segments[0].ident == "app" && segments[1].ident == "view"
     })
+}
+
+/// Parse `version = N` out of `#[app::state(version = N, …)]`. `None` if no version arg.
+fn app_state_version(attrs: &[syn::Attribute]) -> Option<u32> {
+    for attr in attrs {
+        let segs: Vec<_> = attr.path().segments.iter().collect();
+        if segs.len() == 2 && segs[0].ident == "app" && segs[1].ident == "state" {
+            let mut found = None;
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("version") {
+                    let lit: syn::LitInt = meta.value()?.parse()?;
+                    found = lit.base10_parse::<u32>().ok();
+                }
+                Ok(())
+            });
+            return found;
+        }
+    }
+    None
+}
+
+/// The migrate method from `#[migrate(method = ident, …)]` on the state struct
+/// (the `#[derive(app::Migrate)]` form).
+fn migrate_method_from_attrs(attrs: &[syn::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if attr.path().is_ident("migrate") {
+            let mut method = None;
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("method") {
+                    let p: syn::Path = meta.value()?.parse()?;
+                    method = p.get_ident().map(|i| i.to_string());
+                } else if meta.input.peek(syn::Token![=]) {
+                    // Consume `= <value>` for keys we don't use (from, emit, …)
+                    // so parse_nested_meta advances past them to reach `method`.
+                    let _: syn::Expr = meta.value()?.parse()?;
+                }
+                Ok(())
+            });
+            if method.is_some() {
+                return method;
+            }
+        }
+    }
+    None
+}
+
+/// The name of a free `#[app::migrate] fn …()` (the attribute-macro form).
+fn free_migrate_fn_name(items: &[syn::Item]) -> Option<String> {
+    for item in items {
+        if let syn::Item::Fn(f) = item {
+            let has = f.attrs.iter().any(|a| {
+                let s: Vec<_> = a.path().segments.iter().collect();
+                s.len() == 2 && s[0].ident == "app" && s[1].ident == "migrate"
+            });
+            if has {
+                return Some(f.sig.ident.to_string());
+            }
+        }
+    }
+    None
 }
 
 impl<'ast> Visit<'ast> for AbiEmitter {
@@ -695,12 +756,35 @@ pub fn emit_manifest_from_crate(
     }
 
     // Create the manifest
+    // Target schema from `#[app::state(version = N)]`, method from
+    // `#[migrate(method = …)]` (derive form) or a free `#[app::migrate] fn`.
+    let mut migration = None;
+    for file in &files {
+        for item in &file.items {
+            if let Item::Struct(s) = item {
+                if has_app_state_attribute(&s.attrs) {
+                    if let Some(to) = app_state_version(&s.attrs) {
+                        if let Some(method) = migrate_method_from_attrs(&s.attrs)
+                            .or_else(|| free_migrate_fn_name(&file.items))
+                        {
+                            migration = Some(MigrationAbi {
+                                method,
+                                to_schema_version: to,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let mut manifest = Manifest {
         schema_version: "wasm-abi/1".to_owned(),
         types: emitter.type_definitions.into_iter().collect(),
         methods: emitter.methods,
         events: emitter.events,
         state_root: emitter.state_type,
+        migration,
     };
 
     // Remove any internal types that shouldn't be exposed
@@ -713,4 +797,53 @@ pub fn emit_manifest_from_crate(
 /// Emit ABI manifest from Rust source code (single file - for backward compatibility)
 pub fn emit_manifest(source: &str) -> Result<Manifest, Box<dyn error::Error>> {
     emit_manifest_from_crate(&[("lib.rs".to_owned(), source.to_owned())])
+}
+
+#[cfg(test)]
+mod migration_tests {
+    use super::*;
+
+    #[test]
+    fn emits_migration_for_derive_form() {
+        let lib = r#"
+            #[app::state(version = 2, emits = Event)]
+            #[derive(app::Migrate)]
+            #[migrate(from = OldState, method = migrate_v1_to_v2, emit = Event::Migrated)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        let mig = m.migration.expect("migration emitted");
+        assert_eq!(mig.method, "migrate_v1_to_v2");
+        assert_eq!(mig.to_schema_version, 2);
+    }
+
+    #[test]
+    fn emits_migration_for_free_fn_form() {
+        let lib = r#"
+            #[app::state(version = 3)]
+            pub struct State { x: u32 }
+            #[app::migrate]
+            pub fn migrate_v2_to_v3() -> State { State { x: 0 } }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        let mig = m.migration.expect("migration emitted");
+        assert_eq!(mig.method, "migrate_v2_to_v3");
+        assert_eq!(mig.to_schema_version, 3);
+    }
+
+    #[test]
+    fn no_migration_when_absent() {
+        let lib = r#"
+            #[app::state(version = 1)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        assert!(m.migration.is_none());
+    }
 }

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -308,6 +308,10 @@ fn app_state_version(attrs: &[syn::Attribute]) -> Option<u32> {
                 if meta.path.is_ident("version") {
                     let lit: syn::LitInt = meta.value()?.parse()?;
                     found = lit.base10_parse::<u32>().ok();
+                } else if meta.input.peek(syn::Token![=]) {
+                    // Consume `= <value>` for keys we don't use (emits, …) so
+                    // parse_nested_meta advances past them regardless of order.
+                    let _: syn::Expr = meta.value()?.parse()?;
                 }
                 Ok(())
             });
@@ -317,8 +321,11 @@ fn app_state_version(attrs: &[syn::Attribute]) -> Option<u32> {
     None
 }
 
-/// The migrate method from `#[migrate(method = ident, …)]` on the state struct
-/// (the `#[derive(app::Migrate)]` form).
+/// The migrate method declared by `#[migrate(method = ident, …)]` on the state
+/// struct (the `#[derive(app::Migrate)]` form). Presence of a `#[migrate(...)]`
+/// attribute IS the migration declaration; `method` is optional and **defaults
+/// to `migrate`** (matching the derive macro), so a `#[migrate(from = ...)]`
+/// without an explicit method still yields the entrypoint name.
 fn migrate_method_from_attrs(attrs: &[syn::Attribute]) -> Option<String> {
     for attr in attrs {
         if attr.path().is_ident("migrate") {
@@ -334,9 +341,9 @@ fn migrate_method_from_attrs(attrs: &[syn::Attribute]) -> Option<String> {
                 }
                 Ok(())
             });
-            if method.is_some() {
-                return method;
-            }
+            // A `#[migrate(...)]` attr present ⇒ this is a migration; default the
+            // method name to `migrate` when not given explicitly.
+            return Some(method.unwrap_or_else(|| "migrate".to_owned()));
         }
     }
     None
@@ -833,6 +840,39 @@ mod migration_tests {
         let mig = m.migration.expect("migration emitted");
         assert_eq!(mig.method, "migrate_v2_to_v3");
         assert_eq!(mig.to_schema_version, 3);
+    }
+
+    #[test]
+    fn derive_without_explicit_method_defaults_to_migrate() {
+        let lib = r#"
+            #[app::state(version = 2)]
+            #[derive(app::Migrate)]
+            #[migrate(from = OldState)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        let mig = m.migration.expect("migration emitted");
+        assert_eq!(mig.method, "migrate");
+        assert_eq!(mig.to_schema_version, 2);
+    }
+
+    #[test]
+    fn version_read_regardless_of_key_order() {
+        // `version` after `emits` — parse_nested_meta must consume `emits`'s value.
+        let lib = r#"
+            #[app::state(emits = Event, version = 5)]
+            #[derive(app::Migrate)]
+            #[migrate(from = OldState, method = migrate_v4_to_v5)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        let mig = m.migration.expect("migration emitted");
+        assert_eq!(mig.method, "migrate_v4_to_v5");
+        assert_eq!(mig.to_schema_version, 5);
     }
 
     #[test]

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -11,6 +11,22 @@ pub struct Manifest {
     pub events: Vec<Event>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_root: Option<String>,
+    /// Present when the app declares a migrate via `#[app::migrate]` /
+    /// `#[derive(app::Migrate)]`. Absent on code-only releases.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub migration: Option<MigrationAbi>,
+}
+
+/// The app declares it migrates from an older schema: the entrypoint to invoke
+/// on cascade and the schema version it targets. Drives the admin "migrate"
+/// action so the method isn't hand-coded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MigrationAbi {
+    /// The migrate entrypoint export to invoke (e.g. `migrate_v1_to_v2`).
+    pub method: String,
+    /// `AppState::SCHEMA_VERSION` (the `#[app::state(version = N)]`) this bundle targets.
+    pub to_schema_version: u32,
 }
 
 impl Default for Manifest {
@@ -21,6 +37,7 @@ impl Default for Manifest {
             methods: Vec::new(),
             events: Vec::new(),
             state_root: None,
+            migration: None,
         }
     }
 }
@@ -367,6 +384,7 @@ impl Manifest {
             methods: Vec::new(),
             events: Vec::new(),
             state_root: None,
+            migration: None,
         }
     }
 
@@ -400,6 +418,7 @@ impl Manifest {
             methods: Vec::new(),
             events: Vec::new(),
             state_root: Some(state_root_name.clone()),
+            migration: self.migration.clone(),
         })
     }
 
@@ -633,6 +652,21 @@ impl TypeRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn migration_field_serde_roundtrip_and_omitted_when_none() {
+        let mut m = Manifest::default();
+        assert!(!serde_json::to_string(&m).unwrap().contains("migration"));
+        m.migration = Some(MigrationAbi {
+            method: "migrate_v1_to_v2".to_owned(),
+            to_schema_version: 2,
+        });
+        let j = serde_json::to_value(&m).unwrap();
+        assert_eq!(j["migration"]["method"], "migrate_v1_to_v2");
+        assert_eq!(j["migration"]["toSchemaVersion"], 2);
+        let back: Manifest = serde_json::from_value(j).unwrap();
+        assert_eq!(back.migration.unwrap().to_schema_version, 2);
+    }
 
     #[test]
     fn collection_category_classifies_every_crdt_type() {

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -12,8 +12,9 @@ pub struct Manifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_root: Option<String>,
     /// Present when the app declares a migrate via `#[app::migrate]` /
-    /// `#[derive(app::Migrate)]`. Absent on code-only releases.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `#[derive(app::Migrate)]`. Absent on code-only releases and on every
+    /// pre-existing ABI — hence `default` so older manifests still deserialize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration: Option<MigrationAbi>,
 }
 

--- a/crates/wasm-abi/tests/schema_validation.rs
+++ b/crates/wasm-abi/tests/schema_validation.rs
@@ -38,6 +38,36 @@ fn test_schema_validation_basic() {
 }
 
 #[test]
+fn test_schema_validation_migration_descriptor() {
+    // A manifest carrying the optional `migration` descriptor must validate:
+    // the root is `additionalProperties: false`, so the schema would reject
+    // `migration` unless it describes the field (the gap this guards).
+    let schema_json = include_str!("../wasm-abi.schema.json");
+    let schema_value: Value = serde_json::from_str(schema_json).unwrap();
+    let schema = JSONSchema::compile(&schema_value).unwrap();
+
+    let manifest = calimero_wasm_abi::schema::Manifest {
+        schema_version: "wasm-abi/1".to_string(),
+        migration: Some(calimero_wasm_abi::schema::MigrationAbi {
+            method: "migrate".to_string(),
+            to_schema_version: 2,
+        }),
+        ..Default::default()
+    };
+
+    let manifest_json = serde_json::to_value(&manifest).unwrap();
+    // Serializes as camelCase `toSchemaVersion` — the schema must match.
+    assert_eq!(manifest_json["migration"]["toSchemaVersion"], 2);
+
+    let validation_result = schema.validate(&manifest_json);
+    assert!(
+        validation_result.is_ok(),
+        "migration-bearing manifest must validate against wasm-abi.schema.json: {:?}",
+        validation_result.err().map(|e| e.collect::<Vec<_>>())
+    );
+}
+
+#[test]
 fn test_schema_validation_shared_storage_crdt_type() {
     use calimero_wasm_abi::schema::{
         CollectionType, CrdtCollectionType, Manifest, Method, TypeRef,

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -31,6 +31,23 @@
     "state_root": {
       "type": "string",
       "description": "Name of the type that represents the application state"
+    },
+    "migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "toSchemaVersion"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "The migrate entrypoint export to invoke"
+        },
+        "toSchemaVersion": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The app-state schema version (#[app::state(version = N)]) this bundle migrates to"
+        }
+      },
+      "description": "Present when the app declares a migration (#[app::migrate] / #[derive(app::Migrate)])"
     }
   },
   "definitions": {

--- a/tools/merodb/src/abi.rs
+++ b/tools/merodb/src/abi.rs
@@ -42,6 +42,7 @@ pub fn load_state_schema_from_json_value(schema_value: &serde_json::Value) -> Re
         methods: Vec::new(),
         events: Vec::new(),
         state_root: Some(state_root),
+        migration: None,
     };
 
     Ok(schema)
@@ -278,5 +279,6 @@ pub fn infer_schema_from_database(
         methods: Vec::new(),
         events: Vec::new(),
         state_root: Some(state_root_type),
+        migration: None,
     })
 }


### PR DESCRIPTION
## What
Make a bundle **self-describe its migration** so admin tooling can discover the migrate entrypoint instead of hardcoding `migrate_v1_to_v2`.

The build-time ABI emitter (`calimero-wasm-abi`, which statically parses crate source) now recognizes the migrate declaration and emits a `migration` descriptor into each service's `abi.json`:
```jsonc
"migration": { "method": "migrate_v1_to_v2", "toSchemaVersion": 2 }
```

### Changes
- **`schema.rs`**: `MigrationAbi { method, toSchemaVersion }` + `Manifest.migration: Option<MigrationAbi>` (serde-omitted when `None` → back-compat with existing ABIs; all `Manifest` constructors updated).
- **`emitter.rs`**: detect both declaration forms — `#[derive(app::Migrate)] #[migrate(method = …)]` on the state struct, and a free `#[app::migrate] fn` — and read `version = N` from `#[app::state(version = N)]`. Absent ⇒ `migration: None` (e.g. a code-only release — the signal a UI uses to *not* prompt for re-sign).

### Tests
4 new: derive-form, free-fn form, no-migration, serde round-trip. Whole `calimero-wasm-abi` suite green.

## Why this shape
The engine gates on the CRDT schema version (`toSchemaVersion`, u32); the user-facing semver is added downstream (build-bundle → manifest `toVersion`). The ABI carries the engine truth. No SDK-macro change, no engine change — metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only ABI extension with backward-compatible serde and no runtime engine changes; incorrect parsing would only mislabel migrate entrypoints in tooling.
> 
> **Overview**
> Adds an optional **`migration`** block to emitted `abi.json` so bundles self-describe their migrate entrypoint and target schema version for admin tooling.
> 
> **Schema & wire format:** Introduces `MigrationAbi` (`method`, `toSchemaVersion`) on `Manifest`, omitted when absent with `serde(default)` for older ABIs. `wasm-abi.schema.json` documents the field (required on the strict root schema). `extract_state_schema` preserves `migration`; `merodb` sets `migration: None` on synthetic manifests.
> 
> **Emitter:** After manifest assembly, scans crate sources for `#[app::state(version = N)]` plus either `#[migrate(…)]` on the state struct (default method name `migrate`) or a free `#[app::migrate]` function. No migrate declaration ⇒ `migration` stays `None`.
> 
> **Tests:** Emitter cases (derive vs free fn, default method, attribute key order, absent migration), serde round-trip, and JSON Schema validation for migration-bearing manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bb750276d288293a3ebf657beb808c273e032f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->