### PR TITLE
fix: propagate bundle-app upgrades to peer nodes (same-ApplicationId migrations)

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -108,7 +108,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-migration-wasm-fixtures
-          path: apps/migrations/**/res/*.wasm
+          # The workflows install the signed same-package .mpk bundles; the
+          # raw wasms ride along for the schema-guard job and local rebuilds.
+          path: |
+            apps/migrations/**/res/*.wasm
+            apps/migrations/**/res/*.mpk
           retention-days: 1
           if-no-files-found: error
 

--- a/apps/migrations/bundle-wasm.sh
+++ b/apps/migrations/bundle-wasm.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Wrap one migration-fixture wasm into a signed single-service `.mpk` bundle.
+#
+#   bundle-wasm.sh <suite-dir> <wasm-file> <package> <app-version>
+#
+# v1/v2 of a scenario pair MUST share <package>: a bundle's ApplicationId is
+# hash(package, signer), so the same package yields the SAME id across
+# versions — the realistic shape for app upgrades (the version delta lives in
+# the bytecode blob). Output: <suite-dir>/res/<package-leaf>-<app-version>.mpk
+set -euo pipefail
+
+SUITE_DIR="$1"
+WASM_FILE="$2"
+PACKAGE="$3"
+APP_VERSION="$4"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$SUITE_DIR"
+
+if [ ! -f "res/$WASM_FILE" ]; then
+    echo "ERROR: res/$WASM_FILE not found (build the suite first)" >&2
+    exit 1
+fi
+
+mkdir -p res/bundle-temp
+rm -f res/bundle-temp/*
+
+cp "res/$WASM_FILE" res/bundle-temp/app.wasm
+if [ -f res/abi.json ]; then
+    cp res/abi.json res/bundle-temp/abi.json
+fi
+
+size() { stat -f%z "$1" 2>/dev/null || stat -c%s "$1"; }
+WASM_SIZE=$(size res/bundle-temp/app.wasm)
+ABI_SIZE=$( [ -f res/bundle-temp/abi.json ] && size res/bundle-temp/abi.json || echo 0)
+
+cat > res/bundle-temp/manifest.json <<EOF
+{
+  "version": "1.0",
+  "package": "${PACKAGE}",
+  "appVersion": "${APP_VERSION}",
+  "minRuntimeVersion": "0.1.0",
+  "wasm": {
+    "path": "app.wasm",
+    "size": ${WASM_SIZE},
+    "hash": null
+  },
+  "abi": {
+    "path": "abi.json",
+    "size": ${ABI_SIZE},
+    "hash": null
+  },
+  "migrations": []
+}
+EOF
+
+cargo run --manifest-path "$REPO_ROOT/Cargo.toml" -p mero-sign --quiet -- \
+    sign res/bundle-temp/manifest.json \
+    --key "$REPO_ROOT/scripts/test-signing-key/test-key.json"
+
+LEAF="${PACKAGE##*.}"
+OUT="${LEAF}-${APP_VERSION}.mpk"
+
+cd res/bundle-temp
+tar -czf "../$OUT" manifest.json app.wasm abi.json 2>/dev/null ||
+    tar -czf "../$OUT" manifest.json app.wasm
+cd ..
+rm -rf bundle-temp
+
+echo "Bundle created: $SUITE_DIR/res/$OUT"

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -457,7 +457,9 @@ impl Handler<ExecuteRequest> for ContextManager {
         // directly without routing through the actor mailbox (which would deadlock while an
         // ActorFuture is in flight on the same actor).
         let lazy_upgrade_task = guard_task.map(move |guard, act, _ctx| {
-            if let Some((target_app_id, migrate_method, group_id)) = lazy_upgrade_params {
+            if let Some((target_app_id, migrate_method, group_id, target_app_key)) =
+                lazy_upgrade_params
+            {
                 info!(
                     %context_id,
                     %target_app_id,
@@ -480,6 +482,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                     application,
                     migrate_method,
                     group_id,
+                    target_app_key,
                 )));
             }
             Ok(Either::Left(guard))
@@ -499,11 +502,38 @@ impl Handler<ExecuteRequest> for ContextManager {
                     application,
                     migrate,
                     group_id,
+                    target_app_key,
                 )) => {
                     if let Some(method) = migrate {
                         let migration_params = MigrationParams { method: method.clone() };
                         let service_name = context_meta.as_ref().and_then(|c| c.service_name.clone());
-                        act.get_module(target_app, service_name)
+                        // Bundle apps keep a version-stable ApplicationId, so the
+                        // bytecode installed under `target_app` can still be the OLD
+                        // version. Fetch + install the group's target blob first;
+                        // otherwise get_module would compile v1 and the migrate
+                        // would no-op/fail.
+                        let blob_node_client = node_client.clone();
+                        async move {
+                            ensure_target_blob_installed(
+                                &blob_node_client,
+                                &cid,
+                                &target_app,
+                                target_app_key,
+                            )
+                            .await
+                        }
+                        .into_actor(act)
+                        .then(move |freshly_installed, act, _ctx| {
+                            if freshly_installed {
+                                // In-place install under the same id: evict the
+                                // (application_id, service)-keyed caches so
+                                // get_module compiles the new bytecode instead of
+                                // serving stale entries.
+                                let _ = act.applications.remove(&target_app);
+                                act.modules.retain(|(id, _), _| *id != target_app);
+                            }
+                            act.get_module(target_app, service_name)
+                        })
                             .then(move |module_result, act, _ctx| {
                                 // Re-read cached values; they may have been refreshed during load
                                 let context_meta =
@@ -1290,6 +1320,96 @@ impl ContextManager {
 enum CachedOrBlob {
     Cached(calimero_runtime::Module),
     Blob(calimero_primitives::application::ApplicationBlob),
+}
+
+/// Ensure the bytecode installed under `target_app` is the group's target
+/// blob (`target_app_key`) before the lazy migrate loads its module.
+///
+/// Bundle apps derive `ApplicationId = hash(package, signer)`, so a version
+/// bump leaves the id unchanged and only moves the blob — without this step
+/// the migrate would compile the OLD bytecode (which lacks the migrate
+/// export) and no-op. Fetches the blob via DHT/peer download (it is
+/// announced at upgrade time) and installs it in place under the same id.
+///
+/// Returns `true` when a fresh install happened (the caller must evict the
+/// module/application caches keyed by `target_app`). All failures warn and
+/// return `false` — the migrate then proceeds against the current bytecode
+/// exactly as before this fix, and the next access retries.
+async fn ensure_target_blob_installed(
+    node_client: &NodeClient,
+    context_id: &ContextId,
+    target_app: &calimero_primitives::application::ApplicationId,
+    target_app_key: [u8; 32],
+) -> bool {
+    if target_app_key == [0u8; 32] {
+        return false;
+    }
+    let installed = match node_client.get_application(target_app) {
+        Ok(Some(app)) => app,
+        // Not installed under this id at all: the distinct-id machinery
+        // (stub row + blob share) owns that case.
+        Ok(None) => return false,
+        Err(err) => {
+            warn!(%context_id, %target_app, %err, "lazy upgrade: failed to read installed application");
+            return false;
+        }
+    };
+    let target_blob = calimero_primitives::blobs::BlobId::from(target_app_key);
+    if installed.blob.bytecode == target_blob {
+        return false;
+    }
+    info!(
+        %context_id,
+        %target_app,
+        %target_blob,
+        installed_blob = %installed.blob.bytecode,
+        "lazy upgrade: fetching target bytecode (version-stable application id)"
+    );
+    let bytes = match node_client
+        .get_blob_bytes(&target_blob, Some(context_id))
+        .await
+    {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => {
+            warn!(%context_id, %target_blob, "lazy upgrade: target blob not available locally or from peers");
+            return false;
+        }
+        Err(err) => {
+            warn!(%context_id, %target_blob, %err, "lazy upgrade: target blob fetch failed");
+            return false;
+        }
+    };
+    if !NodeClient::is_bundle_blob(&bytes) {
+        // Same-id blob swaps only occur for bundles (raw-wasm ids are
+        // content-addressed, so their upgrades change the id); anything else
+        // here is unexpected — leave it to the sync machinery.
+        warn!(%context_id, %target_blob, "lazy upgrade: target blob is not a bundle; skipping in-place install");
+        return false;
+    }
+    match node_client
+        .install_application_from_bundle_blob(&target_blob, &installed.source)
+        .await
+    {
+        Ok(installed_id) if installed_id == *target_app => {
+            info!(%context_id, %target_app, %target_blob, "lazy upgrade: installed target bundle in place");
+            true
+        }
+        Ok(installed_id) => {
+            // The bundle resolves to a different id (package/signer changed)
+            // — not the in-place case; the id-keyed path owns it.
+            warn!(
+                %context_id,
+                %target_app,
+                %installed_id,
+                "lazy upgrade: fetched bundle installed under a different application id"
+            );
+            false
+        }
+        Err(err) => {
+            warn!(%context_id, %target_blob, %err, "lazy upgrade: in-place bundle install failed");
+            false
+        }
+    }
 }
 
 async fn internal_execute(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -60,8 +60,8 @@ use governance_position::compute_governance_position_for_context;
 pub(crate) use signing::{persist_signed_signatures, sign_authorized_actions};
 use storage::{ContextPrivateStorage, ContextStorage, ReadOnlyContextStorage};
 use upgrade_gate::{
-    maybe_lazy_upgrade, resolve_producing_app_key, should_block, upgrade_blocks_write,
-    upgrade_rejects_committed_write,
+    activation_marker, maybe_lazy_upgrade, resolve_producing_app_key, should_block,
+    upgrade_blocks_write, upgrade_rejects_committed_write,
 };
 
 impl Handler<ExecuteRequest> for ContextManager {
@@ -599,11 +599,12 @@ impl Handler<ExecuteRequest> for ContextManager {
                     } else {
                         // No migration. A same-id (bundle) code-only bump must
                         // first activate the staged bytecode: install it in
-                        // place under the unchanged id and drop stale caches.
-                        // Local-only — if the blob hasn't been staged yet (the
-                        // sync layer delivers it), skip silently and let the
-                        // next access retry; a spurious trigger from a legacy
-                        // group's random app_key therefore costs nothing.
+                        // place under the unchanged id (if the blob has been
+                        // staged — the sync layer delivers it; otherwise the
+                        // next access retries) and drop stale caches. The
+                        // eviction is unconditional: an in-place install may
+                        // have flipped the row BEFORE this upgrade, leaving
+                        // the caches on the old build with nothing to fetch.
                         let blob_node_client = node_client.clone();
                         async move {
                             let staged = blob_node_client
@@ -612,25 +613,43 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 ))
                                 .unwrap_or(false);
                             if staged {
-                                ensure_target_blob_installed(
+                                let _ = ensure_target_blob_installed(
                                     &blob_node_client,
                                     &cid,
                                     &target_app,
                                     target_app_key,
                                 )
-                                .await
+                                .await;
+                                true
                             } else {
                                 false
                             }
                         }
                         .into_actor(act)
-                        .then(move |freshly_installed, act, _ctx| {
-                            if freshly_installed {
+                        .then(move |blob_available, act, _ctx| {
+                            if blob_available {
+                                // Activate: the row now holds the target
+                                // bytecode — drop the stale caches so the next
+                                // load compiles it (an in-place install may
+                                // have flipped the row long before this
+                                // upgrade), release any executing-blob pin,
+                                // and record the per-context marker that stops
+                                // the lazy trigger from re-firing. A missing
+                                // blob (not yet staged, or a legacy random
+                                // app_key that never resolves) changes
+                                // nothing — caches stay warm.
                                 let _ = act.applications.remove(&target_app);
                                 act.modules.retain(|(id, _), _| *id != target_app);
-                                // Activation is the code-only promote: any
-                                // executing-blob pin is now satisfied.
                                 clear_executing_blob_pin(&act.datastore, cid);
+                                if let Err(err) = MigrationsRepository::new(&act.datastore)
+                                    .set_last_migration(
+                                        &group_id,
+                                        &cid,
+                                        &activation_marker(&target_app_key),
+                                    )
+                                {
+                                    warn!(%cid, %err, "failed to record activation marker");
+                                }
                             }
                             async move {
                                 if let Err(err) = update_application_id(

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -531,8 +531,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                             // admin install. Evict unconditionally: a lazy
                             // migration runs once per context, so one recompile
                             // is irrelevant.
-                            let _ = act.applications.remove(&target_app);
-                            act.modules.retain(|(id, _), _| *id != target_app);
+                            act.evict_application_caches(target_app);
                             act.get_module(target_app, service_name)
                         })
                             .then(move |module_result, act, _ctx| {
@@ -638,8 +637,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 // blob (not yet staged, or a legacy random
                                 // app_key that never resolves) changes
                                 // nothing — caches stay warm.
-                                let _ = act.applications.remove(&target_app);
-                                act.modules.retain(|(id, _), _| *id != target_app);
+                                act.evict_application_caches(target_app);
                                 clear_executing_blob_pin(&act.datastore, cid);
                                 if let Err(err) = MigrationsRepository::new(&act.datastore)
                                     .set_last_migration(
@@ -697,6 +695,10 @@ impl Handler<ExecuteRequest> for ContextManager {
             // the OLD schema while the (version-stable bundle id) application
             // row may already hold the NEW bytecode — honor the executing-blob
             // pin so reads keep running the code the state was written under.
+            // Per-execution cost: one point-get on a dedicated, near-empty
+            // column family (pins exist only between an abort and the next
+            // successful migrate) — bloom-filtered to a memtable miss, noise
+            // next to the wasm call it precedes.
             let pinned = act
                 .datastore
                 .handle()
@@ -1392,6 +1394,10 @@ impl ContextManager {
     /// pinned blob: pins are rare (they only exist after a migration abort),
     /// blob ids and application ids are both opaque 32-byte hashes, and a
     /// collision would only alias two cache slots, never corrupt execution.
+    /// `update_application`'s per-id eviction never targets pseudo keys; that
+    /// is fine — the entry is content-addressed (same blob ⇒ same module, so
+    /// reuse is always correct) and `modules` is a BoundedCache, which
+    /// reclaims the slot under capacity pressure.
     pub fn get_pinned_module(
         &self,
         pinned_blob: [u8; 32],

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -46,7 +46,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::ContextError;
 use crate::handlers::update_application::{
-    update_application_id, update_application_with_migration,
+    clear_executing_blob_pin, update_application_id, update_application_with_migration,
 };
 use crate::ContextManager;
 use calimero_governance_store::metrics::ExecutionLabels;
@@ -597,30 +597,65 @@ impl Handler<ExecuteRequest> for ContextManager {
                             })
                             .boxed_local()
                     } else {
-                        // No migration: call update_application_id directly — no mailbox.
+                        // No migration. A same-id (bundle) code-only bump must
+                        // first activate the staged bytecode: install it in
+                        // place under the unchanged id and drop stale caches.
+                        // Local-only — if the blob hasn't been staged yet (the
+                        // sync layer delivers it), skip silently and let the
+                        // next access retry; a spurious trigger from a legacy
+                        // group's random app_key therefore costs nothing.
+                        let blob_node_client = node_client.clone();
                         async move {
-                            if let Err(err) = update_application_id(
-                                datastore,
-                                node_client,
-                                context_client,
-                                cid,
-                                context_meta,
-                                target_app,
-                                application,
-                                executor,
-                            )
-                            .await
-                            {
-                                warn!(
-                                    %cid,
-                                    %target_app,
-                                    %err,
-                                    "lazy upgrade failed, proceeding with current application"
-                                );
+                            let staged = blob_node_client
+                                .has_blob(&calimero_primitives::blobs::BlobId::from(
+                                    target_app_key,
+                                ))
+                                .unwrap_or(false);
+                            if staged {
+                                ensure_target_blob_installed(
+                                    &blob_node_client,
+                                    &cid,
+                                    &target_app,
+                                    target_app_key,
+                                )
+                                .await
+                            } else {
+                                false
                             }
-                            Ok(guard)
                         }
                         .into_actor(act)
+                        .then(move |freshly_installed, act, _ctx| {
+                            if freshly_installed {
+                                let _ = act.applications.remove(&target_app);
+                                act.modules.retain(|(id, _), _| *id != target_app);
+                                // Activation is the code-only promote: any
+                                // executing-blob pin is now satisfied.
+                                clear_executing_blob_pin(&act.datastore, cid);
+                            }
+                            async move {
+                                if let Err(err) = update_application_id(
+                                    datastore,
+                                    node_client,
+                                    context_client,
+                                    cid,
+                                    context_meta,
+                                    target_app,
+                                    application,
+                                    executor,
+                                )
+                                .await
+                                {
+                                    warn!(
+                                        %cid,
+                                        %target_app,
+                                        %err,
+                                        "lazy upgrade failed, proceeding with current application"
+                                    );
+                                }
+                                Ok(guard)
+                            }
+                            .into_actor(act)
+                        })
                         .boxed_local()
                     }
                 }
@@ -639,8 +674,25 @@ impl Handler<ExecuteRequest> for ContextManager {
             });
 
         let module_task = context_task.and_then(move |(guard, context), act, _ctx| {
-            act.get_module(context.application_id, context.service_name.clone())
-                .map_ok(move |module, _act, _ctx| (guard, context, module))
+            // A logically-aborted migration leaves this context's state on
+            // the OLD schema while the (version-stable bundle id) application
+            // row may already hold the NEW bytecode — honor the executing-blob
+            // pin so reads keep running the code the state was written under.
+            let pinned = act
+                .datastore
+                .handle()
+                .get(&calimero_store::key::ContextExecutingBlob::new(context.id))
+                .ok()
+                .flatten();
+            let module_fut = match pinned {
+                Some(pin) => act
+                    .get_pinned_module(pin.blob, context.service_name.clone())
+                    .boxed_local(),
+                None => act
+                    .get_module(context.application_id, context.service_name.clone())
+                    .boxed_local(),
+            };
+            module_fut.map_ok(move |module, _act, _ctx| (guard, context, module))
         });
 
         let execution_count = self.metrics.as_ref().map(|m| m.execution_count.clone());
@@ -1309,6 +1361,63 @@ impl ContextManager {
                 error!(?err, "failed to initialize module for execution");
 
                 err
+            })
+    }
+
+    /// Load the module for a context PINNED to a bytecode blob the
+    /// application row no longer references (post-abort, version-stable
+    /// bundle id overwritten in place). Compiles from the raw blob bytes —
+    /// the displaced version has no row to carry a precompiled artifact.
+    ///
+    /// Cached in `modules` under a pseudo application id derived from the
+    /// pinned blob: pins are rare (they only exist after a migration abort),
+    /// blob ids and application ids are both opaque 32-byte hashes, and a
+    /// collision would only alias two cache slots, never corrupt execution.
+    pub fn get_pinned_module(
+        &self,
+        pinned_blob: [u8; 32],
+        service_name: Option<String>,
+    ) -> impl ActorFuture<Self, Output = eyre::Result<calimero_runtime::Module>> + 'static {
+        let pseudo_id = calimero_primitives::application::ApplicationId::from(pinned_blob);
+        let cache_key = (pseudo_id, service_name.clone());
+        let lookup_key = cache_key.clone();
+
+        async {}
+            .into_actor(self)
+            .map(move |_, act, _ctx| {
+                if let Some(cached) = act.modules.get(&lookup_key) {
+                    return Either::Left(cached.clone());
+                }
+                Either::Right((act.node_client.clone(), act.vm_limits))
+            })
+            .then(move |either, act, _ctx| {
+                let (node_client, vm_limits) = match either {
+                    Either::Left(module) => {
+                        return actix::fut::ready(Ok(module)).into_actor(act).boxed_local()
+                    }
+                    Either::Right(parts) => parts,
+                };
+                let blob_id = calimero_primitives::blobs::BlobId::from(pinned_blob);
+                async move {
+                    let Some(bytecode) = node_client
+                        .application_bytes_from_blob(&blob_id, service_name.as_deref())
+                        .await?
+                    else {
+                        bail!("pinned bytecode blob {} not found in blobstore", blob_id);
+                    };
+                    calimero_utils_actix::global_runtime()
+                        .spawn_blocking(move || {
+                            calimero_runtime::Engine::with_limits(vm_limits).compile(&bytecode)
+                        })
+                        .await?
+                        .map_err(Into::into)
+                }
+                .into_actor(act)
+                .map_ok(move |module: calimero_runtime::Module, act, _ctx| {
+                    let _ = act.modules.insert(cache_key, module.clone());
+                    module
+                })
+                .boxed_local()
             })
     }
 }

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -523,7 +523,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                             .await
                         }
                         .into_actor(act)
-                        .then(move |_freshly_installed, act, _ctx| {
+                        .then(move |_row_holds_target, act, _ctx| {
                             // The target id is version-stable for bundles, so the
                             // (application_id, service)-keyed caches may hold the
                             // PREVIOUS version's module — whether the new bytecode
@@ -597,32 +597,23 @@ impl Handler<ExecuteRequest> for ContextManager {
                             .boxed_local()
                     } else {
                         // No migration. A same-id (bundle) code-only bump must
-                        // first activate the staged bytecode: install it in
-                        // place under the unchanged id (if the blob has been
-                        // staged — the sync layer delivers it; otherwise the
-                        // next access retries) and drop stale caches. The
-                        // eviction is unconditional: an in-place install may
-                        // have flipped the row BEFORE this upgrade, leaving
-                        // the caches on the old build with nothing to fetch.
+                        // first activate the target bytecode: fetch it if
+                        // needed (sync pre-stages it, but a peer can also
+                        // serve it on demand), install it in place under the
+                        // unchanged id, and drop stale caches. `true` only
+                        // when the row verifiably holds the target blob — a
+                        // failed fetch/install must NOT record the activation
+                        // marker, or the lazy trigger would stop retrying
+                        // while the node still runs the old build.
                         let blob_node_client = node_client.clone();
                         async move {
-                            let staged = blob_node_client
-                                .has_blob(&calimero_primitives::blobs::BlobId::from(
-                                    target_app_key,
-                                ))
-                                .unwrap_or(false);
-                            if staged {
-                                let _ = ensure_target_blob_installed(
-                                    &blob_node_client,
-                                    &cid,
-                                    &target_app,
-                                    target_app_key,
-                                )
-                                .await;
-                                true
-                            } else {
-                                false
-                            }
+                            ensure_target_blob_installed(
+                                &blob_node_client,
+                                &cid,
+                                &target_app,
+                                target_app_key,
+                            )
+                            .await
                         }
                         .into_actor(act)
                         .then(move |blob_available, act, _ctx| {
@@ -1466,10 +1457,12 @@ enum CachedOrBlob {
 /// export) and no-op. Fetches the blob via DHT/peer download (it is
 /// announced at upgrade time) and installs it in place under the same id.
 ///
-/// Returns `true` when a fresh install happened (the caller must evict the
-/// module/application caches keyed by `target_app`). All failures warn and
-/// return `false` — the migrate then proceeds against the current bytecode
-/// exactly as before this fix, and the next access retries.
+/// Returns `true` when the application row holds the target bytecode on
+/// return — either it already matched or a fresh in-place install succeeded
+/// (callers evict the `target_app`-keyed caches unconditionally; reuse of an
+/// already-current module is a cheap recompile at most). All failures warn
+/// and return `false` — the upgrade proceeds against the current bytecode
+/// and the next access retries.
 async fn ensure_target_blob_installed(
     node_client: &NodeClient,
     context_id: &ContextId,
@@ -1491,7 +1484,7 @@ async fn ensure_target_blob_installed(
     };
     let target_blob = calimero_primitives::blobs::BlobId::from(target_app_key);
     if installed.blob.bytecode == target_blob {
-        return false;
+        return true;
     }
     info!(
         %context_id,

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -523,15 +523,16 @@ impl Handler<ExecuteRequest> for ContextManager {
                             .await
                         }
                         .into_actor(act)
-                        .then(move |freshly_installed, act, _ctx| {
-                            if freshly_installed {
-                                // In-place install under the same id: evict the
-                                // (application_id, service)-keyed caches so
-                                // get_module compiles the new bytecode instead of
-                                // serving stale entries.
-                                let _ = act.applications.remove(&target_app);
-                                act.modules.retain(|(id, _), _| *id != target_app);
-                            }
+                        .then(move |_freshly_installed, act, _ctx| {
+                            // The target id is version-stable for bundles, so the
+                            // (application_id, service)-keyed caches may hold the
+                            // PREVIOUS version's module — whether the new bytecode
+                            // arrived via the fetch above or an earlier in-place
+                            // admin install. Evict unconditionally: a lazy
+                            // migration runs once per context, so one recompile
+                            // is irrelevant.
+                            let _ = act.applications.remove(&target_app);
+                            act.modules.retain(|(id, _), _| *id != target_app);
                             act.get_module(target_app, service_name)
                         })
                             .then(move |module_result, act, _ctx| {

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -200,11 +200,5 @@ pub(super) fn resolve_producing_app_key(
 /// migration-marker repository under a synthetic method name; the `blob:`
 /// prefix cannot collide with a real `#[app::migrate]` method.
 pub(super) fn activation_marker(app_key: &[u8; 32]) -> String {
-    use core::fmt::Write as _;
-    let mut s = String::with_capacity(5 + 64);
-    s.push_str("blob:");
-    for byte in app_key {
-        let _ = write!(s, "{byte:02x}");
-    }
-    s
+    format!("blob:{}", hex::encode(app_key))
 }

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -109,24 +109,48 @@ pub(super) fn maybe_lazy_upgrade(
 
     // 5. Compare current vs target application
     if *current_application_id == meta.target_application_id {
-        // IDs match — only proceed if there is a pending migration that
-        // hasn't been applied to this context yet.
-        let Some(ref method) = migrate_method else {
-            return None; // no migration, context is already up to date
-        };
+        // IDs match — bundle ids are version-stable, so this is either a
+        // pending migration or a pending code-only bytecode bump.
+        match migrate_method {
+            Some(ref method) => {
+                // Check per-context marker set after a successful migration run.
+                let already_applied = MigrationsRepository::new(datastore)
+                    .last_migration(&group_id, context_id)
+                    .ok()
+                    .flatten()
+                    .map(|last| last == *method)
+                    .unwrap_or(false);
 
-        // Check per-context marker set after a successful migration run.
-        let already_applied = MigrationsRepository::new(datastore)
-            .last_migration(&group_id, context_id)
-            .ok()
-            .flatten()
-            .map(|last| last == *method)
-            .unwrap_or(false);
-
-        if already_applied {
-            return None; // migration was already applied to this context
+                if already_applied {
+                    return None; // migration was already applied to this context
+                }
+                // Fall through: migration is pending.
+            }
+            None => {
+                // Code-only: pending iff the group's recorded target blob
+                // (app_key, stamped by the upgrade) differs from the blob the
+                // application row is installed at. Comparing against the row
+                // keeps legacy groups safe: a randomly-seeded app_key with NO
+                // upgrade behind it fires here, but the activation step is
+                // local-only (it skips silently unless the blob is already in
+                // the blobstore), so the spurious trigger costs one store
+                // read per access and nothing else.
+                let row_blob = datastore
+                    .handle()
+                    .get(&calimero_store::key::ApplicationMeta::new(
+                        *current_application_id,
+                    ))
+                    .ok()
+                    .flatten()
+                    .map(|app| *app.bytecode.blob_id().as_ref());
+                let stale =
+                    meta.app_key != [0u8; 32] && row_blob.is_some_and(|blob| blob != meta.app_key);
+                if !stale {
+                    return None; // bytecode current — context is up to date
+                }
+                // Fall through: code-only bytecode bump is pending.
+            }
         }
-        // Fall through: migration is pending.
     }
 
     info!(

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -56,9 +56,14 @@ pub(super) fn upgrade_rejects_committed_write(block_writes: bool, produced_write
 /// Checks if a context belongs to a group with LazyOnAccess policy and
 /// needs an upgrade or migration.
 ///
-/// Returns `(target_application_id, migrate_method, group_id)` when an
-/// upgrade should be performed.  The `group_id` is included so the caller
-/// can record a per-context migration marker after a successful run.
+/// Returns `(target_application_id, migrate_method, group_id, target_app_key)`
+/// when an upgrade should be performed.  The `group_id` is included so the
+/// caller can record a per-context migration marker after a successful run.
+/// `target_app_key` is the group's blob-derived app key (the target bytecode
+/// blob id, stamped by the upgrade): bundle apps keep a version-stable
+/// `ApplicationId`, so the caller must compare this against the blob actually
+/// installed under `target_application_id` and fetch it first when they
+/// differ — otherwise the migrate would load the OLD bytecode.
 pub(super) fn maybe_lazy_upgrade(
     datastore: &Store,
     context_id: &ContextId,
@@ -67,6 +72,7 @@ pub(super) fn maybe_lazy_upgrade(
     ApplicationId,
     Option<String>,
     calimero_context_config::types::ContextGroupId,
+    [u8; 32],
 )> {
     use calimero_governance_store;
 
@@ -131,7 +137,12 @@ pub(super) fn maybe_lazy_upgrade(
         "lazy upgrade triggered for context"
     );
 
-    Some((meta.target_application_id, migrate_method, group_id))
+    Some((
+        meta.target_application_id,
+        migrate_method,
+        group_id,
+        meta.app_key,
+    ))
 }
 
 /// The blob-derived app key the sender is executing under — `GroupMeta.app_key`

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -127,28 +127,29 @@ pub(super) fn maybe_lazy_upgrade(
                 // Fall through: migration is pending.
             }
             None => {
-                // Code-only: pending iff the group's recorded target blob
-                // (app_key, stamped by the upgrade) differs from the blob the
-                // application row is installed at. Comparing against the row
-                // keeps legacy groups safe: a randomly-seeded app_key with NO
-                // upgrade behind it fires here, but the activation step is
-                // local-only (it skips silently unless the blob is already in
-                // the blobstore), so the spurious trigger costs one store
-                // read per access and nothing else.
-                let row_blob = datastore
-                    .handle()
-                    .get(&calimero_store::key::ApplicationMeta::new(
-                        *current_application_id,
-                    ))
+                // Code-only: pending until this context has ACTIVATED the
+                // group's recorded target blob (app_key). The row alone can't
+                // signal this — an in-place install flips the row before the
+                // upgrade, leaving the actor's module cache on the old build —
+                // so activation is tracked per context, as a synthetic marker
+                // in the migration-marker store (real migrate methods never
+                // collide with the "blob:" prefix). Legacy groups whose
+                // app_key was randomly seeded converge after one activation
+                // pass (the marker then matches and this stops firing).
+                if meta.app_key == [0u8; 32] {
+                    return None;
+                }
+                let marker = activation_marker(&meta.app_key);
+                let activated = MigrationsRepository::new(datastore)
+                    .last_migration(&group_id, context_id)
                     .ok()
                     .flatten()
-                    .map(|app| *app.bytecode.blob_id().as_ref());
-                let stale =
-                    meta.app_key != [0u8; 32] && row_blob.is_some_and(|blob| blob != meta.app_key);
-                if !stale {
+                    .map(|last| last == marker)
+                    .unwrap_or(false);
+                if activated {
                     return None; // bytecode current — context is up to date
                 }
-                // Fall through: code-only bytecode bump is pending.
+                // Fall through: code-only bytecode activation is pending.
             }
         }
     }
@@ -192,4 +193,18 @@ pub(super) fn resolve_producing_app_key(
     Ok(MetaRepository::new(datastore)
         .load(&gid)?
         .map(|m| m.app_key))
+}
+
+/// Per-context marker recording that the group's target bytecode (`app_key`)
+/// has been activated (caches evicted, row verified). Stored via the
+/// migration-marker repository under a synthetic method name; the `blob:`
+/// prefix cannot collide with a real `#[app::migrate]` method.
+pub(super) fn activation_marker(app_key: &[u8; 32]) -> String {
+    use core::fmt::Write as _;
+    let mut s = String::with_capacity(5 + 64);
+    s.push_str("blob:");
+    for byte in app_key {
+        let _ = write!(s, "{byte:02x}");
+    }
+    s
 }

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -1120,6 +1120,14 @@ pub(crate) fn clear_migration_failed(datastore: &calimero_store::Store, context_
 /// so post-abort reads keep executing the code the context's state was written
 /// under. No-op when no in-place install happened (no breadcrumb) or the pin
 /// is already set (the oldest pin wins until a migrate commits). Best-effort.
+///
+/// Known residual: the breadcrumb is one slot per application, overwritten by
+/// each in-place install. A context whose state lags MORE than one version
+/// behind (two installs landed before it ever migrated) gets pinned to the
+/// intermediate blob, not its true original — exact pinning needs a
+/// per-context executed-blob record, which is the install-time activation
+/// follow-up. Single pending upgrade at a time (the normal fleet cadence) is
+/// always pinned correctly.
 pub(crate) fn pin_executing_blob_to_previous(
     datastore: &calimero_store::Store,
     context_id: ContextId,

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -734,6 +734,11 @@ fn commit_or_abort_migration(
         // Record the abort so the heartbeat surfaces this member as `failed`
         // (not a silent in-progress). Cleared if a later migrate commits.
         persist_migration_failed(datastore, context_id, MigrationFailureKind::CheckAborted);
+        // The state stays pre-migration, but a version-stable bundle id's row
+        // may already hold the NEW bytecode (in-place install) — pin this
+        // context to the displaced blob so reads keep executing the code its
+        // state was written under. Deleted when a later migrate commits.
+        pin_executing_blob_to_previous(datastore, context_id, context.application_id);
         return Err(MigrationCheckFailed { context_id }.into());
     }
 
@@ -766,6 +771,9 @@ fn commit_or_abort_migration(
     // The migrate committed: drop any prior failure marker so a context that
     // recovered (this attempt, or after an earlier abort) stops reporting failed.
     clear_migration_failed(datastore, context_id);
+    // And drop any executing-blob pin from an earlier abort — the state is now
+    // on the target schema, so the application row's bytecode is correct again.
+    clear_executing_blob_pin(datastore, context_id);
 
     Ok(new_root_hash)
 }
@@ -1105,6 +1113,58 @@ pub(crate) fn clear_migration_failed(datastore: &calimero_store::Store, context_
     let key = key::ContextMigrationFailed::new(context_id);
     if let Err(err) = handle.delete(&key) {
         debug!(%context_id, %err, "failed to clear migration_failed marker");
+    }
+}
+
+/// Pin `context_id` to the bytecode an in-place (same-id) install displaced,
+/// so post-abort reads keep executing the code the context's state was written
+/// under. No-op when no in-place install happened (no breadcrumb) or the pin
+/// is already set (the oldest pin wins until a migrate commits). Best-effort.
+pub(crate) fn pin_executing_blob_to_previous(
+    datastore: &calimero_store::Store,
+    context_id: ContextId,
+    application_id: calimero_primitives::application::ApplicationId,
+) {
+    let mut handle = datastore.handle();
+    let pin_key = key::ContextExecutingBlob::new(context_id);
+    match handle.get(&pin_key) {
+        Ok(Some(_)) => return, // earlier abort already pinned the right blob
+        Ok(None) => {}
+        Err(err) => {
+            debug!(%context_id, %err, "failed to read executing-blob pin");
+            return;
+        }
+    }
+    let previous = match handle.get(&key::ApplicationPreviousBlob::new(application_id)) {
+        Ok(Some(p)) => p,
+        Ok(None) => return, // row never overwritten in place — nothing to pin
+        Err(err) => {
+            debug!(%context_id, %err, "failed to read previous-blob breadcrumb");
+            return;
+        }
+    };
+    if let Err(err) = handle.put(
+        &pin_key,
+        &types::ContextExecutingBlob {
+            blob: previous.bytecode,
+        },
+    ) {
+        debug!(%context_id, %err, "failed to pin executing blob");
+    } else {
+        info!(
+            %context_id,
+            %application_id,
+            "pinned context to pre-upgrade bytecode after migration abort"
+        );
+    }
+}
+
+/// Drop the executing-blob pin once a migrate commits — the context's state is
+/// on the target schema, so the application row's bytecode is correct again.
+pub(crate) fn clear_executing_blob_pin(datastore: &calimero_store::Store, context_id: ContextId) {
+    let mut handle = datastore.handle();
+    if let Err(err) = handle.delete(&key::ContextExecutingBlob::new(context_id)) {
+        debug!(%context_id, %err, "failed to clear executing-blob pin");
     }
 }
 

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -99,6 +99,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
             from_version,
             to_version,
             current_application_id,
+            current_app_key,
         } = preamble;
 
         let now = SystemTime::now()
@@ -158,9 +159,8 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     if has_migration {
                         let old = resolve_pre_upgrade_schema(
                             &node_client,
-                            &datastore,
+                            current_app_key,
                             &current_application_id,
-                            &target_application_id,
                         )
                         .await;
                         let new =
@@ -190,20 +190,24 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         )
                         .await?;
                         report.observe("upgrade_group", "TargetApplicationSet");
-                        if migration_bytes.is_some() {
-                            let report = calimero_governance_store::sign_apply_and_publish(
-                                &datastore,
-                                &node_client,
-                                &ack_router_for_lazy,
-                                &group_id,
-                                &sk,
-                                GroupOp::GroupMigrationSet {
-                                    migration: migration_bytes.clone(),
-                                },
-                            )
-                            .await?;
-                            report.observe("upgrade_group", "GroupMigrationSet");
-                        }
+                        // Unconditional: a code-only upgrade (migration None)
+                        // must CLEAR any method left by an earlier migration
+                        // upgrade — a stale Some(method) makes the same-id
+                        // lazy trigger take the migration arm and short-circuit
+                        // on its applied marker, so the new bytecode would
+                        // never activate.
+                        let report = calimero_governance_store::sign_apply_and_publish(
+                            &datastore,
+                            &node_client,
+                            &ack_router_for_lazy,
+                            &group_id,
+                            &sk,
+                            GroupOp::GroupMigrationSet {
+                                migration: migration_bytes.clone(),
+                            },
+                        )
+                        .await?;
+                        report.observe("upgrade_group", "GroupMigrationSet");
                     }
 
                     let mut meta = MetaRepository::new(&datastore)
@@ -294,7 +298,6 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
         let context_client = self.context_client.clone();
         let datastore_for_canary = self.datastore.clone();
         let datastore = self.datastore.clone();
-        let datastore_for_gate = self.datastore.clone();
         let migrate_method = migration.as_ref().map(|m| m.method.clone());
 
         let canary_signer = match calimero_governance_store::find_local_signing_identity(
@@ -323,9 +326,8 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
             if has_migration {
                 let old = resolve_pre_upgrade_schema(
                     &node_client,
-                    &datastore_for_gate,
+                    current_app_key,
                     &current_application_id,
-                    &target_application_id,
                 )
                 .await;
                 let new = resolve_embedded_schema(&node_client, &target_application_id).await;
@@ -352,20 +354,21 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                 )
                 .await?;
                 report.observe("upgrade_group", "TargetApplicationSet");
-                if migration_bytes.is_some() {
-                    let report = calimero_governance_store::sign_apply_and_publish(
-                        &datastore_for_canary,
-                        &node_client,
-                        &ack_router_for_canary,
-                        &group_id,
-                        &sk,
-                        GroupOp::GroupMigrationSet {
-                            migration: migration_bytes.clone(),
-                        },
-                    )
-                    .await?;
-                    report.observe("upgrade_group", "GroupMigrationSet");
-                }
+                // Unconditional — see the LazyOnAccess site: clearing a stale
+                // method on code-only upgrades keeps the same-id lazy trigger
+                // out of the migration arm.
+                let report = calimero_governance_store::sign_apply_and_publish(
+                    &datastore_for_canary,
+                    &node_client,
+                    &ack_router_for_canary,
+                    &group_id,
+                    &sk,
+                    GroupOp::GroupMigrationSet {
+                        migration: migration_bytes.clone(),
+                    },
+                )
+                .await?;
+                report.observe("upgrade_group", "GroupMigrationSet");
             }
 
             context_client
@@ -546,37 +549,28 @@ fn verify_no_identity_downgrade(
 
 /// Read a context application's embedded state schema, or None if unavailable
 /// (no blob, no embedded section, or a read error — all fail-open).
-/// "From" side of the L1 gate for a same-id upgrade. An in-place (same-id)
-/// bundle install leaves the application row already on the NEW wasm —
-/// comparing row-to-row would diff a manifest against itself and wave a
-/// downgrade through. Prefer the displaced bytecode's breadcrumb; fall back
-/// to the row when none exists (distinct-id upgrades, or no in-place install
-/// ever happened).
+/// "From" side of the L1 gate. An in-place (same-id) bundle install leaves
+/// the application row already on the NEW wasm — comparing row-to-row would
+/// diff a manifest against itself and wave a downgrade through. The group's
+/// `app_key` is the bytecode the group actually runs before this upgrade
+/// (stamped by the previous upgrade / group creation), so read the "from"
+/// ABI from that blob; fall back to the row when the blob is unreadable
+/// (legacy randomly-seeded app_key → fail-open, same as before).
 async fn resolve_pre_upgrade_schema(
     node_client: &calimero_node_primitives::client::NodeClient,
-    datastore: &calimero_store::Store,
+    current_app_key: [u8; 32],
     current_application_id: &ApplicationId,
-    target_application_id: &ApplicationId,
 ) -> Option<Manifest> {
-    if current_application_id == target_application_id {
-        let previous = datastore
-            .handle()
-            .get(&key::ApplicationPreviousBlob::new(*current_application_id))
-            .ok()
-            .flatten();
-        if let Some(previous) = previous {
-            let blob = calimero_primitives::blobs::BlobId::from(previous.bytecode);
-            match node_client.application_bytes_from_blob(&blob, None).await {
-                Ok(Some(bytes)) => {
-                    return calimero_wasm_abi::embed::read_embedded_state_schema(&bytes)
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    tracing::warn!(
-                        %current_application_id, error = %err,
-                        "L1 gate: failed to read displaced bytecode; falling back to the row"
-                    );
-                }
+    if current_app_key != [0u8; 32] {
+        let blob = calimero_primitives::blobs::BlobId::from(current_app_key);
+        match node_client.application_bytes_from_blob(&blob, None).await {
+            Ok(Some(bytes)) => return calimero_wasm_abi::embed::read_embedded_state_schema(&bytes),
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(
+                    %current_application_id, error = %err,
+                    "L1 gate: failed to read current app_key bytecode; falling back to the row"
+                );
             }
         }
     }
@@ -612,6 +606,11 @@ struct UpgradePreamble {
     /// The group's CURRENT target application id (before this upgrade), used by
     /// the L1 identity-downgrade gate as the "old" schema source.
     current_application_id: ApplicationId,
+    /// The group's CURRENT blob-derived app key (the bytecode the group runs
+    /// before this upgrade). For same-id (bundle) upgrades the application
+    /// row may already hold the NEW wasm, so the gate must read the "from"
+    /// ABI from this blob rather than the row.
+    current_app_key: [u8; 32],
 }
 
 fn validate_upgrade(
@@ -651,7 +650,10 @@ fn validate_upgrade(
     // 5. Target must differ from current. Same id no longer implies no-op:
     //    bundle ids are version-stable (hash(package, signer)), so a new
     //    version moves only the bytecode blob — compare the group's recorded
-    //    app_key against the target row's blob before rejecting.
+    //    app_key against the target row's blob before rejecting. The row read
+    //    races a concurrent in-place install (installs bypass this actor);
+    //    the worst case either way is a rejected retry or a no-op upgrade op,
+    //    never state corruption, so the window is accepted.
     if meta.target_application_id == *target_application_id && !has_migration {
         let target_blob = datastore
             .handle()
@@ -695,6 +697,7 @@ fn validate_upgrade(
         from_version,
         to_version,
         current_application_id: meta.target_application_id,
+        current_app_key: meta.app_key,
     })
 }
 
@@ -1191,6 +1194,7 @@ fn dispatch_cascade(
     // op rewrites every matched descendant from `from_app_key` to the new app,
     // so a single gate check on the signed group's app pair covers the family.
     let current_application_id = meta.target_application_id;
+    let current_app_key_for_gate = meta.app_key;
 
     // Stamp the cascade_hlc ONCE at the initiator so every receiver
     // applies the same fence boundary (Task 3 apply handler stores this
@@ -1204,9 +1208,8 @@ fn dispatch_cascade(
         if has_migration {
             let old = resolve_pre_upgrade_schema(
                 &node_client_for_publish,
-                &datastore_for_publish,
+                current_app_key_for_gate,
                 &current_application_id,
-                &target_application_id,
             )
             .await;
             let new =

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -156,8 +156,13 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     // is emitted so a forbidden downgrade never reaches the network.
                     // Fail-open when either app lacks an embedded ABI section.
                     if has_migration {
-                        let old =
-                            resolve_embedded_schema(&node_client, &current_application_id).await;
+                        let old = resolve_pre_upgrade_schema(
+                            &node_client,
+                            &datastore,
+                            &current_application_id,
+                            &target_application_id,
+                        )
+                        .await;
                         let new =
                             resolve_embedded_schema(&node_client, &target_application_id).await;
                         verify_no_identity_downgrade(old.as_ref(), new.as_ref())?;
@@ -289,6 +294,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
         let context_client = self.context_client.clone();
         let datastore_for_canary = self.datastore.clone();
         let datastore = self.datastore.clone();
+        let datastore_for_gate = self.datastore.clone();
         let migrate_method = migration.as_ref().map(|m| m.method.clone());
 
         let canary_signer = match calimero_governance_store::find_local_signing_identity(
@@ -315,7 +321,13 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
             // is emitted so a forbidden downgrade never reaches the network.
             // Fail-open when either app lacks an embedded ABI section.
             if has_migration {
-                let old = resolve_embedded_schema(&node_client, &current_application_id).await;
+                let old = resolve_pre_upgrade_schema(
+                    &node_client,
+                    &datastore_for_gate,
+                    &current_application_id,
+                    &target_application_id,
+                )
+                .await;
                 let new = resolve_embedded_schema(&node_client, &target_application_id).await;
                 verify_no_identity_downgrade(old.as_ref(), new.as_ref())?;
             }
@@ -534,6 +546,43 @@ fn verify_no_identity_downgrade(
 
 /// Read a context application's embedded state schema, or None if unavailable
 /// (no blob, no embedded section, or a read error — all fail-open).
+/// "From" side of the L1 gate for a same-id upgrade. An in-place (same-id)
+/// bundle install leaves the application row already on the NEW wasm —
+/// comparing row-to-row would diff a manifest against itself and wave a
+/// downgrade through. Prefer the displaced bytecode's breadcrumb; fall back
+/// to the row when none exists (distinct-id upgrades, or no in-place install
+/// ever happened).
+async fn resolve_pre_upgrade_schema(
+    node_client: &calimero_node_primitives::client::NodeClient,
+    datastore: &calimero_store::Store,
+    current_application_id: &ApplicationId,
+    target_application_id: &ApplicationId,
+) -> Option<Manifest> {
+    if current_application_id == target_application_id {
+        let previous = datastore
+            .handle()
+            .get(&key::ApplicationPreviousBlob::new(*current_application_id))
+            .ok()
+            .flatten();
+        if let Some(previous) = previous {
+            let blob = calimero_primitives::blobs::BlobId::from(previous.bytecode);
+            match node_client.application_bytes_from_blob(&blob, None).await {
+                Ok(Some(bytes)) => {
+                    return calimero_wasm_abi::embed::read_embedded_state_schema(&bytes)
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    tracing::warn!(
+                        %current_application_id, error = %err,
+                        "L1 gate: failed to read displaced bytecode; falling back to the row"
+                    );
+                }
+            }
+        }
+    }
+    resolve_embedded_schema(node_client, current_application_id).await
+}
+
 async fn resolve_embedded_schema(
     node_client: &calimero_node_primitives::client::NodeClient,
     application_id: &ApplicationId,
@@ -599,9 +648,19 @@ fn validate_upgrade(
         }
     }
 
-    // 5. Target must differ from current
+    // 5. Target must differ from current. Same id no longer implies no-op:
+    //    bundle ids are version-stable (hash(package, signer)), so a new
+    //    version moves only the bytecode blob — compare the group's recorded
+    //    app_key against the target row's blob before rejecting.
     if meta.target_application_id == *target_application_id && !has_migration {
-        bail!("group is already targeting this application and no migration was requested");
+        let target_blob = datastore
+            .handle()
+            .get(&key::ApplicationMeta::new(*target_application_id))?
+            .map(|app| *app.bytecode.blob_id().as_ref());
+        let bytecode_unchanged = target_blob.is_none_or(|blob| blob == meta.app_key);
+        if bytecode_unchanged {
+            bail!("group is already targeting this application and no migration was requested");
+        }
     }
 
     // 6. Group must have contexts
@@ -1143,8 +1202,13 @@ fn dispatch_cascade(
         // identity from a top-level state field. Runs BEFORE the CascadeUpgrade
         // op is emitted. Fail-open when either app lacks an embedded ABI section.
         if has_migration {
-            let old =
-                resolve_embedded_schema(&node_client_for_publish, &current_application_id).await;
+            let old = resolve_pre_upgrade_schema(
+                &node_client_for_publish,
+                &datastore_for_publish,
+                &current_application_id,
+                &target_application_id,
+            )
+            .await;
             let new =
                 resolve_embedded_schema(&node_client_for_publish, &target_application_id).await;
             verify_no_identity_downgrade(old.as_ref(), new.as_ref())?;

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -602,6 +602,22 @@ impl GovernancePreflight {
 }
 
 impl ContextManager {
+    /// Evict every per-application actor cache for `application_id`:
+    /// the application record, compiled modules (all services), and
+    /// read-only method sets. Required whenever the bytecode under an
+    /// application id may have changed (in-place same-id installs,
+    /// migrations) — a stale read_only_methods entry would take a shared
+    /// read lock for methods whose #[app::view] intent changed.
+    pub(crate) fn evict_application_caches(
+        &mut self,
+        application_id: calimero_primitives::application::ApplicationId,
+    ) {
+        let _ = self.applications.remove(&application_id);
+        self.modules.retain(|(id, _), _| *id != application_id);
+        self.read_only_methods
+            .retain(|(id, _), _| *id != application_id);
+    }
+
     /// Common preflight for governance mutation handlers.
     ///
     /// Resolves the requester identity, loads group metadata, checks admin

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -279,3 +279,51 @@ impl NodeClient {
 
 #[cfg(test)]
 mod tests;
+
+impl NodeClient {
+    /// Application wasm bytes straight from a bytecode BLOB — used for a
+    /// context pinned to a blob the application row no longer references
+    /// (version-stable bundle id overwritten in place). Fully in-memory: the
+    /// pinned version's extracted dir may be gone, but the blob is still in
+    /// the blobstore. `None` when the blob itself is absent locally.
+    pub async fn application_bytes_from_blob(
+        &self,
+        blob_id: &BlobId,
+        service_name: Option<&str>,
+    ) -> eyre::Result<Option<Arc<[u8]>>> {
+        let Some(blob_bytes) = self.get_blob_bytes(blob_id, None).await? else {
+            return Ok(None);
+        };
+        if !Self::is_bundle_blob(&blob_bytes) {
+            return Ok(Some(blob_bytes));
+        }
+        let service_owned = service_name.map(str::to_owned);
+        let wasm = tokio::task::spawn_blocking(move || -> eyre::Result<Option<Vec<u8>>> {
+            let (_, manifest) = bundle::extract_manifest_allow_unsigned(&blob_bytes)?;
+            let wasm_relative_path = match service_owned.as_deref() {
+                Some(name) => manifest
+                    .services
+                    .as_ref()
+                    .and_then(|svcs| svcs.iter().find(|s| s.name == name))
+                    .map(|s| s.wasm.path.clone())
+                    .ok_or_else(|| {
+                        eyre::eyre!("service '{}' not found in bundle manifest", name)
+                    })?,
+                None => manifest
+                    .wasm
+                    .as_ref()
+                    .map(|w| w.path.clone())
+                    .unwrap_or_else(|| "app.wasm".to_owned()),
+            };
+            if wasm_relative_path.contains("..") {
+                bail!(
+                    "WASM path traversal detected: {} contains '..' component",
+                    wasm_relative_path
+                );
+            }
+            bundle::extract_bundle_file(&blob_bytes, &wasm_relative_path)
+        })
+        .await??;
+        Ok(wasm.map(Into::into))
+    }
+}

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -215,3 +215,24 @@ pub fn is_bundle_blob(blob_bytes: &[u8]) -> bool {
 pub fn is_bundle_archive(path: &camino::Utf8Path) -> bool {
     path.extension().map(|ext| ext == "mpk").unwrap_or(false)
 }
+
+/// Read one file's bytes out of a bundle archive in memory (no extraction to
+/// disk). `file_path` is the manifest-relative artifact path (already
+/// validated against traversal by the manifest parser). Returns `None` when
+/// the archive has no such entry.
+pub fn extract_bundle_file(bundle_data: &[u8], file_path: &str) -> eyre::Result<Option<Vec<u8>>> {
+    let tar = GzDecoder::new(bundle_data);
+    let mut archive = Archive::new(tar);
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        if path.to_str() == Some(file_path)
+            || path.file_name().and_then(|n| n.to_str()) == Some(file_path)
+        {
+            let mut bytes = Vec::new();
+            let _ = entry.read_to_end(&mut bytes)?;
+            return Ok(Some(bytes));
+        }
+    }
+    Ok(None)
+}

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -94,6 +94,19 @@ impl NodeClient {
 
         let mut handle = self.datastore.handle();
         let key = key::ApplicationMeta::new(application_id);
+        // Bundle ids are version-stable (hash(package, signer)), so a new
+        // version overwrites the row in place. Breadcrumb the displaced
+        // bytecode: a logically-aborted migration pins its context back to it,
+        // and the L1 downgrade gate reads its ABI as the "from" side.
+        if let Some(existing) = handle.get(&key)? {
+            let old_blob = *existing.bytecode.blob_id().as_ref();
+            if old_blob != *application.bytecode.blob_id().as_ref() {
+                handle.put(
+                    &key::ApplicationPreviousBlob::new(application_id),
+                    &types::ApplicationPreviousBlob { bytecode: old_blob },
+                )?;
+            }
+        }
         handle.put(&key, &application)?;
         Ok(application_id)
     }

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -166,7 +166,14 @@ impl SyncManager {
 
         let Some(mut blob) = self.node_client.get_blob(&blob_id, None).await? else {
             warn!(%blob_id, "blob not found");
-
+            // Tell the initiator instead of going silent — without a reply it
+            // sits in recv() until the stream times out, stalling its whole
+            // sync attempt (the upgrade pre-stage path requests blobs this
+            // node may not hold yet). OpaqueError makes it bail fast and
+            // retry after its backoff.
+            if let Err(err) = self.send(stream, &StreamMessage::OpaqueError, None).await {
+                warn!(%blob_id, %err, "failed to signal missing blob to initiator");
+            }
             return Ok(());
         };
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -178,8 +178,9 @@ pub struct SyncManager {
     /// resolves to a real blob would otherwise issue one doomed BlobShare per
     /// sync tick forever; with the memo a failed stage retries at most every
     /// few minutes. Shared across clones (initiator/responder handles).
-    pub(super) stale_blob_attempts:
-        Arc<std::sync::Mutex<std::collections::HashMap<(ContextId, [u8; 32]), Instant>>>,
+    pub(super) stale_blob_attempts: Arc<
+        std::sync::Mutex<std::collections::HashMap<(ContextId, [u8; 32]), (Option<Instant>, u32)>>,
+    >,
 
     /// Reconcile-after-divergence orchestrator. Owns the orchestration
     /// for [`Self::reconcile_after_divergence`]; that method is a thin
@@ -1408,7 +1409,9 @@ impl SyncManager {
         // state our own LazyOnAccess migration must read as input. Skip
         // as a clean no-op; we self-migrate on next access, after which
         // the gate lifts. See `pending_upgrade_target`.
-        if let Some(target) = self.pending_upgrade_target(&context_id) {
+        let store_for_gate = self.context_client.datastore_handle().into_inner();
+        if let Some((target, gate_stage_blob)) = pending_upgrade_info(&store_for_gate, &context_id)
+        {
             info!(
                 %context_id,
                 %chosen_peer,
@@ -1424,8 +1427,7 @@ impl SyncManager {
             // responder-side gate for exactly this. Failures are benign —
             // every sync attempt retries until the migrate lifts the gate.
             {
-                let store = self.context_client.datastore_handle().into_inner();
-                if let Some(stage) = pending_upgrade_stage_blob(&store, &context_id) {
+                if let Some(stage) = gate_stage_blob {
                     let stage_blob = calimero_primitives::blobs::BlobId::from(stage);
                     if !self.node_client.has_blob(&stage_blob).unwrap_or(true)
                         && self.should_attempt_stage(context_id, stage)
@@ -3339,22 +3341,30 @@ impl super::driver::SyncDriverDispatch for SyncManager {
 
 impl SyncManager {
     /// Whether a stage attempt for `(context, blob)` is due — records the
-    /// attempt when it is. A failed stage retries only after the backoff, so
-    /// a blob that never materialises (legacy randomly-seeded `app_key`)
-    /// costs one doomed BlobShare per window, not one per sync tick.
+    /// attempt when it is. A failed stage retries only after the backoff,
+    /// and after `MAX_ATTEMPTS` consecutive failures the pair is parked for
+    /// the process lifetime — a blob that never materialises (legacy
+    /// randomly-seeded `app_key`) costs a bounded number of doomed
+    /// BlobShares, not one per window forever.
     fn should_attempt_stage(&self, context_id: ContextId, blob: [u8; 32]) -> bool {
         const RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(300);
+        const MAX_ATTEMPTS: u32 = 12; // ~1h of retries, then give up
         let mut memo = self
             .stale_blob_attempts
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
-        if let Some(last) = memo.get(&(context_id, blob)) {
-            if now.duration_since(*last) < RETRY_AFTER {
+        let entry = memo.entry((context_id, blob)).or_insert((None, 0));
+        if entry.1 >= MAX_ATTEMPTS {
+            return false;
+        }
+        if let Some(last) = entry.0 {
+            if now.duration_since(last) < RETRY_AFTER {
                 return false;
             }
         }
-        let _ = memo.insert((context_id, blob), now);
+        entry.0 = Some(now);
+        entry.1 += 1;
         true
     }
 
@@ -3399,21 +3409,17 @@ impl SyncManager {
     }
 }
 
-/// The bytecode blob worth pre-staging for `context_id`: the group's recorded
-/// target blob (`app_key`) when it differs from the bytecode installed under
-/// the group's target application — i.e. an upgrade (migration-carrying or
-/// code-only) moved the blob under a version-stable bundle id and this node
-/// doesn't run it yet. `None` once the row catches up. A legacy group's
-/// randomly-seeded `app_key` reads as permanently stale; the BlobShare retry
-/// memo bounds what that can cost.
-pub(crate) fn pending_upgrade_stage_blob(
+/// The bytecode blob worth pre-staging for an already-loaded group `meta`:
+/// the group's recorded target blob (`app_key`) when it differs from the
+/// bytecode installed under the group's target application — i.e. an upgrade
+/// (migration-carrying or code-only) moved the blob under a version-stable
+/// bundle id and this node doesn't run it yet. `None` once the row catches
+/// up. A legacy group's randomly-seeded `app_key` reads as permanently
+/// stale; the BlobShare retry memo caps what that can cost.
+fn stage_blob_for(
     store: &calimero_store::Store,
-    context_id: &ContextId,
+    meta: &calimero_store::key::GroupMetaValue,
 ) -> Option<[u8; 32]> {
-    let group_id = calimero_context::group_store::get_group_for_context(store, context_id)
-        .ok()
-        .flatten()?;
-    let meta = MetaRepository::new(store).load(&group_id).ok().flatten()?;
     if meta.app_key == [0u8; 32] {
         return None;
     }
@@ -3426,6 +3432,19 @@ pub(crate) fn pending_upgrade_stage_blob(
         .flatten()
         .map(|app| *app.bytecode.blob_id().as_ref())?;
     (row_blob != meta.app_key).then_some(meta.app_key)
+}
+
+/// One-load variant for `context_id` (group + meta resolved internally) —
+/// used by the mid-session stage step where no meta is already in hand.
+pub(crate) fn pending_upgrade_stage_blob(
+    store: &calimero_store::Store,
+    context_id: &ContextId,
+) -> Option<[u8; 32]> {
+    let group_id = calimero_context::group_store::get_group_for_context(store, context_id)
+        .ok()
+        .flatten()?;
+    let meta = MetaRepository::new(store).load(&group_id).ok().flatten()?;
+    stage_blob_for(store, &meta)
 }
 
 /// Store-level core of [`SyncManager::pending_upgrade_target`], extracted so
@@ -3446,6 +3465,19 @@ pub(crate) fn pending_upgrade_target_in(
     store: &calimero_store::Store,
     context_id: &ContextId,
 ) -> Option<calimero_primitives::application::ApplicationId> {
+    pending_upgrade_info(store, context_id).map(|(target, _)| target)
+}
+
+/// [`pending_upgrade_target_in`] plus the stage-blob decision from the SAME
+/// group/meta load — the sync gate needs both, and loading meta twice per
+/// gated sync attempt is wasted I/O.
+pub(crate) fn pending_upgrade_info(
+    store: &calimero_store::Store,
+    context_id: &ContextId,
+) -> Option<(
+    calimero_primitives::application::ApplicationId,
+    Option<[u8; 32]>,
+)> {
     let ctx_meta = store
         .handle()
         .get(&calimero_store::key::ContextMeta::new(*context_id))
@@ -3467,7 +3499,7 @@ pub(crate) fn pending_upgrade_target_in(
         return None;
     }
     if current_app != target {
-        return Some(target);
+        return Some((target, stage_blob_for(store, &meta)));
     }
     // Same id: bundle-app upgrade. Pending while the group's migration has
     // not been applied to this context — until the lazy migrate runs on next
@@ -3482,7 +3514,7 @@ pub(crate) fn pending_upgrade_target_in(
         .ok()
         .flatten()
         .is_some_and(|last| last == method);
-    (!applied).then_some(target)
+    (!applied).then(|| (target, stage_blob_for(store, &meta)))
 }
 
 #[cfg(test)]

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -173,6 +173,14 @@ pub struct SyncManager {
     /// opaque anyway.
     pub(crate) metrics: Option<Arc<dyn super::metrics::SyncMetricsCollector>>,
 
+    /// Retry-backoff memo for target-blob pre-staging: (context, blob) ->
+    /// last attempt. A legacy group whose randomly-seeded `app_key` never
+    /// resolves to a real blob would otherwise issue one doomed BlobShare per
+    /// sync tick forever; with the memo a failed stage retries at most every
+    /// few minutes. Shared across clones (initiator/responder handles).
+    pub(super) stale_blob_attempts:
+        Arc<std::sync::Mutex<std::collections::HashMap<(ContextId, [u8; 32]), Instant>>>,
+
     /// Reconcile-after-divergence orchestrator. Owns the orchestration
     /// for [`Self::reconcile_after_divergence`]; that method is a thin
     /// forwarder. See `sync::reconciler`.
@@ -217,6 +225,7 @@ impl Clone for SyncManager {
             // recording surface unified across the original (which runs
             // `start`) and every responder/initiator clone.
             metrics: self.metrics.clone(),
+            stale_blob_attempts: Arc::clone(&self.stale_blob_attempts),
             // Reconciler holds Arcs internally, so its `Clone` is
             // cheap and clones share the same state_access/sync_network
             // surfaces as the parent.
@@ -281,6 +290,7 @@ impl SyncManager {
             session_tx: None,
             session_result_rx: None,
             metrics: None,
+            stale_blob_attempts: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             reconciler,
             protocol_selector,
         }
@@ -1415,9 +1425,11 @@ impl SyncManager {
             // every sync attempt retries until the migrate lifts the gate.
             {
                 let store = self.context_client.datastore_handle().into_inner();
-                if let Some(stage_blob) = pending_upgrade_stage_blob(&store, &context_id) {
-                    let stage_blob = calimero_primitives::blobs::BlobId::from(stage_blob);
-                    if !self.node_client.has_blob(&stage_blob).unwrap_or(true) {
+                if let Some(stage) = pending_upgrade_stage_blob(&store, &context_id) {
+                    let stage_blob = calimero_primitives::blobs::BlobId::from(stage);
+                    if !self.node_client.has_blob(&stage_blob).unwrap_or(true)
+                        && self.should_attempt_stage(context_id, stage)
+                    {
                         if let Err(err) = self
                             .stage_target_blob(&context, stage_blob, chosen_peer)
                             .await
@@ -1427,9 +1439,10 @@ impl SyncManager {
                                 %chosen_peer,
                                 %stage_blob,
                                 %err,
-                                "failed to pre-stage target app blob; will retry on next sync"
+                                "failed to pre-stage target app blob; will retry after backoff"
                             );
                         } else {
+                            self.clear_stage_attempt(context_id, stage);
                             info!(
                                 %context_id,
                                 %stage_blob,
@@ -1508,6 +1521,47 @@ impl SyncManager {
                 )
                 .await
                 .wrap_err("install bundle after blob share")?;
+            }
+        }
+
+        // Same-id (bundle) upgrades move only the bytecode under an unchanged
+        // application id — additionally stage the group's recorded target
+        // blob so the next access can activate it. Code-only upgrades never
+        // arm the state-sync gate (same schema, sync stays safe), so this is
+        // their only staging point. Best-effort with retry backoff.
+        {
+            let store = self.context_client.datastore_handle().into_inner();
+            if let Some(stage) = pending_upgrade_stage_blob(&store, &context_id) {
+                let stage_blob = calimero_primitives::blobs::BlobId::from(stage);
+                if !self.node_client.has_blob(&stage_blob).unwrap_or(true)
+                    && self.should_attempt_stage(context_id, stage)
+                {
+                    match self
+                        .initiate_blob_share_process(
+                            &context,
+                            our_identity,
+                            stage_blob,
+                            0,
+                            &mut stream,
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            self.clear_stage_attempt(context_id, stage);
+                            info!(
+                                %context_id,
+                                %stage_blob,
+                                "staged target app bytecode for pending same-id upgrade"
+                            );
+                        }
+                        Err(err) => warn!(
+                            %context_id,
+                            %stage_blob,
+                            %err,
+                            "failed to stage target app bytecode; will retry after backoff"
+                        ),
+                    }
+                }
             }
         }
 
@@ -3284,6 +3338,36 @@ impl super::driver::SyncDriverDispatch for SyncManager {
 // `super::peers::partition_peers_anchor_first`.
 
 impl SyncManager {
+    /// Whether a stage attempt for `(context, blob)` is due — records the
+    /// attempt when it is. A failed stage retries only after the backoff, so
+    /// a blob that never materialises (legacy randomly-seeded `app_key`)
+    /// costs one doomed BlobShare per window, not one per sync tick.
+    fn should_attempt_stage(&self, context_id: ContextId, blob: [u8; 32]) -> bool {
+        const RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(300);
+        let mut memo = self
+            .stale_blob_attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let now = Instant::now();
+        if let Some(last) = memo.get(&(context_id, blob)) {
+            if now.duration_since(*last) < RETRY_AFTER {
+                return false;
+            }
+        }
+        let _ = memo.insert((context_id, blob), now);
+        true
+    }
+
+    /// Drop the stage-attempt memo after a successful share so a later
+    /// upgrade of the same context starts fresh.
+    fn clear_stage_attempt(&self, context_id: ContextId, blob: [u8; 32]) {
+        let mut memo = self
+            .stale_blob_attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _ = memo.remove(&(context_id, blob));
+    }
+
     /// Fetch `blob_id` from `chosen_peer` over a dedicated BlobShare stream.
     /// Used to pre-stage a pending upgrade's target bytecode while the
     /// state-sync gate is closed (the responder serves BlobShare during the
@@ -3315,11 +3399,13 @@ impl SyncManager {
     }
 }
 
-/// The bytecode blob to pre-stage while [`pending_upgrade_target_in`] gates a
-/// context: the group's recorded target blob (`app_key`). Restricted to
-/// migration-carrying upgrades — the same corroboration as the gate's
-/// same-id arm — so a legacy group's randomly-seeded `app_key` is never
-/// requested from peers.
+/// The bytecode blob worth pre-staging for `context_id`: the group's recorded
+/// target blob (`app_key`) when it differs from the bytecode installed under
+/// the group's target application — i.e. an upgrade (migration-carrying or
+/// code-only) moved the blob under a version-stable bundle id and this node
+/// doesn't run it yet. `None` once the row catches up. A legacy group's
+/// randomly-seeded `app_key` reads as permanently stale; the BlobShare retry
+/// memo bounds what that can cost.
 pub(crate) fn pending_upgrade_stage_blob(
     store: &calimero_store::Store,
     context_id: &ContextId,
@@ -3328,7 +3414,18 @@ pub(crate) fn pending_upgrade_stage_blob(
         .ok()
         .flatten()?;
     let meta = MetaRepository::new(store).load(&group_id).ok().flatten()?;
-    meta.migration.is_some().then_some(meta.app_key)
+    if meta.app_key == [0u8; 32] {
+        return None;
+    }
+    let row_blob = store
+        .handle()
+        .get(&calimero_store::key::ApplicationMeta::new(
+            meta.target_application_id,
+        ))
+        .ok()
+        .flatten()
+        .map(|app| *app.bytecode.blob_id().as_ref())?;
+    (row_blob != meta.app_key).then_some(meta.app_key)
 }
 
 /// Store-level core of [`SyncManager::pending_upgrade_target`], extracted so
@@ -3514,26 +3611,70 @@ mod pending_upgrade_tests {
     }
 
     // The pre-stage blob is the group's recorded target blob, surfaced only
-    // for migration-carrying upgrades — a legacy group's randomly-seeded
-    // app_key (migration None) must never be requested from peers.
+    // while it diverges from the bytecode installed under the target
+    // application row — equal blobs (caught up) and a missing row both
+    // surface nothing.
     #[test]
-    fn stage_blob_requires_a_migration() {
+    fn stage_blob_tracks_row_divergence() {
         let store = store();
         let app = ApplicationId::from([0xAA; 32]);
 
-        let with_migration = ContextId::from([6u8; 32]);
-        let _g = seed(&store, with_migration, app, app, Some("migrate_v1_to_v2"));
+        // No application row at all: nothing to compare, nothing to stage.
+        let no_row = ContextId::from([6u8; 32]);
+        let _g = seed(&store, no_row, app, app, None);
+        assert_eq!(super::pending_upgrade_stage_blob(&store, &no_row), None);
+
+        // Row installed at a DIFFERENT blob than the group's app_key
+        // ([0x11; 32] in the fixture): the upgrade's bytecode is pending.
+        let mut handle = store.handle();
+        handle
+            .put(
+                &ApplicationMetaKey::new(app),
+                &calimero_store::types::ApplicationMeta::new(
+                    calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
+                        [0x99; 32],
+                    )),
+                    1,
+                    "test://stage".to_owned().into_boxed_str(),
+                    Box::default(),
+                    calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
+                        [0u8; 32],
+                    )),
+                    "stage-pkg".to_owned().into_boxed_str(),
+                    "1.0.0".to_owned().into_boxed_str(),
+                    "stage-signer".to_owned().into_boxed_str(),
+                ),
+            )
+            .expect("put app row");
+        drop(handle);
         assert_eq!(
-            super::pending_upgrade_stage_blob(&store, &with_migration),
+            super::pending_upgrade_stage_blob(&store, &no_row),
             Some([0x11; 32])
         );
 
-        let without_migration = ContextId::from([7u8; 32]);
-        let _g = seed(&store, without_migration, app, app, None);
-        assert_eq!(
-            super::pending_upgrade_stage_blob(&store, &without_migration),
-            None
-        );
+        // Row caught up to the group's app_key: nothing to stage.
+        let mut handle = store.handle();
+        handle
+            .put(
+                &ApplicationMetaKey::new(app),
+                &calimero_store::types::ApplicationMeta::new(
+                    calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
+                        [0x11; 32],
+                    )),
+                    1,
+                    "test://stage".to_owned().into_boxed_str(),
+                    Box::default(),
+                    calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
+                        [0u8; 32],
+                    )),
+                    "stage-pkg".to_owned().into_boxed_str(),
+                    "1.0.0".to_owned().into_boxed_str(),
+                    "stage-signer".to_owned().into_boxed_str(),
+                ),
+            )
+            .expect("put app row");
+        drop(handle);
+        assert_eq!(super::pending_upgrade_stage_blob(&store, &no_row), None);
     }
 }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1407,6 +1407,38 @@ impl SyncManager {
                 "Skipping context-state sync: application upgrade pending (gate); \
                  node self-migrates on next access before reconciling"
             );
+            // Pre-stage the target bytecode while state sync is gated, so the
+            // lazy migrate on next access has it locally. Bundle apps keep a
+            // version-stable ApplicationId, so nothing else fetches the new
+            // blob under the same id; BlobShare is exempt from the
+            // responder-side gate for exactly this. Failures are benign —
+            // every sync attempt retries until the migrate lifts the gate.
+            {
+                let store = self.context_client.datastore_handle().into_inner();
+                if let Some(stage_blob) = pending_upgrade_stage_blob(&store, &context_id) {
+                    let stage_blob = calimero_primitives::blobs::BlobId::from(stage_blob);
+                    if !self.node_client.has_blob(&stage_blob).unwrap_or(true) {
+                        if let Err(err) = self
+                            .stage_target_blob(&context, stage_blob, chosen_peer)
+                            .await
+                        {
+                            warn!(
+                                %context_id,
+                                %chosen_peer,
+                                %stage_blob,
+                                %err,
+                                "failed to pre-stage target app blob; will retry on next sync"
+                            );
+                        } else {
+                            info!(
+                                %context_id,
+                                %stage_blob,
+                                "pre-staged target app bytecode for pending upgrade"
+                            );
+                        }
+                    }
+                }
+            }
             return Ok(SyncProtocol::None);
         }
 
@@ -3251,6 +3283,54 @@ impl super::driver::SyncDriverDispatch for SyncManager {
 // `SyncManager` decomposition. Call sites use
 // `super::peers::partition_peers_anchor_first`.
 
+impl SyncManager {
+    /// Fetch `blob_id` from `chosen_peer` over a dedicated BlobShare stream.
+    /// Used to pre-stage a pending upgrade's target bytecode while the
+    /// state-sync gate is closed (the responder serves BlobShare during the
+    /// gate window by design).
+    async fn stage_target_blob(
+        &self,
+        context: &calimero_primitives::context::Context,
+        blob_id: calimero_primitives::blobs::BlobId,
+        chosen_peer: libp2p::PeerId,
+    ) -> eyre::Result<()> {
+        let identities = self
+            .context_client
+            .get_context_members(&context.id, Some(true));
+        let Some((our_identity, _)) = choose_stream(identities, &mut rand::thread_rng())
+            .await
+            .transpose()?
+        else {
+            bail!("no owned identities found for context: {}", context.id);
+        };
+        let mut stream = self
+            .sync_network
+            .open_stream(chosen_peer)
+            .await
+            .wrap_err("open stream for target blob share")?;
+        // Size unknown ahead of the transfer (the target app may not have a
+        // local ApplicationMeta row yet); 0 disables the expected-size check.
+        self.initiate_blob_share_process(context, our_identity, blob_id, 0, &mut stream)
+            .await
+    }
+}
+
+/// The bytecode blob to pre-stage while [`pending_upgrade_target_in`] gates a
+/// context: the group's recorded target blob (`app_key`). Restricted to
+/// migration-carrying upgrades — the same corroboration as the gate's
+/// same-id arm — so a legacy group's randomly-seeded `app_key` is never
+/// requested from peers.
+pub(crate) fn pending_upgrade_stage_blob(
+    store: &calimero_store::Store,
+    context_id: &ContextId,
+) -> Option<[u8; 32]> {
+    let group_id = calimero_context::group_store::get_group_for_context(store, context_id)
+        .ok()
+        .flatten()?;
+    let meta = MetaRepository::new(store).load(&group_id).ok().flatten()?;
+    meta.migration.is_some().then_some(meta.app_key)
+}
+
 /// Store-level core of [`SyncManager::pending_upgrade_target`], extracted so
 /// the predicate is unit-testable without constructing a `SyncManager`.
 ///
@@ -3431,6 +3511,29 @@ mod pending_upgrade_tests {
         let target = ApplicationId::from([0xBB; 32]);
         let _gid = seed(&store, ctx, zero, target, Some("migrate_v1_to_v2"));
         assert_eq!(pending_upgrade_target_in(&store, &ctx), None);
+    }
+
+    // The pre-stage blob is the group's recorded target blob, surfaced only
+    // for migration-carrying upgrades — a legacy group's randomly-seeded
+    // app_key (migration None) must never be requested from peers.
+    #[test]
+    fn stage_blob_requires_a_migration() {
+        let store = store();
+        let app = ApplicationId::from([0xAA; 32]);
+
+        let with_migration = ContextId::from([6u8; 32]);
+        let _g = seed(&store, with_migration, app, app, Some("migrate_v1_to_v2"));
+        assert_eq!(
+            super::pending_upgrade_stage_blob(&store, &with_migration),
+            Some([0x11; 32])
+        );
+
+        let without_migration = ContextId::from([7u8; 32]);
+        let _g = seed(&store, without_migration, app, app, None);
+        assert_eq!(
+            super::pending_upgrade_stage_blob(&store, &without_migration),
+            None
+        );
     }
 }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -718,25 +718,7 @@ impl SyncManager {
         context_id: &ContextId,
     ) -> Option<calimero_primitives::application::ApplicationId> {
         let store = self.context_client.datastore_handle().into_inner();
-        let ctx_meta = store
-            .handle()
-            .get(&calimero_store::key::ContextMeta::new(*context_id))
-            .ok()
-            .flatten()?;
-        let current_app = ctx_meta.application.application_id();
-        let group_id = calimero_context::group_store::get_group_for_context(&store, context_id)
-            .ok()
-            .flatten()?;
-        let meta = MetaRepository::new(&store).load(&group_id).ok().flatten()?;
-        let target = meta.target_application_id;
-        // Only gate a context that is bound to a REAL application and differs
-        // from the group target. A context with no app yet
-        // (`current_app == ZERO`, e.g. a freshly-joined node still
-        // bootstrapping its state) must be allowed to sync — gating it would
-        // block the very state sync it needs to come up. Likewise `target ==
-        // ZERO` means no upgrade is set.
-        let zero = calimero_primitives::application::ZERO_APPLICATION_ID;
-        (current_app != zero && target != zero && current_app != target).then_some(target)
+        pending_upgrade_target_in(&store, context_id)
     }
 
     /// Look up the trusted-anchor identity set for the group that owns
@@ -3268,6 +3250,189 @@ impl super::driver::SyncDriverDispatch for SyncManager {
 // `partition_peers_anchor_first` moved to `sync::peers` as Phase 1 of
 // `SyncManager` decomposition. Call sites use
 // `super::peers::partition_peers_anchor_first`.
+
+/// Store-level core of [`SyncManager::pending_upgrade_target`], extracted so
+/// the predicate is unit-testable without constructing a `SyncManager`.
+///
+/// An upgrade is pending in two shapes:
+/// * `current != target` — distinct ids (single-wasm apps, whose ids are
+///   content-addressed and change per version), or
+/// * `current == target` with the group's replicated migration not yet
+///   applied to this context — bundle apps, whose
+///   `ApplicationId = hash(package, signer)` is version-stable so the id
+///   never moves; mirrors `maybe_lazy_upgrade`'s same-id condition. Keyed
+///   off `meta.migration` + the per-context applied marker (NOT a raw
+///   `meta.app_key` blob comparison): groups created before `app_key` was
+///   blob-derived hold a random `app_key`, and a blob comparison would gate
+///   their state sync forever.
+pub(crate) fn pending_upgrade_target_in(
+    store: &calimero_store::Store,
+    context_id: &ContextId,
+) -> Option<calimero_primitives::application::ApplicationId> {
+    let ctx_meta = store
+        .handle()
+        .get(&calimero_store::key::ContextMeta::new(*context_id))
+        .ok()
+        .flatten()?;
+    let current_app = ctx_meta.application.application_id();
+    let group_id = calimero_context::group_store::get_group_for_context(store, context_id)
+        .ok()
+        .flatten()?;
+    let meta = MetaRepository::new(store).load(&group_id).ok().flatten()?;
+    let target = meta.target_application_id;
+    // Only gate a context that is bound to a REAL application. A context with
+    // no app yet (`current_app == ZERO`, e.g. a freshly-joined node still
+    // bootstrapping its state) must be allowed to sync — gating it would
+    // block the very state sync it needs to come up. Likewise `target ==
+    // ZERO` means no upgrade is set.
+    let zero = calimero_primitives::application::ZERO_APPLICATION_ID;
+    if current_app == zero || target == zero {
+        return None;
+    }
+    if current_app != target {
+        return Some(target);
+    }
+    // Same id: bundle-app upgrade. Pending while the group's migration has
+    // not been applied to this context — until the lazy migrate runs on next
+    // access, this node's pre-migration state must not reconcile against
+    // already-migrated peers.
+    let method = meta
+        .migration
+        .as_ref()
+        .and_then(|bytes| String::from_utf8(bytes.clone()).ok())?;
+    let applied = calimero_governance_store::MigrationsRepository::new(store)
+        .last_migration(&group_id, context_id)
+        .ok()
+        .flatten()
+        .is_some_and(|last| last == method);
+    (!applied).then_some(target)
+}
+
+#[cfg(test)]
+mod pending_upgrade_tests {
+    use std::sync::Arc;
+
+    use calimero_context::group_store::{register_context_in_group, MetaRepository};
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_governance_store::MigrationsRepository;
+    use calimero_primitives::application::ApplicationId;
+    use calimero_primitives::context::{ContextId, UpgradePolicy};
+    use calimero_primitives::identity::PublicKey;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::key::{
+        ApplicationMeta as ApplicationMetaKey, ContextMeta as ContextMetaKey, GroupMetaValue,
+    };
+    use calimero_store::types::ContextMeta;
+    use calimero_store::Store;
+
+    use super::pending_upgrade_target_in;
+
+    /// Seed a context bound to `current` in a group whose meta carries
+    /// `target` + `migration`. Mirrors the cascade e2e fixtures, but only
+    /// the rows the predicate reads.
+    fn seed(
+        store: &Store,
+        ctx: ContextId,
+        current: ApplicationId,
+        target: ApplicationId,
+        migration: Option<&str>,
+    ) -> ContextGroupId {
+        let group_id = ContextGroupId::from([0x42; 32]);
+        let admin = PublicKey::from([0x07; 32]);
+        let meta = GroupMetaValue {
+            app_key: [0x11; 32],
+            target_application_id: target,
+            upgrade_policy: UpgradePolicy::LazyOnAccess,
+            created_at: 1_700_000_000,
+            admin_identity: admin,
+            owner_identity: admin,
+            migration: migration.map(|m| m.as_bytes().to_vec()),
+            auto_join: true,
+        };
+        MetaRepository::new(store)
+            .save(&group_id, &meta)
+            .expect("save group meta");
+        let ctx_meta = ContextMeta::new(
+            ApplicationMetaKey::new(current),
+            [0x01; 32],
+            Vec::new(),
+            None,
+        );
+        let mut handle = store.handle();
+        handle
+            .put(&ContextMetaKey::new(ctx), &ctx_meta)
+            .expect("put ContextMeta");
+        drop(handle);
+        register_context_in_group(store, &group_id, &ctx).expect("register context");
+        group_id
+    }
+
+    fn store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    // Bundle shape: ApplicationId is version-stable, so v1→v2 leaves
+    // current == target. The replicated-but-unapplied migration is the
+    // pending signal; before this arm existed the gate returned None here
+    // and migrated peers reconciled their state onto pre-migration nodes.
+    #[test]
+    fn same_id_with_unapplied_migration_is_pending() {
+        let store = store();
+        let ctx = ContextId::from([1u8; 32]);
+        let app = ApplicationId::from([0xAA; 32]);
+        let _gid = seed(&store, ctx, app, app, Some("migrate_v1_to_v2"));
+        assert_eq!(pending_upgrade_target_in(&store, &ctx), Some(app));
+    }
+
+    // No migration on the group (never upgraded, or a legacy group with a
+    // random app_key): same id must NOT read as pending — gating here would
+    // freeze state sync for every group that never runs a migration.
+    #[test]
+    fn same_id_without_migration_is_not_pending() {
+        let store = store();
+        let ctx = ContextId::from([2u8; 32]);
+        let app = ApplicationId::from([0xAA; 32]);
+        let _gid = seed(&store, ctx, app, app, None);
+        assert_eq!(pending_upgrade_target_in(&store, &ctx), None);
+    }
+
+    // Once the per-context applied marker matches the group's migration,
+    // the gate lifts (state sync resumes after the lazy migrate).
+    #[test]
+    fn same_id_with_applied_migration_is_not_pending() {
+        let store = store();
+        let ctx = ContextId::from([3u8; 32]);
+        let app = ApplicationId::from([0xAA; 32]);
+        let gid = seed(&store, ctx, app, app, Some("migrate_v1_to_v2"));
+        MigrationsRepository::new(&store)
+            .set_last_migration(&gid, &ctx, "migrate_v1_to_v2")
+            .expect("record applied migration");
+        assert_eq!(pending_upgrade_target_in(&store, &ctx), None);
+    }
+
+    // Distinct ids (single-wasm upgrades) keep the original behavior.
+    #[test]
+    fn distinct_ids_remain_pending() {
+        let store = store();
+        let ctx = ContextId::from([4u8; 32]);
+        let v1 = ApplicationId::from([0xAA; 32]);
+        let v2 = ApplicationId::from([0xBB; 32]);
+        let _gid = seed(&store, ctx, v1, v2, None);
+        assert_eq!(pending_upgrade_target_in(&store, &ctx), Some(v2));
+    }
+
+    // A bootstrapping context (zero app id) must never be gated, even with
+    // a pending migration on its group — it needs state sync to come up.
+    #[test]
+    fn zero_current_app_is_never_pending() {
+        let store = store();
+        let ctx = ContextId::from([5u8; 32]);
+        let zero = calimero_primitives::application::ZERO_APPLICATION_ID;
+        let target = ApplicationId::from([0xBB; 32]);
+        let _gid = seed(&store, ctx, zero, target, Some("migrate_v1_to_v2"));
+        assert_eq!(pending_upgrade_target_in(&store, &ctx), None);
+    }
+}
 
 mod blob_fetch;
 mod handshake;

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -53,6 +53,20 @@ pub enum Column {
     /// `ContextLocal` (e.g. `ContextAuthoredRemaining`). NOT synchronized;
     /// auto-created from `Column::iter()` at `open_cf` (no DB migration).
     ContextMigrationFailed,
+    /// Node-local per-context pin to the bytecode blob the context's
+    /// committed state executes under, written by a logically-aborted
+    /// migration: the version-stable bundle ApplicationId's row already holds
+    /// the NEW bytecode, so the pin keeps reads on the old code until a
+    /// migrate succeeds. Own column for the same collision reason as above.
+    /// NOT synchronized; auto-created from `Column::iter()` (no DB migration).
+    ContextExecutingBlob,
+    /// Node-local per-application breadcrumb of the bytecode blob an in-place
+    /// (same-id) bundle install overwrote — the source for the executing-blob
+    /// pin above and the L1 downgrade gate's pre-install ABI. Own column: the
+    /// `application_id`-only key shape would collide with `ApplicationMeta`
+    /// in `Application`. NOT synchronized; auto-created from `Column::iter()`
+    /// (no DB migration).
+    ApplicationPreviousBlob,
 }
 
 pub trait Database<'a>: Debug + Send + Sync + 'static {

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -23,13 +23,14 @@ mod group;
 
 pub use absorb::{AbsorbBufferKey, ABSORB_BUFFER_PREFIX};
 pub use alias::{Alias, Aliasable, StoreScopeCompat};
-pub use application::ApplicationMeta;
+pub use application::{ApplicationMeta, ApplicationPreviousBlob};
 pub use blobs::BlobMeta;
 pub use calimero_primitives::context::GroupMemberRole;
 use component::KeyComponents;
 pub use context::{
-    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker,
-    ContextMeta, ContextMigrationFailed, ContextPrivateState, ContextState,
+    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextExecutingBlob,
+    ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed, ContextPrivateState,
+    ContextState,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/application.rs
+++ b/crates/store/src/key/application.rs
@@ -60,3 +60,54 @@ impl Debug for ApplicationMeta {
             .finish()
     }
 }
+
+/// Per-application breadcrumb of the bytecode blob that an in-place install
+/// (same id, new bundle version) overwrote. Bundle ApplicationIds are
+/// version-stable, so the overwritten blob is otherwise unrecoverable from
+/// the row — this is what lets a logically-aborted migration pin its context
+/// back to the pre-upgrade code. Own column: the key is application_id-only,
+/// same shape as [`ApplicationMeta`], and sharing `Column::Application` would
+/// collide with it.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ApplicationPreviousBlob(Key<ApplicationId>);
+
+impl ApplicationPreviousBlob {
+    #[must_use]
+    pub fn new(application_id: PrimitiveApplicationId) -> Self {
+        Self(Key((*application_id).into()))
+    }
+
+    #[must_use]
+    pub fn application_id(&self) -> PrimitiveApplicationId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ApplicationPreviousBlob {
+    type Components = (ApplicationId,);
+
+    fn column() -> Column {
+        Column::ApplicationPreviousBlob
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ApplicationPreviousBlob {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ApplicationPreviousBlob {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApplicationPreviousBlob")
+            .field("id", &self.application_id())
+            .finish()
+    }
+}

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -166,6 +166,57 @@ impl Debug for ContextMigrationFailed {
     }
 }
 
+/// Node-local pin to the bytecode blob this context's committed state runs
+/// under, written when a logically-aborted migration leaves the context on
+/// its pre-upgrade state while the application row (version-stable bundle id)
+/// already holds the NEW bytecode. Module loading honors the pin so reads
+/// keep executing the old code; a successful migrate deletes it. Own column —
+/// a `context_id`-only key would collide with the other same-shaped keys.
+/// Not synchronized; absence means "execute the application row's bytecode".
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextExecutingBlob(Key<ContextId>);
+
+impl ContextExecutingBlob {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId) -> Self {
+        Self(Key((*context_id).into()))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ContextExecutingBlob {
+    type Components = (ContextId,);
+
+    fn column() -> Column {
+        Column::ContextExecutingBlob
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ContextExecutingBlob {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ContextExecutingBlob {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextExecutingBlob")
+            .field("id", &self.context_id())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextConfig(Key<ContextId>);

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -8,11 +8,12 @@ mod context;
 mod generic;
 mod group;
 
-pub use application::{ApplicationMeta, ServiceMeta};
+pub use application::{ApplicationMeta, ApplicationPreviousBlob, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
-    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextIdentity, ContextLeftMarker,
-    ContextMeta, ContextMigrationFailed, ContextPrivateState, ContextState,
+    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextExecutingBlob,
+    ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed, ContextPrivateState,
+    ContextState,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -123,3 +123,23 @@ impl PredefinedEntry for key::ApplicationMeta {
     type Codec = Borsh;
     type DataType<'a> = ApplicationMeta;
 }
+
+/// Value for [`key::ApplicationPreviousBlob`]: the bytecode blob that an
+/// in-place (same-id) bundle install overwrote. Node-local breadcrumb — lets
+/// a logically-aborted migration pin its context back to the pre-upgrade
+/// code, and gives the L1 downgrade gate a pre-install ABI to compare. A
+/// brand-new key, so a missing row reads as `None` (no prior in-place
+/// install on record).
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "single breadcrumb value; additions would need a migration"
+)]
+pub struct ApplicationPreviousBlob {
+    pub bytecode: [u8; 32],
+}
+
+impl PredefinedEntry for key::ApplicationPreviousBlob {
+    type Codec = Borsh;
+    type DataType<'a> = ApplicationPreviousBlob;
+}

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -303,3 +303,23 @@ mod context_local_key_isolation_tests {
         assert!(h.get(&mf).unwrap().is_none());
     }
 }
+
+/// Value for [`key::ContextExecutingBlob`]: the bytecode blob this context's
+/// committed state executes under, when it differs from the application
+/// row's (version-stable bundle id, row already overwritten in place by a
+/// newer version). Written on logical migration abort; deleted when a
+/// migrate succeeds. Node-local; a missing row means "execute the row's
+/// bytecode" (today's behavior).
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "single pin value; additions would need a migration"
+)]
+pub struct ContextExecutingBlob {
+    pub blob: [u8; 32],
+}
+
+impl PredefinedEntry for key::ContextExecutingBlob {
+    type Codec = Borsh;
+    type DataType<'a> = ContextExecutingBlob;
+}

--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -39,18 +39,10 @@ steps:
   - name: Install migration-suite-v1 on node 1
     type: install_application
     node: app-migration-baseline-1
-    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    path: apps/migrations/migration-suite-v1/res/migration-suite-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install migration-suite-v2-add-field on node 1
-    type: install_application
-    node: app-migration-baseline-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace on node 1
@@ -174,6 +166,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-baseline-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade with migrate_v1_to_v2
     type: upgrade_group
     node: app-migration-baseline-1
@@ -307,9 +316,5 @@ steps:
     node: app-migration-baseline-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-baseline-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -35,31 +35,27 @@ nodes:
   base_rpc_port: 9330
 
 steps:
-  # Phase 1: Install v1 + v2 binaries on the ADMIN node only.
+  # Phase 1: Install the v1 BUNDLE on the ADMIN node only.
   #
   # Realistic distribution: only the admin (node 1) holds the bytecode.
-  # Node 2 never runs install_application — it obtains both versions
-  # automatically: v1 when it joins the context (blob announced for the
-  # context, fetched over BlobShare on first execution), and v2 when the
-  # cascade upgrade announces the target blob (pulled during node 2's
-  # lazy migration; the sync-gate leaves BlobShare open for exactly this).
-  # App ids are content-addressed, so node 1's app_v1/app_v2 ids are the
-  # same ids node 2 resolves and fetches.
+  # Node 2 never runs install_application — it obtains v1 automatically
+  # when it joins the context (blob announced for the context, fetched
+  # over BlobShare on first execution), and v2 when the cascade upgrade
+  # announces the target blob (pulled during node 2's lazy migration).
+  #
+  # Bundles derive ApplicationId = hash(package, signer): v1 and v2 share
+  # one package, so they install under the SAME id and the upgrade moves
+  # only the bytecode blob — the realistic app-update shape. The v2
+  # install therefore happens LATER (right before the cascade), as an
+  # in-place version bump; installing it earlier would flip node 1's
+  # bytecode before the v1 phase runs.
   - name: Install migration-suite-v1 on node 1
     type: install_application
     node: app-migration-cascade-1
-    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    path: apps/migrations/migration-suite-v1/res/migration-suite-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install migration-suite-v2-add-field on node 1
-    type: install_application
-    node: app-migration-cascade-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + subgroup + context. NO
   # pre-cascade alignment — cascade should work straight out of
@@ -218,6 +214,23 @@ steps:
   # The cascade engine emits a single atomic CascadeUpgrade op on the
   # namespace DAG; the apply path runs on every peer subscribed to the
   # namespace (node 1 + node 2).
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-cascade-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Cascade namespace v1 → v2 (initiated by node 1)
     type: upgrade_group
     node: app-migration-cascade-1
@@ -444,9 +457,5 @@ steps:
     node: app-migration-cascade-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-cascade-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/02-scenario-additive-field.yml
+++ b/workflows/app-migration/02-scenario-additive-field.yml
@@ -41,18 +41,10 @@ steps:
   - name: Install migration-suite-v1 on node 1
     type: install_application
     node: app-migration-additive-1
-    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    path: apps/migrations/migration-suite-v1/res/migration-suite-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install migration-suite-v2-add-field on node 1
-    type: install_application
-    node: app-migration-additive-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -201,6 +193,23 @@ steps:
   # Under LazyOnAccess this sets the target + migration method on the
   # subgroup meta and returns WITHOUT running a propagator — no node
   # migrates eagerly; each migrates on its next access below.
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-additive-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, not cascade)
     type: upgrade_group
     node: app-migration-additive-1
@@ -339,9 +348,5 @@ steps:
     node: app-migration-additive-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-additive-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/03-scenario-remove-field.yml
+++ b/workflows/app-migration/03-scenario-remove-field.yml
@@ -42,18 +42,10 @@ steps:
   - name: Install migration-suite-v2-add-field on node 1
     type: install_application
     node: app-migration-remove-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
     dev: true
     outputs:
       app_v2: applicationId
-
-  - name: Install migration-suite-v3-remove-field on node 1
-    type: install_application
-    node: app-migration-remove-1
-    path: apps/migrations/migration-suite-v3-remove-field/res/migration_suite_v3_remove_field.wasm
-    dev: true
-    outputs:
-      app_v3: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v2) on node 1
@@ -182,6 +174,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install migration-suite-v3-remove-field on node 1
+    type: install_application
+    node: app-migration-remove-1
+    path: apps/migrations/migration-suite-v3-remove-field/res/migration-suite-3.0.0.mpk
+    dev: true
+    outputs:
+      app_v3: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v2}}", "{{app_v3}}")'
+
   - name: Upgrade subgroup v2 → v3 (drops notes field)
     type: upgrade_group
     node: app-migration-remove-1
@@ -286,9 +295,5 @@ steps:
     node: app-migration-remove-1
     application_id: "{{app_v2}}"
 
-  - name: Uninstall v3 on node 1
-    type: uninstall_application
-    node: app-migration-remove-1
-    application_id: "{{app_v3}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/04-scenario-rename-field.yml
+++ b/workflows/app-migration/04-scenario-rename-field.yml
@@ -38,18 +38,10 @@ steps:
   - name: Install migration-suite-v3-remove-field on node 1
     type: install_application
     node: app-migration-rename-1
-    path: apps/migrations/migration-suite-v3-remove-field/res/migration_suite_v3_remove_field.wasm
+    path: apps/migrations/migration-suite-v3-remove-field/res/migration-suite-3.0.0.mpk
     dev: true
     outputs:
       app_v3: applicationId
-
-  - name: Install migration-suite-v4-rename-field on node 1
-    type: install_application
-    node: app-migration-rename-1
-    path: apps/migrations/migration-suite-v4-rename-field/res/migration_suite_v4_rename_field.wasm
-    dev: true
-    outputs:
-      app_v4: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v3) on node 1
@@ -170,6 +162,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install migration-suite-v4-rename-field on node 1
+    type: install_application
+    node: app-migration-rename-1
+    path: apps/migrations/migration-suite-v4-rename-field/res/migration-suite-4.0.0.mpk
+    dev: true
+    outputs:
+      app_v4: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v3}}", "{{app_v4}}")'
+
   - name: Upgrade subgroup v3 → v4 (renames description → details)
     type: upgrade_group
     node: app-migration-rename-1
@@ -305,9 +314,5 @@ steps:
     node: app-migration-rename-1
     application_id: "{{app_v3}}"
 
-  - name: Uninstall v4 on node 1
-    type: uninstall_application
-    node: app-migration-rename-1
-    application_id: "{{app_v4}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/05-scenario-change-type.yml
+++ b/workflows/app-migration/05-scenario-change-type.yml
@@ -38,18 +38,10 @@ steps:
   - name: Install migration-suite-v4-rename-field on node 1
     type: install_application
     node: app-migration-typechange-1
-    path: apps/migrations/migration-suite-v4-rename-field/res/migration_suite_v4_rename_field.wasm
+    path: apps/migrations/migration-suite-v4-rename-field/res/migration-suite-4.0.0.mpk
     dev: true
     outputs:
       app_v4: applicationId
-
-  - name: Install migration-suite-v5-change-type on node 1
-    type: install_application
-    node: app-migration-typechange-1
-    path: apps/migrations/migration-suite-v5-change-type/res/migration_suite_v5_change_type.wasm
-    dev: true
-    outputs:
-      app_v5: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v4) on node 1
@@ -184,6 +176,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install migration-suite-v5-change-type on node 1
+    type: install_application
+    node: app-migration-typechange-1
+    path: apps/migrations/migration-suite-v5-change-type/res/migration-suite-5.0.0.mpk
+    dev: true
+    outputs:
+      app_v5: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v4}}", "{{app_v5}}")'
+
   - name: Upgrade subgroup v4 → v5 (counter u64 → String)
     type: upgrade_group
     node: app-migration-typechange-1
@@ -312,9 +321,5 @@ steps:
     node: app-migration-typechange-1
     application_id: "{{app_v4}}"
 
-  - name: Uninstall v5 on node 1
-    type: uninstall_application
-    node: app-migration-typechange-1
-    application_id: "{{app_v5}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -40,18 +40,10 @@ steps:
   - name: Install scenario-new-method-v1 on node 1
     type: install_application
     node: app-migration-newmethod-1
-    path: apps/migrations/scenario-new-method-v1/res/scenario_new_method_v1.wasm
+    path: apps/migrations/scenario-new-method-v1/res/scenario-new-method-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-new-method-v2 on node 1
-    type: install_application
-    node: app-migration-newmethod-1
-    path: apps/migrations/scenario-new-method-v2/res/scenario_new_method_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -196,6 +188,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install scenario-new-method-v2 on node 1
+    type: install_application
+    node: app-migration-newmethod-1
+    path: apps/migrations/scenario-new-method-v2/res/scenario-new-method-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (no migrate; layout unchanged)
     type: upgrade_group
     node: app-migration-newmethod-1
@@ -324,9 +333,5 @@ steps:
     node: app-migration-newmethod-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-newmethod-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -27,6 +27,10 @@ nodes:
   base_port: 9280
   base_rpc_port: 9380
 
+# NOTE: still on distinct-id raw-wasm fixtures — code-only (no-migration)
+# upgrades do not yet work under a version-stable bundle ApplicationId.
+# Convert to the same-package .mpk fixtures when #2755 lands.
+
 steps:
   # Phase 1: Install both binaries on the ADMIN node (node 1) only.
   #
@@ -40,10 +44,18 @@ steps:
   - name: Install scenario-new-method-v1 on node 1
     type: install_application
     node: app-migration-newmethod-1
-    path: apps/migrations/scenario-new-method-v1/res/scenario-new-method-1.0.0.mpk
+    path: apps/migrations/scenario-new-method-v1/res/scenario_new_method_v1.wasm
     dev: true
     outputs:
       app_v1: applicationId
+
+  - name: Install scenario-new-method-v2 on node 1
+    type: install_application
+    node: app-migration-newmethod-1
+    path: apps/migrations/scenario-new-method-v2/res/scenario_new_method_v2.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -188,23 +200,6 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
-  - name: Install scenario-new-method-v2 on node 1
-    type: install_application
-    node: app-migration-newmethod-1
-    path: apps/migrations/scenario-new-method-v2/res/scenario-new-method-2.0.0.mpk
-    dev: true
-    outputs:
-      app_v2: applicationId
-
-
-  - name: Assert both versions share one application id (bundle same-id)
-    # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
-    # below then exercises the same-id (blob-only) propagation path.
-    type: json_assert
-    statements:
-      - 'equal("{{app_v1}}", "{{app_v2}}")'
-
   - name: Upgrade subgroup v1 → v2 (no migrate; layout unchanged)
     type: upgrade_group
     node: app-migration-newmethod-1
@@ -333,5 +328,9 @@ steps:
     node: app-migration-newmethod-1
     application_id: "{{app_v1}}"
 
+  - name: Uninstall v2 on node 1
+    type: uninstall_application
+    node: app-migration-newmethod-1
+    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -27,10 +27,6 @@ nodes:
   base_port: 9280
   base_rpc_port: 9380
 
-# NOTE: still on distinct-id raw-wasm fixtures — code-only (no-migration)
-# upgrades do not yet work under a version-stable bundle ApplicationId.
-# Convert to the same-package .mpk fixtures when #2755 lands.
-
 steps:
   # Phase 1: Install both binaries on the ADMIN node (node 1) only.
   #
@@ -44,18 +40,10 @@ steps:
   - name: Install scenario-new-method-v1 on node 1
     type: install_application
     node: app-migration-newmethod-1
-    path: apps/migrations/scenario-new-method-v1/res/scenario_new_method_v1.wasm
+    path: apps/migrations/scenario-new-method-v1/res/scenario-new-method-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-new-method-v2 on node 1
-    type: install_application
-    node: app-migration-newmethod-1
-    path: apps/migrations/scenario-new-method-v2/res/scenario_new_method_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -200,6 +188,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install scenario-new-method-v2 on node 1
+    type: install_application
+    node: app-migration-newmethod-1
+    path: apps/migrations/scenario-new-method-v2/res/scenario-new-method-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (no migrate; layout unchanged)
     type: upgrade_group
     node: app-migration-newmethod-1
@@ -328,9 +333,5 @@ steps:
     node: app-migration-newmethod-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-newmethod-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -39,18 +39,10 @@ steps:
   - name: Install scenario-new-enum-variant-v1 on node 1
     type: install_application
     node: app-migration-newenum-1
-    path: apps/migrations/scenario-new-enum-variant-v1/res/scenario_new_enum_variant_v1.wasm
+    path: apps/migrations/scenario-new-enum-variant-v1/res/scenario-new-enum-variant-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-new-enum-variant-v2 on node 1
-    type: install_application
-    node: app-migration-newenum-1
-    path: apps/migrations/scenario-new-enum-variant-v2/res/scenario_new_enum_variant_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -180,6 +172,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install scenario-new-enum-variant-v2 on node 1
+    type: install_application
+    node: app-migration-newenum-1
+    path: apps/migrations/scenario-new-enum-variant-v2/res/scenario-new-enum-variant-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (no migrate — append-only enum is borsh-compatible)
     type: upgrade_group
     node: app-migration-newenum-1
@@ -301,9 +310,5 @@ steps:
     node: app-migration-newenum-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-newenum-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -26,10 +26,6 @@ nodes:
   base_port: 9290
   base_rpc_port: 9390
 
-# NOTE: still on distinct-id raw-wasm fixtures — code-only (no-migration)
-# upgrades do not yet work under a version-stable bundle ApplicationId.
-# Convert to the same-package .mpk fixtures when #2755 lands.
-
 steps:
   # Phase 1: Install both binaries on the ADMIN node (node 1) only.
   #
@@ -43,18 +39,10 @@ steps:
   - name: Install scenario-new-enum-variant-v1 on node 1
     type: install_application
     node: app-migration-newenum-1
-    path: apps/migrations/scenario-new-enum-variant-v1/res/scenario_new_enum_variant_v1.wasm
+    path: apps/migrations/scenario-new-enum-variant-v1/res/scenario-new-enum-variant-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-new-enum-variant-v2 on node 1
-    type: install_application
-    node: app-migration-newenum-1
-    path: apps/migrations/scenario-new-enum-variant-v2/res/scenario_new_enum_variant_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -184,6 +172,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install scenario-new-enum-variant-v2 on node 1
+    type: install_application
+    node: app-migration-newenum-1
+    path: apps/migrations/scenario-new-enum-variant-v2/res/scenario-new-enum-variant-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (no migrate — append-only enum is borsh-compatible)
     type: upgrade_group
     node: app-migration-newenum-1
@@ -305,9 +310,5 @@ steps:
     node: app-migration-newenum-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-newenum-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -26,6 +26,10 @@ nodes:
   base_port: 9290
   base_rpc_port: 9390
 
+# NOTE: still on distinct-id raw-wasm fixtures — code-only (no-migration)
+# upgrades do not yet work under a version-stable bundle ApplicationId.
+# Convert to the same-package .mpk fixtures when #2755 lands.
+
 steps:
   # Phase 1: Install both binaries on the ADMIN node (node 1) only.
   #
@@ -39,10 +43,18 @@ steps:
   - name: Install scenario-new-enum-variant-v1 on node 1
     type: install_application
     node: app-migration-newenum-1
-    path: apps/migrations/scenario-new-enum-variant-v1/res/scenario-new-enum-variant-1.0.0.mpk
+    path: apps/migrations/scenario-new-enum-variant-v1/res/scenario_new_enum_variant_v1.wasm
     dev: true
     outputs:
       app_v1: applicationId
+
+  - name: Install scenario-new-enum-variant-v2 on node 1
+    type: install_application
+    node: app-migration-newenum-1
+    path: apps/migrations/scenario-new-enum-variant-v2/res/scenario_new_enum_variant_v2.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -172,23 +184,6 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
-  - name: Install scenario-new-enum-variant-v2 on node 1
-    type: install_application
-    node: app-migration-newenum-1
-    path: apps/migrations/scenario-new-enum-variant-v2/res/scenario-new-enum-variant-2.0.0.mpk
-    dev: true
-    outputs:
-      app_v2: applicationId
-
-
-  - name: Assert both versions share one application id (bundle same-id)
-    # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
-    # below then exercises the same-id (blob-only) propagation path.
-    type: json_assert
-    statements:
-      - 'equal("{{app_v1}}", "{{app_v2}}")'
-
   - name: Upgrade subgroup v1 → v2 (no migrate — append-only enum is borsh-compatible)
     type: upgrade_group
     node: app-migration-newenum-1
@@ -310,5 +305,9 @@ steps:
     node: app-migration-newenum-1
     application_id: "{{app_v1}}"
 
+  - name: Uninstall v2 on node 1
+    type: uninstall_application
+    node: app-migration-newenum-1
+    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -41,18 +41,10 @@ steps:
   - name: Install scenario-pure-bugfix-v1 on node 1
     type: install_application
     node: app-migration-bugfix-1
-    path: apps/migrations/scenario-pure-bugfix-v1/res/scenario_pure_bugfix_v1.wasm
+    path: apps/migrations/scenario-pure-bugfix-v1/res/scenario-pure-bugfix-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-pure-bugfix-v2 on node 1
-    type: install_application
-    node: app-migration-bugfix-1
-    path: apps/migrations/scenario-pure-bugfix-v2/res/scenario_pure_bugfix_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -201,6 +193,23 @@ steps:
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
   # Pure-bugfix: state struct is byte-identical, so no migrate_method is
   # supplied. Existing v1 state bytes must decode as v2 directly.
+  - name: Install scenario-pure-bugfix-v2 on node 1
+    type: install_application
+    node: app-migration-bugfix-1
+    path: apps/migrations/scenario-pure-bugfix-v2/res/scenario-pure-bugfix-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, no migrate handler)
     type: upgrade_group
     node: app-migration-bugfix-1
@@ -338,9 +347,5 @@ steps:
     node: app-migration-bugfix-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-bugfix-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -28,10 +28,6 @@ nodes:
   base_port: 9300
   base_rpc_port: 9400
 
-# NOTE: still on distinct-id raw-wasm fixtures — code-only (no-migration)
-# upgrades do not yet work under a version-stable bundle ApplicationId.
-# Convert to the same-package .mpk fixtures when #2755 lands.
-
 steps:
   # Phase 1: Install both binaries on the ADMIN node (node 1) only.
   #
@@ -45,18 +41,10 @@ steps:
   - name: Install scenario-pure-bugfix-v1 on node 1
     type: install_application
     node: app-migration-bugfix-1
-    path: apps/migrations/scenario-pure-bugfix-v1/res/scenario_pure_bugfix_v1.wasm
+    path: apps/migrations/scenario-pure-bugfix-v1/res/scenario-pure-bugfix-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-pure-bugfix-v2 on node 1
-    type: install_application
-    node: app-migration-bugfix-1
-    path: apps/migrations/scenario-pure-bugfix-v2/res/scenario_pure_bugfix_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -205,6 +193,23 @@ steps:
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
   # Pure-bugfix: state struct is byte-identical, so no migrate_method is
   # supplied. Existing v1 state bytes must decode as v2 directly.
+  - name: Install scenario-pure-bugfix-v2 on node 1
+    type: install_application
+    node: app-migration-bugfix-1
+    path: apps/migrations/scenario-pure-bugfix-v2/res/scenario-pure-bugfix-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, no migrate handler)
     type: upgrade_group
     node: app-migration-bugfix-1
@@ -342,9 +347,5 @@ steps:
     node: app-migration-bugfix-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-bugfix-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -28,6 +28,10 @@ nodes:
   base_port: 9300
   base_rpc_port: 9400
 
+# NOTE: still on distinct-id raw-wasm fixtures — code-only (no-migration)
+# upgrades do not yet work under a version-stable bundle ApplicationId.
+# Convert to the same-package .mpk fixtures when #2755 lands.
+
 steps:
   # Phase 1: Install both binaries on the ADMIN node (node 1) only.
   #
@@ -41,10 +45,18 @@ steps:
   - name: Install scenario-pure-bugfix-v1 on node 1
     type: install_application
     node: app-migration-bugfix-1
-    path: apps/migrations/scenario-pure-bugfix-v1/res/scenario-pure-bugfix-1.0.0.mpk
+    path: apps/migrations/scenario-pure-bugfix-v1/res/scenario_pure_bugfix_v1.wasm
     dev: true
     outputs:
       app_v1: applicationId
+
+  - name: Install scenario-pure-bugfix-v2 on node 1
+    type: install_application
+    node: app-migration-bugfix-1
+    path: apps/migrations/scenario-pure-bugfix-v2/res/scenario_pure_bugfix_v2.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -193,23 +205,6 @@ steps:
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
   # Pure-bugfix: state struct is byte-identical, so no migrate_method is
   # supplied. Existing v1 state bytes must decode as v2 directly.
-  - name: Install scenario-pure-bugfix-v2 on node 1
-    type: install_application
-    node: app-migration-bugfix-1
-    path: apps/migrations/scenario-pure-bugfix-v2/res/scenario-pure-bugfix-2.0.0.mpk
-    dev: true
-    outputs:
-      app_v2: applicationId
-
-
-  - name: Assert both versions share one application id (bundle same-id)
-    # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
-    # below then exercises the same-id (blob-only) propagation path.
-    type: json_assert
-    statements:
-      - 'equal("{{app_v1}}", "{{app_v2}}")'
-
   - name: Upgrade subgroup v1 → v2 (per-context, no migrate handler)
     type: upgrade_group
     node: app-migration-bugfix-1
@@ -347,5 +342,9 @@ steps:
     node: app-migration-bugfix-1
     application_id: "{{app_v1}}"
 
+  - name: Uninstall v2 on node 1
+    type: uninstall_application
+    node: app-migration-bugfix-1
+    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/09-scenario-crdt-native.yml
+++ b/workflows/app-migration/09-scenario-crdt-native.yml
@@ -51,18 +51,10 @@ steps:
   - name: Install scenario-crdt-native-v1 on node 1
     type: install_application
     node: app-migration-crdt-1
-    path: apps/migrations/scenario-crdt-native-v1/res/scenario_crdt_native_v1.wasm
+    path: apps/migrations/scenario-crdt-native-v1/res/scenario-crdt-native-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-crdt-native-v2 on node 1
-    type: install_application
-    node: app-migration-crdt-1
-    path: apps/migrations/scenario-crdt-native-v2/res/scenario_crdt_native_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -214,6 +206,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install scenario-crdt-native-v2 on node 1
+    type: install_application
+    node: app-migration-crdt-1
+    path: apps/migrations/scenario-crdt-native-v2/res/scenario-crdt-native-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, not cascade)
     type: upgrade_group
     node: app-migration-crdt-1
@@ -452,9 +461,5 @@ steps:
     node: app-migration-crdt-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-crdt-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/10-scenario-struct-to-enum.yml
+++ b/workflows/app-migration/10-scenario-struct-to-enum.yml
@@ -40,18 +40,10 @@ steps:
   - name: Install scenario-struct-to-enum-v1 on node 1
     type: install_application
     node: app-migration-struct2enum-1
-    path: apps/migrations/scenario-struct-to-enum-v1/res/scenario_struct_to_enum_v1.wasm
+    path: apps/migrations/scenario-struct-to-enum-v1/res/scenario-struct-to-enum-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-struct-to-enum-v2 on node 1
-    type: install_application
-    node: app-migration-struct2enum-1
-    path: apps/migrations/scenario-struct-to-enum-v2/res/scenario_struct_to_enum_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -177,6 +169,23 @@ steps:
   # Under LazyOnAccess this sets the target + migration method on the
   # subgroup meta and returns WITHOUT running a propagator — no node
   # migrates eagerly; each migrates on its next access below.
+  - name: Install scenario-struct-to-enum-v2 on node 1
+    type: install_application
+    node: app-migration-struct2enum-1
+    path: apps/migrations/scenario-struct-to-enum-v2/res/scenario-struct-to-enum-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, not cascade)
     type: upgrade_group
     node: app-migration-struct2enum-1
@@ -307,9 +316,5 @@ steps:
     node: app-migration-struct2enum-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-struct2enum-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/11-scenario-field-split.yml
+++ b/workflows/app-migration/11-scenario-field-split.yml
@@ -40,18 +40,10 @@ steps:
   - name: Install scenario-field-split-v1 on node 1
     type: install_application
     node: app-migration-split-1
-    path: apps/migrations/scenario-field-split-v1/res/scenario_field_split_v1.wasm
+    path: apps/migrations/scenario-field-split-v1/res/scenario-field-split-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-field-split-v2 on node 1
-    type: install_application
-    node: app-migration-split-1
-    path: apps/migrations/scenario-field-split-v2/res/scenario_field_split_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -187,6 +179,23 @@ steps:
   # Under LazyOnAccess this sets the target + migration method on the
   # subgroup meta and returns WITHOUT running a propagator — no node
   # migrates eagerly; each migrates on its next access below.
+  - name: Install scenario-field-split-v2 on node 1
+    type: install_application
+    node: app-migration-split-1
+    path: apps/migrations/scenario-field-split-v2/res/scenario-field-split-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, not cascade)
     type: upgrade_group
     node: app-migration-split-1
@@ -333,9 +342,5 @@ steps:
     node: app-migration-split-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-split-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/12-scenario-field-remove-archive.yml
+++ b/workflows/app-migration/12-scenario-field-remove-archive.yml
@@ -45,18 +45,10 @@ steps:
   - name: Install scenario-field-remove-archive-v1 on node 1
     type: install_application
     node: app-migration-archive-1
-    path: apps/migrations/scenario-field-remove-archive-v1/res/scenario_field_remove_archive_v1.wasm
+    path: apps/migrations/scenario-field-remove-archive-v1/res/scenario-field-remove-archive-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-field-remove-archive-v2 on node 1
-    type: install_application
-    node: app-migration-archive-1
-    path: apps/migrations/scenario-field-remove-archive-v2/res/scenario_field_remove_archive_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -200,6 +192,23 @@ steps:
   # Under LazyOnAccess this sets the target + migration method on the
   # subgroup meta and returns WITHOUT running a propagator — no node
   # migrates eagerly; each migrates on its next access below.
+  - name: Install scenario-field-remove-archive-v2 on node 1
+    type: install_application
+    node: app-migration-archive-1
+    path: apps/migrations/scenario-field-remove-archive-v2/res/scenario-field-remove-archive-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, not cascade)
     type: upgrade_group
     node: app-migration-archive-1
@@ -340,9 +349,5 @@ steps:
     node: app-migration-archive-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-archive-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/13-scenario-invariant-reshuffle.yml
+++ b/workflows/app-migration/13-scenario-invariant-reshuffle.yml
@@ -47,18 +47,10 @@ steps:
   - name: Install scenario-invariant-reshuffle-v1 on node 1
     type: install_application
     node: app-migration-reshuffle-1
-    path: apps/migrations/scenario-invariant-reshuffle-v1/res/scenario_invariant_reshuffle_v1.wasm
+    path: apps/migrations/scenario-invariant-reshuffle-v1/res/scenario-invariant-reshuffle-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-invariant-reshuffle-v2 on node 1
-    type: install_application
-    node: app-migration-reshuffle-1
-    path: apps/migrations/scenario-invariant-reshuffle-v2/res/scenario_invariant_reshuffle_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -216,6 +208,23 @@ steps:
   # Under LazyOnAccess this sets the target + migration method on the
   # subgroup meta and returns WITHOUT running a propagator — no node
   # migrates eagerly; each migrates on its next access below.
+  - name: Install scenario-invariant-reshuffle-v2 on node 1
+    type: install_application
+    node: app-migration-reshuffle-1
+    path: apps/migrations/scenario-invariant-reshuffle-v2/res/scenario-invariant-reshuffle-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context, not cascade)
     type: upgrade_group
     node: app-migration-reshuffle-1
@@ -390,9 +399,5 @@ steps:
     node: app-migration-reshuffle-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-reshuffle-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -43,18 +43,10 @@ steps:
   - name: Install migration-suite-v1 on node 1
     type: install_application
     node: app-migration-status-1
-    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    path: apps/migrations/migration-suite-v1/res/migration-suite-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install migration-suite-v2-add-field on node 1
-    type: install_application
-    node: app-migration-status-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace on node 1 (anchors app_v1)
@@ -145,6 +137,23 @@ steps:
     node: app-migration-status-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-status-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (initiated by node 1)
     type: upgrade_group
@@ -256,9 +265,5 @@ steps:
     node: app-migration-status-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-status-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/15-scenario-authored-map.yml
+++ b/workflows/app-migration/15-scenario-authored-map.yml
@@ -33,18 +33,10 @@ steps:
   - name: Install scenario-authored-map-v1 on node 1
     type: install_application
     node: app-migration-authmap-1
-    path: apps/migrations/scenario-authored-map-v1/res/scenario_authored_map_v1.wasm
+    path: apps/migrations/scenario-authored-map-v1/res/scenario-authored-map-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-authored-map-v2 on node 1
-    type: install_application
-    node: app-migration-authmap-1
-    path: apps/migrations/scenario-authored-map-v2/res/scenario_authored_map_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: namespace + Open subgroup + context.
   - name: Create namespace (v1) on node 1
@@ -184,6 +176,23 @@ steps:
     upgrade_policy: lazy_on_access
 
   # Phase 5: per-context upgrade on the subgroup (cascade=false).
+  - name: Install scenario-authored-map-v2 on node 1
+    type: install_application
+    node: app-migration-authmap-1
+    path: apps/migrations/scenario-authored-map-v2/res/scenario-authored-map-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context)
     type: upgrade_group
     node: app-migration-authmap-1
@@ -311,9 +320,5 @@ steps:
     node: app-migration-authmap-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-authmap-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/16-scenario-user-storage.yml
+++ b/workflows/app-migration/16-scenario-user-storage.yml
@@ -30,18 +30,10 @@ steps:
   - name: Install scenario-user-storage-v1 on node 1
     type: install_application
     node: app-migration-userstore-1
-    path: apps/migrations/scenario-user-storage-v1/res/scenario_user_storage_v1.wasm
+    path: apps/migrations/scenario-user-storage-v1/res/scenario-user-storage-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-user-storage-v2 on node 1
-    type: install_application
-    node: app-migration-userstore-1
-    path: apps/migrations/scenario-user-storage-v2/res/scenario_user_storage_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   - name: Create namespace (v1) on node 1
     type: create_namespace
@@ -175,6 +167,22 @@ steps:
     group_id: "{{group_id}}"
     upgrade_policy: lazy_on_access
 
+  - name: Install scenario-user-storage-v2 on node 1
+    type: install_application
+    node: app-migration-userstore-1
+    path: apps/migrations/scenario-user-storage-v2/res/scenario-user-storage-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context)
     type: upgrade_group
     node: app-migration-userstore-1
@@ -280,9 +288,5 @@ steps:
     node: app-migration-userstore-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-userstore-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/17-scenario-frozen-storage.yml
+++ b/workflows/app-migration/17-scenario-frozen-storage.yml
@@ -32,18 +32,10 @@ steps:
   - name: Install scenario-frozen-storage-v1 on node 1
     type: install_application
     node: app-migration-frozen-1
-    path: apps/migrations/scenario-frozen-storage-v1/res/scenario_frozen_storage_v1.wasm
+    path: apps/migrations/scenario-frozen-storage-v1/res/scenario-frozen-storage-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-frozen-storage-v2 on node 1
-    type: install_application
-    node: app-migration-frozen-1
-    path: apps/migrations/scenario-frozen-storage-v2/res/scenario_frozen_storage_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   - name: Create namespace (v1) on node 1
     type: create_namespace
@@ -172,6 +164,22 @@ steps:
     node: app-migration-frozen-1
     group_id: "{{group_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-frozen-storage-v2 on node 1
+    type: install_application
+    node: app-migration-frozen-1
+    path: apps/migrations/scenario-frozen-storage-v2/res/scenario-frozen-storage-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Upgrade subgroup v1 → v2 (per-context)
     type: upgrade_group
@@ -303,9 +311,5 @@ steps:
     node: app-migration-frozen-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-frozen-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/18-scenario-shared-storage.yml
+++ b/workflows/app-migration/18-scenario-shared-storage.yml
@@ -30,18 +30,10 @@ steps:
   - name: Install scenario-shared-storage-v1 on node 1
     type: install_application
     node: app-migration-shared-1
-    path: apps/migrations/scenario-shared-storage-v1/res/scenario_shared_storage_v1.wasm
+    path: apps/migrations/scenario-shared-storage-v1/res/scenario-shared-storage-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-shared-storage-v2 on node 1
-    type: install_application
-    node: app-migration-shared-1
-    path: apps/migrations/scenario-shared-storage-v2/res/scenario_shared_storage_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   - name: Create namespace (v1) on node 1
     type: create_namespace
@@ -170,6 +162,22 @@ steps:
     node: app-migration-shared-1
     group_id: "{{group_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-shared-storage-v2 on node 1
+    type: install_application
+    node: app-migration-shared-1
+    path: apps/migrations/scenario-shared-storage-v2/res/scenario-shared-storage-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Upgrade subgroup v1 → v2 (per-context)
     type: upgrade_group
@@ -300,9 +308,5 @@ steps:
     node: app-migration-shared-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-shared-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/19-scenario-authored-vector.yml
+++ b/workflows/app-migration/19-scenario-authored-vector.yml
@@ -30,18 +30,10 @@ steps:
   - name: Install scenario-authored-vector-v1 on node 1
     type: install_application
     node: app-migration-authvec-1
-    path: apps/migrations/scenario-authored-vector-v1/res/scenario_authored_vector_v1.wasm
+    path: apps/migrations/scenario-authored-vector-v1/res/scenario-authored-vector-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-authored-vector-v2 on node 1
-    type: install_application
-    node: app-migration-authvec-1
-    path: apps/migrations/scenario-authored-vector-v2/res/scenario_authored_vector_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   - name: Create namespace (v1) on node 1
     type: create_namespace
@@ -176,6 +168,22 @@ steps:
     group_id: "{{group_id}}"
     upgrade_policy: lazy_on_access
 
+  - name: Install scenario-authored-vector-v2 on node 1
+    type: install_application
+    node: app-migration-authvec-1
+    path: apps/migrations/scenario-authored-vector-v2/res/scenario-authored-vector-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Upgrade subgroup v1 → v2 (per-context)
     type: upgrade_group
     node: app-migration-authvec-1
@@ -300,9 +308,5 @@ steps:
     node: app-migration-authvec-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-authvec-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/20-scenario-unordered-set.yml
+++ b/workflows/app-migration/20-scenario-unordered-set.yml
@@ -33,18 +33,10 @@ steps:
   - name: Install scenario-unordered-set-v1 on node 1
     type: install_application
     node: app-migration-uset-1
-    path: apps/migrations/scenario-unordered-set-v1/res/scenario_unordered_set_v1.wasm
+    path: apps/migrations/scenario-unordered-set-v1/res/scenario-unordered-set-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-unordered-set-v2 on node 1
-    type: install_application
-    node: app-migration-uset-1
-    path: apps/migrations/scenario-unordered-set-v2/res/scenario_unordered_set_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   - name: Create namespace (v1) on node 1
     type: create_namespace
@@ -168,6 +160,22 @@ steps:
     node: app-migration-uset-1
     group_id: "{{group_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-unordered-set-v2 on node 1
+    type: install_application
+    node: app-migration-uset-1
+    path: apps/migrations/scenario-unordered-set-v2/res/scenario-unordered-set-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Upgrade subgroup v1 → v2 (per-context)
     type: upgrade_group
@@ -300,9 +308,5 @@ steps:
     node: app-migration-uset-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-uset-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/21-reads-available-during-upgrade.yml
+++ b/workflows/app-migration/21-reads-available-during-upgrade.yml
@@ -34,18 +34,10 @@ steps:
   - name: Install migration-suite-v1
     type: install_application
     node: app-migration-reads-1
-    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    path: apps/migrations/migration-suite-v1/res/migration-suite-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install migration-suite-v2-add-field
-    type: install_application
-    node: app-migration-reads-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -109,6 +101,23 @@ steps:
 
   # Fire the cascade. This RPC returns after publishing the op (status is
   # InProgress, propagator runs async) — it does NOT wait for completion.
+  - name: Install migration-suite-v2-add-field
+    type: install_application
+    node: app-migration-reads-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Cascade namespace v1 → v2
     type: upgrade_group
     node: app-migration-reads-1
@@ -175,9 +184,5 @@ steps:
     node: app-migration-reads-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-reads-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/22-scenario-identity-downgrade.yml
+++ b/workflows/app-migration/22-scenario-identity-downgrade.yml
@@ -36,18 +36,10 @@ steps:
   - name: Install scenario-identity-downgrade-v1 on node 1
     type: install_application
     node: app-migration-iddowngrade-1
-    path: apps/migrations/scenario-identity-downgrade-v1/res/scenario_identity_downgrade_v1.wasm
+    path: apps/migrations/scenario-identity-downgrade-v1/res/scenario-identity-downgrade-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-identity-downgrade-v2 on node 1
-    type: install_application
-    node: app-migration-iddowngrade-1
-    path: apps/migrations/scenario-identity-downgrade-v2/res/scenario_identity_downgrade_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace on node 1
@@ -113,6 +105,23 @@ steps:
   # Err before emitting any GroupOp. The RPC surfaces this as an error;
   # expected_failure: true makes the step PASS on refusal and FAIL if the
   # upgrade unexpectedly succeeds (gate broken).
+  - name: Install scenario-identity-downgrade-v2 on node 1
+    type: install_application
+    node: app-migration-iddowngrade-1
+    path: apps/migrations/scenario-identity-downgrade-v2/res/scenario-identity-downgrade-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Attempt identity-downgrade upgrade (L1 gate must refuse it)
     type: upgrade_group
     node: app-migration-iddowngrade-1
@@ -174,9 +183,5 @@ steps:
     node: app-migration-iddowngrade-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-iddowngrade-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/22-scenario-identity-downgrade.yml
+++ b/workflows/app-migration/22-scenario-identity-downgrade.yml
@@ -26,11 +26,6 @@ nodes:
   base_port: 9280
   base_rpc_port: 9380
 
-# NOTE: still on distinct-id raw-wasm fixtures — post-abort execution and
-# the L1 downgrade gate assume two coexisting app rows and break on a
-# same-id in-place install. Convert to the same-package .mpk fixtures
-# when #2756 lands.
-
 steps:
   # Phase 1: Install both binaries on the node.
   #
@@ -41,18 +36,10 @@ steps:
   - name: Install scenario-identity-downgrade-v1 on node 1
     type: install_application
     node: app-migration-iddowngrade-1
-    path: apps/migrations/scenario-identity-downgrade-v1/res/scenario_identity_downgrade_v1.wasm
+    path: apps/migrations/scenario-identity-downgrade-v1/res/scenario-identity-downgrade-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-identity-downgrade-v2 on node 1
-    type: install_application
-    node: app-migration-iddowngrade-1
-    path: apps/migrations/scenario-identity-downgrade-v2/res/scenario_identity_downgrade_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace on node 1
@@ -118,6 +105,23 @@ steps:
   # Err before emitting any GroupOp. The RPC surfaces this as an error;
   # expected_failure: true makes the step PASS on refusal and FAIL if the
   # upgrade unexpectedly succeeds (gate broken).
+  - name: Install scenario-identity-downgrade-v2 on node 1
+    type: install_application
+    node: app-migration-iddowngrade-1
+    path: apps/migrations/scenario-identity-downgrade-v2/res/scenario-identity-downgrade-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Attempt identity-downgrade upgrade (L1 gate must refuse it)
     type: upgrade_group
     node: app-migration-iddowngrade-1
@@ -179,9 +183,5 @@ steps:
     node: app-migration-iddowngrade-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-iddowngrade-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/22-scenario-identity-downgrade.yml
+++ b/workflows/app-migration/22-scenario-identity-downgrade.yml
@@ -26,6 +26,11 @@ nodes:
   base_port: 9280
   base_rpc_port: 9380
 
+# NOTE: still on distinct-id raw-wasm fixtures — post-abort execution and
+# the L1 downgrade gate assume two coexisting app rows and break on a
+# same-id in-place install. Convert to the same-package .mpk fixtures
+# when #2756 lands.
+
 steps:
   # Phase 1: Install both binaries on the node.
   #
@@ -36,10 +41,18 @@ steps:
   - name: Install scenario-identity-downgrade-v1 on node 1
     type: install_application
     node: app-migration-iddowngrade-1
-    path: apps/migrations/scenario-identity-downgrade-v1/res/scenario-identity-downgrade-1.0.0.mpk
+    path: apps/migrations/scenario-identity-downgrade-v1/res/scenario_identity_downgrade_v1.wasm
     dev: true
     outputs:
       app_v1: applicationId
+
+  - name: Install scenario-identity-downgrade-v2 on node 1
+    type: install_application
+    node: app-migration-iddowngrade-1
+    path: apps/migrations/scenario-identity-downgrade-v2/res/scenario_identity_downgrade_v2.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace on node 1
@@ -105,23 +118,6 @@ steps:
   # Err before emitting any GroupOp. The RPC surfaces this as an error;
   # expected_failure: true makes the step PASS on refusal and FAIL if the
   # upgrade unexpectedly succeeds (gate broken).
-  - name: Install scenario-identity-downgrade-v2 on node 1
-    type: install_application
-    node: app-migration-iddowngrade-1
-    path: apps/migrations/scenario-identity-downgrade-v2/res/scenario-identity-downgrade-2.0.0.mpk
-    dev: true
-    outputs:
-      app_v2: applicationId
-
-
-  - name: Assert both versions share one application id (bundle same-id)
-    # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
-    # below then exercises the same-id (blob-only) propagation path.
-    type: json_assert
-    statements:
-      - 'equal("{{app_v1}}", "{{app_v2}}")'
-
   - name: Attempt identity-downgrade upgrade (L1 gate must refuse it)
     type: upgrade_group
     node: app-migration-iddowngrade-1
@@ -183,5 +179,9 @@ steps:
     node: app-migration-iddowngrade-1
     application_id: "{{app_v1}}"
 
+  - name: Uninstall v2 on node 1
+    type: uninstall_application
+    node: app-migration-iddowngrade-1
+    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/26-owner-driven-authored.yml
+++ b/workflows/app-migration/26-owner-driven-authored.yml
@@ -57,18 +57,10 @@ steps:
   - name: Install scenario-user-storage-v1 on node 1
     type: install_application
     node: app-migration-owner-1
-    path: apps/migrations/scenario-user-storage-v1/res/scenario_user_storage_v1.wasm
+    path: apps/migrations/scenario-user-storage-v1/res/scenario-user-storage-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-user-storage-v2 on node 1
-    type: install_application
-    node: app-migration-owner-1
-    path: apps/migrations/scenario-user-storage-v2/res/scenario_user_storage_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open descendant subgroup + context.
   - name: Create namespace on node 1 (anchors app_v1)
@@ -182,6 +174,23 @@ steps:
     node: app-migration-owner-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-user-storage-v2 on node 1
+    type: install_application
+    node: app-migration-owner-1
+    path: apps/migrations/scenario-user-storage-v2/res/scenario-user-storage-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (initiated by node 1)
     type: upgrade_group
@@ -385,9 +394,5 @@ steps:
     node: app-migration-owner-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-owner-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -59,18 +59,10 @@ steps:
   - name: Install migration-suite-v1 on node 1
     type: install_application
     node: app-migration-mstatus-1
-    path: apps/migrations/migration-suite-v1/res/migration_suite_v1.wasm
+    path: apps/migrations/migration-suite-v1/res/migration-suite-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install migration-suite-v2-add-field on node 1
-    type: install_application
-    node: app-migration-mstatus-1
-    path: apps/migrations/migration-suite-v2-add-field/res/migration_suite_v2_add_field.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Node 1 builds namespace + Open subgroup + context.
   - name: Create namespace on node 1 (anchors app_v1)
@@ -163,6 +155,23 @@ steps:
     node: app-migration-mstatus-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-mstatus-1
+    path: apps/migrations/migration-suite-v2-add-field/res/migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (initiated by node 1)
     type: upgrade_group
@@ -311,9 +320,5 @@ steps:
     node: app-migration-mstatus-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-mstatus-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/29-migration-check-pass.yml
+++ b/workflows/app-migration/29-migration-check-pass.yml
@@ -36,18 +36,10 @@ steps:
   - name: Install scenario-migration-check-pass-v1
     type: install_application
     node: app-migration-check-pass-1
-    path: apps/migrations/scenario-migration-check-pass-v1/res/scenario_migration_check_pass_v1.wasm
+    path: apps/migrations/scenario-migration-check-pass-v1/res/scenario-migration-check-pass-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-migration-check-pass-v2
-    type: install_application
-    node: app-migration-check-pass-1
-    path: apps/migrations/scenario-migration-check-pass-v2/res/scenario_migration_check_pass_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -128,6 +120,23 @@ steps:
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
 
+  - name: Install scenario-migration-check-pass-v2
+    type: install_application
+    node: app-migration-check-pass-1
+    path: apps/migrations/scenario-migration-check-pass-v2/res/scenario-migration-check-pass-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Cascade namespace v1 → v2
     type: upgrade_group
     node: app-migration-check-pass-1
@@ -196,9 +205,5 @@ steps:
     node: app-migration-check-pass-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-check-pass-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/30-migration-check-fail-abort.yml
+++ b/workflows/app-migration/30-migration-check-fail-abort.yml
@@ -44,15 +44,28 @@ nodes:
   base_port: 10050
   base_rpc_port: 10150
 
+# NOTE: still on distinct-id raw-wasm fixtures — post-abort execution and
+# the L1 downgrade gate assume two coexisting app rows and break on a
+# same-id in-place install. Convert to the same-package .mpk fixtures
+# when #2756 lands.
+
 steps:
   # Install v1 + v2 (the lossy v2) on the single node.
   - name: Install scenario-migration-check-fail-v1
     type: install_application
     node: app-migration-check-fail-1
-    path: apps/migrations/scenario-migration-check-fail-v1/res/scenario-migration-check-fail-1.0.0.mpk
+    path: apps/migrations/scenario-migration-check-fail-v1/res/scenario_migration_check_fail_v1.wasm
     dev: true
     outputs:
       app_v1: applicationId
+
+  - name: Install scenario-migration-check-fail-v2
+    type: install_application
+    node: app-migration-check-fail-1
+    path: apps/migrations/scenario-migration-check-fail-v2/res/scenario_migration_check_fail_v2.wasm
+    dev: true
+    outputs:
+      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -132,23 +145,6 @@ steps:
     node: app-migration-check-fail-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
-
-  - name: Install scenario-migration-check-fail-v2
-    type: install_application
-    node: app-migration-check-fail-1
-    path: apps/migrations/scenario-migration-check-fail-v2/res/scenario-migration-check-fail-2.0.0.mpk
-    dev: true
-    outputs:
-      app_v2: applicationId
-
-
-  - name: Assert both versions share one application id (bundle same-id)
-    # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
-    # below then exercises the same-id (blob-only) propagation path.
-    type: json_assert
-    statements:
-      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (lossy migrate)
     type: upgrade_group
@@ -244,5 +240,9 @@ steps:
     node: app-migration-check-fail-1
     application_id: "{{app_v1}}"
 
+  - name: Uninstall v2
+    type: uninstall_application
+    node: app-migration-check-fail-1
+    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/30-migration-check-fail-abort.yml
+++ b/workflows/app-migration/30-migration-check-fail-abort.yml
@@ -44,28 +44,15 @@ nodes:
   base_port: 10050
   base_rpc_port: 10150
 
-# NOTE: still on distinct-id raw-wasm fixtures — post-abort execution and
-# the L1 downgrade gate assume two coexisting app rows and break on a
-# same-id in-place install. Convert to the same-package .mpk fixtures
-# when #2756 lands.
-
 steps:
   # Install v1 + v2 (the lossy v2) on the single node.
   - name: Install scenario-migration-check-fail-v1
     type: install_application
     node: app-migration-check-fail-1
-    path: apps/migrations/scenario-migration-check-fail-v1/res/scenario_migration_check_fail_v1.wasm
+    path: apps/migrations/scenario-migration-check-fail-v1/res/scenario-migration-check-fail-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-migration-check-fail-v2
-    type: install_application
-    node: app-migration-check-fail-1
-    path: apps/migrations/scenario-migration-check-fail-v2/res/scenario_migration_check_fail_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -145,6 +132,23 @@ steps:
     node: app-migration-check-fail-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-migration-check-fail-v2
+    type: install_application
+    node: app-migration-check-fail-1
+    path: apps/migrations/scenario-migration-check-fail-v2/res/scenario-migration-check-fail-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (lossy migrate)
     type: upgrade_group
@@ -240,9 +244,5 @@ steps:
     node: app-migration-check-fail-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-check-fail-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/30-migration-check-fail-abort.yml
+++ b/workflows/app-migration/30-migration-check-fail-abort.yml
@@ -49,18 +49,10 @@ steps:
   - name: Install scenario-migration-check-fail-v1
     type: install_application
     node: app-migration-check-fail-1
-    path: apps/migrations/scenario-migration-check-fail-v1/res/scenario_migration_check_fail_v1.wasm
+    path: apps/migrations/scenario-migration-check-fail-v1/res/scenario-migration-check-fail-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-migration-check-fail-v2
-    type: install_application
-    node: app-migration-check-fail-1
-    path: apps/migrations/scenario-migration-check-fail-v2/res/scenario_migration_check_fail_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -140,6 +132,23 @@ steps:
     node: app-migration-check-fail-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-migration-check-fail-v2
+    type: install_application
+    node: app-migration-check-fail-1
+    path: apps/migrations/scenario-migration-check-fail-v2/res/scenario-migration-check-fail-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (lossy migrate)
     type: upgrade_group
@@ -235,9 +244,5 @@ steps:
     node: app-migration-check-fail-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-check-fail-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/31-admin-abort-logical.yml
+++ b/workflows/app-migration/31-admin-abort-logical.yml
@@ -58,18 +58,10 @@ steps:
   - name: Install scenario-migration-check-pass-v1
     type: install_application
     node: app-migration-admin-abort-1
-    path: apps/migrations/scenario-migration-check-pass-v1/res/scenario_migration_check_pass_v1.wasm
+    path: apps/migrations/scenario-migration-check-pass-v1/res/scenario-migration-check-pass-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-migration-check-pass-v2
-    type: install_application
-    node: app-migration-admin-abort-1
-    path: apps/migrations/scenario-migration-check-pass-v2/res/scenario_migration_check_pass_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -133,6 +125,23 @@ steps:
   # Fire the cascade. On the initiating node this applies the migration eagerly
   # (the context commits to v2 here) and records a pending migration marker for
   # the group — the marker the abort below drops.
+  - name: Install scenario-migration-check-pass-v2
+    type: install_application
+    node: app-migration-admin-abort-1
+    path: apps/migrations/scenario-migration-check-pass-v2/res/scenario-migration-check-pass-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Cascade namespace v1 → v2 (commits v2, records the pending marker)
     type: upgrade_group
     node: app-migration-admin-abort-1
@@ -218,9 +227,5 @@ steps:
     node: app-migration-admin-abort-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-admin-abort-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -38,18 +38,10 @@ steps:
   - name: Install scenario-authored-migrate-ux-v1 on node 1
     type: install_application
     node: app-migration-ux-1
-    path: apps/migrations/scenario-authored-migrate-ux-v1/res/scenario_authored_migrate_ux_v1.wasm
+    path: apps/migrations/scenario-authored-migrate-ux-v1/res/scenario-authored-migrate-ux-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-authored-migrate-ux-v2 on node 1
-    type: install_application
-    node: app-migration-ux-1
-    path: apps/migrations/scenario-authored-migrate-ux-v2/res/scenario_authored_migrate_ux_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Phase 2: Namespace + Open descendant subgroup + context.
   - name: Create namespace on node 1 (anchors app_v1)
@@ -173,6 +165,23 @@ steps:
     node: app-migration-ux-1
     group_id: "{{namespace_id}}"
     upgrade_policy: lazy_on_access
+
+  - name: Install scenario-authored-migrate-ux-v2 on node 1
+    type: install_application
+    node: app-migration-ux-1
+    path: apps/migrations/scenario-authored-migrate-ux-v2/res/scenario-authored-migrate-ux-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
 
   - name: Cascade namespace v1 → v2 (initiated by node 1)
     type: upgrade_group
@@ -443,9 +452,5 @@ steps:
     node: app-migration-ux-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2 on node 1
-    type: uninstall_application
-    node: app-migration-ux-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/33-authored-remaining-count.yml
+++ b/workflows/app-migration/33-authored-remaining-count.yml
@@ -46,18 +46,10 @@ steps:
   - name: Install scenario-authored-migrate-ux-v1
     type: install_application
     node: app-migration-authored-count-1
-    path: apps/migrations/scenario-authored-migrate-ux-v1/res/scenario_authored_migrate_ux_v1.wasm
+    path: apps/migrations/scenario-authored-migrate-ux-v1/res/scenario-authored-migrate-ux-1.0.0.mpk
     dev: true
     outputs:
       app_v1: applicationId
-
-  - name: Install scenario-authored-migrate-ux-v2
-    type: install_application
-    node: app-migration-authored-count-1
-    path: apps/migrations/scenario-authored-migrate-ux-v2/res/scenario_authored_migrate_ux_v2.wasm
-    dev: true
-    outputs:
-      app_v2: applicationId
 
   # Namespace (anchors v1) + descendant Open subgroup + context, all local.
   - name: Create namespace (anchors app_v1)
@@ -134,6 +126,23 @@ steps:
   # Cascade the namespace v1 → v2. The owning node applies the migration: the
   # state schema flips to 2.0.0, but the two notes keep their per-entry
   # schema_version 1 until the owner re-signs them (owner-driven convert).
+  - name: Install scenario-authored-migrate-ux-v2
+    type: install_application
+    node: app-migration-authored-count-1
+    path: apps/migrations/scenario-authored-migrate-ux-v2/res/scenario-authored-migrate-ux-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id — the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
   - name: Cascade namespace v1 → v2
     type: upgrade_group
     node: app-migration-authored-count-1
@@ -242,9 +251,5 @@ steps:
     node: app-migration-authored-count-1
     application_id: "{{app_v1}}"
 
-  - name: Uninstall v2
-    type: uninstall_application
-    node: app-migration-authored-count-1
-    application_id: "{{app_v2}}"
 
 stop_all_nodes: false

--- a/workflows/app-migration/build-wasms.sh
+++ b/workflows/app-migration/build-wasms.sh
@@ -73,4 +73,21 @@ for suite in "${SUITES[@]}"; do
     bash "$suite/build.sh"
 done
 
+# Wrap every fixture into a signed single-service `.mpk`. v1/v2 of a pair
+# share the package name, so they install under the SAME ApplicationId
+# (hash(package, signer)) — the realistic upgrade shape, where only the
+# bytecode blob changes between versions. The workflows install these
+# bundles (not the raw wasms) so the same-id propagation path is exercised.
+for suite in "${SUITES[@]}"; do
+    dir_name="$(basename "$suite")"
+    wasm_file="${dir_name//-/_}.wasm"
+    # `migration-suite-v3-remove-field` → base `migration-suite`, version 3.
+    # `scenario-user-storage-v2`       → base `scenario-user-storage`, version 2.
+    base="${dir_name%%-v[0-9]*}"
+    v_num="$(printf '%s' "$dir_name" | sed -E 's/.*-v([0-9]+).*/\1/')"
+    echo ">>> Bundling $suite (com.calimero.${base} @ ${v_num}.0.0)"
+    bash apps/migrations/bundle-wasm.sh \
+        "$suite" "$wasm_file" "com.calimero.${base}" "${v_num}.0.0"
+done
+
 echo ">>> All migration-suite fixtures built."


### PR DESCRIPTION
## Problem

Bundle apps derive `ApplicationId = hash(package, signer)` — deliberately version-stable (the handle contexts and frontends pin). A version bump therefore moves only the bytecode blob under an unchanged id. But every peer-side upgrade mechanism keyed off the ApplicationId changing:

1. **Lazy migrate loaded the wrong code.** The lazy-upgrade path called `get_module(target_app)`, which compiles whatever blob is *installed* under that id. On a peer that's still the OLD bytecode (nothing fetches a new blob under a stable id), so the migrate found no migrate export and warned `lazy upgrade (migration) failed, proceeding with current application`. **Net effect: a bundle migration only ever ran on the initiating node — peers never upgraded.** Found by live 2-node testing of a real app upgrade.
2. **The sync gate never armed.** `pending_upgrade_target` compared `current_app != target` — never true for bundles — so an already-migrated peer could reconcile its post-migration state onto a pre-migration node (the exact corruption the gate exists to prevent).

## Why the e2e suite missed it

Every app-migration workflow installed v1/v2 as **two distinct single-wasm crates** → distinct content-addressed ids → the id-keyed path always fired. The same-id bundle shape (one package, version bump, blob-only delta) was never installed in any workflow.

## Fix

- **`crates/context` (actuation):** `maybe_lazy_upgrade` now also returns the group's blob-derived `app_key` (the target bytecode blob id, stamped at upgrade time and replicated in group meta). Before `get_module`, the execute path compares it against the installed bytecode; on mismatch it fetches the blob (DHT/peer download — it is announced at upgrade time), installs it **in place** under the stable id, and evicts the `(application_id, service)`-keyed module/application caches so the fresh bytecode is compiled. Fetch/install failures warn and fall back to the previous behaviour; the next access retries.
- **`crates/node` (detection):** `pending_upgrade_target` gains a same-id arm — pending while the group's replicated migration has not been applied to this context (mirrors `maybe_lazy_upgrade`). Keyed off `meta.migration` + the per-context applied marker rather than a raw `app_key` comparison, so legacy groups whose `app_key` predates blob-derivation (randomly seeded) are unaffected. Extracted as a free function with unit tests covering the bundle, single-wasm, applied, legacy, and bootstrapping cases.

## Test conversion (regression guard)

All 30 app-migration workflows now install **same-package signed `.mpk` bundles** (one generic `bundle-wasm.sh` + wired into `build-wasms.sh`), node-1 only:

- v1/v2 of a pair share the package → both install under **one ApplicationId**; each workflow asserts the ids are equal (the same-id precondition the suite never produced before).
- The target-version install moves to right before `upgrade_group`: same-package installs flip the bytecode in place, so installing earlier would run the v1 phase on v2 code — this is exactly the "publish v2, then migrate" production sequence.
- Node-2 installs nothing and must obtain both versions via blob propagation + lazy migrate — these workflows fail without the fix above.

## Notes

- No store/wire schema change: `GroupMeta.app_key` already exists, is set by `set_target_application` on every upgrade apply, and is serde-defaulted for legacy rows.
- The namespace listing filter (`list_namespaces`) compares `target_application_id` for *identity* (which app), not version — correct as-is for bundles and unchanged.
- JS SDK companion (separate repo PR): `UpgradeGroupRequest.cascade` exposure, so app-initiated upgrades can fan out to subgroups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core upgrade, migration abort, sync gating, and WASM execution paths; wrong bytecode or pin logic could corrupt context state or block peer upgrades.
> 
> **Overview**
> Fixes **bundle app upgrades** where `ApplicationId` stays fixed (`hash(package, signer)`) and only the bytecode blob changes — peers previously never ran lazy migrations and the sync gate could miss pending same-id work.
> 
> **Lazy upgrade / execute path** now threads the group’s `app_key` (target bytecode blob). Before loading a migrate module it **fetches and in-place installs** the target bundle when the row’s blob differs, **evicts** application/module caches, and for code-only bumps records a per-context **`blob:` activation marker**. Execution honors a **`ContextExecutingBlob` pin** after aborted migrations via **`get_pinned_module`** (compile from raw blob bytes). **`upgrade_group`** always publishes **`GroupMigrationSet`** (clears stale migrate methods on code-only upgrades), allows same-id upgrades when bytecode changed, and runs the L1 gate’s “from” schema from **`current_app_key`** via **`resolve_pre_upgrade_schema`**.
> 
> **Node / sync:** **`pending_upgrade_info`** treats same-id bundle migrations as pending (migration marker, not id diff); gated sync **pre-stages** target blobs with retry backoff; missing blob shares reply with **`OpaqueError`**. **Install** breadcrumbs displaced bytecode in **`ApplicationPreviousBlob`**; **`application_bytes_from_blob`** / in-archive **`extract_bundle_file`** support pinned loads.
> 
> **Store:** new local columns **`ContextExecutingBlob`** and **`ApplicationPreviousBlob`**.
> 
> **E2E:** **`bundle-wasm.sh`** + **`build-wasms.sh`** produce signed **`.mpk`** fixtures; CI uploads `.mpk`; all app-migration workflows install bundles (v2 right before upgrade), assert **same application id**, and drop duplicate uninstalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc9f2f0ef038c74c408d65b1527630c22bbde56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->