### PR TITLE
feat(migration): surface failed migration state in heartbeat + rollup (#2539)

### DIFF
--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1036,6 +1036,52 @@ pub struct MemberMigrationReport {
     /// Member's self-reported pending-authored count (best-effort; 6f). Counted
     /// into the rollup's `members_pending_signature`.
     pub authored_remaining: u64,
+    /// Set when the member's migrate aborted (a developer-declared
+    /// migration-check failed, or the migrate apply errored). Surfaces the
+    /// member as `Failed` in the rollup rather than a silent `in_progress`.
+    pub migration_failed: Option<MigrationFailureKind>,
+}
+
+/// Why a member's migration did not complete. A categorized, `Copy`-safe
+/// reason (the human string is derived from this in the UI); kept narrow so
+/// the report stays `Copy` and the heartbeat carries a single discriminant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MigrationFailureKind {
+    /// The app's `#[app::migrate(..)]` migration-check returned a failure, so
+    /// the migrate was aborted (state rolled back, zero residue).
+    CheckAborted,
+    /// The migrate apply itself errored (e.g. the target wasm could not run).
+    ApplyFailed,
+}
+
+impl MigrationFailureKind {
+    /// Stable JSON discriminant for the admin API.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CheckAborted => "check_aborted",
+            Self::ApplyFailed => "apply_failed",
+        }
+    }
+
+    /// Map a wire discriminant byte back to a kind (`1`/`2`); other values None.
+    #[must_use]
+    pub const fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            1 => Some(Self::CheckAborted),
+            2 => Some(Self::ApplyFailed),
+            _ => None,
+        }
+    }
+
+    /// The wire discriminant byte (`0` = none is handled by the caller).
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        match self {
+            Self::CheckAborted => 1,
+            Self::ApplyFailed => 2,
+        }
+    }
 }
 
 /// The migration state the rollup assigns a pinned-cohort member.
@@ -1050,6 +1096,8 @@ pub enum MemberMigrationState {
     /// keeps `all_migrated == false` rather than being silently dropped, so a
     /// member that stopped reporting can never produce a false green.
     Unknown,
+    /// The member's migrate aborted (migration-check failed or apply errored).
+    Failed,
 }
 
 impl MemberMigrationState {
@@ -1060,6 +1108,7 @@ impl MemberMigrationState {
             Self::Migrated => "migrated",
             Self::InProgress => "in_progress",
             Self::Unknown => "unknown",
+            Self::Failed => "failed",
         }
     }
 }
@@ -1081,10 +1130,12 @@ pub struct MigrationStatusRollup {
     pub migrated: usize,
     pub in_progress: usize,
     pub unknown: usize,
+    /// Members whose migrate aborted (migration-check failed or apply errored).
+    pub failed: usize,
     pub total: usize,
     /// `true` iff **every** pinned-cohort member reported
     /// `schema_version >= target && residue_auto == 0 && residue_identity == 0`.
-    /// Any `unknown` (or any member still in progress) keeps this `false`.
+    /// Any `unknown`, `failed`, or in-progress member keeps this `false`.
     pub all_migrated: bool,
     /// Count of pinned-cohort members reporting `authored_remaining > 0` — i.e.
     /// members whose owners still have identity-gated entries to re-sign (6f,
@@ -1145,6 +1196,7 @@ pub fn compute_migration_status_rollup(
     let mut migrated = 0usize;
     let mut in_progress = 0usize;
     let mut unknown = 0usize;
+    let mut failed = 0usize;
     let mut members_pending_signature = 0usize;
 
     for peer in closure {
@@ -1174,6 +1226,12 @@ pub fn compute_migration_status_rollup(
             None => {
                 unknown += 1;
                 MemberMigrationState::Unknown
+            }
+            Some(r) if r.migration_failed.is_some() => {
+                // An aborted migrate takes precedence: surface it explicitly
+                // rather than as a silent in-progress.
+                failed += 1;
+                MemberMigrationState::Failed
             }
             Some(r) => {
                 // Advisory skew-#1 count, independent of the migrated/in-progress
@@ -1214,6 +1272,7 @@ pub fn compute_migration_status_rollup(
             migrated,
             in_progress,
             unknown,
+            failed,
             total,
             all_migrated,
             members_pending_signature,
@@ -1230,7 +1289,10 @@ mod migration_status_tests {
 
     use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 
-    use super::{compute_migration_status_rollup, MemberMigrationReport, MemberMigrationState};
+    use super::{
+        compute_migration_status_rollup, MemberMigrationReport, MemberMigrationState,
+        MigrationFailureKind,
+    };
 
     fn pk(b: u8) -> PublicKey {
         PublicKey::from([b; 32])
@@ -1263,7 +1325,35 @@ mod migration_status_tests {
             synced_up_to_hlc: synced_up_to_seq,
             reported_at: 0,
             authored_remaining: 0,
+            migration_failed: None,
         }
+    }
+
+    /// A report whose member's migrate aborted (e.g. migration-check failed).
+    fn report_failed(kind: MigrationFailureKind) -> MemberMigrationReport {
+        MemberMigrationReport {
+            migration_failed: Some(kind),
+            ..report(1, 0, 0)
+        }
+    }
+
+    #[test]
+    fn failed_member_surfaces_as_failed_not_in_progress() {
+        let pa = pk(0xA1);
+        let pb = pk(0xB2);
+        let st = compute_migration_status_rollup(2, None, None, &[pa, pb], |peer| {
+            if *peer == pa {
+                Some(report(2, 0, 0)) // migrated
+            } else {
+                Some(report_failed(MigrationFailureKind::CheckAborted))
+            }
+        });
+        assert_eq!(st.rollup.failed, 1);
+        assert_eq!(st.rollup.migrated, 1);
+        assert_eq!(st.rollup.in_progress, 0);
+        assert!(!st.rollup.all_migrated);
+        let failed = st.members.iter().find(|m| m.peer == pb).unwrap();
+        assert_eq!(failed.state, MemberMigrationState::Failed);
     }
 
     /// Build the DISPLAY-only HLC fence (`cascade_hlc`) the way the initiator

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use actix::{ActorResponse, ActorTryFutureExt, Handler, Message, WrapFuture};
 use borsh::BorshDeserialize;
 use calimero_context_client::client::ContextClient;
+use calimero_context_client::group::MigrationFailureKind;
 use calimero_context_client::messages::{MigrationParams, UpdateApplicationRequest};
 use calimero_node_primitives::client::NodeClient;
 use calimero_prelude::ROOT_STORAGE_ENTRY_ID;
@@ -512,7 +513,7 @@ pub(crate) async fn update_application_with_migration(
         // transient witness, so the check below sees the produced v2 state and
         // the gate can commit-or-drop the buffer (zero-residue abort).
         let (new_state_bytes, migration_witness, migration_events, migration_logs, storage) =
-            execute_migration(
+            match execute_migration(
                 &datastore,
                 node_client.clone(),
                 &context,
@@ -520,7 +521,21 @@ pub(crate) async fn update_application_with_migration(
                 &migration_params,
                 public_key,
             )
-            .await?;
+            .await
+            {
+                Ok(out) => out,
+                Err(err) => {
+                    // The migrate apply itself errored (e.g. the v2 wasm trapped).
+                    // Record the reason so the heartbeat surfaces this member as
+                    // `failed`, then propagate — the context stays on v1.
+                    persist_migration_failed(
+                        &datastore,
+                        context_id,
+                        MigrationFailureKind::ApplyFailed,
+                    );
+                    return Err(err);
+                }
+            };
 
         // Log migration logs
         for log_line in &migration_logs {
@@ -716,6 +731,9 @@ fn commit_or_abort_migration(
         // `finalize_application_update`.
         drop(storage);
         clear_pending_delta();
+        // Record the abort so the heartbeat surfaces this member as `failed`
+        // (not a silent in-progress). Cleared if a later migrate commits.
+        persist_migration_failed(datastore, context_id, MigrationFailureKind::CheckAborted);
         return Err(MigrationCheckFailed { context_id }.into());
     }
 
@@ -744,6 +762,10 @@ fn commit_or_abort_migration(
         new_root_hash = %new_root_hash,
         "Updated dag_heads to new root after migration"
     );
+
+    // The migrate committed: drop any prior failure marker so a context that
+    // recovered (this attempt, or after an earlier abort) stops reporting failed.
+    clear_migration_failed(datastore, context_id);
 
     Ok(new_root_hash)
 }
@@ -1055,6 +1077,34 @@ pub(crate) fn persist_authored_remaining(
     };
     if let Err(err) = handle.put(&key, &value) {
         debug!(%context_id, %err, "failed to persist authored_remaining");
+    }
+}
+
+/// Persist a node-local marker that this context's last migration attempt did
+/// not complete, with a categorized reason. Read by the migration heartbeat so
+/// the member surfaces as `failed` rather than a silent `in_progress`; cleared
+/// by [`clear_migration_failed`] once a later migrate commits. Best-effort.
+pub(crate) fn persist_migration_failed(
+    datastore: &calimero_store::Store,
+    context_id: ContextId,
+    kind: MigrationFailureKind,
+) {
+    let mut handle = datastore.handle();
+    let key = key::ContextMigrationFailed::new(context_id);
+    let value = types::ContextMigrationFailed { kind: kind.to_u8() };
+    if let Err(err) = handle.put(&key, &value) {
+        debug!(%context_id, %err, "failed to persist migration_failed marker");
+    }
+}
+
+/// Drop any persisted migration-failure marker for `context_id` — called when a
+/// migration commits so a recovered context stops reporting `failed`. Deleting
+/// an absent marker (the common case) is a store no-op, not an error.
+pub(crate) fn clear_migration_failed(datastore: &calimero_store::Store, context_id: ContextId) {
+    let mut handle = datastore.handle();
+    let key = key::ContextMigrationFailed::new(context_id);
+    if let Err(err) = handle.delete(&key) {
+        debug!(%context_id, %err, "failed to clear migration_failed marker");
     }
 }
 
@@ -2366,6 +2416,16 @@ mod tests {
         };
         let v2_bytes = borsh::to_vec(&("v2-state-much-longer".to_owned())).expect("serialize v2");
 
+        // Reads the node-local migration-failure marker (the heartbeat's source
+        // for surfacing a member as `failed`), as its raw discriminant.
+        let failed_marker = |store: &calimero_store::Store| {
+            store
+                .handle()
+                .get(&key::ContextMigrationFailed::new(context_id))
+                .expect("read failure marker")
+                .map(|m| m.kind)
+        };
+
         // --- ABORT: stage a v2 child through the buffer, then drop it. ---
         {
             let mut staging = ContextStorage::from(store.clone(), context_id);
@@ -2419,6 +2479,14 @@ mod tests {
                 !is_present(&store),
                 "abort must DROP the staged child entry — zero residue"
             );
+
+            // (e) the abort persists a CheckAborted marker so the heartbeat
+            // surfaces this member as `failed` rather than a silent in-progress.
+            assert_eq!(
+                failed_marker(&store),
+                Some(super::MigrationFailureKind::CheckAborted.to_u8()),
+                "a logical abort must persist the check-aborted failure marker"
+            );
         }
 
         // --- COMMIT: stage a v2 child through the buffer, then promote it. ---
@@ -2451,6 +2519,14 @@ mod tests {
             assert!(
                 is_present(&store),
                 "commit must FLUSH the staged child entry to the live store"
+            );
+
+            // ...and the prior abort's failure marker is cleared (self-heal): a
+            // context that recovered must stop reporting `failed`.
+            assert_eq!(
+                failed_marker(&store),
+                None,
+                "a passing commit must clear the prior failure marker"
             );
         }
     }

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -600,6 +600,7 @@ fn signed_heartbeat(
         ts_millis: 1_700_000_000_000,
         signature: [0u8; 64],
         authored_remaining: 0,
+        migration_failed: 0,
     };
     hb.signature = sk
         .sign(&hb.signable_bytes().expect("signable_bytes"))

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -192,7 +192,7 @@ pub struct SignableMigrationHeartbeat {
 /// the signature prevents a peer from forging another peer's completion.
 // MAINTENANCE: this struct has a hand-written `BorshDeserialize` (below) that
 // reads these fields positionally. If you ADD / REMOVE / REORDER any field
-// here, update that impl in lockstep (new fields go AFTER authored_remaining as
+// here, update that impl in lockstep (new fields go AFTER migration_failed as
 // another trailing read, or behind a version discriminant). The round-trip +
 // mixed-fleet tests (serialize via this derive, deserialize via the custom impl)
 // fail loudly on a desync — keep them in step.
@@ -214,6 +214,14 @@ pub struct SignedMigrationHeartbeat {
     /// still deserializes (EOF ⇒ 0) and verifies against the unchanged 7-field
     /// signed body — full mixed-fleet compatibility, no version discriminator.
     pub authored_remaining: u64,
+    /// Self-reported migration-failure reason as a discriminant: `0` = none,
+    /// `1` = the developer's migration-check aborted, `2` = the migrate apply
+    /// errored. Like `authored_remaining`, DELIBERATELY OUTSIDE the signature —
+    /// advisory telemetry, not a gate (a forged value can only make the
+    /// publisher's OWN status look failed; completion is covered by the signed
+    /// residue fields). The trailing byte after `authored_remaining`, so a node
+    /// that omits it still deserializes (EOF ⇒ 0) and verifies unchanged.
+    pub migration_failed: u8,
 }
 
 /// Read an optional trailing fixed-width LE value: `None` when no trailing field
@@ -252,11 +260,11 @@ fn read_trailing<R: borsh::io::Read, const N: usize>(
 // MUST deserialize the prefix fields in the exact order the derived
 // `BorshSerialize` above writes them — namespace_id, peer_pubkey, schema_version,
 // residue_auto, residue_identity, synced_up_to_hlc, ts_millis, signature — then
-// the trailing authored_remaining. Reordering/adding a field above without
-// updating this reader silently misreads. The round-trip + mixed-fleet tests
-// (which serialize via the derive and deserialize via this impl) guard against
-// such a desync; keep them in step. A future field should go AFTER
-// authored_remaining (another trailing read) or behind a version discriminant.
+// the trailing authored_remaining, then migration_failed. Reordering/adding a
+// field above without updating this reader silently misreads. The round-trip +
+// mixed-fleet tests (which serialize via the derive and deserialize via this
+// impl) guard against such a desync; keep them in step. A future field should
+// go AFTER migration_failed (another trailing read) or behind a discriminant.
 impl BorshDeserialize for SignedMigrationHeartbeat {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let namespace_id = <[u8; 32]>::deserialize_reader(reader)?;
@@ -269,6 +277,9 @@ impl BorshDeserialize for SignedMigrationHeartbeat {
         let signature = <[u8; 64]>::deserialize_reader(reader)?;
         // borsh integers are little-endian; absent trailing bytes ⇒ old hb ⇒ 0.
         let authored_remaining = read_trailing::<_, 8>(reader)?.map_or(0, u64::from_le_bytes);
+        // migration_failed is the NEXT trailing byte (after authored_remaining).
+        // Absent on any node that predates it ⇒ 0 (no failure on record).
+        let migration_failed = read_trailing::<_, 1>(reader)?.map_or(0, |[b]| b);
         Ok(Self {
             namespace_id,
             peer_pubkey,
@@ -279,6 +290,7 @@ impl BorshDeserialize for SignedMigrationHeartbeat {
             ts_millis,
             signature,
             authored_remaining,
+            migration_failed,
         })
     }
 }
@@ -564,6 +576,7 @@ mod tests {
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
             authored_remaining: 0,
+            migration_failed: 0,
         };
         hb.signature = sk
             .sign(&hb.signable_bytes().expect("signable"))
@@ -587,6 +600,7 @@ mod tests {
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
             authored_remaining: 0,
+            migration_failed: 0,
         };
         hb.signature = sk
             .sign(&hb.signable_bytes().expect("signable"))
@@ -616,6 +630,7 @@ mod tests {
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
             authored_remaining: 5,
+            migration_failed: 0,
         };
         hb.signature = sk
             .sign(&hb.signable_bytes().expect("signable"))
@@ -629,14 +644,16 @@ mod tests {
         assert_eq!(back.authored_remaining, 5);
         assert!(back.verify_signature().is_ok());
 
-        // Old-format heartbeat: drop the trailing u64. Defaults to 0 and the
-        // signature (over the unchanged 7-field body) still verifies.
-        let legacy = &bytes[..bytes.len() - core::mem::size_of::<u64>()];
+        // Old-format heartbeat: drop BOTH trailing fields (authored_remaining
+        // u64 + migration_failed u8). Both default to 0 and the signature (over
+        // the unchanged 7-field body) still verifies.
+        let legacy = &bytes[..bytes.len() - core::mem::size_of::<u64>() - 1];
         let old = SignedMigrationHeartbeat::try_from_slice(legacy).expect("de legacy");
         assert_eq!(old.authored_remaining, 0, "absent trailing field ⇒ 0");
+        assert_eq!(old.migration_failed, 0, "absent trailing field ⇒ 0");
         assert!(
             old.verify_signature().is_ok(),
-            "signature unaffected by the unsigned trailing field"
+            "signature unaffected by the unsigned trailing fields"
         );
 
         // Tampering the advisory field does not break verification.
@@ -645,6 +662,55 @@ mod tests {
         assert!(
             tampered.verify_signature().is_ok(),
             "authored_remaining is unsigned advisory telemetry"
+        );
+    }
+
+    // migration_failed is the trailing byte AFTER authored_remaining: a fresh
+    // heartbeat round-trips it; a heartbeat that carries authored_remaining but
+    // omits migration_failed (a node from before this field) reads it as 0; it
+    // is unsigned advisory telemetry, so tampering it never breaks verification.
+    #[test]
+    fn migration_heartbeat_migration_failed_unsigned_and_eof_tolerant() {
+        let sk = PrivateKey::random(&mut rand::thread_rng());
+        let mut hb = SignedMigrationHeartbeat {
+            namespace_id: [7u8; 32],
+            peer_pubkey: sk.public_key(),
+            schema_version: 2,
+            residue_auto: 0,
+            residue_identity: 0,
+            synced_up_to_hlc: 50,
+            ts_millis: 1_700_000_000_000,
+            signature: [0u8; 64],
+            authored_remaining: 5,
+            migration_failed: 1, // check-aborted
+        };
+        hb.signature = sk
+            .sign(&hb.signable_bytes().expect("signable"))
+            .expect("sign")
+            .to_bytes();
+
+        // Fresh heartbeat round-trips both trailing fields.
+        let bytes = borsh::to_vec(&hb).expect("ser");
+        let back = SignedMigrationHeartbeat::try_from_slice(&bytes).expect("de");
+        assert_eq!(back.authored_remaining, 5);
+        assert_eq!(back.migration_failed, 1);
+        assert!(back.verify_signature().is_ok());
+
+        // A node that carries authored_remaining but omits migration_failed:
+        // drop only the final byte. authored_remaining is preserved, the absent
+        // migration_failed reads as 0, and the signature still verifies.
+        let no_failed = &bytes[..bytes.len() - 1];
+        let prior = SignedMigrationHeartbeat::try_from_slice(no_failed).expect("de prior");
+        assert_eq!(prior.authored_remaining, 5, "preceding field intact");
+        assert_eq!(prior.migration_failed, 0, "absent trailing byte ⇒ 0");
+        assert!(prior.verify_signature().is_ok());
+
+        // Tampering the advisory field does not break verification.
+        let mut tampered = hb.clone();
+        tampered.migration_failed = 2;
+        assert!(
+            tampered.verify_signature().is_ok(),
+            "migration_failed is unsigned advisory telemetry"
         );
     }
 
@@ -675,6 +741,7 @@ mod tests {
             ts_millis: hb_unsigned.ts_millis,
             signature,
             authored_remaining: 0,
+            migration_failed: 0,
         };
         assert!(
             hb.verify_signature().is_err(),
@@ -695,6 +762,7 @@ mod tests {
             ts_millis: 42,
             signature: [5u8; 64],
             authored_remaining: 0,
+            migration_failed: 0,
         });
         let bytes = borsh::to_vec(&envelope).expect("ser");
         let parsed: NamespaceTopicMsg = borsh::from_slice(&bytes).expect("de");

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -103,4 +103,9 @@ pub struct MigrationStatusReport {
     /// Member's self-reported pending-authored count (sum across its namespace
     /// contexts); feeds the rollup's `membersPendingSignature` (6f).
     pub authored_remaining: u64,
+    /// Member's self-reported migration-failure discriminant (`0` = none, `1` =
+    /// migration-check aborted, `2` = apply errored). Raw `u8` — kept primitive
+    /// so this crate need not depend on `calimero-context-client` (cycle); the
+    /// server maps it to a typed kind for the rollup.
+    pub migration_failed: u8,
 }

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -28,6 +28,7 @@ use std::time::{Duration, Instant};
 
 use actix::{Actor, AsyncContext, Context, Handler, Message};
 use calimero_context::group_store::NamespaceRepository;
+use calimero_context_client::group::MigrationFailureKind;
 use calimero_context_client::local_governance::{NamespaceTopicMsg, SignedMigrationHeartbeat};
 use calimero_node_primitives::client::NodeClient;
 use calimero_node_primitives::messages::MigrationStatusReport;
@@ -65,6 +66,10 @@ pub struct CacheEntry {
     /// Peer's self-reported pending-authored count (sum across its namespace
     /// contexts). Surfaced in the rollup as `membersPendingSignature` (6f).
     pub authored_remaining: u64,
+    /// Peer's self-reported migration-failure discriminant (`0` = none, `1` =
+    /// migration-check aborted, `2` = apply errored). Raw `u8` mirroring the
+    /// wire; the server maps it back to a typed kind for the rollup.
+    pub migration_failed: u8,
     /// Peer-signed millis-since-epoch from the heartbeat itself.
     /// Authoritative per-peer ordering signal — used by `insert` to drop
     /// stale heartbeats that gossipsub may re-deliver out-of-order on mesh
@@ -89,6 +94,7 @@ pub fn cache_entry_to_report(entry: &CacheEntry) -> MigrationStatusReport {
         synced_up_to_hlc: entry.synced_up_to_hlc,
         reported_at: entry.ts_millis,
         authored_remaining: entry.authored_remaining,
+        migration_failed: entry.migration_failed,
     }
 }
 
@@ -187,6 +193,7 @@ impl MigrationStatusCache {
                 residue_identity: hb.residue_identity,
                 synced_up_to_hlc: hb.synced_up_to_hlc,
                 authored_remaining: hb.authored_remaining,
+                migration_failed: hb.migration_failed,
                 ts_millis: hb.ts_millis,
                 received_at: now,
             },
@@ -261,6 +268,11 @@ pub struct MigrationFacts {
     /// like the residue fields (a per-namespace sum of per-context u32 counts).
     /// Best-effort self-report — distinct from `residue_identity` (still 0).
     pub authored_remaining: u64,
+    /// Set when one of this namespace's contexts has a migration-failure marker
+    /// persisted (migration-check aborted or apply errored) AND that context is
+    /// still below target — so a recovered context never reports stale failure.
+    /// `None` = no failure on record. Self-report; categorized, not a gate.
+    pub migration_failed: Option<MigrationFailureKind>,
 }
 
 /// Decide whether the local node should emit an *on-change* heartbeat for a
@@ -269,8 +281,9 @@ pub struct MigrationFacts {
 ///
 /// Mirrors the readiness "edge-trigger on tier transition" pattern: a peer
 /// should re-advertise immediately when its *reported state* changes —
-/// here when `schema_version`, `residue_auto`, or `residue_identity` flips
-/// — rather than waiting up to a full periodic interval. `synced_up_to_hlc`
+/// here when `schema_version`, `residue_auto`, `residue_identity`,
+/// `authored_remaining`, or `migration_failed` flips — rather than waiting up
+/// to a full periodic interval. `synced_up_to_hlc`
 /// is intentionally NOT an edge trigger: it advances on every applied op and
 /// would defeat the purpose of debouncing to the periodic tick; the periodic
 /// beat carries its latest value.
@@ -283,6 +296,7 @@ pub fn should_emit_on_change(last: Option<MigrationFacts>, current: MigrationFac
                 || prev.residue_auto != current.residue_auto
                 || prev.residue_identity != current.residue_identity
                 || prev.authored_remaining != current.authored_remaining
+                || prev.migration_failed != current.migration_failed
         }
     }
 }
@@ -421,6 +435,9 @@ pub fn compute_namespace_migration_facts(
     // the dedicated node-local key (6f.8). A plain store read — no wasm, no
     // committed-state iteration. Absent row ⇒ 0.
     let mut authored_remaining: u64 = 0;
+    // Most-severe persisted migration-failure across the namespace's contexts,
+    // honored only for contexts still below target (self-healing on recovery).
+    let mut migration_failed: Option<MigrationFailureKind> = None;
     for context_id in &contexts {
         if let Ok(Some(entry)) =
             datastore
@@ -431,7 +448,30 @@ pub fn compute_namespace_migration_facts(
         {
             authored_remaining = authored_remaining.saturating_add(u64::from(entry.count));
         }
-        let Some(loaded) = loaded_context_version(datastore, context_id) else {
+
+        let loaded = loaded_context_version(datastore, context_id);
+
+        // A persisted failure marker is honored only while the context has NOT
+        // reached target. A context that has since converged (via a later
+        // migrate, lazy access, or cascade) is migrated — a stale marker must
+        // never force a false `failed`. An unresolvable version (None) is
+        // conservatively treated as below-target so a genuine failure surfaces.
+        let below_target = loaded.is_none_or(|l| l < target_version);
+        if below_target {
+            if let Ok(Some(marker)) =
+                datastore
+                    .handle()
+                    .get(&calimero_store::key::ContextMigrationFailed::new(
+                        *context_id,
+                    ))
+            {
+                if let Some(kind) = MigrationFailureKind::from_u8(marker.kind) {
+                    migration_failed = Some(more_severe_failure(migration_failed, kind));
+                }
+            }
+        }
+
+        let Some(loaded) = loaded else {
             continue;
         };
         min_loaded = Some(min_loaded.map_or(loaded, |m| m.min(loaded)));
@@ -466,6 +506,20 @@ pub fn compute_namespace_migration_facts(
         residue_identity,
         synced_up_to_hlc: 0,
         authored_remaining,
+        migration_failed,
+    }
+}
+
+/// Pick the more severe of an accumulated failure and a freshly-read one:
+/// `ApplyFailed` outranks `CheckAborted` (higher discriminant wins). Used to
+/// fold a namespace's per-context failure markers into one reported reason.
+fn more_severe_failure(
+    acc: Option<MigrationFailureKind>,
+    next: MigrationFailureKind,
+) -> MigrationFailureKind {
+    match acc {
+        Some(prev) if prev.to_u8() >= next.to_u8() => prev,
+        _ => next,
     }
 }
 
@@ -554,6 +608,9 @@ pub fn build_signed_heartbeat(
         residue_identity: facts.residue_identity,
         synced_up_to_hlc: facts.synced_up_to_hlc,
         authored_remaining: facts.authored_remaining,
+        migration_failed: facts
+            .migration_failed
+            .map_or(0, MigrationFailureKind::to_u8),
         ts_millis,
         signature: [0u8; 64],
     };
@@ -794,6 +851,7 @@ mod tests {
             ts_millis,
             signature,
             authored_remaining: 0,
+            migration_failed: 0,
         }
     }
 
@@ -970,6 +1028,7 @@ mod tests {
             residue_identity: 4,
             synced_up_to_hlc: 10,
             authored_remaining: 0,
+            migration_failed: None,
         };
         // First-ever emit (no prior) always fires.
         assert!(should_emit_on_change(None, base));
@@ -994,6 +1053,16 @@ mod tests {
             ..base
         };
         assert!(should_emit_on_change(Some(base), bumped));
+        // A migration failure appearing must fire so the failed state propagates
+        // immediately rather than waiting a full periodic interval.
+        let failed = MigrationFacts {
+            migration_failed: Some(MigrationFailureKind::CheckAborted),
+            ..base
+        };
+        assert!(
+            should_emit_on_change(Some(base), failed),
+            "a migration failure appearing must edge-trigger an emit"
+        );
     }
 
     #[test]
@@ -1007,6 +1076,7 @@ mod tests {
             residue_identity: 0,
             synced_up_to_hlc: 10,
             authored_remaining: 0,
+            migration_failed: None,
         };
         let advanced = MigrationFacts {
             synced_up_to_hlc: 99,
@@ -1032,6 +1102,7 @@ mod tests {
             residue_identity: 3,
             synced_up_to_hlc: 10,
             authored_remaining: 0,
+            migration_failed: None,
         };
 
         let emit = record_facts_update(&mut last_emitted, NS, facts);
@@ -1255,6 +1326,75 @@ mod tests {
         );
     }
 
+    /// A persisted migration-failure marker is reported as `migration_failed`
+    /// ONLY while the context is still below the target. A context that has
+    /// since reached the target must not surface a stale marker — the facts are
+    /// self-healing so a recovered member never produces a false `failed`.
+    #[test]
+    fn facts_report_failed_marker_only_while_context_below_target() {
+        use calimero_context::group_store::UpgradesRepository;
+        use calimero_context_config::types::ContextGroupId;
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::key::{GroupUpgradeStatus, GroupUpgradeValue};
+        use std::sync::Arc;
+
+        let save_v2_target = |store: &Store, ns: [u8; 32]| {
+            UpgradesRepository::new(store)
+                .save(
+                    &ContextGroupId::from(ns),
+                    &GroupUpgradeValue {
+                        from_version: "1".to_owned(),
+                        to_version: "2".to_owned(),
+                        migration: None,
+                        initiated_at: 0,
+                        initiated_by: PrivateKey::random(&mut rand::thread_rng()).public_key(),
+                        status: GroupUpgradeStatus::InProgress {
+                            total: 1,
+                            completed: 0,
+                            failed: 0,
+                        },
+                        cascade_hlc: None,
+                        cascade_seq: None,
+                    },
+                )
+                .unwrap();
+        };
+        let set_marker = |store: &Store, ctx: [u8; 32], kind: MigrationFailureKind| {
+            let mut handle = store.handle();
+            handle
+                .put(
+                    &calimero_store::key::ContextMigrationFailed::new(ctx.into()),
+                    &calimero_store::types::ContextMigrationFailed { kind: kind.to_u8() },
+                )
+                .expect("put marker");
+        };
+
+        // Context still on v1 (below the v2 target) with a check-aborted marker:
+        // the facts surface the failure.
+        let below = Store::new(Arc::new(InMemoryDB::owned()));
+        let ns = [0x79u8; 32];
+        save_v2_target(&below, ns);
+        install_loaded_context(&below, ns, [0xD1u8; 32], "1.0.0");
+        set_marker(&below, [0xD1u8; 32], MigrationFailureKind::CheckAborted);
+        assert_eq!(
+            compute_namespace_migration_facts(&below, ns).migration_failed,
+            Some(MigrationFailureKind::CheckAborted),
+            "a failure marker on a still-below-target context must surface as failed"
+        );
+
+        // Same marker, but the context has since reached v2: the stale marker is
+        // NOT honored (self-healing — a recovered context never reports failed).
+        let healed = Store::new(Arc::new(InMemoryDB::owned()));
+        save_v2_target(&healed, ns);
+        install_loaded_context(&healed, ns, [0xD2u8; 32], "2.0.0");
+        set_marker(&healed, [0xD2u8; 32], MigrationFailureKind::CheckAborted);
+        assert_eq!(
+            compute_namespace_migration_facts(&healed, ns).migration_failed,
+            None,
+            "a context that reached target must not report a stale failure marker"
+        );
+    }
+
     #[test]
     fn built_heartbeat_verifies_and_carries_facts() {
         let sk = PrivateKey::random(&mut rand::thread_rng());
@@ -1264,6 +1404,7 @@ mod tests {
             residue_identity: 1,
             synced_up_to_hlc: 77,
             authored_remaining: 0,
+            migration_failed: None,
         };
         let hb = build_signed_heartbeat(&sk, NS, facts, 1234).expect("sign");
         // The receiver's signature gate accepts it, and the cache then reads

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2923,16 +2923,18 @@ mod tests {
         // member surfacing as `unknown` with its `report` field omitted.
         let migrated_peer = PublicKey::from([0x11; 32]);
         let unknown_peer = PublicKey::from([0x22; 32]);
+        let failed_peer = PublicKey::from([0x33; 32]);
 
         let resp = GetMigrationStatusApiResponse {
             target_version: 2,
-            expected_members: 2,
+            expected_members: 3,
             cohort_pinned_at_hlc: Some("hlc-abc".into()),
             rollup: MigrationStatusRollupApiData {
                 migrated: 1,
                 in_progress: 0,
                 unknown: 1,
-                total: 2,
+                failed: 1,
+                total: 3,
                 all_migrated: false,
                 members_pending_signature: 1,
             },
@@ -2946,6 +2948,7 @@ mod tests {
                         synced_up_to_hlc: 7,
                         reported_at: 1_700_000_000,
                         authored_remaining: 3,
+                        migration_failed: None,
                     }),
                     state: "migrated".into(),
                 },
@@ -2954,27 +2957,46 @@ mod tests {
                     report: None,
                     state: "unknown".into(),
                 },
+                MemberMigrationStatusApiEntry {
+                    peer: failed_peer,
+                    report: Some(MemberMigrationReportApiData {
+                        schema_version: 1,
+                        residue_auto: 1,
+                        residue_identity: 0,
+                        synced_up_to_hlc: 5,
+                        reported_at: 1_700_000_001,
+                        authored_remaining: 0,
+                        migration_failed: Some("check_aborted".into()),
+                    }),
+                    state: "failed".into(),
+                },
             ],
         };
 
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["targetVersion"], 2);
-        assert_eq!(json["expectedMembers"], 2);
+        assert_eq!(json["expectedMembers"], 3);
         assert_eq!(json["cohortPinnedAtHlc"], "hlc-abc");
         assert_eq!(json["rollup"]["allMigrated"], false);
         assert_eq!(json["rollup"]["migrated"], 1);
         assert_eq!(json["rollup"]["unknown"], 1);
+        assert_eq!(json["rollup"]["failed"], 1);
         assert_eq!(json["rollup"]["membersPendingSignature"], 1);
 
         let members = json["members"].as_array().unwrap();
-        assert_eq!(members.len(), 2);
+        assert_eq!(members.len(), 3);
         assert_eq!(members[0]["state"], "migrated");
         assert_eq!(members[0]["report"]["schemaVersion"], 2);
         assert_eq!(members[0]["report"]["syncedUpToHlc"], 7);
         assert_eq!(members[0]["report"]["authoredRemaining"], 3);
+        // A migrated member carries no failure reason — `migrationFailed` omitted.
+        assert!(members[0]["report"].get("migrationFailed").is_none());
         // The unknown member has no fresh report — `report` is omitted.
         assert_eq!(members[1]["state"], "unknown");
         assert!(members[1].get("report").is_none());
+        // The failed member surfaces its categorized reason.
+        assert_eq!(members[2]["state"], "failed");
+        assert_eq!(members[2]["report"]["migrationFailed"], "check_aborted");
     }
 
     #[test]
@@ -2988,6 +3010,7 @@ mod tests {
                 migrated: 0,
                 in_progress: 0,
                 unknown: 0,
+                failed: 0,
                 total: 0,
                 all_migrated: false,
                 members_pending_signature: 0,

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1959,6 +1959,11 @@ pub struct MemberMigrationReportApiData {
     /// Member's self-reported pending-authored count (best-effort; 6f).
     #[serde(default)]
     pub authored_remaining: u64,
+    /// Why this member's migration did not complete: `"check_aborted"` or
+    /// `"apply_failed"`. Absent when the member has no failure on record (its
+    /// `state` is then `"migrated"`/`"in_progress"`/`"unknown"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_failed: Option<String>,
 }
 
 /// One per-member row in the migration-status rollup: a pinned-cohort member,
@@ -1972,7 +1977,8 @@ pub struct MemberMigrationStatusApiEntry {
     /// heartbeat (in which case `state == "unknown"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub report: Option<MemberMigrationReportApiData>,
-    /// Derived state discriminant: `"migrated"`, `"in_progress"`, or `"unknown"`.
+    /// Derived state discriminant: `"migrated"`, `"in_progress"`, `"unknown"`,
+    /// or `"failed"`.
     pub state: String,
 }
 
@@ -1983,9 +1989,13 @@ pub struct MigrationStatusRollupApiData {
     pub migrated: usize,
     pub in_progress: usize,
     pub unknown: usize,
+    /// Members whose migrate aborted (migration-check failed or apply errored).
+    #[serde(default)]
+    pub failed: usize,
     pub total: usize,
     /// `true` iff every pinned-cohort member reported a converged schema with
-    /// zero residue. Any `unknown` (or in-progress) member keeps this `false`.
+    /// zero residue. Any `unknown`, `failed`, or in-progress member keeps this
+    /// `false`.
     pub all_migrated: bool,
     /// Count of members reporting `authored_remaining > 0` (owners with
     /// identity-gated entries still to re-sign; 6f, skew #1). Best-effort.

--- a/crates/server/src/admin/handlers/groups/get_migration_status.rs
+++ b/crates/server/src/admin/handlers/groups/get_migration_status.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
-use calimero_context_client::group::{GetMigrationStatusRequest, MemberMigrationReport};
+use calimero_context_client::group::{
+    GetMigrationStatusRequest, MemberMigrationReport, MigrationFailureKind,
+};
 use calimero_primitives::identity::PublicKey;
 use calimero_server_primitives::admin::{
     GetMigrationStatusApiResponse, MemberMigrationReportApiData, MemberMigrationStatusApiEntry,
@@ -55,6 +57,7 @@ pub async fn handler(
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
                         authored_remaining: r.authored_remaining,
+                        migration_failed: MigrationFailureKind::from_u8(r.migration_failed),
                     },
                 )
             })
@@ -88,6 +91,7 @@ pub async fn handler(
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
                         authored_remaining: r.authored_remaining,
+                        migration_failed: r.migration_failed.map(|k| k.as_str().to_owned()),
                     }),
                     state: m.state.as_str().to_owned(),
                 })
@@ -102,6 +106,7 @@ pub async fn handler(
                         migrated: status.rollup.migrated,
                         in_progress: status.rollup.in_progress,
                         unknown: status.rollup.unknown,
+                        failed: status.rollup.failed,
                         total: status.rollup.total,
                         all_migrated: status.rollup.all_migrated,
                         members_pending_signature: status.rollup.members_pending_signature,

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -47,6 +47,12 @@ pub enum Column {
     /// migration). Keys are `prefix(1) ‖ context(32) ‖ producing_app_key(32) ‖
     /// delta_id(32)`; values are borsh'd `AbsorbRecord`s.
     AbsorbBuffer,
+    /// Node-local per-context marker that the last migration attempt did not
+    /// complete (read by the migration heartbeat). Its own column so its
+    /// `context_id`-only key cannot collide with the same-shaped key in
+    /// `ContextLocal` (e.g. `ContextAuthoredRemaining`). NOT synchronized;
+    /// auto-created from `Column::iter()` at `open_cf` (no DB migration).
+    ContextMigrationFailed,
 }
 
 pub trait Database<'a>: Debug + Send + Sync + 'static {

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -29,7 +29,7 @@ pub use calimero_primitives::context::GroupMemberRole;
 use component::KeyComponents;
 pub use context::{
     ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker,
-    ContextMeta, ContextPrivateState, ContextState,
+    ContextMeta, ContextMigrationFailed, ContextPrivateState, ContextState,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -113,6 +113,55 @@ impl Debug for ContextAuthoredRemaining {
     }
 }
 
+/// Node-local marker that this context's most recent migration attempt did not
+/// complete (the developer's migration-check aborted it, or the migrate apply
+/// errored). Read by the migration heartbeat so the member surfaces as `failed`
+/// rather than a silent `in_progress`. Lives in the node-local `ContextLocal`
+/// column — not synchronized; absence means "no failure on record".
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextMigrationFailed(Key<ContextId>);
+
+impl ContextMigrationFailed {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId) -> Self {
+        Self(Key((*context_id).into()))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ContextMigrationFailed {
+    type Components = (ContextId,);
+
+    fn column() -> Column {
+        Column::ContextLocal
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ContextMigrationFailed {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ContextMigrationFailed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextMigrationFailed")
+            .field("id", &self.context_id())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextConfig(Key<ContextId>);

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -116,8 +116,10 @@ impl Debug for ContextAuthoredRemaining {
 /// Node-local marker that this context's most recent migration attempt did not
 /// complete (the developer's migration-check aborted it, or the migrate apply
 /// errored). Read by the migration heartbeat so the member surfaces as `failed`
-/// rather than a silent `in_progress`. Lives in the node-local `ContextLocal`
-/// column — not synchronized; absence means "no failure on record".
+/// rather than a silent `in_progress`. Lives in its own node-local
+/// `ContextMigrationFailed` column (a `context_id`-only key would collide with
+/// `ContextAuthoredRemaining` in `ContextLocal`) — not synchronized; absence
+/// means "no failure on record".
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextMigrationFailed(Key<ContextId>);
@@ -138,7 +140,9 @@ impl AsKeyParts for ContextMigrationFailed {
     type Components = (ContextId,);
 
     fn column() -> Column {
-        Column::ContextLocal
+        // Own column — NOT `ContextLocal` — so this context_id-only key cannot
+        // collide with the same-shaped `ContextAuthoredRemaining` key there.
+        Column::ContextMigrationFailed
     }
 
     fn as_key(&self) -> &Key<Self::Components> {

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -12,7 +12,7 @@ pub use application::{ApplicationMeta, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
     ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker,
-    ContextMeta, ContextPrivateState, ContextState,
+    ContextMeta, ContextMigrationFailed, ContextPrivateState, ContextState,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -265,3 +265,41 @@ mod context_authored_remaining_tests {
         assert_eq!(back.count, 5);
     }
 }
+
+#[cfg(test)]
+mod context_local_key_isolation_tests {
+    use std::sync::Arc;
+
+    use calimero_primitives::context::ContextId;
+
+    use crate::db::InMemoryDB;
+    use crate::key;
+    use crate::types::{ContextAuthoredRemaining, ContextMigrationFailed};
+    use crate::Store;
+
+    // ContextMigrationFailed lives in its own column, so its context_id-only key
+    // must not share a KV row with the same-shaped ContextAuthoredRemaining key.
+    // (Sharing ContextLocal collided: a failure write clobbered the count, and a
+    // count of 1 misdecoded as `check_aborted`.) Writing/clearing one must leave
+    // the other untouched.
+    #[test]
+    fn migration_failed_does_not_collide_with_authored_remaining() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let ctx = ContextId::from([7u8; 32]);
+        let ar = key::ContextAuthoredRemaining::new(ctx);
+        let mf = key::ContextMigrationFailed::new(ctx);
+
+        let mut h = store.handle();
+        h.put(&ar, &ContextAuthoredRemaining { count: 5 }).unwrap();
+        h.put(&mf, &ContextMigrationFailed { kind: 2 }).unwrap();
+
+        // Independent rows — neither write clobbered the other.
+        assert_eq!(h.get(&ar).unwrap().unwrap().count, 5);
+        assert_eq!(h.get(&mf).unwrap().unwrap().kind, 2);
+
+        // Clearing the failure marker must NOT delete the authored-remaining row.
+        h.delete(&mf).unwrap();
+        assert_eq!(h.get(&ar).unwrap().unwrap().count, 5);
+        assert!(h.get(&mf).unwrap().is_none());
+    }
+}

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -61,6 +61,25 @@ impl PredefinedEntry for key::ContextAuthoredRemaining {
     type DataType<'a> = ContextAuthoredRemaining;
 }
 
+/// Value for [`key::ContextMigrationFailed`]: the categorized reason this
+/// context's last migration attempt did not complete, as a stable discriminant
+/// (`1` = migration-check aborted, `2` = migrate apply errored). Node-local +
+/// advisory; the key's presence is the signal, the byte carries the reason. A
+/// brand-new key, so a missing row reads as `None` (no failure on record).
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "single advisory discriminant; additions would need a migration"
+)]
+pub struct ContextMigrationFailed {
+    pub kind: u8,
+}
+
+impl PredefinedEntry for key::ContextMigrationFailed {
+    type Codec = Borsh;
+    type DataType<'a> = ContextMigrationFailed;
+}
+
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ContextConfig {


### PR DESCRIPTION
## What

A namespace member whose migrate **aborts** (the developer's `#[app::migrate]` migration-check returned a failure) or whose migrate **apply errors** previously looked identical, on the migration-status rollup, to a member that simply had not migrated yet — a silent `in_progress`. There was no way for an operator to tell "this node tried and it failed" apart from "this node hasn't gotten to it yet".

This threads a categorized **failed** state end-to-end so the rollup distinguishes the two.

## How

- **store** — a new node-local `ContextMigrationFailed` key (in the `ContextLocal` column, mirroring `ContextAuthoredRemaining`). Its value is a single discriminant byte: `1` = migration-check aborted, `2` = apply errored. Presence is the signal; absence means no failure on record.
- **context handler** — at the commit/abort gate, persist `CheckAborted` on the logical-abort path and `ApplyFailed` when the migrate apply itself errors. A committing migrate clears the marker.
- **node** — `compute_namespace_migration_facts` reads the per-context marker and folds the most-severe reason into the heartbeat facts, but **only while the context is still below target**. A context that later converges via any path (retry, lazy-on-access, cascade) stops reporting failed — the state is self-healing, so a recovered member can never produce a false `failed`. Threaded through `CacheEntry` / `MigrationFacts` / the signed heartbeat, with an on-change edge-trigger so a failure propagates immediately rather than waiting a full periodic interval.
- **wire** — `migration_failed` is a trailing `u8` after `authored_remaining`, read EOF-tolerantly so a heartbeat from a node that predates the field still deserializes (absent ⇒ `0`) and verifies against the unchanged signed body. Like `authored_remaining` it is deliberately **outside the signature**: advisory telemetry, not a gate (a forged value can only make the publisher's own status look failed; completion is covered by the signed residue fields).
- **server** — the admin `get_migration_status` rollup gains a `failed` counter and each member report carries an optional `migrationFailed` reason (`"check_aborted"` / `"apply_failed"`). The derived member `state` adds `"failed"`, which takes precedence over migrated/in-progress and keeps `allMigrated` false.

## Tests

- wire: round-trip + EOF-tolerance for the new trailing byte, including the mixed-fleet case where a node carries `authored_remaining` but omits `migration_failed` (reads `0`); tamper-tolerance (advisory ⇒ verification unaffected).
- node: failure marker honored while below target and **ignored once the context reaches target** (self-heal); on-change emit fires when the failure appears.
- context: the abort gate persists a `CheckAborted` marker; a committing migrate clears it.
- rollup: a failed member surfaces as `failed`, not a silent `in_progress`, and keeps `allMigrated` false.

Part of #2539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches migration commit/abort paths and new store column, but changes are advisory telemetry and node-local markers that do not gate replication or migration correctness.
> 
> **Overview**
> Members whose migrate **aborted** or **apply failed** no longer show up as silent `in_progress` on the migration-status rollup. The change adds an explicit **`failed`** path from local persistence through gossip heartbeats to the admin API.
> 
> **Persistence:** A dedicated node-local `ContextMigrationFailed` store column records `check_aborted` vs `apply_failed` when the migration gate aborts or `execute_migration` errors; a successful commit clears the marker.
> 
> **Telemetry:** `compute_migration_status_rollup` treats `migration_failed` on heartbeats as **`MemberMigrationState::Failed`**, increments a `failed` rollup counter, and keeps `allMigrated` false. Heartbeats gain an unsigned trailing `migration_failed` byte (EOF-tolerant for older peers); on-change emit fires when failure appears. Namespace facts only honor markers while the context is still below target.
> 
> **API:** `get_migration_status` exposes `rollup.failed`, per-member `state: "failed"`, and optional `migrationFailed` reason strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ffe3fa01b9f4788a87abba7b62f5edc3d6ab9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->