### PR TITLE
chore: bump version to 0.11.0-rc.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the shared workspace release version from `0.11.0-rc.2` to `0.11.0-rc.3`.

Single-line change to `[workspace.metadata.workspaces].version` in `Cargo.toml`, following the established release-candidate bump convention (see #2748).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or logic changes.
> 
> **Overview**
> Bumps the shared workspace release version in `Cargo.toml` from **`0.11.0-rc.2`** to **`0.11.0-rc.3`** under `[workspace.metadata.workspaces].version`, advancing the release-candidate tag used by cargo-workspaces for public crates (per `docs/RELEASE.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8073331e46336cd43ff85717df48d5b3b3ee13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->